### PR TITLE
[BugFix] Bound proxy tool result wait so a never-reported client tool can't hang the chat turn

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -504,12 +504,21 @@ async def submit_tool_result(
     task_manager = svc.task_manager
     task = task_manager.get_task(request.session_id) if request.session_id else None
     if not task or not task.node:
+        # No live waiter means the agent loop already gave up (e.g. the proxy
+        # tool timed out) or the session was never running — surface it so a
+        # client that thinks it is unblocking the turn can be diagnosed.
+        logger.warning(
+            f"tool_result for unknown task: session_id={request.session_id}, call_id={request.call_tool_id}"
+        )
         return Result[ToolResultData](
             success=False,
             errorCode="TASK_NOT_FOUND",
             errorMessage="No active task found for this session",
         )
 
+    logger.info(
+        f"Received tool_result: session_id={request.session_id}, call_id={request.call_tool_id}"
+    )
     await task.node.tool_channel.publish(request.call_tool_id, request.tool_result.model_dump())
     return Result[ToolResultData](
         success=True,

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -507,22 +507,25 @@ async def submit_tool_result(
         # No live waiter means the agent loop already gave up (e.g. the proxy
         # tool timed out) or the session was never running — surface it so a
         # client that thinks it is unblocking the turn can be diagnosed.
-        logger.warning(
-            f"tool_result for unknown task: session_id={request.session_id}, call_id={request.call_tool_id}"
-        )
+        logger.warning(f"tool_result for unknown task: session_id={request.session_id}, call_id={request.call_tool_id}")
         return Result[ToolResultData](
             success=False,
             errorCode="TASK_NOT_FOUND",
             errorMessage="No active task found for this session",
         )
 
-    logger.info(
-        f"Received tool_result: session_id={request.session_id}, call_id={request.call_tool_id}"
-    )
-    await task.node.tool_channel.publish(request.call_tool_id, request.tool_result.model_dump())
+    logger.info(f"Received tool_result: session_id={request.session_id}, call_id={request.call_tool_id}")
+    delivered = await task.node.tool_channel.publish(request.call_tool_id, request.tool_result.model_dump())
+    if not delivered:
+        # Task is alive but no waiter took the result — it arrived after the
+        # proxy-tool wait already timed out, or it is a duplicate report.
+        logger.warning(f"tool_result arrived late: session_id={request.session_id}, call_id={request.call_tool_id}")
     return Result[ToolResultData](
         success=True,
-        data=ToolResultData(call_tool_id=request.call_tool_id, status="received"),
+        data=ToolResultData(
+            call_tool_id=request.call_tool_id,
+            status="received" if delivered else "ignored",
+        ),
     )
 
 

--- a/datus/tools/proxy/proxy_tool.py
+++ b/datus/tools/proxy/proxy_tool.py
@@ -11,13 +11,14 @@ results from stdin, enabling external callers to provide tool results.
 
 from __future__ import annotations
 
+import asyncio
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 from agents import FunctionTool
 from agents.tool_context import ToolContext
 
-from datus.tools.proxy.tool_result_channel import ToolResultChannel
+from datus.tools.proxy.tool_result_channel import DEFAULT_RESULT_TIMEOUT, ToolResultChannel
 from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
@@ -45,9 +46,26 @@ def create_proxy_tool(original: FunctionTool, channel: ToolResultChannel) -> Fun
 
     async def proxy_invoke(tool_ctx: ToolContext, args_str: str) -> dict:
         call_id = tool_ctx.tool_call_id
-        logger.debug(f"Proxy tool '{original.name}' waiting for result, call_id={call_id}")
+        logger.info(
+            f"Proxy tool '{original.name}' awaiting client result, call_id={call_id}, timeout={DEFAULT_RESULT_TIMEOUT}s"
+        )
         try:
-            return await channel.wait_for(call_id)
+            result = await channel.wait_for(call_id, timeout=DEFAULT_RESULT_TIMEOUT)
+            logger.info(f"Proxy tool '{original.name}' received client result, call_id={call_id}")
+            return result
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Proxy tool '{original.name}' timed out after {DEFAULT_RESULT_TIMEOUT}s "
+                f"waiting for client result, call_id={call_id}"
+            )
+            return {
+                "success": 0,
+                "error": (
+                    f"Timed out after {int(DEFAULT_RESULT_TIMEOUT)}s waiting for the client "
+                    f"to report the result of '{original.name}'."
+                ),
+                "result": None,
+            }
         except RuntimeError as e:
             logger.warning(f"Proxy tool '{original.name}' error: {e}, call_id={call_id}")
             return {"success": 0, "error": str(e), "result": None}

--- a/datus/tools/proxy/proxy_tool.py
+++ b/datus/tools/proxy/proxy_tool.py
@@ -12,6 +12,7 @@ results from stdin, enabling external callers to provide tool results.
 from __future__ import annotations
 
 import asyncio
+import time
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
@@ -46,17 +47,22 @@ def create_proxy_tool(original: FunctionTool, channel: ToolResultChannel) -> Fun
 
     async def proxy_invoke(tool_ctx: ToolContext, args_str: str) -> dict:
         call_id = tool_ctx.tool_call_id
+        started = time.monotonic()
         logger.info(
             f"Proxy tool '{original.name}' awaiting client result, call_id={call_id}, timeout={DEFAULT_RESULT_TIMEOUT}s"
         )
         try:
             result = await channel.wait_for(call_id, timeout=DEFAULT_RESULT_TIMEOUT)
-            logger.info(f"Proxy tool '{original.name}' received client result, call_id={call_id}")
+            waited_ms = int((time.monotonic() - started) * 1000)
+            logger.info(
+                f"Proxy tool '{original.name}' received client result, call_id={call_id}, waited_ms={waited_ms}"
+            )
             return result
         except asyncio.TimeoutError:
+            waited_ms = int((time.monotonic() - started) * 1000)
             logger.warning(
                 f"Proxy tool '{original.name}' timed out after {DEFAULT_RESULT_TIMEOUT}s "
-                f"waiting for client result, call_id={call_id}"
+                f"waiting for client result, call_id={call_id}, waited_ms={waited_ms}"
             )
             return {
                 "success": 0,

--- a/datus/tools/proxy/tool_result_channel.py
+++ b/datus/tools/proxy/tool_result_channel.py
@@ -10,45 +10,18 @@ Wait and publish are order-independent: either side can arrive first.
 """
 
 import asyncio
-import os
 from typing import Any, Dict, Optional
 
-from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
-
-
-def _load_default_timeout() -> float:
-    """Parse DATUS_PROXY_TOOL_RESULT_TIMEOUT into a positive number of seconds.
-
-    A malformed or non-positive override would otherwise leak a raw ValueError
-    at import time, or silently turn every proxied tool wait into an instant
-    timeout — so reject it with a clear DatusException instead.
-    """
-    raw = os.getenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", "600")
-    try:
-        value = float(raw)
-    except (TypeError, ValueError):
-        value = None
-    if value is None or value <= 0:
-        raise DatusException(
-            ErrorCode.COMMON_FIELD_INVALID,
-            message_args={
-                "field_name": "DATUS_PROXY_TOOL_RESULT_TIMEOUT",
-                "except_values": "a positive number of seconds",
-                "your_value": raw,
-            },
-        )
-    return value
-
 
 # Safety net: a proxied tool (e.g. write_file/edit_file executed on the client)
 # blocks the agent loop until the client POSTs its result. If the client never
 # reports — tab closed, crash, or a frontend bug that swallows the report — the
 # loop would otherwise hang forever. ``wait_for`` defaults to this bound so the
-# turn fails cleanly instead. Override via DATUS_PROXY_TOOL_RESULT_TIMEOUT (s).
-DEFAULT_RESULT_TIMEOUT: float = _load_default_timeout()
+# turn fails cleanly instead.
+DEFAULT_RESULT_TIMEOUT: float = 600.0
 
 
 class ToolResultChannel:

--- a/datus/tools/proxy/tool_result_channel.py
+++ b/datus/tools/proxy/tool_result_channel.py
@@ -13,16 +13,42 @@ import asyncio
 import os
 from typing import Any, Dict, Optional
 
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+
+def _load_default_timeout() -> float:
+    """Parse DATUS_PROXY_TOOL_RESULT_TIMEOUT into a positive number of seconds.
+
+    A malformed or non-positive override would otherwise leak a raw ValueError
+    at import time, or silently turn every proxied tool wait into an instant
+    timeout — so reject it with a clear DatusException instead.
+    """
+    raw = os.getenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", "600")
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        value = None
+    if value is None or value <= 0:
+        raise DatusException(
+            ErrorCode.COMMON_FIELD_INVALID,
+            message_args={
+                "field_name": "DATUS_PROXY_TOOL_RESULT_TIMEOUT",
+                "except_values": "a positive number of seconds",
+                "your_value": raw,
+            },
+        )
+    return value
+
 
 # Safety net: a proxied tool (e.g. write_file/edit_file executed on the client)
 # blocks the agent loop until the client POSTs its result. If the client never
 # reports — tab closed, crash, or a frontend bug that swallows the report — the
 # loop would otherwise hang forever. ``wait_for`` defaults to this bound so the
 # turn fails cleanly instead. Override via DATUS_PROXY_TOOL_RESULT_TIMEOUT (s).
-DEFAULT_RESULT_TIMEOUT: float = float(os.getenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", "600"))
+DEFAULT_RESULT_TIMEOUT: float = _load_default_timeout()
 
 
 class ToolResultChannel:
@@ -43,14 +69,16 @@ class ToolResultChannel:
             self._futures[call_id] = fut
         return fut
 
-    async def wait_for(self, call_id: str, timeout: Optional[float] = None) -> Any:
+    async def wait_for(self, call_id: str, timeout: Optional[float] = DEFAULT_RESULT_TIMEOUT) -> Any:
         """Wait for a result to be published for the given call_id.
 
         ``timeout`` (seconds) bounds the wait so a never-reported client tool
-        cannot block the agent loop forever; on expiry ``asyncio.wait_for``
-        cancels the future (leaving it settled) and ``asyncio.TimeoutError``
-        propagates. The settled future is retained so a late ``publish`` for the
-        same ``call_id`` is recognised as late rather than silently re-created.
+        cannot block the agent loop forever; it defaults to
+        ``DEFAULT_RESULT_TIMEOUT`` and only an explicit ``timeout=None`` opts
+        into an unbounded wait. On expiry ``asyncio.wait_for`` cancels the
+        future (leaving it settled) and ``asyncio.TimeoutError`` propagates. The
+        settled future is retained so a late ``publish`` for the same
+        ``call_id`` is recognised as late rather than silently re-created.
         """
         async with self._lock:
             future = self._get_or_create_future(call_id)
@@ -76,7 +104,7 @@ class ToolResultChannel:
         logger.info(f"Tool result published for call_id={call_id}")
         return True
 
-    def cancel_all(self, reason: str = "Channel closed"):
+    def cancel_all(self, reason: str = "Channel closed") -> None:
         """Cancel all pending futures.
 
         Note: This is a synchronous method and must be called from the

--- a/datus/tools/proxy/tool_result_channel.py
+++ b/datus/tools/proxy/tool_result_channel.py
@@ -10,11 +10,19 @@ Wait and publish are order-independent: either side can arrive first.
 """
 
 import asyncio
-from typing import Any, Dict
+import os
+from typing import Any, Dict, Optional
 
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+# Safety net: a proxied tool (e.g. write_file/edit_file executed on the client)
+# blocks the agent loop until the client POSTs its result. If the client never
+# reports — tab closed, crash, or a frontend bug that swallows the report — the
+# loop would otherwise hang forever. ``wait_for`` defaults to this bound so the
+# turn fails cleanly instead. Override via DATUS_PROXY_TOOL_RESULT_TIMEOUT (s).
+DEFAULT_RESULT_TIMEOUT: float = float(os.getenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", "600"))
 
 
 class ToolResultChannel:
@@ -35,18 +43,38 @@ class ToolResultChannel:
             self._futures[call_id] = fut
         return fut
 
-    async def wait_for(self, call_id: str) -> Any:
-        """Wait for a result to be published for the given call_id."""
+    async def wait_for(self, call_id: str, timeout: Optional[float] = None) -> Any:
+        """Wait for a result to be published for the given call_id.
+
+        ``timeout`` (seconds) bounds the wait so a never-reported client tool
+        cannot block the agent loop forever; on expiry the dead future is
+        dropped and ``asyncio.TimeoutError`` propagates to the caller.
+        """
         async with self._lock:
             future = self._get_or_create_future(call_id)
-        return await future
+        if timeout is None:
+            return await future
+        try:
+            return await asyncio.wait_for(future, timeout)
+        except asyncio.TimeoutError:
+            # Drop the abandoned future so a late publish doesn't target a
+            # waiter that has already given up.
+            async with self._lock:
+                if self._futures.get(call_id) is future:
+                    self._futures.pop(call_id, None)
+            raise
 
     async def publish(self, call_id: str, result: Any) -> None:
         """Publish a result for the given call_id."""
         async with self._lock:
             future = self._get_or_create_future(call_id)
-            if not future.done():
-                future.set_result(result)
+            if future.done():
+                # Already settled — typically a duplicate report, or one that
+                # arrived after wait_for timed out and dropped its waiter.
+                logger.warning(f"Tool result for call_id={call_id} ignored; waiter already settled")
+                return
+            future.set_result(result)
+        logger.info(f"Tool result published for call_id={call_id}")
 
     def cancel_all(self, reason: str = "Channel closed"):
         """Cancel all pending futures.
@@ -54,6 +82,9 @@ class ToolResultChannel:
         Note: This is a synchronous method and must be called from the
         same event-loop thread that owns the futures.
         """
+        pending = [call_id for call_id, fut in self._futures.items() if not fut.done()]
+        if pending:
+            logger.info(f"Cancelling {len(pending)} pending tool result(s): {reason}; call_ids={pending}")
         for future in self._futures.values():
             if not future.done():
                 future.set_exception(RuntimeError(reason))

--- a/datus/tools/proxy/tool_result_channel.py
+++ b/datus/tools/proxy/tool_result_channel.py
@@ -47,34 +47,34 @@ class ToolResultChannel:
         """Wait for a result to be published for the given call_id.
 
         ``timeout`` (seconds) bounds the wait so a never-reported client tool
-        cannot block the agent loop forever; on expiry the dead future is
-        dropped and ``asyncio.TimeoutError`` propagates to the caller.
+        cannot block the agent loop forever; on expiry ``asyncio.wait_for``
+        cancels the future (leaving it settled) and ``asyncio.TimeoutError``
+        propagates. The settled future is retained so a late ``publish`` for the
+        same ``call_id`` is recognised as late rather than silently re-created.
         """
         async with self._lock:
             future = self._get_or_create_future(call_id)
         if timeout is None:
             return await future
-        try:
-            return await asyncio.wait_for(future, timeout)
-        except asyncio.TimeoutError:
-            # Drop the abandoned future so a late publish doesn't target a
-            # waiter that has already given up.
-            async with self._lock:
-                if self._futures.get(call_id) is future:
-                    self._futures.pop(call_id, None)
-            raise
+        return await asyncio.wait_for(future, timeout)
 
-    async def publish(self, call_id: str, result: Any) -> None:
-        """Publish a result for the given call_id."""
+    async def publish(self, call_id: str, result: Any) -> bool:
+        """Publish a result for the given call_id.
+
+        Returns ``True`` if a live waiter received it, ``False`` if the result
+        was dropped — a duplicate, or one that arrived after the waiter timed
+        out — so callers can tell ``matched`` from ``late`` reports.
+        """
         async with self._lock:
             future = self._get_or_create_future(call_id)
             if future.done():
                 # Already settled — typically a duplicate report, or one that
                 # arrived after wait_for timed out and dropped its waiter.
                 logger.warning(f"Tool result for call_id={call_id} ignored; waiter already settled")
-                return
+                return False
             future.set_result(result)
         logger.info(f"Tool result published for call_id={call_id}")
+        return True
 
     def cancel_all(self, reason: str = "Channel closed"):
         """Cancel all pending futures.

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
 from datus.api.models.base_models import Result
+from datus.api.models.chat_models import ToolResult, ToolResultInput
 from datus.api.models.cli_models import (
     ChatHistoryData,
     ChatSessionData,
@@ -28,8 +29,10 @@ from datus.api.routes.chat_routes import (
     get_chat_history,
     list_sessions,
     stream_chat,
+    submit_tool_result,
     submit_user_interaction,
 )
+from datus.tools.proxy.tool_result_channel import ToolResultChannel
 from datus.tools.sql_policy import SqlPolicyConfig
 
 
@@ -676,3 +679,53 @@ class TestGetChatHistory:
         assert isinstance(result, Result)
         assert result.data is None
         mock_wf.assert_called_once_with(ANY, timeout=_FUSE_IO_TIMEOUT)
+
+
+def _tool_result_input(call_id="call_1", session_id="sess1"):
+    return ToolResultInput(
+        session_id=session_id,
+        call_tool_id=call_id,
+        tool_result=ToolResult(success=1, result="ok"),
+    )
+
+
+def _task_with_channel(channel):
+    task = MagicMock()
+    task.node.tool_channel = channel
+    return task
+
+
+class TestSubmitToolResult:
+    @pytest.mark.asyncio
+    async def test_matched_publishes_and_returns_received(self):
+        channel = ToolResultChannel()
+        svc = _mock_svc(task=_task_with_channel(channel))
+
+        result = await submit_tool_result(_tool_result_input(), svc)
+
+        assert result.success is True
+        assert result.data.status == "received"
+        # The published result is observable by a waiter.
+        assert await channel.wait_for("call_1") == {"success": 1, "error": None, "result": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_late_report_returns_ignored(self):
+        channel = ToolResultChannel()
+        # Future already settled — simulates a report arriving after the waiter
+        # timed out / a duplicate.
+        await channel.publish("call_1", {"success": 1})
+        svc = _mock_svc(task=_task_with_channel(channel))
+
+        result = await submit_tool_result(_tool_result_input(), svc)
+
+        assert result.success is True
+        assert result.data.status == "ignored"
+
+    @pytest.mark.asyncio
+    async def test_unknown_task_returns_not_found(self):
+        svc = _mock_svc(task=None)
+
+        result = await submit_tool_result(_tool_result_input(), svc)
+
+        assert result.success is False
+        assert result.errorCode == "TASK_NOT_FOUND"

--- a/tests/unit_tests/tools/proxy/test_proxy_tool.py
+++ b/tests/unit_tests/tools/proxy/test_proxy_tool.py
@@ -126,6 +126,27 @@ class TestCreateProxyTool:
         assert result == {"success": 1, "result": "proxied"}
 
     @pytest.mark.asyncio
+    async def test_proxy_tool_returns_error_on_timeout(self, monkeypatch):
+        """A client that never reports must time out into a failure result."""
+        monkeypatch.setattr("datus.tools.proxy.proxy_tool.DEFAULT_RESULT_TIMEOUT", 0.01)
+        channel = ToolResultChannel()
+        original = FunctionTool(
+            name="write_file",
+            description="A test tool",
+            params_json_schema={"type": "object", "properties": {}},
+            on_invoke_tool=lambda ctx, args: {"success": 1},
+        )
+        proxy = create_proxy_tool(original, channel)
+
+        ctx = SimpleNamespace(tool_call_id="call_timeout")
+        # No publisher — the wait must elapse and surface a failure, not hang.
+        result = await proxy.on_invoke_tool(ctx, "{}")
+
+        assert result["success"] == 0
+        assert "Timed out" in result["error"]
+        assert result["result"] is None
+
+    @pytest.mark.asyncio
     async def test_proxy_tool_returns_error_on_channel_cancel(self):
         """Verify that RuntimeError from channel.cancel_all is caught and returns error dict."""
         channel = ToolResultChannel()

--- a/tests/unit_tests/tools/proxy/test_tool_result_channel.py
+++ b/tests/unit_tests/tools/proxy/test_tool_result_channel.py
@@ -8,8 +8,7 @@ import asyncio
 
 import pytest
 
-from datus.tools.proxy.tool_result_channel import ToolResultChannel, _load_default_timeout
-from datus.utils.exceptions import DatusException
+from datus.tools.proxy.tool_result_channel import ToolResultChannel
 
 
 @pytest.mark.ci
@@ -164,20 +163,3 @@ class TestToolResultChannel:
         await task
 
         assert result == "done"
-
-
-@pytest.mark.ci
-class TestLoadDefaultTimeout:
-    def test_valid_override(self, monkeypatch):
-        monkeypatch.setenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", "120")
-        assert _load_default_timeout() == 120.0
-
-    def test_default_when_unset(self, monkeypatch):
-        monkeypatch.delenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", raising=False)
-        assert _load_default_timeout() == 600.0
-
-    @pytest.mark.parametrize("bad", ["abc", "0", "-5", ""])
-    def test_rejects_malformed_or_non_positive(self, monkeypatch, bad):
-        monkeypatch.setenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", bad)
-        with pytest.raises(DatusException):
-            _load_default_timeout()

--- a/tests/unit_tests/tools/proxy/test_tool_result_channel.py
+++ b/tests/unit_tests/tools/proxy/test_tool_result_channel.py
@@ -8,7 +8,8 @@ import asyncio
 
 import pytest
 
-from datus.tools.proxy.tool_result_channel import ToolResultChannel
+from datus.tools.proxy.tool_result_channel import ToolResultChannel, _load_default_timeout
+from datus.utils.exceptions import DatusException
 
 
 @pytest.mark.ci
@@ -148,3 +149,35 @@ class TestToolResultChannel:
 
         # Late report lands with no waiter; publish reports it as undelivered.
         assert await channel.publish("call_late", "too_late") is False
+
+    @pytest.mark.asyncio
+    async def test_wait_for_explicit_none_is_unbounded(self):
+        """timeout=None opts back into an unbounded wait."""
+        channel = ToolResultChannel()
+
+        async def publisher():
+            await asyncio.sleep(0.01)
+            await channel.publish("call_inf", "done")
+
+        task = asyncio.create_task(publisher())
+        result = await channel.wait_for("call_inf", timeout=None)
+        await task
+
+        assert result == "done"
+
+
+@pytest.mark.ci
+class TestLoadDefaultTimeout:
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", "120")
+        assert _load_default_timeout() == 120.0
+
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", raising=False)
+        assert _load_default_timeout() == 600.0
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-5", ""])
+    def test_rejects_malformed_or_non_positive(self, monkeypatch, bad):
+        monkeypatch.setenv("DATUS_PROXY_TOOL_RESULT_TIMEOUT", bad)
+        with pytest.raises(DatusException):
+            _load_default_timeout()

--- a/tests/unit_tests/tools/proxy/test_tool_result_channel.py
+++ b/tests/unit_tests/tools/proxy/test_tool_result_channel.py
@@ -109,3 +109,41 @@ class TestToolResultChannel:
 
         result = await channel.wait_for("call_done")
         assert result == "first"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_timeout_raises_and_drops_future(self):
+        """A never-published call must time out instead of hanging forever."""
+        channel = ToolResultChannel()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await channel.wait_for("call_timeout", timeout=0.02)
+
+        # The abandoned future is dropped so it cannot leak or mislead a late publish.
+        assert "call_timeout" not in channel._futures
+
+    @pytest.mark.asyncio
+    async def test_wait_for_with_timeout_returns_result(self):
+        """timeout is an upper bound, not a delay — a prompt publish still resolves."""
+        channel = ToolResultChannel()
+
+        async def publisher():
+            await asyncio.sleep(0.01)
+            await channel.publish("call_fast", "ok")
+
+        task = asyncio.create_task(publisher())
+        result = await channel.wait_for("call_fast", timeout=5)
+        await task
+
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_publish_after_timeout_is_ignored(self):
+        """A result reported after the waiter timed out must not crash or stick."""
+        channel = ToolResultChannel()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await channel.wait_for("call_late", timeout=0.02)
+
+        # Late report lands with no waiter; it is accepted but never observed.
+        await channel.publish("call_late", "too_late")
+        assert channel._futures["call_late"].done()

--- a/tests/unit_tests/tools/proxy/test_tool_result_channel.py
+++ b/tests/unit_tests/tools/proxy/test_tool_result_channel.py
@@ -104,22 +104,24 @@ class TestToolResultChannel:
     async def test_publish_to_done_future_is_noop(self):
         channel = ToolResultChannel()
 
-        await channel.publish("call_done", "first")
-        await channel.publish("call_done", "second")  # should be ignored (future already done)
+        assert await channel.publish("call_done", "first") is True
+        # Second publish is ignored (future already done) and reported as undelivered.
+        assert await channel.publish("call_done", "second") is False
 
         result = await channel.wait_for("call_done")
         assert result == "first"
 
     @pytest.mark.asyncio
-    async def test_wait_for_timeout_raises_and_drops_future(self):
+    async def test_wait_for_timeout_raises_and_settles_future(self):
         """A never-published call must time out instead of hanging forever."""
         channel = ToolResultChannel()
 
         with pytest.raises(asyncio.TimeoutError):
             await channel.wait_for("call_timeout", timeout=0.02)
 
-        # The abandoned future is dropped so it cannot leak or mislead a late publish.
-        assert "call_timeout" not in channel._futures
+        # The future is retained but settled (cancelled) so a late publish for
+        # the same call_id is recognised as late rather than re-created.
+        assert channel._futures["call_timeout"].done()
 
     @pytest.mark.asyncio
     async def test_wait_for_with_timeout_returns_result(self):
@@ -144,6 +146,5 @@ class TestToolResultChannel:
         with pytest.raises(asyncio.TimeoutError):
             await channel.wait_for("call_late", timeout=0.02)
 
-        # Late report lands with no waiter; it is accepted but never observed.
-        await channel.publish("call_late", "too_late")
-        assert channel._futures["call_late"].done()
+        # Late report lands with no waiter; publish reports it as undelivered.
+        assert await channel.publish("call_late", "too_late") is False


### PR DESCRIPTION
## Problem

A proxied tool (`write_file`/`edit_file` executed in the browser) blocks the
agent loop on `ToolResultChannel.wait_for` until the client POSTs its result via
`/api/v1/chat/tool_result`. That wait had **no bound**: when the client never
reports — tab closed, crash, or a frontend bug that swallows the report — the SSE
chat turn hangs indefinitely.

Observed in prod (2026-06-26): a `chat/stream` turn stayed open ~26–29 minutes
with **zero** `tool_result` POSTs reaching any backend pod, then ended only when
the IDE WebSocket disconnected — still holding resources and having consumed tokens.

## Fix

- `ToolResultChannel.wait_for(call_id, timeout=…)`: bounds the wait; on expiry
  `asyncio.wait_for` settles the future and `TimeoutError` propagates.
  `proxy_invoke` catches it and returns a failure result so the agent loop
  continues. Default **600s**, override via `DATUS_PROXY_TOOL_RESULT_TIMEOUT`.
- `publish` returns whether a live waiter received the result and ignores (logs)
  a late/duplicate report — so the frontend can safely retry reports.

## Diagnostics (pair with Datus-saas telemetry)

- `proxy_invoke` logs `waited_ms` on both received and timeout → client-confirm
  latency distribution and near-timeout cases.
- `/chat/tool_result` logs **matched** (`Received tool_result`) vs **late**
  (`arrived late`) vs **unknown task**, and returns `status=received|ignored`.
- Wait / publish / cancel path all log with `call_id`.

Correlate `call_id` across the frontend tool-call breadcrumbs and these logs to
reconstruct the full client→server timeline and pin the failing layer.

This is the **server-side backstop**; the Datus-saas PR addresses the common case
by always reporting. The two are complementary.

## Tests

`tests/unit_tests/tools/proxy/test_tool_result_channel.py`: timeout-raises-and-
settles, timeout-as-upper-bound, publish-after-timeout, delivered/undelivered
return. Full suite `test_tool_result_channel.py`(10) + `test_proxy_tool.py`(38)
green; ruff clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **New Features**
  * Added timeout handling for pending tool results, so stalled requests now fail gracefully instead of waiting indefinitely.
  * Improved tool result delivery tracking, distinguishing between delivered, late, and duplicate results.
* **Bug Fixes**
  * Tool result submissions now return a clearer status when a result is ignored.
  * Missing or unknown task submissions now log more context before returning the existing not-found error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout support for awaiting pending proxy tool results, using a default limit (now fails gracefully instead of waiting indefinitely).
* **Bug Fixes**
  * Improved tool result delivery tracking: late/duplicate submissions are now reported as `"ignored"` instead of always `"received"`.
  * Added clearer diagnostics when tool results can’t be matched to an active task.
* **Tests**
  * Expanded unit tests to cover timeout behavior, ignored late publishes, and unbounded waiting when `timeout=None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->