### PR TITLE
[UT] Add MetricFlow nightly integration tests for DuckDB, MySQL, PostgreSQL

### DIFF
--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -809,6 +809,9 @@ export ADAPTERS_TRINO="${ADAPTERS_TRINO:-1}"
 export ADAPTERS_GP="${ADAPTERS_GP:-1}"
 export ADAPTERS_HIVE="${ADAPTERS_HIVE:-1}"
 export ADAPTERS_SPARK="${ADAPTERS_SPARK:-1}"
+export ADAPTERS_METRICFLOW_DUCKDB="${ADAPTERS_METRICFLOW_DUCKDB:-1}"
+export ADAPTERS_METRICFLOW_MYSQL="${ADAPTERS_METRICFLOW_MYSQL:-1}"
+export ADAPTERS_METRICFLOW_PG="${ADAPTERS_METRICFLOW_PG:-1}"
 export SUPERSET_PORT="${SUPERSET_PORT:-18088}"
 export SUPERSET_POSTGRES_HOST="${SUPERSET_POSTGRES_HOST:-127.0.0.1}"
 export SUPERSET_POSTGRES_PORT="${SUPERSET_POSTGRES_PORT:-15433}"
@@ -1587,6 +1590,9 @@ NIGHTLY_DEDICATED_SUITE_DESELECTS=(
   --deselect tests/integration/adapters/test_greenplum.py
   --deselect tests/integration/adapters/test_hive.py
   --deselect tests/integration/adapters/test_spark.py
+  --deselect tests/integration/adapters/test_semantic_metricflow_duckdb.py
+  --deselect tests/integration/adapters/test_semantic_metricflow_mysql.py
+  --deselect tests/integration/adapters/test_semantic_metricflow_postgresql.py
   --deselect tests/regression/test_regression_web_e2e.py
 )
 
@@ -1600,14 +1606,15 @@ run_compose_suite "Grafana Nightly Tests" "$GRAFANA_COMPOSE" "postgres:300" "gra
 
 run_compose_suite "Airflow Nightly Tests" "$AIRFLOW_COMPOSE" "airflow:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_scheduler_agentic.py --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
 
-run_compose_suite "PostgreSQL Adapter Tests" "$POSTGRES_COMPOSE" "postgres:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_postgresql.py --tb=short --verbose --timeout=300 --timeout-method=thread
-run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_mysql.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_compose_suite "PostgreSQL Adapter Tests" "$POSTGRES_COMPOSE" "postgres:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_postgresql.py tests/integration/adapters/test_semantic_metricflow_postgresql.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_mysql.py tests/integration/adapters/test_semantic_metricflow_mysql.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "ClickHouse Adapter Tests" "$CLICKHOUSE_COMPOSE" "clickhouse:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_clickhouse.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "StarRocks Adapter Tests" "$STARROCKS_COMPOSE" "starrocks:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_starrocks.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_trino.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Spark Adapter Tests" "$SPARK_COMPOSE" "spark-thrift:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_logged "MetricFlow DuckDB Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_semantic_metricflow_duckdb.py --tb=short --verbose --timeout=300 --timeout-method=thread
 
 run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and provider_health" "${NIGHTLY_PYTEST_ROOTS[@]}" --tb=short --verbose --timeout=300 --timeout-method=thread --reruns 1 --reruns-delay 5
 

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -80,3 +80,51 @@ that the agent actually calls:
 4. Pick a new opt-in flag (`ADAPTERS_<NAME>=1`) and document env vars here.
 5. Confirm the adapter's `docker-compose.yml` ports don't collide with others
    you run simultaneously.
+
+---
+
+## MetricFlow Semantic Adapter Tests
+
+These suites exercise `MetricFlowAdapter` against real databases:
+`validate_semantic`, `list_metrics`, `get_dimensions`, `query_metrics(dry_run=True)`.
+
+Each suite seeds a minimal `mf_orders` fact table plus `mf_time_spine` (required
+by MetricFlow) and cleans up on teardown.
+
+### DuckDB (no Docker)
+
+```bash
+ADAPTERS_METRICFLOW_DUCKDB=1 uv run pytest tests/integration/adapters/test_semantic_metricflow_duckdb.py -v
+```
+
+No container needed. The database file is created in a pytest tmp directory.
+
+### MySQL (shares container with MySQL Adapter Tests)
+
+```bash
+cd /path/to/datus-db-adapters/datus-mysql && docker compose up -d
+cd /path/to/Datus-agent
+ADAPTERS_METRICFLOW_MYSQL=1 uv run pytest tests/integration/adapters/test_semantic_metricflow_mysql.py -v
+```
+
+MetricFlow tables (`mf_orders`, `mf_time_spine`) are created inside the existing
+`test` database used by the MySQL Adapter Tests and dropped on teardown.
+
+### PostgreSQL (shares container with PostgreSQL Adapter Tests)
+
+```bash
+cd /path/to/datus-db-adapters/datus-postgresql && docker compose up -d
+cd /path/to/Datus-agent
+ADAPTERS_METRICFLOW_PG=1 uv run pytest tests/integration/adapters/test_semantic_metricflow_postgresql.py -v
+```
+
+MetricFlow tables are created in the `mf_nightly` schema within the existing
+`test` database and dropped on teardown.
+
+### MetricFlow env vars
+
+| Suite | Opt-in flag | Connection env | Notes |
+|---|---|---|---|
+| DuckDB | `ADAPTERS_METRICFLOW_DUCKDB=1` | none | DB file auto-generated in tmp dir |
+| MySQL | `ADAPTERS_METRICFLOW_MYSQL=1` | same as `ADAPTERS_MYSQL` vars | tables in `test` DB |
+| PostgreSQL | `ADAPTERS_METRICFLOW_PG=1` | same as `ADAPTERS_PG` vars | tables in `mf_nightly` schema |

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -86,7 +86,9 @@ that the agent actually calls:
 ## MetricFlow Semantic Adapter Tests
 
 These suites exercise `MetricFlowAdapter` against real databases:
-`validate_semantic`, `list_metrics`, `get_dimensions`, `query_metrics(dry_run=True)`.
+`validate_semantic`, `list_metrics`, `get_dimensions`, `query_metrics(dry_run=True)`,
+and live `query_metrics(...)` behavior including time filters, multi-metric queries,
+and `where`-clause SQL generation.
 
 Each suite seeds a minimal `mf_orders` fact table plus `mf_time_spine` (required
 by MetricFlow) and cleans up on teardown.

--- a/tests/integration/adapters/test_semantic_metricflow_duckdb.py
+++ b/tests/integration/adapters/test_semantic_metricflow_duckdb.py
@@ -200,3 +200,6 @@ async def test_query_metrics_where_clause_dry_run(mf_adapter):
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"
     assert "WHERE" in sql.upper(), f"Expected WHERE in generated SQL; got:\n{sql}"
+    # Assert the caller-supplied predicate survives: a framework-generated WHERE
+    # could otherwise pass this test even if the where= argument were dropped.
+    assert "2020-01-04" in sql, f"Expected dry_run SQL to preserve the caller filter; got:\n{sql}"

--- a/tests/integration/adapters/test_semantic_metricflow_duckdb.py
+++ b/tests/integration/adapters/test_semantic_metricflow_duckdb.py
@@ -10,7 +10,8 @@ The DuckDB instance lives in a pytest tmp directory; no Docker required.
 Env overrides: none (DuckDB is file-based, path is auto-generated)
 """
 
-import asyncio
+import logging
+import pathlib
 
 import pytest
 
@@ -26,7 +27,9 @@ datus_semantic_metricflow = import_required(  # noqa: E402
 MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
 MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
 
-pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.integration, pytest.mark.nightly, pytest.mark.asyncio]
 
 _SCHEMA = "mf_nightly"
 _DATA_TABLE = "mf_orders"
@@ -117,23 +120,22 @@ def seeded_db(mf_config):
 
     yield
 
-    import os as _os
-
+    # Remove the DuckDB file and its write-ahead log; unlink(missing_ok=True)
+    # avoids swallowing unexpected errors the way a bare try/except would.
     for suffix in ("", ".wal"):
-        try:
-            _os.remove(db_path + suffix)
-        except FileNotFoundError:
-            pass
+        pathlib.Path(db_path + suffix).unlink(missing_ok=True)
 
 
 @pytest.fixture(scope="module")
 def mf_adapter(mf_config, seeded_db):
     adapter = MetricFlowAdapter(mf_config)
     yield adapter
+    # Best-effort connection teardown: log (instead of silently passing) so a
+    # close failure stays visible without breaking the suite.
     try:
         adapter.client.sql_client.close()
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+        logger.warning("Failed to close MetricFlow SQL client during teardown: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -141,63 +143,59 @@ def mf_adapter(mf_config, seeded_db):
 # ---------------------------------------------------------------------------
 
 
-def test_validate_semantic_passes(mf_adapter):
-    result = asyncio.run(mf_adapter.validate_semantic())
+async def test_validate_semantic_passes(mf_adapter):
+    result = await mf_adapter.validate_semantic()
     errors = [i for i in result.issues if i.severity == "error"]
     assert result.valid, f"Unexpected validation errors: {errors}"
 
 
-def test_list_metrics_returns_metric(mf_adapter):
-    metrics = asyncio.run(mf_adapter.list_metrics())
+async def test_list_metrics_returns_metric(mf_adapter):
+    metrics = await mf_adapter.list_metrics()
     names = {m.name for m in metrics}
     assert len(metrics) >= 1, "Expected at least one metric"
     assert "total_amount" in names, f"'total_amount' not in {sorted(names)}"
 
 
-def test_get_dimensions_returns_dimension(mf_adapter):
-    dims = asyncio.run(mf_adapter.get_dimensions("total_amount"))
+async def test_get_dimensions_returns_dimension(mf_adapter):
+    dims = await mf_adapter.get_dimensions("total_amount")
     assert len(dims) >= 1, f"Expected at least one dimension, got {dims}"
 
 
-def test_query_metrics_dry_run_returns_sql(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount"], dry_run=True))
+async def test_query_metrics_dry_run_returns_sql(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount"], dry_run=True)
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL from dry_run; metadata={result.metadata}"
 
 
-def test_query_metrics_live(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount"]))
+async def test_query_metrics_live(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount"])
     assert len(result.data) >= 1, f"Expected data rows; got: {result}"
     assert "total_amount" in result.columns, f"Expected 'total_amount' in columns; got: {result.columns}"
 
 
-def test_query_metrics_with_time_filter(mf_adapter):
-    result = asyncio.run(
-        mf_adapter.query_metrics(
-            ["total_amount"],
-            time_start="2020-01-01",
-            time_end="2020-01-03",
-        )
+async def test_query_metrics_with_time_filter(mf_adapter):
+    result = await mf_adapter.query_metrics(
+        ["total_amount"],
+        time_start="2020-01-01",
+        time_end="2020-01-03",
     )
     assert len(result.data) >= 1, f"Expected data with time filter; got: {result}"
     total = sum(float(row["total_amount"]) for row in result.data if row.get("total_amount") is not None)
     assert total == pytest.approx(60.0), f"Expected SUM=60 for 2020-01-01..03, got {total}"
 
 
-def test_query_metrics_multi_metric(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount", "order_count"]))
+async def test_query_metrics_multi_metric(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount", "order_count"])
     assert len(result.data) >= 1, f"Expected data rows; got: {result}"
     assert "total_amount" in result.columns, f"'total_amount' missing from {result.columns}"
     assert "order_count" in result.columns, f"'order_count' missing from {result.columns}"
 
 
-def test_query_metrics_where_clause_dry_run(mf_adapter):
-    result = asyncio.run(
-        mf_adapter.query_metrics(
-            ["total_amount"],
-            where="metric_time >= '2020-01-04'",
-            dry_run=True,
-        )
+async def test_query_metrics_where_clause_dry_run(mf_adapter):
+    result = await mf_adapter.query_metrics(
+        ["total_amount"],
+        where="metric_time >= '2020-01-04'",
+        dry_run=True,
     )
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"

--- a/tests/integration/adapters/test_semantic_metricflow_duckdb.py
+++ b/tests/integration/adapters/test_semantic_metricflow_duckdb.py
@@ -1,0 +1,204 @@
+"""
+MetricFlow semantic adapter nightly tests -- DuckDB backend.
+
+Opt-in:
+  * datus-semantic-metricflow must be installed
+  * set env var: ADAPTERS_METRICFLOW_DUCKDB=1
+
+The DuckDB instance lives in a pytest tmp directory; no Docker required.
+
+Env overrides: none (DuckDB is file-based, path is auto-generated)
+"""
+
+import asyncio
+
+import pytest
+
+from tests.nightly_requirements import import_required, require_opt_in_env
+
+require_opt_in_env("ADAPTERS_METRICFLOW_DUCKDB", "tests/integration/adapters/README.md")
+
+datus_semantic_metricflow = import_required(  # noqa: E402
+    "datus_semantic_metricflow",
+    reason="datus-semantic-metricflow not installed; install it before running this suite",
+)
+
+MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
+MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
+
+pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+
+_SCHEMA = "mf_nightly"
+_DATA_TABLE = "mf_orders"
+_TIME_SPINE_TABLE = "mf_time_spine"
+
+_SEMANTIC_YAML = """\
+data_source:
+  name: mf_orders
+  sql_table: mf_nightly.mf_orders
+  identifiers:
+    - name: order_id
+      type: primary
+      expr: id
+  measures:
+    - name: total_amount
+      agg: sum
+      expr: amount
+    - name: order_count
+      agg: count
+      expr: id
+  dimensions:
+    - name: created_at
+      type: time
+      type_params:
+        is_primary: true
+        time_granularity: day
+---
+metric:
+  name: total_amount
+  type: measure_proxy
+  type_params:
+    measure: total_amount
+---
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+"""
+
+_SAMPLE_ROWS = [
+    (1, 10.00, "2020-01-01"),
+    (2, 20.00, "2020-01-02"),
+    (3, 30.00, "2020-01-03"),
+    (4, 40.00, "2020-01-04"),
+    (5, 50.00, "2020-01-05"),
+]
+
+
+@pytest.fixture(scope="module")
+def mf_config(tmp_path_factory):
+    base = tmp_path_factory.mktemp("mf_duckdb")
+    yaml_dir = base / "models"
+    yaml_dir.mkdir()
+    (yaml_dir / "mf_orders.yaml").write_text(_SEMANTIC_YAML)
+    db_path = base / "test.duckdb"
+    return MetricFlowConfig(
+        datasource="mf_nightly",
+        db_config={
+            "type": "duckdb",
+            "database": str(db_path),
+            "schema": _SCHEMA,
+        },
+        semantic_models_path=str(yaml_dir),
+    )
+
+
+@pytest.fixture(scope="module")
+def seeded_db(mf_config):
+    import duckdb as _duckdb
+
+    db_path = mf_config.db_config["database"]
+    conn = _duckdb.connect(db_path)
+    try:
+        conn.execute(f"CREATE SCHEMA IF NOT EXISTS {_SCHEMA}")
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {_SCHEMA}.{_DATA_TABLE} (id INTEGER, amount DECIMAL(10,2), created_at DATE)"
+        )
+        values = ", ".join(f"({r[0]}, {r[1]}, '{r[2]}')" for r in _SAMPLE_ROWS)
+        conn.execute(f"INSERT INTO {_SCHEMA}.{_DATA_TABLE} VALUES {values}")
+        conn.execute(f"CREATE TABLE IF NOT EXISTS {_SCHEMA}.{_TIME_SPINE_TABLE} (ds DATE NOT NULL)")
+        conn.execute(
+            f"INSERT INTO {_SCHEMA}.{_TIME_SPINE_TABLE} "
+            "SELECT range::DATE FROM range(DATE '2020-01-01', DATE '2026-01-01', INTERVAL '1 day')"
+        )
+    finally:
+        conn.close()
+
+    yield
+
+    import os as _os
+
+    for suffix in ("", ".wal"):
+        try:
+            _os.remove(db_path + suffix)
+        except FileNotFoundError:
+            pass
+
+
+@pytest.fixture(scope="module")
+def mf_adapter(mf_config, seeded_db):
+    adapter = MetricFlowAdapter(mf_config)
+    yield adapter
+    try:
+        adapter.client.sql_client.close()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_semantic_passes(mf_adapter):
+    result = asyncio.run(mf_adapter.validate_semantic())
+    errors = [i for i in result.issues if i.severity == "error"]
+    assert result.valid, f"Unexpected validation errors: {errors}"
+
+
+def test_list_metrics_returns_metric(mf_adapter):
+    metrics = asyncio.run(mf_adapter.list_metrics())
+    names = {m.name for m in metrics}
+    assert len(metrics) >= 1, "Expected at least one metric"
+    assert "total_amount" in names, f"'total_amount' not in {sorted(names)}"
+
+
+def test_get_dimensions_returns_dimension(mf_adapter):
+    dims = asyncio.run(mf_adapter.get_dimensions("total_amount"))
+    assert len(dims) >= 1, f"Expected at least one dimension, got {dims}"
+
+
+def test_query_metrics_dry_run_returns_sql(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount"], dry_run=True))
+    sql = result.metadata.get("sql", "")
+    assert sql, f"Expected non-empty SQL from dry_run; metadata={result.metadata}"
+
+
+def test_query_metrics_live(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount"]))
+    assert len(result.data) >= 1, f"Expected data rows; got: {result}"
+    assert "total_amount" in result.columns, f"Expected 'total_amount' in columns; got: {result.columns}"
+
+
+def test_query_metrics_with_time_filter(mf_adapter):
+    result = asyncio.run(
+        mf_adapter.query_metrics(
+            ["total_amount"],
+            time_start="2020-01-01",
+            time_end="2020-01-03",
+        )
+    )
+    assert len(result.data) >= 1, f"Expected data with time filter; got: {result}"
+    total = sum(float(row["total_amount"]) for row in result.data if row.get("total_amount") is not None)
+    assert total == pytest.approx(60.0), f"Expected SUM=60 for 2020-01-01..03, got {total}"
+
+
+def test_query_metrics_multi_metric(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount", "order_count"]))
+    assert len(result.data) >= 1, f"Expected data rows; got: {result}"
+    assert "total_amount" in result.columns, f"'total_amount' missing from {result.columns}"
+    assert "order_count" in result.columns, f"'order_count' missing from {result.columns}"
+
+
+def test_query_metrics_where_clause_dry_run(mf_adapter):
+    result = asyncio.run(
+        mf_adapter.query_metrics(
+            ["total_amount"],
+            where="metric_time >= '2020-01-04'",
+            dry_run=True,
+        )
+    )
+    sql = result.metadata.get("sql", "")
+    assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"
+    assert "WHERE" in sql.upper(), f"Expected WHERE in generated SQL; got:\n{sql}"

--- a/tests/integration/adapters/test_semantic_metricflow_mysql.py
+++ b/tests/integration/adapters/test_semantic_metricflow_mysql.py
@@ -15,6 +15,7 @@ are created inside the existing `test` database alongside the adapter test
 tables and dropped on teardown.
 """
 
+import logging
 import os
 from datetime import date, timedelta
 
@@ -31,6 +32,8 @@ datus_semantic_metricflow = import_required(  # noqa: E402
 
 MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
 MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.integration, pytest.mark.nightly, pytest.mark.asyncio]
 
@@ -120,40 +123,45 @@ def seeded_db(mf_config):
         charset="utf8mb4",
         autocommit=True,
     )
-    cursor = conn.cursor()
+    # Outer try/finally guarantees the connection is closed even if seeding
+    # raises before `yield`; each cursor is scoped with a context manager.
     try:
-        cursor.execute(f"DROP TABLE IF EXISTS `{_DATA_TABLE}`")
-        cursor.execute(f"DROP TABLE IF EXISTS `{_TIME_SPINE_TABLE}`")
-        cursor.execute(
-            f"CREATE TABLE `{_DATA_TABLE}` (id INT NOT NULL, amount DECIMAL(10,2), created_at DATE, PRIMARY KEY (id))"
-        )
-        values = ", ".join(f"({r[0]}, {r[1]}, '{r[2]}')" for r in _SAMPLE_ROWS)
-        cursor.execute(f"INSERT INTO `{_DATA_TABLE}` VALUES {values}")
+        with conn.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS `{_DATA_TABLE}`")
+            cursor.execute(f"DROP TABLE IF EXISTS `{_TIME_SPINE_TABLE}`")
+            cursor.execute(
+                f"CREATE TABLE `{_DATA_TABLE}` (id INT NOT NULL, amount DECIMAL(10,2), created_at DATE, PRIMARY KEY (id))"
+            )
+            values = ", ".join(f"({r[0]}, {r[1]}, '{r[2]}')" for r in _SAMPLE_ROWS)
+            cursor.execute(f"INSERT INTO `{_DATA_TABLE}` VALUES {values}")
 
-        cursor.execute(f"CREATE TABLE `{_TIME_SPINE_TABLE}` (ds DATE NOT NULL)")
-        spine_values = []
-        d = date(2020, 1, 1)
-        while d <= date(2025, 12, 31):
-            spine_values.append(f"('{d}')")
-            d += timedelta(days=1)
-        cursor.execute(f"INSERT INTO `{_TIME_SPINE_TABLE}` VALUES {','.join(spine_values)}")
+            cursor.execute(f"CREATE TABLE `{_TIME_SPINE_TABLE}` (ds DATE NOT NULL)")
+            spine_values = []
+            d = date(2020, 1, 1)
+            while d <= date(2025, 12, 31):
+                spine_values.append(f"('{d}')")
+                d += timedelta(days=1)
+            cursor.execute(f"INSERT INTO `{_TIME_SPINE_TABLE}` VALUES {','.join(spine_values)}")
+
+        yield
+
+        with conn.cursor() as cleanup:
+            cleanup.execute(f"DROP TABLE IF EXISTS `{_DATA_TABLE}`")
+            cleanup.execute(f"DROP TABLE IF EXISTS `{_TIME_SPINE_TABLE}`")
     finally:
-        cursor.close()
-
-    yield
-
-    cleanup = conn.cursor()
-    try:
-        cleanup.execute(f"DROP TABLE IF EXISTS `{_DATA_TABLE}`")
-        cleanup.execute(f"DROP TABLE IF EXISTS `{_TIME_SPINE_TABLE}`")
-    finally:
-        cleanup.close()
         conn.close()
 
 
 @pytest.fixture(scope="module")
 def mf_adapter(mf_config, seeded_db):
-    return MetricFlowAdapter(mf_config)
+    adapter = MetricFlowAdapter(mf_config)
+    yield adapter
+    # Best-effort connection teardown so the adapter's SQL client does not stay
+    # open for the rest of the pytest process; log instead of silently passing.
+    try:
+        adapter.client.sql_client.close()
+    except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+        logger.warning("Failed to close MetricFlow SQL client during teardown: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -218,3 +226,6 @@ async def test_query_metrics_where_clause_dry_run(mf_adapter):
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"
     assert "WHERE" in sql.upper(), f"Expected WHERE in generated SQL; got:\n{sql}"
+    # Assert the caller-supplied predicate survives: a framework-generated WHERE
+    # could otherwise pass this test even if the where= argument were dropped.
+    assert "2020-01-04" in sql, f"Expected dry_run SQL to preserve the caller filter; got:\n{sql}"

--- a/tests/integration/adapters/test_semantic_metricflow_mysql.py
+++ b/tests/integration/adapters/test_semantic_metricflow_mysql.py
@@ -1,0 +1,225 @@
+"""
+MetricFlow semantic adapter nightly tests -- MySQL backend.
+
+Opt-in (all required):
+  * datus-semantic-metricflow must be installed
+  * MySQL container must be running (shared with MySQL Adapter Tests suite)
+  * set env var: ADAPTERS_METRICFLOW_MYSQL=1
+
+Env overrides (defaults match datus-mysql/docker-compose.yml):
+  MYSQL_HOST=localhost  MYSQL_PORT=3306
+  MYSQL_USER=test_user  MYSQL_PASSWORD=test_password  MYSQL_DATABASE=test
+
+In MySQL, schema == database. MetricFlow tables (mf_orders, mf_time_spine)
+are created inside the existing `test` database alongside the adapter test
+tables and dropped on teardown.
+"""
+
+import asyncio
+import os
+from datetime import date, timedelta
+
+import pytest
+
+from tests.nightly_requirements import import_required, require_opt_in_env
+
+require_opt_in_env("ADAPTERS_METRICFLOW_MYSQL", "tests/integration/adapters/README.md")
+
+datus_semantic_metricflow = import_required(  # noqa: E402
+    "datus_semantic_metricflow",
+    reason="datus-semantic-metricflow not installed; install it before running this suite",
+)
+
+MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
+MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
+
+pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+
+_HOST = os.getenv("MYSQL_HOST", "localhost")
+_PORT = int(os.getenv("MYSQL_PORT", "3306"))
+_USER = os.getenv("MYSQL_USER", "test_user")
+_PASSWORD = os.getenv("MYSQL_PASSWORD", "test_password")
+_DATABASE = os.getenv("MYSQL_DATABASE", "test")
+
+_DATA_TABLE = "mf_orders"
+_TIME_SPINE_TABLE = "mf_time_spine"
+
+# sql_table uses the full database-qualified name (MySQL has no separate schema concept).
+_SEMANTIC_YAML = f"""\
+data_source:
+  name: mf_orders
+  sql_table: {_DATABASE}.{_DATA_TABLE}
+  identifiers:
+    - name: order_id
+      type: primary
+      expr: id
+  measures:
+    - name: total_amount
+      agg: sum
+      expr: amount
+    - name: order_count
+      agg: count
+      expr: id
+  dimensions:
+    - name: created_at
+      type: time
+      type_params:
+        is_primary: true
+        time_granularity: day
+---
+metric:
+  name: total_amount
+  type: measure_proxy
+  type_params:
+    measure: total_amount
+---
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+"""
+
+_SAMPLE_ROWS = [
+    (1, 10.00, "2020-01-01"),
+    (2, 20.00, "2020-01-02"),
+    (3, 30.00, "2020-01-03"),
+    (4, 40.00, "2020-01-04"),
+    (5, 50.00, "2020-01-05"),
+]
+
+
+@pytest.fixture(scope="module")
+def mf_config(tmp_path_factory):
+    yaml_dir = tmp_path_factory.mktemp("mf_mysql_models")
+    (yaml_dir / "mf_orders.yaml").write_text(_SEMANTIC_YAML)
+    return MetricFlowConfig(
+        datasource="mf_nightly",
+        db_config={
+            "type": "mysql",
+            "host": _HOST,
+            "port": str(_PORT),
+            "username": _USER,
+            "password": _PASSWORD,
+            "database": _DATABASE,
+            "schema": _DATABASE,
+        },
+        semantic_models_path=str(yaml_dir),
+    )
+
+
+@pytest.fixture(scope="module")
+def seeded_db(mf_config):
+    import pymysql
+
+    conn = pymysql.connect(
+        host=_HOST,
+        port=_PORT,
+        user=_USER,
+        password=_PASSWORD,
+        database=_DATABASE,
+        charset="utf8mb4",
+        autocommit=True,
+    )
+    cursor = conn.cursor()
+    try:
+        cursor.execute(f"DROP TABLE IF EXISTS `{_DATA_TABLE}`")
+        cursor.execute(f"DROP TABLE IF EXISTS `{_TIME_SPINE_TABLE}`")
+        cursor.execute(
+            f"CREATE TABLE `{_DATA_TABLE}` (id INT NOT NULL, amount DECIMAL(10,2), created_at DATE, PRIMARY KEY (id))"
+        )
+        values = ", ".join(f"({r[0]}, {r[1]}, '{r[2]}')" for r in _SAMPLE_ROWS)
+        cursor.execute(f"INSERT INTO `{_DATA_TABLE}` VALUES {values}")
+
+        cursor.execute(f"CREATE TABLE `{_TIME_SPINE_TABLE}` (ds DATE NOT NULL)")
+        spine_values = []
+        d = date(2020, 1, 1)
+        while d <= date(2025, 12, 31):
+            spine_values.append(f"('{d}')")
+            d += timedelta(days=1)
+        cursor.execute(f"INSERT INTO `{_TIME_SPINE_TABLE}` VALUES {','.join(spine_values)}")
+    finally:
+        cursor.close()
+
+    yield
+
+    cleanup = conn.cursor()
+    try:
+        cleanup.execute(f"DROP TABLE IF EXISTS `{_DATA_TABLE}`")
+        cleanup.execute(f"DROP TABLE IF EXISTS `{_TIME_SPINE_TABLE}`")
+    finally:
+        cleanup.close()
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def mf_adapter(mf_config, seeded_db):
+    return MetricFlowAdapter(mf_config)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_semantic_passes(mf_adapter):
+    result = asyncio.run(mf_adapter.validate_semantic())
+    errors = [i for i in result.issues if i.severity == "error"]
+    assert result.valid, f"Unexpected validation errors: {errors}"
+
+
+def test_list_metrics_returns_metric(mf_adapter):
+    metrics = asyncio.run(mf_adapter.list_metrics())
+    names = {m.name for m in metrics}
+    assert len(metrics) >= 1, "Expected at least one metric"
+    assert "total_amount" in names, f"'total_amount' not in {sorted(names)}"
+
+
+def test_get_dimensions_returns_dimension(mf_adapter):
+    dims = asyncio.run(mf_adapter.get_dimensions("total_amount"))
+    assert len(dims) >= 1, f"Expected at least one dimension, got {dims}"
+
+
+def test_query_metrics_dry_run_returns_sql(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount"], dry_run=True))
+    sql = result.metadata.get("sql", "")
+    assert sql, f"Expected non-empty SQL from dry_run; metadata={result.metadata}"
+
+
+def test_query_metrics_live(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount"]))
+    assert len(result.data) >= 1, f"Expected data rows; got: {result}"
+    assert "total_amount" in result.columns, f"Expected 'total_amount' in columns; got: {result.columns}"
+
+
+def test_query_metrics_with_time_filter(mf_adapter):
+    result = asyncio.run(
+        mf_adapter.query_metrics(
+            ["total_amount"],
+            time_start="2020-01-01",
+            time_end="2020-01-03",
+        )
+    )
+    assert len(result.data) >= 1, f"Expected data with time filter; got: {result}"
+    total = sum(float(row["total_amount"]) for row in result.data if row.get("total_amount") is not None)
+    assert total == pytest.approx(60.0), f"Expected SUM=60 for 2020-01-01..03, got {total}"
+
+
+def test_query_metrics_multi_metric(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount", "order_count"]))
+    assert len(result.data) >= 1, f"Expected data rows; got: {result}"
+    assert "total_amount" in result.columns, f"'total_amount' missing from {result.columns}"
+    assert "order_count" in result.columns, f"'order_count' missing from {result.columns}"
+
+
+def test_query_metrics_where_clause_dry_run(mf_adapter):
+    result = asyncio.run(
+        mf_adapter.query_metrics(
+            ["total_amount"],
+            where="metric_time >= '2020-01-04'",
+            dry_run=True,
+        )
+    )
+    sql = result.metadata.get("sql", "")
+    assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"
+    assert "WHERE" in sql.upper(), f"Expected WHERE in generated SQL; got:\n{sql}"

--- a/tests/integration/adapters/test_semantic_metricflow_mysql.py
+++ b/tests/integration/adapters/test_semantic_metricflow_mysql.py
@@ -15,7 +15,6 @@ are created inside the existing `test` database alongside the adapter test
 tables and dropped on teardown.
 """
 
-import asyncio
 import os
 from datetime import date, timedelta
 
@@ -33,7 +32,7 @@ datus_semantic_metricflow = import_required(  # noqa: E402
 MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
 MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
 
-pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+pytestmark = [pytest.mark.integration, pytest.mark.nightly, pytest.mark.asyncio]
 
 _HOST = os.getenv("MYSQL_HOST", "localhost")
 _PORT = int(os.getenv("MYSQL_PORT", "3306"))
@@ -162,63 +161,59 @@ def mf_adapter(mf_config, seeded_db):
 # ---------------------------------------------------------------------------
 
 
-def test_validate_semantic_passes(mf_adapter):
-    result = asyncio.run(mf_adapter.validate_semantic())
+async def test_validate_semantic_passes(mf_adapter):
+    result = await mf_adapter.validate_semantic()
     errors = [i for i in result.issues if i.severity == "error"]
     assert result.valid, f"Unexpected validation errors: {errors}"
 
 
-def test_list_metrics_returns_metric(mf_adapter):
-    metrics = asyncio.run(mf_adapter.list_metrics())
+async def test_list_metrics_returns_metric(mf_adapter):
+    metrics = await mf_adapter.list_metrics()
     names = {m.name for m in metrics}
     assert len(metrics) >= 1, "Expected at least one metric"
     assert "total_amount" in names, f"'total_amount' not in {sorted(names)}"
 
 
-def test_get_dimensions_returns_dimension(mf_adapter):
-    dims = asyncio.run(mf_adapter.get_dimensions("total_amount"))
+async def test_get_dimensions_returns_dimension(mf_adapter):
+    dims = await mf_adapter.get_dimensions("total_amount")
     assert len(dims) >= 1, f"Expected at least one dimension, got {dims}"
 
 
-def test_query_metrics_dry_run_returns_sql(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount"], dry_run=True))
+async def test_query_metrics_dry_run_returns_sql(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount"], dry_run=True)
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL from dry_run; metadata={result.metadata}"
 
 
-def test_query_metrics_live(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount"]))
+async def test_query_metrics_live(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount"])
     assert len(result.data) >= 1, f"Expected data rows; got: {result}"
     assert "total_amount" in result.columns, f"Expected 'total_amount' in columns; got: {result.columns}"
 
 
-def test_query_metrics_with_time_filter(mf_adapter):
-    result = asyncio.run(
-        mf_adapter.query_metrics(
-            ["total_amount"],
-            time_start="2020-01-01",
-            time_end="2020-01-03",
-        )
+async def test_query_metrics_with_time_filter(mf_adapter):
+    result = await mf_adapter.query_metrics(
+        ["total_amount"],
+        time_start="2020-01-01",
+        time_end="2020-01-03",
     )
     assert len(result.data) >= 1, f"Expected data with time filter; got: {result}"
     total = sum(float(row["total_amount"]) for row in result.data if row.get("total_amount") is not None)
     assert total == pytest.approx(60.0), f"Expected SUM=60 for 2020-01-01..03, got {total}"
 
 
-def test_query_metrics_multi_metric(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount", "order_count"]))
+async def test_query_metrics_multi_metric(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount", "order_count"])
     assert len(result.data) >= 1, f"Expected data rows; got: {result}"
     assert "total_amount" in result.columns, f"'total_amount' missing from {result.columns}"
     assert "order_count" in result.columns, f"'order_count' missing from {result.columns}"
 
 
-def test_query_metrics_where_clause_dry_run(mf_adapter):
-    result = asyncio.run(
-        mf_adapter.query_metrics(
-            ["total_amount"],
-            where="metric_time >= '2020-01-04'",
-            dry_run=True,
-        )
+async def test_query_metrics_where_clause_dry_run(mf_adapter):
+    result = await mf_adapter.query_metrics(
+        ["total_amount"],
+        where="metric_time >= '2020-01-04'",
+        dry_run=True,
     )
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"

--- a/tests/integration/adapters/test_semantic_metricflow_postgresql.py
+++ b/tests/integration/adapters/test_semantic_metricflow_postgresql.py
@@ -14,7 +14,6 @@ MetricFlow tables are isolated in the `mf_nightly` schema within the existing
 `test` database and dropped on teardown.
 """
 
-import asyncio
 import os
 
 import pytest
@@ -31,7 +30,7 @@ datus_semantic_metricflow = import_required(  # noqa: E402
 MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
 MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
 
-pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+pytestmark = [pytest.mark.integration, pytest.mark.nightly, pytest.mark.asyncio]
 
 _HOST = os.getenv("POSTGRESQL_HOST", "localhost")
 _PORT = int(os.getenv("POSTGRESQL_PORT", "5432"))
@@ -157,63 +156,59 @@ def mf_adapter(mf_config, seeded_db):
 # ---------------------------------------------------------------------------
 
 
-def test_validate_semantic_passes(mf_adapter):
-    result = asyncio.run(mf_adapter.validate_semantic())
+async def test_validate_semantic_passes(mf_adapter):
+    result = await mf_adapter.validate_semantic()
     errors = [i for i in result.issues if i.severity == "error"]
     assert result.valid, f"Unexpected validation errors: {errors}"
 
 
-def test_list_metrics_returns_metric(mf_adapter):
-    metrics = asyncio.run(mf_adapter.list_metrics())
+async def test_list_metrics_returns_metric(mf_adapter):
+    metrics = await mf_adapter.list_metrics()
     names = {m.name for m in metrics}
     assert len(metrics) >= 1, "Expected at least one metric"
     assert "total_amount" in names, f"'total_amount' not in {sorted(names)}"
 
 
-def test_get_dimensions_returns_dimension(mf_adapter):
-    dims = asyncio.run(mf_adapter.get_dimensions("total_amount"))
+async def test_get_dimensions_returns_dimension(mf_adapter):
+    dims = await mf_adapter.get_dimensions("total_amount")
     assert len(dims) >= 1, f"Expected at least one dimension, got {dims}"
 
 
-def test_query_metrics_dry_run_returns_sql(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount"], dry_run=True))
+async def test_query_metrics_dry_run_returns_sql(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount"], dry_run=True)
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL from dry_run; metadata={result.metadata}"
 
 
-def test_query_metrics_live(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount"]))
+async def test_query_metrics_live(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount"])
     assert len(result.data) >= 1, f"Expected data rows; got: {result}"
     assert "total_amount" in result.columns, f"Expected 'total_amount' in columns; got: {result.columns}"
 
 
-def test_query_metrics_with_time_filter(mf_adapter):
-    result = asyncio.run(
-        mf_adapter.query_metrics(
-            ["total_amount"],
-            time_start="2020-01-01",
-            time_end="2020-01-03",
-        )
+async def test_query_metrics_with_time_filter(mf_adapter):
+    result = await mf_adapter.query_metrics(
+        ["total_amount"],
+        time_start="2020-01-01",
+        time_end="2020-01-03",
     )
     assert len(result.data) >= 1, f"Expected data with time filter; got: {result}"
     total = sum(float(row["total_amount"]) for row in result.data if row.get("total_amount") is not None)
     assert total == pytest.approx(60.0), f"Expected SUM=60 for 2020-01-01..03, got {total}"
 
 
-def test_query_metrics_multi_metric(mf_adapter):
-    result = asyncio.run(mf_adapter.query_metrics(["total_amount", "order_count"]))
+async def test_query_metrics_multi_metric(mf_adapter):
+    result = await mf_adapter.query_metrics(["total_amount", "order_count"])
     assert len(result.data) >= 1, f"Expected data rows; got: {result}"
     assert "total_amount" in result.columns, f"'total_amount' missing from {result.columns}"
     assert "order_count" in result.columns, f"'order_count' missing from {result.columns}"
 
 
-def test_query_metrics_where_clause_dry_run(mf_adapter):
-    result = asyncio.run(
-        mf_adapter.query_metrics(
-            ["total_amount"],
-            where="metric_time >= '2020-01-04'",
-            dry_run=True,
-        )
+async def test_query_metrics_where_clause_dry_run(mf_adapter):
+    result = await mf_adapter.query_metrics(
+        ["total_amount"],
+        where="metric_time >= '2020-01-04'",
+        dry_run=True,
     )
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"

--- a/tests/integration/adapters/test_semantic_metricflow_postgresql.py
+++ b/tests/integration/adapters/test_semantic_metricflow_postgresql.py
@@ -1,0 +1,220 @@
+"""
+MetricFlow semantic adapter nightly tests -- PostgreSQL backend.
+
+Opt-in (all required):
+  * datus-semantic-metricflow must be installed
+  * PostgreSQL container must be running (shared with PostgreSQL Adapter Tests suite)
+  * set env var: ADAPTERS_METRICFLOW_PG=1
+
+Env overrides (defaults match datus-postgresql/docker-compose.yml):
+  POSTGRESQL_HOST=localhost  POSTGRESQL_PORT=5432
+  POSTGRESQL_USER=test_user  POSTGRESQL_PASSWORD=test_password  POSTGRESQL_DATABASE=test
+
+MetricFlow tables are isolated in the `mf_nightly` schema within the existing
+`test` database and dropped on teardown.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+from tests.nightly_requirements import import_required, require_opt_in_env
+
+require_opt_in_env("ADAPTERS_METRICFLOW_PG", "tests/integration/adapters/README.md")
+
+datus_semantic_metricflow = import_required(  # noqa: E402
+    "datus_semantic_metricflow",
+    reason="datus-semantic-metricflow not installed; install it before running this suite",
+)
+
+MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
+MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
+
+pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+
+_HOST = os.getenv("POSTGRESQL_HOST", "localhost")
+_PORT = int(os.getenv("POSTGRESQL_PORT", "5432"))
+_USER = os.getenv("POSTGRESQL_USER", "test_user")
+_PASSWORD = os.getenv("POSTGRESQL_PASSWORD", "test_password")
+_DATABASE = os.getenv("POSTGRESQL_DATABASE", "test")
+_SCHEMA = "mf_nightly"
+
+_DATA_TABLE = "mf_orders"
+_TIME_SPINE_TABLE = "mf_time_spine"
+
+_SEMANTIC_YAML = f"""\
+data_source:
+  name: mf_orders
+  sql_table: {_SCHEMA}.{_DATA_TABLE}
+  identifiers:
+    - name: order_id
+      type: primary
+      expr: id
+  measures:
+    - name: total_amount
+      agg: sum
+      expr: amount
+    - name: order_count
+      agg: count
+      expr: id
+  dimensions:
+    - name: created_at
+      type: time
+      type_params:
+        is_primary: true
+        time_granularity: day
+---
+metric:
+  name: total_amount
+  type: measure_proxy
+  type_params:
+    measure: total_amount
+---
+metric:
+  name: order_count
+  type: measure_proxy
+  type_params:
+    measure: order_count
+"""
+
+_SAMPLE_ROWS = [
+    (1, 10.00, "2020-01-01"),
+    (2, 20.00, "2020-01-02"),
+    (3, 30.00, "2020-01-03"),
+    (4, 40.00, "2020-01-04"),
+    (5, 50.00, "2020-01-05"),
+]
+
+
+@pytest.fixture(scope="module")
+def mf_config(tmp_path_factory):
+    yaml_dir = tmp_path_factory.mktemp("mf_pg_models")
+    (yaml_dir / "mf_orders.yaml").write_text(_SEMANTIC_YAML)
+    return MetricFlowConfig(
+        datasource="mf_nightly",
+        db_config={
+            "type": "postgres",
+            "host": _HOST,
+            "port": str(_PORT),
+            "username": _USER,
+            "password": _PASSWORD,
+            "database": _DATABASE,
+            "schema": _SCHEMA,
+        },
+        semantic_models_path=str(yaml_dir),
+    )
+
+
+@pytest.fixture(scope="module")
+def seeded_db(mf_config):
+    import psycopg2
+
+    conn = psycopg2.connect(
+        host=_HOST,
+        port=_PORT,
+        user=_USER,
+        password=_PASSWORD,
+        dbname=_DATABASE,
+    )
+    conn.autocommit = True
+    cursor = conn.cursor()
+    try:
+        cursor.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_TIME_SPINE_TABLE}" CASCADE')
+        cursor.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_DATA_TABLE}" CASCADE')
+        cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {_SCHEMA}")
+        cursor.execute(
+            f'CREATE TABLE "{_SCHEMA}"."{_DATA_TABLE}" (id INTEGER PRIMARY KEY, amount DECIMAL(10,2), created_at DATE)'
+        )
+        values = ", ".join(f"({r[0]}, {r[1]}, '{r[2]}')" for r in _SAMPLE_ROWS)
+        cursor.execute(f'INSERT INTO "{_SCHEMA}"."{_DATA_TABLE}" VALUES {values}')
+        cursor.execute(f'CREATE TABLE "{_SCHEMA}"."{_TIME_SPINE_TABLE}" (ds DATE NOT NULL)')
+        cursor.execute(
+            f'INSERT INTO "{_SCHEMA}"."{_TIME_SPINE_TABLE}" '
+            "SELECT d::date FROM generate_series('2020-01-01'::date, '2025-12-31'::date, '1 day') d"
+        )
+    finally:
+        cursor.close()
+
+    yield
+
+    cleanup = conn.cursor()
+    try:
+        cleanup.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_TIME_SPINE_TABLE}" CASCADE')
+        cleanup.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_DATA_TABLE}" CASCADE')
+    finally:
+        cleanup.close()
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def mf_adapter(mf_config, seeded_db):
+    return MetricFlowAdapter(mf_config)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_semantic_passes(mf_adapter):
+    result = asyncio.run(mf_adapter.validate_semantic())
+    errors = [i for i in result.issues if i.severity == "error"]
+    assert result.valid, f"Unexpected validation errors: {errors}"
+
+
+def test_list_metrics_returns_metric(mf_adapter):
+    metrics = asyncio.run(mf_adapter.list_metrics())
+    names = {m.name for m in metrics}
+    assert len(metrics) >= 1, "Expected at least one metric"
+    assert "total_amount" in names, f"'total_amount' not in {sorted(names)}"
+
+
+def test_get_dimensions_returns_dimension(mf_adapter):
+    dims = asyncio.run(mf_adapter.get_dimensions("total_amount"))
+    assert len(dims) >= 1, f"Expected at least one dimension, got {dims}"
+
+
+def test_query_metrics_dry_run_returns_sql(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount"], dry_run=True))
+    sql = result.metadata.get("sql", "")
+    assert sql, f"Expected non-empty SQL from dry_run; metadata={result.metadata}"
+
+
+def test_query_metrics_live(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount"]))
+    assert len(result.data) >= 1, f"Expected data rows; got: {result}"
+    assert "total_amount" in result.columns, f"Expected 'total_amount' in columns; got: {result.columns}"
+
+
+def test_query_metrics_with_time_filter(mf_adapter):
+    result = asyncio.run(
+        mf_adapter.query_metrics(
+            ["total_amount"],
+            time_start="2020-01-01",
+            time_end="2020-01-03",
+        )
+    )
+    assert len(result.data) >= 1, f"Expected data with time filter; got: {result}"
+    total = sum(float(row["total_amount"]) for row in result.data if row.get("total_amount") is not None)
+    assert total == pytest.approx(60.0), f"Expected SUM=60 for 2020-01-01..03, got {total}"
+
+
+def test_query_metrics_multi_metric(mf_adapter):
+    result = asyncio.run(mf_adapter.query_metrics(["total_amount", "order_count"]))
+    assert len(result.data) >= 1, f"Expected data rows; got: {result}"
+    assert "total_amount" in result.columns, f"'total_amount' missing from {result.columns}"
+    assert "order_count" in result.columns, f"'order_count' missing from {result.columns}"
+
+
+def test_query_metrics_where_clause_dry_run(mf_adapter):
+    result = asyncio.run(
+        mf_adapter.query_metrics(
+            ["total_amount"],
+            where="metric_time >= '2020-01-04'",
+            dry_run=True,
+        )
+    )
+    sql = result.metadata.get("sql", "")
+    assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"
+    assert "WHERE" in sql.upper(), f"Expected WHERE in generated SQL; got:\n{sql}"

--- a/tests/integration/adapters/test_semantic_metricflow_postgresql.py
+++ b/tests/integration/adapters/test_semantic_metricflow_postgresql.py
@@ -14,6 +14,7 @@ MetricFlow tables are isolated in the `mf_nightly` schema within the existing
 `test` database and dropped on teardown.
 """
 
+import logging
 import os
 
 import pytest
@@ -29,6 +30,8 @@ datus_semantic_metricflow = import_required(  # noqa: E402
 
 MetricFlowAdapter = datus_semantic_metricflow.MetricFlowAdapter
 MetricFlowConfig = datus_semantic_metricflow.MetricFlowConfig
+
+logger = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.integration, pytest.mark.nightly, pytest.mark.asyncio]
 
@@ -117,38 +120,43 @@ def seeded_db(mf_config):
         dbname=_DATABASE,
     )
     conn.autocommit = True
-    cursor = conn.cursor()
+    # Outer try/finally guarantees the connection is closed even if seeding
+    # raises before `yield`; each cursor is scoped with a context manager.
     try:
-        cursor.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_TIME_SPINE_TABLE}" CASCADE')
-        cursor.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_DATA_TABLE}" CASCADE')
-        cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {_SCHEMA}")
-        cursor.execute(
-            f'CREATE TABLE "{_SCHEMA}"."{_DATA_TABLE}" (id INTEGER PRIMARY KEY, amount DECIMAL(10,2), created_at DATE)'
-        )
-        values = ", ".join(f"({r[0]}, {r[1]}, '{r[2]}')" for r in _SAMPLE_ROWS)
-        cursor.execute(f'INSERT INTO "{_SCHEMA}"."{_DATA_TABLE}" VALUES {values}')
-        cursor.execute(f'CREATE TABLE "{_SCHEMA}"."{_TIME_SPINE_TABLE}" (ds DATE NOT NULL)')
-        cursor.execute(
-            f'INSERT INTO "{_SCHEMA}"."{_TIME_SPINE_TABLE}" '
-            "SELECT d::date FROM generate_series('2020-01-01'::date, '2025-12-31'::date, '1 day') d"
-        )
-    finally:
-        cursor.close()
+        with conn.cursor() as cursor:
+            cursor.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_TIME_SPINE_TABLE}" CASCADE')
+            cursor.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_DATA_TABLE}" CASCADE')
+            cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {_SCHEMA}")
+            cursor.execute(
+                f'CREATE TABLE "{_SCHEMA}"."{_DATA_TABLE}" (id INTEGER PRIMARY KEY, amount DECIMAL(10,2), created_at DATE)'
+            )
+            values = ", ".join(f"({r[0]}, {r[1]}, '{r[2]}')" for r in _SAMPLE_ROWS)
+            cursor.execute(f'INSERT INTO "{_SCHEMA}"."{_DATA_TABLE}" VALUES {values}')
+            cursor.execute(f'CREATE TABLE "{_SCHEMA}"."{_TIME_SPINE_TABLE}" (ds DATE NOT NULL)')
+            cursor.execute(
+                f'INSERT INTO "{_SCHEMA}"."{_TIME_SPINE_TABLE}" '
+                "SELECT d::date FROM generate_series('2020-01-01'::date, '2025-12-31'::date, '1 day') d"
+            )
 
-    yield
+        yield
 
-    cleanup = conn.cursor()
-    try:
-        cleanup.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_TIME_SPINE_TABLE}" CASCADE')
-        cleanup.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_DATA_TABLE}" CASCADE')
+        with conn.cursor() as cleanup:
+            cleanup.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_TIME_SPINE_TABLE}" CASCADE')
+            cleanup.execute(f'DROP TABLE IF EXISTS "{_SCHEMA}"."{_DATA_TABLE}" CASCADE')
     finally:
-        cleanup.close()
         conn.close()
 
 
 @pytest.fixture(scope="module")
 def mf_adapter(mf_config, seeded_db):
-    return MetricFlowAdapter(mf_config)
+    adapter = MetricFlowAdapter(mf_config)
+    yield adapter
+    # Best-effort connection teardown so the adapter's SQL client does not stay
+    # open for the rest of the pytest process; log instead of silently passing.
+    try:
+        adapter.client.sql_client.close()
+    except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+        logger.warning("Failed to close MetricFlow SQL client during teardown: %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -213,3 +221,6 @@ async def test_query_metrics_where_clause_dry_run(mf_adapter):
     sql = result.metadata.get("sql", "")
     assert sql, f"Expected non-empty SQL with where clause; metadata={result.metadata}"
     assert "WHERE" in sql.upper(), f"Expected WHERE in generated SQL; got:\n{sql}"
+    # Assert the caller-supplied predicate survives: a framework-generated WHERE
+    # could otherwise pass this test even if the where= argument were dropped.
+    assert "2020-01-04" in sql, f"Expected dry_run SQL to preserve the caller filter; got:\n{sql}"

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -44,7 +44,7 @@ def test_nightly_pytest_commands_set_explicit_test_layer():
         if " uv run pytest " in line and ("run_logged" in line or "run_compose_suite" in line)
     ]
 
-    assert len(pytest_command_lines) == 19
+    assert len(pytest_command_lines) == 20
     for line in pytest_command_lines:
         expected_layer = "unit" if "Full Unit Tests" in line else "nightly"
         assert f"env DATUS_TEST_LAYER={expected_layer} uv run pytest" in line


### PR DESCRIPTION
## Why

`MetricFlowAdapter` core methods (`validate_semantic`, `list_metrics`, `get_dimensions`, `query_metrics`) have zero real-database coverage in the nightly suite. The existing `test_gen_semantic_model_agentic.py` / `test_gen_metrics_agentic.py` files are mock-only tests — they never start a real MetricFlow service or connect to a real database.

## Solution

Add three nightly integration test suites, 8 tests each (24 total):

- `test_semantic_metricflow_duckdb.py` — DuckDB backend, no Docker needed; uses a pytest tmp-dir file database
- `test_semantic_metricflow_mysql.py` — MySQL backend, reuses the existing MySQL Adapter Tests compose environment
- `test_semantic_metricflow_postgresql.py` — PostgreSQL backend, reuses the existing PostgreSQL Adapter Tests compose environment

Each file covers:
1. `test_validate_semantic_passes` — `validate_semantic()` returns no error-level issues
2. `test_list_metrics_returns_metric` — `list_metrics()` includes the expected metric name
3. `test_get_dimensions_returns_dimension` — `get_dimensions()` returns at least one dimension
4. `test_query_metrics_dry_run_returns_sql` — `dry_run=True` returns non-empty SQL
5. `test_query_metrics_live` — actual execution returns data rows with the expected column
6. `test_query_metrics_with_time_filter` — `time_start`/`time_end` filter; asserts `SUM=60` for Jan 1–3
7. `test_query_metrics_multi_metric` — two metrics queried together (`total_amount` + `order_count`)
8. `test_query_metrics_where_clause_dry_run` — `where` clause + `dry_run=True`; asserts generated SQL contains `WHERE`

Changes to `ci/run-nightly-tests.sh`:
- Export three opt-in env vars (`ADAPTERS_METRICFLOW_DUCKDB/MYSQL/PG`, default `1`)
- Deselect all three files in `NIGHTLY_DEDICATED_SUITE_DESELECTS` to prevent double-execution by Main Nightly Tests
- Append MetricFlow test files to the existing MySQL and PostgreSQL compose suite calls (shared containers)
- Run DuckDB MetricFlow tests via `run_logged` (no compose needed)

Key implementation notes:
- MetricFlow v0.x requires an `mf_time_spine` table (`ds DATE`) in the target schema; the `seeded_db` fixture creates it and drops it on teardown
- The YAML `created_at` dimension must declare `is_primary: true`; without it MetricFlow raises "No primary time dimension" validation errors
- The `where` parameter must use `metric_time` (MetricFlow's internal canonical time dimension name); the dbt Semantic Layer syntax `{{ Dimension('...') }}` and the `datasource__dimension` format are not supported in MetricFlow v0.x standalone

## Test Cases

This PR is itself the test cases. All 24 tests verified locally:

- DuckDB: 8/8 passed (no Docker)
- MySQL: 8/8 passed (`MYSQL_PORT=33306`, shared existing container)
- PostgreSQL: 8/8 passed (`POSTGRESQL_PORT=35432`, shared existing container)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in nightly MetricFlow semantic adapter test coverage for DuckDB, MySQL, and PostgreSQL.
  - Extended nightly adapter suite runs to execute the corresponding MetricFlow semantic adapter tests.
- **Documentation**
  - Added a new “MetricFlow Semantic Adapter Tests” section and environment variable guidance for running the tests.
- **Bug Fixes**
  - Updated nightly test selection to exclude MetricFlow semantic adapter tests from the main nightly run, ensuring they run only in the intended adapter suites.
  - Adjusted CI expectations for the added nightly test command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->