### PR TITLE
[BugFix] Fix tool-failure rendering across backends and unrestrict write_file extensions

### DIFF
--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -1092,8 +1092,18 @@ def _build_edit_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
 
 
 def _build_write_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """write_file: show file path and write result."""
+    """write_file: show file path and write result.
+
+    A rejected write returns ``FuncToolResult(success=0)`` without raising, so
+    the compact line must surface the error and flip the icon to ✗ instead of
+    fabricating a ``wrote N lines`` success from the input ``content`` alone.
+    """
     tc = make_base_content(action)
+    data = parse_output_data(action.output)
+    tool_error: Optional[str] = None
+    if data is not None and (data.get("success") == 0 or data.get("error")):
+        tool_error = str(data.get("error") or "Failed")
+        tc.status_mark = "✗"
     if verbose:
         # Custom args: show path/file_type, truncate long content
         args_lines: List[str] = []
@@ -1118,18 +1128,22 @@ def _build_write_file(action: ActionHistory, verbose: bool) -> ToolCallContent:
         if action.output:
             tc.output_lines = _format_result_only_markup(action.output)
     else:
-        data = parse_output_data(action.output)
-        args = _parse_args_dict(action)
-        content = args.get("content")
-        if isinstance(content, str) and content:
-            line_count = len(content.splitlines()) or 1
-            tc.compact_result = f"wrote {line_count} lines"
-        elif data:
-            result = data.get("result")
-            if isinstance(result, str) and "success" in result.lower():
-                tc.compact_result = "File written"
-            elif data.get("success"):
-                tc.compact_result = "File written"
+        if action.status == ActionStatus.FAILED:
+            tc.compact_result = action.output if isinstance(action.output, str) else (tool_error or "Failed")
+        elif tool_error is not None:
+            tc.compact_result = tool_error
+        else:
+            args = _parse_args_dict(action)
+            content = args.get("content")
+            if isinstance(content, str) and content:
+                line_count = len(content.splitlines()) or 1
+                tc.compact_result = f"wrote {line_count} lines"
+            elif data:
+                result = data.get("result")
+                if isinstance(result, str) and "success" in result.lower():
+                    tc.compact_result = "File written"
+                elif data.get("success"):
+                    tc.compact_result = "File written"
     return tc
 
 

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -34,6 +34,7 @@ from datus.models.mcp_utils import multiple_mcp_servers
 from datus.models.openai_compatible import OpenAICompatibleModel
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
+from datus.schemas.tool_summary import detect_tool_failure
 from datus.utils.constants import SQLType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -1088,15 +1089,20 @@ class ClaudeModel(OpenAICompatibleModel):
                             if not tool_executed:
                                 logger.error(f"Tool {block.name} could not be executed")
 
-                            # Yield SUCCESS/FAILURE action for real-time tool call display
+                            # Yield SUCCESS/FAILURE action for real-time tool call display.
+                            # A tool that returns FuncToolResult(success=0) executed without
+                            # raising (tool_executed=True), so keying status off tool_executed
+                            # alone would render a green ✓ on a soft failure. Fold the payload's
+                            # success/error signal in via detect_tool_failure.
                             result_text = ""
                             if block.id in tool_call_cache:
                                 result_text = tool_call_cache[block.id].content[0].text
+                            tool_failed = (not tool_executed) or detect_tool_failure(hook_result)
                             result_summary = (
-                                self._format_tool_result(result_text, block.name) if tool_executed else "Failed"
+                                self._format_tool_result(result_text, block.name) if not tool_failed else "Failed"
                             )
                             tool_output = {
-                                "success": tool_executed,
+                                "success": not tool_failed,
                                 "raw_output": result_text,
                                 "summary": result_summary,
                                 "status_message": result_summary,
@@ -1119,7 +1125,7 @@ class ClaudeModel(OpenAICompatibleModel):
                                 action_type=block.name,
                                 input={"function_name": block.name, "arguments": block.input},
                                 output=tool_output,
-                                status=ActionStatus.SUCCESS if tool_executed else ActionStatus.FAILED,
+                                status=ActionStatus.SUCCESS if not tool_failed else ActionStatus.FAILED,
                             )
                             complete_action.end_time = datetime.now()
                             if action_history_manager is not None:

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -26,6 +26,7 @@ from datus.models.mcp_result_extractors import extract_sql_contexts
 from datus.models.mcp_utils import multiple_mcp_servers
 from datus.observability.manager import get_observability_manager
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.tool_summary import detect_tool_failure
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.trace_context import build_agents_run_config_kwargs, build_trace_span_attributes
@@ -743,14 +744,18 @@ class CodexModel(LLMBaseModel):
                                 args_display = tool_info["args_display"] if tool_info else ""
                                 arguments = tool_info["arguments"] if tool_info else "{}"
 
+                                # FuncToolResult(success=0) returns normally rather than
+                                # raising, so inspect the payload instead of hardcoding
+                                # SUCCESS — otherwise a rejected write renders a green ✓.
+                                tool_failed = detect_tool_failure(output_content)
                                 action = ActionHistory(
                                     action_id=f"complete_{call_id}",
                                     role=ActionRole.TOOL,
                                     messages=f"Tool call: {tool_name}('{args_display}...')",
                                     action_type=tool_name,
                                     input={"function_name": tool_name, "arguments": arguments},
-                                    output={"success": True, "raw_output": output_content},
-                                    status=ActionStatus.SUCCESS,
+                                    output={"success": not tool_failed, "raw_output": output_content},
+                                    status=ActionStatus.FAILED if tool_failed else ActionStatus.SUCCESS,
                                 )
                                 action_history_manager.add_action(action)
                                 yield action

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -34,7 +34,7 @@ from datus.models.mcp_result_extractors import extract_sql_contexts
 from datus.models.mcp_utils import multiple_mcp_servers
 from datus.observability.manager import get_observability_manager
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
-from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY, looks_like_failure
+from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY, detect_tool_failure
 from datus.utils.constants import LLMProvider
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_str
@@ -230,27 +230,10 @@ def classify_openai_compatible_error(error: Exception) -> tuple[ErrorCode, bool]
 # CLI compact rendering and SSE share a single source of truth.
 
 
-def _detect_tool_failure(output_content: Any) -> bool:
-    """Return True when the tool's output payload signals failure.
-
-    Tools built on :class:`FuncToolResult` report errors via ``success=0`` /
-    non-empty ``error`` instead of raising. The Agents SDK therefore emits a
-    ``tool_call_output_item`` for them and we must inspect the payload to
-    render ✗ (and mark the action FAILED) correctly.
-    """
-    data: Optional[dict] = None
-    if isinstance(output_content, dict):
-        data = output_content
-    elif isinstance(output_content, str):
-        try:
-            parsed = json.loads(output_content)
-        except (TypeError, ValueError):
-            return False
-        if isinstance(parsed, dict):
-            data = parsed
-    if data is None:
-        return False
-    return looks_like_failure(data)
+# Failure detection is shared across all model backends so OpenAI-compatible,
+# Claude-native and Codex render ✗ identically for FuncToolResult(success=0).
+# Kept as a module-level alias for backward-compatible imports.
+_detect_tool_failure = detect_tool_failure
 
 
 class OpenAICompatibleModel(LLMBaseModel):

--- a/datus/schemas/tool_summary.py
+++ b/datus/schemas/tool_summary.py
@@ -66,6 +66,33 @@ def looks_like_failure(data: dict) -> bool:
     return False
 
 
+def detect_tool_failure(output_content: Any) -> bool:
+    """Return True when a tool's output payload signals failure.
+
+    Tools built on :class:`~datus.tools.func_tool.base.FuncToolResult` report
+    errors via ``success=0`` / non-empty ``error`` instead of raising, so the
+    model integrations cannot infer failure from "did the call throw". Every
+    backend (OpenAI-compatible, Claude-native, Codex) must run the returned
+    payload through this helper to render ✗ and mark the action FAILED.
+
+    Accepts the raw ``ToolCallOutputItem.output`` shape: a dict (normal SDK
+    path), a JSON string, or anything else (treated as non-failure).
+    """
+    data: Optional[dict] = None
+    if isinstance(output_content, dict):
+        data = output_content
+    elif isinstance(output_content, str):
+        try:
+            parsed = json.loads(output_content)
+        except (TypeError, ValueError):
+            return False
+        if isinstance(parsed, dict):
+            data = parsed
+    if data is None:
+        return False
+    return looks_like_failure(data)
+
+
 def format_failure(data: dict) -> str:
     error = data.get("error")
     if not isinstance(error, str) or not error.strip():

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -326,9 +326,10 @@ class FilesystemFuncTool(BaseTool):
             if resolved.read_only:
                 return self._read_only_reject(resolved)
 
+            # write_file intentionally skips the extension whitelist: the agent
+            # must be able to emit any text artifact (shell/infra/scala/etc.).
+            # Zone, read-only and strict-external gating above still apply.
             target_path = resolved.resolved
-            if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
 
             try:
                 target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -799,6 +799,51 @@ class TestBuildWriteFile:
         tc = _build_write_file(a, verbose=True)
         assert tc.args_lines == []
 
+    def test_compact_soft_failure_flips_mark_and_shows_error(self):
+        """FuncToolResult(success=0) with no raised exception (status SUCCESS)
+        must still render ✗ and surface the error, not a fabricated
+        'wrote N lines' from the input content."""
+        a = _make(
+            status=ActionStatus.SUCCESS,
+            input_data={
+                "function_name": "write_file",
+                "arguments": {"path": "infra/x.sh", "content": "#!/bin/sh\necho hi"},
+            },
+            output_data={"raw_output": '{"success": 0, "error": "File type not allowed: infra/x.sh"}'},
+        )
+        tc = _build_write_file(a, verbose=False)
+        assert tc.status_mark == "✗"
+        assert tc.compact_result == "File type not allowed: infra/x.sh"
+        assert "wrote" not in tc.compact_result
+
+    def test_compact_error_only_payload_flips_mark(self):
+        """An error-only payload (no success field) is also a failure."""
+        a = _make(
+            input_data={
+                "function_name": "write_file",
+                "arguments": {"path": "x.sql", "content": "SELECT 1"},
+            },
+            output_data={"raw_output": '{"error": "Permission denied: x.sql"}'},
+        )
+        tc = _build_write_file(a, verbose=False)
+        assert tc.status_mark == "✗"
+        assert tc.compact_result == "Permission denied: x.sql"
+
+    def test_compact_failed_status_shows_error(self):
+        """When the backend already marked the action FAILED, the compact line
+        reflects the failure rather than fabricating a write count."""
+        a = _make(
+            status=ActionStatus.FAILED,
+            input_data={
+                "function_name": "write_file",
+                "arguments": {"path": "x.sql", "content": "SELECT 1"},
+            },
+            output_data={"raw_output": '{"success": 0, "error": "disk full"}'},
+        )
+        tc = _build_write_file(a, verbose=False)
+        assert tc.status_mark == "✗"
+        assert "wrote" not in (tc.compact_result or "")
+
 
 # ── Builder registry: new tools registered ────────────────────────
 

--- a/tests/unit_tests/schemas/test_tool_summary.py
+++ b/tests/unit_tests/schemas/test_tool_summary.py
@@ -25,6 +25,7 @@ from datus.schemas.tool_summary import (
     SUMMARY_TEXT_MAX_CHARS,
     TOOL_SUMMARY_REGISTRY,
     ToolSummaryRegistry,
+    detect_tool_failure,
     format_failure,
     format_generic_result,
     format_list_envelope,
@@ -72,6 +73,44 @@ class TestPublicHelpers:
     def test_looks_like_failure_default_false(self):
         assert looks_like_failure({"success": 1}) is False
         assert looks_like_failure({}) is False
+
+    def test_detect_tool_failure_dict_payload(self):
+        assert detect_tool_failure({"success": 0, "error": "boom"}) is True
+        assert detect_tool_failure({"success": False}) is True
+        assert detect_tool_failure({"error": "connection refused"}) is True
+        assert detect_tool_failure({"success": 1, "result": [1, 2]}) is False
+        assert detect_tool_failure({"success": 1, "error": "  "}) is False
+
+    def test_detect_tool_failure_json_string_payload(self):
+        # Claude-native path stores raw_output as a JSON string.
+        assert detect_tool_failure(json.dumps({"success": 0, "error": "x"})) is True
+        assert detect_tool_failure(json.dumps({"success": 1})) is False
+
+    def test_detect_tool_failure_non_json_string_is_not_failure(self):
+        # A Python repr (single quotes) or plain text is not JSON-parseable and
+        # must NOT be misread — return False rather than raising.
+        assert detect_tool_failure("{'success': 0}") is False
+        assert detect_tool_failure("ok") is False
+        assert detect_tool_failure("") is False
+
+    def test_detect_tool_failure_other_types(self):
+        assert detect_tool_failure(None) is False
+        assert detect_tool_failure([{"success": 0}]) is False
+
+    def test_detect_tool_failure_real_functoolresult_contract(self):
+        """Contract test: the exact payload model backends receive from a
+        FuncToolResult (its model_dump) must be detected. This locks the
+        producer (func_tool) ↔ consumer (detect_tool_failure) shape so a
+        rejected write never renders a green ✓."""
+        from datus.tools.func_tool.base import FuncToolResult
+
+        failed = FuncToolResult(success=0, error="File type not allowed: x.sh").model_dump(mode="json")
+        ok = FuncToolResult(success=1, result="File written successfully").model_dump(mode="json")
+        assert detect_tool_failure(failed) is True
+        assert detect_tool_failure(ok) is False
+        # Claude-native serializes the same payload as a JSON string.
+        assert detect_tool_failure(json.dumps(failed)) is True
+        assert detect_tool_failure(json.dumps(ok)) is False
 
     def test_format_failure_with_message(self):
         # Error text is clipped to SUMMARY_ERROR_MAX_CHARS (19).

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -237,11 +237,20 @@ class TestWriteFile:
         assert result.success == 1
         assert (tmp_path / "subdir" / "nested" / "file.txt").exists()
 
-    def test_write_disallowed_extension(self, tmp_path):
+    def test_write_skips_extension_whitelist(self, tmp_path):
+        """write_file accepts any text artifact regardless of extension; the
+        whitelist only gates read/edit/delete, not creation."""
+        tool = _make_tool(str(tmp_path))
+        result = tool.write_file("infra/deploy.sh", "#!/bin/sh\necho hi\n")
+        assert result.success == 1
+        assert (tmp_path / "infra" / "deploy.sh").read_text() == "#!/bin/sh\necho hi\n"
+
+    def test_write_non_whitelisted_extension_in_zone(self, tmp_path):
+        """A previously-rejected extension (.exe) now writes successfully."""
         tool = _make_tool(str(tmp_path))
         result = tool.write_file("file.exe", "binary")
-        assert result.success == 0
-        assert "not allowed" in result.error.lower()
+        assert result.success == 1
+        assert (tmp_path / "file.exe").read_text() == "binary"
 
     def test_write_path_traversal_classified_external(self, tmp_path):
         """Write with ``../`` escape also classifies EXTERNAL — gating lives


### PR DESCRIPTION
## Why

A rejected `write_file` — and more generally any tool returning `FuncToolResult(success=0)` — rendered a **green ✓ "success"** in the TUI on the Claude-native and Codex backends, with the error text leaking out below it. This is misleading: the user sees ✓ while the operation actually failed.

Two independent root causes:

1. **Failure detection was only implemented in `openai_compatible`.** `claude_model` derived status from `tool_executed` (i.e. "did the call raise an exception"), but a `FuncToolResult(success=0)` returns *normally*, so `tool_executed=True` → `SUCCESS`. `codex_model` hardcoded `output={"success": True}` / `status=SUCCESS` and never inspected the payload at all.
2. **`_build_write_file` fabricated a success line.** It set `compact_result = "wrote N lines"` purely from the input `content` arg, never checking `success`/`error`, and never flipped the status mark to ✗ (unlike `_build_read_query`).

Separately, `write_file` rejected any extension outside a hardcoded whitelist (`.txt/.md/.py/...`), so the agent could not emit `.sh`/`.tf`/`.scala`/infra artifacts — surfacing as `File type not allowed`.

## Solution

- Extracted `detect_tool_failure()` into `datus/schemas/tool_summary.py` (next to `looks_like_failure`) as the single source of truth for FuncToolResult-shaped failure detection (handles dict and JSON-string payloads). `openai_compatible` now imports it (keeps the `_detect_tool_failure` alias for back-compat).
- Wired **all three** model backends through it:
  - `claude_model`: `tool_failed = (not tool_executed) or detect_tool_failure(hook_result)`; status/summary/success follow.
  - `codex_model`: replaced the hardcoded `SUCCESS` with `detect_tool_failure(output_content)`.
- `_build_write_file`: detect `success == 0` / `error`, flip the icon to ✗ and surface the error, and only show `wrote N lines` on real success — aligned with `_build_read_query`.
- Removed the extension whitelist check from `write_file` so the agent can write any text artifact. Zone classification, read-only, hidden (`.datus/memory`) and strict-external gating are unchanged.

## Test Cases

These are deterministic unit tests (no LLM calls), appropriate for this CLI/rendering + helper logic:

- `tests/unit_tests/schemas/test_tool_summary.py`: full branch coverage for `detect_tool_failure` (dict / JSON-string / non-JSON-string / other types) plus a **producer↔consumer contract test** feeding a real `FuncToolResult(...).model_dump()` to lock the shape model backends actually receive.
- `tests/unit_tests/cli/action_display/test_tool_content.py`: `_build_write_file` failure cases (soft `success=0`, error-only payload, already-FAILED status) asserting ✗ and no fabricated `wrote N lines`.
- `tests/unit_tests/tools/func_tool/test_filesystem_tools.py`: `write_file` now succeeds for non-whitelisted extensions (`.sh`, `.exe`), replacing the old "extension rejected" assertion.

The claude/codex streaming `tool_call_output_item` wiring is a one-line use of the now-unit-tested `detect_tool_failure`; building full Anthropic/Codex streaming mocks for it was judged high-cost/brittle versus the covered helper + render layers.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results now surface failure states more clearly in compact output, including error messages and a failed status mark.
  * File writing now allows more flexible output types, including files that were previously blocked by extension checks.

* **Bug Fixes**
  * Fixed cases where failed tool calls could still appear successful.
  * Compact file-write summaries no longer show misleading “wrote N lines” text when the tool actually failed.

* **Tests**
  * Added coverage for tool-failure detection and file-write behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->