### PR TITLE
[Enhancement] list_tables returns qualified_name ([db.][schema.]table)

### DIFF
--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -157,7 +157,7 @@ def _item_name(item) -> str:
     if isinstance(item, str):
         return item
     if isinstance(item, dict):
-        for key in ("name", "table_name", "database", "schema", "identifier", "title", "id"):
+        for key in ("name", "qualified_name", "table_name", "database", "schema", "identifier", "title", "id"):
             val = item.get(key)
             if val:
                 return str(val)

--- a/datus/tools/db_tools/duckdb_connector.py
+++ b/datus/tools/db_tools/duckdb_connector.py
@@ -679,35 +679,53 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
                 sql_query=sql_query,
             )
 
+    @staticmethod
+    def _qualify_name(table: str, real_db: str, real_schema: str, arg_db: str, arg_schema: str) -> str:
+        """Prefix ``table`` with the database/schema levels the caller did not pin down.
+
+        ``real_db``/``real_schema`` are the row's actual coordinates; ``arg_db``/``arg_schema``
+        are the caller's *original* arguments. A level is prepended only when the caller left it
+        blank, yielding ``[db.][schema.]table`` so an unscoped listing stays addressable.
+        """
+        parts: List[str] = []
+        if not arg_db and real_db:
+            parts.append(real_db)
+        if not arg_schema and real_schema:
+            parts.append(real_schema)
+        parts.append(table)
+        return ".".join(parts)
+
     @override
     @_serialised
     def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
-        """Get all table names."""
+        """Get qualified table names (``[db.][schema.]table`` for levels not given by the caller)."""
         self.connect()
-        sql = "SELECT table_name FROM duckdb_tables() WHERE database_name != 'system'"
+        sql = "SELECT database_name, schema_name, table_name FROM duckdb_tables() WHERE database_name != 'system'"
         if database_name:
             sql += f" AND database_name = '{database_name}'"
         if schema_name:
             sql += f" AND schema_name = '{schema_name}'"
 
         result = self.connection.execute(sql)
-        return [row[0] for row in result.fetchall()]
+        return [self._qualify_name(row[2], row[0], row[1], database_name, schema_name) for row in result.fetchall()]
 
     @override
     @_serialised
     def get_views(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> List[str]:
-        """Get all view names."""
+        """Get qualified view names (``[db.][schema.]view`` for levels not given by the caller)."""
         self.connect()
-        database_name = database_name or self.database_name
-        schema_name = schema_name or self.schema_name
-        sql = "SELECT view_name FROM duckdb_views() WHERE database_name != 'system'"
-        if database_name:
-            sql += f" AND database_name = '{database_name}'"
-        if schema_name:
-            sql += f" AND schema_name = '{schema_name}'"
+        # Keep the historical query scope (current db/schema when unspecified); qualification still
+        # uses the caller's *original* args so an unscoped call surfaces the resolved db/schema.
+        eff_db = database_name or self.database_name
+        eff_schema = schema_name or self.schema_name
+        sql = "SELECT database_name, schema_name, view_name FROM duckdb_views() WHERE database_name != 'system'"
+        if eff_db:
+            sql += f" AND database_name = '{eff_db}'"
+        if eff_schema:
+            sql += f" AND schema_name = '{eff_schema}'"
 
         result = self.connection.execute(sql)
-        return [row[0] for row in result.fetchall()]
+        return [self._qualify_name(row[2], row[0], row[1], database_name, schema_name) for row in result.fetchall()]
 
     @override
     @_serialised

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -656,7 +656,7 @@ class DBFuncTool:
         filtered: List[Dict[str, Any]] = []
         for entry in entries:
             coordinate = self._build_table_coordinate(
-                raw_name=str(entry.get("name", "")),
+                raw_name=str(entry.get("qualified_name", "")),
                 catalog=catalog,
                 database=database,
                 schema=schema,
@@ -1015,8 +1015,10 @@ class DBFuncTool:
             include_views: When True (default) also include views and materialized views.
 
         Returns:
-            FuncToolResult with result=[{"type": "table|view|materialized_view", "name": str}, ...]. On failure
-            success=0 with an explanatory error message.
+            FuncToolResult with result=[{"type": "table|view|materialized_view", "qualified_name": str}, ...].
+            ``qualified_name`` is ``[db.][schema.]table``, prefixing only the levels the caller did not pass
+            (e.g. pass ``database`` but not ``schema`` and each entry carries its resolved ``schema.table``).
+            On failure success=0 with an explanatory error message.
         """
         try:
             catalog, database, schema_name = self._normalize_namespace_args(
@@ -1028,7 +1030,7 @@ class DBFuncTool:
             connector = self._get_connector(datasource, database)
             result = []
             for tb in connector.get_tables(catalog, database, schema_name):
-                result.append({"type": "table", "name": tb})
+                result.append({"type": "table", "qualified_name": tb})
 
             if include_views:
                 # Add views. We deliberately swallow any exception — some connectors
@@ -1039,7 +1041,7 @@ class DBFuncTool:
                 try:
                     views = connector.get_views(catalog, database, schema_name)
                     for view in views:
-                        result.append({"type": "view", "name": view})
+                        result.append({"type": "view", "qualified_name": view})
                 except Exception as e:
                     logger.debug(f"get_views unavailable on {connector.dialect}: {e}")
 
@@ -1047,7 +1049,7 @@ class DBFuncTool:
                 try:
                     materialized_views = connector.get_materialized_views(catalog, database, schema_name)
                     for mv in materialized_views:
-                        result.append({"type": "materialized_view", "name": mv})
+                        result.append({"type": "materialized_view", "qualified_name": mv})
                 except Exception as e:
                     logger.debug(f"get_materialized_views unavailable on {connector.dialect}: {e}")
 

--- a/tests/integration/adapters/test_clickhouse.py
+++ b/tests/integration/adapters/test_clickhouse.py
@@ -147,7 +147,7 @@ def db_tool(seeded_connector: ClickHouseConnector) -> DBFuncTool:
 def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
     assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
 

--- a/tests/integration/adapters/test_greenplum.py
+++ b/tests/integration/adapters/test_greenplum.py
@@ -139,7 +139,7 @@ def db_tool(seeded_connector: GreenplumConnector) -> DBFuncTool:
 def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
     assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
 

--- a/tests/integration/adapters/test_hive.py
+++ b/tests/integration/adapters/test_hive.py
@@ -134,7 +134,7 @@ def db_tool(seeded_connector: HiveConnector) -> DBFuncTool:
 def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
     assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
 

--- a/tests/integration/adapters/test_mysql.py
+++ b/tests/integration/adapters/test_mysql.py
@@ -133,7 +133,7 @@ def db_tool(seeded_connector: MySQLConnector) -> DBFuncTool:
 def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
     assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
 

--- a/tests/integration/adapters/test_postgresql.py
+++ b/tests/integration/adapters/test_postgresql.py
@@ -153,7 +153,7 @@ def db_tool(seeded_connector: PostgreSQLConnector) -> DBFuncTool:
 def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
     assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
 

--- a/tests/integration/adapters/test_spark.py
+++ b/tests/integration/adapters/test_spark.py
@@ -135,7 +135,7 @@ def db_tool(seeded_connector: SparkConnector) -> DBFuncTool:
 def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
     assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
 

--- a/tests/integration/adapters/test_starrocks.py
+++ b/tests/integration/adapters/test_starrocks.py
@@ -155,7 +155,7 @@ def db_tool(seeded_connector: StarRocksConnector) -> DBFuncTool:
 def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
     assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
 

--- a/tests/integration/adapters/test_trino.py
+++ b/tests/integration/adapters/test_trino.py
@@ -78,7 +78,7 @@ def db_tool(trino_connector: TrinoConnector) -> DBFuncTool:
 def test_list_tables_returns_tpch_tables(db_tool: DBFuncTool) -> None:
     result = db_tool.list_tables()
     assert result.success == 1, f"list_tables failed: {result.error}"
-    names = {entry["name"] for entry in result.result}
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
     # tpch.tiny ships 8 standard TPC-H tables; we check the ones we actually query.
     assert "region" in names, f"region missing from {sorted(names)}"
     assert "nation" in names, f"nation missing from {sorted(names)}"

--- a/tests/integration/tools/test_func_tools_db.py
+++ b/tests/integration/tools/test_func_tools_db.py
@@ -34,7 +34,7 @@ class TestDBFuncToolIntegrationReal:
         result = ssb_db_tool.list_tables()
 
         assert result.success == 1
-        table_names = [t["name"] for t in result.result]
+        table_names = [t["qualified_name"].split(".")[-1] for t in result.result]
         # SSB database has: date, supplier, customer, part, lineorder
         expected_tables = {"date", "supplier", "customer", "part", "lineorder"}
         assert expected_tables.issubset(set(table_names))
@@ -143,13 +143,13 @@ class TestSqliteMultiConnector:
         result = db_tool.list_tables(database="california_schools")
         assert result.success == 1
         assert len(result.result) > 1
-        table_names = set([item["name"] for item in result.result])
+        table_names = set([item["qualified_name"].split(".")[-1] for item in result.result])
         assert {"frpm", "satscores", "schools"}.issubset(table_names)
 
         result = db_tool.list_tables(database="card_games")
         assert result.success == 1
         assert len(result.result) > 1
-        table_names = set([item["name"] for item in result.result])
+        table_names = set([item["qualified_name"].split(".")[-1] for item in result.result])
         assert {"cards", "legalities", "set_translations", "foreign_data", "rulings", "sets"}.issubset(table_names)
 
 
@@ -178,7 +178,7 @@ class TestDuckDBTool:
         result = duckdb_tool.list_tables(schema_name="mf_demo")
 
         assert result.success == 1
-        table_names = [t["name"] for t in result.result]
+        table_names = [t["qualified_name"].split(".")[-1] for t in result.result]
         # DuckDB has: mf_demo_countries, mf_demo_customers, mf_demo_transactions, mf_time_spine
         expected_tables = {"mf_demo_countries", "mf_demo_customers", "mf_demo_transactions", "mf_time_spine"}
         assert expected_tables.issubset(set(table_names))
@@ -333,7 +333,7 @@ class TestScopedTables:
         result = scoped_db_tool.list_tables()
 
         assert result.success == 1, f"list_tables should succeed, got error: {result.error}"
-        table_names = [t["name"] for t in result.result]
+        table_names = [t["qualified_name"].split(".")[-1] for t in result.result]
 
         assert "customer" in table_names, "customer should be in scoped results"
         assert "lineorder" in table_names, "lineorder should be in scoped results"

--- a/tests/unit_tests/tools/db_tools/test_db_func_tools.py
+++ b/tests/unit_tests/tools/db_tools/test_db_func_tools.py
@@ -206,11 +206,11 @@ class TestDBFuncTool:
 
         # Should include tables, views, and materialized views
         expected_result = [
-            {"type": "table", "name": "users"},
-            {"type": "table", "name": "orders"},
-            {"type": "view", "name": "user_view"},
-            {"type": "view", "name": "order_view"},
-            {"type": "materialized_view", "name": "sales_mv"},
+            {"type": "table", "qualified_name": "users"},
+            {"type": "table", "qualified_name": "orders"},
+            {"type": "view", "qualified_name": "user_view"},
+            {"type": "view", "qualified_name": "order_view"},
+            {"type": "materialized_view", "qualified_name": "sales_mv"},
         ]
 
         assert len(result.result) == len(expected_result)
@@ -225,7 +225,7 @@ class TestDBFuncTool:
         result = scoped_db_func_tool.list_tables(include_views=True)
 
         assert result.success == 1
-        assert [item["name"] for item in result.result] == [
+        assert [item["qualified_name"] for item in result.result] == [
             "users",
             "orders",
             "user_view",
@@ -353,7 +353,7 @@ class TestDBFuncTool:
 
         allowed = tool.list_tables(database="analytics", schema_name="schema1", include_views=True)
         assert allowed.success == 1
-        assert [entry["name"] for entry in allowed.result] == ["orders", "users", "view1", "mv1"]
+        assert [entry["qualified_name"] for entry in allowed.result] == ["orders", "users", "view1", "mv1"]
         connector.get_tables.assert_called_with("", "analytics", "schema1")
         connector.get_views.assert_called_with("", "analytics", "schema1")
         connector.get_materialized_views.assert_called_with("", "analytics", "schema1")
@@ -738,7 +738,7 @@ class TestDBFuncTool:
         assert blocked_schema.result == []
 
         allowed_tables = tool.list_tables(catalog="cat1", database="analytics", schema_name="public")
-        assert [entry["name"] for entry in allowed_tables.result] == ["orders"]
+        assert [entry["qualified_name"] for entry in allowed_tables.result] == ["orders"]
 
         blocked_tables = tool.list_tables(catalog="cat1", database="analytics", schema_name="marketing")
         assert blocked_tables.result == []
@@ -947,7 +947,7 @@ class TestScopedContextFromSubAgentConfig:
         """list_tables should only return in-scope tables."""
         result = scoped_tool.list_tables(database="db1", schema_name="schema1")
         assert result.success == 1
-        names = [entry["name"] for entry in result.result]
+        names = [entry["qualified_name"] for entry in result.result]
         assert "orders" in names
         assert "users" not in names
 


### PR DESCRIPTION
## Why

`list_tables` returned each entry under a bare `name` field. When a caller listed tables without fully scoping the namespace (no schema, or neither db nor schema), that bare name was ambiguous: the model could not tell which db/schema a table lived in, nor build a valid qualified reference for a follow-up query.

## Solution

Replace the `name` field with `qualified_name`, formatted as `[db.][schema.]table`. Only the namespace levels the caller did **not** pass are prefixed:

- caller passed neither db nor schema → `db.schema.table`
- caller passed db but not schema → `schema.table`
- caller passed both → `table` (bare)

Key decisions / tradeoffs:

- **Query scope is unchanged** — no extra namespace enumeration or N+1 queries. The qualified name is assembled from the db/schema coordinates the connector already resolved for the rows it returns.
- The actual name assembly lives in the connectors (datus-db-adapters, see companion PR below). In this repo: `DuckDBConnector` gains the same qualification, `list_tables` exposes `qualified_name`, scope filtering (`_filter_table_entries`) reads `qualified_name`, and the CLI tool-content renderer recognizes the new field.
- `name` is replaced outright (no dual-field backward-compat), per the desired single-field contract.

Companion adapters PR (required for non-DuckDB datasources): Datus-ai/datus-db-adapters#75

## Test Cases

Manually verified end-to-end against a live Snowflake datasource: no args → `AWS_PUBLIC_BLOCKCHAIN.RAW.ETH_BLOCKS_EXT`, db only → `RAW.ETH_BLOCKS_EXT`, db+schema → `ETH_BLOCKS_EXT`.

Tests migrated to `qualified_name`:
- Unit (`tests/unit_tests/tools/db_tools/test_db_func_tools.py`): mocked connectors return bare names, so the asserted key changed from `name` to `qualified_name` with unchanged values. Full unit suite: **15389 passed, 0 failed**.
- Integration/acceptance (`tests/integration/tools/test_func_tools_db.py`, `tests/integration/adapters/test_*.py`): unscoped `list_tables()` now yields qualified names, so membership checks compare the leaf segment (`split(".")[-1]`) to stay correct under `[db.][schema.]table`. These require live datasources and were not executed in this environment.
