### PR TITLE
[BugFix] Gate hosted web tools to official endpoints; fix kimi server_tool_use crash

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -673,7 +673,7 @@ class ClaudeModel(OpenAICompatibleModel):
                 # web_search_tool_result / web_fetch_tool_result content blocks),
                 # so they are NOT registered in func_tool_map.
                 builtin_web = kwargs.get("builtin_web_tools") or {}
-                if builtin_web.get("web_search"):
+                if builtin_web.get("web_search") and self.supports_builtin_web_search():
                     tools.append({"type": "web_search_20250305", "name": "web_search", "max_uses": 5})
                 if builtin_web.get("web_fetch") and self.supports_builtin_web_fetch():
                     tools.append({"type": "web_fetch_20250910", "name": "web_fetch", "max_uses": 5})
@@ -764,6 +764,11 @@ class ClaudeModel(OpenAICompatibleModel):
                     emitted_server_ids: set = set()
                     server_tool_names: dict = {}
                     server_tool_queries: dict = {}
+                    # Track the most recent server-tool start id so a result block
+                    # whose ``tool_use_id`` is ``None`` (malformed proxies) pairs back
+                    # to the generated ``srv_*`` id instead of collapsing onto
+                    # ``complete_None`` (which ActionHistoryManager would dedupe away).
+                    last_server_tool_id: Optional[str] = None
                     if self.async_anthropic_client is not None:
                         # Streaming path: yield text deltas as ``thinking_delta``
                         # ActionHistory in real time (parity with
@@ -794,6 +799,7 @@ class ClaudeModel(OpenAICompatibleModel):
                                         sname = getattr(block_start, "name", None) or "web_search"
                                         server_tool_names[sid] = sname
                                         emitted_server_ids.add(sid)
+                                        last_server_tool_id = sid
                                         s_input = getattr(block_start, "input", {}) or {}
                                         if isinstance(s_input, dict):
                                             server_tool_queries[sid] = str(
@@ -809,7 +815,16 @@ class ClaudeModel(OpenAICompatibleModel):
                                             status=ActionStatus.PROCESSING,
                                         )
                                     elif bs_type in ("web_search_tool_result", "web_fetch_tool_result"):
-                                        tid = getattr(block_start, "tool_use_id", None)
+                                        # Malformed proxies (e.g. kimi) echo a result
+                                        # block with a null ``tool_use_id``; fall back
+                                        # to the matching start's generated id so the
+                                        # completion pairs with it and never collapses
+                                        # onto ``complete_None``.
+                                        tid = (
+                                            getattr(block_start, "tool_use_id", None)
+                                            or last_server_tool_id
+                                            or f"srv_{uuid.uuid4().hex[:8]}"
+                                        )
                                         sname = server_tool_names.get(tid, "web_search")
                                         summary, canonical = summarize_web_tool_result(
                                             block_start, query=server_tool_queries.get(tid, "")

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -30,6 +30,7 @@ from agents.tool_context import ToolContext
 from agents.usage import InputTokensDetails, OutputTokensDetails, RequestUsage
 
 from datus.configuration.agent_config import ModelConfig
+from datus.models.litellm_adapter import is_official_anthropic_endpoint
 from datus.models.mcp_utils import multiple_mcp_servers
 from datus.models.openai_compatible import OpenAICompatibleModel
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
@@ -275,8 +276,13 @@ class ClaudeModel(OpenAICompatibleModel):
 
     def supports_builtin_web_search(self) -> bool:
         # Anthropic web_search_20250305 (GA) runs server-side via the native path,
-        # which is available for both OAuth and API-key auth. Prefer it over Tavily.
-        return True
+        # which is available for both OAuth and API-key auth. Gate on the official
+        # ``api.anthropic.com`` host: third-party Claude-compatible proxies (e.g.
+        # ``kimi_coding`` at ``api.kimi.com/coding``) share ``type: claude`` but do
+        # not really support the hosted tool — they return malformed
+        # ``server_tool_use`` blocks (missing ``id``) or an empty stub, so those
+        # endpoints fall back to the local Tavily backend instead.
+        return is_official_anthropic_endpoint(self._get_base_url())
 
     def supports_builtin_web_fetch(self) -> bool:
         # web_fetch is served by the LOCAL httpx backend (``web_tool.web_fetch``)
@@ -918,19 +924,32 @@ class ClaudeModel(OpenAICompatibleModel):
 
                     # Surface server-side tool calls (Anthropic web_search /
                     # web_fetch) as TOOL ActionHistory. The streaming path already
-                    # emits these in real time (tracked in ``emitted_server_ids``);
-                    # this post-stream pass only covers the non-streaming fallback,
-                    # so it skips ids already emitted to avoid duplicates.
+                    # emits these in real time (tracked in ``emitted_server_ids``),
+                    # so this post-stream pass only covers the non-streaming
+                    # fallback. When streaming ran we skip it entirely: dedup-by-id
+                    # is unreliable for providers (e.g. kimi) that return
+                    # ``server_tool_use`` blocks with a null ``id`` — the streaming
+                    # path substitutes a generated ``srv_*`` id, leaving the
+                    # final-message block's ``id`` as ``None``, which would miss the
+                    # ``emitted_server_ids`` check and re-emit here with
+                    # ``action_id=None`` (crashing ActionHistory validation).
+                    used_streaming = self.async_anthropic_client is not None
                     server_results = {
                         getattr(b, "tool_use_id", None): b
                         for b in message
                         if getattr(b, "type", None) in ("web_search_tool_result", "web_fetch_tool_result")
                     }
                     for block in message:
+                        if used_streaming:
+                            break
                         if getattr(block, "type", None) != "server_tool_use":
                             continue
                         if block.id in emitted_server_ids:
                             continue
+                        # Fall back to a generated id when the provider omits one,
+                        # mirroring the streaming path, so ActionHistory never sees
+                        # a ``None`` action_id.
+                        sid = block.id or f"srv_{uuid.uuid4().hex[:8]}"
                         block_input = getattr(block, "input", {}) or {}
                         s_args = json.dumps(block_input, ensure_ascii=False)[:80]
                         q = (
@@ -940,7 +959,7 @@ class ClaudeModel(OpenAICompatibleModel):
                         )
                         summary, canonical = summarize_web_tool_result(server_results.get(block.id), query=q)
                         start_action = ActionHistory(
-                            action_id=block.id,
+                            action_id=sid,
                             role=ActionRole.TOOL,
                             messages=f"Tool call: {block.name}('{s_args}...')",
                             action_type=block.name,
@@ -952,7 +971,7 @@ class ClaudeModel(OpenAICompatibleModel):
                             action_history_manager.add_action(start_action)
                         yield start_action
                         complete_action = ActionHistory(
-                            action_id=f"complete_{block.id}",
+                            action_id=f"complete_{sid}",
                             role=ActionRole.TOOL,
                             messages=f"Tool call: {block.name}('{s_args}...')",
                             action_type=block.name,

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -458,7 +458,7 @@ class CodexModel(LLMBaseModel):
                 agent_kwargs["mcp_servers"] = list(connected_servers.values())
             if tools:
                 agent_kwargs["tools"] = tools
-            if (kwargs.get("builtin_web_tools") or {}).get("web_search"):
+            if (kwargs.get("builtin_web_tools") or {}).get("web_search") and self.supports_builtin_web_search():
                 agent_kwargs["tools"] = [*(agent_kwargs.get("tools") or []), WebSearchTool()]
             if kwargs.get("hooks"):
                 agent_kwargs["hooks"] = kwargs["hooks"]
@@ -548,7 +548,7 @@ class CodexModel(LLMBaseModel):
                 agent_kwargs["mcp_servers"] = list(connected_servers.values())
             if tools:
                 agent_kwargs["tools"] = tools
-            if (kwargs.get("builtin_web_tools") or {}).get("web_search"):
+            if (kwargs.get("builtin_web_tools") or {}).get("web_search") and self.supports_builtin_web_search():
                 agent_kwargs["tools"] = [*(agent_kwargs.get("tools") or []), WebSearchTool()]
             if hooks:
                 agent_kwargs["hooks"] = hooks

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -11,6 +11,7 @@ import time
 import uuid
 from contextlib import nullcontext
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 from agents import Agent, ModelSettings, Runner, SQLiteSession, Tool, WebSearchTool
 from agents.exceptions import MaxTurnsExceeded
@@ -110,8 +111,16 @@ class CodexModel(LLMBaseModel):
         self._prompt_cache_keys: Dict[str, str] = {}
 
     def supports_builtin_web_search(self) -> bool:
-        # OpenAI Responses API exposes a hosted ``web_search`` tool.
-        return True
+        # OpenAI Responses API exposes a hosted ``web_search`` tool, but only the
+        # official ChatGPT Codex backend (``chatgpt.com/backend-api/codex``) honors
+        # it. A custom ``base_url`` points at a third-party relay that may not
+        # support the hosted tool, so gate on the official host and fall back to
+        # the local Tavily backend otherwise.
+        try:
+            hostname = (urlparse(self._base_url).hostname or "").lower() if self._base_url else ""
+        except Exception:
+            return False
+        return hostname == "chatgpt.com"
 
     def supports_builtin_web_fetch(self) -> bool:
         # OpenAI Responses has no hosted fetch tool; web_fetch uses the local backend.

--- a/datus/models/litellm_adapter.py
+++ b/datus/models/litellm_adapter.py
@@ -71,6 +71,26 @@ def is_official_openai_endpoint(provider: Optional[str], base_url: Optional[str]
     return hostname == "api.openai.com"
 
 
+def is_official_anthropic_endpoint(base_url: Optional[str]) -> bool:
+    """True iff ``base_url`` resolves to Anthropic's hosted API (``api.anthropic.com``).
+
+    A missing ``base_url`` implies the Anthropic SDK default
+    (``https://api.anthropic.com``). Any other host is treated as a third-party
+    Claude-compatible proxy (e.g. ``kimi_coding``'s ``api.kimi.com/coding``,
+    self-hosted gateways). Those advertise Anthropic compatibility but do NOT
+    honor Anthropic's server-side tools (``web_search_20250305``): they either
+    ignore the tool or echo back malformed ``server_tool_use`` blocks with a
+    missing ``id``, so callers must not inject the hosted tool for them.
+    """
+    if not base_url:
+        return True
+    try:
+        hostname = (urlparse(base_url).hostname or "").lower()
+    except Exception:
+        return False
+    return hostname == "api.anthropic.com"
+
+
 def is_known_non_thinking_model(provider: Optional[str], model_name: Optional[str]) -> bool:
     """Return True only when the (provider, model) is on the deny-list.
 

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -29,11 +29,19 @@ def test_base_defaults_false():
     assert LLMBaseModel.supports_builtin_web_fetch(s) is False
 
 
-def test_codex_search_yes_fetch_no():
-    s = Mock()
-    # OpenAI Responses exposes hosted web_search but no hosted fetch.
-    assert CodexModel.supports_builtin_web_search(s) is True
-    assert CodexModel.supports_builtin_web_fetch(s) is False
+def test_codex_search_yes_only_on_official_endpoint():
+    # OpenAI Responses exposes hosted web_search but no hosted fetch — and the
+    # hosted tool is only honored by the official ChatGPT Codex host. A custom
+    # base_url (third-party relay) must fall back to the local backend.
+    official = Mock()
+    official._base_url = "https://chatgpt.com/backend-api/codex"
+    assert CodexModel.supports_builtin_web_search(official) is True
+    assert CodexModel.supports_builtin_web_fetch(official) is False
+
+    proxy = Mock()
+    proxy._base_url = "https://my-proxy.example.com/codex"
+    assert CodexModel.supports_builtin_web_search(proxy) is False
+    assert CodexModel.supports_builtin_web_fetch(proxy) is False
 
 
 def test_openai_search_yes_only_on_official_endpoint():
@@ -57,14 +65,23 @@ def test_openai_search_yes_only_on_official_endpoint():
 
 
 def test_claude_search_server_fetch_local():
-    s = Mock()
-    # web_search runs server-side (Anthropic web_search_20250305, GA). web_fetch
-    # is served by the LOCAL httpx backend instead of the hosted
-    # web_fetch_20250910: the hosted tool emits server_tool_use blocks whose
-    # rehydrated form carries an output-only ``citations`` field the message
-    # input schema rejects on replay (400), so we keep fetch local.
-    assert ClaudeModel.supports_builtin_web_search(s) is True
-    assert ClaudeModel.supports_builtin_web_fetch(s) is False
+    # web_search runs server-side (Anthropic web_search_20250305, GA) — but only
+    # on the official api.anthropic.com host. Third-party Claude-compatible
+    # proxies (e.g. kimi_coding at api.kimi.com/coding) share type:claude yet
+    # return malformed hosted-tool blocks, so they fall back to the local
+    # backend. web_fetch is ALWAYS served by the LOCAL httpx backend instead of
+    # the hosted web_fetch_20250910: the hosted tool emits server_tool_use blocks
+    # whose rehydrated form carries an output-only ``citations`` field the
+    # message input schema rejects on replay (400), so we keep fetch local.
+    official = Mock()
+    official._get_base_url.return_value = "https://api.anthropic.com"
+    assert ClaudeModel.supports_builtin_web_search(official) is True
+    assert ClaudeModel.supports_builtin_web_fetch(official) is False
+
+    proxy = Mock()
+    proxy._get_base_url.return_value = "https://api.kimi.com/coding/"
+    assert ClaudeModel.supports_builtin_web_search(proxy) is False
+    assert ClaudeModel.supports_builtin_web_fetch(proxy) is False
 
 
 def test_describe_hosted_tool_item_web_search_dict():

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -2496,6 +2496,110 @@ class TestGenerateWithMcpStreamTextDeltas:
         assert "final_response" in persisted_types
 
     @pytest.mark.asyncio
+    async def test_stream_null_id_server_tool_pairs_with_generated_id(self):
+        """Regression: malformed proxies (kimi) stream ``server_tool_use`` /
+        ``web_search_tool_result`` blocks with a null id. The completion must
+        reuse the start's generated ``srv_*`` id instead of collapsing onto
+        ``complete_None`` — otherwise ``ActionHistoryManager.add_action`` dedupes
+        a second null-id search away and the pair never matches the start.
+        """
+        from datus.schemas.action_history import ActionHistoryManager, ActionRole
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        def _srv_start(name="web_search"):
+            block = MagicMock()
+            block.type = "server_tool_use"
+            block.id = None  # provider omits the id
+            block.name = name
+            block.input = {"query": "datus"}
+            return block
+
+        def _srv_result():
+            block = MagicMock()
+            block.type = "web_search_tool_result"
+            block.tool_use_id = None  # provider omits the id
+            block.content = []
+            return block
+
+        # Two interleaved null-id server searches in one turn.
+        events = [
+            _FakeStreamEvent("content_block_start", content_block=_srv_start()),
+            _FakeStreamEvent("content_block_start", content_block=_srv_result()),
+            _FakeStreamEvent("content_block_start", content_block=_srv_start()),
+            _FakeStreamEvent("content_block_start", content_block=_srv_result()),
+        ]
+        final_msg = _make_response([_make_text_block("done")])
+        stream_manager = _FakeAsyncStreamManager(events, final_msg)
+
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        ahm = ActionHistoryManager()
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for action in model._generate_with_mcp_stream(
+                prompt="search the web",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                builtin_web_tools={"web_search": True},
+                action_history_manager=ahm,
+            ):
+                actions.append(action)
+
+        tool_actions = [a for a in actions if a.role == ActionRole.TOOL]
+        # Two starts (srv_*) + two completions (complete_srv_*) all surface.
+        starts = [a for a in tool_actions if a.action_id.startswith("srv_")]
+        completes = [a for a in tool_actions if a.action_id.startswith("complete_")]
+        assert len(starts) == 2
+        assert len(completes) == 2
+        # No action_id is None or collapses onto the bare ``complete_None`` id.
+        assert all(isinstance(a.action_id, str) and a.action_id for a in actions)
+        assert all(a.action_id != "complete_None" for a in completes)
+        # Each completion pairs with a distinct start's generated id.
+        assert {c.action_id for c in completes} == {f"complete_{s.action_id}" for s in starts}
+
+    @pytest.mark.asyncio
+    async def test_stream_proxy_endpoint_does_not_inject_hosted_web_search(self):
+        """A non-official Claude-compatible proxy (kimi) must NOT receive the
+        hosted ``web_search_20250305`` tool even when ``web_search`` is requested
+        — it falls back to the local Tavily backend instead.
+        """
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True, base_url="https://api.kimi.com/coding")
+        model = _make_claude_model(cfg)
+
+        final_msg = _make_response([_make_text_block("done")])
+        stream_manager = _FakeAsyncStreamManager([], final_msg)
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        ahm = ActionHistoryManager()
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt="search the web",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                builtin_web_tools={"web_search": True},
+                action_history_manager=ahm,
+            ):
+                pass
+
+        captured_tools = async_client.messages.stream.call_args.kwargs.get("tools", [])
+        tool_types = {t.get("type") for t in captured_tools if isinstance(t, dict)}
+        assert "web_search_20250305" not in tool_types
+
+    @pytest.mark.asyncio
     async def test_interrupt_during_stream_raises_execution_interrupted(self):
         """When ``interrupt_controller.is_interrupted`` is True during the stream
         loop, the generator must raise ``ExecutionInterrupted`` so the caller can

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -239,6 +239,33 @@ class TestGetBaseUrl:
         assert model._get_base_url() == "https://api.anthropic.com"
 
 
+class TestSupportsBuiltinWebSearch:
+    """Hosted ``web_search_20250305`` is gated on the official Anthropic host.
+
+    Third-party Claude-compatible proxies (e.g. ``kimi_coding`` at
+    ``api.kimi.com/coding``) share ``type: claude`` but return malformed
+    ``server_tool_use`` blocks for the hosted tool, so it must NOT be injected
+    for them — they fall back to the local Tavily backend.
+    """
+
+    def test_official_anthropic_enables_web_search(self):
+        model = _make_claude_model(_make_model_config(base_url="https://api.anthropic.com"))
+        assert model.supports_builtin_web_search() is True
+
+    def test_default_base_url_enables_web_search(self):
+        # base_url=None resolves to the Anthropic default host.
+        model = _make_claude_model(_make_model_config(base_url=None))
+        assert model.supports_builtin_web_search() is True
+
+    def test_kimi_coding_proxy_disables_web_search(self):
+        model = _make_claude_model(_make_model_config(base_url="https://api.kimi.com/coding/"))
+        assert model.supports_builtin_web_search() is False
+
+    def test_arbitrary_proxy_disables_web_search(self):
+        model = _make_claude_model(_make_model_config(base_url="https://myproxy.example.com/v1"))
+        assert model.supports_builtin_web_search() is False
+
+
 # ---------------------------------------------------------------------------
 # generate (litellm path vs native path)
 # ---------------------------------------------------------------------------
@@ -842,6 +869,55 @@ class TestGenerateWithMcpStream:
         assert set(srv) == {"type", "id", "name", "input"}
         result = next(b for b in assistant_blocks if b.get("type") == "web_search_tool_result")
         assert set(result) == {"type", "tool_use_id", "content"}
+
+    @pytest.mark.asyncio
+    async def test_server_tool_use_with_null_id_does_not_crash(self):
+        """Regression: a ``server_tool_use`` block with a missing ``id`` (as
+        ``kimi_coding``'s Anthropic-compatible endpoint returns for the hosted
+        web_search tool) must not crash ActionHistory validation.
+
+        The provider omits ``id`` / ``tool_use_id``, which the SDK parses as
+        ``None``. The post-stream server-tool pass used to build the action with
+        ``action_id=block.id`` (=None) and the dedup-by-id check missed it,
+        raising ``ValidationError: action_id Input should be a valid string``.
+        The fix substitutes a generated ``srv_*`` id so action_id is never None.
+        """
+        from datus.schemas.action_history import ActionHistoryManager, ActionRole
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        # Mirror the captured kimi response: server_tool_use + result both lack ids.
+        message_blocks = [
+            _make_server_tool_use_block(block_id=None),
+            _make_web_search_result_block(tool_use_id=None),
+            _make_text_block("done"),
+        ]
+        model.anthropic_client.messages.create.return_value = _make_response(message_blocks)
+
+        ahm = ActionHistoryManager()
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            # Must not raise pydantic ValidationError.
+            async for action in model._generate_with_mcp_stream(
+                prompt="select 1",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                builtin_web_tools={"web_search": True},
+                action_history_manager=ahm,
+            ):
+                actions.append(action)
+
+        # Every emitted action carries a valid non-None string action_id.
+        assert actions, "expected at least the final assistant action"
+        assert all(isinstance(a.action_id, str) and a.action_id for a in actions)
+        # The server tool was still surfaced with a generated fallback id.
+        tool_actions = [a for a in actions if a.role == ActionRole.TOOL]
+        assert tool_actions, "server_tool_use should still surface as a TOOL action"
+        assert all(a.action_id.startswith(("srv_", "complete_")) for a in tool_actions)
 
     @pytest.mark.asyncio
     async def test_tool_call_yields_processing_and_success(self):

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -742,6 +742,78 @@ class TestCodexSupportsBuiltinWebSearch:
         assert model.supports_builtin_web_search() is False
 
 
+class TestCodexBuiltinWebSearchInjection:
+    """The hosted ``WebSearchTool`` must only be injected when
+    ``supports_builtin_web_search()`` is True — i.e. on the official ChatGPT
+    Codex host. Custom relay hosts fall back to the local Tavily backend.
+    """
+
+    @pytest.mark.asyncio
+    @patch("datus.models.codex_model.OAuthManager")
+    @patch("datus.models.codex_model.multiple_mcp_servers")
+    @patch("datus.models.codex_model.Runner")
+    @patch("datus.models.codex_model.Agent")
+    async def test_official_host_injects_web_search_tool(
+        self, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
+    ):
+        from agents import WebSearchTool
+
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth_cls.return_value = MagicMock()
+        model = CodexModel(model_config=model_config)
+        model._async_client = MagicMock()
+
+        with (
+            patch("agents.models.openai_responses.OpenAIResponsesModel"),
+            patch("datus.models.codex_model.extract_sql_contexts", return_value=[]),
+        ):
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_runner.run_streamed.return_value = _mock_streamed_result("done", 1)
+
+            await model.generate_with_tools(prompt="test", builtin_web_tools={"web_search": True})
+
+        injected = mock_agent_cls.call_args.kwargs.get("tools") or []
+        assert any(isinstance(t, WebSearchTool) for t in injected)
+
+    @pytest.mark.asyncio
+    @patch("datus.models.codex_model.OAuthManager")
+    @patch("datus.models.codex_model.multiple_mcp_servers")
+    @patch("datus.models.codex_model.Runner")
+    @patch("datus.models.codex_model.Agent")
+    async def test_custom_proxy_does_not_inject_web_search_tool(
+        self, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls
+    ):
+        from agents import WebSearchTool
+
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth_cls.return_value = MagicMock()
+        config = ModelConfig(
+            type="codex",
+            api_key="",
+            model="gpt-5.3-codex",
+            base_url="https://my-proxy.example.com/codex",
+            auth_type="oauth",
+        )
+        model = CodexModel(model_config=config)
+        model._async_client = MagicMock()
+
+        with (
+            patch("agents.models.openai_responses.OpenAIResponsesModel"),
+            patch("datus.models.codex_model.extract_sql_contexts", return_value=[]),
+        ):
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_runner.run_streamed.return_value = _mock_streamed_result("done", 1)
+
+            await model.generate_with_tools(prompt="test", builtin_web_tools={"web_search": True})
+
+        injected = mock_agent_cls.call_args.kwargs.get("tools") or []
+        assert not any(isinstance(t, WebSearchTool) for t in injected)
+
+
 class TestCodexModelJsonOutput401Retry:
     @patch("datus.models.codex_model.OAuthManager")
     def test_json_output_401_retry(self, mock_oauth_cls, model_config):

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -702,6 +702,46 @@ class TestCodexModelBaseUrl:
         assert model._base_url == "https://my-proxy.example.com/codex"
 
 
+class TestCodexSupportsBuiltinWebSearch:
+    """Hosted ``web_search`` is gated on the official ChatGPT Codex host.
+
+    A custom ``base_url`` points at a third-party relay that may not support the
+    hosted tool, so it must fall back to the local Tavily backend.
+    """
+
+    @patch("datus.models.codex_model.OAuthManager")
+    def test_official_codex_enables_web_search(self, mock_oauth_cls, model_config):
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth_cls.return_value = MagicMock()
+        model = CodexModel(model_config=model_config)
+        assert model.supports_builtin_web_search() is True
+
+    @patch("datus.models.codex_model.OAuthManager")
+    def test_default_base_url_enables_web_search(self, mock_oauth_cls):
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth_cls.return_value = MagicMock()
+        config = ModelConfig(type="codex", api_key="", model="gpt-5.3-codex", auth_type="oauth")
+        model = CodexModel(model_config=config)
+        assert model.supports_builtin_web_search() is True
+
+    @patch("datus.models.codex_model.OAuthManager")
+    def test_custom_proxy_disables_web_search(self, mock_oauth_cls):
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth_cls.return_value = MagicMock()
+        config = ModelConfig(
+            type="codex",
+            api_key="",
+            model="gpt-5.3-codex",
+            base_url="https://my-proxy.example.com/codex",
+            auth_type="oauth",
+        )
+        model = CodexModel(model_config=config)
+        assert model.supports_builtin_web_search() is False
+
+
 class TestCodexModelJsonOutput401Retry:
     @patch("datus.models.codex_model.OAuthManager")
     def test_json_output_401_retry(self, mock_oauth_cls, model_config):

--- a/tests/unit_tests/models/test_litellm_adapter.py
+++ b/tests/unit_tests/models/test_litellm_adapter.py
@@ -16,6 +16,7 @@ from datus.models.litellm_adapter import (
     LiteLLMAdapter,
     create_litellm_adapter,
     is_known_non_thinking_model,
+    is_official_anthropic_endpoint,
 )
 
 
@@ -509,6 +510,38 @@ class TestIsKnownNonThinkingModel:
         assert is_known_non_thinking_model(None, "anything") is False
         assert is_known_non_thinking_model("deepseek", None) is False
         assert is_known_non_thinking_model(None, None) is False
+
+
+class TestIsOfficialAnthropicEndpoint:
+    """Only ``api.anthropic.com`` (or the SDK default, i.e. no base_url) counts as
+    official. Third-party Claude-compatible proxies must be rejected so the
+    hosted ``web_search_20250305`` tool is never injected for them."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            None,
+            "",
+            "https://api.anthropic.com",
+            "https://api.anthropic.com/v1",
+            "https://API.Anthropic.com",  # case-insensitive host
+        ],
+    )
+    def test_official_or_default(self, base_url):
+        assert is_official_anthropic_endpoint(base_url) is True
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.kimi.com/coding/",  # kimi_coding proxy
+            "https://api.moonshot.ai/anthropic",
+            "https://my-proxy.example.com/v1",
+            "https://anthropic.com.evil.example/v1",  # lookalike host
+            "not-a-url",
+        ],
+    )
+    def test_third_party_proxies_rejected(self, base_url):
+        assert is_official_anthropic_endpoint(base_url) is False
 
 
 class TestGetAgentsSdkModelRouting:


### PR DESCRIPTION
## Why

Running `datus -p` with a third-party Claude-compatible provider (`kimi_coding/kimi-k2.7-code`, served at `api.kimi.com/coding/`) crashed every turn:

```
chat interaction failed: 1 validation error for ActionHistory
action_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

Root cause confirmed by intercepting the HTTPS traffic (mitmproxy):

- These providers share `type: claude`, so Datus advertised support for Anthropic's server-side `web_search_20250305` tool and injected it into the request.
- `api.kimi.com/coding` does **not** really support the hosted tool. It echoes back a malformed, empty `server_tool_use` / `web_search_tool_result` pair **with a missing `id` / `tool_use_id`** (captured: the local `tool_use` block had an id, the web_search blocks did not).
- The SDK parses the missing id as `None`. The post-stream server-tool re-emission pass deduped by `block.id in emitted_server_ids` — which missed the `None`-id block (the streaming path had substituted a generated `srv_*` id) — so it rebuilt the action with `action_id=None` and `ActionHistory` validation raised.
- The same malformed blocks, once persisted and **replayed in a later turn**, also explain the intermittent `400 invalid_request_error` from the endpoint (the message input schema rejects a `server_tool_use` with a null `id`).

## Solution

- **Gate hosted web tools on the official endpoint.** Added `is_official_anthropic_endpoint()` (mirroring the existing `is_official_openai_endpoint`). `ClaudeModel.supports_builtin_web_search` now returns `True` only when `base_url` resolves to `api.anthropic.com`; `CodexModel.supports_builtin_web_search` only for `chatgpt.com`. Third-party proxies fall back to the local Tavily backend instead of the hosted tool. (`OpenAIModel` already gated on `_is_official_openai()`.)
- **Defensive crash fix in `claude_model.py`.** When streaming ran, skip the post-stream server-tool re-emission entirely (it was already emitted live), and fall back to a generated `srv_*` id for null block ids so `ActionHistory` never receives `None`.

Verified through the proxy after the fix: the request no longer carries `web_search_20250305`, no `server_tool_use` events are emitted, and the turn completes normally (executes `execute_sql`, returns the result).

## Test Cases

Unit tests (CI-tier, fully mocked — no network):

- `tests/unit_tests/models/test_litellm_adapter.py::TestIsOfficialAnthropicEndpoint` — official host / SDK default accepted; `api.kimi.com/coding`, lookalike hosts, and malformed URLs rejected.
- `tests/unit_tests/models/test_claude_model.py::TestSupportsBuiltinWebSearch` — official/default base_url enables web_search; kimi_coding and arbitrary proxies disable it.
- `tests/unit_tests/models/test_claude_model.py::TestGenerateWithMcpStream::test_server_tool_use_with_null_id_does_not_crash` — regression: a `server_tool_use` block with a missing id no longer crashes `ActionHistory`, and the tool still surfaces with a generated fallback id.
- `tests/unit_tests/models/test_codex_model.py::TestCodexSupportsBuiltinWebSearch` — official ChatGPT host enables web_search; custom proxy disables it.

All 296 model unit tests pass. `ci/audit_tests.py --diff-only` reports P0=0 P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
## Summary by CodeRabbit

* **Bug Fixes**
  * Web search support now appears only for official hosted providers, avoiding incorrect availability on custom proxy endpoints.
  * Improved handling of streaming tool activity so missing tool IDs no longer cause failures during action history creation.
  * When tool IDs are absent, fallback IDs are generated consistently to keep actions valid and traceable.

* **Tests**
  * Added coverage for web search detection across official, default, and proxy base URLs.
  * Added regression tests for streaming tool events with missing IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited built-in web search to official hosted endpoints for both Claude and Codex, preventing web search from being enabled for custom proxy/relay base URLs.
  * Fixed native tool-streaming and post-stream handling to avoid crashes and incorrect action-history pairing when tool/block IDs are missing or null.
  * Added robust fallback action identifiers to keep emitted tool actions consistently valid.

* **Tests**
  * Expanded unit tests for web search capability detection (official, default, and proxy base URLs).
  * Added regression tests covering streaming stability and correct `server_tool_use`/result pairing when IDs are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->