### PR TITLE
[Enhancement] Add semantic SQL history profiler skill

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -49,7 +49,7 @@ class GenMetricsAgenticNode(AgenticNode):
     result_class = SemanticNodeResult
 
     # Define-metric workflow scoped to ``gen_metrics`` via SKILL.md allowed_agents.
-    DEFAULT_SKILLS = "gen-metrics, gen-semantic-model"
+    DEFAULT_SKILLS = "gen-metrics, metricflow-semantic-authoring"
 
     def __init__(
         self,

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -43,7 +43,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
     NODE_NAME = "gen_semantic_model"
     result_class = SemanticNodeResult
-    DEFAULT_SKILLS = "gen-semantic-model"
+    DEFAULT_SKILLS = "metricflow-semantic-authoring"
 
     def __init__(
         self,
@@ -156,11 +156,29 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 logger.warning("DBFuncTool not initialized, skipping semantic discovery tools setup")
                 return
 
-            self.semantic_discovery_tools = SemanticDiscoveryTools(self.db_func_tool)
+            self.semantic_discovery_tools = SemanticDiscoveryTools(
+                self.db_func_tool,
+                enable_semantic_model_profiler=self._semantic_sql_history_profiler_enabled(),
+            )
             self.tools.extend(self.semantic_discovery_tools.available_tools())
             logger.debug("Added semantic discovery tools from SemanticDiscoveryTools")
         except Exception as e:
             logger.error(f"Failed to setup semantic discovery tools: {e}")
+
+    def _semantic_sql_history_profiler_enabled(self) -> bool:
+        """Return true when the optional profiler skill is visible to this node."""
+        if not self.skill_manager:
+            return False
+        skill_patterns_str = self.node_config.get("skills", "")
+        if not skill_patterns_str:
+            return False
+        skill_patterns = self.skill_manager.parse_skill_patterns(skill_patterns_str)
+        skills = self.skill_manager.get_available_skills(
+            self.get_node_name(),
+            patterns=skill_patterns,
+            node_class=self.get_node_class_name(),
+        )
+        return any(skill.name == "semantic-sql-history-profiler" for skill in skills)
 
     def _setup_semantic_tools(self):
         """Setup semantic function tools (for querying metrics via adapters)."""

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -261,6 +261,7 @@ _TOOL_ARGS_FORMATTERS: Dict[str, Callable[[dict], str]] = {
     "render_reference_template": lambda a: _format_positional(a, "template_id", "name"),
     "execute_reference_template": lambda a: _format_positional(a, "template_id", "name"),
     # Semantic discovery tools
+    "profile_semantic_model_evidence": lambda a: _format_kw(a, "query_text", "tables", "profile_mode"),
     "analyze_metric_candidates_from_history": lambda a: _format_kw(a, "query_text", "tables", "sample_sql_queries"),
     # Platform document tools
     "list_document_nav": lambda _a: "",
@@ -1935,6 +1936,27 @@ def _build_analyze_columns(action: ActionHistory, verbose: bool) -> ToolCallCont
     return tc
 
 
+def _build_profile_semantic_model_evidence(action: ActionHistory, verbose: bool) -> ToolCallContent:
+    """profile_semantic_model_evidence: show profiled table count."""
+    tc = make_base_content(action)
+    if verbose:
+        tc.args_lines = extract_args_markup(action)
+        if action.output:
+            tc.output_lines = _format_result_only_markup(action.output)
+    else:
+        data = parse_output_data(action.output)
+        if data:
+            result = data.get("result")
+            if isinstance(result, dict):
+                tables = result.get("tables", {})
+                count = len(tables) if isinstance(tables, dict) else 0
+                noun = "table" if count == 1 else "tables"
+                tc.compact_result = f"{count} {noun} profiled"
+                if result.get("data_profiled"):
+                    tc.compact_result += ", data sampled"
+    return tc
+
+
 def _build_analyze_metric_candidates(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """analyze_metric_candidates_from_history: show mined metric candidate count."""
     tc = make_base_content(action)
@@ -2149,6 +2171,7 @@ class ToolCallContentBuilder:
         self._registry["analyze_table_relationships"] = _build_analyze_relationships
         self._registry["get_multiple_tables_ddl"] = _build_get_multiple_ddl
         self._registry["analyze_column_usage_patterns"] = _build_analyze_columns
+        self._registry["profile_semantic_model_evidence"] = _build_profile_semantic_model_evidence
         self._registry["analyze_metric_candidates_from_history"] = _build_analyze_metric_candidates
 
         # Skill tools

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -217,7 +217,8 @@ def _summary_from_registry(action: ActionHistory, function_name: str) -> str:
     if action.status != ActionStatus.SUCCESS or not action.output:
         return ""
     output = action.output if isinstance(action.output, dict) else {}
-    summary = TOOL_SUMMARY_REGISTRY.summarize_dict(output, function_name)
+    data = parse_output_data(output) or output
+    summary = TOOL_SUMMARY_REGISTRY.summarize_dict(data, function_name)
     if not summary or summary in ("Empty result", "OK"):
         return ""
     return summary
@@ -1944,16 +1945,7 @@ def _build_profile_semantic_model_evidence(action: ActionHistory, verbose: bool)
         if action.output:
             tc.output_lines = _format_result_only_markup(action.output)
     else:
-        data = parse_output_data(action.output)
-        if data:
-            result = data.get("result")
-            if isinstance(result, dict):
-                tables = result.get("tables", {})
-                count = len(tables) if isinstance(tables, dict) else 0
-                noun = "table" if count == 1 else "tables"
-                tc.compact_result = f"{count} {noun} profiled"
-                if result.get("data_profiled"):
-                    tc.compact_result += ", data sampled"
+        tc.compact_result = _summary_from_registry(action, "profile_semantic_model_evidence")
     return tc
 
 

--- a/datus/prompts/prompt_templates/_semantic_sql_history_profiler_gate.j2
+++ b/datus/prompts/prompt_templates/_semantic_sql_history_profiler_gate.j2
@@ -1,0 +1,5 @@
+## Optional Historical SQL Profiling
+- If `<available_skills>` includes `semantic-sql-history-profiler` and the request includes historical SQL or success-story SQL, call `load_skill("semantic-sql-history-profiler")` before schema sampling, per-table column-usage analysis, ad hoc `execute_sql` sampling, YAML authoring, or any `write_file` call.
+- After loading the skill, call `profile_semantic_model_evidence` before deciding identifiers, relationships, dimensions, time fields, measures, or field descriptions.
+- When historical SQL is provided inline, pass every provided SQL statement via `sql_entries_json` or `sql_queries`; do not choose only representative examples. Use `query_text` only when direct SQL text is unavailable and existing reference SQL must be searched.
+- Use profiler evidence to choose the semantic model shape and to include compact distribution notes in descriptions when useful.

--- a/datus/prompts/prompt_templates/gen_metrics_osi_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_osi_system_1.0.j2
@@ -7,7 +7,7 @@ CRITICAL MODEL RULE - **build the model once, then only add metrics**:
 - The datasets and relationships are owned by the semantic-model step and are ALREADY built.
 - The semantic model file is the durable OSI domain document. Load it, preserve existing datasets and relationships, and append metrics under `semantic_model[0].metrics`.
 - A given logical dataset has one canonical definition shared by all metrics. Reuse that dataset by name in each metric's DATUS `dataset` hint.
-- This is the OSI authoring path. Do NOT load or follow generic MetricFlow `gen-metrics` / `gen-semantic-model` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
+- This is the OSI authoring path. Do NOT load or follow MetricFlow `gen-metrics` / `metricflow-semantic-authoring` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
 
 {% set target_model_name = default_osi_semantic_model_name | default('<model_name>', true) %}
 {% set target_model_file = default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) %}

--- a/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_1.2.j2
@@ -81,7 +81,7 @@ Before generating metrics, verify that semantic models exist for all involved ta
 1. **Extract table names** from SQL queries or user description
 2. **Check each table** using `check_semantic_object_exists(name="{table_name}", kind="table")`
 3. **If any table is missing a semantic model**:
-   - Follow the `gen-semantic-model` skill workflow when available
+   - Follow the `metricflow-semantic-authoring` skill workflow when available
    - Use `describe_table(table_name)` to inspect the real table structure
    - Use `analyze_table_relationships(tables=[...])` to discover foreign key relationships between tables
    - Use `analyze_column_usage_patterns(table_name)` to understand historical query patterns

--- a/datus/prompts/prompt_templates/gen_semantic_model_osi_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_osi_system_1.0.j2
@@ -1,7 +1,11 @@
 You are a semantic modeling expert. Your task is to describe tables as strict **OSI (Open Semantic Interchange) core schema** documents plus Datus business hints.
 
 CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow `data_source:`, `measures:`, `identifiers:`, `agg_time_dimension`, `create_metric`, or any execution-engine YAML. The Datus OSI compiler lowers OSI core documents to the configured backend.
-This is the OSI authoring path. Do NOT load or follow generic MetricFlow `gen-semantic-model` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
+This is the OSI authoring path. Do NOT load or follow MetricFlow `metricflow-semantic-authoring` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
+
+The MetricFlow-skill restriction above does not apply to `semantic-sql-history-profiler`.
+{% include "_semantic_sql_history_profiler_gate.j2" %}
+
 
 {% set target_model_name = default_osi_semantic_model_name | default('<model_name>', true) %}
 {% set target_model_file = default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) %}
@@ -68,7 +72,7 @@ semantic_model:
    - `ai_context` is for AI use: include `instructions`, optional `synonyms`, and optional `examples`. The instructions should explain when to use this dataset, the row grain, the primary time field, important row-selection or grouping columns, and relationship caveats. Keep it generic and derived from schema/comments/history; do not write scenario-specific examples unless they come from provided history.
 7. **Primary / unique keys** -> OSI core `primary_key: [<column>]`. Use real columns only.
 8. **Time dimension**: mark the primary date/time field with `dimension.is_time: true` and Datus extension `{"type":"time","time_granularity":"day|week|month|quarter|year"}`. Point it at a real date/time column, never a numeric surrogate key.
-9. **Fields**: include every business-meaningful column the user may group or slice by. Populate `description` for ALL non-obvious fields by combining the column comment, sample values, and external knowledge. Wrap descriptions in double quotes.
+9. **Fields**: include every business-meaningful column the user may group or slice by. Populate `description` for ALL non-obvious fields by combining the column comment, sample values, profiler evidence, and external knowledge. Useful profiler evidence may include null rate, numeric ranges/percentiles, date span/freshness/duration, distinct counts, representative stable values, common filter templates, and relationship coverage/fanout. Wrap descriptions in double quotes and keep each description concise.
 10. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
 11. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
 12. Preserve literal values and column names exactly; do not invent columns.

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_1.1.j2
@@ -24,8 +24,10 @@ When user mentions multiple tables (e.g., "orders, customers, products"), you sh
 Please strictly follow the instructions below:
 
 **Skill-first workflow**:
-- Before starting generation, check `<available_skills>` for `gen-semantic-model`.
-- If available, call `load_skill("gen-semantic-model")` and follow it.
+- Before starting generation, check `<available_skills>`.
+{% include "_semantic_sql_history_profiler_gate.j2" %}
+
+- If `<available_skills>` includes `metricflow-semantic-authoring`, call `load_skill("metricflow-semantic-authoring")` and follow it. If the profiler gate applies, also follow the profiler skill before writing YAML.
 - Continue to use the rules below for detailed YAML structure and output format.
 
 0. **Clarify blocking ambiguity first**:
@@ -44,15 +46,15 @@ Please strictly follow the instructions below:
 
 2. **Analyze column usage patterns** (STRONGLY RECOMMENDED):
    - Use `analyze_column_usage_patterns(table_name)` to discover how columns are used in historical SQL queries
-   - This reveals filter operators (LIKE, IN, FIND_IN_SET, etc.), functions, and **actual filter examples** commonly used with each column
+   - This reveals filter operators, functions, and **actual filter examples** commonly used with each column
    - Example output:
      ```json
      {
        "column_patterns": {
-         "tags": {
-           "operators": ["LIKE"],
-           "functions": ["FIND_IN_SET"],
-           "usage_description": "Use FIND_IN_SET() for queries. Commonly filtered with LIKE"
+         "status": {
+           "operators": ["=", "IN"],
+           "functions": [],
+           "usage_description": "Commonly filtered with = and IN"
          }
        }
      }
@@ -70,15 +72,16 @@ Please strictly follow the instructions below:
    - **CRITICAL**: Populate `description` fields for ALL measures, dimensions, and identifiers by **COMBINING ALL** available information:
      - Start with DDL comments (preserve original language)
      - Append usage patterns and **filter examples** from `analyze_column_usage_patterns`
+     - Append compact observed distribution evidence from `profile_semantic_model_evidence` when available: null rate, numeric ranges and percentiles, date spans/freshness/duration, distinct counts, representative stable values, referential coverage, common filter templates, and enum/code mappings
      - Append Enum-like patterns (e.g., "status: 1=Active, 2=Inactive")
-   - **Describe what a column means, not how to query it.** Capture business meaning — term, encodings, term→column mappings; do not embed query directives for the reader to execute. Facts that need verifying against data belong in a knowledge atom, not the model description.
+   - **Describe what a column means first, then add concise observed evidence.** Capture business meaning, encodings, term→column mappings, and compact profiler observations. Avoid long SQL snippets or procedural query instructions; mention operator/function usage only when it is directly supported by evidence and helps interpret the column.
    - **YAML String Quoting Rule**: ALWAYS wrap `description` values in double quotes (`"`). Escape special characters: `"` → `\"`, `\` → `\\`.
    - **Example dimension with usage pattern**:
      ```yaml
-     - name: tags
+     - name: status
        type: CATEGORICAL
-       expr: tags
-       description: "Product tags (comma-separated). Use FIND_IN_SET() for tag membership checks. Examples: FIND_IN_SET('vip', tags)"
+       expr: status
+       description: "Order status; commonly filtered with =/IN; representative values include paid/refund"
      ```
    - **NO TRANSLATION**: Ensure all descriptions match the original DDL comments exactly. If the comment is in Chinese, the description MUST be in Chinese.
    - **Time dimension correctness**:
@@ -131,9 +134,9 @@ Use `get_multiple_tables_ddl` to get all table DDLs.
 
 ### Step 2.5: Analyze Column Usage Patterns (STRONGLY RECOMMENDED)
 For each table, call `analyze_column_usage_patterns(table_name)` to discover:
-- Filter operators commonly used (LIKE, IN, FIND_IN_SET, etc.)
-- Functions applied to columns (JSON_EXTRACT, REGEXP, etc.)
-- **Actual historical filter examples** (e.g. "tags LIKE '%vip%'")
+- Filter operators commonly used by historical SQL
+- Functions applied to columns
+- **Actual historical filter examples**
 - This helps generate much better dimension descriptions with concrete usage hints
 
 ### Step 3: Discover Table Relationships (CRITICAL)
@@ -162,8 +165,8 @@ For each table, call `check_semantic_object_exists` to avoid duplicates.
 Create one YAML file per table with proper identifier definitions:
 - **CRITICAL**: Extract `description` from DDL column comments for ALL fields. **DO NOT TRANSLATE**.
 - **RECOMMENDED**: Enrich dimension descriptions with usage patterns from `analyze_column_usage_patterns`:
-  - Append usage hints like "Use FIND_IN_SET() for filtering" or "Commonly filtered with LIKE"
-  - Example: "Product tags (comma-separated). Use FIND_IN_SET() for tag membership checks"
+  - Append concise usage hints only when they are backed by historical evidence, such as common equality/range/text-search filters or function-based predicates.
+  - Keep examples short and redacted; do not paste long SQL fragments.
 - Use `entity` field to reference other tables (singular form: customer, not customers).
 - `type: PRIMARY` for the table's primary key.
 - `type: FOREIGN` for columns that join to other tables.

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -148,7 +148,7 @@ For each table involved in the metric:
 
 ### 2b. Create Missing Model
 
-If the semantic model is missing, follow the `gen-semantic-model` workflow when that skill is available. In brief: inspect table structure with `describe_table`, discover joins with `analyze_table_relationships` when multiple tables are involved, use `analyze_column_usage_patterns` for likely measures and dimensions, write the semantic model YAML under the semantic model directory shown in the system prompt, then run `validate_semantic` and fix issues until it passes before continuing.
+If the semantic model is missing, follow the `metricflow-semantic-authoring` workflow when that skill is available. In brief: inspect table structure with `describe_table`, discover joins with `analyze_table_relationships` when multiple tables are involved, use `analyze_column_usage_patterns` for likely measures and dimensions, write the semantic model YAML under the semantic model directory shown in the system prompt, then run `validate_semantic` and fix issues until it passes before continuing.
 
 ### 2c. Multi-Table / JOIN SQL Modeling
 

--- a/datus/resources/skills/metricflow-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/metricflow-semantic-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: gen-semantic-model
-description: Generate MetricFlow semantic models from database tables with validation and Knowledge Base publishing
+name: metricflow-semantic-authoring
+description: Author MetricFlow semantic model YAML from database tables with validation and Knowledge Base publishing
 tags:
   - semantic-model
   - metricflow
@@ -12,7 +12,7 @@ allowed_agents:
   - gen_metrics
 ---
 
-# Generate Semantic Model Skill
+# MetricFlow Semantic Authoring
 
 Create production-ready MetricFlow semantic model YAML for one or more database tables, validate it, and publish it to the Knowledge Base.
 
@@ -22,8 +22,16 @@ Create production-ready MetricFlow semantic model YAML for one or more database 
    - Identify the table or tables from the user request.
    - Use `describe_table` and relationship tools as needed.
    - Use `ask_user` only when a critical modeling choice cannot be inferred.
+   - If the request includes historical SQL or success-story SQL and the `semantic-sql-history-profiler`
+     skill is available, load that skill and call `profile_semantic_model_evidence` before modeling
+     columns or writing YAML.
+   - Pass every provided historical SQL statement to the profiler via `sql_entries_json` or `sql_queries`;
+     do not truncate to a few representative examples.
 
 2. **Model columns**
+   - For historical-SQL requests with profiler evidence, use the profiler output as the primary source
+     for join hints, commonly filtered/grouped dimensions, aggregate candidates, and concise usage hints.
+     Use `analyze_column_usage_patterns` only as a fallback or to fill a narrow gap.
    - Choose one primary time dimension when a reliable time column exists.
    - Define `type: TIME` only for a physical DATE/TIME/TIMESTAMP column, or for a SQL expression / `sql_query` alias that is guaranteed to return a DATE/TIME/TIMESTAMP value.
    - Do not mark numeric surrogate keys such as `*_date_sk`, `*_date_key`, `*_dt_key`, or integer YYYYMMDD keys as `type: TIME`; model them as identifiers or categorical dimensions unless you explicitly convert them to a real date.

--- a/datus/resources/skills/semantic-sql-history-profiler/SKILL.md
+++ b/datus/resources/skills/semantic-sql-history-profiler/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: semantic-sql-history-profiler
+description: Optional semantic-model profiling workflow that mines historical SQL and bounded column distributions before YAML authoring
+tags:
+  - semantic-model
+  - sql-history
+  - profiling
+version: "1.0.0"
+user_invocable: false
+disable_model_invocation: false
+allowed_agents:
+  - gen_semantic_model
+---
+
+# Semantic SQL History Profiler
+
+Use this workflow when the skill is loaded because the user provided historical SQL, success-story SQL, or explicitly asked for profiling. Once loaded, run the profiler before semantic YAML authoring.
+
+## Workflow
+
+1. Call `profile_semantic_model_evidence` before writing semantic model YAML.
+   - When historical SQL is provided inline, pass every provided SQL statement via `sql_entries_json` or `sql_queries`; do not choose only representative examples.
+   - Use `query_text` only when direct SQL text is unavailable and existing reference SQL must be searched.
+   - Use `profile_mode="sql_only"` when the user wants quick generation.
+   - Use `profile_mode="lightweight"` when sampled field distributions are helpful.
+   - Use `profile_mode="deep"` only when the user explicitly allows a slower exploration.
+   - Set conservative bounds such as `max_tables`, `max_columns_per_table`, `top_n`, and `max_profile_seconds`.
+
+2. Use the evidence to decide the model shape:
+   - Join relationships from historical SQL become identifier/entity hints.
+   - Group-by and filter fields are dimension candidates.
+   - Aggregate expressions and numeric profiles are measure candidates.
+   - Min/max values, percentiles, and null/fill rates help describe numeric ranges and data quality.
+   - Date spans, freshness, and duration profiles help identify usable time columns and common lifecycle intervals.
+   - Top values and distinct ratios help detect enum-like categorical columns.
+   - Referential coverage and join fanout hints help judge relationship reliability.
+   - Common filter templates help capture reusable row-selection semantics without copying long SQL.
+
+3. Put useful distribution evidence into YAML descriptions while keeping them readable:
+   - Start with the DDL comment or stable business meaning.
+   - Add a compact distribution note when it helps downstream generation:
+     - numeric fields: include observed min/max, p50/p90, or null rate when material.
+     - date/time fields: include observed span, freshness, or paired duration when useful.
+     - low-cardinality categorical fields: include distinct count and representative stable values.
+     - enum-like fields: include the full stable code mapping when available.
+     - relationship hints: mention low referential coverage or fanout only when it affects join semantics.
+     - filter templates: mention common equality/range/text-search/function filters only when backed by history.
+   - Convert raw evidence into concise semantic phrasing. Prefer "Order status, 4 distinct values; common values include paid/refund" over dumping profiler JSON.
+   - Do not include SQL snippets longer than a short operator/function hint, and do not paste entire top-N lists or long filter examples.
+   - Prefer omitting a field over writing a low-confidence or very verbose description.
+
+4. Treat profiling evidence as non-exhaustive.
+   - Sampled top values and min/max values are hints, not hard constraints.
+   - If evidence conflicts with DDL comments or validation, prefer DDL comments and validated schema.
+
+5. Validate and publish exactly as in the active semantic-model authoring workflow.

--- a/datus/schemas/tool_summary.py
+++ b/datus/schemas/tool_summary.py
@@ -634,6 +634,19 @@ def _fmt_analyze_column_usage_patterns(result: Any) -> str:
     return ""
 
 
+def _fmt_profile_semantic_model_evidence(result: Any) -> str:
+    if isinstance(result, dict):
+        tables = result.get("tables")
+        if isinstance(tables, dict):
+            n = len(tables)
+            suffix = " + data" if result.get("data_profiled") else ""
+            return (f"{n} table profiled" if n == 1 else f"{n} tables profiled") + suffix
+        summary = result.get("summary")
+        if isinstance(summary, str) and summary:
+            return summary
+    return ""
+
+
 def _fmt_get_multiple_tables_ddl(result: Any) -> str:
     if isinstance(result, list):
         n = len(result)
@@ -1234,6 +1247,7 @@ def _register_builtins(registry: ToolSummaryRegistry) -> None:
         "generate_sql_summary_id": _fmt_generate_sql_summary_id,
         "analyze_table_relationships": _fmt_analyze_table_relationships,
         "analyze_column_usage_patterns": _fmt_analyze_column_usage_patterns,
+        "profile_semantic_model_evidence": _fmt_profile_semantic_model_evidence,
         "analyze_metric_candidates_from_history": _fmt_analyze_metric_candidates_from_history,
         "get_multiple_tables_ddl": _fmt_get_multiple_tables_ddl,
         # Scheduler tools

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -11,6 +11,10 @@ mined from historical SQL.
 """
 
 import json
+import time
+from collections import Counter, defaultdict
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from agents import Tool
@@ -34,16 +38,19 @@ class SemanticDiscoveryTools:
 
     _AGGREGATE_CLASSES = ()
 
-    def __init__(self, db_tool: DBFuncTool):
+    def __init__(self, db_tool: DBFuncTool, enable_semantic_model_profiler: bool = False):
         """
         Initialize semantic discovery tools.
 
         Args:
             db_tool: Database function tool instance for accessing database info
+            enable_semantic_model_profiler: Whether to expose the optional
+                semantic SQL history profiler tool.
         """
         self.db_tool = db_tool
         self.agent_config = db_tool.agent_config
         self.sub_agent_name = db_tool.sub_agent_name
+        self.enable_semantic_model_profiler = enable_semantic_model_profiler
 
     @classmethod
     def _aggregate_classes(cls):
@@ -65,6 +72,8 @@ class SemanticDiscoveryTools:
             self.analyze_column_usage_patterns,
             self.analyze_metric_candidates_from_history,
         ]
+        if self.enable_semantic_model_profiler:
+            methods_to_convert.insert(3, self.profile_semantic_model_evidence)
 
         for bound_method in methods_to_convert:
             bound_tools.append(trans_to_function_tool(bound_method))
@@ -193,12 +202,14 @@ class SemanticDiscoveryTools:
         Analyze how columns are used in historical SQL queries.
 
         Discovers column usage patterns including:
-        1. Filter operators (LIKE, IN, FIND_IN_SET, =, >, <, BETWEEN, etc.)
-        2. Common filter values or patterns
-        3. Usage frequency
+        1. Filter operators from parsed SQL predicates
+        2. Function predicates from parsed SQL expressions
+        3. Common redacted filter patterns and usage frequency
 
         Use this tool when generating semantic models to understand
-        how columns are typically queried and filtered.
+        how one table's columns are typically queried and filtered. For
+        multi-table semantic model evidence or sampled data distributions, use
+        the skill-gated `profile_semantic_model_evidence` tool.
 
         Args:
             table_name: Table name to analyze
@@ -215,16 +226,16 @@ class SemanticDiscoveryTools:
                     "status": {
                         "operators": ["=", "IN"],
                         "functions": [],
-                        "common_filters": ["status = 1", "status IN (1,2,3)"],
+                        "common_filters": ["status = <REDACTED>", "status IN (<REDACTED>)"],
                         "usage_count": 45,
                         "usage_description": "Commonly filtered with =, IN"
                     },
-                    "tags": {
-                        "operators": ["LIKE"],
-                        "functions": ["FIND_IN_SET"],
-                        "common_filters": ["FIND_IN_SET('vip', tags)"],
+                    "normalized_name": {
+                        "operators": ["="],
+                        "functions": ["LOWER"],
+                        "common_filters": ["LOWER(name) = '<REDACTED>'"],
                         "usage_count": 23,
-                        "usage_description": "Use FIND_IN_SET() for filtering"
+                        "usage_description": "Commonly filtered with =. Function predicates: LOWER"
                     }
                 },
                 "summary": "Analyzed 2 columns from 50 SQL queries"
@@ -236,8 +247,6 @@ class SemanticDiscoveryTools:
                     success=0, error="Cannot analyze column patterns without agent_config (no SQL history available)"
                 )
 
-            import re
-
             from datus.storage.reference_sql.store import ReferenceSqlRAG
 
             # Get table schema to know which columns exist
@@ -246,21 +255,11 @@ class SemanticDiscoveryTools:
                 return FuncToolResult(success=0, error=f"Failed to get table schema: {schema_result.error}")
 
             # describe_table returns {"columns": [...], "table": {...}}
-            table_columns = schema_result.result.get("columns", [])
-            all_columns = [col["name"] for col in table_columns]
-            target_columns = columns if columns else all_columns
-
-            # Initialize pattern tracking
-            column_patterns = {
-                col: {
-                    "operators": set(),
-                    "functions": set(),
-                    "common_filters": [],
-                    "usage_count": 0,
-                    "filter_examples": [],
-                }
-                for col in target_columns
-            }
+            table_columns = schema_result.result.get("columns", []) if isinstance(schema_result.result, dict) else []
+            all_columns = [
+                str(col.get("name") or "") for col in table_columns if isinstance(col, dict) and col.get("name")
+            ]
+            target_columns = [str(col) for col in (columns if columns else all_columns) if col]
 
             # Search for SQL queries containing the table
             sql_rag = ReferenceSqlRAG(self.agent_config, self.sub_agent_name)
@@ -269,130 +268,129 @@ class SemanticDiscoveryTools:
             )
 
             logger.info(f"Found {len(search_results)} historical SQL queries for table {table_name}")
-
-            # Pattern definitions for different operators and functions
-            operator_patterns = {
-                "LIKE": r"\b{col}\b\s+LIKE\s+",
-                "IN": r"\b{col}\b\s+IN\s*\(",
-                "BETWEEN": r"\b{col}\b\s+BETWEEN\s+",
-                "=": r"\b{col}\b\s*=\s*",
-                ">": r"\b{col}\b\s*>\s*",
-                "<": r"\b{col}\b\s*<\s*",
-                ">=": r"\b{col}\b\s*>=\s*",
-                "<=": r"\b{col}\b\s*<=\s*",
-                "!=": r"\b{col}\b\s*(?:!=|<>)\s*",
-            }
-
-            function_patterns = {
-                "FIND_IN_SET": r"FIND_IN_SET\s*\([^,]+,\s*\b{col}\b\s*\)",
-                "JSON_EXTRACT": r"JSON_EXTRACT\s*\(\s*\b{col}\b\s*,",
-                "JSON_CONTAINS": r"JSON_CONTAINS\s*\(\s*\b{col}\b\s*,",
-                "REGEXP": r"\b{col}\b\s+REGEXP\s+",
-                "MATCH": r"MATCH\s*\(\s*\b{col}\b\s*\)",
-            }
-
-            # Helper function to sanitize filter examples by redacting sensitive literals
-            def sanitize_example(example: str) -> str:
-                """Redact sensitive literals from SQL example snippets."""
-                sanitized = example
-                # Redact quoted strings (single and double quotes)
-                sanitized = re.sub(r"'[^']*'", "'<REDACTED>'", sanitized)
-                sanitized = re.sub(r'"[^"]*"', '"<REDACTED>"', sanitized)
-                # Redact numeric literals (integers and decimals) after operators
-                sanitized = re.sub(r"(?<=[=<>!\s,(\[])\s*\d+\.?\d*(?=\s*[,)\];\s]|$)", " <REDACTED>", sanitized)
-                return sanitized
-
-            # Analyze each SQL query
-            for sql_entry in search_results:
-                sql_text = sql_entry.get("sql", "")
-
-                # Check if this SQL actually uses our target table
-                if not sql_text or table_name.lower() not in sql_text.lower():
-                    continue
-
-                # Track columns seen in this query to increment usage_count only once per query
-                seen_columns_in_query: set = set()
-
-                for col in target_columns:
-                    # Check for operators
-                    for op, pattern_template in operator_patterns.items():
-                        pattern = pattern_template.replace("{col}", re.escape(col))
-                        if re.search(pattern, sql_text, re.IGNORECASE):
-                            column_patterns[col]["operators"].add(op)
-
-                            # Increment usage_count only once per column per query
-                            if col not in seen_columns_in_query:
-                                column_patterns[col]["usage_count"] += 1
-                                seen_columns_in_query.add(col)
-
-                            # Extract example filter (limit to 150 chars), sanitize before storing
-                            match = re.search(rf"\b{re.escape(col)}\b[^,;)]*", sql_text, re.IGNORECASE)
-                            if match and len(column_patterns[col]["filter_examples"]) < 3:
-                                example = sanitize_example(match.group(0).strip()[:150])
-                                if example not in column_patterns[col]["filter_examples"]:
-                                    column_patterns[col]["filter_examples"].append(example)
-
-                    # Check for functions
-                    for func, pattern_template in function_patterns.items():
-                        pattern = pattern_template.replace("{col}", re.escape(col))
-                        if re.search(pattern, sql_text, re.IGNORECASE):
-                            column_patterns[col]["functions"].add(func)
-
-                            # Increment usage_count only once per column per query
-                            if col not in seen_columns_in_query:
-                                column_patterns[col]["usage_count"] += 1
-                                seen_columns_in_query.add(col)
-
-                            # Extract example function call, sanitize before storing
-                            match = re.search(rf"{func}\s*\([^)]*\b{re.escape(col)}\b[^)]*\)", sql_text, re.IGNORECASE)
-                            if match and len(column_patterns[col]["filter_examples"]) < 3:
-                                example = sanitize_example(match.group(0).strip()[:150])
-                                if example not in column_patterns[col]["filter_examples"]:
-                                    column_patterns[col]["filter_examples"].append(example)
-
-            # Generate usage descriptions
-            result_patterns = {}
-            for col, patterns in column_patterns.items():
-                if patterns["usage_count"] == 0:
-                    continue
-
-                # Convert sets to sorted lists
-                operators = sorted(patterns["operators"])
-                functions = sorted(patterns["functions"])
-
-                # Generate natural language description
-                desc_parts = []
-                if functions:
-                    desc_parts.append(f"Use {', '.join(functions)}() for queries")
-                if operators:
-                    op_desc = "Commonly filtered with " + ", ".join(operators)
-                    desc_parts.append(op_desc)
-
-                if patterns["filter_examples"]:
-                    examples = " | ".join(patterns["filter_examples"][:2])
-                    desc_parts.append(f"Example filters: {examples}")
-
-                usage_description = ". ".join(desc_parts) if desc_parts else "Used in queries"
-
-                result_patterns[col] = {
-                    "operators": operators,
-                    "functions": functions,
-                    "common_filters": patterns["filter_examples"][:3],
-                    "usage_count": patterns["usage_count"],
-                    "usage_description": usage_description,
+            entries = [
+                {
+                    "name": entry.get("name") or entry.get("summary") or entry.get("filepath") or f"sql_{idx + 1}",
+                    **entry,
+                    "sql": str(entry.get("sql") or "").strip(),
                 }
+                for idx, entry in enumerate(search_results)
+                if str(entry.get("sql") or "").strip()
+            ]
+            table_evidence, parse_errors = self._semantic_profile_sql_evidence(entries, [table_name], 1)
+            table_profile = self._semantic_profile_table_evidence_for(table_evidence, table_name)
+            result_patterns = self._column_usage_patterns_from_semantic_profile(
+                table_profile.get("field_usage_statistics", {}),
+                target_columns,
+            )
 
             logger.info(f"Analyzed {len(result_patterns)} columns with usage patterns")
 
-            return FuncToolResult(
-                result={
-                    "column_patterns": result_patterns,
-                    "summary": f"Analyzed {len(result_patterns)} columns from {len(search_results)} SQL queries",
-                }
-            )
+            result = {
+                "column_patterns": result_patterns,
+                "summary": f"Analyzed {len(result_patterns)} columns from {len(search_results)} SQL queries",
+            }
+            if parse_errors:
+                result["parse_errors"] = parse_errors[:5]
+            return FuncToolResult(result=result)
 
         except Exception as e:
             logger.exception("Error analyzing column usage patterns")
+            return FuncToolResult(success=0, error=str(e))
+
+    def profile_semantic_model_evidence(
+        self,
+        sql_queries: Optional[List[str]] = None,
+        sql_entries_json: Optional[str] = "",
+        query_text: Optional[str] = "",
+        tables: Optional[List[str]] = None,
+        catalog: Optional[str] = "",
+        database: Optional[str] = "",
+        schema_name: Optional[str] = "",
+        profile_mode: str = "sql_only",
+        sample_sql_queries: int = 50,
+        max_tables: int = 8,
+        max_columns_per_table: int = 10,
+        top_n: int = 5,
+        max_profile_seconds: int = 30,
+    ) -> FuncToolResult:
+        """
+        Build semantic-model evidence from historical SQL and optional table profiling.
+
+        This read-only tool is intended for semantic model generation when the
+        `semantic-sql-history-profiler` skill is loaded. It mines the provided
+        SQL for joins, filters, grouping fields, and aggregate candidates, then
+        optionally samples bounded column distributions from the connected DB.
+
+        Args:
+            sql_queries: Raw historical SQL statements to analyze.
+            sql_entries_json: JSON array of dictionaries with `sql` plus optional
+                `name`, `question`, or `summary`.
+            query_text: Reference SQL search text when direct SQL is not provided.
+            tables: Optional table allowlist. Also used as profiling targets.
+            catalog: Optional catalog override for describe/profile calls.
+            database: Optional database override for describe/profile calls.
+            schema_name: Optional schema override for describe/profile calls.
+            profile_mode: `none`/`sql_only` skips DB profiling; `lightweight`
+                profiles fields seen in SQL evidence; `deep` may also profile
+                schema columns up to max_columns_per_table.
+            sample_sql_queries: Maximum reference SQL rows to inspect.
+            max_tables: Maximum tables to include.
+            max_columns_per_table: Maximum columns profiled per table.
+            top_n: Maximum categorical top values per column.
+            max_profile_seconds: Best-effort wall-clock budget for DB profiling.
+
+        Returns:
+            FuncToolResult with table-level evidence. Values sampled from data are
+            evidence to summarize compactly in YAML descriptions, not to copy wholesale.
+        """
+        try:
+            mode = (profile_mode or "sql_only").strip().lower()
+            has_sql_seed = bool(sql_queries or sql_entries_json or query_text)
+            entries = (
+                self._load_metric_mining_entries(sql_queries, sql_entries_json, query_text, tables, sample_sql_queries)
+                if has_sql_seed
+                else []
+            )
+            table_evidence, parse_errors = self._semantic_profile_sql_evidence(entries, tables, max_tables)
+
+            data_profiled = mode in {"lightweight", "deep"}
+            if data_profiled:
+                self._ensure_semantic_profile_tables(table_evidence, tables, max_tables)
+                self._attach_table_distribution_profiles(
+                    table_evidence=table_evidence,
+                    mode=mode,
+                    catalog=catalog or "",
+                    database=database or "",
+                    schema_name=schema_name or "",
+                    max_tables=max_tables,
+                    max_columns_per_table=max_columns_per_table,
+                    top_n=top_n,
+                    max_profile_seconds=max_profile_seconds,
+                )
+
+            return FuncToolResult(
+                result={
+                    "summary": (
+                        f"Profiled semantic evidence for {len(table_evidence)} table(s) "
+                        f"from {len(entries)} SQL entr{'y' if len(entries) == 1 else 'ies'}"
+                    ),
+                    "profile_mode": mode,
+                    "data_profiled": data_profiled,
+                    "tables": table_evidence,
+                    "parse_errors": parse_errors[:5],
+                    "yaml_guidance": (
+                        "Keep generated YAML concise: use profiling evidence to choose identifiers, "
+                        "measures, dimensions, and time columns; include compact distribution notes "
+                        "in descriptions when useful, such as observed min/max, percentiles, "
+                        "null rate, date span/freshness/duration, low-cardinality distinct counts, "
+                        "stable enum mappings, referential coverage, and common business filter "
+                        "templates. Do not dump profiling JSON, long top-N lists, or long filter examples."
+                    ),
+                }
+            )
+        except Exception as e:
+            logger.exception("Error profiling semantic model evidence")
             return FuncToolResult(success=0, error=str(e))
 
     def analyze_metric_candidates_from_history(
@@ -663,6 +661,1085 @@ class SemanticDiscoveryTools:
             return FuncToolResult(success=0, error=str(e))
 
     # ========== Private helper methods ==========
+
+    def _semantic_profile_sql_evidence(
+        self,
+        entries: List[Dict[str, Any]],
+        table_filter: Optional[List[str]],
+        max_tables: int,
+    ) -> tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
+        """Mine table-level semantic modeling evidence from SQL ASTs."""
+        from sqlglot import expressions as exp
+
+        allowed_tables = {self._normalize_identifier(table.split(".")[-1]) for table in table_filter or [] if table}
+        table_stats: Dict[str, Dict[str, Any]] = defaultdict(self._new_semantic_profile_table)
+        parse_errors: List[Dict[str, Any]] = []
+
+        for idx, entry in enumerate(entries):
+            sql_text = str(entry.get("sql") or "").strip()
+            source_name = entry.get("name") or entry.get("summary") or entry.get("filepath") or f"sql_{idx + 1}"
+            if not sql_text:
+                continue
+            try:
+                parsed_expressions = self._parse_sql(sql_text)
+            except Exception as exc:
+                parse_errors.append({"source_sql_name": source_name, "error": str(exc)})
+                continue
+
+            source = {
+                "source_sql_name": str(source_name),
+                "question": self._clip_profile_text(str(entry.get("question") or ""), 120),
+            }
+            for parsed in parsed_expressions:
+                cte_names = self._profile_cte_names(parsed)
+                alias_to_table = self._profile_alias_to_table_map(parsed, cte_names)
+                for select in self._iter_selects(parsed, include_nested=True):
+                    select_tables = self._profile_select_tables(select, cte_names)
+                    if not select_tables:
+                        select_tables = set(alias_to_table.values())
+                    if allowed_tables:
+                        select_tables = {
+                            table
+                            for table in select_tables
+                            if self._normalize_identifier(table.split(".")[-1]) in allowed_tables
+                        }
+                    for table in select_tables:
+                        self._add_semantic_profile_source(table_stats[table], source)
+
+                    for projection in select.expressions:
+                        for column in projection.find_all(exp.Column):
+                            table = self._profile_column_table(column, alias_to_table, select_tables)
+                            if table:
+                                table_stats[table]["fields"][column.name]["selected_count"] += 1
+
+                    self._collect_semantic_profile_groups(select, table_stats, alias_to_table, select_tables)
+                    self._collect_semantic_profile_filters(select, table_stats, alias_to_table, select_tables)
+                    self._collect_semantic_profile_aggregates(select, table_stats, alias_to_table, select_tables)
+                    self._collect_semantic_profile_joins(select, table_stats, alias_to_table)
+
+        sorted_items = sorted(
+            table_stats.items(),
+            key=lambda item: (-len(item[1]["source_queries"]), item[0]),
+        )[: max(max_tables, 1)]
+        return {table: self._finalize_semantic_profile_table(stats) for table, stats in sorted_items}, parse_errors
+
+    def _semantic_profile_table_evidence_for(
+        self,
+        table_evidence: Dict[str, Dict[str, Any]],
+        table_name: str,
+    ) -> Dict[str, Any]:
+        normalized = self._normalize_identifier(table_name.split(".")[-1])
+        for candidate, evidence in table_evidence.items():
+            if self._normalize_identifier(candidate.split(".")[-1]) == normalized:
+                return evidence
+        return {}
+
+    def _column_usage_patterns_from_semantic_profile(
+        self,
+        field_usage_statistics: Dict[str, Dict[str, Any]],
+        target_columns: List[str],
+    ) -> Dict[str, Dict[str, Any]]:
+        fields_by_name = {
+            self._normalize_identifier(field_name): field_stats
+            for field_name, field_stats in field_usage_statistics.items()
+        }
+        result: Dict[str, Dict[str, Any]] = {}
+        for column in target_columns:
+            field_stats = fields_by_name.get(self._normalize_identifier(column))
+            if not field_stats:
+                continue
+            operators = list(field_stats.get("operators") or [])
+            functions = list(field_stats.get("functions") or [])
+            common_filters = list(field_stats.get("common_filters") or [])[:3]
+            usage_count = int(field_stats.get("filter_count") or 0)
+            if usage_count <= 0 and not operators and not functions and not common_filters:
+                continue
+
+            desc_parts = []
+            if operators:
+                desc_parts.append("Commonly filtered with " + ", ".join(operators))
+            if functions:
+                desc_parts.append("Function predicates: " + ", ".join(functions))
+            if common_filters:
+                desc_parts.append("Example filters: " + " | ".join(common_filters[:2]))
+
+            result[column] = {
+                "operators": operators,
+                "functions": functions,
+                "common_filters": common_filters,
+                "usage_count": usage_count,
+                "usage_description": ". ".join(desc_parts) if desc_parts else "Used in filter predicates",
+            }
+        return result
+
+    def _ensure_semantic_profile_tables(
+        self,
+        table_evidence: Dict[str, Dict[str, Any]],
+        tables: Optional[List[str]],
+        max_tables: int,
+    ) -> None:
+        """Add explicit table targets so deep profiling can run without SQL evidence."""
+        for table in (tables or [])[: max(max_tables, 1)]:
+            table_name = str(table or "").strip()
+            if table_name and table_name not in table_evidence:
+                table_evidence[table_name] = self._empty_semantic_profile_table()
+
+    def _empty_semantic_profile_table(self) -> Dict[str, Any]:
+        return {
+            "query_count": 0,
+            "source_queries": [],
+            "field_usage_statistics": {},
+            "common_filter_conditions": [],
+            "common_business_filter_templates": [],
+            "join_relationships": [],
+            "aggregate_expressions": [],
+            "group_by_expressions": [],
+        }
+
+    def _new_semantic_profile_table(self) -> Dict[str, Any]:
+        return {
+            "source_queries": {},
+            "fields": defaultdict(self._new_semantic_profile_field),
+            "common_filters": Counter(),
+            "business_filter_templates": Counter(),
+            "join_relationships": Counter(),
+            "aggregate_expressions": Counter(),
+            "group_by_expressions": Counter(),
+        }
+
+    def _new_semantic_profile_field(self) -> Dict[str, Any]:
+        return {
+            "selected_count": 0,
+            "filter_count": 0,
+            "group_by_count": 0,
+            "aggregate_count": 0,
+            "operators": Counter(),
+            "functions": Counter(),
+            "common_filters": Counter(),
+        }
+
+    def _add_semantic_profile_source(self, stats: Dict[str, Any], source: Dict[str, str]) -> None:
+        source_name = source["source_sql_name"]
+        if source_name not in stats["source_queries"] and len(stats["source_queries"]) < 5:
+            stats["source_queries"][source_name] = source
+
+    def _profile_cte_names(self, parsed: Any) -> set[str]:
+        from sqlglot import expressions as exp
+
+        return {self._normalize_identifier(cte.alias) for cte in parsed.find_all(exp.CTE) if cte.alias}
+
+    def _profile_alias_to_table_map(self, parsed: Any, cte_names: set[str]) -> Dict[str, str]:
+        from sqlglot import expressions as exp
+
+        mapping: Dict[str, str] = {}
+        for table in parsed.find_all(exp.Table):
+            table_name = self._profile_table_name(table)
+            if not table_name or self._normalize_identifier(table.name) in cte_names:
+                continue
+            mapping[self._normalize_identifier(table.name)] = table_name
+            mapping[self._normalize_identifier(table_name)] = table_name
+            if table.alias_or_name:
+                mapping[self._normalize_identifier(table.alias_or_name)] = table_name
+        return mapping
+
+    def _profile_table_name(self, table: Any) -> str:
+        parts = [part for part in (getattr(table, "catalog", ""), getattr(table, "db", ""), table.name) if part]
+        return ".".join(str(part).strip('"`[]') for part in parts if str(part).strip('"`[]'))
+
+    def _profile_select_tables(self, select: Any, cte_names: set[str]) -> set[str]:
+        from sqlglot import expressions as exp
+
+        tables = set()
+        for table in select.find_all(exp.Table):
+            table_name = self._profile_table_name(table)
+            if table_name and self._normalize_identifier(table.name) not in cte_names:
+                tables.add(table_name)
+        return tables
+
+    def _profile_column_table(
+        self,
+        column: Any,
+        alias_to_table: Dict[str, str],
+        select_tables: set[str],
+    ) -> Optional[str]:
+        table_key = self._normalize_identifier(column.table)
+        if table_key:
+            return alias_to_table.get(table_key)
+        if len(select_tables) == 1:
+            return next(iter(select_tables))
+        return None
+
+    def _profile_tables_for_expression(
+        self,
+        expression: Any,
+        alias_to_table: Dict[str, str],
+        select_tables: set[str],
+    ) -> set[str]:
+        from sqlglot import expressions as exp
+
+        tables = {
+            table
+            for column in expression.find_all(exp.Column)
+            if (table := self._profile_column_table(column, alias_to_table, select_tables))
+        }
+        if tables:
+            return tables
+        return set(select_tables) if len(select_tables) == 1 else set()
+
+    def _collect_semantic_profile_groups(
+        self,
+        select: Any,
+        table_stats: Dict[str, Dict[str, Any]],
+        alias_to_table: Dict[str, str],
+        select_tables: set[str],
+    ) -> None:
+        from sqlglot import expressions as exp
+
+        group = select.args.get("group")
+        if not group:
+            return
+        for expression in group.expressions:
+            expression_sql = self._sanitize_profile_sql(expression.sql())
+            for table in self._profile_tables_for_expression(expression, alias_to_table, select_tables):
+                table_stats[table]["group_by_expressions"][expression_sql] += 1
+            for column in expression.find_all(exp.Column):
+                table = self._profile_column_table(column, alias_to_table, select_tables)
+                if table:
+                    table_stats[table]["fields"][column.name]["group_by_count"] += 1
+
+    def _collect_semantic_profile_filters(
+        self,
+        select: Any,
+        table_stats: Dict[str, Dict[str, Any]],
+        alias_to_table: Dict[str, str],
+        select_tables: set[str],
+    ) -> None:
+        from sqlglot import expressions as exp
+
+        for clause_key in ("where", "having", "qualify"):
+            clause = select.args.get(clause_key)
+            predicate_root = getattr(clause, "this", None)
+            if predicate_root is None:
+                continue
+            for predicate in self._semantic_profile_filter_predicates(predicate_root):
+                condition = self._sanitize_profile_sql(predicate.sql())
+                operator = self._semantic_profile_operator(predicate)
+                function_names = self._semantic_profile_function_names(predicate)
+                business_filter_templates = self._semantic_profile_business_filter_templates(
+                    predicate=predicate,
+                    alias_to_table=alias_to_table,
+                    select_tables=select_tables,
+                    condition_template=condition,
+                    operator=operator,
+                    function_names=function_names,
+                )
+                for table, template in business_filter_templates:
+                    table_stats[table]["business_filter_templates"][
+                        json.dumps(template, ensure_ascii=False, sort_keys=True)
+                    ] += 1
+                for table in self._profile_tables_for_expression(predicate, alias_to_table, select_tables):
+                    table_stats[table]["common_filters"][condition] += 1
+                for column in predicate.find_all(exp.Column):
+                    table = self._profile_column_table(column, alias_to_table, select_tables)
+                    if not table:
+                        continue
+                    field = table_stats[table]["fields"][column.name]
+                    field["filter_count"] += 1
+                    if operator:
+                        field["operators"][operator] += 1
+                    for function_name in function_names:
+                        field["functions"][function_name] += 1
+                    field["common_filters"][condition] += 1
+
+    def _collect_semantic_profile_aggregates(
+        self,
+        select: Any,
+        table_stats: Dict[str, Dict[str, Any]],
+        alias_to_table: Dict[str, str],
+        select_tables: set[str],
+    ) -> None:
+        from sqlglot import expressions as exp
+
+        for aggregate in select.find_all(*self._aggregate_classes()):
+            aggregate_sql = self._sanitize_profile_sql(aggregate.sql())
+            aggregate_tables = (
+                self._profile_tables_for_expression(aggregate, alias_to_table, select_tables) or select_tables
+            )
+            for table in aggregate_tables:
+                table_stats[table]["aggregate_expressions"][aggregate_sql] += 1
+            for column in aggregate.find_all(exp.Column):
+                table = self._profile_column_table(column, alias_to_table, select_tables)
+                if table:
+                    table_stats[table]["fields"][column.name]["aggregate_count"] += 1
+
+    def _collect_semantic_profile_joins(
+        self,
+        select: Any,
+        table_stats: Dict[str, Dict[str, Any]],
+        alias_to_table: Dict[str, str],
+    ) -> None:
+        from sqlglot import expressions as exp
+
+        for eq in select.find_all(exp.EQ):
+            left = eq.left
+            right = eq.right
+            if not isinstance(left, exp.Column) or not isinstance(right, exp.Column):
+                continue
+            left_table = alias_to_table.get(self._normalize_identifier(left.table))
+            right_table = alias_to_table.get(self._normalize_identifier(right.table))
+            if not left_table or not right_table or left_table == right_table:
+                continue
+            relationship = json.dumps(
+                {
+                    "source_table": left_table,
+                    "source_column": left.name,
+                    "target_table": right_table,
+                    "target_column": right.name,
+                    "evidence": "historical_sql_join",
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            table_stats[left_table]["join_relationships"][relationship] += 1
+            table_stats[right_table]["join_relationships"][relationship] += 1
+
+    def _semantic_profile_filter_predicates(self, root: Any) -> List[Any]:
+        from sqlglot import expressions as exp
+
+        operator_classes = tuple(self._semantic_profile_operator_map().keys())
+        predicates = []
+        covered_nodes = set()
+        for node in root.walk():
+            if isinstance(node, operator_classes):
+                predicates.append(node)
+                covered_nodes.update(id(child) for child in node.walk())
+        for node in root.walk():
+            if isinstance(node, exp.Func) and id(node) not in covered_nodes:
+                predicates.append(node)
+        return predicates
+
+    def _semantic_profile_operator_map(self) -> Dict[type, str]:
+        from sqlglot import expressions as exp
+
+        mapping: Dict[type, str] = {}
+        for class_name, operator in (
+            ("EQ", "="),
+            ("NEQ", "!="),
+            ("GT", ">"),
+            ("GTE", ">="),
+            ("LT", "<"),
+            ("LTE", "<="),
+            ("In", "IN"),
+            ("Like", "LIKE"),
+            ("ILike", "ILIKE"),
+            ("Between", "BETWEEN"),
+            ("Is", "IS"),
+            ("RegexpLike", "REGEXP"),
+        ):
+            expression_class = getattr(exp, class_name, None)
+            if expression_class is not None:
+                mapping[expression_class] = operator
+        return mapping
+
+    def _semantic_profile_operator(self, predicate: Any) -> str:
+        for expression_class, operator in self._semantic_profile_operator_map().items():
+            if isinstance(predicate, expression_class):
+                return operator
+        return ""
+
+    def _semantic_profile_function_names(self, expression: Any) -> List[str]:
+        from sqlglot import expressions as exp
+
+        names = set()
+        for func in expression.find_all(exp.Func):
+            if isinstance(func, exp.Anonymous):
+                name = func.name or func.this
+            else:
+                sql_name = getattr(func, "sql_name", None)
+                if callable(sql_name):
+                    name = sql_name()
+                else:
+                    name = getattr(func, "key", "") or func.__class__.__name__
+            if name:
+                names.add(str(name).upper())
+        return sorted(names)
+
+    def _semantic_profile_business_filter_templates(
+        self,
+        predicate: Any,
+        alias_to_table: Dict[str, str],
+        select_tables: set[str],
+        condition_template: str,
+        operator: str,
+        function_names: List[str],
+    ) -> List[tuple[str, Dict[str, Any]]]:
+        from sqlglot import expressions as exp
+
+        fields_by_table: Dict[str, set[str]] = defaultdict(set)
+        for column in predicate.find_all(exp.Column):
+            table = self._profile_column_table(column, alias_to_table, select_tables)
+            if table:
+                fields_by_table[table].add(column.name)
+        if not fields_by_table:
+            return []
+
+        literal_values = self._semantic_profile_literal_values(predicate)
+        usage_kind = self._semantic_profile_filter_usage_kind(operator, function_names)
+        templates = []
+        for table, fields in fields_by_table.items():
+            template = {
+                "condition_template": condition_template,
+                "fields": sorted(fields),
+            }
+            if operator:
+                template["operator"] = operator
+            if function_names:
+                template["functions"] = function_names
+            if literal_values:
+                template["literal_values"] = literal_values
+            if usage_kind:
+                template["usage_kind"] = usage_kind
+            templates.append((table, template))
+        return templates
+
+    def _semantic_profile_literal_values(self, expression: Any, max_values: int = 5) -> List[str]:
+        from sqlglot import expressions as exp
+
+        values = []
+        seen = set()
+        for literal in expression.find_all(exp.Literal):
+            raw = literal.this
+            if raw is None:
+                continue
+            value = str(raw).strip()
+            if not value or len(value) > 40 or value in seen:
+                continue
+            seen.add(value)
+            values.append(self._clip_profile_text(value, 40))
+            if len(values) >= max_values:
+                break
+        return values
+
+    def _semantic_profile_filter_usage_kind(self, operator: str, function_names: List[str]) -> str:
+        if function_names:
+            return "function_filter"
+        if operator in {"LIKE", "ILIKE", "REGEXP"}:
+            return "text_search"
+        if operator in {"=", "!=", "IN"}:
+            return "categorical_filter"
+        if operator in {">", ">=", "<", "<=", "BETWEEN"}:
+            return "range_filter"
+        if operator == "IS":
+            return "null_check"
+        return ""
+
+    def _finalize_semantic_profile_table(self, stats: Dict[str, Any]) -> Dict[str, Any]:
+        fields = {}
+        for field, field_stats in sorted(
+            stats["fields"].items(),
+            key=lambda item: (-self._semantic_profile_field_usage_count(item[1]), item[0]),
+        ):
+            usage_count = self._semantic_profile_field_usage_count(field_stats)
+            if usage_count <= 0:
+                continue
+            fields[field] = {
+                "usage_count": usage_count,
+                "selected_count": field_stats["selected_count"],
+                "filter_count": field_stats["filter_count"],
+                "group_by_count": field_stats["group_by_count"],
+                "aggregate_count": field_stats["aggregate_count"],
+                "operators": [item for item, _count in field_stats["operators"].most_common()],
+                "functions": [item for item, _count in field_stats["functions"].most_common()],
+                "common_filters": [item for item, _count in field_stats["common_filters"].most_common(3)],
+            }
+        return {
+            "query_count": len(stats["source_queries"]),
+            "source_queries": list(stats["source_queries"].values()),
+            "field_usage_statistics": fields,
+            "common_filter_conditions": self._counter_to_profile_list(stats["common_filters"], "condition", 8),
+            "common_business_filter_templates": self._counter_json_to_profile_list(
+                stats["business_filter_templates"], 8
+            ),
+            "join_relationships": self._counter_json_to_profile_list(stats["join_relationships"], 12),
+            "aggregate_expressions": self._counter_to_profile_list(stats["aggregate_expressions"], "expression", 8),
+            "group_by_expressions": self._counter_to_profile_list(stats["group_by_expressions"], "expression", 8),
+        }
+
+    def _semantic_profile_field_usage_count(self, stats: Dict[str, Any]) -> int:
+        return (
+            int(stats["selected_count"])
+            + int(stats["filter_count"])
+            + int(stats["group_by_count"])
+            + int(stats["aggregate_count"])
+        )
+
+    def _counter_to_profile_list(self, counter: Counter, value_key: str, limit: int) -> List[Dict[str, Any]]:
+        return [{value_key: value, "count": count} for value, count in counter.most_common(limit)]
+
+    def _counter_json_to_profile_list(self, counter: Counter, limit: int) -> List[Dict[str, Any]]:
+        items: List[Dict[str, Any]] = []
+        for value, count in counter.most_common(limit):
+            try:
+                item = json.loads(value)
+            except json.JSONDecodeError:
+                item = {"evidence": value}
+            item["count"] = count
+            items.append(item)
+        return items
+
+    def _attach_table_distribution_profiles(
+        self,
+        table_evidence: Dict[str, Dict[str, Any]],
+        mode: str,
+        catalog: str,
+        database: str,
+        schema_name: str,
+        max_tables: int,
+        max_columns_per_table: int,
+        top_n: int,
+        max_profile_seconds: int,
+    ) -> None:
+        """Attach bounded data-distribution profiles to table evidence."""
+        started_at = time.monotonic()
+        for table_name, evidence in list(table_evidence.items())[: max(max_tables, 1)]:
+            if time.monotonic() - started_at > max_profile_seconds:
+                evidence["data_profile_skipped"] = "max_profile_seconds exceeded"
+                continue
+
+            describe = self.db_tool.describe_table(table_name, catalog, database, schema_name)
+            if not describe.success:
+                evidence["data_profile_error"] = describe.error or "describe_table failed"
+                continue
+
+            columns = (describe.result or {}).get("columns") if isinstance(describe.result, dict) else []
+            columns = [col for col in columns if isinstance(col, dict) and col.get("name")]
+            selected = self._select_columns_for_distribution_profile(
+                evidence=evidence,
+                columns=columns,
+                mode=mode,
+                max_columns=max_columns_per_table,
+            )
+            table_ref = self._profile_table_reference(table_name, catalog, database, schema_name)
+            profile = {
+                "profile_mode": mode,
+                "table_reference": table_ref,
+                "columns": {},
+            }
+            row_count = self._run_profile_scalar_query(f"SELECT COUNT(*) AS row_count FROM {table_ref}", database)
+            if row_count:
+                profile["row_count"] = row_count.get("row_count")
+
+            for column in selected:
+                if time.monotonic() - started_at > max_profile_seconds:
+                    profile["partial"] = True
+                    break
+                column_name = str(column.get("name") or "")
+                column_type = str(column.get("type") or "")
+                kind = self._profile_column_kind(column_type)
+                column_profile = self._profile_single_column(
+                    table_ref=table_ref,
+                    column_name=column_name,
+                    column_type=column_type,
+                    kind=kind,
+                    database=database,
+                    top_n=top_n,
+                )
+                profile["columns"][column_name] = column_profile
+
+            duration_profiles = self._profile_date_duration_pairs(
+                table_ref=table_ref,
+                columns=columns,
+                database=database,
+                deadline=started_at + max_profile_seconds,
+            )
+            if duration_profiles:
+                profile["date_duration_profiles"] = duration_profiles
+
+            join_profiles = self._profile_join_relationship_profiles(
+                relationships=evidence.get("join_relationships") or [],
+                catalog=catalog,
+                database=database,
+                schema_name=schema_name,
+                deadline=started_at + max_profile_seconds,
+            )
+            if join_profiles:
+                profile["join_relationship_profiles"] = join_profiles
+
+            evidence["data_distribution_profile"] = profile
+
+    def _select_columns_for_distribution_profile(
+        self,
+        evidence: Dict[str, Any],
+        columns: List[Dict[str, Any]],
+        mode: str,
+        max_columns: int,
+    ) -> List[Dict[str, Any]]:
+        by_name = {str(col.get("name")): col for col in columns}
+        field_usage = evidence.get("field_usage_statistics") or {}
+        selected_names = [
+            name
+            for name, stats in sorted(
+                field_usage.items(),
+                key=lambda item: (
+                    -int(item[1].get("filter_count", 0)),
+                    -int(item[1].get("group_by_count", 0)),
+                    -int(item[1].get("aggregate_count", 0)),
+                    -int(item[1].get("usage_count", 0)),
+                    item[0],
+                ),
+            )
+            if name in by_name
+        ]
+        if mode == "deep":
+            selected_set = set(selected_names)
+            for col in columns:
+                name = str(col.get("name") or "")
+                if name and name not in selected_set:
+                    selected_names.append(name)
+                    selected_set.add(name)
+                if len(selected_names) >= max_columns:
+                    break
+        return [by_name[name] for name in selected_names[: max(max_columns, 1)]]
+
+    def _profile_single_column(
+        self,
+        table_ref: str,
+        column_name: str,
+        column_type: str,
+        kind: str,
+        database: str,
+        top_n: int,
+    ) -> Dict[str, Any]:
+        column_ref = self._quote_sql_identifier(column_name)
+        stats_exprs = [
+            "COUNT(*) AS row_count",
+            f"COUNT({column_ref}) AS non_null_count",
+            f"COUNT(DISTINCT {column_ref}) AS distinct_count",
+        ]
+        if kind in {"numeric", "temporal"}:
+            stats_exprs.extend([f"MIN({column_ref}) AS min_value", f"MAX({column_ref}) AS max_value"])
+        stats_sql = f"SELECT {', '.join(stats_exprs)} FROM {table_ref}"
+        profile = {
+            "type": column_type,
+            "kind": kind,
+            "stats_sql": stats_sql,
+        }
+        stats = self._run_profile_scalar_query(stats_sql, database)
+        if stats:
+            self._attach_null_and_distinct_rates(stats)
+            profile["stats"] = stats
+            if kind == "numeric":
+                percentiles = self._profile_numeric_percentiles(
+                    table_ref=table_ref,
+                    column_ref=column_ref,
+                    stats=stats,
+                    database=database,
+                )
+                if percentiles:
+                    profile["percentiles"] = percentiles
+            if kind == "temporal":
+                temporal_summary = self._profile_temporal_summary(stats)
+                if temporal_summary:
+                    profile["temporal_summary"] = temporal_summary
+
+        if kind in {"categorical", "boolean"} and top_n > 0:
+            top_sql = (
+                f"SELECT {column_ref} AS value, COUNT(*) AS count "
+                f"FROM {table_ref} WHERE {column_ref} IS NOT NULL "
+                f"GROUP BY {column_ref} ORDER BY count DESC LIMIT {max(top_n, 1)}"
+            )
+            top_values = self._run_profile_rows_query(top_sql, database)
+            profile["top_values_sql"] = top_sql
+            if top_values:
+                profile["top_values"] = [
+                    {
+                        "value": self._clip_profile_text(str(row.get("value", "")), 120),
+                        "count": self._coerce_profile_scalar(row.get("count")),
+                    }
+                    for row in top_values[:top_n]
+                ]
+        return profile
+
+    def _attach_null_and_distinct_rates(self, stats: Dict[str, Any]) -> None:
+        row_count = self._profile_number(stats.get("row_count"))
+        non_null_count = self._profile_number(stats.get("non_null_count"))
+        distinct_count = self._profile_number(stats.get("distinct_count"))
+        if row_count is not None and non_null_count is not None and row_count > 0:
+            null_count = max(row_count - non_null_count, 0)
+            stats["null_count"] = int(null_count) if float(null_count).is_integer() else null_count
+            stats["null_rate"] = round(null_count / row_count, 6)
+            stats["fill_rate"] = round(non_null_count / row_count, 6)
+        if non_null_count is not None and distinct_count is not None and non_null_count > 0:
+            stats["distinct_ratio"] = round(distinct_count / non_null_count, 6)
+
+    def _profile_numeric_percentiles(
+        self,
+        table_ref: str,
+        column_ref: str,
+        stats: Dict[str, Any],
+        database: str,
+    ) -> Dict[str, Any]:
+        non_null_count = self._profile_number(stats.get("non_null_count"))
+        if non_null_count is None or non_null_count <= 0:
+            return {}
+        positions = {
+            "p25": self._profile_percentile_position(non_null_count, 0.25),
+            "p50": self._profile_percentile_position(non_null_count, 0.50),
+            "p75": self._profile_percentile_position(non_null_count, 0.75),
+            "p90": self._profile_percentile_position(non_null_count, 0.90),
+            "p95": self._profile_percentile_position(non_null_count, 0.95),
+        }
+        select_exprs = [
+            f"MAX(CASE WHEN rn = {position} THEN value END) AS {name}" for name, position in positions.items()
+        ]
+        sql = (
+            "WITH ordered_profile_values AS ("
+            f"SELECT {column_ref} AS value, ROW_NUMBER() OVER (ORDER BY {column_ref}) AS rn "
+            f"FROM {table_ref} WHERE {column_ref} IS NOT NULL"
+            f") SELECT {', '.join(select_exprs)} FROM ordered_profile_values"
+        )
+        result = self._run_profile_scalar_query(sql, database)
+        if not result or result.get("error"):
+            return {}
+        result["method"] = "exact_position_from_ordered_non_null_values"
+        result["positions"] = positions
+        return result
+
+    def _profile_percentile_position(self, count: float, percentile: float) -> int:
+        return max(1, min(int(count), int(round((count - 1) * percentile)) + 1))
+
+    def _profile_temporal_summary(self, stats: Dict[str, Any]) -> Dict[str, Any]:
+        min_date = self._parse_profile_date(stats.get("min_value"))
+        max_date = self._parse_profile_date(stats.get("max_value"))
+        if not min_date and not max_date:
+            return {}
+        summary: Dict[str, Any] = {"profiled_at_date": date.today().isoformat()}
+        if min_date and max_date:
+            summary["span_days"] = (max_date - min_date).days
+        if max_date:
+            summary["freshness_days_from_profile_date"] = (date.today() - max_date).days
+        return summary
+
+    def _profile_date_duration_pairs(
+        self,
+        table_ref: str,
+        columns: List[Dict[str, Any]],
+        database: str,
+        deadline: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        pairs = self._candidate_temporal_column_pairs(columns)
+        profiles = []
+        for pair in pairs[:3]:
+            if deadline is not None and time.monotonic() > deadline:
+                break
+            left_column = pair["left_column"]
+            right_column = pair["right_column"]
+            left_ref = self._quote_sql_identifier(left_column)
+            right_ref = self._quote_sql_identifier(right_column)
+            sql = (
+                f"SELECT {left_ref} AS left_value, {right_ref} AS right_value "
+                f"FROM {table_ref} WHERE {left_ref} IS NOT NULL AND {right_ref} IS NOT NULL LIMIT 1000"
+            )
+            rows = self._run_profile_rows_query(sql, database)
+            deltas = []
+            negative_count = 0
+            for row in rows:
+                if row.get("error"):
+                    deltas = []
+                    break
+                left_date = self._parse_profile_date(row.get("left_value"))
+                right_date = self._parse_profile_date(row.get("right_value"))
+                if not left_date or not right_date:
+                    continue
+                delta = (right_date - left_date).days
+                if delta < 0:
+                    negative_count += 1
+                deltas.append(delta)
+            if not deltas:
+                continue
+            profile = {
+                "left_column": left_column,
+                "right_column": right_column,
+                "candidate_reason": pair["candidate_reason"],
+                "directional": pair["directional"],
+                "sample_size": len(deltas),
+                "delta_days": self._profile_numeric_summary_from_values(deltas),
+            }
+            if negative_count:
+                profile["negative_delta_count"] = negative_count
+            profiles.append(profile)
+        return profiles
+
+    def _candidate_temporal_column_pairs(self, columns: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        temporal_names = sorted(
+            str(column.get("name") or "")
+            for column in columns
+            if self._profile_column_kind(str(column.get("type") or "")) == "temporal"
+        )
+        if len(temporal_names) < 2:
+            return []
+
+        starts: Dict[str, str] = {}
+        ends: Dict[str, str] = {}
+        for name in temporal_names:
+            boundary = self._temporal_boundary_stem(name)
+            if not boundary:
+                continue
+            side, stem = boundary
+            if side == "left":
+                starts.setdefault(stem, name)
+            else:
+                ends.setdefault(stem, name)
+
+        pairs = []
+        seen = set()
+        for stem, left_name in sorted(starts.items()):
+            right_name = ends.get(stem)
+            if right_name:
+                key = (left_name, right_name)
+                if key not in seen:
+                    seen.add(key)
+                    pairs.append(
+                        {
+                            "left_column": left_name,
+                            "right_column": right_name,
+                            "candidate_reason": "shared_stem_boundary_tokens",
+                            "directional": True,
+                        }
+                    )
+        if not pairs and len(temporal_names) == 2:
+            pairs.append(
+                {
+                    "left_column": temporal_names[0],
+                    "right_column": temporal_names[1],
+                    "candidate_reason": "only_two_temporal_columns",
+                    "directional": False,
+                }
+            )
+        return pairs
+
+    def _temporal_boundary_stem(self, column_name: str) -> Optional[tuple[str, str]]:
+        tokens = self._identifier_tokens(column_name)
+        if not tokens:
+            return None
+        left_tokens = {"start", "begin", "from", "open", "opened"}
+        right_tokens = {"end", "finish", "to", "close", "closed", "expire", "expired"}
+        for index, token in enumerate(tokens):
+            if token in left_tokens:
+                return "left", "|".join(tokens[:index] + ["<boundary>"] + tokens[index + 1 :])
+            if token in right_tokens:
+                return "right", "|".join(tokens[:index] + ["<boundary>"] + tokens[index + 1 :])
+        return None
+
+    def _identifier_tokens(self, value: str) -> List[str]:
+        import re
+
+        return [token for token in re.split(r"[^A-Za-z0-9]+", str(value).lower()) if token]
+
+    def _profile_join_relationship_profiles(
+        self,
+        relationships: List[Dict[str, Any]],
+        catalog: str,
+        database: str,
+        schema_name: str,
+        deadline: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        profiles = []
+        seen = set()
+        for relationship in relationships[:5]:
+            if deadline is not None and time.monotonic() > deadline:
+                break
+            source_table = str(relationship.get("source_table") or "")
+            source_column = str(relationship.get("source_column") or "")
+            target_table = str(relationship.get("target_table") or "")
+            target_column = str(relationship.get("target_column") or "")
+            key = (source_table, source_column, target_table, target_column)
+            if not all(key) or key in seen:
+                continue
+            seen.add(key)
+            source_ref = self._profile_table_reference(source_table, catalog, database, schema_name)
+            target_ref = self._profile_table_reference(target_table, catalog, database, schema_name)
+            source_col_ref = self._quote_sql_identifier(source_column)
+            target_col_ref = self._quote_sql_identifier(target_column)
+            sql = (
+                "SELECT "
+                "COUNT(*) AS source_rows, "
+                f"COUNT(src.{source_col_ref}) AS non_null_source_rows, "
+                f"COUNT(DISTINCT src.{source_col_ref}) AS distinct_source_keys, "
+                f"COUNT(tgt.{target_col_ref}) AS matched_join_rows, "
+                f"COUNT(DISTINCT CASE WHEN tgt.{target_col_ref} IS NOT NULL THEN src.{source_col_ref} END) "
+                "AS matched_distinct_source_keys "
+                f"FROM {source_ref} src LEFT JOIN {target_ref} tgt "
+                f"ON src.{source_col_ref} = tgt.{target_col_ref}"
+            )
+            stats = self._run_profile_scalar_query(sql, database)
+            profile = {
+                "source_table": source_table,
+                "source_column": source_column,
+                "target_table": target_table,
+                "target_column": target_column,
+                "stats_sql": sql,
+            }
+            if stats:
+                profile["stats"] = stats
+                non_null_rows = self._profile_number(stats.get("non_null_source_rows"))
+                matched_rows = self._profile_number(stats.get("matched_join_rows"))
+                distinct_keys = self._profile_number(stats.get("distinct_source_keys"))
+                matched_distinct_keys = self._profile_number(stats.get("matched_distinct_source_keys"))
+                if non_null_rows and non_null_rows > 0 and matched_rows is not None:
+                    fanout_ratio = matched_rows / non_null_rows
+                    profile["join_fanout_ratio"] = round(fanout_ratio, 6)
+                    if fanout_ratio == 0:
+                        profile["join_cardinality_hint"] = "no_observed_matches"
+                    elif fanout_ratio <= 1.01:
+                        profile["join_cardinality_hint"] = "many_to_one_or_one_to_one"
+                    else:
+                        profile["join_cardinality_hint"] = "possible_one_to_many_or_non_unique_target"
+                if distinct_keys and distinct_keys > 0 and matched_distinct_keys is not None:
+                    profile["referential_coverage"] = round(matched_distinct_keys / distinct_keys, 6)
+            profiles.append(profile)
+        return profiles
+
+    def _profile_numeric_summary_from_values(self, values: List[float]) -> Dict[str, Any]:
+        sorted_values = sorted(values)
+        count = len(sorted_values)
+        return {
+            "min": sorted_values[0],
+            "p50": sorted_values[self._profile_percentile_position(count, 0.50) - 1],
+            "p90": sorted_values[self._profile_percentile_position(count, 0.90) - 1],
+            "max": sorted_values[-1],
+        }
+
+    def _run_profile_scalar_query(self, sql: str, database: str) -> Dict[str, Any]:
+        result = self.db_tool.read_query(sql, database=database)
+        if not result.success:
+            return {"error": result.error or "query failed"}
+        rows = self._profile_result_rows(result.result)
+        if not rows:
+            return {}
+        return {key: self._coerce_profile_scalar(value) for key, value in rows[0].items() if key != "index"}
+
+    def _run_profile_rows_query(self, sql: str, database: str) -> List[Dict[str, Any]]:
+        result = self.db_tool.read_query(sql, database=database)
+        if not result.success:
+            return [{"error": result.error or "query failed"}]
+        return self._profile_result_rows(result.result)
+
+    def _profile_result_rows(self, result: Any) -> List[Dict[str, Any]]:
+        if isinstance(result, list):
+            return [row for row in result if isinstance(row, dict)]
+        if isinstance(result, dict):
+            compressed = result.get("compressed_data")
+            if isinstance(compressed, str) and compressed and compressed != "Empty dataset":
+                import csv
+                from io import StringIO
+
+                rows = []
+                for row in csv.DictReader(StringIO(compressed)):
+                    if "index" in row:
+                        row.pop("index", None)
+                    rows.append(dict(row))
+                return rows
+            items = result.get("items")
+            if isinstance(items, list):
+                return [row for row in items if isinstance(row, dict)]
+        return []
+
+    def _profile_column_kind(self, column_type: str) -> str:
+        normalized = (column_type or "").upper()
+        if any(token in normalized for token in ("INT", "NUMBER", "NUMERIC", "DECIMAL", "DOUBLE", "FLOAT", "REAL")):
+            return "numeric"
+        if any(token in normalized for token in ("DATE", "TIME", "TIMESTAMP")):
+            return "temporal"
+        if any(token in normalized for token in ("BOOL",)):
+            return "boolean"
+        if any(token in normalized for token in ("CHAR", "TEXT", "STRING", "VARCHAR", "ENUM")):
+            return "categorical"
+        return "unknown"
+
+    def _profile_table_reference(self, table_name: str, catalog: str, database: str, schema_name: str) -> str:
+        if "." in table_name:
+            return table_name
+        parts = [part for part in (catalog, database, schema_name, table_name) if part]
+        return ".".join(self._quote_sql_identifier(part) for part in parts)
+
+    def _quote_sql_identifier(self, value: str) -> str:
+        value = str(value).strip().strip('"`[]')
+        if value and value.replace("_", "").isalnum() and not value[0].isdigit():
+            return value
+        return '"' + value.replace('"', '""') + '"'
+
+    def _sanitize_profile_sql(self, value: str) -> str:
+        import re
+
+        sanitized = str(value)
+        sanitized = re.sub(r"'(?:''|[^'])*'", "'<REDACTED>'", sanitized)
+        sanitized = re.sub(r'"(?:""|[^"])*"', '"<REDACTED>"', sanitized)
+        sanitized = re.sub(r"\b\d+(?:\.\d+)?\b", "<REDACTED>", sanitized)
+        return self._clip_profile_text(sanitized, 180)
+
+    def _clip_profile_text(self, value: str, max_chars: int) -> str:
+        value = " ".join(str(value).split())
+        if len(value) <= max_chars:
+            return value
+        return value[: max_chars - 1].rstrip() + "..."
+
+    def _coerce_profile_scalar(self, value: Any) -> Any:
+        if isinstance(value, Decimal):
+            numeric = float(value)
+            if numeric.is_integer():
+                return int(numeric)
+            return numeric
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, date):
+            return value.isoformat()
+        if not isinstance(value, str):
+            return value
+        stripped = value.strip()
+        if stripped == "":
+            return ""
+        try:
+            numeric = float(stripped)
+        except ValueError:
+            return stripped
+        if numeric.is_integer():
+            return int(numeric)
+        return numeric
+
+    def _profile_number(self, value: Any) -> Optional[float]:
+        if value is None or value == "":
+            return None
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float, Decimal)):
+            return float(value)
+        try:
+            return float(str(value).strip())
+        except (TypeError, ValueError):
+            return None
+
+    def _parse_profile_date(self, value: Any) -> Optional[date]:
+        if value in (None, ""):
+            return None
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        text = str(value).strip()
+        if not text:
+            return None
+        normalized = text.replace("Z", "+00:00")
+        for candidate in (normalized, normalized[:19], normalized[:10]):
+            try:
+                parsed = datetime.fromisoformat(candidate)
+                return parsed.date()
+            except ValueError:
+                try:
+                    return date.fromisoformat(candidate[:10])
+                except ValueError:
+                    continue
+        return None
 
     def _classify_source_query(
         self,

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -1349,6 +1349,7 @@ class SemanticDiscoveryTools:
                 f"GROUP BY {column_ref} ORDER BY count DESC LIMIT {max(top_n, 1)}"
             )
             top_values = self._run_profile_rows_query(top_sql, database)
+            top_values = [row for row in top_values if isinstance(row, dict) and not row.get("error")]
             profile["top_values_sql"] = top_sql
             if top_values:
                 profile["top_values"] = [

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -1044,7 +1044,9 @@ class TestBashToolToggle:
             agent_config=mock_agent_config,
         )
 
-        assert node.bash_tool is not None
+        from datus.tools.func_tool.bash_tool import BashTool
+
+        assert isinstance(node.bash_tool, BashTool)
         bash_names = {t.name for t in node.bash_tool.available_tools()}
         assert "execute_command" in bash_names
 

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -887,12 +887,12 @@ class TestBuiltinNodeDefaultSkills:
     def test_gen_metrics_defaults(self):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
-        assert GenMetricsAgenticNode.DEFAULT_SKILLS == "gen-metrics, gen-semantic-model"
+        assert GenMetricsAgenticNode.DEFAULT_SKILLS == "gen-metrics, metricflow-semantic-authoring"
 
     def test_gen_semantic_model_defaults(self):
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 
-        assert GenSemanticModelAgenticNode.DEFAULT_SKILLS == "gen-semantic-model"
+        assert GenSemanticModelAgenticNode.DEFAULT_SKILLS == "metricflow-semantic-authoring"
 
     def test_gen_dashboard_leaves_defaults_unset(self):
         """gen_dashboard injects {platform}-dashboard dynamically in setup, not via DEFAULT_SKILLS."""
@@ -962,8 +962,8 @@ class TestSkillAllowedAgentsConsistency:
         [
             ("gen_job", ["gen-table", "table-validation", "data-migration"]),
             ("gen_table", ["gen-table", "table-validation"]),
-            ("gen_semantic_model", ["gen-semantic-model"]),
-            ("gen_metrics", ["gen-metrics", "gen-semantic-model"]),
+            ("gen_semantic_model", ["metricflow-semantic-authoring"]),
+            ("gen_metrics", ["gen-metrics", "metricflow-semantic-authoring"]),
             ("gen_dashboard", ["bi-validation", "grafana-dashboard", "superset-dashboard"]),
             ("gen_skill", ["create-skill", "optimize-skill"]),
             ("scheduler", ["airflow-workflow", "scheduler-validation"]),
@@ -974,6 +974,31 @@ class TestSkillAllowedAgentsConsistency:
             fm = self._read_skill_frontmatter(skill)
             allowed = fm.get("allowed_agents") or []
             assert node_name in allowed, f"Skill '{skill}' must list '{node_name}' in allowed_agents — got {allowed}"
+
+    def test_semantic_sql_history_profiler_is_optional_and_scoped(self):
+        import pathlib
+
+        project_root = pathlib.Path(__file__).resolve().parents[4]
+        skills_dir = project_root / "datus" / "resources" / "skills"
+        manager = SkillManager(config=SkillConfig(directories=[str(skills_dir)]))
+
+        semantic_names = {
+            skill.name
+            for skill in manager.get_available_skills(
+                "gen_semantic_model",
+                patterns=["semantic-sql-history-profiler"],
+            )
+        }
+        metric_names = {
+            skill.name
+            for skill in manager.get_available_skills(
+                "gen_metrics",
+                patterns=["semantic-sql-history-profiler"],
+            )
+        }
+
+        assert semantic_names == {"semantic-sql-history-profiler"}
+        assert metric_names == set()
 
     def test_dashboard_router_skill_is_not_exposed_to_chat(self):
         """Dashboard routing is handled by task(type="gen_dashboard"), not a chat-visible skill."""

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -542,9 +542,9 @@ class TestExecutionModeGenSemanticModel:
         # in all modes), so _compose_hooks may return CompositeHooks. Check
         # the permission gate on the node so the test stays robust.
         hooks = node._compose_hooks()
-        assert hooks is not None
-        assert node.permission_hooks is not None
         assert node.permission_hooks.non_interactive is True
+        hooks_list = getattr(hooks, "hooks_list", [hooks])
+        assert node.permission_hooks in hooks_list
         # Permission manager must be loaded with the dangerous profile, not the
         # user's profile, so workflow flows always operate against a known
         # baseline.

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -99,6 +99,27 @@ class TestGenSemanticModelAgenticNodeInit:
 
         # SemanticDiscoveryTools should be present
         assert isinstance(node.semantic_discovery_tools, SemanticDiscoveryTools)
+        assert "profile_semantic_model_evidence" not in tool_names
+
+    def test_semantic_sql_history_profiler_tool_is_skill_gated(self, real_agent_config, mock_llm_create):
+        """Profiler tool is exposed only when the optional skill is configured."""
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+
+        original = dict(real_agent_config.agentic_nodes.get("gen_semantic_model", {}))
+        try:
+            real_agent_config.agentic_nodes["gen_semantic_model"] = {
+                **original,
+                "skills": "metricflow-semantic-authoring, semantic-sql-history-profiler",
+            }
+            node = GenSemanticModelAgenticNode(
+                agent_config=real_agent_config,
+                execution_mode="workflow",
+            )
+        finally:
+            real_agent_config.agentic_nodes["gen_semantic_model"] = original
+
+        tool_names = {tool.name for tool in node.tools}
+        assert "profile_semantic_model_evidence" in tool_names
 
     def test_semantic_model_max_turns(self, real_agent_config, mock_llm_create):
         """Test max_turns is read from agentic_nodes config."""
@@ -345,7 +366,7 @@ class TestGenSemanticModelAgenticNodeExecution:
         async def _raise_interrupted(*args, **kwargs):
             """Async generator that raises ExecutionInterrupted."""
             raise ExecutionInterrupted("User pressed ESC")
-            yield  # noqa: makes this an async generator
+            yield  # noqa
 
         node = GenSemanticModelAgenticNode(
             agent_config=real_agent_config,

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -72,7 +72,7 @@ def test_select_impacted_unit_tests_maps_prompt_and_resource_paths_without_full_
         [
             "datus/prompts/prompt_templates/gen_metrics_system_1.2.j2",
             "datus/resources/skills/gen-metrics/SKILL.md",
-            "datus/resources/skills/gen-semantic-model/SKILL.md",
+            "datus/resources/skills/metricflow-semantic-authoring/SKILL.md",
         ]
     )
 

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -41,6 +41,7 @@ from datus.cli.action_display.tool_content import (
     _build_list_tables,
     _build_load_skill,
     _build_parse_dates,
+    _build_profile_semantic_model_evidence,
     _build_query_metrics,
     _build_read_file,
     _build_read_query,
@@ -1724,6 +1725,21 @@ class TestBuildAnalyzeColumns:
 
 
 @pytest.mark.ci
+class TestBuildProfileSemanticModelEvidence:
+    def test_compact(self):
+        a = _make(
+            input_data={"function_name": "profile_semantic_model_evidence"},
+            output_data={
+                "raw_output": '{"success": 1, "result": {'
+                '"data_profiled": true, '
+                '"tables": {"orders": {}, "customers": {}}, "summary": "ok"}}'
+            },
+        )
+        tc = _build_profile_semantic_model_evidence(a, verbose=False)
+        assert "2 tables profiled, data sampled" in tc.compact_result
+
+
+@pytest.mark.ci
 class TestBuildAnalyzeMetricCandidates:
     def test_compact(self):
         a = _make(
@@ -1922,6 +1938,7 @@ class TestAllToolsRegistered:
         "analyze_table_relationships",
         "get_multiple_tables_ddl",
         "analyze_column_usage_patterns",
+        "profile_semantic_model_evidence",
         "analyze_metric_candidates_from_history",
         # Skill
         "execute_command",

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -73,6 +73,7 @@ from datus.cli.action_display.tool_content import (
     parse_output_data,
 )
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY
 
 
 def _make(
@@ -1724,19 +1725,22 @@ class TestBuildAnalyzeColumns:
         assert "2 columns analyzed" in tc.compact_result
 
 
-@pytest.mark.ci
 class TestBuildProfileSemanticModelEvidence:
     def test_compact(self):
+        payload = {
+            "success": 1,
+            "result": {
+                "data_profiled": True,
+                "tables": {"orders": {}, "customers": {}},
+                "summary": "ok",
+            },
+        }
         a = _make(
             input_data={"function_name": "profile_semantic_model_evidence"},
-            output_data={
-                "raw_output": '{"success": 1, "result": {'
-                '"data_profiled": true, '
-                '"tables": {"orders": {}, "customers": {}}, "summary": "ok"}}'
-            },
+            output_data={"raw_output": json.dumps(payload)},
         )
         tc = _build_profile_semantic_model_evidence(a, verbose=False)
-        assert "2 tables profiled, data sampled" in tc.compact_result
+        assert tc.compact_result == TOOL_SUMMARY_REGISTRY.summarize_dict(payload, "profile_semantic_model_evidence")
 
 
 @pytest.mark.ci

--- a/tests/unit_tests/schemas/test_tool_summary.py
+++ b/tests/unit_tests/schemas/test_tool_summary.py
@@ -509,6 +509,19 @@ class TestGenerationFormatters:
         )
         assert out == "2 metric cands"
 
+    def test_profile_semantic_model_evidence(self):
+        out = _summarize(
+            "profile_semantic_model_evidence",
+            {
+                "success": 1,
+                "result": {
+                    "data_profiled": True,
+                    "tables": {"orders": {}, "customers": {}},
+                },
+            },
+        )
+        assert out == "2 tables profiled…"
+
     def test_analyze_metric_candidates_from_history_with_derived_datasource(self):
         out = _summarize(
             "analyze_metric_candidates_from_history",
@@ -922,6 +935,11 @@ def test_failure_path_uniform(tool: str):
             "Analyzed 5 columns…",
         ),
         ("analyze_column_usage_patterns", {"column_patterns": {"a": {}, "b": {}}}, "2 cols analyzed"),
+        (
+            "profile_semantic_model_evidence",
+            {"data_profiled": False, "tables": {"orders": {}}},
+            "1 table profiled",
+        ),
         # Scheduler fallbacks
         ("submit_sql_job", {"job_id": "j"}, "+job j"),
         ("submit_sparksql_job", {"job_id": "j2"}, "+spark j2"),
@@ -1029,6 +1047,7 @@ _LENGTH_CONTRACT_SAMPLES: list[tuple[str, Any]] = [
     ("generate_sql_summary_id", "very_long_summary_id_12345"),
     ("analyze_table_relationships", {"relationships": [{}] * 99, "summary": "x" * 100}),
     ("analyze_column_usage_patterns", {"column_patterns": {str(i): {} for i in range(99)}}),
+    ("profile_semantic_model_evidence", {"data_profiled": True, "tables": {str(i): {} for i in range(99)}}),
     ("get_multiple_tables_ddl", [{}] * 99),
     # scheduler
     ("submit_sql_job", {"job_id": "very_long_job_id_here"}),

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -22,7 +22,9 @@ def _make_db_tool(agent_config=None, sub_agent_name="test_agent"):
     return db_tool
 
 
-def _make_tools(db_tool=None, enable_semantic_model_profiler=False) -> SemanticDiscoveryTools:
+def _make_tools(
+    db_tool: MagicMock | None = None, enable_semantic_model_profiler: bool = False
+) -> SemanticDiscoveryTools:
     if db_tool is None:
         db_tool = _make_db_tool()
     return SemanticDiscoveryTools(
@@ -524,6 +526,28 @@ class TestProfileSemanticModelEvidence:
         assert profile["columns"]["amount"]["stats"]["min_value"] == 1
         assert profile["columns"]["amount"]["stats"]["max_value"] == 99
         assert profile["columns"]["amount"]["percentiles"]["p50"] == 50
+
+    def test_top_values_profile_skips_error_rows(self):
+        db_tool = _make_db_tool()
+        db_tool.read_query.side_effect = [
+            FuncToolResult(
+                success=1, result={"compressed_data": "index,row_count,non_null_count,distinct_count\n0,10,9,2\n"}
+            ),
+            FuncToolResult(success=0, result=[{"error": "top values failed"}]),
+        ]
+        tools = _make_tools(db_tool)
+
+        profile = tools._profile_single_column(
+            table_ref="orders",
+            column_name="status",
+            column_type="VARCHAR",
+            kind="categorical",
+            database="",
+            top_n=2,
+        )
+
+        assert "top_values_sql" in profile
+        assert "top_values" not in profile
 
     def test_deep_profiles_explicit_table_without_sql_evidence(self):
         db_tool = _make_db_tool()

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -22,10 +22,13 @@ def _make_db_tool(agent_config=None, sub_agent_name="test_agent"):
     return db_tool
 
 
-def _make_tools(db_tool=None) -> SemanticDiscoveryTools:
+def _make_tools(db_tool=None, enable_semantic_model_profiler=False) -> SemanticDiscoveryTools:
     if db_tool is None:
         db_tool = _make_db_tool()
-    return SemanticDiscoveryTools(db_tool=db_tool)
+    return SemanticDiscoveryTools(
+        db_tool=db_tool,
+        enable_semantic_model_profiler=enable_semantic_model_profiler,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -391,7 +394,7 @@ class TestAnalyzeColumnUsagePatterns:
     def test_finds_function_pattern(self):
         db_tool = _make_db_tool()
         db_tool.describe_table.return_value = FuncToolResult(success=1, result={"columns": [{"name": "tags"}]})
-        sql_entries = [{"sql": "SELECT * FROM orders WHERE FIND_IN_SET('vip', tags)"}]
+        sql_entries = [{"sql": "SELECT * FROM orders WHERE CUSTOM_MATCH(tags, 'vip')"}]
         mock_rag = MagicMock()
         mock_rag.search_reference_sql.return_value = sql_entries
         with patch("datus.storage.reference_sql.store.ReferenceSqlRAG", return_value=mock_rag):
@@ -399,7 +402,8 @@ class TestAnalyzeColumnUsagePatterns:
             result = tools.analyze_column_usage_patterns("orders", columns=["tags"])
         assert result.success == 1
         assert "tags" in result.result["column_patterns"]
-        assert "FIND_IN_SET" in result.result["column_patterns"]["tags"]["functions"]
+        assert "CUSTOM_MATCH" in result.result["column_patterns"]["tags"]["functions"]
+        assert "Function predicates: CUSTOM_MATCH" in result.result["column_patterns"]["tags"]["usage_description"]
 
     def test_filters_sql_not_containing_table(self):
         db_tool = _make_db_tool()
@@ -438,6 +442,217 @@ class TestAnalyzeColumnUsagePatterns:
 
 
 # ---------------------------------------------------------------------------
+# profile_semantic_model_evidence
+# ---------------------------------------------------------------------------
+
+
+class TestProfileSemanticModelEvidence:
+    def test_sql_only_mines_fields_filters_aggregates_and_joins(self):
+        tools = _make_tools()
+        result = tools.profile_semantic_model_evidence(
+            sql_queries=[
+                """
+                SELECT c.region, SUM(o.amount) AS revenue
+                FROM orders o
+                JOIN customers c ON o.customer_id = c.id
+                WHERE o.status = 'paid'
+                GROUP BY c.region
+                """
+            ],
+            profile_mode="sql_only",
+        )
+
+        assert result.success == 1
+        assert result.result["data_profiled"] is False
+        tables = result.result["tables"]
+        assert set(tables) == {"orders", "customers"}
+        assert tables["orders"]["field_usage_statistics"]["status"]["operators"] == ["="]
+        assert tables["orders"]["common_filter_conditions"][0]["condition"] == "o.status = '<REDACTED>'"
+        filter_template = tables["orders"]["common_business_filter_templates"][0]
+        assert filter_template["condition_template"] == "o.status = '<REDACTED>'"
+        assert filter_template["fields"] == ["status"]
+        assert filter_template["literal_values"] == ["paid"]
+        assert filter_template["usage_kind"] == "categorical_filter"
+        assert tables["orders"]["aggregate_expressions"][0]["expression"] == "SUM(o.amount)"
+        assert tables["customers"]["group_by_expressions"][0]["expression"] == "c.region"
+        assert tables["orders"]["join_relationships"][0]["evidence"] == "historical_sql_join"
+        assert "compact distribution notes" in result.result["yaml_guidance"]
+
+    def test_lightweight_profiles_used_columns(self):
+        db_tool = _make_db_tool()
+        db_tool.describe_table.return_value = FuncToolResult(
+            success=1,
+            result={
+                "columns": [
+                    {"name": "status", "type": "VARCHAR"},
+                    {"name": "amount", "type": "DECIMAL"},
+                ]
+            },
+        )
+        db_tool.read_query.side_effect = [
+            FuncToolResult(success=1, result={"compressed_data": "index,row_count\n0,10\n"}),
+            FuncToolResult(
+                success=1,
+                result={"compressed_data": "index,row_count,non_null_count,distinct_count\n0,10,9,2\n"},
+            ),
+            FuncToolResult(success=1, result={"compressed_data": "index,value,count\n0,paid,7\n1,refund,2\n"}),
+            FuncToolResult(
+                success=1,
+                result={
+                    "compressed_data": "index,row_count,non_null_count,distinct_count,min_value,max_value\n0,10,10,8,1,99\n"
+                },
+            ),
+            FuncToolResult(
+                success=1,
+                result={"compressed_data": "index,p25,p50,p75,p90,p95\n0,10,50,75,90,95\n"},
+            ),
+        ]
+        tools = _make_tools(db_tool)
+
+        result = tools.profile_semantic_model_evidence(
+            sql_queries=["SELECT SUM(amount) AS revenue FROM orders WHERE status = 'paid'"],
+            profile_mode="lightweight",
+            max_columns_per_table=2,
+        )
+
+        assert result.success == 1
+        assert result.result["data_profiled"] is True
+        profile = result.result["tables"]["orders"]["data_distribution_profile"]
+        assert profile["row_count"] == 10
+        assert profile["columns"]["status"]["stats"]["null_rate"] == 0.1
+        assert profile["columns"]["status"]["top_values"][0] == {"value": "paid", "count": 7}
+        assert profile["columns"]["amount"]["stats"]["min_value"] == 1
+        assert profile["columns"]["amount"]["stats"]["max_value"] == 99
+        assert profile["columns"]["amount"]["percentiles"]["p50"] == 50
+
+    def test_deep_profiles_explicit_table_without_sql_evidence(self):
+        db_tool = _make_db_tool()
+        db_tool.describe_table.return_value = FuncToolResult(
+            success=1,
+            result={"columns": [{"name": "amount", "type": "DECIMAL"}]},
+        )
+        db_tool.read_query.side_effect = [
+            FuncToolResult(success=1, result={"compressed_data": "index,row_count\n0,10\n"}),
+            FuncToolResult(
+                success=1,
+                result={
+                    "compressed_data": "index,row_count,non_null_count,distinct_count,min_value,max_value\n0,10,10,8,1,99\n"
+                },
+            ),
+            FuncToolResult(
+                success=1,
+                result={"compressed_data": "index,p25,p50,p75,p90,p95\n0,10,50,75,90,95\n"},
+            ),
+        ]
+        tools = _make_tools(db_tool)
+
+        result = tools.profile_semantic_model_evidence(
+            tables=["orders"],
+            profile_mode="deep",
+            max_columns_per_table=1,
+        )
+
+        assert result.success == 1
+        assert result.result["tables"]["orders"]["query_count"] == 0
+        profile = result.result["tables"]["orders"]["data_distribution_profile"]
+        assert profile["columns"]["amount"]["stats"]["max_value"] == 99
+        assert profile["columns"]["amount"]["percentiles"]["p90"] == 90
+
+    def test_deep_profiles_temporal_span_and_duration_pairs(self):
+        db_tool = _make_db_tool()
+        db_tool.describe_table.return_value = FuncToolResult(
+            success=1,
+            result={
+                "columns": [
+                    {"name": "opened_at", "type": "DATE"},
+                    {"name": "closed_at", "type": "DATE"},
+                ]
+            },
+        )
+        db_tool.read_query.side_effect = [
+            FuncToolResult(success=1, result={"compressed_data": "index,row_count\n0,3\n"}),
+            FuncToolResult(
+                success=1,
+                result={
+                    "compressed_data": (
+                        "index,row_count,non_null_count,distinct_count,min_value,max_value\n"
+                        "0,3,3,3,2025-01-01,2025-01-05\n"
+                    )
+                },
+            ),
+            FuncToolResult(
+                success=1,
+                result={
+                    "compressed_data": (
+                        "index,row_count,non_null_count,distinct_count,min_value,max_value\n"
+                        "0,3,3,3,2025-01-03,2025-01-10\n"
+                    )
+                },
+            ),
+            FuncToolResult(
+                success=1,
+                result={
+                    "compressed_data": (
+                        "index,left_value,right_value\n"
+                        "0,2025-01-01,2025-01-03\n"
+                        "1,2025-01-02,2025-01-05\n"
+                        "2,2025-01-05,2025-01-10\n"
+                    )
+                },
+            ),
+        ]
+        tools = _make_tools(db_tool)
+
+        result = tools.profile_semantic_model_evidence(
+            tables=["events"],
+            profile_mode="deep",
+            max_columns_per_table=2,
+        )
+
+        assert result.success == 1
+        profile = result.result["tables"]["events"]["data_distribution_profile"]
+        assert profile["columns"]["opened_at"]["temporal_summary"]["span_days"] == 4
+        duration = profile["date_duration_profiles"][0]
+        assert duration["candidate_reason"] == "shared_stem_boundary_tokens"
+        assert duration["left_column"] == "opened_at"
+        assert duration["right_column"] == "closed_at"
+        assert duration["delta_days"] == {"min": 2, "p50": 3, "p90": 5, "max": 5}
+
+    def test_join_relationship_profile_reports_coverage_and_fanout_generically(self):
+        db_tool = _make_db_tool()
+        db_tool.read_query.return_value = FuncToolResult(
+            success=1,
+            result={
+                "compressed_data": (
+                    "index,source_rows,non_null_source_rows,distinct_source_keys,"
+                    "matched_join_rows,matched_distinct_source_keys\n"
+                    "0,10,9,3,8,2\n"
+                )
+            },
+        )
+        tools = _make_tools(db_tool)
+
+        profiles = tools._profile_join_relationship_profiles(
+            relationships=[
+                {
+                    "source_table": "events",
+                    "source_column": "user_id",
+                    "target_table": "users",
+                    "target_column": "id",
+                }
+            ],
+            catalog="",
+            database="",
+            schema_name="",
+        )
+
+        assert profiles[0]["referential_coverage"] == 0.666667
+        assert profiles[0]["join_fanout_ratio"] == 0.888889
+        assert profiles[0]["join_cardinality_hint"] == "many_to_one_or_one_to_one"
+        assert "matched_row_ratio" not in profiles[0]
+
+
+# ---------------------------------------------------------------------------
 # analyze_metric_candidates_from_history
 # ---------------------------------------------------------------------------
 
@@ -452,6 +667,12 @@ class TestAnalyzeMetricCandidatesFromHistory:
             "analyze_column_usage_patterns",
             "analyze_metric_candidates_from_history",
         }.issubset(tool_names)
+        assert "profile_semantic_model_evidence" not in tool_names
+
+    def test_available_tools_includes_profiler_when_enabled(self):
+        tools = _make_tools(enable_semantic_model_profiler=True)
+        tool_names = {tool.name for tool in tools.available_tools()}
+        assert "profile_semantic_model_evidence" in tool_names
 
     def test_ratio_candidate_preserves_base_measures(self):
         tools = _make_tools()
@@ -1048,7 +1269,7 @@ class TestAnalyzeMetricCandidatesFromHistory:
                 SELECT COUNT(*) AS order_row_count,
                        COUNT(DISTINCT order_id) AS order_count
                 FROM fact_orders
-                WHERE buyer_name LIKE '%test%' AND FIND_IN_SET('priority', order_tags)
+                WHERE buyer_name LIKE '%test%' AND CUSTOM_MATCH(order_tags, 'priority')
                 """
             ]
         )


### PR DESCRIPTION
## Summary
- replace the old gen-semantic-model skill with a MetricFlow-specific authoring skill
- add an optional semantic-sql-history-profiler skill gated by subagent `skills` configuration
- enrich semantic discovery with reusable SQL/history evidence: column usage, null/fill rates, numeric percentiles, date spans and duration, join coverage/fanout, and common filter templates
- update OSI and MetricFlow semantic-model prompts to consume profiler evidence compactly in YAML descriptions when the skill is enabled

## Why
Semantic model generation needs a controllable way to spend extra time exploring historical SQL and table distributions. Keeping this as an optional skill lets callers decide whether a subagent should use the deeper profiler path.

## Validation
- `git diff --check upstream/main...HEAD`
- `uv run ruff check datus/agent/node/gen_metrics_agentic_node.py datus/agent/node/gen_semantic_model_agentic_node.py datus/cli/action_display/tool_content.py datus/schemas/tool_summary.py datus/tools/func_tool/semantic_discovery_tools.py tests/unit_tests/agent/node/test_agentic_node_skills.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/ci/test_run_pr_tests.py tests/unit_tests/cli/action_display/test_tool_content.py tests/unit_tests/schemas/test_tool_summary.py tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py`
- `uv run pytest tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/agent/node/test_agentic_node_skills.py tests/unit_tests/cli/action_display/test_tool_content.py tests/unit_tests/schemas/test_tool_summary.py tests/unit_tests/ci/test_run_pr_tests.py -q` (673 passed)
- Baisheng benchmark semantic-model generation against local StarRocks for both OSI and MetricFlow profiles, with and without the profiler opt-in

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added support for profiling historical SQL to improve semantic model authoring guidance.
  * Introduced a new semantic-model evidence profiling tool in the CLI output and summary views.
  * Updated semantic authoring workflows to use the newer MetricFlow-oriented skill path.

* **Bug Fixes**
  * Improved handling of semantic descriptions by incorporating richer evidence from prior queries and profiling results.
  * Refined skill availability so historical SQL profiling is only shown where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional profiling of historical SQL to strengthen semantic model authoring guidance.
  * Introduced `profile_semantic_model_evidence` tool support in CLI output/summary views.
  * Updated semantic authoring workflows to prefer the newer MetricFlow skill path (`metricflow-semantic-authoring`).

* **Bug Fixes**
  * Improved semantic description generation by incorporating richer profiler evidence and usage-pattern signals.
  * Refined skill/tool availability so historical SQL profiling appears only when explicitly supported.

* **Tests**
  * Expanded unit test coverage for the new tool, formatter output, and skill gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->