### PR TITLE
[BugFix] Propagate parent database to task-tool subagents; sort glob matches

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -216,6 +216,9 @@ class AskMetricsAgenticNode(AgenticNode):
         patterns = [str(item).strip() for item in items if str(item).strip()]
         return patterns or list(self.DEFAULT_TOOLS)
 
+    def _input_database(self) -> Optional[str]:
+        return getattr(self.input, "database", None) if self.input else None
+
     def _setup_tool_pattern(self, pattern: str) -> None:
         try:
             if "." not in pattern:
@@ -273,14 +276,22 @@ class AskMetricsAgenticNode(AgenticNode):
             return self.semantic_tools
         if category == "db_tools":
             if not self.db_func_tool:
-                self.db_func_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=sub_agent_name)
+                self.db_func_tool = DBFuncTool(
+                    agent_config=self.agent_config,
+                    default_database=self._input_database(),
+                    sub_agent_name=sub_agent_name,
+                )
             return self.db_func_tool
         if category == "reference_template_tools":
             if not self.reference_template_tools:
                 db_tool = self.db_func_tool
                 if not db_tool:
                     try:
-                        db_tool = DBFuncTool(agent_config=self.agent_config, sub_agent_name=sub_agent_name)
+                        db_tool = DBFuncTool(
+                            agent_config=self.agent_config,
+                            default_database=self._input_database(),
+                            sub_agent_name=sub_agent_name,
+                        )
                         self.db_func_tool = db_tool
                     except Exception as exc:  # noqa: BLE001
                         logger.warning("Reference template tools will run without db_tools: %s", exc)

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -169,6 +169,8 @@ class AskMetricsAgenticNode(AgenticNode):
             return
 
         self.tools = []
+        self.db_func_tool = None
+        self.reference_template_tools = None
         sub_agent_name = self.get_node_name()
         tool_patterns = self._configured_tool_patterns()
 

--- a/datus/agent/node/explore_agentic_node.py
+++ b/datus/agent/node/explore_agentic_node.py
@@ -125,6 +125,7 @@ class ExploreAgenticNode(AgenticNode):
                 dynamic_scoped_tables = self.input.scoped_tables
             self.db_func_tool = DBFuncTool(
                 agent_config=self.agent_config,
+                default_database=getattr(self.input, "database", None) if self.input else None,
                 sub_agent_name=self.get_node_name(),
                 scoped_tables=dynamic_scoped_tables,
                 # Explore profiles the datasource and must stay read-only;

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -215,6 +215,9 @@ class GenSQLAgenticNode(AgenticNode):
         )
         self._rebuild_tools()
 
+    def _input_database(self) -> Optional[str]:
+        return getattr(self.input, "database", None) if self.input else None
+
     def _rebuild_tools(self):
         """Rebuild the tools list with current tool instances."""
         self.tools = []
@@ -288,6 +291,7 @@ class GenSQLAgenticNode(AgenticNode):
         try:
             self.db_func_tool = DBFuncTool(
                 agent_config=self.agent_config,
+                default_database=self._input_database(),
                 sub_agent_name=self.node_config.get("system_prompt"),
             )
             self.tools.extend(self.db_func_tool.available_tools())
@@ -328,6 +332,7 @@ class GenSQLAgenticNode(AgenticNode):
             if not db_tool:
                 db_tool = DBFuncTool(
                     agent_config=self.agent_config,
+                    default_database=self._input_database(),
                     sub_agent_name=self.node_config.get("system_prompt"),
                 )
             self.reference_template_tools = ReferenceTemplateTools(
@@ -454,6 +459,7 @@ class GenSQLAgenticNode(AgenticNode):
                 if not self.db_func_tool:
                     self.db_func_tool = DBFuncTool(
                         agent_config=self.agent_config,
+                        default_database=self._input_database(),
                         sub_agent_name=self.node_config.get("system_prompt"),
                     )
                 tool_instance = self.db_func_tool
@@ -475,6 +481,7 @@ class GenSQLAgenticNode(AgenticNode):
                     if not db_tool:
                         db_tool = DBFuncTool(
                             agent_config=self.agent_config,
+                            default_database=self._input_database(),
                             sub_agent_name=self.node_config.get("system_prompt"),
                         )
                     self.reference_template_tools = ReferenceTemplateTools(

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -124,7 +124,7 @@ class GenSQLAgenticNode(AgenticNode):
         self.setup_tools()
 
         # Setup ask_user tool for clarification questions (interactive mode only)
-        if self.execution_mode == "interactive":
+        if self.execution_mode == "interactive" and not self.ask_user_tool:
             self._setup_ask_user_tool()
 
         logger.debug(f"GenSQLAgenticNode tools: {len(self.tools)} tools - {[tool.name for tool in self.tools]}")
@@ -254,6 +254,8 @@ class GenSQLAgenticNode(AgenticNode):
             return
 
         self.tools = []
+        self.db_func_tool = None
+        self.reference_template_tools = None
         tools_str = self.node_config.get("tools")
         if not tools_str:
             tools_str = self.DEFAULT_TOOLS
@@ -272,6 +274,9 @@ class GenSQLAgenticNode(AgenticNode):
         self._setup_sub_agent_task_tool()
         if self.sub_agent_task_tool:
             self.tools.extend(self.sub_agent_task_tool.available_tools())
+
+        if self.execution_mode == "interactive":
+            self._setup_ask_user_tool()
 
         # Plan-mode tools (confirm_plan + todo_*) for main agents; no-op for sub-agents.
         self._register_plan_mode_tools()

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from datus.agent.node.agentic_node import AgenticNode
     from datus.cli.execution_state import InteractionBroker
     from datus.schemas.action_bus import ActionBus
+    from datus.schemas.base import BaseInput
 
 logger = get_logger(__name__)
 
@@ -758,8 +759,11 @@ class SubAgentTaskTool:
                     ),
                 )
 
-            # Set input on the node
-            node.input = self._build_node_input(node, prompt)
+            # Set input on the node, then refresh DB-backed tools so connector
+            # routing follows the inherited physical database as well.
+            db_ctx = self._parent_db_context()
+            node.input = self._build_node_input(node, prompt, db_ctx=db_ctx)
+            self._refresh_node_db_tools(node, db_ctx)
 
             # Inject parent's InteractionBroker so that sub-agent INTERACTION
             # actions are routed through the parent's broker queue.  When injected,
@@ -943,18 +947,27 @@ class SubAgentTaskTool:
         if parent is None:
             return {}
         parent_input = getattr(parent, "input", None)
-        requested_db = getattr(parent_input, "database", "") or ""
+        requested_db = self._string_attr(parent_input, "database") or ""
         connector = getattr(getattr(parent, "db_func_tool", None), "connector", None)
         from datus.utils.node_utils import resolve_database_name_for_prompt
 
+        resolved_db = resolve_database_name_for_prompt(connector, requested_db)
+        if not isinstance(resolved_db, str) or not resolved_db:
+            resolved_db = None
+
         return {
-            "database": resolve_database_name_for_prompt(connector, requested_db) or None,
-            "catalog": (getattr(parent_input, "catalog", "") or None),
-            "db_schema": (getattr(parent_input, "db_schema", "") or None),
+            "database": resolved_db,
+            "catalog": self._string_attr(parent_input, "catalog"),
+            "db_schema": self._string_attr(parent_input, "db_schema"),
         }
 
     @staticmethod
-    def _apply_db_context(node_input, ctx: Dict[str, Optional[str]]):
+    def _string_attr(obj: Any, name: str) -> Optional[str]:
+        value = getattr(obj, name, None)
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _apply_db_context(node_input: "BaseInput", ctx: Dict[str, Optional[str]]) -> "BaseInput":
         """Set inherited DB context on a freshly-built subagent input in place.
 
         Only assigns fields the input model actually declares (``ExploreNodeInput`` carries
@@ -966,7 +979,17 @@ class SubAgentTaskTool:
                 setattr(node_input, field, value)
         return node_input
 
-    def _build_node_input(self, node, prompt: str):
+    @staticmethod
+    def _refresh_node_db_tools(node: "AgenticNode", ctx: Dict[str, Optional[str]]) -> None:
+        """Rebuild DB-backed tool instances after inherited input context is set."""
+        node_database = SubAgentTaskTool._string_attr(getattr(node, "input", None), "database")
+        if not node_database or not ctx.get("database") or not hasattr(node, "db_func_tool"):
+            return
+        setup_tools = getattr(node, "setup_tools", None)
+        if callable(setup_tools):
+            setup_tools()
+
+    def _build_node_input(self, node, prompt: str, db_ctx: Optional[Dict[str, Optional[str]]] = None):
         """Build the appropriate input object for the given node.
 
         The subagent inherits the parent node's resolved physical ``database`` (and
@@ -979,7 +1002,7 @@ class SubAgentTaskTool:
         from datus.schemas.explore_agentic_node_models import ExploreNodeInput
         from datus.schemas.gen_sql_agentic_node_models import GenSQLNodeInput
 
-        db_ctx = self._parent_db_context()
+        db_ctx = db_ctx if db_ctx is not None else self._parent_db_context()
 
         if isinstance(node, ExploreAgenticNode):
             return self._apply_db_context(ExploreNodeInput(user_message=prompt), db_ctx)

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -988,6 +988,12 @@ class SubAgentTaskTool:
         setup_tools = getattr(node, "setup_tools", None)
         if callable(setup_tools):
             setup_tools()
+            ask_user_tool = getattr(node, "ask_user_tool", None)
+            tools = getattr(node, "tools", None)
+            if ask_user_tool is not None and isinstance(tools, list):
+                tool_names = {getattr(tool, "name", "") for tool in tools}
+                if "ask_user" not in tool_names:
+                    tools.extend(ask_user_tool.available_tools())
 
     def _build_node_input(self, node, prompt: str, db_ctx: Optional[Dict[str, Optional[str]]] = None):
         """Build the appropriate input object for the given node.

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -929,37 +929,70 @@ class SubAgentTaskTool:
 
     # ── input building ─────────────────────────────────────────────────
 
+    def _parent_db_context(self) -> Dict[str, Optional[str]]:
+        """Physical DB context (database/catalog/schema) the parent node targets.
+
+        A subagent must inherit the parent's *resolved* database rather than fall back to
+        the datasource's default. For a multi-database glob (``path_pattern``) datasource
+        the default is an arbitrary first-matched file, so an un-inherited subagent would
+        silently target the wrong database (e.g. a california_schools task exploring an
+        unrelated bird database). Mirrors the parent's ``database`` — a physical database
+        name, never the datasource key.
+        """
+        parent = self._parent_node
+        if parent is None:
+            return {}
+        parent_input = getattr(parent, "input", None)
+        requested_db = getattr(parent_input, "database", "") or ""
+        connector = getattr(getattr(parent, "db_func_tool", None), "connector", None)
+        from datus.utils.node_utils import resolve_database_name_for_prompt
+
+        return {
+            "database": resolve_database_name_for_prompt(connector, requested_db) or None,
+            "catalog": (getattr(parent_input, "catalog", "") or None),
+            "db_schema": (getattr(parent_input, "db_schema", "") or None),
+        }
+
+    @staticmethod
+    def _apply_db_context(node_input, ctx: Dict[str, Optional[str]]):
+        """Set inherited DB context on a freshly-built subagent input in place.
+
+        Only assigns fields the input model actually declares (``ExploreNodeInput`` carries
+        ``database`` alone; gen_sql/ask_metrics also carry ``catalog``/``db_schema``), so a
+        sparser input silently skips what it does not support.
+        """
+        for field, value in ctx.items():
+            if value and hasattr(node_input, field):
+                setattr(node_input, field, value)
+        return node_input
+
     def _build_node_input(self, node, prompt: str):
         """Build the appropriate input object for the given node.
 
-        The ``database`` context field is intentionally left unset: it denotes a physical
-        database name, not a datasource. Each node is constructed with ``agent_config`` and
-        routes through ``current_datasource``'s default database on its own, so stuffing the
-        datasource name into ``database`` here would only mislabel the context.
+        The subagent inherits the parent node's resolved physical ``database`` (and
+        ``catalog``/``db_schema`` where supported) via :meth:`_parent_db_context`; without
+        this a subagent on a multi-database glob datasource falls back to the arbitrary
+        default database and explores the wrong one.
         """
         from datus.agent.node.explore_agentic_node import ExploreAgenticNode
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
         from datus.schemas.explore_agentic_node_models import ExploreNodeInput
         from datus.schemas.gen_sql_agentic_node_models import GenSQLNodeInput
 
+        db_ctx = self._parent_db_context()
+
         if isinstance(node, ExploreAgenticNode):
-            return ExploreNodeInput(
-                user_message=prompt,
-            )
+            return self._apply_db_context(ExploreNodeInput(user_message=prompt), db_ctx)
 
         if isinstance(node, GenSQLAgenticNode):
-            return GenSQLNodeInput(
-                user_message=prompt,
-            )
+            return self._apply_db_context(GenSQLNodeInput(user_message=prompt), db_ctx)
 
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
 
         if isinstance(node, AskMetricsAgenticNode):
             from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
 
-            return AskMetricsNodeInput(
-                user_message=prompt,
-            )
+            return self._apply_db_context(AskMetricsNodeInput(user_message=prompt), db_ctx)
 
         # Built-in system subagent input types
         from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode

--- a/datus/utils/path_utils.py
+++ b/datus/utils/path_utils.py
@@ -123,7 +123,10 @@ def get_files_from_glob_pattern(path_pattern: str, dialect: str | DBType = DBTyp
         dir_pattern, _ = "", normalized_pattern
     dir_has_wildcard = any(ch in dir_pattern for ch in ("*", "?", "["))
 
-    files = glob.glob(path_pattern, recursive=True)
+    # Sort for a deterministic order: a glob datasource's default database is the first
+    # match (see DBManager._resolve_db_config), and glob.glob() returns filesystem order,
+    # which varies across machines. Sorting keeps the default stable across runners.
+    files = sorted(glob.glob(path_pattern, recursive=True))
     result: List[Dict[str, str]] = []
 
     for file_path in files:

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -1012,6 +1012,28 @@ class TestAskMetricsAgenticNode:
 
         assert node.db_func_tool._default_database == "california_schools"
 
+    def test_setup_tools_refreshes_db_tools_for_changed_input_database(self, real_agent_config, mock_llm_create):
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree=tree,
+            node_config={"type": "ask_metrics", "tools": "db_tools.read_query"},
+        )
+        original_db_tool = node.db_func_tool
+
+        node.input = AskMetricsNodeInput(user_message="Show revenue", database="california_schools")
+        with (
+            patch("datus.agent.node.ask_metrics_agentic_node.SemanticTools", return_value=_semantic_tools()),
+            patch("datus.agent.node.ask_metrics_agentic_node.ContextSearchTools", return_value=_context_tools(tree)),
+            patch("datus.agent.node.ask_metrics_agentic_node.trans_to_function_tool", side_effect=_fake_function_tool),
+        ):
+            node.setup_tools()
+
+        assert node.db_func_tool is not original_db_tool
+        assert node.db_func_tool._default_database == "california_schools"
+
     def test_setup_tools_handles_context_search_failure(self, real_agent_config, mock_llm_create):
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
 

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -1000,6 +1000,18 @@ class TestAskMetricsAgenticNode:
         assert registry.get("read_query") == "db_tools"
         assert registry.get("parse_temporal_expressions") == "date_parsing_tools"
 
+    def test_db_tools_use_input_database(self, real_agent_config, mock_llm_create):
+        from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+
+        node, _, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["revenue"]}}},
+            node_config={"type": "ask_metrics", "tools": "db_tools.read_query"},
+            input_data=AskMetricsNodeInput(user_message="Show revenue", database="california_schools"),
+        )
+
+        assert node.db_func_tool._default_database == "california_schools"
+
     def test_setup_tools_handles_context_search_failure(self, real_agent_config, mock_llm_create):
         from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
 

--- a/tests/unit_tests/agent/node/test_explore_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_explore_agentic_node.py
@@ -112,6 +112,25 @@ class TestExploreAgenticNodeTools:
         assert "describe_table" in tool_names
         assert "execute_sql" in tool_names
 
+    def test_explore_db_tools_use_input_database(self, real_agent_config, mock_llm_create):
+        """Rebuilt DB tools should route to the physical database on node input."""
+        from datus.agent.node.explore_agentic_node import ExploreAgenticNode
+        from datus.schemas.explore_agentic_node_models import ExploreNodeInput
+
+        node = ExploreAgenticNode(
+            node_id="test_explore_tools_database",
+            description="Test Explore node",
+            node_type=NodeType.TYPE_EXPLORE,
+            agent_config=real_agent_config,
+            node_name="explore",
+        )
+        node.input = ExploreNodeInput(user_message="Explore schools", database="california_schools")
+
+        node._setup_db_tools()
+
+        assert node.db_func_tool._default_database == "california_schools"
+        assert node.db_func_tool.read_only is True
+
     def test_explore_has_readonly_filesystem_tools(self, real_agent_config, mock_llm_create):
         """Node should have read-only filesystem tools."""
         from datus.agent.node.explore_agentic_node import ExploreAgenticNode

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -80,6 +80,23 @@ class TestGenSQLAgenticNodeInit:
         tool_names = {t.name for t in node.tools}
         assert {"list_tables", "describe_table", "execute_sql"} <= tool_names
 
+    def test_gen_sql_db_tools_use_input_database(self, real_agent_config, mock_llm_create):
+        """Rebuilt DB tools should route to the physical database on node input."""
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        node = GenSQLAgenticNode(
+            node_id="test_gen_sql_database",
+            description="Test GenSQL node",
+            node_type=NodeType.TYPE_GEN_SQL,
+            agent_config=real_agent_config,
+            node_name="gen_sql",
+        )
+        node.input = GenSQLNodeInput(user_message="Show all schools", database="california_schools")
+
+        node._setup_db_tools()
+
+        assert node.db_func_tool._default_database == "california_schools"
+
     def test_gen_sql_max_turns_from_config(self, real_agent_config, mock_llm_create):
         """max_turns is read from agentic_nodes config (set to 5 in fixture)."""
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -97,6 +97,30 @@ class TestGenSQLAgenticNodeInit:
 
         assert node.db_func_tool._default_database == "california_schools"
 
+    def test_gen_sql_setup_tools_refreshes_specific_db_tool_database(self, real_agent_config, mock_llm_create):
+        """Specific db_tools methods should rebuild DBFuncTool with current input database."""
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+
+        real_agent_config.agentic_nodes["custom_gen_sql_db"] = {
+            "system_prompt": "gen_sql",
+            "tools": "db_tools.read_query",
+            "max_turns": 5,
+        }
+        node = GenSQLAgenticNode(
+            node_id="test_gen_sql_specific_database",
+            description="Test GenSQL node",
+            node_type=NodeType.TYPE_GEN_SQL,
+            agent_config=real_agent_config,
+            node_name="custom_gen_sql_db",
+        )
+        original_db_tool = node.db_func_tool
+
+        node.input = GenSQLNodeInput(user_message="Show all schools", database="california_schools")
+        node.setup_tools()
+
+        assert node.db_func_tool is not original_db_tool
+        assert node.db_func_tool._default_database == "california_schools"
+
     def test_gen_sql_max_turns_from_config(self, real_agent_config, mock_llm_create):
         """max_turns is read from agentic_nodes config (set to 5 in fixture)."""
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
@@ -852,6 +876,33 @@ class TestGenSQLNodeReferenceTemplateToolSetup:
             node_name="tpl_test2",
         )
         assert isinstance(node.reference_template_tools, ReferenceTemplateTools)
+
+    def test_reference_template_only_refreshes_internal_db_tool_database(self, real_agent_config, mock_llm_create):
+        """Reference-template-only configs should refresh their internal DBFuncTool."""
+        real_agent_config.agentic_nodes["tpl_only"] = {
+            "system_prompt": "gen_sql",
+            "tools": "reference_template_tools.execute_reference_template",
+            "max_turns": 5,
+        }
+        from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
+        from datus.configuration.node_type import NodeType
+        from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
+
+        node = GenSQLAgenticNode(
+            node_id="tpl_only_id",
+            description="Test",
+            node_type=NodeType.TYPE_GEN_SQL,
+            agent_config=real_agent_config,
+            node_name="tpl_only",
+        )
+        original_template_tools = node.reference_template_tools
+
+        node.input = GenSQLNodeInput(user_message="Show all schools", database="california_schools")
+        node.setup_tools()
+
+        assert isinstance(node.reference_template_tools, ReferenceTemplateTools)
+        assert node.reference_template_tools is not original_template_tools
+        assert node.reference_template_tools.db_func_tool._default_database == "california_schools"
 
 
 # ===========================================================================

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -727,6 +727,12 @@ class TestSubAgentTaskAcceptance:
         parent.get_node_name.return_value = "chat"
         parent.proxy_tool_patterns = []
         parent.tool_channel = None
+        # A chat parent carries no bound physical database, so the delegated subagent must
+        # inherit nothing here (contrast TestSubagentInheritsParentDatabase, where a DB-bound
+        # parent does propagate). Pin these so the auto-MagicMock attributes don't masquerade
+        # as a real database.
+        parent.input.database = None
+        parent.db_func_tool = None
         task_tool._parent_node = parent
 
         assert "sales_analyst" in task_tool._get_available_types()
@@ -2566,3 +2572,93 @@ class TestSessionPersistence:
         desc = schema["properties"]["session_id"]["description"]
         assert "continue" in desc.lower()
         assert "type" in desc.lower()  # callout that types must match
+
+
+@pytest.mark.ci
+class TestSubagentInheritsParentDatabase:
+    """A subagent spawned via the task tool must inherit the parent node's resolved
+    physical database (and catalog/schema where supported).
+
+    Regression guard: for a multi-database glob (``path_pattern``) datasource the default
+    database is an arbitrary first-matched file, so a subagent that does NOT inherit the
+    parent's database silently explores the wrong one — the root cause of a benchmark task
+    delegating to ``explore`` and hanging on an unrelated bird database.
+    """
+
+    @staticmethod
+    def _parent(database="", catalog="", db_schema="", connector_db=None):
+        parent = MagicMock()
+        parent.input.database = database
+        parent.input.catalog = catalog
+        parent.input.db_schema = db_schema
+        if connector_db is None:
+            parent.db_func_tool = None
+        else:
+            parent.db_func_tool.connector.database_name = connector_db
+        return parent
+
+    def test_parent_db_context_reads_parent_input(self, task_tool):
+        task_tool._parent_node = self._parent(database="california_schools", catalog="cat", db_schema="sch")
+        assert task_tool._parent_db_context() == {
+            "database": "california_schools",
+            "catalog": "cat",
+            "db_schema": "sch",
+        }
+
+    def test_parent_db_context_falls_back_to_connector_database_name(self, task_tool):
+        # Parent set no explicit database → use the connector's real database name, not the
+        # datasource default (resolve_database_name_for_prompt contract).
+        task_tool._parent_node = self._parent(database="", connector_db="california_schools")
+        assert task_tool._parent_db_context()["database"] == "california_schools"
+
+    def test_parent_db_context_no_parent_returns_empty(self, task_tool):
+        task_tool._parent_node = None
+        assert task_tool._parent_db_context() == {}
+
+    def test_apply_db_context_skips_fields_the_input_lacks(self):
+        # ExploreNodeInput declares only `database`; catalog/db_schema must be skipped, not error.
+        class OnlyDatabase:
+            database = None
+
+        obj = SubAgentTaskTool._apply_db_context(OnlyDatabase(), {"database": "db1", "catalog": "c", "db_schema": "s"})
+        assert obj.database == "db1"
+        assert not hasattr(obj, "catalog")
+
+    def test_apply_db_context_sets_all_declared_fields(self):
+        from datus.schemas.gen_sql_agentic_node_models import GenSQLNodeInput
+
+        ctx = {"database": "california_schools", "catalog": "cat", "db_schema": "sch"}
+        gen = SubAgentTaskTool._apply_db_context(GenSQLNodeInput(user_message="x"), ctx)
+        assert (gen.database, gen.catalog, gen.db_schema) == ("california_schools", "cat", "sch")
+
+    def test_build_node_input_explore_inherits_parent_database(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.explore_agentic_node import ExploreAgenticNode
+        from datus.schemas.explore_agentic_node_models import ExploreNodeInput
+
+        tool = SubAgentTaskTool(agent_config=real_agent_config)
+        tool._parent_node = self._parent(database="california_schools")
+        node = ExploreAgenticNode(
+            node_id="t",
+            description="d",
+            node_type=NodeType.TYPE_EXPLORE,
+            agent_config=real_agent_config,
+            node_name="explore",
+        )
+        inp = tool._build_node_input(node, "explore schools")
+        assert isinstance(inp, ExploreNodeInput)
+        assert inp.database == "california_schools"
+
+    def test_build_node_input_explore_no_parent_leaves_database_unset(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.explore_agentic_node import ExploreAgenticNode
+
+        tool = SubAgentTaskTool(agent_config=real_agent_config)
+        tool._parent_node = None
+        node = ExploreAgenticNode(
+            node_id="t",
+            description="d",
+            node_type=NodeType.TYPE_EXPLORE,
+            agent_config=real_agent_config,
+            node_name="explore",
+        )
+        inp = tool._build_node_input(node, "explore schools")
+        assert inp.database is None

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -732,6 +732,8 @@ class TestSubAgentTaskAcceptance:
         # parent does propagate). Pin these so the auto-MagicMock attributes don't masquerade
         # as a real database.
         parent.input.database = None
+        parent.input.catalog = None
+        parent.input.db_schema = None
         parent.db_func_tool = None
         task_tool._parent_node = parent
 
@@ -2611,6 +2613,19 @@ class TestSubagentInheritsParentDatabase:
         task_tool._parent_node = self._parent(database="", connector_db="california_schools")
         assert task_tool._parent_db_context()["database"] == "california_schools"
 
+    def test_parent_db_context_ignores_mock_connector_database_name(self, task_tool):
+        parent = MagicMock()
+        parent.input.database = ""
+        parent.input.catalog = None
+        parent.input.db_schema = None
+        task_tool._parent_node = parent
+
+        assert task_tool._parent_db_context() == {
+            "database": None,
+            "catalog": None,
+            "db_schema": None,
+        }
+
     def test_parent_db_context_no_parent_returns_empty(self, task_tool):
         task_tool._parent_node = None
         assert task_tool._parent_db_context() == {}
@@ -2662,3 +2677,27 @@ class TestSubagentInheritsParentDatabase:
         )
         inp = tool._build_node_input(node, "explore schools")
         assert inp.database is None
+
+    def test_refresh_node_db_tools_rebuilds_when_database_inherited(self):
+        node = MagicMock()
+        node.input.database = "california_schools"
+        node.db_func_tool = MagicMock()
+
+        SubAgentTaskTool._refresh_node_db_tools(
+            node,
+            {"database": "california_schools", "catalog": None, "db_schema": None},
+        )
+
+        node.setup_tools.assert_called_once_with()
+
+    def test_refresh_node_db_tools_skips_when_database_absent(self):
+        node = MagicMock()
+        node.input.database = None
+        node.db_func_tool = MagicMock()
+
+        SubAgentTaskTool._refresh_node_db_tools(
+            node,
+            {"database": None, "catalog": None, "db_schema": None},
+        )
+
+        node.setup_tools.assert_not_called()

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -2690,6 +2690,30 @@ class TestSubagentInheritsParentDatabase:
 
         node.setup_tools.assert_called_once_with()
 
+    def test_refresh_node_db_tools_preserves_ask_user_after_setup(self):
+        read_query = Mock()
+        read_query.name = "read_query"
+        ask_user = Mock()
+        ask_user.name = "ask_user"
+
+        node = MagicMock()
+        node.input.database = "california_schools"
+        node.db_func_tool = MagicMock()
+        node.tools = [read_query, ask_user]
+        node.ask_user_tool.available_tools.return_value = [ask_user]
+
+        def reset_tools():
+            node.tools = [read_query]
+
+        node.setup_tools.side_effect = reset_tools
+
+        SubAgentTaskTool._refresh_node_db_tools(
+            node,
+            {"database": "california_schools", "catalog": None, "db_schema": None},
+        )
+
+        assert [tool.name for tool in node.tools] == ["read_query", "ask_user"]
+
     def test_refresh_node_db_tools_skips_when_database_absent(self):
         node = MagicMock()
         node.input.database = None

--- a/tests/unit_tests/utils/test_path_utils.py
+++ b/tests/unit_tests/utils/test_path_utils.py
@@ -100,6 +100,23 @@ class TestGetFilesFromGlobPattern:
             result = get_files_from_glob_pattern(pattern)
         assert result == []
 
+    def test_results_sorted_by_path_deterministically(self):
+        """Matches come back in a stable (sorted) order, not raw filesystem order.
+
+        A glob datasource's default database is ``files[0]`` (DBManager._resolve_db_config),
+        so an unsorted order makes the default non-deterministic across machines — which is
+        how a benchmark runner ended up defaulting to the wrong database. Create files out of
+        alphabetical order to prove the sort is applied rather than relying on OS ordering.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ("european_football_2.sqlite", "california_schools.sqlite", "card_games.sqlite"):
+                Path(tmpdir, name).write_text("data")
+
+            pattern = os.path.join(tmpdir, "*.sqlite")
+            names = [entry["name"] for entry in get_files_from_glob_pattern(pattern)]
+
+        assert names == ["california_schools", "card_games", "european_football_2"]
+
     def test_wildcard_directory_uses_parent_as_datasource(self):
         """When the directory part contains wildcards, datasource is parent dir name."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Why

A subagent spawned via the `task` tool (`explore` / `gen_sql` / `ask_metrics`) did **not** inherit the parent node's physical `database`. On a multi-database glob (`path_pattern`) datasource — e.g. the bird benchmark's `bird_sqlite`, which globs every BIRD `.sqlite` — the subagent then fell back to the datasource's *default* database, i.e. the first glob match.

Because `glob.glob()` returns unsorted filesystem order, that default was **non-deterministic across machines**. On the weekly benchmark runner a `california_schools` task delegated to `explore`, which was authoritatively told its database was the unrelated `european_football_2`, could not find the schools tables, wandered the filesystem with `grep`/`glob`, and finally issued an `ATTACH DATABASE '<file>'` that hung with no timeout — running out the 6h CI limit and failing the job.

Root cause introduced in #455 (the task-tool `explore` path): the sibling workflow-node path already passed `database=workflow.task.database_name`, but the task-tool input builder dropped it.

## Solution

- `SubAgentTaskTool._build_node_input` now derives the parent node's resolved physical database (and `catalog`/`db_schema` where the input model supports them) via a new `_parent_db_context()` and applies it to the subagent input. The parent's explicit `input.database` wins; otherwise it falls back to the connector's real `database_name` (via the existing `resolve_database_name_for_prompt`). `_apply_db_context` only sets fields the target input model declares, so `ExploreNodeInput` (database-only) and gen_sql/ask_metrics (catalog/db_schema too) are both handled.
- `get_files_from_glob_pattern` now sorts `glob.glob()` results so a glob datasource's default database is stable across machines (defense in depth; the propagation fix is the actual root-cause fix).

Considered but rejected: raising on "multi-db glob + empty database". It would break legitimate default-connection callers (`first_conn_with_name` is used by repl / datasource_commands / database_service / cli_service), so a deterministic sort is the safer hardening.

## Test Cases

- `TestSubagentInheritsParentDatabase` (unit): parent-context resolution (explicit db, connector fallback, no parent), field-scoped application, and end-to-end `_build_node_input` inheritance for a real `ExploreAgenticNode` (with and without a DB-bound parent).
- `test_path_utils`: new determinism test proving out-of-order files come back sorted.
- Updated `test_custom_subagent_discovery_scope_and_delegation` so its chat parent mock realistically carries no bound database.
- Benchmark validation (bird, deepseek-v4-pro, real DBs): the original hanging task 40 (`california_schools`) now completes in ~22s with correct `california_schools` SQL; and `european_football_2` tasks (which sort *after* `california_schools`, so sorting alone wouldn't help) spawn `explore` that correctly inherits `european_football_2` — `database='california_schools'` never appears — proving the propagation fix, not just the sort, is doing the work.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [x] release/0.3.7
## Summary by CodeRabbit

* **Bug Fixes**
  * Sub-agents now inherit the correct database context from their parent, improving consistency when exploring data, generating SQL, and checking metrics.
  * File discovery results are now returned in a stable, deterministic order across runs and environments.

* **Tests**
  * Expanded coverage for database-context inheritance and deterministic file sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sub-agent tasks now inherit the parent’s resolved physical database context, and database-backed tools are rebuilt to match.
  * Explore, SQL generation, and metrics nodes now default their database tools from the current node input database (when provided).

* **Bug Fixes**
  * Improved delegated execution alignment so child routing targets the same physical database as the parent.
  * File glob matches are now returned in a deterministic (sorted) order.

* **Tests**
  * Added/extended unit coverage for database inheritance, tool refresh when input database changes, and stable file ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->