### PR TITLE
[UT] Fix nightly model tests: base_url fixture collision and DatusException.code

### DIFF
--- a/tests/integration/models/test_other_models.py
+++ b/tests/integration/models/test_other_models.py
@@ -103,7 +103,7 @@ class TestOpenAIModel:
 
             logger.debug(f"MCP response: {result.get('content', '')}")
         except DatusException as e:
-            if e.error_code == ErrorCode.MODEL_MAX_TURNS_EXCEEDED:
+            if e.code == ErrorCode.MODEL_MAX_TURNS_EXCEEDED:
                 pytest.skip(f"MCP test skipped due to max turns exceeded: {str(e)}")
             else:
                 raise
@@ -285,7 +285,7 @@ class TestKimiModel:
 
             logger.debug(f"MCP response: {result.get('content', '')}")
         except DatusException as e:
-            if e.error_code == ErrorCode.MODEL_MAX_TURNS_EXCEEDED:
+            if e.code == ErrorCode.MODEL_MAX_TURNS_EXCEEDED:
                 pytest.skip(f"MCP test skipped due to max turns exceeded: {str(e)}")
             else:
                 raise
@@ -386,7 +386,7 @@ class TestGeminiModel:
 
             logger.debug(f"MCP response: {result.get('content', '')}")
         except DatusException as e:
-            if e.error_code == ErrorCode.MODEL_MAX_TURNS_EXCEEDED:
+            if e.code == ErrorCode.MODEL_MAX_TURNS_EXCEEDED:
                 pytest.skip(f"MCP test skipped due to max turns exceeded: {str(e)}")
             else:
                 raise

--- a/tests/unit_tests/models/test_litellm_adapter.py
+++ b/tests/unit_tests/models/test_litellm_adapter.py
@@ -517,8 +517,11 @@ class TestIsOfficialAnthropicEndpoint:
     official. Third-party Claude-compatible proxies must be rejected so the
     hosted ``web_search_20250305`` tool is never injected for them."""
 
+    # NOTE: the param is named ``endpoint`` (not ``base_url``) on purpose. The
+    # ``pytest-base-url`` plugin registers a session-scoped ``base_url`` fixture,
+    # and a same-named parametrize param collides with it (ScopeMismatch).
     @pytest.mark.parametrize(
-        "base_url",
+        "endpoint",
         [
             None,
             "",
@@ -527,11 +530,11 @@ class TestIsOfficialAnthropicEndpoint:
             "https://API.Anthropic.com",  # case-insensitive host
         ],
     )
-    def test_official_or_default(self, base_url):
-        assert is_official_anthropic_endpoint(base_url) is True
+    def test_official_or_default(self, endpoint):
+        assert is_official_anthropic_endpoint(endpoint) is True
 
     @pytest.mark.parametrize(
-        "base_url",
+        "endpoint",
         [
             "https://api.kimi.com/coding/",  # kimi_coding proxy
             "https://api.moonshot.ai/anthropic",
@@ -540,8 +543,8 @@ class TestIsOfficialAnthropicEndpoint:
             "not-a-url",
         ],
     )
-    def test_third_party_proxies_rejected(self, base_url):
-        assert is_official_anthropic_endpoint(base_url) is False
+    def test_third_party_proxies_rejected(self, endpoint):
+        assert is_official_anthropic_endpoint(endpoint) is False
 
 
 class TestGetAgentsSdkModelRouting:


### PR DESCRIPTION
## Why

Two nightly test failures were unrelated to product code and blocked the nightly run on both `main` and `release/0.3.7`:

1. **`test_litellm_adapter.py::TestIsOfficialAnthropicEndpoint` — 10 errors (`ScopeMismatch`).** The tests parametrize on `base_url`, which collides with the session-scoped `base_url` fixture provided by the `pytest-base-url` plugin present in the nightly environment. pytest then tries to resolve the function-scoped parametrize value through a session-scoped request and raises `ScopeMismatch: You tried to access the function scoped fixture base_url with a session scoped request object`.

2. **`test_other_models.py::TestOpenAIModel::test_generate_with_mcp` — `AttributeError`.** The `except DatusException` handlers referenced `e.error_code`, but `DatusException` only exposes `.code`. When a non-`MODEL_MAX_TURNS_EXCEEDED` error was raised (in the nightly this was the OpenAI quota error `300020`), the handler itself raised `AttributeError: 'DatusException' object has no attribute 'error_code'`, masking the real cause.

## Solution

1. Rename the parametrize param `base_url` → `endpoint` in both `test_official_or_default` and `test_third_party_proxies_rejected`, with a comment explaining the plugin collision. No behavior change — same inputs, same assertions.
2. Replace `e.error_code` with `e.code` in the three `except DatusException` handlers so quota / other errors propagate correctly via `else: raise` instead of being swallowed by an `AttributeError`.

Reproduced locally by installing `pytest-base-url` (matching the nightly env): before the fix, all 10 `TestIsOfficialAnthropicEndpoint` cases error with `ScopeMismatch`; after, `test_litellm_adapter.py` is 100 passed.

Note: the remaining nightly model-test failures (`test_generate_basic`, `test_generate_with_json_output`, `test_generate_with_mcp_token_consumption`, and the DeepSeek empty-response cases) are environmental — the `OPENAI_API_KEY` account quota was exhausted (`error_code=300020`) — and are not addressed here.

## Test Cases

No new tests added; these are fixes to existing nightly tests.
- `tests/unit_tests/models/test_litellm_adapter.py` — CI unit test, now `100 passed` with `pytest-base-url` installed (previously 10 errors).
- `tests/integration/models/test_other_models.py` — nightly integration test; `e.code` fix lets the real error surface instead of `AttributeError`.
- `ruff format --check` and `ruff check` pass on both files.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [x] release/0.3.7
