### PR TITLE
[Enhancement] Sync semantic model refresh artifacts

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -30,6 +30,7 @@ from datus.storage.semantic_model.semantic_model_init import (
     init_success_story_semantic_model,
 )
 from datus.storage.semantic_model.store import SemanticModelRAG
+from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 from datus.tools.db_tools.db_manager import DBManager, db_manager_instance
 from datus.utils.benchmark_utils import load_benchmark_tasks
 from datus.utils.exceptions import DatusException, ErrorCode
@@ -417,13 +418,15 @@ class Agent:
                         self.global_config.check_init_storage_config("database")
 
                         self.metadata_store = SchemaWithValueRAG(self.global_config)
-                        return {
+                        result = {
                             "status": "success",
                             "message": f"current metadata is already built, "
                             f"dir_path={dir_path},"
                             f"schema_size={self.metadata_store.get_schema_size()}, "
                             f"value_size={self.metadata_store.get_value_size()}",
                         }
+                        results[component] = result
+                        continue
 
                 if kb_update_strategy == "overwrite":
                     self.global_config.save_storage_config("database")
@@ -482,9 +485,26 @@ class Agent:
                     f"schema_size={self.metadata_store.get_schema_size()}, "
                     f"value_size={self.metadata_store.get_value_size()}",
                 }
-                return result
+                results[component] = result
+                continue
 
             elif component == "semantic_model":
+                uses_adapter = hasattr(self.args, "from_adapter") and self.args.from_adapter
+                uses_semantic_yaml = hasattr(self.args, "semantic_yaml") and self.args.semantic_yaml
+                if kb_update_strategy == "check":
+                    temp_rag = SemanticModelRAG(self.global_config)
+                    profile_rag = TableSemanticProfileRAG(self.global_config)
+                    result = {
+                        "status": "success",
+                        "message": (
+                            "semantic_model check completed, "
+                            f"semantic_object_count={temp_rag.get_size()}, "
+                            f"table_semantic_profile_count={profile_rag.get_size()}"
+                        ),
+                    }
+                    results[component] = result
+                    continue
+
                 if kb_update_strategy == "overwrite":
                     # Only clear semantic_models/{datasource} directory when NOT using --from_adapter
                     # because MetricFlow adapter needs to read YAML files from this directory
@@ -504,24 +524,25 @@ class Agent:
                 else:
                     self.global_config.check_init_storage_config("semantic_model")
                 temp_rag = SemanticModelRAG(self.global_config)
-                if kb_update_strategy == "overwrite":
+                if kb_update_strategy == "overwrite" and (uses_adapter or uses_semantic_yaml):
                     temp_rag.truncate()
+                    TableSemanticProfileRAG(self.global_config).truncate()
 
                 # Initialize semantic model
-                if hasattr(self.args, "from_adapter") and self.args.from_adapter:
+                if uses_adapter:
                     # Pull from semantic adapter
                     from datus.storage.semantic_model.adapter_init import init_from_adapter
 
                     successful, error_message = asyncio.run(
                         init_from_adapter(self.global_config, self.args.from_adapter)
                     )
-                elif hasattr(self.args, "semantic_yaml") and self.args.semantic_yaml:
+                elif uses_semantic_yaml:
                     successful, error_message = init_semantic_yaml_semantic_model(
                         self.args.semantic_yaml, self.global_config
                     )
                 else:
                     successful, error_message = init_success_story_semantic_model(
-                        self.global_config, self.args.success_story
+                        self.global_config, self.args.success_story, build_mode=kb_update_strategy
                     )
 
                 if successful:
@@ -532,27 +553,39 @@ class Agent:
                     }
                 else:
                     result = {"status": "failed", "message": error_message}
-                return result
+                results[component] = result
+                continue
 
             elif component == "metrics":
+                uses_adapter = hasattr(self.args, "from_adapter") and self.args.from_adapter
+                uses_semantic_yaml = hasattr(self.args, "semantic_yaml") and self.args.semantic_yaml
+                if kb_update_strategy == "check":
+                    self.metrics_store = MetricRAG(self.global_config)
+                    result = {
+                        "status": "success",
+                        "message": f"metrics check completed, metrics_count={self.metrics_store.get_metrics_size()}",
+                    }
+                    results[component] = result
+                    continue
+
                 if kb_update_strategy == "overwrite":
                     self.global_config.save_storage_config("metric")  # Keep compatibility
                 else:
                     self.global_config.check_init_storage_config("metric")
                 self.metrics_store = MetricRAG(self.global_config)
-                if kb_update_strategy == "overwrite":
+                if kb_update_strategy == "overwrite" and uses_adapter:
                     self.metrics_store.truncate()
                 self._reset_metrics_stream_state()
 
                 # Initialize metrics
-                if hasattr(self.args, "from_adapter") and self.args.from_adapter:
+                if uses_adapter:
                     # Pull from semantic adapter
                     from datus.storage.metric.adapter_init import init_from_adapter
 
                     successful, error_message = asyncio.run(
                         init_from_adapter(self.global_config, self.args.from_adapter, subject_path=subject_tree)
                     )
-                elif hasattr(self.args, "semantic_yaml") and self.args.semantic_yaml:
+                elif uses_semantic_yaml:
                     successful, error_message = init_semantic_yaml_metrics(self.args.semantic_yaml, self.global_config)
                 else:
                     successful, error_message, _ = init_success_story_metrics(
@@ -560,6 +593,7 @@ class Agent:
                         self.args.success_story,
                         subject_tree,
                         emit=self._emit_metrics_event,
+                        build_mode=kb_update_strategy,
                         batch_size=getattr(self.args, "metrics_batch_size", 5),
                     )
 
@@ -573,7 +607,8 @@ class Agent:
                     }
                 else:
                     result = {"status": "failed", "message": error_message}
-                return result
+                results[component] = result
+                continue
             elif component == "reference_sql":
                 if kb_update_strategy == "overwrite":
                     # Also clear the sql_summaries directory (YAML files)
@@ -605,7 +640,8 @@ class Agent:
                     subject_tree=subject_tree,
                     emit=self._emit_reference_sql_event,
                 )
-                return result
+                results[component] = result
+                continue
             elif component == "reference_template":
                 if kb_update_strategy == "overwrite":
                     self.global_config.save_storage_config("reference_template")
@@ -629,7 +665,8 @@ class Agent:
                     subject_tree=subject_tree,
                     emit=self._emit_reference_template_event,
                 )
-                return result
+                results[component] = result
+                continue
             results[component] = True
 
         # Initialize success story storage (always created)
@@ -639,10 +676,18 @@ class Agent:
         results["success_story"] = True
 
         logger.info(f"Knowledge base components initialized successfully: {', '.join(selected_components)}")
+        component_results = {key: value for key, value in results.items() if key != "success_story"}
+        if len(component_results) == 1:
+            return next(iter(component_results.values()))
+        failed = {
+            key: value
+            for key, value in component_results.items()
+            if isinstance(value, dict) and value.get("status") not in {"success", "skipped"}
+        }
         return {
-            "status": "success",
+            "status": "failed" if failed else "success",
             "message": "Knowledge base initialized",
-            "components": results,
+            "components": component_results,
         }
 
     def benchmark(self, run_id: Optional[str] = None):

--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -28,6 +28,7 @@ from datus.storage.schema_metadata.local_init import init_local_schema
 from datus.storage.semantic_model.semantic_model_init import (
     init_semantic_yaml_semantic_model,
     init_success_story_semantic_model,
+    refresh_success_story_semantic_model_profile,
 )
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
@@ -396,6 +397,11 @@ class Agent:
         selected_components = self.args.components
 
         kb_update_strategy = self.args.kb_update_strategy
+        if kb_update_strategy == "refresh-profile" and set(selected_components) != {"semantic_model"}:
+            return {
+                "status": "failed",
+                "message": "kb_update_strategy=refresh-profile is only supported with --components semantic_model",
+            }
         benchmark_platform = self.args.benchmark
         pool_size = 4 if not self.args.pool_size else self.args.pool_size
         dir_path = self.global_config.rag_storage_path()
@@ -502,6 +508,31 @@ class Agent:
                             f"table_semantic_profile_count={profile_rag.get_size()}"
                         ),
                     }
+                    results[component] = result
+                    continue
+
+                if kb_update_strategy == "refresh-profile":
+                    self.global_config.check_init_storage_config("semantic_model")
+                    temp_rag = SemanticModelRAG(self.global_config)
+                    profile_rag = TableSemanticProfileRAG(self.global_config)
+                    successful, error_message, changed = refresh_success_story_semantic_model_profile(
+                        self.global_config,
+                        self.args.semantic_yaml,
+                        self.args.success_story,
+                    )
+                    if successful:
+                        result = {
+                            "status": "success",
+                            "message": (
+                                "semantic_model profile refresh completed, "
+                                f"changed_description_count={changed}, "
+                                f"semantic_object_count={temp_rag.get_size()}, "
+                                f"table_semantic_profile_count={profile_rag.get_size()}"
+                            ),
+                            "error": error_message,
+                        }
+                    else:
+                        result = {"status": "failed", "message": error_message}
                     results[component] = result
                     continue
 

--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -506,9 +506,8 @@ class Agent:
                     continue
 
                 if kb_update_strategy == "overwrite":
-                    # Only clear semantic_models/{datasource} directory when NOT using --from_adapter
-                    # because MetricFlow adapter needs to read YAML files from this directory
-                    if not (hasattr(self.args, "from_adapter") and self.args.from_adapter):
+                    # Adapter and explicit YAML imports need their source files intact.
+                    if not (uses_adapter or uses_semantic_yaml):
                         semantic_yaml_dir = self.global_config.path_manager.semantic_model_path(
                             self.global_config.current_datasource
                         )
@@ -684,9 +683,12 @@ class Agent:
             for key, value in component_results.items()
             if isinstance(value, dict) and value.get("status") not in {"success", "skipped"}
         }
+        overall_status = "failed" if failed else "success"
         return {
-            "status": "failed" if failed else "success",
-            "message": "Knowledge base initialized",
+            "status": overall_status,
+            "message": (
+                "Knowledge base initialized" if overall_status == "success" else "Knowledge base initialization failed"
+            ),
             "components": component_results,
         }
 

--- a/datus/api/models/kb_models.py
+++ b/datus/api/models/kb_models.py
@@ -34,11 +34,12 @@ class BootstrapKbInput(BaseModel):
             "`reference_sql` indexes reusable SQL files."
         ),
     )
-    strategy: Literal["overwrite", "check", "incremental"] = Field(
+    strategy: Literal["overwrite", "check", "incremental", "refresh-profile"] = Field(
         default="incremental",
         description=(
             "Update strategy. `check` inspects existing data without rebuilding where supported, "
-            "`overwrite` clears and rebuilds, and `incremental` appends or updates changed entries."
+            "`overwrite` clears and rebuilds, `incremental` appends or updates changed entries, "
+            "and `refresh-profile` updates profile-derived descriptions in an existing semantic YAML."
         ),
     )
 
@@ -71,6 +72,13 @@ class BootstrapKbInput(BaseModel):
         description=(
             "Project-root-relative path to a success-story CSV containing historical question/SQL pairs. "
             "Used by `semantic_model` and `metrics` when bootstrapping from success stories."
+        ),
+    )
+    semantic_yaml: Optional[str] = Field(
+        default=None,
+        description=(
+            "Project-root-relative semantic model YAML path. Required by `semantic_model` with "
+            "`strategy=refresh-profile` so profile descriptions can be refreshed in place."
         ),
     )
     subject_tree: Optional[list[str]] = Field(

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -23,6 +23,7 @@ from datus.storage.semantic_model.semantic_model_init import (
     init_success_story_semantic_model,
 )
 from datus.storage.semantic_model.store import SemanticModelRAG
+from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
 from datus.utils.time_utils import now_utc_iso, to_utc_iso
@@ -253,9 +254,21 @@ class KbService:
         args: types.SimpleNamespace,
         emit,
     ) -> dict:
-        successful, error_message = init_success_story_semantic_model(config, args.success_story, emit=emit)
+        rag = SemanticModelRAG(config)
+        if strategy == "check":
+            profile_rag = TableSemanticProfileRAG(config)
+            return {
+                "status": "success",
+                "message": (
+                    "semantic_model check completed, "
+                    f"semantic_object_count={rag.get_size()}, "
+                    f"table_semantic_profile_count={profile_rag.get_size()}"
+                ),
+            }
+        successful, error_message = init_success_story_semantic_model(
+            config, args.success_story, emit=emit, build_mode=strategy
+        )
         if successful:
-            rag = SemanticModelRAG(config)
             return {
                 "status": "success",
                 "message": f"semantic_model bootstrap completed, semantic_object_count={rag.get_size()}",
@@ -272,9 +285,16 @@ class KbService:
         subject_tree: Optional[list],
         emit,
     ) -> dict:
-        successful, error_message, _ = init_success_story_metrics(config, args.success_story, subject_tree, emit=emit)
+        rag = MetricRAG(config)
+        if strategy == "check":
+            return {
+                "status": "success",
+                "message": f"metrics check completed, metrics_count={rag.get_metrics_size()}",
+            }
+        successful, error_message, _ = init_success_story_metrics(
+            config, args.success_story, subject_tree, emit=emit, build_mode=strategy
+        )
         if successful:
-            rag = MetricRAG(config)
             return {
                 "status": "success",
                 "message": f"metrics bootstrap completed, metrics_count={rag.get_metrics_size()}",

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -21,6 +21,7 @@ from datus.storage.schema_metadata import SchemaWithValueRAG
 from datus.storage.schema_metadata.local_init import init_local_schema
 from datus.storage.semantic_model.semantic_model_init import (
     init_success_story_semantic_model,
+    refresh_success_story_semantic_model_profile,
 )
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
@@ -183,6 +184,12 @@ class KbService:
         subject_tree = request.subject_tree
 
         try:
+            if strategy == "refresh-profile" and component != KbComponent.SEMANTIC_MODEL:
+                return {
+                    "status": "failed",
+                    "message": "strategy=refresh-profile is only supported with semantic_model",
+                }
+
             if component == KbComponent.METADATA:
                 return self._init_metadata(config, strategy, pool_size, dir_path, args, emit)
 
@@ -265,6 +272,26 @@ class KbService:
                     f"table_semantic_profile_count={profile_rag.get_size()}"
                 ),
             }
+        if strategy == "refresh-profile":
+            profile_rag = TableSemanticProfileRAG(config)
+            successful, error_message, changed = refresh_success_story_semantic_model_profile(
+                config,
+                args.semantic_yaml,
+                args.success_story,
+                emit=emit,
+            )
+            if successful:
+                return {
+                    "status": "success",
+                    "message": (
+                        "semantic_model profile refresh completed, "
+                        f"changed_description_count={changed}, "
+                        f"semantic_object_count={rag.get_size()}, "
+                        f"table_semantic_profile_count={profile_rag.get_size()}"
+                    ),
+                    "error": error_message,
+                }
+            return {"status": "failed", "message": error_message}
         successful, error_message = init_success_story_semantic_model(
             config, args.success_story, emit=emit, build_mode=strategy
         )
@@ -475,10 +502,12 @@ class KbService:
         """Create a SimpleNamespace mimicking argparse.Namespace for the bootstrap-kb helpers."""
         # Resolve relative paths against the project root
         success_story = os.path.join(project_root, request.success_story) if request.success_story else None
+        semantic_yaml = os.path.join(project_root, request.semantic_yaml) if request.semantic_yaml else None
         sql_dir = os.path.join(project_root, request.sql_dir) if request.sql_dir else None
 
         return types.SimpleNamespace(
             success_story=success_story,
+            semantic_yaml=semantic_yaml,
             sql_dir=sql_dir,
             schema_linking_type=request.schema_linking_type,
             catalog=request.catalog or "",

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1377,13 +1377,21 @@ class GenerationHooks(AgentHooks):
                     else None
                 )
                 replacement_plans = []
+                restore_plans = []
                 if semantic_objects:
-                    replacement_plans.append((semantic_rag, yaml_path_to_store, semantic_objects))
+                    plan = (semantic_rag, yaml_path_to_store, semantic_objects)
+                    replacement_plans.append(plan)
+                    restore_plans.append(plan)
                 if profile_rag is not None:
-                    replacement_plans.append((profile_rag, yaml_path_to_store, table_profiles))
-                if metric_objects and replace_metric_artifact:
-                    replacement_plans.append((metric_rag, yaml_path_to_store, metric_objects))
-                snapshots = snapshot_artifact_replacements(replacement_plans)
+                    plan = (profile_rag, yaml_path_to_store, table_profiles)
+                    replacement_plans.append(plan)
+                    restore_plans.append(plan)
+                if metric_objects:
+                    plan = (metric_rag, yaml_path_to_store, metric_objects)
+                    restore_plans.append(plan)
+                    if replace_metric_artifact:
+                        replacement_plans.append(plan)
+                snapshots = snapshot_artifact_replacements(restore_plans)
                 try:
                     if semantic_objects:
                         semantic_rag.upsert_batch(semantic_objects)
@@ -1396,8 +1404,13 @@ class GenerationHooks(AgentHooks):
                         metric_rag.upsert_batch(metric_objects)
                         metric_rag.create_indices()
                     delete_stale_artifact_rows(replacement_plans)
-                except Exception:
-                    restore_artifact_replacements(snapshots)
+                except Exception as sync_exc:
+                    restore_failures = restore_artifact_replacements(snapshots)
+                    if restore_failures:
+                        raise RuntimeError(
+                            "Artifact replacement failed and rollback was incomplete for: "
+                            f"{', '.join(restore_failures)}"
+                        ) from sync_exc
                     raise
                 result = {
                     "success": True,

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -645,6 +645,7 @@ class GenerationHooks(AgentHooks):
                         include_metrics=True,
                         metric_sqls=metric_sqls,
                         original_yaml_path=file_path,
+                        replace_metric_artifact=False,
                     ),
                 )
                 item_type = "metric"
@@ -728,6 +729,7 @@ class GenerationHooks(AgentHooks):
                         include_metrics=True,
                         metric_sqls=metric_sqls,
                         original_yaml_path=metric_file,  # Use original metric file path, not temp file
+                        replace_metric_artifact=False,
                     ),
                 )
 
@@ -913,12 +915,16 @@ class GenerationHooks(AgentHooks):
         }
 
     @staticmethod
-    def _sync_table_semantic_profiles(agent_config: AgentConfig, profiles: list[dict]) -> int:
+    def _sync_table_semantic_profiles(
+        agent_config: AgentConfig, profiles: list[dict], replace_yaml_path: Optional[str] = None
+    ) -> int:
         if not profiles:
             return 0
         if not isinstance(getattr(agent_config, "project_name", ""), str):
             return 0
         profile_rag = TableSemanticProfileRAG(agent_config)
+        if replace_yaml_path:
+            profile_rag.delete_artifact_rows(replace_yaml_path)
         profile_rag.upsert_batch(profiles)
         profile_rag.create_indices()
         return len(profiles)
@@ -934,6 +940,7 @@ class GenerationHooks(AgentHooks):
         include_metrics: bool = True,
         metric_sqls: dict = None,
         original_yaml_path: Optional[str] = None,
+        replace_metric_artifact: bool = True,
     ) -> dict:
         """
         Sync semantic objects and/or metrics from YAML file to Knowledge Base.
@@ -946,6 +953,9 @@ class GenerationHooks(AgentHooks):
             metric_sqls: Optional dict mapping metric names to generated SQL (from dry_run)
             original_yaml_path: Original YAML file path to store
                 (if different from file_path, e.g., when using temp files)
+            replace_metric_artifact: Whether metric sync should replace all
+                metric rows for original_yaml_path before upserting. Use False
+                for incremental sub-agent partial publishes.
 
         Now parses tables, columns, metrics, and entities as individual 'semantic_objects'.
         """
@@ -1353,11 +1363,16 @@ class GenerationHooks(AgentHooks):
             all_objects = semantic_objects + metric_objects
             if all_objects:
                 if semantic_objects:
+                    semantic_rag.delete_artifact_rows(yaml_path_to_store)
                     semantic_rag.upsert_batch(semantic_objects)
                     semantic_rag.create_indices()
-                profile_count = GenerationHooks._sync_table_semantic_profiles(agent_config, table_profiles)
+                profile_count = GenerationHooks._sync_table_semantic_profiles(
+                    agent_config, table_profiles, replace_yaml_path=yaml_path_to_store if table_profiles else None
+                )
 
                 if metric_objects:
+                    if replace_metric_artifact:
+                        metric_rag.delete_artifact_rows(yaml_path_to_store)
                     metric_rag.upsert_batch(metric_objects)
                     metric_rag.create_indices()
                 result = {

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -17,6 +17,11 @@ from datus_storage_base.conditions import And, eq
 
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
 from datus.configuration.agent_config import AgentConfig
+from datus.storage.artifact_replacement import (
+    delete_stale_artifact_rows,
+    restore_artifact_replacements,
+    snapshot_artifact_replacements,
+)
 from datus.storage.metric.store import MetricRAG, build_metric_id
 from datus.storage.reference_sql.store import ReferenceSqlRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
@@ -924,7 +929,10 @@ class GenerationHooks(AgentHooks):
             return 0
         profile_rag = TableSemanticProfileRAG(agent_config)
         if replace_yaml_path:
-            profile_rag.delete_artifact_rows(replace_yaml_path)
+            profile_rag.upsert_batch(profiles)
+            profile_rag.create_indices()
+            profile_rag.delete_artifact_rows_except(replace_yaml_path, [profile.get("id", "") for profile in profiles])
+            return len(profiles)
         profile_rag.upsert_batch(profiles)
         profile_rag.create_indices()
         return len(profiles)
@@ -1362,19 +1370,35 @@ class GenerationHooks(AgentHooks):
             # Store all objects using upsert (update if id exists, insert if not)
             all_objects = semantic_objects + metric_objects
             if all_objects:
-                if semantic_objects:
-                    semantic_rag.delete_artifact_rows(yaml_path_to_store)
-                    semantic_rag.upsert_batch(semantic_objects)
-                    semantic_rag.create_indices()
-                profile_count = GenerationHooks._sync_table_semantic_profiles(
-                    agent_config, table_profiles, replace_yaml_path=yaml_path_to_store if table_profiles else None
+                profile_count = 0
+                profile_rag = (
+                    TableSemanticProfileRAG(agent_config)
+                    if table_profiles and isinstance(getattr(agent_config, "project_name", ""), str)
+                    else None
                 )
-
-                if metric_objects:
-                    if replace_metric_artifact:
-                        metric_rag.delete_artifact_rows(yaml_path_to_store)
-                    metric_rag.upsert_batch(metric_objects)
-                    metric_rag.create_indices()
+                replacement_plans = []
+                if semantic_objects:
+                    replacement_plans.append((semantic_rag, yaml_path_to_store, semantic_objects))
+                if profile_rag is not None:
+                    replacement_plans.append((profile_rag, yaml_path_to_store, table_profiles))
+                if metric_objects and replace_metric_artifact:
+                    replacement_plans.append((metric_rag, yaml_path_to_store, metric_objects))
+                snapshots = snapshot_artifact_replacements(replacement_plans)
+                try:
+                    if semantic_objects:
+                        semantic_rag.upsert_batch(semantic_objects)
+                        semantic_rag.create_indices()
+                    if profile_rag is not None:
+                        profile_rag.upsert_batch(table_profiles)
+                        profile_rag.create_indices()
+                        profile_count = len(table_profiles)
+                    if metric_objects:
+                        metric_rag.upsert_batch(metric_objects)
+                        metric_rag.create_indices()
+                    delete_stale_artifact_rows(replacement_plans)
+                except Exception:
+                    restore_artifact_replacements(snapshots)
+                    raise
                 result = {
                     "success": True,
                     "message": (

--- a/datus/cli/screen/catalog_screen.py
+++ b/datus/cli/screen/catalog_screen.py
@@ -36,6 +36,43 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 
+_NESTED_TABLE_PRIMARY_KEYS = (
+    "name",
+    "expr",
+    "role",
+    "type",
+    "time_granularity",
+    "entity",
+    "agg",
+    "agg_time_dimension",
+    "from",
+    "to",
+    "from_columns",
+    "to_columns",
+)
+_NESTED_TABLE_TRAILING_KEYS = ("description", "ai_context")
+
+
+def _ordered_nested_table_keys(items: List[Dict[str, Any]]) -> List[str]:
+    """Return stable, human-readable columns for semantic nested tables."""
+    seen_keys = set()
+    encountered_keys = []
+    for item in items:
+        for key in item.keys():
+            if key not in seen_keys:
+                encountered_keys.append(key)
+                seen_keys.add(key)
+
+    primary = [key for key in _NESTED_TABLE_PRIMARY_KEYS if key in seen_keys]
+    trailing = [key for key in _NESTED_TABLE_TRAILING_KEYS if key in seen_keys]
+    middle = [
+        key
+        for key in encountered_keys
+        if key not in _NESTED_TABLE_PRIMARY_KEYS and key not in _NESTED_TABLE_TRAILING_KEYS
+    ]
+    return primary + middle + trailing
+
+
 class SemanticModelPanel(Vertical):
     """Display and edit semantic model metadata."""
 
@@ -791,14 +828,8 @@ class CatalogScreen(ContextScreen):
                 row_styles=["on grey15", "on grey23"],
             )
             if parsed_data and isinstance(parsed_data[0], dict):
-                # Collect all unique keys from all items to handle heterogeneous dicts
-                all_keys = []
-                seen_keys = set()
-                for item in parsed_data:
-                    for key in item.keys():
-                        if key not in seen_keys:
-                            all_keys.append(key)
-                            seen_keys.add(key)
+                # Collect all unique keys with a readable semantic-column order.
+                all_keys = _ordered_nested_table_keys(parsed_data)
 
                 for key in all_keys:
                     nested_table.add_column(str(key), style="dim cyan", justify="center")

--- a/datus/main.py
+++ b/datus/main.py
@@ -181,9 +181,12 @@ def create_parser() -> argparse.ArgumentParser:
     bootstrap_parser.add_argument(
         "--kb_update_strategy",
         type=str,
-        choices=["check", "overwrite", "incremental"],
+        choices=["check", "overwrite", "incremental", "refresh-profile"],
         default="check",
-        help="Knowledge base update strategy: check (verify paths and data), overwrite (careful!), or incremental",
+        help=(
+            "Knowledge base update strategy: check (verify paths and data), overwrite (careful!), "
+            "incremental, or refresh-profile (semantic_model only; update profile descriptions in an existing YAML)"
+        ),
     )
     bootstrap_parser.add_argument(
         "--components",

--- a/datus/storage/artifact_replacement.py
+++ b/datus/storage/artifact_replacement.py
@@ -21,12 +21,21 @@ def snapshot_artifact_replacements(replacement_plans: List[ArtifactReplacementPl
     return snapshots
 
 
-def restore_artifact_replacements(snapshots: List[ArtifactSnapshot]) -> None:
+def restore_artifact_replacements(snapshots: List[ArtifactSnapshot]) -> List[str]:
+    failures = []
     for rag, yaml_path, rows in reversed(snapshots):
         try:
             rag.restore_artifact_rows(yaml_path, rows)
         except Exception as restore_exc:
-            logger.warning("Failed to restore artifact rows for %s after sync failure: %s", yaml_path, restore_exc)
+            failure = f"{type(rag).__name__}:{yaml_path}"
+            logger.error(
+                "Failed to restore artifact rows for %s after sync failure: %s",
+                yaml_path,
+                restore_exc,
+                exc_info=True,
+            )
+            failures.append(failure)
+    return failures
 
 
 def delete_stale_artifact_rows(replacement_plans: List[ArtifactReplacementPlan]) -> None:

--- a/datus/storage/artifact_replacement.py
+++ b/datus/storage/artifact_replacement.py
@@ -1,0 +1,34 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+ArtifactReplacementPlan = Tuple[Any, str, List[Dict[str, Any]]]
+ArtifactSnapshot = Tuple[Any, str, List[Dict[str, Any]]]
+
+
+def snapshot_artifact_replacements(replacement_plans: List[ArtifactReplacementPlan]) -> List[ArtifactSnapshot]:
+    snapshots = []
+    for rag, yaml_path, _rows in replacement_plans:
+        snapshots.append((rag, yaml_path, rag.list_artifact_rows(yaml_path)))
+    return snapshots
+
+
+def restore_artifact_replacements(snapshots: List[ArtifactSnapshot]) -> None:
+    for rag, yaml_path, rows in reversed(snapshots):
+        try:
+            rag.restore_artifact_rows(yaml_path, rows)
+        except Exception as restore_exc:
+            logger.warning("Failed to restore artifact rows for %s after sync failure: %s", yaml_path, restore_exc)
+
+
+def delete_stale_artifact_rows(replacement_plans: List[ArtifactReplacementPlan]) -> None:
+    for rag, yaml_path, rows in replacement_plans:
+        rag.delete_artifact_rows_except(yaml_path, [row.get("id", "") for row in rows])

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -980,8 +980,8 @@ async def init_success_story_metrics_async(
         emit: Optional callback to stream BatchEvent progress events
         extra_instructions: Optional extra instructions for the LLM
         build_mode: ``"overwrite"`` (default) regenerates unconditionally;
-            ``"incremental"`` skips the LLM call when the metric store
-            already contains entries.
+            ``"incremental"`` skips only batches whose metric candidates are
+            already satisfied by existing metric definitions.
         batch_size: Number of SQL queries per batch (default 5).
     """
     if batch_size <= 0:
@@ -992,6 +992,16 @@ async def init_success_story_metrics_async(
         )
 
     event_helper = BatchEventHelper(BIZ_NAME, emit)
+
+    if build_mode == "check":
+        from datus.storage.metric.store import MetricRAG
+
+        metric_rag = MetricRAG(agent_config)
+        logger.info(
+            "[check] metrics rows=%d; generation skipped",
+            metric_rag.get_metrics_size(),
+        )
+        return True, "", {"checked": True, "metrics_count": metric_rag.get_metrics_size()}
 
     if build_mode == "overwrite":
         from datus.storage.metric.store import MetricRAG
@@ -1323,6 +1333,16 @@ def init_semantic_yaml_metrics(
     if not os.path.exists(yaml_file_path):
         logger.error(f"Semantic YAML file {yaml_file_path} not found")
         return False, f"Semantic YAML file {yaml_file_path} not found"
+
+    if _metrics_authoring_format(agent_config) == AUTHORING_FORMAT_OSI:
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        result = GenerationTools(
+            agent_config=agent_config, authoring_format=AUTHORING_FORMAT_OSI
+        )._sync_osi_metric_to_db(yaml_file_path)
+        if result.get("success"):
+            return True, result.get("message", "")
+        return False, result.get("error", "Unknown error")
 
     # Import from semantic_model package to avoid circular dependency
     from datus.storage.semantic_model.semantic_model_init import process_semantic_yaml_file

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Set
 
 import pyarrow as pa
 import yaml
-from datus_storage_base.conditions import WhereExpr, and_, eq, in_
+from datus_storage_base.conditions import WhereExpr, and_, eq, in_, not_
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
@@ -732,6 +732,35 @@ class MetricRAG:
         if not yaml_path:
             return
         self.storage._delete_rows(and_(eq("yaml_path", yaml_path), *self._sub_agent_conditions()))
+
+    def delete_artifact_rows_except(self, yaml_path: str, keep_ids: List[str]) -> None:
+        """Delete stale metric rows for one YAML artifact after replacement succeeds."""
+        if not yaml_path:
+            return
+        normalized_keep_ids = [row_id for row_id in keep_ids if row_id]
+        if not normalized_keep_ids:
+            self.delete_artifact_rows(yaml_path)
+            return
+        self.storage._delete_rows(
+            and_(eq("yaml_path", yaml_path), not_(in_("id", normalized_keep_ids)), *self._sub_agent_conditions())
+        )
+
+    def list_artifact_rows(self, yaml_path: str) -> List[Dict[str, Any]]:
+        """Return metric rows projected from a single YAML artifact."""
+        if not yaml_path:
+            return []
+        return self.storage._search_all(
+            where=and_(eq("yaml_path", yaml_path), *self._sub_agent_conditions())
+        ).to_pylist()
+
+    def restore_artifact_rows(self, yaml_path: str, rows: List[Dict[str, Any]]) -> None:
+        """Restore one YAML artifact to a previously captured row snapshot."""
+        if not yaml_path:
+            return
+        self.delete_artifact_rows(yaml_path)
+        if rows:
+            self.upsert_batch(rows)
+        self.create_indices()
 
     def store_batch(self, metrics: List[Dict[str, Any]]):
         logger.info(f"store metrics: {metrics}")

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Set
 
 import pyarrow as pa
 import yaml
-from datus_storage_base.conditions import WhereExpr, and_, in_
+from datus_storage_base.conditions import WhereExpr, and_, eq, in_
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
@@ -726,6 +726,12 @@ class MetricRAG:
     def truncate(self) -> None:
         """Delete all metrics for this datasource."""
         self.storage.delete_datasource_rows(self.datasource_id)
+
+    def delete_artifact_rows(self, yaml_path: str) -> None:
+        """Delete metric rows projected from a single YAML artifact."""
+        if not yaml_path:
+            return
+        self.storage._delete_rows(and_(eq("yaml_path", yaml_path), *self._sub_agent_conditions()))
 
     def store_batch(self, metrics: List[Dict[str, Any]]):
         logger.info(f"store metrics: {metrics}")

--- a/datus/storage/semantic_model/profile_description.py
+++ b/datus/storage/semantic_model/profile_description.py
@@ -1,0 +1,379 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Deterministic description refresh helpers for semantic-model profiles."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+OBSERVED_PROFILE_PREFIX = "Observed profile:"
+_OBSERVED_PROFILE_RE = re.compile(r"\s*Observed profile:.*$", re.IGNORECASE | re.DOTALL)
+
+
+def strip_observed_profile(description: Any) -> str:
+    """Return the stable business description without the generated profile suffix."""
+    text = " ".join(str(description or "").split())
+    return _OBSERVED_PROFILE_RE.sub("", text).strip()
+
+
+def merge_observed_profile(description: Any, observed_profile: str, *, max_chars: int = 420) -> str:
+    """Replace the generated profile suffix while preserving the stable description prefix."""
+    base = strip_observed_profile(description).rstrip(" .;")
+    observed = " ".join(str(observed_profile or "").split()).strip(" .;")
+    if not observed:
+        return base
+
+    suffix = f"{OBSERVED_PROFILE_PREFIX} {observed}."
+    merged = f"{base}. {suffix}" if base else suffix
+    if len(merged) <= max_chars:
+        return merged
+    if base:
+        budget = max_chars - len(base) - len(f". {OBSERVED_PROFILE_PREFIX} ...")
+        clipped = _clip_text(observed, max(40, budget)).strip(" .;")
+        return f"{base}. {OBSERVED_PROFILE_PREFIX} {clipped}."
+    return _clip_text(merged, max_chars)
+
+
+def build_table_observed_profile(table_evidence: Dict[str, Any]) -> str:
+    """Summarize table-level SQL/profile evidence for a description."""
+    parts: List[str] = []
+    distribution = table_evidence.get("data_distribution_profile") or {}
+    row_count = _profile_scalar(distribution.get("row_count"))
+    if row_count:
+        parts.append(f"observed row count {row_count}")
+
+    query_count = _as_int(table_evidence.get("query_count"))
+    if query_count:
+        parts.append(f"referenced by {query_count} historical quer{'y' if query_count == 1 else 'ies'}")
+
+    duration_phrases = _duration_profile_phrases(distribution.get("date_duration_profiles") or [])
+    if duration_phrases:
+        parts.append(f"typical durations include {duration_phrases[0]}")
+
+    filter_fields = _business_filter_fields(table_evidence.get("common_business_filter_templates") or [])
+    if filter_fields:
+        parts.append(f"common filters use {', '.join(filter_fields[:3])}")
+
+    return "; ".join(parts[:4])
+
+
+def build_column_observed_profile(
+    column_profile: Dict[str, Any],
+    *,
+    field_usage: Optional[Dict[str, Any]] = None,
+    join_profile: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Summarize one column's sampled distribution and SQL-history usage."""
+    field_usage = field_usage or {}
+    parts: List[str] = []
+    kind = str(column_profile.get("kind") or "").lower()
+    stats = column_profile.get("stats") if isinstance(column_profile.get("stats"), dict) else {}
+
+    if kind in {"categorical", "boolean"}:
+        distinct_count = _as_int(stats.get("distinct_count"))
+        if distinct_count is not None:
+            parts.append(f"{distinct_count} distinct non-null value{'s' if distinct_count != 1 else ''}")
+        top_values = [
+            _profile_scalar(item.get("value"))
+            for item in column_profile.get("top_values") or []
+            if isinstance(item, dict) and item.get("value") not in (None, "")
+        ]
+        if top_values:
+            parts.append(f"common values include {', '.join(top_values[:3])}")
+
+    elif kind == "numeric":
+        min_value = _profile_scalar(stats.get("min_value"))
+        max_value = _profile_scalar(stats.get("max_value"))
+        if min_value and max_value:
+            parts.append(f"observed range {min_value}-{max_value}")
+        percentiles = column_profile.get("percentiles") if isinstance(column_profile.get("percentiles"), dict) else {}
+        p50 = _profile_scalar(percentiles.get("p50"))
+        p90 = _profile_scalar(percentiles.get("p90"))
+        if p50 and p90:
+            parts.append(f"p50 {p50}, p90 {p90}")
+
+    elif kind == "temporal":
+        min_value = _profile_scalar(stats.get("min_value"))
+        max_value = _profile_scalar(stats.get("max_value"))
+        if min_value and max_value:
+            parts.append(f"observed span {min_value} to {max_value}")
+        temporal = (
+            column_profile.get("temporal_summary") if isinstance(column_profile.get("temporal_summary"), dict) else {}
+        )
+        freshness = _as_int(temporal.get("freshness_days_from_profile_date"))
+        if freshness is not None:
+            parts.append(f"latest value {freshness} day{'s' if freshness != 1 else ''} before profiling")
+
+    null_rate = _as_float(stats.get("null_rate"))
+    if null_rate is not None and null_rate >= 0.01:
+        parts.append(f"null rate {_format_percent(null_rate)}")
+
+    usage_part = _field_usage_phrase(field_usage)
+    if usage_part:
+        parts.append(usage_part)
+
+    join_part = _join_profile_phrase(join_profile)
+    if join_part:
+        parts.append(join_part)
+
+    return "; ".join(_dedupe(parts)[:4])
+
+
+def refresh_metricflow_yaml_descriptions(docs: List[dict], profile_evidence: Dict[str, Any]) -> int:
+    """Patch MetricFlow data_source descriptions from profiler evidence."""
+    tables = _tables_from_evidence(profile_evidence)
+    changed = 0
+    for doc in docs:
+        data_source = doc.get("data_source") if isinstance(doc, dict) else None
+        if not isinstance(data_source, dict):
+            continue
+        table_key = _match_table_key(data_source.get("sql_table") or data_source.get("name"), tables)
+        table_evidence = tables.get(table_key or "")
+        if not table_evidence:
+            continue
+        table_observed = build_table_observed_profile(table_evidence)
+        if table_observed:
+            changed += _merge_description(data_source, table_observed)
+        changed += _refresh_named_items(
+            items=list(data_source.get("identifiers") or [])
+            + list(data_source.get("dimensions") or [])
+            + list(data_source.get("measures") or []),
+            table_evidence=table_evidence,
+        )
+    return changed
+
+
+def refresh_osi_yaml_descriptions(docs: List[dict], profile_evidence: Dict[str, Any]) -> int:
+    """Patch OSI dataset/field descriptions from profiler evidence."""
+    tables = _tables_from_evidence(profile_evidence)
+    changed = 0
+    for dataset in _iter_osi_datasets(docs):
+        table_key = _match_table_key(_osi_dataset_table_name(dataset), tables)
+        table_evidence = tables.get(table_key or "")
+        if not table_evidence:
+            continue
+        table_observed = build_table_observed_profile(table_evidence)
+        if table_observed:
+            changed += _merge_description(dataset, table_observed)
+        field_items = []
+        for key in ("dimensions", "measures", "identifiers", "columns"):
+            value = dataset.get(key)
+            if isinstance(value, list):
+                field_items.extend(item for item in value if isinstance(item, dict))
+        changed += _refresh_named_items(items=field_items, table_evidence=table_evidence)
+    return changed
+
+
+def _refresh_named_items(items: Iterable[dict], table_evidence: Dict[str, Any]) -> int:
+    changed = 0
+    distribution = table_evidence.get("data_distribution_profile") or {}
+    column_profiles = distribution.get("columns") or {}
+    field_usage = table_evidence.get("field_usage_statistics") or {}
+    join_profiles = distribution.get("join_relationship_profiles") or []
+    for item in items:
+        name = str(item.get("name") or "")
+        expr = str(item.get("expr") or name)
+        column_key = _match_column_key(expr, column_profiles) or _match_column_key(name, column_profiles)
+        usage_key = _match_column_key(expr, field_usage) or _match_column_key(name, field_usage)
+        column_profile = column_profiles.get(column_key or "")
+        usage = field_usage.get(usage_key or "") if usage_key else None
+        if not isinstance(column_profile, dict):
+            continue
+        observed = build_column_observed_profile(
+            column_profile,
+            field_usage=usage if isinstance(usage, dict) else None,
+            join_profile=_join_profile_for_column(expr or name, join_profiles),
+        )
+        if observed:
+            changed += _merge_description(item, observed)
+    return changed
+
+
+def _merge_description(item: dict, observed: str) -> int:
+    current = item.get("description", "")
+    updated = merge_observed_profile(current, observed)
+    if updated != current:
+        item["description"] = updated
+        return 1
+    return 0
+
+
+def _tables_from_evidence(profile_evidence: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    tables = profile_evidence.get("tables") if isinstance(profile_evidence, dict) else None
+    return {str(key): value for key, value in (tables or {}).items() if isinstance(value, dict)}
+
+
+def _match_table_key(value: Any, tables: Dict[str, Any]) -> str:
+    candidates = _identifier_candidates(value)
+    for candidate in candidates:
+        for table_name in tables:
+            if candidate == table_name.lower() or candidate == table_name.split(".")[-1].lower():
+                return table_name
+    return ""
+
+
+def _match_column_key(value: Any, columns: Dict[str, Any]) -> str:
+    candidates = _identifier_candidates(value)
+    for candidate in candidates:
+        for column_name in columns:
+            if candidate == column_name.lower():
+                return column_name
+    return ""
+
+
+def _identifier_candidates(value: Any) -> List[str]:
+    text = str(value or "").strip().strip('`"[]')
+    if not text:
+        return []
+    parts = [part.strip().strip('`"[]') for part in text.split(".") if part.strip()]
+    candidates = [text.lower()]
+    if parts:
+        candidates.append(parts[-1].lower())
+    return _dedupe(candidates)
+
+
+def _iter_osi_datasets(docs: List[dict]) -> Iterable[dict]:
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        semantic_models = doc.get("semantic_model")
+        if isinstance(semantic_models, list):
+            for semantic_model in semantic_models:
+                if isinstance(semantic_model, dict):
+                    for dataset in semantic_model.get("datasets") or []:
+                        if isinstance(dataset, dict):
+                            yield dataset
+        for dataset in doc.get("datasets") or []:
+            if isinstance(dataset, dict):
+                yield dataset
+
+
+def _osi_dataset_table_name(dataset: dict) -> str:
+    source = dataset.get("source")
+    if isinstance(source, dict) and source.get("table"):
+        return str(source["table"])
+    if isinstance(source, str) and source:
+        return source
+    return str(dataset.get("table") or dataset.get("name") or "")
+
+
+def _business_filter_fields(templates: List[dict]) -> List[str]:
+    fields = []
+    for template in templates:
+        for field in template.get("fields") or []:
+            if field:
+                fields.append(str(field))
+    return _dedupe(fields)
+
+
+def _duration_profile_phrases(duration_profiles: List[dict]) -> List[str]:
+    phrases = []
+    for profile in duration_profiles:
+        if not isinstance(profile, dict):
+            continue
+        left = str(profile.get("left_column") or "")
+        right = str(profile.get("right_column") or "")
+        deltas = profile.get("delta_days") if isinstance(profile.get("delta_days"), dict) else {}
+        p50 = _profile_scalar(deltas.get("p50"))
+        p90 = _profile_scalar(deltas.get("p90"))
+        if not left or not right or not p50:
+            continue
+        phrase = f"{left} to {right} p50 {p50} days"
+        if p90:
+            phrase += f", p90 {p90} days"
+        phrases.append(phrase)
+    return _dedupe(phrases)
+
+
+def _field_usage_phrase(field_usage: Dict[str, Any]) -> str:
+    phrases = []
+    operators = {str(item).upper() for item in field_usage.get("operators") or []}
+    if _as_int(field_usage.get("filter_count")):
+        if operators & {"=", "IN", "!="}:
+            phrases.append("frequently used as a categorical filter")
+        elif operators & {">", ">=", "<", "<=", "BETWEEN"}:
+            phrases.append("frequently used as a range filter")
+        else:
+            phrases.append("frequently filtered")
+    if _as_int(field_usage.get("group_by_count")):
+        phrases.append("commonly grouped")
+    if _as_int(field_usage.get("aggregate_count")):
+        phrases.append("used in aggregate expressions")
+    return ", ".join(phrases[:2])
+
+
+def _join_profile_for_column(column_name: str, join_profiles: List[dict]) -> Optional[dict]:
+    column_leaf = _identifier_candidates(column_name)
+    for profile in join_profiles:
+        if not isinstance(profile, dict):
+            continue
+        source = _identifier_candidates(profile.get("source_column"))
+        target = _identifier_candidates(profile.get("target_column"))
+        if set(column_leaf) & (set(source) | set(target)):
+            return profile
+    return None
+
+
+def _join_profile_phrase(join_profile: Optional[Dict[str, Any]]) -> str:
+    if not join_profile:
+        return ""
+    parts = []
+    coverage = _as_float(join_profile.get("referential_coverage"))
+    if coverage is not None:
+        parts.append(f"referential coverage {_format_percent(coverage)}")
+    hint = str(join_profile.get("join_cardinality_hint") or "").replace("_", " ")
+    if hint:
+        parts.append(hint)
+    return ", ".join(parts[:2])
+
+
+def _as_int(value: Any) -> Optional[int]:
+    try:
+        if value in (None, ""):
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _profile_scalar(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def _format_percent(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def _clip_text(value: str, max_chars: int) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip(" ,;") + "..."
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen = set()
+    result = []
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result

--- a/datus/storage/semantic_model/profile_description.py
+++ b/datus/storage/semantic_model/profile_description.py
@@ -160,7 +160,7 @@ def refresh_osi_yaml_descriptions(docs: List[dict], profile_evidence: Dict[str, 
         if table_observed:
             changed += _merge_description(dataset, table_observed)
         field_items = []
-        for key in ("dimensions", "measures", "identifiers", "columns"):
+        for key in ("fields", "dimensions", "measures", "identifiers", "columns"):
             value = dataset.get(key)
             if isinstance(value, list):
                 field_items.extend(item for item in value if isinstance(item, dict))

--- a/datus/storage/semantic_model/profile_description.py
+++ b/datus/storage/semantic_model/profile_description.py
@@ -106,7 +106,7 @@ def build_column_observed_profile(
         )
         freshness = _as_int(temporal.get("freshness_days_from_profile_date"))
         if freshness is not None:
-            parts.append(f"latest value {freshness} day{'s' if freshness != 1 else ''} before profiling")
+            parts.append(_freshness_phrase(freshness))
 
     null_rate = _as_float(stats.get("null_rate"))
     if null_rate is not None and null_rate >= 0.01:
@@ -287,6 +287,17 @@ def _duration_profile_phrases(duration_profiles: List[dict]) -> List[str]:
             phrase += f", p90 {p90} days"
         phrases.append(phrase)
     return _dedupe(phrases)
+
+
+def _freshness_phrase(freshness_days_from_profile_date: int) -> str:
+    if freshness_days_from_profile_date == 0:
+        return "latest value on profiling date"
+    if freshness_days_from_profile_date > 0:
+        unit = "day" if freshness_days_from_profile_date == 1 else "days"
+        return f"latest value {freshness_days_from_profile_date} {unit} before profiling"
+    days_after = abs(freshness_days_from_profile_date)
+    unit = "day" if days_after == 1 else "days"
+    return f"latest value {days_after} {unit} after profiling"
 
 
 def _field_usage_phrase(field_usage: Dict[str, Any]) -> str:

--- a/datus/storage/semantic_model/profile_description.py
+++ b/datus/storage/semantic_model/profile_description.py
@@ -33,7 +33,8 @@ def merge_observed_profile(description: Any, observed_profile: str, *, max_chars
     if base:
         budget = max_chars - len(base) - len(f". {OBSERVED_PROFILE_PREFIX} ...")
         clipped = _clip_text(observed, max(40, budget)).strip(" .;")
-        return f"{base}. {OBSERVED_PROFILE_PREFIX} {clipped}."
+        result = f"{base}. {OBSERVED_PROFILE_PREFIX} {clipped}."
+        return _clip_text(result, max_chars) if len(result) > max_chars else result
     return _clip_text(merged, max_chars)
 
 
@@ -362,9 +363,13 @@ def _format_percent(value: float) -> str:
 
 def _clip_text(value: str, max_chars: int) -> str:
     text = " ".join(str(value).split())
+    if max_chars <= 0:
+        return ""
     if len(text) <= max_chars:
         return text
-    return text[: max_chars - 1].rstrip(" ,;") + "..."
+    if max_chars <= 3:
+        return "." * max_chars
+    return text[: max_chars - 3].rstrip(" ,;") + "..."
 
 
 def _dedupe(values: Iterable[str]) -> List[str]:

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -95,12 +95,16 @@ async def init_success_story_semantic_model_async(
         logger.error(error_msg)
         return False, error_msg
 
-    if build_mode == "check":
+    semantic_model_rag = None
+    table_profile_rag = None
+    if build_mode in {"check", "overwrite"}:
         from datus.storage.semantic_model.store import SemanticModelRAG
         from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 
         semantic_model_rag = SemanticModelRAG(agent_config)
         table_profile_rag = TableSemanticProfileRAG(agent_config)
+
+    if build_mode == "check":
         logger.info(
             "[check] semantic_model rows=%d table_semantic_profile rows=%d; generation skipped",
             semantic_model_rag.get_size(),
@@ -109,11 +113,6 @@ async def init_success_story_semantic_model_async(
         return True, ""
 
     if build_mode == "overwrite":
-        from datus.storage.semantic_model.store import SemanticModelRAG
-        from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
-
-        semantic_model_rag = SemanticModelRAG(agent_config)
-        table_profile_rag = TableSemanticProfileRAG(agent_config)
         logger.info(
             "[overwrite] Wiping semantic_model rows for datasource '%s' before re-population",
             semantic_model_rag.datasource_id,

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -7,6 +7,7 @@ import os
 from typing import Callable, Optional
 
 import pandas as pd
+import yaml
 
 from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 from datus.cli.generation_hooks import GenerationHooks
@@ -45,8 +46,8 @@ async def init_success_story_semantic_model_async(
         emit: Optional callback to stream BatchEvent progress events
         build_mode: ``"overwrite"`` (default) wipes the semantic model store
             for the current project before regenerating. ``"incremental"``
-            does not wipe; the LLM still runs and new entries are upserted
-            on top of existing ones (no row-level dedup).
+            skips generation when all referenced tables already have semantic
+            model rows; otherwise it generates and upserts missing coverage.
     """
     # Load and validate CSV file
     csv_path = success_story
@@ -94,15 +95,58 @@ async def init_success_story_semantic_model_async(
         logger.error(error_msg)
         return False, error_msg
 
-    if build_mode == "overwrite":
+    if build_mode == "check":
         from datus.storage.semantic_model.store import SemanticModelRAG
+        from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 
         semantic_model_rag = SemanticModelRAG(agent_config)
+        table_profile_rag = TableSemanticProfileRAG(agent_config)
+        logger.info(
+            "[check] semantic_model rows=%d table_semantic_profile rows=%d; generation skipped",
+            semantic_model_rag.get_size(),
+            table_profile_rag.get_size(),
+        )
+        return True, ""
+
+    if build_mode == "overwrite":
+        from datus.storage.semantic_model.store import SemanticModelRAG
+        from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
+
+        semantic_model_rag = SemanticModelRAG(agent_config)
+        table_profile_rag = TableSemanticProfileRAG(agent_config)
         logger.info(
             "[overwrite] Wiping semantic_model rows for datasource '%s' before re-population",
             semantic_model_rag.datasource_id,
         )
         semantic_model_rag.truncate()
+        table_profile_rag.truncate()
+
+    elif build_mode == "incremental":
+        try:
+            from datus.storage.semantic_model.auto_create import (
+                extract_tables_from_sql_list,
+                find_missing_semantic_models,
+            )
+
+            referenced_tables = extract_tables_from_sql_list(
+                [str(sql) for sql in all_sqls if str(sql).strip()], agent_config
+            )
+            if referenced_tables:
+                missing_tables = find_missing_semantic_models(referenced_tables, agent_config)
+                if not missing_tables:
+                    logger.info(
+                        "[incremental] semantic models already exist for %d referenced table(s); generation skipped",
+                        len(referenced_tables),
+                    )
+                    return True, ""
+                logger.info(
+                    "[incremental] %d/%d referenced table(s) need semantic model refresh: %s",
+                    len(missing_tables),
+                    len(referenced_tables),
+                    missing_tables,
+                )
+        except Exception as exc:
+            logger.warning("Failed to compute incremental semantic-model coverage; generation will continue: %s", exc)
 
     # Build comprehensive context from all rows
     context_message = "Generate semantic models for the following SQL queries:\n\n"
@@ -297,3 +341,79 @@ def process_semantic_yaml_file(
         error_msg = f"Failed to sync '{yaml_file_path}' to vector store: {error}"
         logger.error(error_msg)
         return False, error
+
+
+def refresh_semantic_yaml_profile_descriptions(
+    yaml_file_path: str,
+    profile_evidence: dict,
+    *,
+    authoring_format: str = "",
+    agent_config: Optional[AgentConfig] = None,
+    sync_to_storage: bool = False,
+) -> tuple[bool, str, int]:
+    """Refresh generated `Observed profile` description suffixes in a semantic YAML file.
+
+    The caller is responsible for producing ``profile_evidence`` via the read-only
+    profiler. This function preserves semantic structure and only updates
+    description fields. When ``sync_to_storage`` is true, the updated YAML is
+    projected back into the semantic stores after it is written.
+    """
+    if sync_to_storage and agent_config is None:
+        return False, "agent_config is required when sync_to_storage=True", 0
+
+    if not os.path.exists(yaml_file_path):
+        return False, f"Semantic YAML file not found: {yaml_file_path}", 0
+
+    try:
+        with open(yaml_file_path, "r", encoding="utf-8") as f:
+            docs = [doc for doc in yaml.safe_load_all(f) if doc is not None]
+    except Exception as exc:
+        return False, f"Failed to read semantic YAML file '{yaml_file_path}': {exc}", 0
+
+    try:
+        from datus.storage.semantic_model.profile_description import (
+            refresh_metricflow_yaml_descriptions,
+            refresh_osi_yaml_descriptions,
+        )
+
+        fmt = (authoring_format or "").strip().lower()
+        if not fmt:
+            fmt = "metricflow" if any(isinstance(doc, dict) and doc.get("data_source") for doc in docs) else "osi"
+        if fmt == "metricflow":
+            changed = refresh_metricflow_yaml_descriptions(docs, profile_evidence)
+        elif fmt == "osi":
+            changed = refresh_osi_yaml_descriptions(docs, profile_evidence)
+        else:
+            return False, f"Unsupported semantic YAML authoring format: {authoring_format}", 0
+    except Exception as exc:
+        return False, f"Failed to refresh semantic YAML descriptions: {exc}", 0
+
+    if changed <= 0:
+        return True, "", 0
+
+    try:
+        with open(yaml_file_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+    except Exception as exc:
+        return False, f"Failed to write semantic YAML file '{yaml_file_path}': {exc}", 0
+
+    if sync_to_storage:
+        if fmt == "metricflow":
+            sync_success, sync_error = process_semantic_yaml_file(
+                yaml_file_path,
+                agent_config,
+                include_semantic_objects=True,
+                include_metrics=True,
+            )
+        else:
+            from datus.tools.func_tool.generation_tools import GenerationTools
+
+            result = GenerationTools(agent_config=agent_config, authoring_format="osi").sync_osi_semantic_to_db(
+                yaml_file_path
+            )
+            sync_success = bool(result.get("success"))
+            sync_error = result.get("error", "")
+        if not sync_success:
+            return False, sync_error, changed
+
+    return True, "", changed

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -3,9 +3,10 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import asyncio
+import json
 import os
 import tempfile
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import pandas as pd
 import yaml
@@ -322,6 +323,231 @@ def init_success_story_semantic_model(
         return asyncio.run(
             init_success_story_semantic_model_async(agent_config, success_story, emit, build_mode=build_mode)
         )
+
+
+def refresh_success_story_semantic_model_profile(
+    agent_config: AgentConfig,
+    yaml_file_path: str,
+    success_story: str,
+    emit: Optional[Callable[[BatchEvent], None]] = None,
+    *,
+    authoring_format: str = "",
+    profile_mode: str = "deep",
+    max_tables: int = 8,
+    max_columns_per_table: int = 40,
+    top_n: int = 8,
+    max_profile_seconds: int = 120,
+) -> tuple[bool, str, int]:
+    """Refresh profile-derived descriptions for an existing semantic YAML file.
+
+    This is the CLI/API orchestration path for ``kb_update_strategy=refresh-profile``:
+    it mines historical SQL from the success-story CSV, samples bounded live-data
+    profiles through read-only DB tools, updates only generated description
+    suffixes in the YAML, and syncs that YAML back to semantic storage.
+    """
+    if not yaml_file_path:
+        return False, "--semantic_yaml is required for semantic_model refresh-profile", 0
+    if not success_story:
+        return False, "--success_story is required for semantic_model refresh-profile", 0
+
+    resolved_yaml_path = _resolve_semantic_yaml_refresh_path(yaml_file_path, agent_config)
+    if not resolved_yaml_path:
+        return False, f"Semantic YAML file rejected by sandbox check: {yaml_file_path}", 0
+    if not os.path.exists(resolved_yaml_path):
+        return False, f"Semantic YAML file not found: {resolved_yaml_path}", 0
+
+    entries, error = _load_success_story_profile_entries(success_story)
+    if error:
+        return False, error, 0
+
+    try:
+        with open(resolved_yaml_path, "r", encoding="utf-8") as f:
+            docs = [doc for doc in yaml.safe_load_all(f) if doc is not None]
+    except Exception as exc:
+        return False, f"Failed to read semantic YAML file '{resolved_yaml_path}': {exc}", 0
+
+    fmt = _infer_semantic_yaml_authoring_format(docs, authoring_format)
+    if fmt not in {"metricflow", "osi"}:
+        return False, f"Unsupported semantic YAML authoring format: {authoring_format}", 0
+    tables = _semantic_yaml_profile_tables(docs, fmt)
+    if not tables:
+        return False, f"No table targets found in semantic YAML file: {resolved_yaml_path}", 0
+
+    current_db_config = agent_config.current_db_config()
+    runtime_db_context_getter = getattr(agent_config, "runtime_db_context", None)
+    runtime_db_context = runtime_db_context_getter() if callable(runtime_db_context_getter) else {}
+    runtime_db_context = runtime_db_context if isinstance(runtime_db_context, dict) else {}
+    catalog = runtime_db_context.get("catalog") or runtime_db_context.get("catalog_name") or current_db_config.catalog
+    database = (
+        runtime_db_context.get("database") or runtime_db_context.get("database_name") or current_db_config.database
+    )
+    schema_name = (
+        runtime_db_context.get("schema")
+        or runtime_db_context.get("db_schema")
+        or runtime_db_context.get("schema_name")
+        or current_db_config.schema
+    )
+
+    if emit:
+        emit(
+            BatchEvent(
+                biz_name="semantic_model_profile_refresh",
+                stage=BatchStage.TASK_STARTED,
+                total_items=len(tables),
+                payload={"semantic_yaml": resolved_yaml_path, "tables": tables},
+            )
+        )
+
+    try:
+        from datus.tools.func_tool.database import DBFuncTool
+        from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
+
+        db_tool = DBFuncTool(agent_config=agent_config, sub_agent_name="gen_semantic_model", read_only=True)
+        discovery_tools = SemanticDiscoveryTools(db_tool=db_tool, enable_semantic_model_profiler=True)
+        profile_result = discovery_tools.profile_semantic_model_evidence(
+            sql_entries_json=json.dumps(entries, ensure_ascii=False),
+            tables=tables,
+            catalog=str(catalog or ""),
+            database=str(database or ""),
+            schema_name=str(schema_name or ""),
+            profile_mode=profile_mode,
+            max_tables=max_tables,
+            max_columns_per_table=max_columns_per_table,
+            top_n=top_n,
+            max_profile_seconds=max_profile_seconds,
+        )
+    except Exception as exc:
+        error = f"Failed to profile semantic YAML '{resolved_yaml_path}': {exc}"
+        logger.exception(error)
+        if emit:
+            emit(BatchEvent(biz_name="semantic_model_profile_refresh", stage=BatchStage.TASK_FAILED, error=error))
+        return False, error, 0
+
+    if not profile_result.success:
+        error = profile_result.error or "profile_semantic_model_evidence failed"
+        if emit:
+            emit(BatchEvent(biz_name="semantic_model_profile_refresh", stage=BatchStage.TASK_FAILED, error=error))
+        return False, error, 0
+
+    success, error, changed = refresh_semantic_yaml_profile_descriptions(
+        resolved_yaml_path,
+        profile_result.result or {},
+        authoring_format=fmt,
+        agent_config=agent_config,
+        sync_to_storage=True,
+    )
+
+    if emit:
+        emit(
+            BatchEvent(
+                biz_name="semantic_model_profile_refresh",
+                stage=BatchStage.TASK_COMPLETED if success else BatchStage.TASK_FAILED,
+                completed_items=len(tables) if success else 0,
+                failed_items=0 if success else len(tables),
+                error=error or None,
+                payload={"semantic_yaml": resolved_yaml_path, "changed_description_count": changed},
+            )
+        )
+    return success, error, changed
+
+
+def _load_success_story_profile_entries(success_story: str) -> tuple[list[dict[str, str]], str]:
+    try:
+        df = pd.read_csv(success_story)
+    except FileNotFoundError:
+        return [], f"Success story CSV file not found: {success_story}"
+    except pd.errors.EmptyDataError:
+        return [], f"Success story CSV file is empty: {success_story}"
+    except Exception as exc:
+        return [], f"Failed to read success story CSV file '{success_story}': {exc}"
+
+    if "sql" not in df.columns:
+        return [], f"Success story CSV '{success_story}' is missing required column: sql"
+
+    entries = []
+    for idx, row in df.iterrows():
+        sql = _success_story_cell(row, "sql")
+        if not sql:
+            continue
+        entries.append(
+            {
+                "name": _success_story_cell(row, "source_context_id")
+                or _success_story_cell(row, "name")
+                or f"success_story_{idx + 1}",
+                "question": _success_story_cell(row, "question"),
+                "sql": sql,
+            }
+        )
+    if not entries:
+        return [], f"Success story CSV '{success_story}' contains no SQL rows"
+    return entries, ""
+
+
+def _success_story_cell(row: Any, key: str) -> str:
+    value = row.get(key)
+    if value is None or pd.isna(value):
+        return ""
+    return str(value).strip()
+
+
+def _infer_semantic_yaml_authoring_format(docs: list[dict], authoring_format: str = "") -> str:
+    fmt = (authoring_format or "").strip().lower()
+    if fmt:
+        return fmt
+    return "metricflow" if any(isinstance(doc, dict) and doc.get("data_source") for doc in docs) else "osi"
+
+
+def _semantic_yaml_profile_tables(docs: list[dict], authoring_format: str) -> list[str]:
+    if authoring_format == "metricflow":
+        return _dedupe_semantic_yaml_values(
+            _metricflow_data_source_table(doc.get("data_source")) for doc in docs if isinstance(doc, dict)
+        )
+    return _dedupe_semantic_yaml_values(
+        _osi_dataset_table(dataset) for doc in docs for dataset in _iter_osi_yaml_datasets(doc)
+    )
+
+
+def _metricflow_data_source_table(data_source: Any) -> str:
+    if not isinstance(data_source, dict):
+        return ""
+    return str(data_source.get("sql_table") or data_source.get("name") or "").strip()
+
+
+def _iter_osi_yaml_datasets(doc: Any) -> list[dict]:
+    if not isinstance(doc, dict):
+        return []
+    datasets = [dataset for dataset in doc.get("datasets") or [] if isinstance(dataset, dict)]
+    semantic_models = doc.get("semantic_model")
+    if isinstance(semantic_models, list):
+        for semantic_model in semantic_models:
+            if isinstance(semantic_model, dict):
+                datasets.extend(
+                    dataset for dataset in semantic_model.get("datasets") or [] if isinstance(dataset, dict)
+                )
+    return datasets
+
+
+def _osi_dataset_table(dataset: dict) -> str:
+    source = dataset.get("source")
+    if isinstance(source, dict) and source.get("table"):
+        return str(source["table"]).strip()
+    if isinstance(source, str) and source.strip():
+        return source.strip()
+    return str(dataset.get("table") or dataset.get("name") or "").strip()
+
+
+def _dedupe_semantic_yaml_values(values) -> list[str]:
+    result = []
+    seen = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        key = text.lower()
+        if key not in seen:
+            seen.add(key)
+            result.append(text)
+    return result
 
 
 def init_semantic_yaml_semantic_model(

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -165,8 +165,13 @@ async def init_success_story_semantic_model_async(
             "[overwrite] Wiping semantic_model rows for datasource '%s' before re-population",
             semantic_model_rag.datasource_id,
         )
-        semantic_model_rag.truncate()
-        table_profile_rag.truncate()
+        try:
+            semantic_model_rag.truncate()
+            table_profile_rag.truncate()
+        except Exception as exc:
+            error_msg = f"Failed to wipe semantic model storage for build_mode='overwrite': {exc}"
+            logger.exception(error_msg)
+            return False, error_msg
 
     elif build_mode == "incremental":
         try:

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import os
+import tempfile
 from typing import Callable, Optional
 
 import pandas as pd
@@ -21,6 +22,40 @@ from datus.utils.terminal_utils import suppress_keyboard_input
 logger = get_logger(__name__)
 
 SEMANTIC_MODEL_RESPONSE_ACTION_TYPE = f"{GenSemanticModelAgenticNode.NODE_NAME}_response"
+_VALID_BUILD_MODES = {"check", "overwrite", "incremental"}
+
+
+def _resolve_semantic_yaml_refresh_path(yaml_file_path: str, agent_config: Optional[AgentConfig]) -> Optional[str]:
+    raw_path = str(yaml_file_path or "")
+    if not raw_path:
+        return None
+
+    path_manager = getattr(agent_config, "path_manager", None) if agent_config is not None else None
+    subject_dir = getattr(path_manager, "subject_dir", None) if path_manager is not None else None
+    if isinstance(subject_dir, (str, os.PathLike)):
+        from datus.cli.generation_hooks import resolve_kb_sandbox_path
+
+        return resolve_kb_sandbox_path(raw_path, "semantic", os.fspath(subject_dir))
+    return os.path.realpath(raw_path)
+
+
+def _atomic_dump_semantic_yaml(yaml_file_path: str, docs: list) -> None:
+    target_dir = os.path.dirname(os.path.realpath(yaml_file_path)) or "."
+    fd, temp_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(yaml_file_path)}.",
+        suffix=".tmp",
+        dir=target_dir,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
+        os.replace(temp_path, yaml_file_path)
+    except Exception:
+        try:
+            os.remove(temp_path)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 async def init_success_story_semantic_model_async(
@@ -95,14 +130,27 @@ async def init_success_story_semantic_model_async(
         logger.error(error_msg)
         return False, error_msg
 
+    if build_mode not in _VALID_BUILD_MODES:
+        error_msg = (
+            f"Unsupported semantic model build_mode: {build_mode!r}. "
+            f"Expected one of: {', '.join(sorted(_VALID_BUILD_MODES))}"
+        )
+        logger.error(error_msg)
+        return False, error_msg
+
     semantic_model_rag = None
     table_profile_rag = None
     if build_mode in {"check", "overwrite"}:
-        from datus.storage.semantic_model.store import SemanticModelRAG
-        from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
+        try:
+            from datus.storage.semantic_model.store import SemanticModelRAG
+            from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 
-        semantic_model_rag = SemanticModelRAG(agent_config)
-        table_profile_rag = TableSemanticProfileRAG(agent_config)
+            semantic_model_rag = SemanticModelRAG(agent_config)
+            table_profile_rag = TableSemanticProfileRAG(agent_config)
+        except Exception as exc:
+            error_msg = f"Failed to initialize semantic model storage for build_mode='{build_mode}': {exc}"
+            logger.exception(error_msg)
+            return False, error_msg
 
     if build_mode == "check":
         logger.info(
@@ -360,14 +408,18 @@ def refresh_semantic_yaml_profile_descriptions(
     if sync_to_storage and agent_config is None:
         return False, "agent_config is required when sync_to_storage=True", 0
 
-    if not os.path.exists(yaml_file_path):
-        return False, f"Semantic YAML file not found: {yaml_file_path}", 0
+    resolved_yaml_path = _resolve_semantic_yaml_refresh_path(yaml_file_path, agent_config)
+    if not resolved_yaml_path:
+        return False, f"Semantic YAML file rejected by sandbox check: {yaml_file_path}", 0
+
+    if not os.path.exists(resolved_yaml_path):
+        return False, f"Semantic YAML file not found: {resolved_yaml_path}", 0
 
     try:
-        with open(yaml_file_path, "r", encoding="utf-8") as f:
+        with open(resolved_yaml_path, "r", encoding="utf-8") as f:
             docs = [doc for doc in yaml.safe_load_all(f) if doc is not None]
     except Exception as exc:
-        return False, f"Failed to read semantic YAML file '{yaml_file_path}': {exc}", 0
+        return False, f"Failed to read semantic YAML file '{resolved_yaml_path}': {exc}", 0
 
     try:
         from datus.storage.semantic_model.profile_description import (
@@ -387,19 +439,19 @@ def refresh_semantic_yaml_profile_descriptions(
     except Exception as exc:
         return False, f"Failed to refresh semantic YAML descriptions: {exc}", 0
 
-    if changed <= 0:
+    if changed <= 0 and not sync_to_storage:
         return True, "", 0
 
-    try:
-        with open(yaml_file_path, "w", encoding="utf-8") as f:
-            yaml.safe_dump_all(docs, f, allow_unicode=True, sort_keys=False)
-    except Exception as exc:
-        return False, f"Failed to write semantic YAML file '{yaml_file_path}': {exc}", 0
+    if changed > 0:
+        try:
+            _atomic_dump_semantic_yaml(resolved_yaml_path, docs)
+        except Exception as exc:
+            return False, f"Failed to write semantic YAML file '{resolved_yaml_path}': {exc}", 0
 
     if sync_to_storage:
         if fmt == "metricflow":
             sync_success, sync_error = process_semantic_yaml_file(
-                yaml_file_path,
+                resolved_yaml_path,
                 agent_config,
                 include_semantic_objects=True,
                 include_metrics=True,
@@ -408,7 +460,7 @@ def refresh_semantic_yaml_profile_descriptions(
             from datus.tools.func_tool.generation_tools import GenerationTools
 
             result = GenerationTools(agent_config=agent_config, authoring_format="osi").sync_osi_semantic_to_db(
-                yaml_file_path
+                resolved_yaml_path
             )
             sync_success = bool(result.get("success"))
             sync_error = result.get("error", "")

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -457,11 +457,16 @@ def refresh_semantic_yaml_profile_descriptions(
                 include_metrics=True,
             )
         else:
-            from datus.tools.func_tool.generation_tools import GenerationTools
+            try:
+                from datus.tools.func_tool.generation_tools import GenerationTools
 
-            result = GenerationTools(agent_config=agent_config, authoring_format="osi").sync_osi_semantic_to_db(
-                resolved_yaml_path
-            )
+                result = GenerationTools(agent_config=agent_config, authoring_format="osi").sync_osi_semantic_to_db(
+                    resolved_yaml_path
+                )
+            except Exception as exc:
+                sync_error = f"Failed to sync OSI semantic YAML file '{resolved_yaml_path}' to vector store: {exc}"
+                logger.exception(sync_error)
+                return False, sync_error, changed
             sync_success = bool(result.get("success"))
             sync_error = result.get("error", "")
         if not sync_success:

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -345,6 +345,12 @@ class SemanticModelRAG:
         """Delete all semantic model data for this datasource."""
         self.storage.delete_datasource_rows(self.datasource_id)
 
+    def delete_artifact_rows(self, yaml_path: str) -> None:
+        """Delete semantic rows projected from a single YAML artifact."""
+        if not yaml_path:
+            return
+        self.storage._delete_rows(And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions()))
+
     def get_semantic_model(
         self,
         catalog_name: str = "",

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pyarrow as pa
 import yaml
-from datus_storage_base.conditions import And, WhereExpr, eq, in_
+from datus_storage_base.conditions import And, WhereExpr, eq, in_, not_
 
 from datus.storage.base import BaseEmbeddingStore, EmbeddingModel
 from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
@@ -350,6 +350,35 @@ class SemanticModelRAG:
         if not yaml_path:
             return
         self.storage._delete_rows(And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions()))
+
+    def delete_artifact_rows_except(self, yaml_path: str, keep_ids: List[str]) -> None:
+        """Delete stale semantic rows for one YAML artifact after replacement succeeds."""
+        if not yaml_path:
+            return
+        normalized_keep_ids = [row_id for row_id in keep_ids if row_id]
+        if not normalized_keep_ids:
+            self.delete_artifact_rows(yaml_path)
+            return
+        self.storage._delete_rows(
+            And([eq("yaml_path", yaml_path), not_(in_("id", normalized_keep_ids))] + self._sub_agent_conditions())
+        )
+
+    def list_artifact_rows(self, yaml_path: str) -> List[Dict[str, Any]]:
+        """Return semantic rows projected from a single YAML artifact."""
+        if not yaml_path:
+            return []
+        return self.storage._search_all(
+            where=And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions())
+        ).to_pylist()
+
+    def restore_artifact_rows(self, yaml_path: str, rows: List[Dict[str, Any]]) -> None:
+        """Restore one YAML artifact to a previously captured row snapshot."""
+        if not yaml_path:
+            return
+        self.delete_artifact_rows(yaml_path)
+        if rows:
+            self.upsert_batch(rows)
+        self.create_indices()
 
     def get_semantic_model(
         self,

--- a/datus/storage/table_semantic_profile/store.py
+++ b/datus/storage/table_semantic_profile/store.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pyarrow as pa
-from datus_storage_base.conditions import And, eq
+from datus_storage_base.conditions import And, eq, in_, not_
 
 from datus.storage.base import BaseEmbeddingStore, EmbeddingModel
 from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
@@ -105,6 +105,35 @@ class TableSemanticProfileRAG:
         if not yaml_path:
             return
         self.storage._delete_rows(And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions()))
+
+    def delete_artifact_rows_except(self, yaml_path: str, keep_ids: List[str]) -> None:
+        """Delete stale table profile rows for one YAML artifact after replacement succeeds."""
+        if not yaml_path:
+            return
+        normalized_keep_ids = [row_id for row_id in keep_ids if row_id]
+        if not normalized_keep_ids:
+            self.delete_artifact_rows(yaml_path)
+            return
+        self.storage._delete_rows(
+            And([eq("yaml_path", yaml_path), not_(in_("id", normalized_keep_ids))] + self._sub_agent_conditions())
+        )
+
+    def list_artifact_rows(self, yaml_path: str) -> List[Dict[str, Any]]:
+        """Return table profile rows projected from a single YAML artifact."""
+        if not yaml_path:
+            return []
+        return self.storage._search_all(
+            where=And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions())
+        ).to_pylist()
+
+    def restore_artifact_rows(self, yaml_path: str, rows: List[Dict[str, Any]]) -> None:
+        """Restore one YAML artifact to a previously captured row snapshot."""
+        if not yaml_path:
+            return
+        self.delete_artifact_rows(yaml_path)
+        if rows:
+            self.upsert_batch(rows)
+        self.create_indices()
 
     def get_profile(
         self,

--- a/datus/storage/table_semantic_profile/store.py
+++ b/datus/storage/table_semantic_profile/store.py
@@ -100,6 +100,12 @@ class TableSemanticProfileRAG:
     def truncate(self) -> None:
         self.storage.delete_datasource_rows(self.datasource_id)
 
+    def delete_artifact_rows(self, yaml_path: str) -> None:
+        """Delete table profile rows projected from a single YAML artifact."""
+        if not yaml_path:
+            return
+        self.storage._delete_rows(And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions()))
+
     def get_profile(
         self,
         catalog_name: str = "",

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -1577,8 +1577,13 @@ class GenerationTools:
                     self.table_semantic_profile_rag.create_indices()
                     profile_count = len(table_profiles)
                 delete_stale_artifact_rows(replacement_plans)
-            except Exception:
-                restore_artifact_replacements(snapshots)
+            except Exception as sync_exc:
+                restore_failures = restore_artifact_replacements(snapshots)
+                if restore_failures:
+                    raise RuntimeError(
+                        "OSI semantic replacement failed and rollback was incomplete for: "
+                        f"{', '.join(restore_failures)}"
+                    ) from sync_exc
                 raise
             return {
                 "success": True,
@@ -1719,14 +1724,19 @@ class GenerationTools:
                     return sem_result
                 synced_semantic_files.append(current_semantic_file)
 
-            replacement_plans = [(self.metric_rag, metric_file, metric_objects)] if replace_metric_artifact else []
-            snapshots = snapshot_artifact_replacements(replacement_plans)
+            metric_plan = (self.metric_rag, metric_file, metric_objects)
+            replacement_plans = [metric_plan] if replace_metric_artifact else []
+            snapshots = snapshot_artifact_replacements([metric_plan])
             try:
                 self.metric_rag.upsert_batch(metric_objects)
                 self.metric_rag.create_indices()
                 delete_stale_artifact_rows(replacement_plans)
-            except Exception:
-                restore_artifact_replacements(snapshots)
+            except Exception as sync_exc:
+                restore_failures = restore_artifact_replacements(snapshots)
+                if restore_failures:
+                    raise RuntimeError(
+                        f"OSI metric replacement failed and rollback was incomplete for: {', '.join(restore_failures)}"
+                    ) from sync_exc
                 raise
             return {
                 "success": True,

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -16,6 +16,11 @@ from agents import Tool
 from datus_storage_base.conditions import And, eq
 
 from datus.configuration.agent_config import AgentConfig
+from datus.storage.artifact_replacement import (
+    delete_stale_artifact_rows,
+    restore_artifact_replacements,
+    snapshot_artifact_replacements,
+)
 from datus.storage.metric.store import MetricRAG, build_metric_id, metric_definition_conflict, normalize_metric_name
 from datus.storage.semantic_model.store import SemanticModelRAG, _identifier_variants, _normalized_identifier
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
@@ -1188,10 +1193,12 @@ class GenerationTools:
         if not profiles or self.table_semantic_profile_rag is None:
             return 0
         yaml_path = str(profiles[0].get("yaml_path") or "")
-        if yaml_path:
-            self.table_semantic_profile_rag.delete_artifact_rows(yaml_path)
         self.table_semantic_profile_rag.upsert_batch(profiles)
         self.table_semantic_profile_rag.create_indices()
+        if yaml_path:
+            self.table_semantic_profile_rag.delete_artifact_rows_except(
+                yaml_path, [profile.get("id", "") for profile in profiles]
+            )
         return len(profiles)
 
     @staticmethod
@@ -1557,10 +1564,22 @@ class GenerationTools:
                         f"context: {', '.join(sorted(target_dataset_names))}"
                     ),
                 }
-            self.semantic_rag.delete_artifact_rows(semantic_model_path)
-            self.semantic_rag.upsert_batch(semantic_objects)
-            self.semantic_rag.create_indices()
-            profile_count = self._upsert_table_semantic_profiles(table_profiles)
+            replacement_plans = [(self.semantic_rag, semantic_model_path, semantic_objects)]
+            if table_profiles and self.table_semantic_profile_rag is not None:
+                replacement_plans.append((self.table_semantic_profile_rag, semantic_model_path, table_profiles))
+            snapshots = snapshot_artifact_replacements(replacement_plans)
+            try:
+                self.semantic_rag.upsert_batch(semantic_objects)
+                self.semantic_rag.create_indices()
+                profile_count = 0
+                if table_profiles and self.table_semantic_profile_rag is not None:
+                    self.table_semantic_profile_rag.upsert_batch(table_profiles)
+                    self.table_semantic_profile_rag.create_indices()
+                    profile_count = len(table_profiles)
+                delete_stale_artifact_rows(replacement_plans)
+            except Exception:
+                restore_artifact_replacements(snapshots)
+                raise
             return {
                 "success": True,
                 "message": f"Synced {len(semantic_objects)} OSI semantic object(s): {', '.join(synced_items[:5])}",
@@ -1700,10 +1719,15 @@ class GenerationTools:
                     return sem_result
                 synced_semantic_files.append(current_semantic_file)
 
-            if replace_metric_artifact:
-                self.metric_rag.delete_artifact_rows(metric_file)
-            self.metric_rag.upsert_batch(metric_objects)
-            self.metric_rag.create_indices()
+            replacement_plans = [(self.metric_rag, metric_file, metric_objects)] if replace_metric_artifact else []
+            snapshots = snapshot_artifact_replacements(replacement_plans)
+            try:
+                self.metric_rag.upsert_batch(metric_objects)
+                self.metric_rag.create_indices()
+                delete_stale_artifact_rows(replacement_plans)
+            except Exception:
+                restore_artifact_replacements(snapshots)
+                raise
             return {
                 "success": True,
                 "message": f"Synced {len(metric_objects)} OSI metric(s): {', '.join(synced_items[:5])}",

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -474,7 +474,9 @@ class GenerationTools:
                 )
 
             if self._is_osi_authoring():
-                sync_result = self._sync_osi_metric_to_db(abs_metric, abs_semantic_files, metric_sqls)
+                sync_result = self._sync_osi_metric_to_db(
+                    abs_metric, abs_semantic_files, metric_sqls, replace_metric_artifact=False
+                )
                 if not sync_result.get("success"):
                     return FuncToolResult(
                         success=0,
@@ -1185,6 +1187,9 @@ class GenerationTools:
     def _upsert_table_semantic_profiles(self, profiles: List[dict]) -> int:
         if not profiles or self.table_semantic_profile_rag is None:
             return 0
+        yaml_path = str(profiles[0].get("yaml_path") or "")
+        if yaml_path:
+            self.table_semantic_profile_rag.delete_artifact_rows(yaml_path)
         self.table_semantic_profile_rag.upsert_batch(profiles)
         self.table_semantic_profile_rag.create_indices()
         return len(profiles)
@@ -1552,6 +1557,7 @@ class GenerationTools:
                         f"context: {', '.join(sorted(target_dataset_names))}"
                     ),
                 }
+            self.semantic_rag.delete_artifact_rows(semantic_model_path)
             self.semantic_rag.upsert_batch(semantic_objects)
             self.semantic_rag.create_indices()
             profile_count = self._upsert_table_semantic_profiles(table_profiles)
@@ -1611,6 +1617,7 @@ class GenerationTools:
         metric_file: str,
         semantic_model_file: Optional[str | List[str]] = None,
         metric_sqls: Optional[Dict[str, str]] = None,
+        replace_metric_artifact: bool = True,
     ) -> dict:
         """Sync OSI metrics into MetricRAG using the OSI document as source of truth."""
         try:
@@ -1693,6 +1700,8 @@ class GenerationTools:
                     return sem_result
                 synced_semantic_files.append(current_semantic_file)
 
+            if replace_metric_artifact:
+                self.metric_rag.delete_artifact_rows(metric_file)
             self.metric_rag.upsert_batch(metric_objects)
             self.metric_rag.create_indices()
             return {
@@ -1766,6 +1775,7 @@ class GenerationTools:
                     include_metrics=True,
                     metric_sqls=sync_metric_sqls,
                     original_yaml_path=metric_file,
+                    replace_metric_artifact=False,
                 )
             finally:
                 if temp_metric_file and os.path.exists(temp_metric_file):

--- a/docs/API/knowledge_base.md
+++ b/docs/API/knowledge_base.md
@@ -15,15 +15,34 @@ metrics, and reference SQL.
 | Field                | Type     | Default        | Notes |
 |----------------------|----------|----------------|-------|
 | `components`         | string[] | _(required)_   | Components to bootstrap: `metadata`, `semantic_model`, `metrics`, `reference_sql` |
-| `strategy`           | string   | `incremental`  | `check` (inspect only), `overwrite` (rebuild), or `incremental` (append/update) |
+| `strategy`           | string   | `incremental`  | `check` (inspect only), `overwrite` (rebuild), `incremental` (append/update), or `refresh-profile` (semantic model only) |
 | `schema_linking_type`| string   | `full`         | Metadata only: `table`, `view`, `mv`, or `full` |
 | `catalog`            | string   | `""`           | Metadata catalog filter for catalog-aware engines such as StarRocks; leave empty for Snowflake |
 | `database_name`      | string   | `""`           | Metadata database filter |
 | `success_story`      | string?  | `null`         | Project-root-relative path to success-story CSV |
+| `semantic_yaml`      | string?  | `null`         | Project-root-relative semantic model YAML path; required with `strategy=refresh-profile` |
 | `subject_tree`       | string[]?| `null`         | Predefined hierarchical categories |
 | `sql_dir`            | string?  | `null`         | Project-root-relative directory with `.sql` files |
 
 **Response**: `text/event-stream`. See [SSE event format](#sse-event-format) below.
+
+`strategy=refresh-profile` is only valid when `components` is exactly `["semantic_model"]`. It requires both
+`semantic_yaml` and `success_story`, refreshes generated `Observed profile:` description suffixes in the existing
+MetricFlow or OSI YAML using bounded read-only data profiling, and syncs the updated YAML back to semantic model storage.
+It does not run full semantic-model generation or truncate the semantic model store.
+
+**Example**:
+
+```bash
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap \
+  -H "Content-Type: application/json" \
+  -d '{
+    "components": ["semantic_model"],
+    "strategy": "refresh-profile",
+    "semantic_yaml": "subject/semantic_models/starrocks/orders.yml",
+    "success_story": "success_story.csv"
+  }'
+```
 
 ### `POST /api/v1/kb/bootstrap/{stream_id}/cancel`
 

--- a/docs/API/knowledge_base.zh.md
+++ b/docs/API/knowledge_base.zh.md
@@ -13,15 +13,34 @@
 | 字段                  | 类型      | 默认值          | 说明 |
 |----------------------|----------|----------------|------|
 | `components`         | string[] | _（必填）_       | 要构建的组件：`metadata`、`semantic_model`、`metrics`、`reference_sql` |
-| `strategy`           | string   | `incremental`  | `check`（仅检查）、`overwrite`（重建）、`incremental`（增量更新） |
+| `strategy`           | string   | `incremental`  | `check`（仅检查）、`overwrite`（重建）、`incremental`（增量更新）或 `refresh-profile`（仅语义模型） |
 | `schema_linking_type`| string   | `full`         | metadata 专用：`table`、`view`、`mv`、`full` |
 | `catalog`            | string   | `""`           | 支持 catalog 的引擎的 metadata catalog 过滤，例如 StarRocks；Snowflake 需要留空 |
 | `database_name`      | string   | `""`           | metadata 数据库过滤 |
 | `success_story`      | string?  | `null`         | 项目根目录的相对路径，指向 success-story CSV |
+| `semantic_yaml`      | string?  | `null`         | 项目根目录的相对路径，指向语义模型 YAML；`strategy=refresh-profile` 时必需 |
 | `subject_tree`       | string[]?| `null`         | 预定义层级分类 |
 | `sql_dir`            | string?  | `null`         | 项目根目录的相对路径，指向 `.sql` 文件目录 |
 
 **响应**：`text/event-stream`，参见下方 [SSE 事件格式](#sse-events)。
+
+`strategy=refresh-profile` 仅在 `components` 恰好为 `["semantic_model"]` 时有效。它要求同时传入 `semantic_yaml`
+和 `success_story`，会用有界、只读的数据 profile 刷新已有 MetricFlow 或 OSI YAML 中生成的 `Observed profile:`
+description 片段，并把更新后的 YAML 同步回 semantic model storage。它不会重新运行完整语义模型生成，也不会清空
+semantic model store。
+
+**示例**：
+
+```bash
+curl -N -X POST http://localhost:8000/api/v1/kb/bootstrap \
+  -H "Content-Type: application/json" \
+  -d '{
+    "components": ["semantic_model"],
+    "strategy": "refresh-profile",
+    "semantic_yaml": "subject/semantic_models/starrocks/orders.yml",
+    "success_story": "success_story.csv"
+  }'
+```
 
 ### `POST /api/v1/kb/bootstrap/{stream_id}/cancel`
 

--- a/docs/knowledge_base/semantic_model.md
+++ b/docs/knowledge_base/semantic_model.md
@@ -58,6 +58,14 @@ datus-agent bootstrap-kb \
     --datasource <your_datasource> \
     --components semantic_model \
     --semantic_yaml path/to/semantic_model.yaml
+
+# Refresh observed profile descriptions in an existing YAML
+datus-agent bootstrap-kb \
+    --datasource <your_datasource> \
+    --components semantic_model \
+    --kb_update_strategy refresh-profile \
+    --semantic_yaml path/to/semantic_model.yaml \
+    --success_story path/to/success_story.csv
 ```
 
 ### Key Parameters
@@ -66,9 +74,14 @@ datus-agent bootstrap-kb \
 |-----------|----------|-------------|---------|
 | `--datasource` | ✅ | Database datasource | `sales_db` |
 | `--components` | ✅ | Components to initialize | `semantic_model` |
-| `--success_story` | ⚠️ | CSV file with historical SQLs (required if no `--semantic_yaml`) | `success_story.csv` |
-| `--semantic_yaml` | ⚠️ | Semantic model YAML file (required if no `--success_story`) | `semantic_model.yaml` |
-| `--kb_update_strategy` | ✅ | Update strategy | `overwrite`/`incremental` |
+| `--success_story` | ⚠️ | CSV file with historical SQLs. Required for generation from SQL history and for `refresh-profile`. | `success_story.csv` |
+| `--semantic_yaml` | ⚠️ | Semantic model YAML file. Required for YAML import and for `refresh-profile`. | `semantic_model.yaml` |
+| `--kb_update_strategy` | ❌ | Update strategy. Defaults to `check`; `refresh-profile` is semantic-model only. | `check`/`overwrite`/`incremental`/`refresh-profile` |
+
+`refresh-profile` updates an existing MetricFlow or OSI semantic YAML in place. It re-runs bounded, read-only data
+profiling guided by the historical SQLs in `--success_story`, replaces the generated `Observed profile:` suffixes in
+table and column descriptions, and syncs the updated YAML back to the semantic model vector store. It does not run full
+LLM semantic-model generation and does not truncate the semantic model store.
 
 ## Data Source Formats
 

--- a/docs/knowledge_base/semantic_model.zh.md
+++ b/docs/knowledge_base/semantic_model.zh.md
@@ -59,6 +59,14 @@ datus-agent bootstrap-kb \
     --datasource <your_datasource> \
     --components semantic_model \
     --semantic_yaml path/to/semantic_model.yaml
+
+# 刷新已有 YAML 中的观测 profile 描述
+datus-agent bootstrap-kb \
+    --datasource <your_datasource> \
+    --components semantic_model \
+    --kb_update_strategy refresh-profile \
+    --semantic_yaml path/to/semantic_model.yaml \
+    --success_story path/to/success_story.csv
 ```
 
 ### 关键参数
@@ -67,9 +75,13 @@ datus-agent bootstrap-kb \
 |-----------|----------|-------------|---------|
 | `--datasource` | ✅ | 数据库数据源 | `sales_db` |
 | `--components` | ✅ | 要初始化的组件 | `semantic_model` |
-| `--success_story` | ⚠️ | 包含历史 SQLs 的 CSV 文件（如果没有 `--semantic_yaml` 则必需） | `success_story.csv` |
-| `--semantic_yaml` | ⚠️ | 语义模型 YAML 文件（如果没有 `--success_story` 则必需） | `semantic_model.yaml` |
-| `--kb_update_strategy` | ✅ | 更新策略 | `overwrite`/`incremental` |
+| `--success_story` | ⚠️ | 包含历史 SQLs 的 CSV 文件。从 SQL 历史生成和 `refresh-profile` 都需要。 | `success_story.csv` |
+| `--semantic_yaml` | ⚠️ | 语义模型 YAML 文件。从 YAML 导入和 `refresh-profile` 都需要。 | `semantic_model.yaml` |
+| `--kb_update_strategy` | ❌ | 更新策略。默认是 `check`；`refresh-profile` 仅支持 `semantic_model` 组件。 | `check`/`overwrite`/`incremental`/`refresh-profile` |
+
+`refresh-profile` 会原地更新已有 MetricFlow 或 OSI 语义模型 YAML。它会根据 `--success_story` 中的历史 SQL
+重新做有界、只读的数据 profile，替换表和字段 description 中生成的 `Observed profile:` 片段，并把更新后的 YAML
+同步回语义模型向量库。它不会重新运行完整 LLM 语义模型生成，也不会清空 semantic model store。
 
 ## 数据源格式
 

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -1139,15 +1139,20 @@ class TestBootstrapKbSemanticModel:
         mock_rag = MagicMock()
         mock_rag.get_size.return_value = 2
         mock_profile_rag = MagicMock()
+        mock_dir = MagicMock()
+        mock_dir.exists.return_value = True
+        agent.global_config.path_manager.semantic_model_path.return_value = mock_dir
 
         with (
             patch("datus.agent.agent.SemanticModelRAG", return_value=mock_rag),
             patch("datus.agent.agent.TableSemanticProfileRAG", return_value=mock_profile_rag),
             patch("datus.agent.agent.init_semantic_yaml_semantic_model", return_value=(True, None)),
+            patch("datus.agent.agent.safe_rmtree") as mock_safe_rmtree,
         ):
             result = agent.bootstrap_kb()
 
         assert result["status"] == "success"
+        mock_safe_rmtree.assert_not_called()
         mock_rag.truncate.assert_called_once_with()
         mock_profile_rag.truncate.assert_called_once_with()
 
@@ -1312,6 +1317,28 @@ class TestBootstrapKbMetrics:
         assert set(result["components"]) == {"semantic_model", "metrics"}
         assert "semantic_object_count=1" in result["components"]["semantic_model"]["message"]
         assert "metrics_count=3" in result["components"]["metrics"]["message"]
+
+    def test_multiple_components_failure_message_matches_status(self):
+        args = _make_args_ext(components=["semantic_model", "metrics"], kb_update_strategy="overwrite")
+        agent = _make_agent_ext(args=args)
+
+        mock_semantic_rag = MagicMock()
+        mock_semantic_rag.get_size.return_value = 1
+        mock_profile_rag = MagicMock()
+        mock_metric_rag = MagicMock()
+
+        with (
+            patch("datus.agent.agent.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.agent.agent.TableSemanticProfileRAG", return_value=mock_profile_rag),
+            patch("datus.agent.agent.MetricRAG", return_value=mock_metric_rag),
+            patch("datus.agent.agent.init_success_story_semantic_model", return_value=(True, None)),
+            patch("datus.agent.agent.init_success_story_metrics", return_value=(False, "metrics failed", {})),
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "failed"
+        assert result["message"] == "Knowledge base initialization failed"
+        assert result["components"]["metrics"]["status"] == "failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -1172,6 +1172,40 @@ class TestBootstrapKbSemanticModel:
         assert result["status"] == "success"
         mock_init.assert_called_once_with(agent.global_config, args.success_story, build_mode="incremental")
 
+    def test_semantic_model_refresh_profile_updates_existing_yaml_without_regeneration(self):
+        args = _make_args_ext(
+            components=["semantic_model"],
+            kb_update_strategy="refresh-profile",
+            semantic_yaml="path/to.yaml",
+            success_story="stories.csv",
+        )
+        agent = _make_agent_ext(args=args)
+
+        mock_rag = MagicMock()
+        mock_rag.get_size.return_value = 2
+        mock_profile_rag = MagicMock()
+        mock_profile_rag.get_size.return_value = 1
+
+        with (
+            patch("datus.agent.agent.SemanticModelRAG", return_value=mock_rag),
+            patch("datus.agent.agent.TableSemanticProfileRAG", return_value=mock_profile_rag),
+            patch(
+                "datus.agent.agent.refresh_success_story_semantic_model_profile",
+                return_value=(True, "", 3),
+            ) as mock_refresh,
+            patch("datus.agent.agent.init_success_story_semantic_model") as mock_generate,
+            patch("datus.agent.agent.init_semantic_yaml_semantic_model") as mock_import_yaml,
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        assert "changed_description_count=3" in result["message"]
+        mock_refresh.assert_called_once_with(agent.global_config, "path/to.yaml", "stories.csv")
+        mock_generate.assert_not_called()
+        mock_import_yaml.assert_not_called()
+        mock_rag.truncate.assert_not_called()
+        mock_profile_rag.truncate.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # bootstrap_kb — metrics branch

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -1045,14 +1045,19 @@ class TestBootstrapKbSemanticModel:
 
         mock_rag = MagicMock()
         mock_rag.get_size.return_value = 5
+        mock_profile_rag = MagicMock()
 
         with (
             patch("datus.agent.agent.SemanticModelRAG", return_value=mock_rag),
-            patch("datus.agent.agent.init_success_story_semantic_model", return_value=(True, None)),
+            patch("datus.agent.agent.TableSemanticProfileRAG", return_value=mock_profile_rag),
+            patch("datus.agent.agent.init_success_story_semantic_model", return_value=(True, None)) as mock_init,
         ):
             result = agent.bootstrap_kb()
 
         assert result["status"] == "success"
+        mock_init.assert_called_once_with(agent.global_config, args.success_story, build_mode="overwrite")
+        mock_rag.truncate.assert_not_called()
+        mock_profile_rag.truncate.assert_not_called()
 
     def test_semantic_model_failure(self):
         args = _make_args_ext(components=["semantic_model"], kb_update_strategy="overwrite")
@@ -1062,11 +1067,33 @@ class TestBootstrapKbSemanticModel:
 
         with (
             patch("datus.agent.agent.SemanticModelRAG", return_value=mock_rag),
+            patch("datus.agent.agent.TableSemanticProfileRAG"),
             patch("datus.agent.agent.init_success_story_semantic_model", return_value=(False, "error msg")),
         ):
             result = agent.bootstrap_kb()
 
         assert result["status"] == "failed"
+
+    def test_semantic_model_check_skips_generation(self):
+        args = _make_args_ext(components=["semantic_model"], kb_update_strategy="check")
+        agent = _make_agent_ext(args=args)
+
+        mock_rag = MagicMock()
+        mock_rag.get_size.return_value = 7
+        mock_profile_rag = MagicMock()
+        mock_profile_rag.get_size.return_value = 3
+
+        with (
+            patch("datus.agent.agent.SemanticModelRAG", return_value=mock_rag),
+            patch("datus.agent.agent.TableSemanticProfileRAG", return_value=mock_profile_rag),
+            patch("datus.agent.agent.init_success_story_semantic_model") as mock_init,
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        assert "semantic_object_count=7" in result["message"]
+        assert "table_semantic_profile_count=3" in result["message"]
+        mock_init.assert_not_called()
 
     def test_semantic_model_overwrite_cancelled_when_dir_exists(self, tmp_path):
         args = _make_args_ext(components=["semantic_model"], kb_update_strategy="overwrite")
@@ -1103,6 +1130,43 @@ class TestBootstrapKbSemanticModel:
 
         assert result["status"] == "success"
 
+    def test_semantic_model_yaml_overwrite_truncates_stores(self):
+        args = _make_args_ext(
+            components=["semantic_model"], kb_update_strategy="overwrite", semantic_yaml="path/to.yaml"
+        )
+        agent = _make_agent_ext(args=args)
+
+        mock_rag = MagicMock()
+        mock_rag.get_size.return_value = 2
+        mock_profile_rag = MagicMock()
+
+        with (
+            patch("datus.agent.agent.SemanticModelRAG", return_value=mock_rag),
+            patch("datus.agent.agent.TableSemanticProfileRAG", return_value=mock_profile_rag),
+            patch("datus.agent.agent.init_semantic_yaml_semantic_model", return_value=(True, None)),
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        mock_rag.truncate.assert_called_once_with()
+        mock_profile_rag.truncate.assert_called_once_with()
+
+    def test_semantic_model_incremental_forwards_strategy(self):
+        args = _make_args_ext(components=["semantic_model"], kb_update_strategy="incremental")
+        agent = _make_agent_ext(args=args)
+
+        mock_rag = MagicMock()
+        mock_rag.get_size.return_value = 2
+
+        with (
+            patch("datus.agent.agent.SemanticModelRAG", return_value=mock_rag),
+            patch("datus.agent.agent.init_success_story_semantic_model", return_value=(True, None)) as mock_init,
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        mock_init.assert_called_once_with(agent.global_config, args.success_story, build_mode="incremental")
+
 
 # ---------------------------------------------------------------------------
 # bootstrap_kb — metrics branch
@@ -1119,11 +1183,13 @@ class TestBootstrapKbMetrics:
 
         with (
             patch("datus.agent.agent.MetricRAG", return_value=mock_rag),
-            patch("datus.agent.agent.init_success_story_metrics", return_value=(True, None, {})),
+            patch("datus.agent.agent.init_success_story_metrics", return_value=(True, None, {})) as mock_init,
         ):
             result = agent.bootstrap_kb()
 
         assert result["status"] == "success"
+        mock_init.assert_called_once()
+        assert mock_init.call_args.kwargs["build_mode"] == "overwrite"
 
     def test_metrics_overwrite_keeps_semantic_yaml_dir(self):
         args = _make_args_ext(components=["metrics"], kb_update_strategy="overwrite")
@@ -1160,6 +1226,39 @@ class TestBootstrapKbMetrics:
 
         assert result["status"] == "success"
 
+    def test_metrics_yaml_overwrite_does_not_truncate_store(self):
+        args = _make_args_ext(components=["metrics"], kb_update_strategy="overwrite", semantic_yaml="metrics.yaml")
+        agent = _make_agent_ext(args=args)
+
+        mock_rag = MagicMock()
+        mock_rag.get_metrics_size.return_value = 5
+
+        with (
+            patch("datus.agent.agent.MetricRAG", return_value=mock_rag),
+            patch("datus.agent.agent.init_semantic_yaml_metrics", return_value=(True, None)),
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        mock_rag.truncate.assert_not_called()
+
+    def test_metrics_incremental_forwards_strategy(self):
+        args = _make_args_ext(components=["metrics"], kb_update_strategy="incremental")
+        agent = _make_agent_ext(args=args)
+
+        mock_rag = MagicMock()
+        mock_rag.get_metrics_size.return_value = 5
+
+        with (
+            patch("datus.agent.agent.MetricRAG", return_value=mock_rag),
+            patch("datus.agent.agent.init_success_story_metrics", return_value=(True, None, {})) as mock_init,
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        mock_init.assert_called_once()
+        assert mock_init.call_args.kwargs["build_mode"] == "incremental"
+
     def test_metrics_failure(self):
         args = _make_args_ext(components=["metrics"], kb_update_strategy="overwrite")
         agent = _make_agent_ext(args=args)
@@ -1173,6 +1272,46 @@ class TestBootstrapKbMetrics:
             result = agent.bootstrap_kb()
 
         assert result["status"] == "failed"
+
+    def test_metrics_check_skips_generation(self):
+        args = _make_args_ext(components=["metrics"], kb_update_strategy="check")
+        agent = _make_agent_ext(args=args)
+
+        mock_rag = MagicMock()
+        mock_rag.get_metrics_size.return_value = 9
+
+        with (
+            patch("datus.agent.agent.MetricRAG", return_value=mock_rag),
+            patch("datus.agent.agent.init_success_story_metrics") as mock_init,
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        assert "metrics_count=9" in result["message"]
+        mock_init.assert_not_called()
+
+    def test_multiple_components_return_summary(self):
+        args = _make_args_ext(components=["semantic_model", "metrics"], kb_update_strategy="check")
+        agent = _make_agent_ext(args=args)
+
+        mock_semantic_rag = MagicMock()
+        mock_semantic_rag.get_size.return_value = 1
+        mock_profile_rag = MagicMock()
+        mock_profile_rag.get_size.return_value = 2
+        mock_metric_rag = MagicMock()
+        mock_metric_rag.get_metrics_size.return_value = 3
+
+        with (
+            patch("datus.agent.agent.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.agent.agent.TableSemanticProfileRAG", return_value=mock_profile_rag),
+            patch("datus.agent.agent.MetricRAG", return_value=mock_metric_rag),
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        assert set(result["components"]) == {"semantic_model", "metrics"}
+        assert "semantic_object_count=1" in result["components"]["semantic_model"]["message"]
+        assert "metrics_count=3" in result["components"]["metrics"]["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/api/models/test_kb_models.py
+++ b/tests/unit_tests/api/models/test_kb_models.py
@@ -3,7 +3,22 @@
 import pytest
 from pydantic import ValidationError
 
-from datus.api.models.kb_models import BootstrapDocInput
+from datus.api.models.kb_models import BootstrapDocInput, BootstrapKbInput
+
+
+class TestBootstrapKbInput:
+    """Tests for BootstrapKbInput validation."""
+
+    def test_refresh_profile_strategy_accepts_semantic_yaml(self):
+        inp = BootstrapKbInput(
+            components=["semantic_model"],
+            strategy="refresh-profile",
+            success_story="stories.csv",
+            semantic_yaml="semantic/orders.yml",
+        )
+
+        assert inp.strategy == "refresh-profile"
+        assert inp.semantic_yaml == "semantic/orders.yml"
 
 
 class TestBootstrapDocInput:

--- a/tests/unit_tests/api/routes/test_kb_routes.py
+++ b/tests/unit_tests/api/routes/test_kb_routes.py
@@ -255,7 +255,7 @@ class TestBootstrapKb:
         assert response.status_code == 422
 
     def test_bootstrap_kb_invalid_strategy_returns_422(self, client):
-        """strategy must be one of overwrite/check/incremental → 422 for invalid."""
+        """strategy must be one of the supported bootstrap modes."""
         response = client.post(
             "/api/v1/kb/bootstrap",
             json={"components": ["metadata"], "strategy": "invalid_strategy"},

--- a/tests/unit_tests/api/services/test_kb_service.py
+++ b/tests/unit_tests/api/services/test_kb_service.py
@@ -324,6 +324,92 @@ class TestKbServiceInitMetadata:
         assert result["status"] == "success"
 
 
+class TestKbServiceInitSemanticAndMetrics:
+    """Tests for semantic model and metrics strategy handling."""
+
+    def test_init_semantic_model_check_skips_generation(self, real_agent_config):
+        svc = KbService(agent_config=real_agent_config)
+        args = KbService._build_args(
+            BootstrapKbInput(components=["semantic_model"], strategy="check"),
+            str(real_agent_config.home),
+        )
+        with (
+            patch("datus.api.services.kb_service.SemanticModelRAG") as mock_rag,
+            patch("datus.api.services.kb_service.TableSemanticProfileRAG") as mock_profile,
+            patch("datus.api.services.kb_service.init_success_story_semantic_model") as mock_init,
+        ):
+            mock_rag.return_value.get_size.return_value = 4
+            mock_profile.return_value.get_size.return_value = 2
+            result = svc._init_semantic_model(real_agent_config, "check", "", args, emit=None)
+
+        assert result["status"] == "success"
+        assert "semantic_object_count=4" in result["message"]
+        assert "table_semantic_profile_count=2" in result["message"]
+        mock_init.assert_not_called()
+
+    def test_init_semantic_model_forwards_strategy(self, real_agent_config):
+        svc = KbService(agent_config=real_agent_config)
+        args = KbService._build_args(
+            BootstrapKbInput(components=["semantic_model"], strategy="incremental", success_story="stories.csv"),
+            str(real_agent_config.home),
+        )
+
+        with (
+            patch("datus.api.services.kb_service.SemanticModelRAG") as mock_rag_cls,
+            patch("datus.api.services.kb_service.TableSemanticProfileRAG"),
+            patch(
+                "datus.api.services.kb_service.init_success_story_semantic_model",
+                return_value=(True, ""),
+            ) as mock_init,
+        ):
+            mock_rag_cls.return_value.get_size.return_value = 5
+            result = svc._init_semantic_model(real_agent_config, "incremental", "", args, emit=None)
+
+        assert result["status"] == "success"
+        mock_init.assert_called_once_with(real_agent_config, args.success_story, emit=None, build_mode="incremental")
+
+    def test_init_metrics_check_skips_generation(self, real_agent_config):
+        svc = KbService(agent_config=real_agent_config)
+        args = KbService._build_args(
+            BootstrapKbInput(components=["metrics"], strategy="check"),
+            str(real_agent_config.home),
+        )
+
+        with (
+            patch("datus.api.services.kb_service.MetricRAG") as mock_rag_cls,
+            patch("datus.api.services.kb_service.init_success_story_metrics") as mock_init,
+        ):
+            mock_rag_cls.return_value.get_metrics_size.return_value = 8
+            result = svc._init_metrics(real_agent_config, "check", "", args, subject_tree=None, emit=None)
+
+        assert result["status"] == "success"
+        assert "metrics_count=8" in result["message"]
+        mock_init.assert_not_called()
+
+    def test_init_metrics_forwards_strategy(self, real_agent_config):
+        svc = KbService(agent_config=real_agent_config)
+        args = KbService._build_args(
+            BootstrapKbInput(components=["metrics"], strategy="incremental", success_story="stories.csv"),
+            str(real_agent_config.home),
+        )
+
+        with (
+            patch("datus.api.services.kb_service.MetricRAG") as mock_rag_cls,
+            patch("datus.api.services.kb_service.init_success_story_metrics", return_value=(True, "", {})) as mock_init,
+        ):
+            mock_rag_cls.return_value.get_metrics_size.return_value = 6
+            result = svc._init_metrics(real_agent_config, "incremental", "", args, subject_tree=["Sales"], emit=None)
+
+        assert result["status"] == "success"
+        mock_init.assert_called_once_with(
+            real_agent_config,
+            args.success_story,
+            ["Sales"],
+            emit=None,
+            build_mode="incremental",
+        )
+
+
 class TestKbServiceRunComponent:
     """Tests for _run_component dispatch."""
 

--- a/tests/unit_tests/api/services/test_kb_service.py
+++ b/tests/unit_tests/api/services/test_kb_service.py
@@ -29,6 +29,7 @@ class TestKbServiceBuildArgs:
             components=["metadata"],
             strategy="check",
             success_story="data/stories",
+            semantic_yaml="semantic/orders.yml",
             sql_dir="data/sql",
             schema_linking_type="table",
             catalog="main",
@@ -36,6 +37,7 @@ class TestKbServiceBuildArgs:
         )
         args = KbService._build_args(request, "/project")
         assert args.success_story == "/project/data/stories"
+        assert args.semantic_yaml == "/project/semantic/orders.yml"
         assert args.sql_dir == "/project/data/sql"
         assert args.schema_linking_type == "table"
         assert args.catalog == "main"
@@ -49,6 +51,7 @@ class TestKbServiceBuildArgs:
         )
         args = KbService._build_args(request, "/project")
         assert args.success_story is None
+        assert args.semantic_yaml is None
         assert args.sql_dir is None
 
     def test_build_args_sets_defaults(self):
@@ -367,6 +370,41 @@ class TestKbServiceInitSemanticAndMetrics:
 
         assert result["status"] == "success"
         mock_init.assert_called_once_with(real_agent_config, args.success_story, emit=None, build_mode="incremental")
+
+    def test_init_semantic_model_refresh_profile_forwards_yaml_and_success_story(self, real_agent_config):
+        svc = KbService(agent_config=real_agent_config)
+        args = KbService._build_args(
+            BootstrapKbInput(
+                components=["semantic_model"],
+                strategy="refresh-profile",
+                success_story="stories.csv",
+                semantic_yaml="semantic/orders.yml",
+            ),
+            str(real_agent_config.home),
+        )
+
+        with (
+            patch("datus.api.services.kb_service.SemanticModelRAG") as mock_rag_cls,
+            patch("datus.api.services.kb_service.TableSemanticProfileRAG") as mock_profile_cls,
+            patch(
+                "datus.api.services.kb_service.refresh_success_story_semantic_model_profile",
+                return_value=(True, "", 4),
+            ) as mock_refresh,
+            patch("datus.api.services.kb_service.init_success_story_semantic_model") as mock_generate,
+        ):
+            mock_rag_cls.return_value.get_size.return_value = 5
+            mock_profile_cls.return_value.get_size.return_value = 2
+            result = svc._init_semantic_model(real_agent_config, "refresh-profile", "", args, emit=None)
+
+        assert result["status"] == "success"
+        assert "changed_description_count=4" in result["message"]
+        mock_refresh.assert_called_once_with(
+            real_agent_config,
+            args.semantic_yaml,
+            args.success_story,
+            emit=None,
+        )
+        mock_generate.assert_not_called()
 
     def test_init_metrics_check_skips_generation(self, real_agent_config):
         svc = KbService(agent_config=real_agent_config)

--- a/tests/unit_tests/cli/screen/test_catalog_screen.py
+++ b/tests/unit_tests/cli/screen/test_catalog_screen.py
@@ -63,3 +63,29 @@ def test_catalog_screen_readonly_panel_shows_profile_fields_without_measures():
     assert "Filters" not in rendered
     assert "Measures" not in rendered
     assert "amount" not in rendered
+
+
+def test_catalog_screen_nested_semantic_table_uses_readable_column_order():
+    screen = object.__new__(CatalogScreen)
+    table = screen._create_nested_table_for_json(
+        [
+            {
+                "description": "Activity key",
+                "expr": "ac_code",
+                "name": "activity",
+                "role": "primary_key",
+                "type": "PRIMARY",
+            },
+            {
+                "description": "Start date",
+                "expr": "start_date",
+                "name": "start_date",
+                "role": "dimension",
+                "time_granularity": "DAY",
+                "type": "TIME",
+            },
+        ]
+    )
+
+    headers = [column.header for column in table.columns]
+    assert headers == ["name", "expr", "role", "type", "time_granularity", "description"]

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -1392,7 +1392,50 @@ metric:
 
         assert result["success"], f"Sync failed: {result.get('error')}"
         mock_metric_rag.delete_artifact_rows.assert_not_called()
+        mock_metric_rag.delete_artifact_rows_except.assert_not_called()
+        mock_metric_rag.list_artifact_rows.assert_called_once_with(str(yaml_file))
         mock_metric_rag.upsert_batch.assert_called_once()
+
+    def test_metric_partial_sync_restores_metric_rows_on_later_failure(self, agent_config, tmp_path):
+        yaml_file = tmp_path / "orders_metrics.yml"
+        yaml_file.write_text(
+            """
+metric:
+  name: total_revenue
+  type: measure_proxy
+  type_params:
+    measure: revenue
+""",
+            encoding="utf-8",
+        )
+        db_config = MagicMock()
+        db_config.catalog = ""
+        db_config.database = "test_db"
+        db_config.schema = "public"
+        agent_config.current_db_config.return_value = db_config
+
+        mock_semantic_rag = MagicMock()
+        mock_metric_rag = MagicMock()
+        mock_metric_rag.list_artifact_rows.return_value = [{"id": "old-metric"}]
+        mock_metric_rag.create_indices.side_effect = RuntimeError("index failed")
+
+        with (
+            patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.cli.generation_hooks.MetricRAG", return_value=mock_metric_rag),
+        ):
+            result = GenerationHooks._sync_semantic_to_db(
+                file_path=str(yaml_file),
+                agent_config=agent_config,
+                include_semantic_objects=False,
+                include_metrics=True,
+                original_yaml_path=str(yaml_file),
+                replace_metric_artifact=False,
+            )
+
+        assert result["success"] is False
+        assert "index failed" in result["error"]
+        mock_metric_rag.delete_artifact_rows_except.assert_not_called()
+        mock_metric_rag.restore_artifact_rows.assert_called_once_with(str(yaml_file), [{"id": "old-metric"}])
 
     def test_metric_id_includes_subject_path_to_avoid_same_name_collision(self, agent_config, tmp_path):
         yaml_file = tmp_path / "metrics.yml"

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -1287,12 +1287,74 @@ metric:
             )
 
         assert result["success"], f"Sync failed: {result.get('error')}"
-        mock_semantic_rag.delete_artifact_rows.assert_called_once_with(str(yaml_file))
+        mock_semantic_rag.delete_artifact_rows.assert_not_called()
         mock_semantic_rag.upsert_batch.assert_called_once()
-        mock_profile_rag.delete_artifact_rows.assert_called_once_with(str(yaml_file))
+        mock_semantic_rag.delete_artifact_rows_except.assert_called_once()
+        mock_profile_rag.delete_artifact_rows.assert_not_called()
         mock_profile_rag.upsert_batch.assert_called_once()
-        mock_metric_rag.delete_artifact_rows.assert_called_once_with(str(yaml_file))
+        mock_profile_rag.delete_artifact_rows_except.assert_called_once()
+        mock_metric_rag.delete_artifact_rows.assert_not_called()
         mock_metric_rag.upsert_batch.assert_called_once()
+        mock_metric_rag.delete_artifact_rows_except.assert_called_once()
+
+    def test_sync_replacement_restores_snapshots_when_later_store_fails(self, agent_config, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: public.orders
+  dimensions:
+    - name: status
+      type: CATEGORICAL
+      expr: status
+  measures:
+    - name: revenue
+      agg: SUM
+      expr: amount
+---
+metric:
+  name: total_revenue
+  type: measure_proxy
+  type_params:
+    measure: revenue
+""",
+            encoding="utf-8",
+        )
+        db_config = MagicMock()
+        db_config.catalog = ""
+        db_config.database = "test_db"
+        db_config.schema = "public"
+        agent_config.current_db_config.return_value = db_config
+        agent_config.project_name = "unit-test-project"
+
+        mock_semantic_rag = MagicMock()
+        mock_semantic_rag.list_artifact_rows.return_value = [{"id": "old-semantic"}]
+        mock_metric_rag = MagicMock()
+        mock_metric_rag.list_artifact_rows.return_value = [{"id": "old-metric"}]
+        mock_metric_rag.upsert_batch.side_effect = RuntimeError("metric write failed")
+        mock_profile_rag = MagicMock()
+        mock_profile_rag.list_artifact_rows.return_value = [{"id": "old-profile"}]
+
+        with (
+            patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.cli.generation_hooks.MetricRAG", return_value=mock_metric_rag),
+            patch("datus.cli.generation_hooks.TableSemanticProfileRAG", return_value=mock_profile_rag),
+        ):
+            result = GenerationHooks._sync_semantic_to_db(
+                file_path=str(yaml_file),
+                agent_config=agent_config,
+                original_yaml_path=str(yaml_file),
+            )
+
+        assert result["success"] is False
+        assert "metric write failed" in result["error"]
+        mock_semantic_rag.delete_artifact_rows.assert_not_called()
+        mock_metric_rag.delete_artifact_rows.assert_not_called()
+        mock_profile_rag.delete_artifact_rows.assert_not_called()
+        mock_semantic_rag.restore_artifact_rows.assert_called_once_with(str(yaml_file), [{"id": "old-semantic"}])
+        mock_profile_rag.restore_artifact_rows.assert_called_once_with(str(yaml_file), [{"id": "old-profile"}])
+        mock_metric_rag.restore_artifact_rows.assert_called_once_with(str(yaml_file), [{"id": "old-metric"}])
 
     def test_metric_partial_sync_does_not_replace_whole_yaml_artifact(self, agent_config, tmp_path):
         yaml_file = tmp_path / "orders_metrics.yml"

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -654,6 +654,7 @@ class TestSyncToStorage:
             include_metrics=True,
             metric_sqls={"m": "SQL"},
             original_yaml_path="/tmp/metric.yaml",
+            replace_metric_artifact=False,
         )
 
     async def test_semantic_type_sync_failure(self, hooks):
@@ -1239,6 +1240,98 @@ class TestSyncSemanticToDbBooleanCoercion:
 
 
 class TestSyncSemanticToDbMetricReferenceNormalization:
+    def test_sync_replaces_rows_for_same_yaml_artifact(self, agent_config, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: public.orders
+  dimensions:
+    - name: status
+      type: CATEGORICAL
+      expr: status
+  measures:
+    - name: revenue
+      agg: SUM
+      expr: amount
+---
+metric:
+  name: total_revenue
+  type: measure_proxy
+  type_params:
+    measure: revenue
+""",
+            encoding="utf-8",
+        )
+        db_config = MagicMock()
+        db_config.catalog = ""
+        db_config.database = "test_db"
+        db_config.schema = "public"
+        agent_config.current_db_config.return_value = db_config
+        agent_config.project_name = "unit-test-project"
+
+        mock_semantic_rag = MagicMock()
+        mock_metric_rag = MagicMock()
+        mock_profile_rag = MagicMock()
+
+        with (
+            patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.cli.generation_hooks.MetricRAG", return_value=mock_metric_rag),
+            patch("datus.cli.generation_hooks.TableSemanticProfileRAG", return_value=mock_profile_rag),
+        ):
+            result = GenerationHooks._sync_semantic_to_db(
+                file_path=str(yaml_file),
+                agent_config=agent_config,
+                original_yaml_path=str(yaml_file),
+            )
+
+        assert result["success"], f"Sync failed: {result.get('error')}"
+        mock_semantic_rag.delete_artifact_rows.assert_called_once_with(str(yaml_file))
+        mock_semantic_rag.upsert_batch.assert_called_once()
+        mock_profile_rag.delete_artifact_rows.assert_called_once_with(str(yaml_file))
+        mock_profile_rag.upsert_batch.assert_called_once()
+        mock_metric_rag.delete_artifact_rows.assert_called_once_with(str(yaml_file))
+        mock_metric_rag.upsert_batch.assert_called_once()
+
+    def test_metric_partial_sync_does_not_replace_whole_yaml_artifact(self, agent_config, tmp_path):
+        yaml_file = tmp_path / "orders_metrics.yml"
+        yaml_file.write_text(
+            """
+metric:
+  name: total_revenue
+  type: measure_proxy
+  type_params:
+    measure: revenue
+""",
+            encoding="utf-8",
+        )
+        db_config = MagicMock()
+        db_config.catalog = ""
+        db_config.database = "test_db"
+        db_config.schema = "public"
+        agent_config.current_db_config.return_value = db_config
+
+        mock_semantic_rag = MagicMock()
+        mock_metric_rag = MagicMock()
+
+        with (
+            patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.cli.generation_hooks.MetricRAG", return_value=mock_metric_rag),
+        ):
+            result = GenerationHooks._sync_semantic_to_db(
+                file_path=str(yaml_file),
+                agent_config=agent_config,
+                include_semantic_objects=False,
+                include_metrics=True,
+                original_yaml_path=str(yaml_file),
+                replace_metric_artifact=False,
+            )
+
+        assert result["success"], f"Sync failed: {result.get('error')}"
+        mock_metric_rag.delete_artifact_rows.assert_not_called()
+        mock_metric_rag.upsert_batch.assert_called_once()
+
     def test_metric_id_includes_subject_path_to_avoid_same_name_collision(self, agent_config, tmp_path):
         yaml_file = tmp_path / "metrics.yml"
         yaml_file.write_text(

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -6,7 +6,7 @@
 
 from enum import Enum
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -116,18 +116,63 @@ class TestInitSemanticYamlMetrics:
         yaml_file.write_text("tables:\n  - name: test\n")
         mock_config = MagicMock()
 
-        # The import happens inside the function body from the semantic_model package
-        from unittest.mock import patch
-
-        with patch(
-            "datus.storage.semantic_model.semantic_model_init.process_semantic_yaml_file",
-            return_value=(True, ""),
-        ) as mock_process:
+        with (
+            patch(
+                "datus.storage.metric.metric_init._metrics_authoring_format",
+                return_value="metricflow",
+            ),
+            patch(
+                "datus.storage.semantic_model.semantic_model_init.process_semantic_yaml_file",
+                return_value=(True, ""),
+            ) as mock_process,
+        ):
             success, error = init_semantic_yaml_metrics(str(yaml_file), mock_config)
 
         assert success is True
         assert error == ""
         mock_process.assert_called_once_with(str(yaml_file), mock_config, include_semantic_objects=False)
+
+    def test_osi_existing_file_calls_osi_metric_sync(self, tmp_path):
+        """OSI metric YAML imports use the OSI sync path."""
+        yaml_file = tmp_path / "metrics.yaml"
+        yaml_file.write_text("metrics:\n  - name: revenue\n")
+        mock_config = MagicMock()
+        mock_tools = MagicMock()
+        mock_tools._sync_osi_metric_to_db.return_value = {"success": True, "message": "synced"}
+
+        with (
+            patch(
+                "datus.storage.metric.metric_init._metrics_authoring_format",
+                return_value="osi",
+            ),
+            patch("datus.tools.func_tool.generation_tools.GenerationTools", return_value=mock_tools) as mock_cls,
+        ):
+            success, error = init_semantic_yaml_metrics(str(yaml_file), mock_config)
+
+        assert success is True
+        assert error == "synced"
+        mock_cls.assert_called_once_with(agent_config=mock_config, authoring_format="osi")
+        mock_tools._sync_osi_metric_to_db.assert_called_once_with(str(yaml_file))
+
+    def test_osi_existing_file_returns_sync_error(self, tmp_path):
+        """OSI sync failures are surfaced as init failures."""
+        yaml_file = tmp_path / "metrics.yaml"
+        yaml_file.write_text("metrics:\n  - name: revenue\n")
+        mock_config = MagicMock()
+        mock_tools = MagicMock()
+        mock_tools._sync_osi_metric_to_db.return_value = {"success": False, "error": "invalid osi metrics"}
+
+        with (
+            patch(
+                "datus.storage.metric.metric_init._metrics_authoring_format",
+                return_value="osi",
+            ),
+            patch("datus.tools.func_tool.generation_tools.GenerationTools", return_value=mock_tools),
+        ):
+            success, error = init_semantic_yaml_metrics(str(yaml_file), mock_config)
+
+        assert success is False
+        assert error == "invalid osi metrics"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -776,6 +776,13 @@ class TestMetricRAGSearch:
 
 
 class TestMetricRAGArtifactDelete:
+    class _Rows:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def to_pylist(self):
+            return self._rows
+
     def test_delete_artifact_rows_uses_sub_agent_scope(self):
         from datus.storage.metric.store import MetricRAG
 
@@ -788,6 +795,18 @@ class TestMetricRAGArtifactDelete:
         rag._sub_agent_conditions.assert_called_once_with()
         rag.storage._delete_rows.assert_called_once()
 
+    def test_delete_artifact_rows_ignores_empty_yaml_path(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+
+        rag.delete_artifact_rows("")
+
+        rag._sub_agent_conditions.assert_not_called()
+        rag.storage._delete_rows.assert_not_called()
+
     def test_delete_artifact_rows_except_keeps_current_ids(self):
         from datus.storage.metric.store import MetricRAG
 
@@ -799,3 +818,63 @@ class TestMetricRAGArtifactDelete:
 
         rag._sub_agent_conditions.assert_called_once_with()
         rag.storage._delete_rows.assert_called_once()
+
+    def test_delete_artifact_rows_except_deletes_all_when_keep_ids_empty(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.delete_artifact_rows = Mock()
+
+        rag.delete_artifact_rows_except("metrics/orders.yml", ["", None])
+
+        rag.delete_artifact_rows.assert_called_once_with("metrics/orders.yml")
+
+    def test_list_artifact_rows_returns_empty_for_empty_yaml_path(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.storage = Mock()
+
+        assert rag.list_artifact_rows("") == []
+        rag.storage._search_all.assert_not_called()
+
+    def test_list_artifact_rows_returns_storage_rows(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+        rag.storage._search_all.return_value = self._Rows([{"id": "metric:orders"}])
+
+        assert rag.list_artifact_rows("metrics/orders.yml") == [{"id": "metric:orders"}]
+        rag._sub_agent_conditions.assert_called_once_with()
+        rag.storage._search_all.assert_called_once()
+
+    def test_restore_artifact_rows_ignores_empty_yaml_path(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.delete_artifact_rows = Mock()
+        rag.upsert_batch = Mock()
+        rag.create_indices = Mock()
+
+        rag.restore_artifact_rows("", [{"id": "metric:orders"}])
+
+        rag.delete_artifact_rows.assert_not_called()
+        rag.upsert_batch.assert_not_called()
+        rag.create_indices.assert_not_called()
+
+    def test_restore_artifact_rows_replaces_snapshot(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.delete_artifact_rows = Mock()
+        rag.upsert_batch = Mock()
+        rag.create_indices = Mock()
+        rows = [{"id": "metric:orders"}]
+
+        rag.restore_artifact_rows("metrics/orders.yml", rows)
+
+        rag.delete_artifact_rows.assert_called_once_with("metrics/orders.yml")
+        rag.upsert_batch.assert_called_once_with(rows)
+        rag.create_indices.assert_called_once_with()

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -787,3 +787,15 @@ class TestMetricRAGArtifactDelete:
 
         rag._sub_agent_conditions.assert_called_once_with()
         rag.storage._delete_rows.assert_called_once()
+
+    def test_delete_artifact_rows_except_keeps_current_ids(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+
+        rag.delete_artifact_rows_except("metrics/orders.yml", ["metric:orders"])
+
+        rag._sub_agent_conditions.assert_called_once_with()
+        rag.storage._delete_rows.assert_called_once()

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -773,3 +773,17 @@ class TestMetricRAGSearch:
         result = MetricRAG._merge_search_results([first], [second], top_n=5)
 
         assert result == [first, second]
+
+
+class TestMetricRAGArtifactDelete:
+    def test_delete_artifact_rows_uses_sub_agent_scope(self):
+        from datus.storage.metric.store import MetricRAG
+
+        rag = MetricRAG.__new__(MetricRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+
+        rag.delete_artifact_rows("metrics/orders.yml")
+
+        rag._sub_agent_conditions.assert_called_once_with()
+        rag.storage._delete_rows.assert_called_once()

--- a/tests/unit_tests/storage/semantic_model/test_profile_description.py
+++ b/tests/unit_tests/storage/semantic_model/test_profile_description.py
@@ -192,3 +192,49 @@ semantic_model:
     assert changed == 2
     assert "referenced by 1 historical query" in dataset["description"]
     assert "2 distinct non-null values" in dataset["dimensions"][0]["description"]
+
+
+def test_refresh_osi_yaml_descriptions_patches_dataset_fields():
+    docs = [
+        yaml.safe_load(
+            """
+semantic_model:
+  - name: commerce
+    datasets:
+      - name: orders
+        description: Orders dataset.
+        source: marts.orders
+        fields:
+          - name: amount
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: amount
+            description: Order amount.
+"""
+        )
+    ]
+    evidence = {
+        "tables": {
+            "orders": {
+                "query_count": 1,
+                "data_distribution_profile": {
+                    "row_count": 10,
+                    "columns": {
+                        "amount": {
+                            "kind": "numeric",
+                            "stats": {"min_value": 1, "max_value": 99},
+                            "percentiles": {"p50": 50, "p90": 90},
+                        }
+                    },
+                },
+            }
+        }
+    }
+
+    changed = refresh_osi_yaml_descriptions(docs, evidence)
+
+    dataset = docs[0]["semantic_model"][0]["datasets"][0]
+    assert changed == 2
+    assert "observed row count 10" in dataset["description"]
+    assert "observed range 1-99" in dataset["fields"][0]["description"]

--- a/tests/unit_tests/storage/semantic_model/test_profile_description.py
+++ b/tests/unit_tests/storage/semantic_model/test_profile_description.py
@@ -1,6 +1,9 @@
 import yaml
 
 from datus.storage.semantic_model.profile_description import (
+    _clip_text,
+    _duration_profile_phrases,
+    _profile_scalar,
     build_column_observed_profile,
     build_table_observed_profile,
     merge_observed_profile,
@@ -25,6 +28,14 @@ def test_merge_observed_profile_clamps_long_base_description():
     updated = merge_observed_profile(description, "y" * 80, max_chars=60)
 
     assert len(updated) <= 60
+
+
+def test_merge_observed_profile_handles_empty_observed_and_no_base_clipping():
+    assert merge_observed_profile("Order status. Observed profile: old values.", "") == "Order status"
+
+    updated = merge_observed_profile("", "x" * 80, max_chars=24)
+
+    assert updated == "Observed profile: xxx..."
 
 
 def test_build_column_observed_profile_for_categorical_usage():
@@ -106,6 +117,33 @@ def test_build_column_observed_profile_formats_future_freshness():
     assert "latest value 121 days after profiling" in observed
 
 
+def test_profile_description_edge_cases_for_usage_and_helpers():
+    temporal_observed = build_column_observed_profile(
+        {
+            "kind": "temporal",
+            "stats": {},
+            "temporal_summary": {"freshness_days_from_profile_date": 0},
+        }
+    )
+    range_observed = build_column_observed_profile(
+        {"kind": "categorical", "stats": {"distinct_count": "bad", "null_rate": "bad"}},
+        field_usage={"filter_count": 1, "group_by_count": 1, "operators": [">"]},
+    )
+    generic_observed = build_column_observed_profile(
+        {"kind": "unknown", "stats": {}},
+        field_usage={"filter_count": 1, "operators": ["LIKE"]},
+    )
+
+    assert temporal_observed == "latest value on profiling date"
+    assert "frequently used as a range filter" in range_observed
+    assert "commonly grouped" in range_observed
+    assert generic_observed == "frequently filtered"
+    assert _duration_profile_phrases(["invalid", {"left_column": "a", "right_column": "b", "delta_days": {}}]) == []
+    assert _profile_scalar(1.23456789) == "1.23457"
+    assert _clip_text("abcdef", 0) == ""
+    assert _clip_text("abcdef", 2) == ".."
+
+
 def test_refresh_metricflow_yaml_descriptions_patches_table_and_column():
     docs = [
         yaml.safe_load(
@@ -149,6 +187,61 @@ data_source:
     data_source = docs[0]["data_source"]
     assert "observed row count 10" in data_source["description"]
     assert "common values include paid, refund" in data_source["dimensions"][0]["description"]
+
+
+def test_refresh_metricflow_yaml_descriptions_skips_invalid_docs_and_missing_profiles():
+    docs = [
+        None,
+        {"data_source": "not-a-dict"},
+        {"data_source": {"name": "orders", "description": "Orders table."}},
+    ]
+
+    changed = refresh_metricflow_yaml_descriptions(docs, {"tables": {"customers": {}}})
+
+    assert changed == 0
+    assert docs[-1]["data_source"]["description"] == "Orders table."
+
+
+def test_refresh_metricflow_yaml_descriptions_matches_join_profiles_by_column():
+    docs = [
+        yaml.safe_load(
+            """
+data_source:
+  name: orders
+  dimensions:
+    - name: customer_id
+      expr: customer_id
+      description: Customer identifier.
+"""
+        )
+    ]
+    evidence = {
+        "tables": {
+            "orders": {
+                "data_distribution_profile": {
+                    "columns": {
+                        "customer_id": {
+                            "kind": "categorical",
+                            "stats": {"distinct_count": 2},
+                        }
+                    },
+                    "join_relationship_profiles": [
+                        "invalid",
+                        {
+                            "source_column": "orders.customer_id",
+                            "target_column": "customers.id",
+                            "referential_coverage": 1.0,
+                        },
+                    ],
+                }
+            }
+        }
+    }
+
+    changed = refresh_metricflow_yaml_descriptions(docs, evidence)
+
+    assert changed == 1
+    assert "referential coverage 100.0%" in docs[0]["data_source"]["dimensions"][0]["description"]
 
 
 def test_refresh_osi_yaml_descriptions_patches_dataset_and_dimension():
@@ -238,3 +331,16 @@ semantic_model:
     assert changed == 2
     assert "observed row count 10" in dataset["description"]
     assert "observed range 1-99" in dataset["fields"][0]["description"]
+
+
+def test_refresh_osi_yaml_descriptions_skips_nonmatching_dataset():
+    docs = [
+        None,
+        {"semantic_model": "not-a-list"},
+        {"datasets": [{"name": "orders", "description": "Orders dataset."}]},
+    ]
+
+    changed = refresh_osi_yaml_descriptions(docs, {"tables": {"customers": {}}})
+
+    assert changed == 0
+    assert docs[-1]["datasets"][0]["description"] == "Orders dataset."

--- a/tests/unit_tests/storage/semantic_model/test_profile_description.py
+++ b/tests/unit_tests/storage/semantic_model/test_profile_description.py
@@ -94,6 +94,18 @@ def test_build_profile_descriptions_cover_distribution_fields():
     assert "many to one or one to one" in join_observed
 
 
+def test_build_column_observed_profile_formats_future_freshness():
+    observed = build_column_observed_profile(
+        {
+            "kind": "temporal",
+            "stats": {"min_value": "2026-01-01", "max_value": "2026-10-31"},
+            "temporal_summary": {"freshness_days_from_profile_date": -121},
+        }
+    )
+
+    assert "latest value 121 days after profiling" in observed
+
+
 def test_refresh_metricflow_yaml_descriptions_patches_table_and_column():
     docs = [
         yaml.safe_load(

--- a/tests/unit_tests/storage/semantic_model/test_profile_description.py
+++ b/tests/unit_tests/storage/semantic_model/test_profile_description.py
@@ -19,6 +19,14 @@ def test_merge_observed_profile_replaces_generated_suffix():
     )
 
 
+def test_merge_observed_profile_clamps_long_base_description():
+    description = "x" * 80
+
+    updated = merge_observed_profile(description, "y" * 80, max_chars=60)
+
+    assert len(updated) <= 60
+
+
 def test_build_column_observed_profile_for_categorical_usage():
     observed = build_column_observed_profile(
         {

--- a/tests/unit_tests/storage/semantic_model/test_profile_description.py
+++ b/tests/unit_tests/storage/semantic_model/test_profile_description.py
@@ -1,0 +1,174 @@
+import yaml
+
+from datus.storage.semantic_model.profile_description import (
+    build_column_observed_profile,
+    build_table_observed_profile,
+    merge_observed_profile,
+    refresh_metricflow_yaml_descriptions,
+    refresh_osi_yaml_descriptions,
+)
+
+
+def test_merge_observed_profile_replaces_generated_suffix():
+    description = "Order status. Observed profile: old values."
+
+    updated = merge_observed_profile(description, "4 distinct non-null values; common values include paid, refund")
+
+    assert updated == (
+        "Order status. Observed profile: 4 distinct non-null values; common values include paid, refund."
+    )
+
+
+def test_build_column_observed_profile_for_categorical_usage():
+    observed = build_column_observed_profile(
+        {
+            "kind": "categorical",
+            "stats": {"distinct_count": 4, "null_rate": 0.02},
+            "top_values": [{"value": "paid"}, {"value": "refund"}, {"value": "cancelled"}],
+        },
+        field_usage={"filter_count": 3, "operators": ["="]},
+    )
+
+    assert "4 distinct non-null values" in observed
+    assert "common values include paid, refund, cancelled" in observed
+    assert "null rate 2.0%" in observed
+    assert "categorical filter" in observed
+
+
+def test_build_profile_descriptions_cover_distribution_fields():
+    table_observed = build_table_observed_profile(
+        {
+            "query_count": 4,
+            "common_business_filter_templates": [
+                {"fields": ["status"], "operator": "="},
+                {"fields": ["created_at"], "operator": "BETWEEN"},
+            ],
+            "data_distribution_profile": {
+                "row_count": 100,
+                "date_duration_profiles": [
+                    {
+                        "left_column": "opened_at",
+                        "right_column": "closed_at",
+                        "delta_days": {"p50": 3, "p90": 5},
+                    }
+                ],
+            },
+        }
+    )
+    numeric_observed = build_column_observed_profile(
+        {
+            "kind": "numeric",
+            "stats": {"min_value": 10, "max_value": 99, "null_rate": 0.1},
+            "percentiles": {"p50": 50, "p90": 90},
+        },
+        field_usage={"aggregate_count": 2},
+    )
+    temporal_observed = build_column_observed_profile(
+        {
+            "kind": "temporal",
+            "stats": {"min_value": "2025-01-01", "max_value": "2025-01-10"},
+            "temporal_summary": {"freshness_days_from_profile_date": 2},
+        }
+    )
+    join_observed = build_column_observed_profile(
+        {"kind": "categorical", "stats": {"distinct_count": 3}},
+        join_profile={"referential_coverage": 0.75, "join_cardinality_hint": "many_to_one_or_one_to_one"},
+    )
+
+    assert "observed row count 100" in table_observed
+    assert "opened_at to closed_at p50 3 days, p90 5 days" in table_observed
+    assert "common filters use status, created_at" in table_observed
+    assert "observed range 10-99" in numeric_observed
+    assert "p50 50, p90 90" in numeric_observed
+    assert "null rate 10.0%" in numeric_observed
+    assert "latest value 2 days before profiling" in temporal_observed
+    assert "referential coverage 75.0%" in join_observed
+    assert "many to one or one to one" in join_observed
+
+
+def test_refresh_metricflow_yaml_descriptions_patches_table_and_column():
+    docs = [
+        yaml.safe_load(
+            """
+data_source:
+  name: orders
+  description: Orders table.
+  sql_table: marts.orders
+  dimensions:
+    - name: status
+      expr: status
+      type: CATEGORICAL
+      description: Order status.
+"""
+        )
+    ]
+    evidence = {
+        "tables": {
+            "orders": {
+                "query_count": 2,
+                "field_usage_statistics": {
+                    "status": {"filter_count": 2, "operators": ["="]},
+                },
+                "data_distribution_profile": {
+                    "row_count": 10,
+                    "columns": {
+                        "status": {
+                            "kind": "categorical",
+                            "stats": {"distinct_count": 3},
+                            "top_values": [{"value": "paid"}, {"value": "refund"}],
+                        }
+                    },
+                },
+            }
+        }
+    }
+
+    changed = refresh_metricflow_yaml_descriptions(docs, evidence)
+
+    assert changed == 2
+    data_source = docs[0]["data_source"]
+    assert "observed row count 10" in data_source["description"]
+    assert "common values include paid, refund" in data_source["dimensions"][0]["description"]
+
+
+def test_refresh_osi_yaml_descriptions_patches_dataset_and_dimension():
+    docs = [
+        yaml.safe_load(
+            """
+semantic_model:
+  - name: commerce
+    datasets:
+      - name: orders
+        description: Orders dataset.
+        source:
+          table: marts.orders
+        dimensions:
+          - name: status
+            description: Order status.
+"""
+        )
+    ]
+    evidence = {
+        "tables": {
+            "orders": {
+                "query_count": 1,
+                "field_usage_statistics": {"status": {"filter_count": 1, "operators": ["="]}},
+                "data_distribution_profile": {
+                    "columns": {
+                        "status": {
+                            "kind": "categorical",
+                            "stats": {"distinct_count": 2},
+                            "top_values": [{"value": "paid"}],
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    changed = refresh_osi_yaml_descriptions(docs, evidence)
+
+    dataset = docs[0]["semantic_model"][0]["datasets"][0]
+    assert changed == 2
+    assert "referenced by 1 historical query" in dataset["description"]
+    assert "2 distinct non-null values" in dataset["dimensions"][0]["description"]

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -316,6 +316,56 @@ semantic_model:
         mock_tools_cls.assert_called_once_with(agent_config=mock_config, authoring_format="osi")
         mock_tools_cls.return_value.sync_osi_semantic_to_db.assert_called_once_with(str(yaml_file))
 
+    def test_osi_refresh_returns_sync_exception(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        description: Orders dataset.
+        source: orders
+        dimensions:
+          - name: status
+            description: Order status.
+""",
+            encoding="utf-8",
+        )
+        evidence = {
+            "tables": {
+                "orders": {
+                    "query_count": 1,
+                    "data_distribution_profile": {
+                        "columns": {
+                            "status": {
+                                "kind": "categorical",
+                                "stats": {"distinct_count": 2},
+                                "top_values": [{"value": "paid"}],
+                            }
+                        }
+                    },
+                }
+            }
+        }
+        mock_config = MagicMock()
+        mock_config.path_manager = None
+
+        with patch("datus.tools.func_tool.generation_tools.GenerationTools") as mock_tools_cls:
+            mock_tools_cls.return_value.sync_osi_semantic_to_db.side_effect = RuntimeError("storage offline")
+            success, error, changed = refresh_semantic_yaml_profile_descriptions(
+                str(yaml_file),
+                evidence,
+                authoring_format="osi",
+                agent_config=mock_config,
+                sync_to_storage=True,
+            )
+
+        assert success is False
+        assert "Failed to sync OSI semantic YAML file" in error
+        assert "storage offline" in error
+        assert changed == 2
+
     def test_unchanged_metricflow_yaml_still_retries_storage_sync(self, tmp_path):
         yaml_file = tmp_path / "orders.yml"
         yaml_file.write_text(

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -591,6 +591,37 @@ class TestInitSuccessStorySemanticModelAsync:
         assert "storage unavailable" in error
 
     @pytest.mark.asyncio
+    async def test_overwrite_mode_truncate_failure_returns_error(self, tmp_path):
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT 1,Q?\n")
+        mock_config = MagicMock()
+        mock_semantic_rag = MagicMock()
+        mock_semantic_rag.datasource_id = "test_ds"
+        mock_semantic_rag.truncate.side_effect = RuntimeError("truncate failed")
+        mock_table_profile_rag = MagicMock()
+
+        with (
+            patch("datus.storage.semantic_model.store.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch(
+                "datus.storage.table_semantic_profile.store.TableSemanticProfileRAG",
+                return_value=mock_table_profile_rag,
+            ),
+        ):
+            success, error = await init_success_story_semantic_model_async(
+                mock_config,
+                str(csv_path),
+                build_mode="overwrite",
+            )
+
+        assert success is False
+        assert "Failed to wipe semantic model storage" in error
+        assert "truncate failed" in error
+        mock_semantic_rag.truncate.assert_called_once()
+        mock_table_profile_rag.truncate.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_check_mode_reports_existing_row_counts(self, tmp_path):
         from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
 

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -9,6 +9,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from datus.storage.semantic_model.semantic_model_init import (
+    _infer_semantic_yaml_authoring_format,
+    _load_success_story_profile_entries,
+    _metricflow_data_source_table,
+    _semantic_yaml_profile_tables,
     init_semantic_yaml_semantic_model,
     process_semantic_yaml_file,
     refresh_semantic_yaml_profile_descriptions,
@@ -523,6 +527,7 @@ data_source:
             result={"tables": {"orders": {"data_distribution_profile": {"columns": {}}}}}
         )
 
+        events = []
         with (
             patch("datus.tools.func_tool.database.DBFuncTool") as mock_db_tool,
             patch(
@@ -538,11 +543,14 @@ data_source:
                 mock_config,
                 str(yaml_file),
                 str(success_story),
+                emit=events.append,
             )
 
         assert success is True
         assert error == ""
         assert changed == 2
+        assert [event.stage for event in events] == ["task_started", "task_completed"]
+        assert events[-1].payload == {"semantic_yaml": str(yaml_file), "changed_description_count": 2}
         mock_db_tool.assert_called_once_with(
             agent_config=mock_config,
             sub_agent_name="gen_semantic_model",
@@ -571,6 +579,180 @@ data_source:
         assert success is False
         assert "--semantic_yaml is required" in error
         assert changed == 0
+
+    def test_refresh_profile_requires_success_story(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text("data_source:\n  name: orders\n", encoding="utf-8")
+
+        success, error, changed = refresh_success_story_semantic_model_profile(
+            MagicMock(),
+            str(yaml_file),
+            "",
+        )
+
+        assert success is False
+        assert "--success_story is required" in error
+        assert changed == 0
+
+    def test_refresh_profile_reports_missing_yaml_file(self, tmp_path):
+        success_story = tmp_path / "stories.csv"
+        success_story.write_text("sql\nSELECT 1\n", encoding="utf-8")
+
+        success, error, changed = refresh_success_story_semantic_model_profile(
+            MagicMock(path_manager=None),
+            str(tmp_path / "missing.yml"),
+            str(success_story),
+        )
+
+        assert success is False
+        assert "Semantic YAML file not found" in error
+        assert changed == 0
+
+    def test_success_story_profile_entries_validate_required_sql(self, tmp_path):
+        missing = tmp_path / "missing.csv"
+        entries, error = _load_success_story_profile_entries(str(missing))
+        assert entries == []
+        assert "not found" in error
+
+        no_sql = tmp_path / "no_sql.csv"
+        no_sql.write_text("question\nhow many orders?\n", encoding="utf-8")
+        entries, error = _load_success_story_profile_entries(str(no_sql))
+        assert entries == []
+        assert "missing required column: sql" in error
+
+        blank_sql = tmp_path / "blank_sql.csv"
+        blank_sql.write_text("source_context_id,name,question,sql\n,,ignored,\n", encoding="utf-8")
+        entries, error = _load_success_story_profile_entries(str(blank_sql))
+        assert entries == []
+        assert "contains no SQL rows" in error
+
+        valid = tmp_path / "valid.csv"
+        valid.write_text("source_context_id,name,question,sql\n,story_name,,SELECT 1\n", encoding="utf-8")
+        entries, error = _load_success_story_profile_entries(str(valid))
+        assert error == ""
+        assert entries == [{"name": "story_name", "question": "", "sql": "SELECT 1"}]
+
+    def test_semantic_yaml_profile_table_helpers_cover_format_variants(self):
+        docs = [
+            None,
+            {"data_source": "not-a-dict"},
+            {
+                "semantic_model": [
+                    {
+                        "datasets": [
+                            {"source": {"table": "mart.orders"}},
+                            {"source": "mart.customers"},
+                            {"table": "fallback_table"},
+                            {"name": "fallback_name"},
+                        ]
+                    },
+                    "ignored",
+                ],
+                "datasets": [{"source": {"table": "mart.orders"}}],
+            },
+        ]
+
+        assert _infer_semantic_yaml_authoring_format([], " OSI ") == "osi"
+        assert _metricflow_data_source_table("not-a-dict") == ""
+        assert _semantic_yaml_profile_tables(docs, "osi") == [
+            "mart.orders",
+            "mart.customers",
+            "fallback_table",
+            "fallback_name",
+        ]
+
+    def test_refresh_profile_rejects_unsupported_authoring_format(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text("data_source:\n  name: orders\n", encoding="utf-8")
+        success_story = tmp_path / "stories.csv"
+        success_story.write_text("sql\nSELECT * FROM orders\n", encoding="utf-8")
+
+        success, error, changed = refresh_success_story_semantic_model_profile(
+            MagicMock(path_manager=None),
+            str(yaml_file),
+            str(success_story),
+            authoring_format="unsupported",
+        )
+
+        assert success is False
+        assert "Unsupported semantic YAML authoring format" in error
+        assert changed == 0
+
+    def test_refresh_profile_rejects_yaml_without_table_targets(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text("data_source:\n  description: no table target\n", encoding="utf-8")
+        success_story = tmp_path / "stories.csv"
+        success_story.write_text("sql\nSELECT * FROM orders\n", encoding="utf-8")
+
+        success, error, changed = refresh_success_story_semantic_model_profile(
+            MagicMock(path_manager=None),
+            str(yaml_file),
+            str(success_story),
+        )
+
+        assert success is False
+        assert "No table targets found" in error
+        assert changed == 0
+
+    def test_refresh_profile_reports_profiler_exception_and_emits_failure(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text("data_source:\n  name: orders\n", encoding="utf-8")
+        success_story = tmp_path / "stories.csv"
+        success_story.write_text("sql\nSELECT * FROM orders\n", encoding="utf-8")
+        current_db_config = MagicMock(catalog="", database="analytics", schema="")
+        mock_config = MagicMock(path_manager=None)
+        mock_config.current_db_config.return_value = current_db_config
+        mock_config.runtime_db_context.return_value = {}
+        events = []
+
+        with patch("datus.tools.func_tool.database.DBFuncTool", side_effect=RuntimeError("db offline")):
+            success, error, changed = refresh_success_story_semantic_model_profile(
+                mock_config,
+                str(yaml_file),
+                str(success_story),
+                emit=events.append,
+            )
+
+        assert success is False
+        assert "Failed to profile semantic YAML" in error
+        assert "db offline" in error
+        assert changed == 0
+        assert [event.stage for event in events] == ["task_started", "task_failed"]
+
+    def test_refresh_profile_reports_profiler_failure_and_emits_failure(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text("data_source:\n  name: orders\n", encoding="utf-8")
+        success_story = tmp_path / "stories.csv"
+        success_story.write_text("sql\nSELECT * FROM orders\n", encoding="utf-8")
+        current_db_config = MagicMock(catalog="", database="analytics", schema="")
+        mock_config = MagicMock(path_manager=None)
+        mock_config.current_db_config.return_value = current_db_config
+        mock_config.runtime_db_context.return_value = {}
+        mock_discovery = MagicMock()
+        mock_discovery.profile_semantic_model_evidence.return_value = MagicMock(
+            success=False,
+            error="profile failed",
+        )
+        events = []
+
+        with (
+            patch("datus.tools.func_tool.database.DBFuncTool"),
+            patch(
+                "datus.tools.func_tool.semantic_discovery_tools.SemanticDiscoveryTools",
+                return_value=mock_discovery,
+            ),
+        ):
+            success, error, changed = refresh_success_story_semantic_model_profile(
+                mock_config,
+                str(yaml_file),
+                str(success_story),
+                emit=events.append,
+            )
+
+        assert success is False
+        assert error == "profile failed"
+        assert changed == 0
+        assert [event.stage for event in events] == ["task_started", "task_failed"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -11,6 +11,7 @@ import pytest
 from datus.storage.semantic_model.semantic_model_init import (
     init_semantic_yaml_semantic_model,
     process_semantic_yaml_file,
+    refresh_semantic_yaml_profile_descriptions,
 )
 
 # ---------------------------------------------------------------------------
@@ -187,6 +188,134 @@ class TestProcessSemanticYamlFile:
 
 
 # ---------------------------------------------------------------------------
+# refresh_semantic_yaml_profile_descriptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestRefreshSemanticYamlProfileDescriptions:
+    def test_metricflow_refresh_writes_description_and_syncs(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+data_source:
+  name: orders
+  description: Orders table.
+  sql_table: orders
+  dimensions:
+    - name: status
+      expr: status
+      type: CATEGORICAL
+      description: Order status.
+""",
+            encoding="utf-8",
+        )
+        evidence = {
+            "tables": {
+                "orders": {
+                    "query_count": 1,
+                    "data_distribution_profile": {
+                        "columns": {
+                            "status": {
+                                "kind": "categorical",
+                                "stats": {"distinct_count": 2},
+                                "top_values": [{"value": "paid"}],
+                            }
+                        }
+                    },
+                }
+            }
+        }
+        mock_config = MagicMock()
+
+        with patch(
+            "datus.storage.semantic_model.semantic_model_init.process_semantic_yaml_file",
+            return_value=(True, ""),
+        ) as mock_sync:
+            success, error, changed = refresh_semantic_yaml_profile_descriptions(
+                str(yaml_file),
+                evidence,
+                agent_config=mock_config,
+                sync_to_storage=True,
+            )
+
+        assert success is True
+        assert error == ""
+        assert changed == 2
+        assert "Observed profile:" in yaml_file.read_text(encoding="utf-8")
+        mock_sync.assert_called_once_with(
+            str(yaml_file),
+            mock_config,
+            include_semantic_objects=True,
+            include_metrics=True,
+        )
+
+    def test_sync_requires_agent_config(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text("data_source:\n  name: orders\n", encoding="utf-8")
+
+        success, error, changed = refresh_semantic_yaml_profile_descriptions(
+            str(yaml_file),
+            {"tables": {}},
+            sync_to_storage=True,
+        )
+
+        assert success is False
+        assert "agent_config is required" in error
+        assert changed == 0
+
+    def test_osi_refresh_syncs_via_generation_tools(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+semantic_model:
+  - name: shop
+    datasets:
+      - name: orders
+        description: Orders dataset.
+        source: orders
+        dimensions:
+          - name: status
+            description: Order status.
+""",
+            encoding="utf-8",
+        )
+        evidence = {
+            "tables": {
+                "orders": {
+                    "query_count": 1,
+                    "data_distribution_profile": {
+                        "columns": {
+                            "status": {
+                                "kind": "categorical",
+                                "stats": {"distinct_count": 2},
+                                "top_values": [{"value": "paid"}],
+                            }
+                        }
+                    },
+                }
+            }
+        }
+        mock_config = MagicMock()
+
+        with patch("datus.tools.func_tool.generation_tools.GenerationTools") as mock_tools_cls:
+            mock_tools_cls.return_value.sync_osi_semantic_to_db.return_value = {"success": True}
+            success, error, changed = refresh_semantic_yaml_profile_descriptions(
+                str(yaml_file),
+                evidence,
+                authoring_format="osi",
+                agent_config=mock_config,
+                sync_to_storage=True,
+            )
+
+        assert success is True
+        assert error == ""
+        assert changed == 2
+        mock_tools_cls.assert_called_once_with(agent_config=mock_config, authoring_format="osi")
+        mock_tools_cls.return_value.sync_osi_semantic_to_db.assert_called_once_with(str(yaml_file))
+
+
+# ---------------------------------------------------------------------------
 # init_success_story_semantic_model_async - importability and coroutine check
 # ---------------------------------------------------------------------------
 
@@ -332,6 +461,10 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
         """
         monkeypatch.setattr(
             "datus.storage.semantic_model.store.SemanticModelRAG",
+            MagicMock(return_value=MagicMock()),
+        )
+        monkeypatch.setattr(
+            "datus.storage.table_semantic_profile.store.TableSemanticProfileRAG",
             MagicMock(return_value=MagicMock()),
         )
 
@@ -824,7 +957,13 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
 
         fake_rag_instance = MagicMock()
         rag_factory = MagicMock(return_value=fake_rag_instance)
+        fake_profile_rag_instance = MagicMock()
+        profile_rag_factory = MagicMock(return_value=fake_profile_rag_instance)
         monkeypatch.setattr("datus.storage.semantic_model.store.SemanticModelRAG", rag_factory)
+        monkeypatch.setattr(
+            "datus.storage.table_semantic_profile.store.TableSemanticProfileRAG",
+            profile_rag_factory,
+        )
 
         class MockSemanticNode:
             def __init__(self, *args, **kwargs):
@@ -850,6 +989,8 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
         assert success is True
         rag_factory.assert_called_once_with(mock_config)
         fake_rag_instance.truncate.assert_called_once_with()
+        profile_rag_factory.assert_called_once_with(mock_config)
+        fake_profile_rag_instance.truncate.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_incremental_does_not_call_truncate(self, tmp_path, monkeypatch):
@@ -870,8 +1011,14 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
         mock_db_config.schema = ""
         mock_config.current_db_config.return_value = mock_db_config
 
-        rag_factory = MagicMock()
+        fake_rag_instance = MagicMock()
+        rag_factory = MagicMock(return_value=fake_rag_instance)
+        profile_rag_factory = MagicMock()
         monkeypatch.setattr("datus.storage.semantic_model.store.SemanticModelRAG", rag_factory)
+        monkeypatch.setattr(
+            "datus.storage.table_semantic_profile.store.TableSemanticProfileRAG",
+            profile_rag_factory,
+        )
 
         class MockSemanticNode:
             def __init__(self, *args, **kwargs):
@@ -895,4 +1042,5 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
         )
 
         assert success is True
-        rag_factory.assert_not_called()
+        fake_rag_instance.truncate.assert_not_called()
+        profile_rag_factory.assert_not_called()

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -12,6 +12,7 @@ from datus.storage.semantic_model.semantic_model_init import (
     init_semantic_yaml_semantic_model,
     process_semantic_yaml_file,
     refresh_semantic_yaml_profile_descriptions,
+    refresh_success_story_semantic_model_profile,
 )
 
 # ---------------------------------------------------------------------------
@@ -485,6 +486,91 @@ data_source:
         assert "dump failed" in error
         assert changed == 0
         assert yaml_file.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.ci
+class TestRefreshSuccessStorySemanticModelProfile:
+    def test_profiles_existing_metricflow_yaml_and_refreshes_descriptions(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: marts.orders
+  description: Orders table.
+""",
+            encoding="utf-8",
+        )
+        success_story = tmp_path / "stories.csv"
+        success_story.write_text(
+            "source_context_id,question,sql\n"
+            "q1,paid orders,\"SELECT status FROM marts.orders WHERE status = 'paid'\"\n",
+            encoding="utf-8",
+        )
+        mock_config = MagicMock()
+        mock_config.path_manager = None
+        mock_config.runtime_db_context.return_value = {}
+        current_db_config = MagicMock()
+        current_db_config.catalog = ""
+        current_db_config.database = "analytics"
+        current_db_config.schema = ""
+        mock_config.current_db_config.return_value = current_db_config
+
+        from datus.tools.func_tool.base import FuncToolResult
+
+        mock_discovery = MagicMock()
+        mock_discovery.profile_semantic_model_evidence.return_value = FuncToolResult(
+            result={"tables": {"orders": {"data_distribution_profile": {"columns": {}}}}}
+        )
+
+        with (
+            patch("datus.tools.func_tool.database.DBFuncTool") as mock_db_tool,
+            patch(
+                "datus.tools.func_tool.semantic_discovery_tools.SemanticDiscoveryTools",
+                return_value=mock_discovery,
+            ),
+            patch(
+                "datus.storage.semantic_model.semantic_model_init.refresh_semantic_yaml_profile_descriptions",
+                return_value=(True, "", 2),
+            ) as mock_refresh,
+        ):
+            success, error, changed = refresh_success_story_semantic_model_profile(
+                mock_config,
+                str(yaml_file),
+                str(success_story),
+            )
+
+        assert success is True
+        assert error == ""
+        assert changed == 2
+        mock_db_tool.assert_called_once_with(
+            agent_config=mock_config,
+            sub_agent_name="gen_semantic_model",
+            read_only=True,
+        )
+        profile_kwargs = mock_discovery.profile_semantic_model_evidence.call_args.kwargs
+        assert profile_kwargs["tables"] == ["marts.orders"]
+        assert profile_kwargs["database"] == "analytics"
+        assert profile_kwargs["profile_mode"] == "deep"
+        assert "paid orders" in profile_kwargs["sql_entries_json"]
+        mock_refresh.assert_called_once()
+        assert mock_refresh.call_args.args[0] == str(yaml_file)
+        assert mock_refresh.call_args.kwargs["authoring_format"] == "metricflow"
+        assert mock_refresh.call_args.kwargs["sync_to_storage"] is True
+
+    def test_refresh_profile_requires_semantic_yaml(self, tmp_path):
+        success_story = tmp_path / "stories.csv"
+        success_story.write_text("sql\nSELECT 1\n", encoding="utf-8")
+
+        success, error, changed = refresh_success_story_semantic_model_profile(
+            MagicMock(),
+            "",
+            str(success_story),
+        )
+
+        assert success is False
+        assert "--semantic_yaml is required" in error
+        assert changed == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -227,6 +227,7 @@ data_source:
             }
         }
         mock_config = MagicMock()
+        mock_config.path_manager = None
 
         with patch(
             "datus.storage.semantic_model.semantic_model_init.process_semantic_yaml_file",
@@ -297,6 +298,7 @@ semantic_model:
             }
         }
         mock_config = MagicMock()
+        mock_config.path_manager = None
 
         with patch("datus.tools.func_tool.generation_tools.GenerationTools") as mock_tools_cls:
             mock_tools_cls.return_value.sync_osi_semantic_to_db.return_value = {"success": True}
@@ -313,6 +315,126 @@ semantic_model:
         assert changed == 2
         mock_tools_cls.assert_called_once_with(agent_config=mock_config, authoring_format="osi")
         mock_tools_cls.return_value.sync_osi_semantic_to_db.assert_called_once_with(str(yaml_file))
+
+    def test_unchanged_metricflow_yaml_still_retries_storage_sync(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: orders
+""",
+            encoding="utf-8",
+        )
+        mock_config = MagicMock()
+        mock_config.path_manager = None
+
+        with patch(
+            "datus.storage.semantic_model.semantic_model_init.process_semantic_yaml_file",
+            return_value=(True, ""),
+        ) as mock_sync:
+            success, error, changed = refresh_semantic_yaml_profile_descriptions(
+                str(yaml_file),
+                {"tables": {}},
+                agent_config=mock_config,
+                sync_to_storage=True,
+            )
+
+        assert success is True
+        assert error == ""
+        assert changed == 0
+        mock_sync.assert_called_once_with(
+            str(yaml_file),
+            mock_config,
+            include_semantic_objects=True,
+            include_metrics=True,
+        )
+
+    def test_unchanged_metricflow_yaml_returns_sync_failure(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        yaml_file.write_text(
+            """
+data_source:
+  name: orders
+  sql_table: orders
+""",
+            encoding="utf-8",
+        )
+        mock_config = MagicMock()
+        mock_config.path_manager = None
+
+        with patch(
+            "datus.storage.semantic_model.semantic_model_init.process_semantic_yaml_file",
+            return_value=(False, "storage unavailable"),
+        ):
+            success, error, changed = refresh_semantic_yaml_profile_descriptions(
+                str(yaml_file),
+                {"tables": {}},
+                agent_config=mock_config,
+                sync_to_storage=True,
+            )
+
+        assert success is False
+        assert error == "storage unavailable"
+        assert changed == 0
+
+    def test_refresh_rejects_path_outside_semantic_sandbox(self, tmp_path):
+        subject_dir = tmp_path / "subject"
+        (subject_dir / "semantic_models").mkdir(parents=True)
+        outside = tmp_path / "outside.yml"
+        outside.write_text("data_source:\n  name: orders\n", encoding="utf-8")
+        mock_config = MagicMock()
+        mock_config.path_manager.subject_dir = subject_dir
+
+        success, error, changed = refresh_semantic_yaml_profile_descriptions(
+            str(outside),
+            {"tables": {}},
+            agent_config=mock_config,
+        )
+
+        assert success is False
+        assert "rejected by sandbox" in error
+        assert changed == 0
+
+    def test_atomic_write_failure_preserves_existing_yaml(self, tmp_path):
+        yaml_file = tmp_path / "orders.yml"
+        original = """
+data_source:
+  name: orders
+  description: Orders table.
+  sql_table: orders
+  dimensions:
+    - name: status
+      expr: status
+      type: CATEGORICAL
+      description: Order status.
+"""
+        yaml_file.write_text(original, encoding="utf-8")
+        evidence = {
+            "tables": {
+                "orders": {
+                    "query_count": 1,
+                    "data_distribution_profile": {
+                        "columns": {
+                            "status": {
+                                "kind": "categorical",
+                                "stats": {"distinct_count": 2},
+                                "top_values": [{"value": "paid"}],
+                            }
+                        }
+                    },
+                }
+            }
+        }
+
+        with patch("datus.storage.semantic_model.semantic_model_init.yaml.safe_dump_all") as mock_dump:
+            mock_dump.side_effect = RuntimeError("dump failed")
+            success, error, changed = refresh_semantic_yaml_profile_descriptions(str(yaml_file), evidence)
+
+        assert success is False
+        assert "dump failed" in error
+        assert changed == 0
+        assert yaml_file.read_text(encoding="utf-8") == original
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +500,75 @@ class TestInitSuccessStorySemanticModelAsync:
 
         assert success is False
         assert "missing required columns: ['sql']" in error
+
+    @pytest.mark.asyncio
+    async def test_async_rejects_unknown_build_mode(self, tmp_path):
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT 1,Q?\n")
+        mock_config = MagicMock()
+
+        success, error = await init_success_story_semantic_model_async(
+            mock_config,
+            str(csv_path),
+            build_mode="full",
+        )
+
+        assert success is False
+        assert "Unsupported semantic model build_mode" in error
+
+    @pytest.mark.asyncio
+    async def test_check_mode_storage_init_failure_returns_error(self, tmp_path):
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT 1,Q?\n")
+        mock_config = MagicMock()
+
+        with patch(
+            "datus.storage.semantic_model.store.SemanticModelRAG",
+            side_effect=RuntimeError("storage unavailable"),
+        ):
+            success, error = await init_success_story_semantic_model_async(
+                mock_config,
+                str(csv_path),
+                build_mode="check",
+            )
+
+        assert success is False
+        assert "Failed to initialize semantic model storage" in error
+        assert "storage unavailable" in error
+
+    @pytest.mark.asyncio
+    async def test_check_mode_reports_existing_row_counts(self, tmp_path):
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT 1,Q?\n")
+        mock_config = MagicMock()
+        mock_semantic_rag = MagicMock()
+        mock_semantic_rag.get_size.return_value = 2
+        mock_table_profile_rag = MagicMock()
+        mock_table_profile_rag.get_size.return_value = 3
+
+        with (
+            patch("datus.storage.semantic_model.store.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch(
+                "datus.storage.table_semantic_profile.store.TableSemanticProfileRAG",
+                return_value=mock_table_profile_rag,
+            ),
+        ):
+            success, error = await init_success_story_semantic_model_async(
+                mock_config,
+                str(csv_path),
+                build_mode="check",
+            )
+
+        assert success is True
+        assert error == ""
+        mock_semantic_rag.get_size.assert_called_once()
+        mock_table_profile_rag.get_size.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -6,6 +6,7 @@
 
 import os
 import tempfile
+from unittest.mock import Mock
 
 import pytest
 import yaml
@@ -917,3 +918,78 @@ class TestSemanticModelRAGCreateIndices:
         sem_rag.create_indices()
         # Verify data is still accessible
         assert sem_rag.get_size() >= 1
+
+
+class TestSemanticModelRAGArtifactRows:
+    """Tests for artifact-scoped semantic row replacement helpers."""
+
+    class _Rows:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def to_pylist(self):
+            return self._rows
+
+    def test_delete_artifact_rows_ignores_empty_yaml_path(self):
+        rag = SemanticModelRAG.__new__(SemanticModelRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+
+        rag.delete_artifact_rows("")
+
+        rag._sub_agent_conditions.assert_not_called()
+        rag.storage._delete_rows.assert_not_called()
+
+    def test_delete_artifact_rows_uses_sub_agent_scope(self):
+        rag = SemanticModelRAG.__new__(SemanticModelRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+
+        rag.delete_artifact_rows("semantic/orders.yml")
+
+        rag._sub_agent_conditions.assert_called_once_with()
+        rag.storage._delete_rows.assert_called_once()
+
+    def test_delete_artifact_rows_except_deletes_all_when_keep_ids_empty(self):
+        rag = SemanticModelRAG.__new__(SemanticModelRAG)
+        rag.delete_artifact_rows = Mock()
+
+        rag.delete_artifact_rows_except("semantic/orders.yml", ["", None])
+
+        rag.delete_artifact_rows.assert_called_once_with("semantic/orders.yml")
+
+    def test_delete_artifact_rows_except_keeps_current_ids(self):
+        rag = SemanticModelRAG.__new__(SemanticModelRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+
+        rag.delete_artifact_rows_except("semantic/orders.yml", ["table:orders"])
+
+        rag._sub_agent_conditions.assert_called_once_with()
+        rag.storage._delete_rows.assert_called_once()
+
+    def test_list_artifact_rows_handles_empty_and_non_empty_paths(self):
+        rag = SemanticModelRAG.__new__(SemanticModelRAG)
+        rag.storage = Mock()
+        rag._sub_agent_conditions = Mock(return_value=[])
+        rag.storage._search_all.return_value = self._Rows([{"id": "table:orders"}])
+
+        assert rag.list_artifact_rows("") == []
+        assert rag.list_artifact_rows("semantic/orders.yml") == [{"id": "table:orders"}]
+
+        rag._sub_agent_conditions.assert_called_once_with()
+        rag.storage._search_all.assert_called_once()
+
+    def test_restore_artifact_rows_handles_empty_and_non_empty_paths(self):
+        rag = SemanticModelRAG.__new__(SemanticModelRAG)
+        rag.delete_artifact_rows = Mock()
+        rag.upsert_batch = Mock()
+        rag.create_indices = Mock()
+        rows = [{"id": "table:orders"}]
+
+        rag.restore_artifact_rows("", rows)
+        rag.restore_artifact_rows("semantic/orders.yml", rows)
+
+        rag.delete_artifact_rows.assert_called_once_with("semantic/orders.yml")
+        rag.upsert_batch.assert_called_once_with(rows)
+        rag.create_indices.assert_called_once_with()

--- a/tests/unit_tests/storage/table_semantic_profile/test_store.py
+++ b/tests/unit_tests/storage/table_semantic_profile/test_store.py
@@ -64,3 +64,72 @@ def test_get_profile_lowercase_fallback_runs_after_ambiguous_broad_lookup():
     result = rag.get_profile(database_name="shop", table_name="Orders")
 
     assert result == expected
+
+
+def _artifact_rag():
+    rag = TableSemanticProfileRAG.__new__(TableSemanticProfileRAG)
+    rag.storage = Mock()
+    rag._sub_agent_conditions = Mock(return_value=[])
+    return rag
+
+
+def test_delete_artifact_rows_ignores_empty_yaml_path():
+    rag = _artifact_rag()
+
+    rag.delete_artifact_rows("")
+
+    rag._sub_agent_conditions.assert_not_called()
+    rag.storage._delete_rows.assert_not_called()
+
+
+def test_delete_artifact_rows_uses_sub_agent_scope():
+    rag = _artifact_rag()
+
+    rag.delete_artifact_rows("semantic/orders.yml")
+
+    rag._sub_agent_conditions.assert_called_once_with()
+    rag.storage._delete_rows.assert_called_once()
+
+
+def test_delete_artifact_rows_except_deletes_all_when_keep_ids_empty():
+    rag = TableSemanticProfileRAG.__new__(TableSemanticProfileRAG)
+    rag.delete_artifact_rows = Mock()
+
+    rag.delete_artifact_rows_except("semantic/orders.yml", ["", None])
+
+    rag.delete_artifact_rows.assert_called_once_with("semantic/orders.yml")
+
+
+def test_delete_artifact_rows_except_keeps_current_ids():
+    rag = _artifact_rag()
+
+    rag.delete_artifact_rows_except("semantic/orders.yml", ["profile:orders"])
+
+    rag._sub_agent_conditions.assert_called_once_with()
+    rag.storage._delete_rows.assert_called_once()
+
+
+def test_list_artifact_rows_handles_empty_and_non_empty_paths():
+    rag = _artifact_rag()
+    rag.storage._search_all.return_value = _Rows([{"id": "profile:orders"}])
+
+    assert rag.list_artifact_rows("") == []
+    assert rag.list_artifact_rows("semantic/orders.yml") == [{"id": "profile:orders"}]
+
+    rag._sub_agent_conditions.assert_called_once_with()
+    rag.storage._search_all.assert_called_once()
+
+
+def test_restore_artifact_rows_handles_empty_and_non_empty_paths():
+    rag = TableSemanticProfileRAG.__new__(TableSemanticProfileRAG)
+    rag.delete_artifact_rows = Mock()
+    rag.upsert_batch = Mock()
+    rag.create_indices = Mock()
+    rows = [{"id": "profile:orders"}]
+
+    rag.restore_artifact_rows("", rows)
+    rag.restore_artifact_rows("semantic/orders.yml", rows)
+
+    rag.delete_artifact_rows.assert_called_once_with("semantic/orders.yml")
+    rag.upsert_batch.assert_called_once_with(rows)
+    rag.create_indices.assert_called_once_with()

--- a/tests/unit_tests/storage/test_artifact_replacement.py
+++ b/tests/unit_tests/storage/test_artifact_replacement.py
@@ -1,0 +1,25 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from unittest.mock import MagicMock
+
+from datus.storage.artifact_replacement import restore_artifact_replacements
+
+
+def test_restore_artifact_replacements_reports_restore_failures():
+    ok_rag = MagicMock()
+    failing_rag = MagicMock()
+    failing_rag.restore_artifact_rows.side_effect = RuntimeError("storage unavailable")
+
+    failures = restore_artifact_replacements(
+        [
+            (ok_rag, "semantic/orders.yml", [{"id": "old-semantic"}]),
+            (failing_rag, "metrics/orders.yml", [{"id": "old-metric"}]),
+        ]
+    )
+
+    assert len(failures) == 1
+    assert "metrics/orders.yml" in failures[0]
+    ok_rag.restore_artifact_rows.assert_called_once_with("semantic/orders.yml", [{"id": "old-semantic"}])
+    failing_rag.restore_artifact_rows.assert_called_once_with("metrics/orders.yml", [{"id": "old-metric"}])

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -200,6 +200,11 @@ class TestCreateParser:
         args = parser.parse_args(["bootstrap-kb", "--datasource", "ds", "--kb_update_strategy", "check"])
         assert args.kb_update_strategy == "check"
 
+    def test_bootstrap_kb_accepts_refresh_profile_strategy(self):
+        parser = create_parser()
+        args = parser.parse_args(["bootstrap-kb", "--datasource", "ds", "--kb_update_strategy", "refresh-profile"])
+        assert args.kb_update_strategy == "refresh-profile"
+
     def test_bootstrap_kb_default_components_and_strategy(self):
         parser = create_parser()
         args = parser.parse_args(["bootstrap-kb", "--datasource", "ds"])

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -952,7 +952,8 @@ class TestOsiSync:
             )
 
         assert result["success"] is True
-        generation_tools.metric_rag.delete_artifact_rows.assert_called_once_with(str(metric_file))
+        generation_tools.metric_rag.delete_artifact_rows.assert_not_called()
+        generation_tools.metric_rag.delete_artifact_rows_except.assert_called_once()
         generation_tools.metric_rag.upsert_batch.assert_called_once()
         metric_objects = generation_tools.metric_rag.upsert_batch.call_args.args[0]
         assert len(metric_objects) == 1
@@ -1228,14 +1229,16 @@ class TestOsiSync:
             result = generation_tools.sync_osi_semantic_to_db(str(semantic_file))
 
         assert result["success"] is True
-        generation_tools.semantic_rag.delete_artifact_rows.assert_called_once_with(str(semantic_file))
+        generation_tools.semantic_rag.delete_artifact_rows.assert_not_called()
+        generation_tools.semantic_rag.delete_artifact_rows_except.assert_called_once()
         generation_tools.semantic_rag.upsert_batch.assert_called_once()
         objects = generation_tools.semantic_rag.upsert_batch.call_args.args[0]
         assert [obj["kind"] for obj in objects] == ["table", "column", "column", "column"]
         assert objects[0]["name"] == "orders"
         assert objects[1]["name"] == "order_id"
         assert objects[1]["is_entity_key"] is True
-        generation_tools.table_semantic_profile_rag.delete_artifact_rows.assert_called_once_with(str(semantic_file))
+        generation_tools.table_semantic_profile_rag.delete_artifact_rows.assert_not_called()
+        generation_tools.table_semantic_profile_rag.delete_artifact_rows_except.assert_called_once()
         generation_tools.table_semantic_profile_rag.upsert_batch.assert_called_once()
         profiles = generation_tools.table_semantic_profile_rag.upsert_batch.call_args.args[0]
         assert profiles[0]["format"] == "osi"
@@ -1279,6 +1282,8 @@ class TestOsiSync:
 
         assert result["success"] is False
         assert "profile sync failed" in result["error"]
+        generation_tools.semantic_rag.restore_artifact_rows.assert_called_once()
+        generation_tools.table_semantic_profile_rag.restore_artifact_rows.assert_called_once()
 
 
 class TestGenerateSqlSummaryId:

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -315,7 +315,7 @@ class TestEndMetricGeneration:
 
         assert result.success == 1
         preflight_mock.assert_not_called()
-        sync_mock.assert_called_once()
+        sync_mock.assert_called_once_with(str(metric_file), [], {}, replace_metric_artifact=False)
 
     def test_osi_forwards_all_semantic_model_files_to_sync(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
@@ -353,7 +353,12 @@ class TestEndMetricGeneration:
 
         assert result.success == 1
         preflight_mock.assert_not_called()
-        sync_mock.assert_called_once_with(str(metric_file), [str(orders_file), str(customers_file)], {})
+        sync_mock.assert_called_once_with(
+            str(metric_file),
+            [str(orders_file), str(customers_file)],
+            {},
+            replace_metric_artifact=False,
+        )
         assert generation_tools.generation_evidence.semantic_kb_sync_passed is True
 
 
@@ -746,6 +751,7 @@ class TestSyncMetricToDb:
             include_metrics=True,
             metric_sqls=None,
             original_yaml_path=str(metric_file),
+            replace_metric_artifact=False,
         )
 
     def test_metric_with_semantic_models_syncs_semantic_then_metric(self, generation_tools, tmp_path):
@@ -773,6 +779,7 @@ class TestSyncMetricToDb:
         assert metric_call[0][0] == str(metric_file)
         assert metric_call.kwargs.get("include_semantic_objects") is False
         assert metric_call.kwargs.get("include_metrics") is True
+        assert metric_call.kwargs.get("replace_metric_artifact") is False
         assert metric_call.kwargs.get("metric_sqls") == {"rev": "SELECT 1"}
         assert metric_call.kwargs.get("original_yaml_path") == str(metric_file)
 
@@ -820,6 +827,7 @@ class TestSyncMetricToDb:
         assert "name: existing_metric" not in captured["content"]
         assert captured["kwargs"]["metric_sqls"] == {"new_metric": "SELECT new_metric"}
         assert captured["kwargs"]["original_yaml_path"] == str(metric_file)
+        assert captured["kwargs"]["replace_metric_artifact"] is False
 
     def test_semantic_sync_failure_aborts_metric_sync(self, generation_tools, tmp_path):
         """When semantic object sync fails, metric sync is skipped and failure propagated."""
@@ -944,6 +952,7 @@ class TestOsiSync:
             )
 
         assert result["success"] is True
+        generation_tools.metric_rag.delete_artifact_rows.assert_called_once_with(str(metric_file))
         generation_tools.metric_rag.upsert_batch.assert_called_once()
         metric_objects = generation_tools.metric_rag.upsert_batch.call_args.args[0]
         assert len(metric_objects) == 1
@@ -956,6 +965,46 @@ class TestOsiSync:
         assert metric_obj["sql"] == "SELECT 1"
         assert metric_obj["yaml_path"] == str(metric_file)
         assert result["metric_names"] == ["order_count"]
+
+    def test_sync_osi_metric_to_db_can_upsert_without_replacing_artifact(self, generation_tools, tmp_path):
+        generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
+            catalog="default_catalog", database="shop", schema=""
+        )
+        metric_file = tmp_path / "orders_metrics.yml"
+        metric_file.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: shop\n"
+            "    metrics:\n"
+            "      - name: order_count\n"
+            "        expression:\n"
+            "          dialects:\n"
+            "            - dialect: ANSI_SQL\n"
+            "              expression: COUNT(DISTINCT order_id)\n"
+        )
+        dataset = SimpleNamespace(
+            name="orders",
+            source=SimpleNamespace(table="orders"),
+            primary_key="order_id",
+            time_dimension=None,
+            dimensions=[],
+        )
+        metric = SimpleNamespace(
+            name="order_count",
+            description="Number of orders",
+            expression="COUNT(DISTINCT order_id)",
+            dataset="orders",
+            subject_path=None,
+            kind=None,
+        )
+        doc = SimpleNamespace(datasets=[dataset], metrics=[metric])
+
+        with patch.object(generation_tools, "_load_osi_document", return_value=doc):
+            result = generation_tools._sync_osi_metric_to_db(str(metric_file), replace_metric_artifact=False)
+
+        assert result["success"] is True
+        generation_tools.metric_rag.delete_artifact_rows.assert_not_called()
+        generation_tools.metric_rag.upsert_batch.assert_called_once()
 
     def test_sync_osi_metric_to_db_includes_derived_and_joined_dimensions(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
@@ -1179,12 +1228,14 @@ class TestOsiSync:
             result = generation_tools.sync_osi_semantic_to_db(str(semantic_file))
 
         assert result["success"] is True
+        generation_tools.semantic_rag.delete_artifact_rows.assert_called_once_with(str(semantic_file))
         generation_tools.semantic_rag.upsert_batch.assert_called_once()
         objects = generation_tools.semantic_rag.upsert_batch.call_args.args[0]
         assert [obj["kind"] for obj in objects] == ["table", "column", "column", "column"]
         assert objects[0]["name"] == "orders"
         assert objects[1]["name"] == "order_id"
         assert objects[1]["is_entity_key"] is True
+        generation_tools.table_semantic_profile_rag.delete_artifact_rows.assert_called_once_with(str(semantic_file))
         generation_tools.table_semantic_profile_rag.upsert_batch.assert_called_once()
         profiles = generation_tools.table_semantic_profile_rag.upsert_batch.call_args.args[0]
         assert profiles[0]["format"] == "osi"
@@ -1624,8 +1675,12 @@ class TestValidateMetricNameConflicts:
         ]
         with patch("datus.tools.func_tool.generation_tools.metric_definition_conflict", return_value="metric_type"):
             result = generation_tools._validate_metric_name_conflicts([{"name": "revenue", "metric_type": "ratio"}])
-        assert result is not None
-        assert "conflict" in result.lower()
+        assert result == (
+            "Metric name conflict within this datasource for 'revenue': "
+            "existing metric id 'm1' has a different 'metric_type'. "
+            "Metric names must be unique within a datasource; choose a more specific name "
+            "or update the existing metric explicitly."
+        )
 
     def test_exception_during_search_returns_none(self, generation_tools):
         generation_tools.metric_rag.search_all_metrics.side_effect = RuntimeError("storage error")

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -1005,7 +1005,54 @@ class TestOsiSync:
 
         assert result["success"] is True
         generation_tools.metric_rag.delete_artifact_rows.assert_not_called()
+        generation_tools.metric_rag.delete_artifact_rows_except.assert_not_called()
+        generation_tools.metric_rag.list_artifact_rows.assert_called_once_with(str(metric_file))
         generation_tools.metric_rag.upsert_batch.assert_called_once()
+
+    def test_sync_osi_metric_partial_publish_restores_on_later_failure(self, generation_tools, tmp_path):
+        generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
+            catalog="default_catalog", database="shop", schema=""
+        )
+        metric_file = tmp_path / "orders_metrics.yml"
+        metric_file.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: shop\n"
+            "    metrics:\n"
+            "      - name: order_count\n"
+            "        expression:\n"
+            "          dialects:\n"
+            "            - dialect: ANSI_SQL\n"
+            "              expression: COUNT(DISTINCT order_id)\n"
+        )
+        dataset = SimpleNamespace(
+            name="orders",
+            source=SimpleNamespace(table="orders"),
+            primary_key="order_id",
+            time_dimension=None,
+            dimensions=[],
+        )
+        metric = SimpleNamespace(
+            name="order_count",
+            description="Number of orders",
+            expression="COUNT(DISTINCT order_id)",
+            dataset="orders",
+            subject_path=None,
+            kind=None,
+        )
+        doc = SimpleNamespace(datasets=[dataset], metrics=[metric])
+        generation_tools.metric_rag.list_artifact_rows.return_value = [{"id": "old-metric"}]
+        generation_tools.metric_rag.create_indices.side_effect = RuntimeError("index failed")
+
+        with patch.object(generation_tools, "_load_osi_document", return_value=doc):
+            result = generation_tools._sync_osi_metric_to_db(str(metric_file), replace_metric_artifact=False)
+
+        assert result["success"] is False
+        assert "index failed" in result["error"]
+        generation_tools.metric_rag.delete_artifact_rows_except.assert_not_called()
+        generation_tools.metric_rag.restore_artifact_rows.assert_called_once_with(
+            str(metric_file), [{"id": "old-metric"}]
+        )
 
     def test_sync_osi_metric_to_db_includes_derived_and_joined_dimensions(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(


### PR DESCRIPTION
## Summary
- Add deterministic semantic profile description refresh for MetricFlow and OSI YAML, appending concise `Observed profile:` snippets from stored table semantic profiles.
- Keep semantic model refresh scoped to the current YAML artifact while syncing the semantic model, table profiles, and vector store rows consistently.
- Make generated metric sync upsert-only for both MetricFlow and OSI paths, avoiding accidental replacement of unrelated metrics.
- Cover bootstrap-kb strategies, artifact-scoped deletes, profile description generation, and MetricFlow/OSI metric sync behavior with focused unit tests.

## Why
Semantic YAML files and their vector-store rows need to stay synchronized when table data changes or a model is regenerated. Metric generation should update metrics that were generated in the current run without clearing unrelated metrics in the same datasource.

## Validation
- `git diff --check`
- `uv run ruff check datus/agent/agent.py datus/api/services/kb_service.py datus/cli/generation_hooks.py datus/storage/metric/metric_init.py datus/storage/metric/store.py datus/storage/semantic_model/semantic_model_init.py datus/storage/semantic_model/store.py datus/storage/semantic_model/profile_description.py datus/storage/table_semantic_profile/store.py datus/tools/func_tool/generation_tools.py tests/unit_tests/agent/test_agent.py tests/unit_tests/api/services/test_kb_service.py tests/unit_tests/cli/test_generation_hooks.py tests/unit_tests/storage/metric/test_metric_init.py tests/unit_tests/storage/metric/test_store.py tests/unit_tests/storage/semantic_model/test_semantic_model_init.py tests/unit_tests/storage/semantic_model/test_profile_description.py tests/unit_tests/tools/func_tool/test_generation_tools.py`
- `uv run pytest -q tests/unit_tests/storage/semantic_model/test_profile_description.py tests/unit_tests/storage/semantic_model/test_semantic_model_init.py tests/unit_tests/storage/metric/test_metric_init.py::TestInitSemanticYamlMetrics tests/unit_tests/storage/metric/test_store.py::TestMetricRAGArtifactDelete tests/unit_tests/agent/test_agent.py::TestBootstrapKbSemanticModel tests/unit_tests/agent/test_agent.py::TestBootstrapKbMetrics tests/unit_tests/api/services/test_kb_service.py::TestKbServiceInitSemanticAndMetrics tests/unit_tests/cli/test_generation_hooks.py::TestSyncToStorage::test_metric_type_calls_sync_metric tests/unit_tests/cli/test_generation_hooks.py::TestSyncSemanticToDbMetricReferenceNormalization tests/unit_tests/tools/func_tool/test_generation_tools.py::TestEndMetricGeneration tests/unit_tests/tools/func_tool/test_generation_tools.py::TestSyncMetricToDb tests/unit_tests/tools/func_tool/test_generation_tools.py::TestOsiSync tests/unit_tests/tools/func_tool/test_generation_tools.py::TestValidateMetricNameConflicts` - 100 passed
- `uv run python ci/audit_tests.py --paths tests/unit_tests/storage/semantic_model/test_profile_description.py tests/unit_tests/storage/semantic_model/test_semantic_model_init.py tests/unit_tests/storage/metric/test_metric_init.py tests/unit_tests/storage/metric/test_store.py tests/unit_tests/agent/test_agent.py tests/unit_tests/api/services/test_kb_service.py tests/unit_tests/cli/test_generation_hooks.py tests/unit_tests/tools/func_tool/test_generation_tools.py` - issues=0

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added a “check” mode that reports current counts for semantic models and metrics without rebuilding data.
  * Added support for refreshing “Observed profile” descriptions in semantic YAML content.

* **Bug Fixes**
  * Improved synchronization so updated artifacts replace old rows more consistently, reducing stale or duplicate entries.
  * Semantic model and metrics initialization now handle overwrite and incremental flows more predictably, including related profile data.

* **Refactor**
  * Combined multi-component bootstrap results into a single response with clearer per-component status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “check” mode for semantic models and metrics to report current counts without generation.
  * Added deterministic “Observed profile” refresh for semantic YAML descriptions, with optional syncing back to storage.

* **Bug Fixes**
  * Improved knowledge-base/YAML syncing with scoped stale-artifact cleanup, safer rollback on failures, and preservation of metric rows when doing metric-only/partial sync.

* **Refactor**
  * Updated multi-component knowledge-base bootstrapping to aggregate per-component outcomes into a single consistent result with clearer top-level status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->