### PR TITLE
[BugFix] Emit hosted web_search completion in-stream to clear the CLI spinner

### DIFF
--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -567,10 +567,6 @@ class CodexModel(LLMBaseModel):
             early_assistant_yielded = False
             thinking_stream_id: Optional[str] = None
             thinking_accumulated = ""
-            # Hosted web_search completions are deferred to stream end so we can
-            # attach the assistant message's url_citation results (the call item
-            # itself carries no results). See the flush after the stream loop.
-            pending_hosted_searches: List[dict] = []
 
             try:
                 while not result.is_complete:
@@ -712,9 +708,13 @@ class CodexModel(LLMBaseModel):
                                 yield action
 
                                 # Hosted tools run server-side with no separate
-                                # output item; their results arrive as url_citation
-                                # annotations on the assistant message, so defer the
-                                # completion until the stream ends (flush below).
+                                # output item. Emit the completion immediately —
+                                # keyed off the call's own ``action.sources`` — so
+                                # the CLI stops the in-progress spinner as soon as
+                                # the server-side search returns, instead of
+                                # leaving it pinned until stream end. The richer
+                                # ``url_citation`` titles still surface inline in
+                                # the assistant answer text.
                                 if is_hosted:
                                     temp_tool_calls.pop(call_id, None)
                                     from datus.schemas.web_result import extract_action_sources, hosted_action_query
@@ -724,16 +724,16 @@ class CodexModel(LLMBaseModel):
                                         if isinstance(raw_item, dict)
                                         else getattr(raw_item, "action", None)
                                     )
-                                    pending_hosted_searches.append(
-                                        {
-                                            "call_id": call_id,
-                                            "tool_name": tool_name,
-                                            "arguments": arguments,
-                                            "args_str": args_str,
-                                            "query": str(hosted_action_query(raw_action) or ""),
-                                            "sources": extract_action_sources(raw_action),
-                                        }
+                                    hosted_done = self._build_hosted_search_completion(
+                                        call_id=call_id,
+                                        tool_name=tool_name,
+                                        arguments=arguments,
+                                        args_str=args_str,
+                                        query=str(hosted_action_query(raw_action) or ""),
+                                        sources=extract_action_sources(raw_action),
                                     )
+                                    action_history_manager.add_action(hosted_done)
+                                    yield hosted_done
 
                         elif item_type == "tool_call_output_item":
                             raw_item = getattr(event.item, "raw_item", None)
@@ -769,11 +769,6 @@ class CodexModel(LLMBaseModel):
                                 action_history_manager.add_action(action)
                                 yield action
 
-                # Flush deferred hosted web_search completions with the canonical
-                # results read back from the assistant message's url_citations.
-                for hosted_done in self._build_hosted_search_completions(pending_hosted_searches, result):
-                    action_history_manager.add_action(hosted_done)
-                    yield hosted_done
             except MaxTurnsExceeded as e:
                 raise DatusException(ErrorCode.MODEL_MAX_TURNS_EXCEEDED, message_args={"max_turns": max_turns}) from e
             except Exception as e:
@@ -825,53 +820,41 @@ class CodexModel(LLMBaseModel):
             yield final_action
 
     @staticmethod
-    def _build_hosted_search_completions(pending: List[dict], result) -> List[ActionHistory]:
-        """Build deferred completions for hosted ``web_search`` calls.
+    def _build_hosted_search_completion(
+        call_id: str,
+        tool_name: str,
+        arguments: str,
+        args_str: str,
+        query: str,
+        sources: List[dict],
+    ) -> ActionHistory:
+        """Build the completion for a single hosted ``web_search`` call.
 
-        Results are not on the call item; the title+url pairs the model used
-        surface as ``url_citation`` annotations on the assistant message. We read
-        them back from ``result.to_input_list()`` and attach the turn's full
-        citation set as each hosted search's canonical results (falling back to
-        the call's own ``action.sources`` URLs when there were no citations).
+        The hosted call item carries no results; the only per-call metadata
+        available in-stream is ``action.sources`` (URLs, no titles). We use those
+        as the canonical result and emit the completion immediately so the CLI
+        stops the in-progress spinner as soon as the server-side search returns.
+        The richer ``url_citation`` titles still surface inline in the assistant
+        answer text.
         """
-        from datus.schemas.web_result import (
-            collect_citations_from_input_list,
-            normalize_search_results,
-            web_search_short_summary,
+        from datus.schemas.web_result import normalize_search_results, web_search_short_summary
+
+        canonical = normalize_search_results(query, sources or [])
+        summary = web_search_short_summary(canonical)
+        return ActionHistory(
+            action_id=f"complete_{call_id}",
+            role=ActionRole.TOOL,
+            messages=f"Tool call: {tool_name}('{args_str}...')",
+            action_type=tool_name,
+            input={"function_name": tool_name, "arguments": arguments},
+            output={
+                "success": True,
+                "raw_output": {"success": True, "result": canonical},
+                "summary": summary,
+                "status_message": summary,
+            },
+            status=ActionStatus.SUCCESS,
         )
-
-        if not pending:
-            return []
-
-        citations: List[dict] = []
-        try:
-            if hasattr(result, "to_input_list"):
-                citations = collect_citations_from_input_list(result.to_input_list())
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"Failed to collect web_search citations: {e}")
-
-        actions: List[ActionHistory] = []
-        for call in pending:
-            items = citations or call.get("sources") or []
-            canonical = normalize_search_results(call.get("query", ""), items)
-            summary = web_search_short_summary(canonical)
-            actions.append(
-                ActionHistory(
-                    action_id=f"complete_{call['call_id']}",
-                    role=ActionRole.TOOL,
-                    messages=f"Tool call: {call['tool_name']}('{call['args_str']}...')",
-                    action_type=call["tool_name"],
-                    input={"function_name": call["tool_name"], "arguments": call["arguments"]},
-                    output={
-                        "success": True,
-                        "raw_output": {"success": True, "result": canonical},
-                        "summary": summary,
-                        "status_message": summary,
-                    },
-                    status=ActionStatus.SUCCESS,
-                )
-            )
-        return actions
 
     def _extract_usage_info(self, source) -> dict:
         """Extract usage info from an SDK ``RunResult`` or ``Usage`` object.

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -770,57 +770,49 @@ class OpenAICompatibleModel(LLMBaseModel):
         return tools
 
     @staticmethod
-    async def _flush_pending_hosted_searches(
-        pending: List[Dict[str, Any]],
-        result: Any,
-        action_history_manager: Optional[ActionHistoryManager],
-    ) -> AsyncGenerator[ActionHistory, None]:
-        """Emit deferred completions for hosted ``web_search`` calls.
+    def _build_hosted_search_completion(
+        call_id: str,
+        tool_name: str,
+        arguments: str,
+        args_str: str,
+        query: str,
+        sources: List[Dict[str, Any]],
+        start_time: Optional[datetime] = None,
+    ) -> ActionHistory:
+        """Build the completion for a single hosted ``web_search`` call.
 
-        OpenAI's hosted search returns no results on the call item; the title+url
-        pairs the model used surface as ``url_citation`` annotations on the
-        assistant message. We read them back from ``result.to_input_list()``
-        (annotations preserved) and, per the agreed model, attach the turn's full
-        citation set as each hosted search's canonical results — falling back to
-        the call's own ``action.sources`` URLs when no citations were produced.
+        OpenAI's hosted search returns no results on the call item; the only
+        per-call metadata available in-stream is ``action.sources`` (URLs, no
+        titles). We use those as the canonical result and emit the completion
+        immediately so the CLI stops the in-progress spinner as soon as the
+        server-side search returns, rather than pinning it until stream end. The
+        richer ``url_citation`` titles still surface inline in the assistant
+        answer text.
         """
         from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
-        from datus.schemas.web_result import (
-            collect_citations_from_input_list,
-            normalize_search_results,
-            web_search_short_summary,
+        from datus.schemas.web_result import normalize_search_results, web_search_short_summary
+
+        canonical = normalize_search_results(query, sources or [])
+        summary = web_search_short_summary(canonical)
+        kwargs: Dict[str, Any] = dict(
+            action_id=f"complete_{call_id}",
+            role=ActionRole.TOOL,
+            messages=f"Tool call: {tool_name}('{args_str}...')",
+            action_type=tool_name,
+            input={"function_name": tool_name, "arguments": arguments},
+            output={
+                "success": True,
+                "raw_output": {"success": True, "result": canonical},
+                "summary": summary,
+                "status_message": summary,
+            },
+            status=ActionStatus.SUCCESS,
         )
-
-        citations: List[dict] = []
-        try:
-            if hasattr(result, "to_input_list"):
-                citations = collect_citations_from_input_list(result.to_input_list())
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"Failed to collect web_search citations: {e}")
-
-        for call in pending:
-            items = citations or call.get("sources") or []
-            canonical = normalize_search_results(call.get("query", ""), items)
-            summary = web_search_short_summary(canonical)
-            done_action = ActionHistory(
-                action_id=f"complete_{call['call_id']}",
-                role=ActionRole.TOOL,
-                messages=f"Tool call: {call['tool_name']}('{call['args_str']}...')",
-                action_type=call["tool_name"],
-                input={"function_name": call["tool_name"], "arguments": call["arguments"]},
-                output={
-                    "success": True,
-                    "raw_output": {"success": True, "result": canonical},
-                    "summary": summary,
-                    "status_message": summary,
-                },
-                status=ActionStatus.SUCCESS,
-                start_time=call.get("start_time"),
-            )
-            done_action.end_time = datetime.now()
-            if action_history_manager is not None:
-                action_history_manager.add_action(done_action)
-            yield done_action
+        if start_time is not None:
+            kwargs["start_time"] = start_time
+        done_action = ActionHistory(**kwargs)
+        done_action.end_time = datetime.now()
+        return done_action
 
     async def generate_with_tools(
         self,
@@ -1330,10 +1322,6 @@ class OpenAICompatibleModel(LLMBaseModel):
                 tool_output_seen = False
                 final_assistant_yielded = False
                 last_assistant_text = ""
-                # Hosted web_search calls run server-side and expose no results on
-                # the call item; we defer their completion until after the stream
-                # so we can attach the assistant message's url_citation results.
-                pending_hosted_searches: List[dict] = []
 
                 # Streaming thinking state: accumulate text deltas for real-time output
                 thinking_stream_id: Optional[str] = None
@@ -1520,10 +1508,14 @@ class OpenAICompatibleModel(LLMBaseModel):
 
                                 # Hosted tools (web_search, …) run server-side and
                                 # emit no ``tool_call_output_item``. The results
-                                # are not on the call item — they arrive as
-                                # url_citation annotations on the assistant
-                                # message — so defer the completion until the
-                                # stream ends (see the pending-hosted flush below).
+                                # are not on the call item — the richer title+url
+                                # pairs arrive as url_citation annotations on the
+                                # assistant message. Emit the completion right away
+                                # from the call's own ``action.sources`` so the CLI
+                                # stops the in-progress spinner as soon as the
+                                # server-side search returns, rather than pinning it
+                                # until stream end. The citation titles still
+                                # surface inline in the assistant answer text.
                                 if is_hosted:
                                     temp_tool_calls.pop(call_id, None)
                                     from datus.schemas.web_result import extract_action_sources, hosted_action_query
@@ -1533,19 +1525,18 @@ class OpenAICompatibleModel(LLMBaseModel):
                                         if isinstance(raw_item, dict)
                                         else getattr(raw_item, "action", None)
                                     )
-                                    pending_hosted_searches.append(
-                                        {
-                                            "call_id": call_id,
-                                            "tool_name": tool_name,
-                                            "arguments": arguments,
-                                            "args_str": args_str,
-                                            "query": str(
-                                                hosted_action_query(raw_action) or args_dict.get("query") or ""
-                                            ),
-                                            "sources": extract_action_sources(raw_action),
-                                            "start_time": datetime.now(),
-                                        }
+                                    hosted_done = self._build_hosted_search_completion(
+                                        call_id=call_id,
+                                        tool_name=tool_name,
+                                        arguments=arguments,
+                                        args_str=args_str,
+                                        query=str(hosted_action_query(raw_action) or args_dict.get("query") or ""),
+                                        sources=extract_action_sources(raw_action),
+                                        start_time=start_action.start_time,
                                     )
+                                    if action_history_manager is not None:
+                                        action_history_manager.add_action(hosted_done)
+                                    yield hosted_done
 
                         # Handle tool call completion
                         elif item_type == "tool_call_output_item":
@@ -1674,16 +1665,6 @@ class OpenAICompatibleModel(LLMBaseModel):
                                     action_history_manager.add_action(thinking_action)
                                     yield thinking_action
                                     mark_assistant_response(text_content, is_thinking)
-
-                # Flush deferred hosted web_search completions. The url_citation
-                # results live on the assistant message(s); read them back from
-                # the final input list (which preserves annotations) and attach
-                # them as the canonical web_search result for the turn's calls.
-                if pending_hosted_searches:
-                    async for hosted_done in self._flush_pending_hosted_searches(
-                        pending_hosted_searches, result, action_history_manager
-                    ):
-                        yield hosted_done
 
                 final_output = getattr(result, "final_output", "") or ""
                 if not isinstance(final_output, str):

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -19,6 +19,7 @@ from datus.models.base import LLMBaseModel
 from datus.models.claude_model import ClaudeModel
 from datus.models.codex_model import CodexModel
 from datus.models.openai_model import OpenAIModel
+from datus.schemas.action_history import ActionStatus
 
 _NOW = datetime(2026, 1, 1, 0, 0, 0)
 
@@ -222,69 +223,45 @@ def test_sanitize_server_block_returns_none_when_unserializable():
     assert sanitize_server_block_for_replay(block) is None
 
 
-def test_codex_hosted_completion_attaches_citations():
-    """Deferred hosted web_search completion carries the canonical result built
-    from the assistant message's url_citation annotations."""
-    from types import SimpleNamespace
-
+def test_codex_hosted_completion_uses_action_sources():
+    """Hosted web_search completion is emitted immediately from the call's own
+    ``action.sources`` (the only per-call metadata available in-stream)."""
     from datus.models.codex_model import CodexModel
 
-    pending = [
-        {
-            "call_id": "ws_1",
-            "tool_name": "web_search",
-            "arguments": "{}",
-            "args_str": "",
-            "query": "duckdb latest",
-            "sources": [{"title": "", "url": "https://fallback", "snippet": ""}],
-        }
-    ]
-    result = SimpleNamespace(
-        to_input_list=lambda: [
-            {
-                "role": "assistant",
-                "content": [
-                    {
-                        "type": "output_text",
-                        "text": "...",
-                        "annotations": [{"type": "url_citation", "title": "DuckDB", "url": "https://duckdb.org"}],
-                    }
-                ],
-            }
-        ]
+    done = CodexModel._build_hosted_search_completion(
+        call_id="ws_1",
+        tool_name="web_search",
+        arguments="{}",
+        args_str="",
+        query="duckdb latest",
+        sources=[{"title": "", "url": "https://only-source", "snippet": ""}],
     )
-    actions = CodexModel._build_hosted_search_completions(pending, result)
-    assert len(actions) == 1
-    done = actions[0]
     assert done.action_id == "complete_ws_1"
     assert done.action_type == "web_search"
+    assert done.status == ActionStatus.SUCCESS
     canonical = done.output["raw_output"]["result"]
     assert canonical["query"] == "duckdb latest"
-    # url_citations win over the action.sources fallback.
-    assert canonical["results"] == [{"title": "DuckDB", "url": "https://duckdb.org", "snippet": "", "age": None}]
-    assert done.output["summary"] == "1 web result: DuckDB"
+    assert canonical["results"] == [{"title": "", "url": "https://only-source", "snippet": "", "age": None}]
+    # No titles on sources, so the label falls back to the domain.
+    assert done.output["summary"] == "1 web result: only-source"
 
 
-def test_codex_hosted_completion_falls_back_to_sources():
-    """With no citations, the call's own action.sources URLs become the results."""
-    from types import SimpleNamespace
-
+def test_codex_hosted_completion_empty_sources_summarizes_query():
+    """With no sources at all, the completion still resolves — summarizing the
+    query so the CLI renders a completed (non-spinning) row."""
     from datus.models.codex_model import CodexModel
 
-    pending = [
-        {
-            "call_id": "ws_2",
-            "tool_name": "web_search",
-            "arguments": "{}",
-            "args_str": "",
-            "query": "q",
-            "sources": [{"title": "", "url": "https://only-source", "snippet": ""}],
-        }
-    ]
-    result = SimpleNamespace(to_input_list=lambda: [])  # no assistant citations
-    actions = CodexModel._build_hosted_search_completions(pending, result)
-    canonical = actions[0].output["raw_output"]["result"]
-    assert canonical["results"] == [{"title": "", "url": "https://only-source", "snippet": "", "age": None}]
+    done = CodexModel._build_hosted_search_completion(
+        call_id="ws_2",
+        tool_name="web_search",
+        arguments="{}",
+        args_str="",
+        query="duckdb latest",
+        sources=[],
+    )
+    canonical = done.output["raw_output"]["result"]
+    assert canonical["results"] == []
+    assert done.output["summary"] == 'searched: "duckdb latest"'
 
 
 def test_describe_hosted_tool_item_ignores_function_call():
@@ -297,69 +274,44 @@ def test_describe_hosted_tool_item_ignores_function_call():
     )
 
 
-@pytest.mark.asyncio
-async def test_openai_flush_pending_hosted_searches_uses_citations():
-    """OpenAI deferred hosted web_search completion builds the canonical result
-    from the assistant message's url_citation annotations."""
-    from types import SimpleNamespace
-
+def test_openai_hosted_completion_uses_action_sources():
+    """OpenAI hosted web_search completion is emitted immediately from the call's
+    own ``action.sources``; ``start_time`` is preserved and ``end_time`` set."""
     from datus.models.openai_compatible import OpenAICompatibleModel
 
-    pending = [
-        {
-            "call_id": "ws_1",
-            "tool_name": "web_search",
-            "arguments": "{}",
-            "args_str": "",
-            "query": "duckdb latest",
-            "sources": [{"title": "", "url": "https://fallback", "snippet": ""}],
-            "start_time": _NOW,
-        }
-    ]
-    result = SimpleNamespace(
-        to_input_list=lambda: [
-            {
-                "role": "assistant",
-                "content": [
-                    {
-                        "type": "output_text",
-                        "annotations": [{"type": "url_citation", "title": "DuckDB", "url": "https://duckdb.org"}],
-                    }
-                ],
-            }
-        ]
+    done = OpenAICompatibleModel._build_hosted_search_completion(
+        call_id="ws_1",
+        tool_name="web_search",
+        arguments="{}",
+        args_str="",
+        query="duckdb latest",
+        sources=[{"title": "", "url": "https://only-source", "snippet": ""}],
+        start_time=_NOW,
     )
-    actions = [a async for a in OpenAICompatibleModel._flush_pending_hosted_searches(pending, result, None)]
-    assert len(actions) == 1
-    done = actions[0]
     assert done.action_id == "complete_ws_1"
+    assert done.start_time == _NOW
+    # end_time is stamped at build time (real now), always after the injected start.
+    assert done.end_time is not None and done.end_time >= done.start_time
     canonical = done.output["raw_output"]["result"]
     assert canonical["query"] == "duckdb latest"
-    assert canonical["results"] == [{"title": "DuckDB", "url": "https://duckdb.org", "snippet": "", "age": None}]
+    assert canonical["results"] == [{"title": "", "url": "https://only-source", "snippet": "", "age": None}]
 
 
-@pytest.mark.asyncio
-async def test_openai_flush_pending_hosted_searches_falls_back_to_sources():
-    """With no assistant citations, the call's own action.sources become results."""
-    from types import SimpleNamespace
-
+def test_openai_hosted_completion_empty_sources_summarizes_query():
+    """With no sources, the completion still resolves so the spinner clears."""
     from datus.models.openai_compatible import OpenAICompatibleModel
 
-    pending = [
-        {
-            "call_id": "ws_2",
-            "tool_name": "web_search",
-            "arguments": "{}",
-            "args_str": "",
-            "query": "q",
-            "sources": [{"title": "", "url": "https://only-source", "snippet": ""}],
-            "start_time": _NOW,
-        }
-    ]
-    result = SimpleNamespace(to_input_list=lambda: [])
-    actions = [a async for a in OpenAICompatibleModel._flush_pending_hosted_searches(pending, result, None)]
-    canonical = actions[0].output["raw_output"]["result"]
-    assert canonical["results"] == [{"title": "", "url": "https://only-source", "snippet": "", "age": None}]
+    done = OpenAICompatibleModel._build_hosted_search_completion(
+        call_id="ws_2",
+        tool_name="web_search",
+        arguments="{}",
+        args_str="",
+        query="q",
+        sources=[],
+    )
+    canonical = done.output["raw_output"]["result"]
+    assert canonical["results"] == []
+    assert done.output["summary"] == 'searched: "q"'
 
 
 def test_describe_hosted_tool_item_ignores_non_web_hosted_calls():

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -570,6 +570,69 @@ class TestCodexModelGenerateWithToolsStream:
     @patch("datus.models.codex_model.Runner")
     @patch("datus.models.codex_model.Agent")
     @patch("datus.models.codex_model.extract_sql_contexts")
+    async def test_stream_hosted_web_search_completes_in_stream(
+        self, mock_extract, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
+    ):
+        """Hosted web_search emits no tool_call_output_item; its SUCCESS completion
+        must be yielded immediately in-stream (from action.sources) so the CLI
+        spinner clears rather than staying pinned until the turn ends."""
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth = MagicMock()
+        mock_oauth.get_access_token.return_value = "tok"
+        mock_oauth_cls.return_value = mock_oauth
+
+        model = CodexModel(model_config=model_config)
+        model._async_client = MagicMock()
+
+        with patch("agents.models.openai_responses.OpenAIResponsesModel"):
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            # Hosted web_search_call item (dict form): no name/output, results
+            # live in action.sources.
+            hosted_event = MagicMock()
+            hosted_event.type = "run_item_stream_event"
+            hosted_event.item.type = "tool_call_item"
+            hosted_event.item.raw_item = {
+                "type": "web_search_call",
+                "id": "ws_1",
+                "action": {"type": "search", "query": "duckdb latest", "sources": [{"url": "https://duckdb.org"}]},
+            }
+
+            mock_result = MagicMock()
+            mock_result.final_output = "Done"
+            is_complete_values = iter([False, True])
+            type(mock_result).is_complete = property(lambda self: next(is_complete_values))
+
+            async def stream_events():
+                yield hosted_event
+
+            mock_result.stream_events = stream_events
+            mock_runner.run_streamed.return_value = mock_result
+            mock_extract.return_value = []
+
+            actions = []
+            async for action in model.generate_with_tools_stream(prompt="test"):
+                actions.append(action)
+
+            # PROCESSING (search dispatched) -> SUCCESS (in-stream, not deferred) -> final
+            assert actions[0].action_type == "web_search"
+            assert str(actions[0].status) == "processing"
+            assert actions[1].action_id == "complete_ws_1"
+            assert actions[1].action_type == "web_search"
+            assert str(actions[1].status) == "success"
+            canonical = actions[1].output["raw_output"]["result"]
+            assert canonical["query"] == "duckdb latest"
+            assert canonical["results"] == [{"title": "", "url": "https://duckdb.org", "snippet": "", "age": None}]
+            assert actions[2].action_type == "final_response"
+
+    @pytest.mark.asyncio
+    @patch("datus.models.codex_model.OAuthManager")
+    @patch("datus.models.codex_model.multiple_mcp_servers")
+    @patch("datus.models.codex_model.Runner")
+    @patch("datus.models.codex_model.Agent")
+    @patch("datus.models.codex_model.extract_sql_contexts")
     async def test_stream_with_raw_response_text(
         self, mock_extract, mock_agent_cls, mock_runner, mock_mcp, mock_oauth_cls, model_config
     ):

--- a/tests/unit_tests/models/test_openai_compatible_stream_order.py
+++ b/tests/unit_tests/models/test_openai_compatible_stream_order.py
@@ -107,6 +107,19 @@ def _make_tool_output_event(call_id="call_001", output="result text"):
     return FakeEvent(item=FakeItem(type="tool_call_output_item", raw_item=raw, output=output))
 
 
+def _make_hosted_web_search_event(call_id="ws_1", query="duckdb latest", sources=None):
+    """A hosted ``web_search_call`` item (dict form) as emitted by the Responses API.
+
+    It carries no ``name`` (so it routes through ``describe_hosted_tool_item``)
+    and there is NO paired ``tool_call_output_item`` — the only per-call metadata
+    is ``action.sources``.
+    """
+    if sources is None:
+        sources = [{"url": "https://duckdb.org"}]
+    raw = {"type": "web_search_call", "id": call_id, "action": {"type": "search", "query": query, "sources": sources}}
+    return FakeEvent(item=FakeItem(type="tool_call_item", raw_item=raw))
+
+
 def _make_message_event(text="I will now query the database"):
     """Create a RunItemStreamEvent for message_output_item (Phase 3 / fallback)."""
     raw = FakeRawItemWithContent(content=[FakeTextContent(text=text)])
@@ -358,6 +371,47 @@ class TestStreamActionOrdering:
         processing_action = [a for a in actions if a.status == ActionStatus.PROCESSING][0]
         assert processing_action.action_id == "unique_123"
         assert processing_action.action_type == "my_tool"
+
+    @pytest.mark.asyncio
+    async def test_hosted_web_search_completes_in_stream(self):
+        """Hosted web_search has no paired tool_call_output_item; its completion
+        must be emitted immediately in-stream (from action.sources) so the CLI
+        spinner clears, rather than being deferred to stream end."""
+        events = [
+            _make_hosted_web_search_event(
+                call_id="ws_1",
+                query="duckdb latest",
+                sources=[{"url": "https://duckdb.org/release"}],
+            ),
+        ]
+
+        actions = await _collect_actions(events)
+
+        roles_and_statuses = [(a.role, a.status) for a in actions]
+        assert roles_and_statuses == [
+            (ActionRole.TOOL, ActionStatus.PROCESSING),  # search dispatched
+            (ActionRole.TOOL, ActionStatus.SUCCESS),  # completion emitted in-stream, not deferred
+        ]
+        done = actions[1]
+        assert done.action_id == "complete_ws_1"
+        assert done.action_type == "web_search"
+        canonical = done.output["raw_output"]["result"]
+        assert canonical["query"] == "duckdb latest"
+        assert canonical["results"] == [{"title": "", "url": "https://duckdb.org/release", "snippet": "", "age": None}]
+
+    @pytest.mark.asyncio
+    async def test_hosted_web_search_no_sources_still_completes(self):
+        """With no sources on the call, the completion still resolves (summarizing
+        the query) so the spinner never stays pinned."""
+        events = [
+            _make_hosted_web_search_event(call_id="ws_2", query="q", sources=[]),
+        ]
+
+        actions = await _collect_actions(events)
+
+        assert [a.status for a in actions] == [ActionStatus.PROCESSING, ActionStatus.SUCCESS]
+        assert actions[1].output["raw_output"]["result"]["results"] == []
+        assert actions[1].output["summary"] == 'searched: "q"'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

For hosted `web_search` (OpenAI Responses API, used by Codex and OpenAI-compatible providers), the TUI's "⏳ in progress" spinner stayed pinned at the bottom for the whole answer-generation window even though the server-side search had already returned; results only printed once the entire turn ended.

Root cause: the TUI clears the spinner only when a `PROCESSING` tool action is paired with a `SUCCESS` one (`datus/cli/action_display/streaming.py`). Hosted `web_search` deferred its `SUCCESS` completion to stream end so it could aggregate the turn's `url_citation` titles from the assistant message — so `PROCESSING` had no matching `SUCCESS` until the run finished, leaving the spinner spinning. Claude native models are unaffected (they emit the paired events in-stream).

## Solution

Emit the `SUCCESS` completion immediately when the `web_search_call` item arrives, built from the call's own `action.sources`, so the spinner clears as soon as the search returns.

- `datus/models/codex_model.py`, `datus/models/openai_compatible.py`: replaced the `pending_hosted_searches` buffer + end-of-stream flush with an in-stream `_build_hosted_search_completion(...)` call that yields the completion right after `PROCESSING`.
- Tradeoff: the result block now labels sources by domain rather than the full citation title (titles live only in `url_citation`, aggregated at turn end). The citation titles still surface inline in the assistant answer text, so no user-visible information is lost — we trade a richer result-block label for a spinner that reflects reality. This was an explicit product decision.

## Test Cases

Unit tests (CI tier, all SDK interactions mocked — no external deps):

- `tests/unit_tests/models/test_builtin_web_tools.py`: rewrote the deferred/citation-based completion tests to cover the new immediate `_build_hosted_search_completion` builder (from `action.sources`; empty-sources fallback summarizing the query; `start_time`/`end_time` handling).
- `tests/unit_tests/models/test_openai_compatible_stream_order.py`: added streaming tests driving the `is_hosted` branch of `_generate_with_tools_stream_internal` — asserts `PROCESSING` → `SUCCESS` are emitted in-stream (not deferred), plus the no-sources path.
- `tests/unit_tests/models/test_codex_model.py`: added the equivalent in-stream hosted-search test for `CodexModel.generate_with_tools_stream`.

Diff coverage 100%; test-quality audit P0=0/P1=0. Real hosted-tool behavior remains exercised by nightly tests against live APIs.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [x] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hosted web search actions now complete and appear during streaming instead of waiting until the response finishes.
  * Search results are shown using the available in-stream source data, with a short summary for each search.

* **Bug Fixes**
  * Improved handling when no sources are returned, so searches still complete with an empty results list and a query-based summary.

* **Tests**
  * Added coverage for in-stream completion ordering and result formatting across both search flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->