### PR TITLE
[Enhancement] Bash tool: stdin-hang fix, disk offload, running indicator, rename to `bash`

### DIFF
--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -742,6 +742,13 @@ class InlineStreamingContext:
             # INTERACTION actions: collect input during live interaction, skip in history
             if action.role == ActionRole.INTERACTION:
                 if action.status == ActionStatus.PROCESSING and self._input_collector:
+                    # An ASK-gated tool (e.g. ``execute_command``) is already
+                    # pinned as the running "○ 🔧 tool(...)" frame. Clearing it
+                    # to draw the prompt is correct, but the same tool resumes
+                    # execution once approved — capture the frame so we can
+                    # restore it, otherwise a long bash runs with a blank pinned
+                    # region and only appears when it completes.
+                    saved_processing = self._processing_action
                     self._stop_processing_live()
                     self._stop_subagent_live()
                     user_input = self._input_collector(action, self.display.console)
@@ -760,6 +767,11 @@ class InlineStreamingContext:
                     except Exception as e:
                         logger.error(f"Error submitting interaction response: {e}")
                         return
+                    # Approval submitted: the gated tool now proceeds to run.
+                    # Restore its PROCESSING frame so the user sees live progress
+                    # for the (possibly long) execution instead of a blank region.
+                    if saved_processing is not None:
+                        self._update_processing_live(saved_processing)
                     self._processed_index += 1
                     return  # Wait for SUCCESS action to arrive
                 else:

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -537,10 +537,18 @@ def _format_result_only_markup(output_data, indent: str = "") -> List[str]:
     if data is None:
         return format_output_verbose_markup(output_data, indent)
 
-    # If there's an error, show it
+    # If there's an error, show it — but keep going to also surface the
+    # ``result`` payload when present. Tools like ``execute_command`` put the
+    # actual stdout/stderr in ``result`` while ``error`` is only a terse
+    # "Command exited with code N"; returning early here would hide the real
+    # failure reason and leave the user with no info to act on.
     error = data.get("error")
     if error and str(error) not in ("None", "null", ""):
-        return [f"{indent}[bold red]error: {_escape_markup(str(error))}[/bold red]"]
+        err_lines = [f"{indent}[bold red]error: {_escape_markup(str(error))}[/bold red]"]
+        result = data.get("result")
+        if result not in (None, "", [], {}):
+            err_lines.extend(_format_value_markup(result, indent))
+        return err_lines
 
     # Extract result and format it
     result = data.get("result")
@@ -1977,8 +1985,32 @@ def _build_analyze_metric_candidates(action: ActionHistory, verbose: bool) -> To
 
 
 def _build_execute_command(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """execute_command: show success."""
-    return _build_simple_action(action, verbose, "Command executed")
+    """execute_command: show the real command output, on success and failure.
+
+    The compact line has little room, so surface the meaningful part — the last
+    non-empty output line (the stdout result on success, the stderr reason on
+    failure) — instead of the boilerplate ``Command executed`` label or the
+    ``Command exited with code N`` prefix. When nothing was captured, fall back
+    to the label / error with its generic exception wrapper stripped.
+    """
+    tc = _build_simple_action(action, verbose, "Command executed")
+    if verbose:
+        return tc
+    data = parse_output_data(action.output)
+    output = data.get("result") if isinstance(data, dict) else None
+    lines: List[str] = []
+    if isinstance(output, str) and output.strip():
+        lines = [ln for ln in output.splitlines() if ln.strip() and ln.strip() != "[stderr]"]
+    if lines:
+        tc.compact_result = _truncate_middle(lines[-1], 80)
+    elif tc.status_mark == "✗":
+        # No captured output: strip the verbose failure-prefix boilerplate.
+        # (Keep "Command exited with code N" / "Command timed out ..." — those
+        # ARE the message; only the generic exception wrapper is noise.)
+        prefix = "Command execution failed: "
+        if tc.compact_result.startswith(prefix):
+            tc.compact_result = tc.compact_result[len(prefix) :]
+    return tc
 
 
 def _build_load_skill(action: ActionHistory, verbose: bool) -> ToolCallContent:

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -144,6 +144,13 @@ class BashTool:
                 text=True,
                 timeout=self.timeout,
                 env=self._get_safe_env(),
+                # Detach the child from the agent's stdin. Without this the child
+                # inherits datus's terminal stdin and any command that reads it
+                # (``cat``, ``read``, ``python`` awaiting input, an interactive
+                # prompt) blocks forever, fighting the TUI's prompt_toolkit for
+                # the same TTY and freezing the whole process. DEVNULL delivers
+                # an immediate EOF so such commands fail fast instead of hanging.
+                stdin=subprocess.DEVNULL,
             )
 
             output = result.stdout

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -815,6 +815,68 @@ class TestStreamingInteractionProcessing:
         assert len(submit_calls) == 1
         assert submit_calls[0] == (action.action_id, "a")
 
+    def test_processing_frame_restored_after_ask_approval(self):
+        """A tool pinned as the running frame is restored after an ASK approval.
+
+        Regression: ``execute_command`` (bash) is ASK-gated, so a permission
+        INTERACTION fires while the tool's PROCESSING frame is pinned. The
+        interaction handler clears the frame to draw the prompt; without a
+        restore the (possibly long) bash then runs with a blank pinned region
+        and only appears on completion.
+        """
+        import threading
+
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+
+        interaction = _make_action(
+            ActionRole.INTERACTION,
+            ActionStatus.PROCESSING,
+            messages="Allow bash?",
+            action_type="request_choice",
+            input_data={"content": "Allow?", "choices": {"y": "Yes", "n": "No"}, "default_choice": "y"},
+        )
+        ctx = InlineStreamingContext([interaction], display, live_state=live_state)
+        ctx._processed_index = 0
+        ctx._tick = 0
+
+        # Simulate the bash tool already pinned as the running frame.
+        bash_action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            messages="Tool call: execute_command",
+            action_type="execute_command",
+            input_data={"function_name": "execute_command", "arguments": {"command": "sleep 5"}},
+        )
+        ctx._processing_action = bash_action
+
+        async def fake_submit(action_id, user_input):
+            return None
+
+        mock_broker = MagicMock()
+        mock_broker.submit = fake_submit
+        ctx._broker = mock_broker
+
+        loop = asyncio.new_event_loop()
+        loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+        loop_thread.start()
+        ctx._event_loop = loop
+        ctx._input_collector = MagicMock(return_value="y")
+
+        try:
+            ctx._process_actions()
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            loop_thread.join(timeout=2)
+            loop.close()
+
+        # Frame restored to the same bash tool so live progress keeps showing.
+        assert ctx._processing_action is bash_action
+
     def test_process_interaction_success_skipped(self):
         """INTERACTION SUCCESS is skipped (not shown after live interaction)."""
         buf = StringIO()

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -1776,13 +1776,48 @@ class TestBuildAnalyzeMetricCandidates:
 
 @pytest.mark.ci
 class TestBuildExecuteCommand:
-    def test_compact(self):
+    def test_compact_success_shows_output(self):
+        """Successful command surfaces the real output (last line), not the label."""
         a = _make(
             input_data={"function_name": "execute_command"},
-            output_data={"raw_output": '{"success": 1, "result": "output text"}'},
+            output_data={"raw_output": '{"success": 1, "result": "line one\\nline two"}'},
         )
         tc = _build_execute_command(a, verbose=False)
-        assert "Command executed" in tc.compact_result
+        assert tc.compact_result == "line two"
+        assert tc.status_mark == "✓"
+
+    def test_compact_success_no_output_falls_back_to_label(self):
+        a = _make(
+            input_data={"function_name": "execute_command"},
+            output_data={"raw_output": '{"success": 1, "result": ""}'},
+        )
+        tc = _build_execute_command(a, verbose=False)
+        assert tc.compact_result == "Command executed"
+
+    def test_compact_failure_shows_stderr_not_exit_code(self):
+        """Non-zero exit: show the stderr reason, drop the 'exited with code' prefix."""
+        a = _make(
+            input_data={"function_name": "execute_command"},
+            output_data={
+                "raw_output": (
+                    '{"success": 0, "error": "Command exited with code 1", '
+                    '"result": "run\\n[stderr]\\nfoo: command not found"}'
+                )
+            },
+        )
+        tc = _build_execute_command(a, verbose=False)
+        assert tc.compact_result == "foo: command not found"
+        assert tc.status_mark == "✗"
+
+    def test_compact_failure_strips_exception_prefix(self):
+        """Exception path with no captured output: strip 'Command execution failed: '."""
+        a = _make(
+            input_data={"function_name": "execute_command"},
+            output_data={"raw_output": '{"success": 0, "error": "Command execution failed: [Errno 2] boom"}'},
+        )
+        tc = _build_execute_command(a, verbose=False)
+        assert tc.compact_result == "[Errno 2] boom"
+        assert tc.status_mark == "✗"
 
 
 @pytest.mark.ci

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -237,6 +237,17 @@ class TestBashToolExecution:
         assert result.success == 0
         assert "not allowed" in result.error.lower()
 
+    def test_stdin_read_gets_eof_not_hang(self, multi_pattern_tool):
+        """A command reading stdin must receive immediate EOF, never block.
+
+        stdin is redirected to DEVNULL; without it the child inherits the
+        agent's terminal stdin and hangs until the tool timeout, freezing the
+        whole process. Reading stdin here should return an empty string fast.
+        """
+        result = multi_pattern_tool.execute_command('python -c "import sys; print(len(sys.stdin.read()))"')
+        assert result.success == 1
+        assert result.result.strip() == "0"
+
 
 class TestBashToolWorkspaceIsolation:
     def test_workspace_root_resolved(self, python_tool, temp_workspace):


### PR DESCRIPTION
## Why

A cluster of bash-tool robustness/UX problems in the CLI/TUI:

1. **Process hang on stdin** — `subprocess.run` didn't redirect stdin, so a command that reads stdin (`cat`, `read`, `python` awaiting input) blocked forever, fighting the TUI's prompt_toolkit for the same TTY and freezing datus.
2. **No live progress** — bash is ASK-gated; the permission prompt cleared the pinned "running" frame and never restored it, so a long command showed nothing until it finished. And no tool showed elapsed time while running.
3. **Uninformative / memory-heavy output** — output was buffered in memory and truncated at 50K with only a terse `Command exited with code N` surfaced; the real stdout/stderr sat unused. A large output both bloated memory and polluted the model context.
4. **Verbose header/name** — the tool showed `execute_command(command: "sleep 5")`.

## Solution

- **stdin**: redirect the child's stdin to `DEVNULL` — stdin reads get immediate EOF instead of hanging.
- **Running indicator (all tools)**: the PROCESSING frame now shows `· running Ns` (integer seconds), recomputed each repaint; restore the frame after an ASK approval so long ASK-gated tools show live progress.
- **Memory-safe disk offload**: bash streams stdout/stderr straight to a file under the session data dir (same location minor compact uses) instead of `capture_output`; after exit it decides by file size — small output is read back and the temp file deleted, oversized output (>8000 chars) stays on disk and the model gets a `[DATUS_ARCHIVED]` preview+path marker (recoverable via `read_file`, no permission prompt). No offload dir wired (MCP/standalone) → in-memory `MAX_OUTPUT_SIZE` fallback. The `ToolArchive` + marker helpers moved to `datus/utils/tool_archive.py` (shared by the compact pass and bash without an inverted `tools -> agent.node` dep); `compact_archive.py` is now a re-export shim.
- **Compact display**: bash shows the first 3 output lines + `… +N lines (ctrl+o to expand)` (claude-style); failures show the real stderr reason with boilerplate prefixes stripped; verbose renders the full `result` payload.
- **Rename `execute_command` → `bash`**: the model-facing tool name, permission rule (`bash_tools.bash`), registry/formatter keys, and renderer are renamed; the `command` parameter is unchanged, matching the Claude Code `bash(command=...)` signature the Claude/Codex models know. The header now reads `bash("sleep 5")` (positional, no `command:` prefix), and the running frame matches.

Key decisions/tradeoffs: offload threshold 8000 chars (between compact's 1000 and the old 50K hard cap); stderr merged into the stdout file (`stderr=STDOUT`) preserving real interleaving order at the cost of an explicit `[stderr]` section; small bash result envelope may be re-archived by minor compact (harmless, sub-threshold).

## Test Cases

All deterministic unit tests (no real LLM/network):

- `tests/unit_tests/tools/func_tool/test_bash_tool.py`: stdin-read gets EOF not hang; disk-offload paths (small→inline+no residual file, empty→no file, oversized→marker + full file kept, non-zero exit + oversized→`success=0` + marker, no-provider→in-memory truncation); rename verified via `.bash(...)` call sites.
- `tests/unit_tests/utils/test_tool_archive.py` (new): relocated marker/`ToolArchive` round-trip, error-preview widening, bad-kind rejection.
- `tests/unit_tests/cli/action_display/test_tool_content.py` / `test_renderers.py`: `format_running_duration` boundaries; multi-line bash compact (3 lines + `… +N lines`) and archived-preview rendering; single-line tools unchanged; `bash(...)` positional header (no `command:` prefix).
- `tests/unit_tests/cli/action_display/test_streaming.py`: PROCESSING frame restored after ASK approval.
- Existing `test_compact_archive.py` passes unchanged via the re-export shim.

Impacted unit tests pass; diff coverage 91%. (Local acceptance-harness integration failures are environmental — an invalid local `.datus/config.yml` `default_datasource` and missing pre-built KB data — unrelated to this diff.)