### PR TITLE
[Enhancement] Bash tool: memory-safe disk offload, running indicator, rename to `bash`

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2342,7 +2342,7 @@ class AgenticNode(Node):
 
         Available to every agentic node when ``agent.bash.enabled`` is
         ``True`` (the default). ``allowed_patterns=["*"]`` means the tool
-        exposes ``execute_command`` for any shell command; per-call gating
+        exposes ``bash`` for any shell command; per-call gating
         is the responsibility of the ``bash_tools`` ASK rule in the
         permission profile, not a static pattern whitelist.
 
@@ -2399,7 +2399,7 @@ class AgenticNode(Node):
             return None
 
     def _ensure_bash_tool_in_tools(self) -> None:
-        """Ensure the BashTool's ``execute_command`` is in ``self.tools``.
+        """Ensure the BashTool's ``bash`` is in ``self.tools``.
 
         Mirrors :meth:`_ensure_skill_tools_in_tools` — called lazily so the
         late ``setup_tools()`` reset in subclasses doesn't strip the tool.

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2368,11 +2368,35 @@ class AgenticNode(Node):
             self.bash_tool = BashTool(
                 workspace_root=self._resolve_workspace_root(),
                 allowed_patterns=["*"],
+                # Offload oversized command output to the session data dir (the
+                # same location minor compact uses). Resolved lazily: this method
+                # runs before ``session_id`` is finalized, so the closure reads it
+                # at execute time. Returns None until a session id exists → the
+                # tool falls back to in-memory truncation.
+                output_dir_provider=self._bash_output_dir,
             )
             logger.debug(f"Setup bash tool with workspace: {self.bash_tool.workspace_root}")
         except Exception as e:
             logger.error(f"Failed to setup bash tool: {e}")
             self.bash_tool = None
+
+    def _bash_output_dir(self) -> Optional[Path]:
+        """Session data dir for bash output offload, or None if unavailable.
+
+        Reused directory convention as the compact archive
+        (``path_manager.session_data_dir(session_id)``). Returns None before a
+        session id is allocated or when the path manager can't be built, so the
+        bash tool degrades to in-memory truncation.
+        """
+        if not self.session_id:
+            return None
+        try:
+            from datus.utils.path_manager import get_path_manager
+
+            return get_path_manager(agent_config=self.agent_config).session_data_dir(self.session_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Failed to resolve bash output dir: %s", exc)
+            return None
 
     def _ensure_bash_tool_in_tools(self) -> None:
         """Ensure the BashTool's ``execute_command`` is in ``self.tools``.

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2385,10 +2385,12 @@ class AgenticNode(Node):
 
         Reused directory convention as the compact archive
         (``path_manager.session_data_dir(session_id)``). Returns None before a
-        session id is allocated or when the path manager can't be built, so the
-        bash tool degrades to in-memory truncation.
+        session id is allocated, when there is no ``agent_config`` (mirrors
+        ``_resolve_session_data_dir`` — otherwise ``get_path_manager`` would fall
+        back to a process-wide default rooted at ``~/.datus``), or when the path
+        manager can't be built, so the bash tool degrades to in-memory truncation.
         """
-        if not self.session_id:
+        if not self.agent_config or not self.session_id:
             return None
         try:
             from datus.utils.path_manager import get_path_manager

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -448,7 +448,7 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
     def _ensure_bash_tool_in_tools(self) -> None:
         """Gate :class:`AgenticNode`'s lazy bash re-injection on the whitelist.
 
-        ``_finalize_system_prompt`` re-adds ``execute_command`` to
+        ``_finalize_system_prompt`` re-adds ``bash`` to
         ``self.tools`` on every prompt build — AFTER ``setup_tools()`` already
         pruned it — which silently re-exposes bash on an ask_* agent whose
         ``tools`` never granted ``bash_tools`` (the model then sees it in its

--- a/datus/agent/node/compact_archive.py
+++ b/datus/agent/node/compact_archive.py
@@ -2,7 +2,14 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Disk-backed archive for compact tool output.
+"""Compact-pass archiving glue.
+
+The disk-archive primitive (:class:`ToolArchive`) and the ``[DATUS_ARCHIVED]``
+marker helpers now live in :mod:`datus.utils.tool_archive` so both the minor
+compact pass and the bash tool can share them without an inverted
+``tools -> agent.node`` dependency. This module re-exports them for existing
+call sites and keeps the compact-pass-specific item rewriting logic
+(:func:`maybe_truncate_item`).
 
 When the rule-based minor compact pass scans the eligible region (everything
 older than ``keep_recent_user_turns`` user-message turns), any
@@ -30,174 +37,24 @@ Two design properties matter:
 
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
-from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-from datus.utils.exceptions import DatusException, ErrorCode
-from datus.utils.path_manager import DatusPathManager, get_path_manager
+# Re-exported for backwards compatibility with existing import sites
+# (datus/api/services/action_sse_converter.py, tests, etc.).
+from datus.utils.tool_archive import (  # noqa: F401
+    _ERROR_FALLBACK_MARKERS,
+    _ERROR_PREVIEW_MULTIPLIER,
+    ARCHIVED_MARKER,
+    ToolArchive,
+    build_archived_marker,
+    is_archived_output,
+    is_error_output,
+    make_single_line_preview,
+    parse_archived_marker,
+)
 
 logger = logging.getLogger(__name__)
-
-#: Fixed prefix written into ``function_call_output.output`` whenever an item
-#: has been offloaded to disk. The choice of bracketed all-caps keeps the
-#: marker visually distinct from real tool output and unlikely to collide with
-#: any legitimate JSON payload.
-ARCHIVED_MARKER = "[DATUS_ARCHIVED]"
-
-_ERROR_FALLBACK_MARKERS = ('"success": 0', "'success': 0", '"error":', "'error':", "Traceback")
-
-
-def is_archived_output(output_str: Any) -> bool:
-    """Detect whether ``function_call_output.output`` is already a marker.
-
-    ``output`` is a free-form string on the wire (real tool outputs are
-    typically JSON-encoded FuncToolResult envelopes), so prefix matching is
-    enough — no nested decode required.
-    """
-    return isinstance(output_str, str) and output_str.startswith(ARCHIVED_MARKER)
-
-
-def parse_archived_marker(text: Any) -> Optional[Dict[str, str]]:
-    """Parse ``[DATUS_ARCHIVED] path=<p> preview=<t>`` into its parts.
-
-    Returns ``{"path": <abs>, "preview": <text>}`` when ``text`` is a marker
-    string, ``None`` otherwise. Pure string parsing — the archive file at
-    ``path`` is never opened, so callers can surface the inline preview on
-    display surfaces (e.g. ``/chat/history``) without any disk I/O or
-    reverse archival.
-
-    The split uses the literal `` preview=`` delimiter, which appears exactly
-    once and is preceded by a single space in markers produced by
-    :meth:`ToolArchive.archive`. This is robust to spaces inside the path's
-    fallback form ``<unavailable: archive write failed>`` because that token
-    contains no ``preview=`` substring.
-    """
-    if not isinstance(text, str) or not text.startswith(ARCHIVED_MARKER):
-        return None
-    body = text[len(ARCHIVED_MARKER) :].strip()
-    path = ""
-    preview = ""
-    if " preview=" in body:
-        head, preview = body.split(" preview=", 1)
-        if head.startswith("path="):
-            path = head[len("path=") :].strip()
-    elif body.startswith("path="):
-        path = body[len("path=") :].strip()
-    return {"path": path, "preview": preview}
-
-
-#: Error-output preview is widened to this multiple of ``preview_chars`` so
-#: the LLM sees the full traceback / error message inline without needing a
-#: round-trip through ``read_file``. Internal constant — not user-tunable
-#: because the relationship is dictated by error semantics, not policy.
-_ERROR_PREVIEW_MULTIPLIER = 2
-
-
-class ToolArchive:
-    """Writes long tool I/O to disk and returns a plain-text marker.
-
-    The archive directory is resolved through :class:`DatusPathManager` so the
-    storage layout stays in one place (``sessions/{project}/{session_id}/data``).
-    Tests pass ``base_dir`` explicitly to keep writes hermetic.
-    """
-
-    def __init__(
-        self,
-        project_name: str,
-        session_id: str,
-        *,
-        base_dir: Optional[Path] = None,
-        preview_chars: int = 1000,
-        path_manager: Optional[DatusPathManager] = None,
-    ) -> None:
-        if base_dir is not None:
-            self.dir = Path(base_dir)
-        else:
-            pm = path_manager or get_path_manager()
-            # session_data_dir() requires a project-bound path manager; if the
-            # caller passed a generic one we rebuild with project_name.
-            if not pm.project_name or pm.project_name != project_name:
-                pm = DatusPathManager(datus_home=pm.datus_home, project_name=project_name)
-            self.dir = pm.session_data_dir(session_id)
-        self.dir.mkdir(parents=True, exist_ok=True)
-        self.preview_chars = preview_chars
-
-    def archive(self, content: str, message_idx: int, kind: str) -> str:
-        """Persist ``content`` to disk and return a single-line marker string.
-
-        Args:
-            content: Original argument or output text. Always written verbatim;
-                no transformation is performed.
-            message_idx: Zero-padded into the filename so a directory listing
-                sorts in original session order, which makes manual debugging
-                much easier.
-            kind: ``"args"`` (extension ``.json``) or ``"output"`` (extension
-                ``.txt``). Drives both the file extension and the preview
-                strategy (error outputs get a longer preview).
-
-        Returns:
-            A single-line string of the form
-            ``"[DATUS_ARCHIVED] path=<abs> preview=<text>"``. Callers store
-            this verbatim in ``function_call_output.output``.
-        """
-        if kind not in ("args", "output"):
-            raise DatusException(
-                ErrorCode.COMMON_FIELD_INVALID,
-                message_args={
-                    "field_name": "kind",
-                    "except_values": "'args' or 'output'",
-                    "your_value": repr(kind),
-                },
-            )
-        ext = "json" if kind == "args" else "txt"
-        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
-        fname = f"{message_idx:06d}_{kind}_{digest[:8]}.{ext}"
-        path = self.dir / fname
-        # Idempotent write: if the same content lands here (same idx + hash)
-        # we just overwrite — the bytes are identical.
-        path.write_text(content, encoding="utf-8")
-        preview_n = (
-            self.preview_chars * _ERROR_PREVIEW_MULTIPLIER
-            if kind == "output" and self._is_error(content)
-            else self.preview_chars
-        )
-        # Preview is single-line — multi-line previews would break log parsing
-        # and the LLM cares only about the gist anyway.
-        preview = content[:preview_n].replace("\n", " ").replace("\r", " ").strip()
-        return f"{ARCHIVED_MARKER} path={path} preview={preview}"
-
-    @staticmethod
-    def _is_error(output_text: str) -> bool:
-        """Detect FuncToolResult-shaped errors so the preview is widened.
-
-        FuncToolResult (datus/tools/func_tool/base.py) wraps every tool return
-        in ``{"success": 0/1, "error": ..., "result": ...}``. We try a JSON
-        parse first because that is the authoritative envelope; only if the
-        payload is not valid JSON do we fall back to substring matching,
-        which catches things like raw tracebacks or partial JSON written by a
-        crashing tool.
-
-        The substring fallback can false-positive on legitimate non-JSON tool
-        output that happens to contain ``"Traceback"`` or ``"error":`` as data
-        (e.g. a SQL string literal, a log-mining query result). The only
-        consequence is a wider preview for that one entry; correctness of the
-        archived content is unaffected, so we accept the false positive in
-        exchange for not missing real tracebacks emitted by crashing tools.
-        """
-        try:
-            obj = json.loads(output_text)
-        except (json.JSONDecodeError, TypeError, ValueError):
-            return any(m in output_text for m in _ERROR_FALLBACK_MARKERS)
-        if isinstance(obj, dict):
-            if obj.get("success") == 0:
-                return True
-            err = obj.get("error")
-            if isinstance(err, str) and err:
-                return True
-        return False
 
 
 def maybe_truncate_item(
@@ -234,7 +91,7 @@ def maybe_truncate_item(
             logger.warning("compact archive write failed (idx=%s, kind=output): %s", idx, exc)
             preview_n = (
                 archive.preview_chars * _ERROR_PREVIEW_MULTIPLIER
-                if archive._is_error(out_text)
+                if is_error_output(out_text)
                 else archive.preview_chars
             )
             return _inline_truncated(item, out_text, preview_n)
@@ -251,6 +108,6 @@ def _inline_truncated(item: Dict[str, Any], text: str, preview_n: int) -> Dict[s
     crash a session over a transient ENOSPC. The placeholder still carries
     :data:`ARCHIVED_MARKER` so a later pass treats it as already-handled.
     """
-    preview = text[:preview_n].replace("\n", " ").replace("\r", " ").strip()
-    marker = f"{ARCHIVED_MARKER} path=<unavailable: archive write failed> preview={preview}"
+    preview = make_single_line_preview(text, preview_n)
+    marker = build_archived_marker("<unavailable: archive write failed>", preview)
     return {**item, "output": marker}

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -913,12 +913,23 @@ class ActionRenderer:
         args part when none were sent. The elapsed time recomputes on every
         repaint, so it ticks up while the tool runs.
         """
-        from datus.cli.action_display.tool_content import extract_args, format_running_duration
+        from datus.cli.action_display.tool_content import (
+            extract_args,
+            format_running_duration,
+            tool_specific_args_summary,
+        )
 
         function_name = action.input.get("function_name", "") if action.input else ""
         label = function_name or action.messages or ""
-        args_lines = extract_args(action)
-        suffix = f"({_truncate_middle(args_lines[0], max_len=80)})" if args_lines else "..."
+        # Prefer the per-tool summary (e.g. bare ``"sleep 5"`` for bash)
+        # so the running frame matches the completed header; fall back to the
+        # generic ``key: value`` first-arg preview.
+        tool_summary = tool_specific_args_summary(action)
+        if tool_summary:
+            suffix = f"({_truncate_middle(tool_summary, max_len=80)})"
+        else:
+            args_lines = extract_args(action)
+            suffix = f"({_truncate_middle(args_lines[0], max_len=80)})" if args_lines else "..."
         running = f" \u00b7 running {format_running_duration(action.start_time)}"
         body = f"{frame} \U0001f527 {rich_escape(label)}{rich_escape(suffix)}{running}"
         if action.depth > 0:

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -828,9 +828,22 @@ class ActionRenderer:
             status_dot = "[red]\u23fa[/red]" if failed else "[green]\u23fa[/green]"
             header = f"\U0001f527 {rich_escape(tc.label)}({rich_escape(tc.args_summary)})"
             mark = "[red]\u00d7[/red]" if failed else "[green]\u2713[/green]"
-            result_text = tc.compact_result or tc.output_preview
             dur = tc.duration_str.strip()  # "(<0.1s)" or "(12.4s)"
             dur_suffix = f" \u00b7 [dim]{dur.strip('()')}[/dim]" if dur else ""
+
+            # Multi-line compact result (e.g. bash showing the first few output
+            # lines). Continuation rows align under the first line's content; an
+            # overflow row folds the remainder claude-style.
+            if tc.compact_result_lines:
+                first, *rest = tc.compact_result_lines
+                body_lines = [f"  \u2514\u2500 {mark} {rich_escape(first)}{dur_suffix}"]
+                body_lines.extend(f"     {rich_escape(line)}" for line in rest)
+                if tc.compact_result_overflow > 0:
+                    body_lines.append(f"     [dim]\u2026 +{tc.compact_result_overflow} lines (ctrl+o to expand)[/dim]")
+                body = "\n".join(body_lines)
+                return [Text.from_markup(f"{status_dot} {header}\n{body}")]
+
+            result_text = tc.compact_result or tc.output_preview
             if result_text:
                 body = f"  \u2514\u2500 {mark} {rich_escape(result_text)}{dur_suffix}"
             else:
@@ -892,20 +905,22 @@ class ActionRenderer:
     def render_processing(self, action: ActionHistory, frame: str) -> Text:
         """Render the static running indicator for a PROCESSING tool.
 
-        Output: ``{frame} 🔧 {function_name}({first_arg_summary})`` at depth=0
-        (no dim — matches the completed top-level tool header colour), and
-        ``  ⎿  {frame} 🔧 …`` inside a subagent group (depth>0) with
-        ``[dim]`` so it aligns with the other ``⎿`` tool rows under the
-        ``⏺`` header. Falls back to ``{frame} 🔧 {label}...`` when no
-        arguments were sent.
+        Output: ``{frame} 🔧 {function_name}({first_arg_summary}) · running {Ns}``
+        at depth=0 (no dim — matches the completed top-level tool header colour),
+        and ``  ⎿  {frame} 🔧 … · running {Ns}`` inside a subagent group
+        (depth>0) with ``[dim]`` so it aligns with the other ``⎿`` tool rows
+        under the ``⏺`` header. Falls back to ``{frame} 🔧 {label}...`` for the
+        args part when none were sent. The elapsed time recomputes on every
+        repaint, so it ticks up while the tool runs.
         """
-        from datus.cli.action_display.tool_content import extract_args
+        from datus.cli.action_display.tool_content import extract_args, format_running_duration
 
         function_name = action.input.get("function_name", "") if action.input else ""
         label = function_name or action.messages or ""
         args_lines = extract_args(action)
         suffix = f"({_truncate_middle(args_lines[0], max_len=80)})" if args_lines else "..."
-        body = f"{frame} \U0001f527 {rich_escape(label)}{rich_escape(suffix)}"
+        running = f" \u00b7 running {format_running_duration(action.start_time)}"
+        body = f"{frame} \U0001f527 {rich_escape(label)}{rich_escape(suffix)}{running}"
         if action.depth > 0:
             return Text.from_markup(f"[dim]  \u23bf  {body}[/dim]")
         return Text.from_markup(body)

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -742,7 +742,7 @@ class InlineStreamingContext:
             # INTERACTION actions: collect input during live interaction, skip in history
             if action.role == ActionRole.INTERACTION:
                 if action.status == ActionStatus.PROCESSING and self._input_collector:
-                    # An ASK-gated tool (e.g. ``execute_command``) is already
+                    # An ASK-gated tool (e.g. ``bash``) is already
                     # pinned as the running "○ 🔧 tool(...)" frame. Clearing it
                     # to draw the prompt is correct, but the same tool resumes
                     # execution once approved — capture the frame so we can

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -303,19 +303,34 @@ _TOOL_ARGS_FORMATTERS: Dict[str, Callable[[dict], str]] = {
     "web_fetch": lambda a: _format_positional(a, "url"),
     # Skill tools
     "load_skill": lambda a: _format_positional(a, "skill_name", "name"),
-    "execute_command": lambda a: _format_kw(a, "command"),
+    # Positional (bare quoted value) — the command is the whole point, the
+    # ``command:`` key prefix is just noise in the ``bash(...)`` header.
+    "bash": lambda a: _format_positional(a, "command"),
 }
+
+
+def tool_specific_args_summary(action: ActionHistory) -> str:
+    """Return the per-tool concise args summary, or "" when no formatter applies.
+
+    Shared by the completed-tool header (via ``set_tool_specific_args_summary``)
+    and the running (PROCESSING) frame so both render args the same way — e.g.
+    ``bash("sleep 5")`` rather than ``command: "sleep 5"``.
+    """
+    function_name = action.input.get("function_name", "") if action.input else ""
+    formatter = _TOOL_ARGS_FORMATTERS.get(function_name)
+    if formatter is None:
+        return ""
+    try:
+        return formatter(_parse_args_dict(action)) or ""
+    except Exception:  # pragma: no cover - defensive
+        return ""
 
 
 def set_tool_specific_args_summary(tc: ToolCallContent, action: ActionHistory) -> None:
     """Populate ``tc.args_summary`` using a per-tool formatter when available."""
     if tc.args_summary:
         return
-    function_name = action.input.get("function_name", "") if action.input else ""
-    formatter = _TOOL_ARGS_FORMATTERS.get(function_name)
-    if formatter is None:
-        return
-    summary = formatter(_parse_args_dict(action))
+    summary = tool_specific_args_summary(action)
     if summary:
         tc.args_summary = summary
 
@@ -569,7 +584,7 @@ def _format_result_only_markup(output_data, indent: str = "") -> List[str]:
         return format_output_verbose_markup(output_data, indent)
 
     # If there's an error, show it — but keep going to also surface the
-    # ``result`` payload when present. Tools like ``execute_command`` put the
+    # ``result`` payload when present. Tools like ``bash`` put the
     # actual stdout/stderr in ``result`` while ``error`` is only a terse
     # "Command exited with code N"; returning early here would hide the real
     # failure reason and leave the user with no info to act on.
@@ -2015,8 +2030,8 @@ def _build_analyze_metric_candidates(action: ActionHistory, verbose: bool) -> To
     return tc
 
 
-def _build_execute_command(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """execute_command: show the real command output, on success and failure.
+def _build_bash(action: ActionHistory, verbose: bool) -> ToolCallContent:
+    """bash: show the real command output, on success and failure.
 
     The compact line has little room, so surface the meaningful part — the last
     non-empty output line (the stdout result on success, the stderr reason on
@@ -2246,7 +2261,7 @@ class ToolCallContentBuilder:
         self._registry["analyze_metric_candidates_from_history"] = _build_analyze_metric_candidates
 
         # Skill tools
-        self._registry["execute_command"] = _build_execute_command
+        self._registry["bash"] = _build_bash
         self._registry["load_skill"] = _build_load_skill
 
         # Interaction tools

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -13,13 +13,19 @@ Architecture:
 
 import json
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
 from datus.schemas.action_history import ActionHistory, ActionStatus
 from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY
 from datus.utils.loggings import get_logger
+from datus.utils.tool_archive import is_archived_output, parse_archived_marker
 
 logger = get_logger(__name__)
+
+# Max output lines shown inline in a bash compact result before folding into a
+# "… +N lines" row (claude-style).
+COMPACT_MAX_LINES = 3
 
 
 @dataclass
@@ -35,6 +41,12 @@ class ToolCallContent:
     # Compact-mode fields used by the new header + └─ line layout:
     args_summary: str = ""  # concise args for header, e.g. '"orders"' or 'pattern: "*.py"'
     compact_result: str = ""  # concise result for └─ line, e.g. '3 tables: a, b, c'
+    # Optional multi-line compact result (e.g. bash showing the first few output
+    # lines, claude-style). When non-empty the renderer draws one └─ row per
+    # line plus a "… +N lines" overflow row; empty → single-line ``compact_result``
+    # path (unchanged for every other tool).
+    compact_result_lines: List[str] = field(default_factory=list)
+    compact_result_overflow: int = 0  # extra lines beyond those shown
 
 
 # Type alias for custom content builder functions
@@ -56,6 +68,25 @@ def calc_duration(action: ActionHistory) -> str:
             return " (<0.1s)"
         return f" ({duration_sec:.1f}s)"
     return ""
+
+
+def format_running_duration(start_time: Optional[datetime]) -> str:
+    """Elapsed time for a still-running action as a compact whole-second string.
+
+    Used by the PROCESSING frame, which has no ``end_time`` yet. Integer-second
+    granularity (``3s``, ``1m5s``) avoids sub-second flicker at the display's
+    ~4 Hz repaint. Returns ``"0s"`` when ``start_time`` is missing or in the
+    future.
+    """
+    if start_time is None:
+        return "0s"
+    elapsed = int((datetime.now() - start_time).total_seconds())
+    if elapsed < 0:
+        elapsed = 0
+    if elapsed < 60:
+        return f"{elapsed}s"
+    minutes, seconds = divmod(elapsed, 60)
+    return f"{minutes}m{seconds}s"
 
 
 # ── Compact-layout helpers (header args + └─ result line) ──────────
@@ -1998,11 +2029,27 @@ def _build_execute_command(action: ActionHistory, verbose: bool) -> ToolCallCont
         return tc
     data = parse_output_data(action.output)
     output = data.get("result") if isinstance(data, dict) else None
+
+    # Oversized output was offloaded to disk (see BashTool): show the inline
+    # preview split across the first rows, never the raw marker. The full
+    # content is recoverable via ``read_file(<path>)``.
+    if is_archived_output(output):
+        preview = (parse_archived_marker(output) or {}).get("preview", "").strip()
+        tc.compact_result_lines = []
+        if preview:
+            tc.compact_result_lines.append(_truncate_middle(preview, 120))
+        tc.compact_result_lines.append("(large output archived — read_file to view)")
+        tc.compact_result = tc.compact_result_lines[0]
+        return tc
+
     lines: List[str] = []
     if isinstance(output, str) and output.strip():
         lines = [ln for ln in output.splitlines() if ln.strip() and ln.strip() != "[stderr]"]
     if lines:
-        tc.compact_result = _truncate_middle(lines[-1], 80)
+        # Show the first few lines (claude-style), fold the rest into "… +N lines".
+        tc.compact_result_lines = [_truncate_middle(ln, 120) for ln in lines[:COMPACT_MAX_LINES]]
+        tc.compact_result_overflow = max(0, len(lines) - COMPACT_MAX_LINES)
+        tc.compact_result = tc.compact_result_lines[0]  # single-line degrade
     elif tc.status_mark == "✗":
         # No captured output: strip the verbose failure-prefix boilerplate.
         # (Keep "Command exited with code N" / "Command timed out ..." — those

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -2033,11 +2033,14 @@ def _build_analyze_metric_candidates(action: ActionHistory, verbose: bool) -> To
 def _build_bash(action: ActionHistory, verbose: bool) -> ToolCallContent:
     """bash: show the real command output, on success and failure.
 
-    The compact line has little room, so surface the meaningful part — the last
-    non-empty output line (the stdout result on success, the stderr reason on
-    failure) — instead of the boilerplate ``Command executed`` label or the
-    ``Command exited with code N`` prefix. When nothing was captured, fall back
-    to the label / error with its generic exception wrapper stripped.
+    The compact line has little room, so surface the meaningful part — the first
+    ``COMPACT_MAX_LINES`` non-empty output lines (the rest folded into a
+    ``… +N lines`` overflow row), covering the stdout result on success and the
+    stderr reason on failure — instead of the boilerplate ``Command executed``
+    label or the ``Command exited with code N`` prefix. Archived (oversized)
+    output shows the marker preview, never the raw marker. When nothing was
+    captured, fall back to the label / error with its generic exception wrapper
+    stripped.
     """
     tc = _build_simple_action(action, verbose, "Command executed")
     if verbose:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -792,7 +792,7 @@ class AgentConfig:
         self._filesystem_strict = bool(filesystem_raw.get("strict", False))
         # ``bash.enabled`` toggles whether agentic nodes instantiate the
         # general-purpose ``BashTool``. Default ``True`` preserves the
-        # current behaviour where every node exposes ``execute_command``
+        # current behaviour where every node exposes ``bash``
         # (gated by the ``bash_tools`` ASK rule in the permission profile).
         # Set to ``False`` for hardened environments where shell execution
         # must be unavailable regardless of profile.
@@ -994,10 +994,10 @@ class AgentConfig:
         """Whether agentic nodes should instantiate the general-purpose ``BashTool``.
 
         ``True`` (default): every :class:`AgenticNode` exposes
-        ``execute_command``; per-call gating is handled by the
+        ``bash``; per-call gating is handled by the
         ``bash_tools`` ASK rule in the permission profile.
 
-        ``False``: ``BashTool`` is not created and ``execute_command`` is
+        ``False``: ``BashTool`` is not created and ``bash`` is
         not advertised to the model. Use this for hardened deployments
         where shell execution must be unavailable regardless of profile.
         """

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -14,6 +14,7 @@ injected by the caller through ``extra_env``.
 """
 
 import fnmatch
+import hashlib
 import logging
 import os
 import shlex
@@ -21,16 +22,25 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from agents import Tool
 
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.utils.tool_archive import build_archived_marker, make_single_line_preview
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 60
 MAX_OUTPUT_SIZE = 50000
+# Output larger than this is offloaded to a file under the session data dir and
+# replaced with a ``[DATUS_ARCHIVED]`` preview marker, so a huge command output
+# neither buffers in memory nor pollutes the model context. Only applies when an
+# ``output_dir_provider`` is wired (agentic-node sessions); otherwise the tool
+# falls back to the in-memory ``MAX_OUTPUT_SIZE`` truncation.
+BASH_ARCHIVE_THRESHOLD = 8000
+# Single-line preview length carried inline in the archive marker.
+BASH_ARCHIVE_PREVIEW_CHARS = 1000
 
 
 class BashTool:
@@ -67,6 +77,7 @@ class BashTool:
         timeout: int = DEFAULT_TIMEOUT,
         extra_env: Optional[Dict[str, str]] = None,
         identity: Optional[str] = None,
+        output_dir_provider: Optional[Callable[[], Optional[Path]]] = None,
     ):
         """Initialize the bash tool.
 
@@ -80,12 +91,23 @@ class BashTool:
                 to carry caller-specific context (e.g. ``SKILL_NAME``).
             identity: Optional label used in log messages so multiple
                 BashTool instances can be distinguished.
+            output_dir_provider: Optional zero-arg callable returning the
+                directory where oversized command output is offloaded (the
+                session data dir). Resolved lazily per call so the session id
+                need not exist at construction time. When ``None`` (or it
+                returns ``None``), output is captured in memory and truncated
+                at :data:`MAX_OUTPUT_SIZE` — the general-purpose fallback used
+                by MCP / standalone callers and tests.
         """
         self.workspace_root = Path(workspace_root).resolve()
         self.allowed_patterns = list(allowed_patterns) if allowed_patterns else []
         self.timeout = timeout
         self.extra_env = dict(extra_env) if extra_env else {}
         self.identity = identity
+        self._output_dir_provider = output_dir_provider
+        # Monotonic per-instance counter zero-padded into archive filenames so a
+        # directory listing sorts in command-invocation order.
+        self._bash_output_seq = 0
         self._tool_context: Any = None
 
         logger.debug(
@@ -133,48 +155,164 @@ class BashTool:
         if argv and argv[0] == "python":
             argv[0] = sys.executable or shutil.which("python3") or "python3"
 
+        logger.info("Executing command (identity=%s): %s", self.identity, command)
+        output_dir = self._resolve_output_dir()
         try:
-            logger.info("Executing command (identity=%s): %s", self.identity, command)
-
-            result = subprocess.run(
-                argv,
-                shell=False,
-                cwd=str(self.workspace_root),
-                capture_output=True,
-                text=True,
-                timeout=self.timeout,
-                env=self._get_safe_env(),
-                # Detach the child from the agent's stdin. Without this the child
-                # inherits datus's terminal stdin and any command that reads it
-                # (``cat``, ``read``, ``python`` awaiting input, an interactive
-                # prompt) blocks forever, fighting the TUI's prompt_toolkit for
-                # the same TTY and freezing the whole process. DEVNULL delivers
-                # an immediate EOF so such commands fail fast instead of hanging.
-                stdin=subprocess.DEVNULL,
-            )
-
-            output = result.stdout
-            if result.stderr:
-                output += f"\n[stderr]\n{result.stderr}"
-
-            if len(output) > MAX_OUTPUT_SIZE:
-                output = output[:MAX_OUTPUT_SIZE] + f"\n... [truncated, total {len(output)} chars]"
-
-            if result.returncode != 0:
-                return FuncToolResult(
-                    success=0,
-                    error=f"Command exited with code {result.returncode}",
-                    result=output,
-                )
-
-            return FuncToolResult(success=1, result=output)
-
+            if output_dir is not None:
+                # Preferred path: stream the child's output straight to disk so
+                # a huge output never buffers in memory; decide by file size
+                # afterwards. Timeout is handled inside so the partial file is
+                # still surfaced.
+                return self._execute_with_redirect(argv, command, output_dir)
+            return self._execute_in_memory(argv)
         except subprocess.TimeoutExpired:
             logger.error("Command timed out (identity=%s): %s", self.identity, command)
             return FuncToolResult(success=0, error=f"Command timed out after {self.timeout} seconds")
         except Exception as e:
             logger.error("Command execution failed (identity=%s): %s", self.identity, e)
             return FuncToolResult(success=0, error=f"Command execution failed: {str(e)}")
+
+    def _resolve_output_dir(self) -> Optional[Path]:
+        """Resolve the offload directory lazily, tolerating any provider error.
+
+        Returns ``None`` (→ in-memory fallback) when no provider is wired, the
+        provider yields nothing, or the directory can't be created.
+        """
+        if self._output_dir_provider is None:
+            return None
+        try:
+            raw = self._output_dir_provider()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("bash output_dir_provider raised: %s", exc)
+            return None
+        if not raw:
+            return None
+        path = Path(raw)
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.debug("bash output dir mkdir failed (%s): %s", path, exc)
+            return None
+        return path
+
+    def _execute_with_redirect(self, argv: List[str], command: str, output_dir: Path) -> FuncToolResult:
+        """Run the command with stdout/stderr redirected to a file on disk.
+
+        stderr is merged into the stdout file (``stderr=STDOUT``) so interleaved
+        output keeps its real order. After the process exits the file size
+        decides the outcome:
+
+        - empty      → delete the file, return an empty result;
+        - <= threshold → read the (small) content back, delete the file;
+        - > threshold  → read only a head preview, keep the file and return a
+          ``[DATUS_ARCHIVED]`` marker so the model can ``read_file(<path>)``.
+        """
+        seq = self._bash_output_seq
+        self._bash_output_seq += 1
+        cmd_hash = hashlib.sha256(command.encode("utf-8")).hexdigest()[:8]
+        path = output_dir / f"{seq:06d}_bash_{cmd_hash}.txt"
+
+        timed_out = False
+        returncode = 0
+        try:
+            with open(path, "wb") as fh:
+                proc = subprocess.run(
+                    argv,
+                    shell=False,
+                    cwd=str(self.workspace_root),
+                    stdout=fh,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    timeout=self.timeout,
+                    env=self._get_safe_env(),
+                )
+            returncode = proc.returncode
+        except subprocess.TimeoutExpired:
+            # The child is killed but the file holds whatever it wrote so far.
+            timed_out = True
+            logger.error("Command timed out (identity=%s): %s", self.identity, command)
+
+        result_str = self._result_from_output_file(path)
+
+        if timed_out:
+            return FuncToolResult(
+                success=0,
+                error=f"Command timed out after {self.timeout} seconds",
+                result=result_str or None,
+            )
+        if returncode != 0:
+            return FuncToolResult(
+                success=0,
+                error=f"Command exited with code {returncode}",
+                result=result_str or None,
+            )
+        return FuncToolResult(success=1, result=result_str)
+
+    def _result_from_output_file(self, path: Path) -> str:
+        """Turn the on-disk output file into a model-facing result string.
+
+        Never loads more than ``BASH_ARCHIVE_PREVIEW_CHARS`` into memory for an
+        oversized file.
+        """
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return ""
+
+        if size == 0:
+            self._safe_unlink(path)
+            return ""
+        if size <= BASH_ARCHIVE_THRESHOLD:
+            content = path.read_text(encoding="utf-8", errors="replace")
+            self._safe_unlink(path)
+            return content
+        # Oversized: read only the head for the inline preview; keep the file.
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            head = fh.read(BASH_ARCHIVE_PREVIEW_CHARS)
+        preview = make_single_line_preview(head, BASH_ARCHIVE_PREVIEW_CHARS)
+        return build_archived_marker(path, preview)
+
+    @staticmethod
+    def _safe_unlink(path: Path) -> None:
+        try:
+            path.unlink()
+        except OSError:  # pragma: no cover - best effort cleanup
+            pass
+
+    def _execute_in_memory(self, argv: List[str]) -> FuncToolResult:
+        """Fallback path (no offload dir): capture output in memory + truncate."""
+        result = subprocess.run(
+            argv,
+            shell=False,
+            cwd=str(self.workspace_root),
+            capture_output=True,
+            text=True,
+            timeout=self.timeout,
+            env=self._get_safe_env(),
+            # Detach the child from the agent's stdin. Without this the child
+            # inherits datus's terminal stdin and any command that reads it
+            # (``cat``, ``read``, ``python`` awaiting input, an interactive
+            # prompt) blocks forever, fighting the TUI's prompt_toolkit for
+            # the same TTY and freezing the whole process. DEVNULL delivers
+            # an immediate EOF so such commands fail fast instead of hanging.
+            stdin=subprocess.DEVNULL,
+        )
+
+        output = result.stdout
+        if result.stderr:
+            output += f"\n[stderr]\n{result.stderr}"
+
+        if len(output) > MAX_OUTPUT_SIZE:
+            output = output[:MAX_OUTPUT_SIZE] + f"\n... [truncated, total {len(output)} chars]"
+
+        if result.returncode != 0:
+            return FuncToolResult(
+                success=0,
+                error=f"Command exited with code {result.returncode}",
+                result=output,
+            )
+
+        return FuncToolResult(success=1, result=output)
 
     def _is_command_allowed(self, command: str) -> bool:
         """Check if a command matches any allowed pattern."""

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -121,7 +121,7 @@ class BashTool:
         """Set tool context (called by framework before tool invocation)."""
         self._tool_context = ctx
 
-    def execute_command(self, command: str) -> FuncToolResult:
+    def bash(self, command: str) -> FuncToolResult:
         """Execute a shell command if it matches the allowed patterns.
 
         The command runs in ``workspace_root`` with ``shell=False``. Only
@@ -391,4 +391,4 @@ class BashTool:
         """
         if not self.allowed_patterns:
             return []
-        return [trans_to_function_tool(self.execute_command)]
+        return [trans_to_function_tool(self.bash)]

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -15,21 +15,22 @@ injected by the caller through ``extra_env``.
 
 import fnmatch
 import hashlib
-import logging
 import os
 import shlex
 import shutil
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from agents import Tool
 
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.utils.loggings import get_logger
 from datus.utils.tool_archive import build_archived_marker, make_single_line_preview
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DEFAULT_TIMEOUT = 60
 MAX_OUTPUT_SIZE = 50000
@@ -106,8 +107,13 @@ class BashTool:
         self.identity = identity
         self._output_dir_provider = output_dir_provider
         # Monotonic per-instance counter zero-padded into archive filenames so a
-        # directory listing sorts in command-invocation order.
+        # directory listing sorts in command-invocation order. Paired with a
+        # per-instance random token so a recreated/resumed BashTool (which
+        # restarts the counter at 0 against the same reused offload dir) never
+        # overwrites an earlier instance's archive — stale ``[DATUS_ARCHIVED]``
+        # markers would otherwise point at the wrong payload.
         self._bash_output_seq = 0
+        self._bash_output_token = uuid.uuid4().hex[:8]
         self._tool_context: Any = None
 
         logger.debug(
@@ -210,7 +216,7 @@ class BashTool:
         seq = self._bash_output_seq
         self._bash_output_seq += 1
         cmd_hash = hashlib.sha256(command.encode("utf-8")).hexdigest()[:8]
-        path = output_dir / f"{seq:06d}_bash_{cmd_hash}.txt"
+        path = output_dir / f"{seq:06d}_{self._bash_output_token}_bash_{cmd_hash}.txt"
 
         timed_out = False
         returncode = 0

--- a/datus/tools/mcp_tools/README.md
+++ b/datus/tools/mcp_tools/README.md
@@ -206,7 +206,7 @@ All tools are permitted except those specifically blocked.
 mcp_tool.set_tool_filter(
     "my-server",
     allowed_tools=None,  # Not used with blocklist
-    blocked_tools=["delete_file", "execute_command", "system_shutdown"],
+    blocked_tools=["delete_file", "bash", "system_shutdown"],
     enabled=True
 )
 ```

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -154,7 +154,7 @@ _NORMAL_RULES = [
     # General-purpose bash execution: always ASK in normal/auto so a stray
     # command can't run without user consent. ``dangerous`` profile (default
     # ALLOW, no rules) lets it through.
-    _rule("bash_tools", "execute_command", PermissionLevel.ASK),
+    _rule("bash_tools", "bash", PermissionLevel.ASK),
 ]
 
 NORMAL = PermissionConfig(

--- a/datus/utils/tool_archive.py
+++ b/datus/utils/tool_archive.py
@@ -1,0 +1,213 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Disk-backed archive for long tool I/O, shared across the codebase.
+
+Two producers write the same ``[DATUS_ARCHIVED]`` marker so a single parser
+(:func:`parse_archived_marker`) understands both:
+
+1. The rule-based minor compact pass (``datus/agent/node/compact_archive.py``)
+   offloads oversized ``function_call_output.output`` items during compaction.
+2. The bash tool (``datus/tools/func_tool/bash_tool.py``) offloads a command's
+   output at execution time when it crosses the tool's threshold.
+
+Both write under ``path_manager.session_data_dir(session_id)`` and replace the
+in-context payload with a single-line marker carrying the absolute file path and
+a short preview, so the LLM can ``read_file(<path>)`` to recover the original.
+
+This module lives under ``datus/utils`` (its only dependencies are
+``path_manager`` and ``exceptions``) so ``datus/tools`` can import it without an
+inverted ``tools -> agent.node`` dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.path_manager import DatusPathManager, get_path_manager
+
+logger = logging.getLogger(__name__)
+
+#: Fixed prefix written into an offloaded payload whenever an item has been
+#: moved to disk. The bracketed all-caps keeps the marker visually distinct from
+#: real tool output and unlikely to collide with any legitimate JSON payload.
+ARCHIVED_MARKER = "[DATUS_ARCHIVED]"
+
+_ERROR_FALLBACK_MARKERS = ('"success": 0', "'success': 0", '"error":', "'error':", "Traceback")
+
+#: Error-output preview is widened to this multiple of ``preview_chars`` so the
+#: LLM sees the full traceback / error message inline without needing a
+#: round-trip through ``read_file``. Internal constant — not user-tunable
+#: because the relationship is dictated by error semantics, not policy.
+_ERROR_PREVIEW_MULTIPLIER = 2
+
+
+def build_archived_marker(path: Any, preview: str) -> str:
+    """Compose the canonical single-line ``[DATUS_ARCHIVED]`` marker.
+
+    Keeping the format in one place guarantees every producer (compact pass,
+    bash tool) emits a string that :func:`parse_archived_marker` can split. The
+    `` preview=`` delimiter must appear exactly once and be preceded by a single
+    space, so callers pass an already-single-line ``preview``.
+    """
+    return f"{ARCHIVED_MARKER} path={path} preview={preview}"
+
+
+def is_archived_output(output_str: Any) -> bool:
+    """Detect whether an offloaded payload is already a marker.
+
+    ``output`` is a free-form string on the wire (real tool outputs are
+    typically JSON-encoded FuncToolResult envelopes), so prefix matching is
+    enough — no nested decode required.
+    """
+    return isinstance(output_str, str) and output_str.startswith(ARCHIVED_MARKER)
+
+
+def parse_archived_marker(text: Any) -> Optional[Dict[str, str]]:
+    """Parse ``[DATUS_ARCHIVED] path=<p> preview=<t>`` into its parts.
+
+    Returns ``{"path": <abs>, "preview": <text>}`` when ``text`` is a marker
+    string, ``None`` otherwise. Pure string parsing — the archive file at
+    ``path`` is never opened, so callers can surface the inline preview on
+    display surfaces (e.g. ``/chat/history``) without any disk I/O or
+    reverse archival.
+
+    The split uses the literal `` preview=`` delimiter, which appears exactly
+    once and is preceded by a single space in markers produced by
+    :func:`build_archived_marker`. This is robust to spaces inside the path's
+    fallback form ``<unavailable: archive write failed>`` because that token
+    contains no ``preview=`` substring.
+    """
+    if not isinstance(text, str) or not text.startswith(ARCHIVED_MARKER):
+        return None
+    body = text[len(ARCHIVED_MARKER) :].strip()
+    path = ""
+    preview = ""
+    if " preview=" in body:
+        head, preview = body.split(" preview=", 1)
+        if head.startswith("path="):
+            path = head[len("path=") :].strip()
+    elif body.startswith("path="):
+        path = body[len("path=") :].strip()
+    return {"path": path, "preview": preview}
+
+
+def is_error_output(output_text: str) -> bool:
+    """Detect FuncToolResult-shaped errors so the preview can be widened.
+
+    FuncToolResult (datus/tools/func_tool/base.py) wraps every tool return in
+    ``{"success": 0/1, "error": ..., "result": ...}``. We try a JSON parse
+    first because that is the authoritative envelope; only if the payload is
+    not valid JSON do we fall back to substring matching, which catches things
+    like raw tracebacks or partial JSON written by a crashing tool.
+
+    The substring fallback can false-positive on legitimate non-JSON tool
+    output that happens to contain ``"Traceback"`` or ``"error":`` as data
+    (e.g. a SQL string literal, a log-mining query result). The only
+    consequence is a wider preview for that one entry; correctness of the
+    archived content is unaffected, so we accept the false positive in
+    exchange for not missing real tracebacks emitted by crashing tools.
+    """
+    try:
+        obj = json.loads(output_text)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return any(m in output_text for m in _ERROR_FALLBACK_MARKERS)
+    if isinstance(obj, dict):
+        if obj.get("success") == 0:
+            return True
+        err = obj.get("error")
+        if isinstance(err, str) and err:
+            return True
+    return False
+
+
+def make_single_line_preview(content: str, preview_chars: int) -> str:
+    """Return a single-line, length-bounded preview of ``content``.
+
+    Newlines/carriage-returns are flattened to spaces because multi-line
+    previews would break the ``[DATUS_ARCHIVED] ... preview=<text>`` marker's
+    single-line contract and the LLM cares only about the gist anyway.
+    """
+    return content[:preview_chars].replace("\n", " ").replace("\r", " ").strip()
+
+
+class ToolArchive:
+    """Writes long tool I/O to disk and returns a plain-text marker.
+
+    The archive directory is resolved through :class:`DatusPathManager` so the
+    storage layout stays in one place (``sessions/{project}/{session_id}/data``).
+    Tests pass ``base_dir`` explicitly to keep writes hermetic.
+    """
+
+    def __init__(
+        self,
+        project_name: str,
+        session_id: str,
+        *,
+        base_dir: Optional[Path] = None,
+        preview_chars: int = 1000,
+        path_manager: Optional[DatusPathManager] = None,
+    ) -> None:
+        if base_dir is not None:
+            self.dir = Path(base_dir)
+        else:
+            pm = path_manager or get_path_manager()
+            # session_data_dir() requires a project-bound path manager; if the
+            # caller passed a generic one we rebuild with project_name.
+            if not pm.project_name or pm.project_name != project_name:
+                pm = DatusPathManager(datus_home=pm.datus_home, project_name=project_name)
+            self.dir = pm.session_data_dir(session_id)
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.preview_chars = preview_chars
+
+    def archive(self, content: str, message_idx: int, kind: str) -> str:
+        """Persist ``content`` to disk and return a single-line marker string.
+
+        Args:
+            content: Original argument or output text. Always written verbatim;
+                no transformation is performed.
+            message_idx: Zero-padded into the filename so a directory listing
+                sorts in original session order, which makes manual debugging
+                much easier.
+            kind: ``"args"`` (extension ``.json``) or ``"output"`` (extension
+                ``.txt``). Drives both the file extension and the preview
+                strategy (error outputs get a longer preview).
+
+        Returns:
+            A single-line string of the form
+            ``"[DATUS_ARCHIVED] path=<abs> preview=<text>"``. Callers store
+            this verbatim in ``function_call_output.output``.
+        """
+        if kind not in ("args", "output"):
+            raise DatusException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                message_args={
+                    "field_name": "kind",
+                    "except_values": "'args' or 'output'",
+                    "your_value": repr(kind),
+                },
+            )
+        ext = "json" if kind == "args" else "txt"
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        fname = f"{message_idx:06d}_{kind}_{digest[:8]}.{ext}"
+        path = self.dir / fname
+        # Idempotent write: if the same content lands here (same idx + hash)
+        # we just overwrite — the bytes are identical.
+        path.write_text(content, encoding="utf-8")
+        preview_n = (
+            self.preview_chars * _ERROR_PREVIEW_MULTIPLIER
+            if kind == "output" and is_error_output(content)
+            else self.preview_chars
+        )
+        return build_archived_marker(path, make_single_line_preview(content, preview_n))
+
+    # Backwards-compat alias: the previous private helper name.
+    @staticmethod
+    def _is_error(output_text: str) -> bool:
+        return is_error_output(output_text)

--- a/datus/utils/tool_archive.py
+++ b/datus/utils/tool_archive.py
@@ -25,14 +25,14 @@ from __future__ import annotations
 
 import hashlib
 import json
-import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.loggings import get_logger
 from datus.utils.path_manager import DatusPathManager, get_path_manager
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 #: Fixed prefix written into an offloaded payload whenever an item has been
 #: moved to disk. The bracketed all-caps keeps the marker visually distinct from

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -746,7 +746,7 @@ class TestSkillIntegrationEdgeCases:
         """Test that finalize_system_prompt preserves existing tools."""
         mock_agent_config.agentic_nodes = {"test_node": {"skills": "sql-*"}}
         # BashTool is fail-closed when no permission manager exists; wire a
-        # permissive config so the lazy injector includes ``execute_command``.
+        # permissive config so the lazy injector includes ``bash``.
         mock_agent_config.permissions_config = PermissionConfig(default_permission=PermissionLevel.ALLOW)
         mock_agent_config.active_profile_name = "normal"
         # Local web_search is mounted only when a Tavily key resolves; pin one so
@@ -781,7 +781,7 @@ class TestSkillIntegrationEdgeCases:
         assert "tool1" in tool_names
         assert "tool2" in tool_names
         assert "load_skill" in tool_names
-        assert "execute_command" in tool_names
+        assert "bash" in tool_names
         assert "add_memory" in tool_names
         assert "edit_memory" in tool_names
         assert "web_search" in tool_names
@@ -1048,7 +1048,7 @@ class TestBashToolToggle:
 
         assert isinstance(node.bash_tool, BashTool)
         bash_names = {t.name for t in node.bash_tool.available_tools()}
-        assert "execute_command" in bash_names
+        assert "bash" in bash_names
 
     def test_bash_tool_disabled_via_config(self, mock_agent_config):
         """``bash_tool_enabled=False`` keeps ``BashTool`` out of the node."""
@@ -1077,7 +1077,7 @@ class TestBashToolToggle:
         """Without permission enforcement, BashTool must NOT be created.
 
         ``_ensure_permission_hooks`` is a no-op when ``permission_manager``
-        is ``None``, so creating an ``execute_command`` tool would expose
+        is ``None``, so creating an ``bash`` tool would expose
         unrestricted shell execution to the model. Fail closed instead.
         """
         # ``permissions_config = None`` short-circuits ``_setup_permission_manager``,

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -2187,14 +2187,14 @@ class TestChatDecoupling:
         assert "You are a helpful AI assistant integrated with Datus-agent" not in prompt
 
     def test_bash_not_reinjected_after_prompt_build(self, real_agent_config):
-        """``execute_command`` stays out of the surface across a prompt build
+        """``bash`` stays out of the surface across a prompt build
         when ``bash_tools`` isn't whitelisted — the core lazy-injection leak."""
         node = _make_ask_report_with_tools(
             real_agent_config, "date_parsing_tools.*,filesystem_tools.*", name="ask_nobash", slug="nobash"
         )
-        assert "execute_command" not in _tool_names(node)
+        assert "bash" not in _tool_names(node)
         node._get_system_prompt()  # runs the lazy bash re-injection path
-        assert "execute_command" not in _tool_names(node), "bash leaked via prompt-build lazy injection"
+        assert "bash" not in _tool_names(node), "bash leaked via prompt-build lazy injection"
 
     def test_skills_not_reinjected_after_prompt_build(self, real_agent_config):
         """Same lazy-injection bypass as bash, for the skill loader tools."""
@@ -2207,12 +2207,12 @@ class TestChatDecoupling:
 
     def test_bash_present_when_whitelisted(self, real_agent_config):
         """The gate is whitelist-driven, not a blanket block: ``bash_tools.*``
-        keeps ``execute_command`` available through the prompt build."""
+        keeps ``bash`` available through the prompt build."""
         node = _make_ask_report_with_tools(
             real_agent_config, "bash_tools.*,filesystem_tools.*", name="ask_bash", slug="withbash"
         )
         node._get_system_prompt()
-        assert "execute_command" in _tool_names(node)
+        assert "bash" in _tool_names(node)
 
     def test_skills_present_when_whitelisted(self, real_agent_config):
         """Symmetric to bash: ``skills.*`` keeps the skill loader tool through

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -270,13 +270,13 @@ class TestChatAgenticNodeToolSetup:
         assert isinstance(node.bash_tool, BashTool)
 
         # ``["*"]`` pattern: tool is exposed; per-call gating is handled by
-        # the PermissionManager ``bash_tools.execute_command`` ASK rule.
+        # the PermissionManager ``bash_tools.bash`` ASK rule.
         tool_names = [t.name for t in node.tools]
-        assert "execute_command" in tool_names
+        assert "bash" in tool_names
 
         # Permission category mapping is mandatory — without it, the ASK rule
         # added in ``profiles._NORMAL_RULES`` would never fire.
-        assert node.tool_registry.get("execute_command") == "bash_tools"
+        assert node.tool_registry.get("bash") == "bash_tools"
 
     def test_context_search_failure_does_not_remove_db_tools(self, real_agent_config, mock_llm_create):
         """Embedding/context setup failures should only remove context tools."""

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -488,6 +488,33 @@ class TestRenderMainAction:
         text = _plain(result)
         assert "list_tables" in text
 
+    def test_bash_multiline_result_folds_extra_lines(self):
+        """bash compact result renders first 3 lines + a '… +N lines' overflow row."""
+        out = "\\n".join(f"line{i}" for i in range(10))
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            input_data={"function_name": "execute_command", "arguments": {"command": "ls"}},
+            output_data={"raw_output": f'{{"success": 1, "result": "{out}"}}'},
+        )
+        result = _renderer().render_main_action(action, verbose=False)
+        text = _plain(result)
+        assert "line0" in text and "line1" in text and "line2" in text
+        assert "line3" not in text  # folded
+        assert "… +7 lines" in text
+
+    def test_single_line_tool_returns_one_text(self):
+        """Regression: tools without multi-line compact fields render exactly one line block."""
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            input_data={"function_name": "list_tables"},
+            output_data={"raw_output": '{"success": 1, "result": ["a", "b"]}'},
+        )
+        result = _renderer().render_main_action(action, verbose=False)
+        # No overflow / continuation rows for a plain single-line result.
+        assert "… +" not in _plain(result)
+
     def test_task_tool_renders_as_subagent(self):
         """TOOL(task) action renders as subagent summary."""
         action = _make_action(
@@ -652,6 +679,30 @@ class TestRenderProcessing:
         assert "list_tables" in result.plain
         assert result.plain.startswith("\u25cb ")
 
+    def test_processing_shows_running_elapsed(self):
+        """PROCESSING frame appends a `· running Ns` elapsed suffix (all tools)."""
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            input_data={"function_name": "execute_command", "arguments": {"command": "sleep 5"}},
+            start_time=datetime.now() - timedelta(seconds=3),
+        )
+        result = _renderer().render_processing(action, "○")
+        assert "running 3s" in result.plain
+
+    def test_processing_depth_gt_zero_dim_and_elbow(self):
+        """Sub-agent (depth>0) PROCESSING frame keeps the ⎿ elbow and running suffix."""
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            input_data={"function_name": "execute_command", "arguments": {"command": "ls"}},
+            start_time=datetime.now() - timedelta(seconds=1),
+        )
+        result = _renderer().render_processing(action, "○")
+        assert "⎿" in result.plain
+        assert "running 1s" in result.plain
+
     def test_processing_includes_first_argument(self):
         """PROCESSING frame includes the first argument as `(key: value)` summary."""
         action = _make_action(
@@ -675,7 +726,9 @@ class TestRenderProcessing:
             input_data={"function_name": "list_tables"},
         )
         result = _renderer().render_processing(action, "\u25cb")
-        assert result.plain.endswith("list_tables...")
+        # Args fall back to "..."; a running-duration suffix now trails the frame.
+        assert "list_tables..." in result.plain
+        assert "running" in result.plain
 
     def test_processing_truncates_long_argument_value(self):
         """Long argument values get middle-truncated at 80 chars."""

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -494,7 +494,7 @@ class TestRenderMainAction:
         action = _make_action(
             ActionRole.TOOL,
             ActionStatus.SUCCESS,
-            input_data={"function_name": "execute_command", "arguments": {"command": "ls"}},
+            input_data={"function_name": "bash", "arguments": {"command": "ls"}},
             output_data={"raw_output": f'{{"success": 1, "result": "{out}"}}'},
         )
         result = _renderer().render_main_action(action, verbose=False)
@@ -684,7 +684,7 @@ class TestRenderProcessing:
         action = _make_action(
             ActionRole.TOOL,
             ActionStatus.PROCESSING,
-            input_data={"function_name": "execute_command", "arguments": {"command": "sleep 5"}},
+            input_data={"function_name": "bash", "arguments": {"command": "sleep 5"}},
             start_time=datetime.now() - timedelta(seconds=3),
         )
         result = _renderer().render_processing(action, "○")
@@ -696,7 +696,7 @@ class TestRenderProcessing:
             ActionRole.TOOL,
             ActionStatus.PROCESSING,
             depth=1,
-            input_data={"function_name": "execute_command", "arguments": {"command": "ls"}},
+            input_data={"function_name": "bash", "arguments": {"command": "ls"}},
             start_time=datetime.now() - timedelta(seconds=1),
         )
         result = _renderer().render_processing(action, "○")
@@ -744,8 +744,9 @@ class TestRenderProcessing:
         result = _renderer().render_processing(action, "\u25cb")
         # Truncation helper inserts " ... " separator in the middle.
         assert " ... " in result.plain
-        # Key label remains visible.
-        assert "sql:" in result.plain
+        # Value is shown positionally (matching the completed header), no key prefix.
+        assert "SELECT" in result.plain
+        assert "sql:" not in result.plain
 
     def test_processing_indents_inside_subagent(self):
         """PROCESSING row inside a subagent (depth>0) gets the `  ⎿  ` prefix."""

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -818,7 +818,7 @@ class TestStreamingInteractionProcessing:
     def test_processing_frame_restored_after_ask_approval(self):
         """A tool pinned as the running frame is restored after an ASK approval.
 
-        Regression: ``execute_command`` (bash) is ASK-gated, so a permission
+        Regression: ``bash`` (bash) is ASK-gated, so a permission
         INTERACTION fires while the tool's PROCESSING frame is pinned. The
         interaction handler clears the frame to draw the prompt; without a
         restore the (possibly long) bash then runs with a blank pinned region
@@ -848,9 +848,9 @@ class TestStreamingInteractionProcessing:
         bash_action = _make_action(
             ActionRole.TOOL,
             ActionStatus.PROCESSING,
-            messages="Tool call: execute_command",
-            action_type="execute_command",
-            input_data={"function_name": "execute_command", "arguments": {"command": "sleep 5"}},
+            messages="Tool call: bash",
+            action_type="bash",
+            input_data={"function_name": "bash", "arguments": {"command": "sleep 5"}},
         )
         ctx._processing_action = bash_action
 

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -18,12 +18,12 @@ from datus.cli.action_display.tool_content import (
     _build_analyze_relationships,
     _build_ask_user,
     _build_attribution_analyze,
+    _build_bash,
     _build_check_exists,
     _build_describe_table,
     _build_doc_search_result,
     _build_end_generation,
     _build_end_metric_generation,
-    _build_execute_command,
     _build_generate_sql_summary_id,
     _build_get_detail,
     _build_get_dimensions,
@@ -1795,10 +1795,10 @@ class TestBuildExecuteCommand:
     def test_compact_success_shows_first_lines(self):
         """Successful command surfaces the real output, first lines first (claude-style)."""
         a = _make(
-            input_data={"function_name": "execute_command"},
+            input_data={"function_name": "bash"},
             output_data={"raw_output": '{"success": 1, "result": "line one\\nline two"}'},
         )
-        tc = _build_execute_command(a, verbose=False)
+        tc = _build_bash(a, verbose=False)
         assert tc.compact_result_lines == ["line one", "line two"]
         assert tc.compact_result_overflow == 0
         assert tc.compact_result == "line one"  # single-line degrade
@@ -1808,10 +1808,10 @@ class TestBuildExecuteCommand:
         """More than COMPACT_MAX_LINES output lines fold into an overflow count."""
         out = "\\n".join(f"line{i}" for i in range(10))
         a = _make(
-            input_data={"function_name": "execute_command"},
+            input_data={"function_name": "bash"},
             output_data={"raw_output": f'{{"success": 1, "result": "{out}"}}'},
         )
-        tc = _build_execute_command(a, verbose=False)
+        tc = _build_bash(a, verbose=False)
         assert tc.compact_result_lines == ["line0", "line1", "line2"]
         assert tc.compact_result_overflow == 7
 
@@ -1821,27 +1821,27 @@ class TestBuildExecuteCommand:
 
         marker = build_archived_marker("/tmp/000001_bash_ab.txt", "hello world preview")
         a = _make(
-            input_data={"function_name": "execute_command"},
+            input_data={"function_name": "bash"},
             output_data={"raw_output": json.dumps({"success": 1, "result": marker})},
         )
-        tc = _build_execute_command(a, verbose=False)
+        tc = _build_bash(a, verbose=False)
         assert any("hello world preview" in line for line in tc.compact_result_lines)
         assert all("[DATUS_ARCHIVED]" not in line for line in tc.compact_result_lines)
         assert any("read_file" in line for line in tc.compact_result_lines)
 
     def test_compact_success_no_output_falls_back_to_label(self):
         a = _make(
-            input_data={"function_name": "execute_command"},
+            input_data={"function_name": "bash"},
             output_data={"raw_output": '{"success": 1, "result": ""}'},
         )
-        tc = _build_execute_command(a, verbose=False)
+        tc = _build_bash(a, verbose=False)
         assert tc.compact_result == "Command executed"
         assert tc.compact_result_lines == []
 
     def test_compact_failure_shows_stderr_reason(self):
         """Non-zero exit: the stderr reason is visible (no 'exited with code' prefix)."""
         a = _make(
-            input_data={"function_name": "execute_command"},
+            input_data={"function_name": "bash"},
             output_data={
                 "raw_output": (
                     '{"success": 0, "error": "Command exited with code 1", '
@@ -1849,7 +1849,7 @@ class TestBuildExecuteCommand:
                 )
             },
         )
-        tc = _build_execute_command(a, verbose=False)
+        tc = _build_bash(a, verbose=False)
         assert tc.compact_result_lines == ["run", "foo: command not found"]
         assert all("exited with code" not in line for line in tc.compact_result_lines)
         assert tc.status_mark == "✗"
@@ -1857,10 +1857,10 @@ class TestBuildExecuteCommand:
     def test_compact_failure_strips_exception_prefix(self):
         """Exception path with no captured output: strip 'Command execution failed: '."""
         a = _make(
-            input_data={"function_name": "execute_command"},
+            input_data={"function_name": "bash"},
             output_data={"raw_output": '{"success": 0, "error": "Command execution failed: [Errno 2] boom"}'},
         )
-        tc = _build_execute_command(a, verbose=False)
+        tc = _build_bash(a, verbose=False)
         assert tc.compact_result == "[Errno 2] boom"
         assert tc.status_mark == "✗"
 
@@ -2025,7 +2025,7 @@ class TestAllToolsRegistered:
         "profile_semantic_model_evidence",
         "analyze_metric_candidates_from_history",
         # Skill
-        "execute_command",
+        "bash",
         "load_skill",
         # Interaction
         "ask_user",
@@ -2270,6 +2270,14 @@ class TestToolArgsFormatters:
 
         fmt = _TOOL_ARGS_FORMATTERS["describe_table"]
         assert fmt(self._args(table_name="orders")) == '"orders"'
+
+    def test_bash_positional_no_key_prefix(self):
+        """bash shows the bare command value, not a ``command:`` prefix."""
+        from datus.cli.action_display.tool_content import _TOOL_ARGS_FORMATTERS
+
+        fmt = _TOOL_ARGS_FORMATTERS["bash"]
+        assert fmt(self._args(command="sleep 5")) == '"sleep 5"'
+        assert "command:" not in fmt(self._args(command="ls -la"))
 
     def test_grep_kw_args(self):
         from datus.cli.action_display.tool_content import _TOOL_ARGS_FORMATTERS

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -135,6 +135,22 @@ class TestSharedHelpers:
     def test_calc_duration_no_end(self):
         assert calc_duration(_make()) == ""
 
+    def test_format_running_duration_seconds(self):
+        from datus.cli.action_display.tool_content import format_running_duration
+
+        assert format_running_duration(datetime.now() - timedelta(seconds=3)) == "3s"
+
+    def test_format_running_duration_minutes(self):
+        from datus.cli.action_display.tool_content import format_running_duration
+
+        assert format_running_duration(datetime.now() - timedelta(seconds=61)) == "1m1s"
+
+    def test_format_running_duration_none_and_future(self):
+        from datus.cli.action_display.tool_content import format_running_duration
+
+        assert format_running_duration(None) == "0s"
+        assert format_running_duration(datetime.now() + timedelta(seconds=5)) == "0s"
+
     def test_extract_args_dict(self):
         a = _make(input_data={"function_name": "f", "arguments": {"a": 1, "b": "x"}})
         lines = extract_args(a)
@@ -1776,15 +1792,42 @@ class TestBuildAnalyzeMetricCandidates:
 
 @pytest.mark.ci
 class TestBuildExecuteCommand:
-    def test_compact_success_shows_output(self):
-        """Successful command surfaces the real output (last line), not the label."""
+    def test_compact_success_shows_first_lines(self):
+        """Successful command surfaces the real output, first lines first (claude-style)."""
         a = _make(
             input_data={"function_name": "execute_command"},
             output_data={"raw_output": '{"success": 1, "result": "line one\\nline two"}'},
         )
         tc = _build_execute_command(a, verbose=False)
-        assert tc.compact_result == "line two"
+        assert tc.compact_result_lines == ["line one", "line two"]
+        assert tc.compact_result_overflow == 0
+        assert tc.compact_result == "line one"  # single-line degrade
         assert tc.status_mark == "✓"
+
+    def test_compact_folds_beyond_three_lines(self):
+        """More than COMPACT_MAX_LINES output lines fold into an overflow count."""
+        out = "\\n".join(f"line{i}" for i in range(10))
+        a = _make(
+            input_data={"function_name": "execute_command"},
+            output_data={"raw_output": f'{{"success": 1, "result": "{out}"}}'},
+        )
+        tc = _build_execute_command(a, verbose=False)
+        assert tc.compact_result_lines == ["line0", "line1", "line2"]
+        assert tc.compact_result_overflow == 7
+
+    def test_compact_archived_output_shows_preview_not_marker(self):
+        """Oversized (archived) output shows the marker preview, never the raw marker."""
+        from datus.utils.tool_archive import build_archived_marker
+
+        marker = build_archived_marker("/tmp/000001_bash_ab.txt", "hello world preview")
+        a = _make(
+            input_data={"function_name": "execute_command"},
+            output_data={"raw_output": json.dumps({"success": 1, "result": marker})},
+        )
+        tc = _build_execute_command(a, verbose=False)
+        assert any("hello world preview" in line for line in tc.compact_result_lines)
+        assert all("[DATUS_ARCHIVED]" not in line for line in tc.compact_result_lines)
+        assert any("read_file" in line for line in tc.compact_result_lines)
 
     def test_compact_success_no_output_falls_back_to_label(self):
         a = _make(
@@ -1793,9 +1836,10 @@ class TestBuildExecuteCommand:
         )
         tc = _build_execute_command(a, verbose=False)
         assert tc.compact_result == "Command executed"
+        assert tc.compact_result_lines == []
 
-    def test_compact_failure_shows_stderr_not_exit_code(self):
-        """Non-zero exit: show the stderr reason, drop the 'exited with code' prefix."""
+    def test_compact_failure_shows_stderr_reason(self):
+        """Non-zero exit: the stderr reason is visible (no 'exited with code' prefix)."""
         a = _make(
             input_data={"function_name": "execute_command"},
             output_data={
@@ -1806,7 +1850,8 @@ class TestBuildExecuteCommand:
             },
         )
         tc = _build_execute_command(a, verbose=False)
-        assert tc.compact_result == "foo: command not found"
+        assert tc.compact_result_lines == ["run", "foo: command not found"]
+        assert all("exited with code" not in line for line in tc.compact_result_lines)
         assert tc.status_mark == "✗"
 
     def test_compact_failure_strips_exception_prefix(self):

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -340,3 +340,78 @@ class TestBashToolOutputLimit:
         assert "truncated" in result.result
         # Truncation marker tells us the source was longer than the cap.
         assert "total" in result.result
+
+
+class TestBashToolOutputOffload:
+    """Redirect-to-disk path: output streams to a file, decided by size afterwards."""
+
+    @pytest.fixture
+    def offload_dir(self, tmp_path):
+        return tmp_path / "session_data"
+
+    @pytest.fixture
+    def offload_tool(self, temp_workspace, offload_dir):
+        return BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            output_dir_provider=lambda: offload_dir,
+        )
+
+    def test_small_output_returned_inline_and_no_residual_file(self, offload_tool, offload_dir):
+        result = offload_tool.execute_command("python -c \"print('hi')\"")
+        assert result.success == 1
+        assert result.result.strip() == "hi"
+        # Small output is read back and the temp file deleted — nothing lingers.
+        assert list(offload_dir.glob("*")) == []
+
+    def test_empty_output_leaves_no_file(self, offload_tool, offload_dir):
+        result = offload_tool.execute_command('python -c "pass"')
+        assert result.success == 1
+        assert (result.result or "") == ""
+        assert list(offload_dir.glob("*")) == []
+
+    def test_large_output_archived_to_file_with_marker(self, offload_tool, offload_dir, monkeypatch):
+        from datus.tools.func_tool import bash_tool as bash_tool_module
+        from datus.utils.tool_archive import build_archived_marker, parse_archived_marker
+
+        monkeypatch.setattr(bash_tool_module, "BASH_ARCHIVE_THRESHOLD", 100)
+        result = offload_tool.execute_command("python -c \"print('Y' * 5000)\"")
+        assert result.success == 1
+        # The file kept on disk holds the complete output.
+        kept = list(offload_dir.glob("*_bash_*.txt"))
+        assert len(kept) == 1
+        assert kept[0].read_text().count("Y") == 5000
+        # Model-facing result is exactly the marker (path + 1000-char preview),
+        # NOT the full 5000-char output.
+        expected = build_archived_marker(str(kept[0]), "Y" * bash_tool_module.BASH_ARCHIVE_PREVIEW_CHARS)
+        assert result.result == expected
+        assert parse_archived_marker(result.result)["path"] == str(kept[0])
+
+    def test_large_failure_sets_error_and_marker(self, offload_tool, offload_dir, monkeypatch):
+        from datus.tools.func_tool import bash_tool as bash_tool_module
+        from datus.utils.tool_archive import is_archived_output
+
+        monkeypatch.setattr(bash_tool_module, "BASH_ARCHIVE_THRESHOLD", 100)
+        result = offload_tool.execute_command("python -c \"import sys; sys.stdout.write('Z'*5000); sys.exit(2)\"")
+        assert result.success == 0
+        assert "exited with code 2" in result.error
+        assert is_archived_output(result.result)
+        assert len(list(offload_dir.glob("*_bash_*.txt"))) == 1
+
+    def test_no_provider_falls_back_to_in_memory(self, temp_workspace, offload_dir):
+        """Without a provider the tool truncates in memory and writes no file."""
+        tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["*"])
+        result = tool.execute_command("python -c \"print('hello')\"")
+        assert result.success == 1
+        assert result.result.strip() == "hello"
+        assert not offload_dir.exists() or list(offload_dir.glob("*")) == []
+
+    def test_provider_returning_none_uses_in_memory(self, temp_workspace):
+        tool = BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            output_dir_provider=lambda: None,
+        )
+        result = tool.execute_command("python -c \"print('ok')\"")
+        assert result.success == 1
+        assert result.result.strip() == "ok"

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -130,7 +130,7 @@ class TestBashToolAvailableTools:
     def test_patterns_present_exposes_tool(self, python_tool):
         tools = python_tool.available_tools()
         assert len(tools) == 1
-        assert tools[0].name == "execute_command"
+        assert tools[0].name == "bash"
 
     def test_empty_patterns_hides_tool(self, empty_tool):
         assert empty_tool.available_tools() == []
@@ -197,43 +197,43 @@ class TestBashToolPatternMatching:
 
 class TestBashToolExecution:
     def test_execute_allowed_command(self, python_tool):
-        result = python_tool.execute_command("python scripts/analyze.py")
+        result = python_tool.bash("python scripts/analyze.py")
         assert result.success == 1
         assert "Analysis complete" in result.result
 
-    def test_execute_command_with_args(self, python_tool):
-        result = python_tool.execute_command("python scripts/analyze.py --input test.json")
+    def test_bash_with_args(self, python_tool):
+        result = python_tool.bash("python scripts/analyze.py --input test.json")
         assert result.success == 1
         assert "--input" in result.result or "test.json" in result.result
 
     def test_execute_denied_command(self, python_tool):
-        result = python_tool.execute_command("rm -rf /")
+        result = python_tool.bash("rm -rf /")
         assert result.success == 0
         assert "not allowed" in result.error.lower()
 
     def test_execute_empty_command(self, python_tool):
-        result = python_tool.execute_command("")
+        result = python_tool.bash("")
         assert result.success == 0
         assert "empty" in result.error.lower()
 
     def test_execute_whitespace_only(self, python_tool):
-        result = python_tool.execute_command("   ")
+        result = python_tool.bash("   ")
         assert result.success == 0
         assert "empty" in result.error.lower()
 
     def test_execute_returns_json_output(self, python_tool):
-        result = python_tool.execute_command("python scripts/process.py")
+        result = python_tool.bash("python scripts/process.py")
         assert result.success == 1
         assert "processed" in result.result
 
     def test_execute_failing_command(self, python_tool):
         # Script doesn't exist — Python exits non-zero.
-        result = python_tool.execute_command("python scripts/nonexistent.py")
+        result = python_tool.bash("python scripts/nonexistent.py")
         assert result.success == 0
         assert result.error is not None
 
     def test_empty_patterns_blocks_execution(self, empty_tool):
-        result = empty_tool.execute_command("python anything.py")
+        result = empty_tool.bash("python anything.py")
         assert result.success == 0
         assert "not allowed" in result.error.lower()
 
@@ -244,7 +244,7 @@ class TestBashToolExecution:
         agent's terminal stdin and hangs until the tool timeout, freezing the
         whole process. Reading stdin here should return an empty string fast.
         """
-        result = multi_pattern_tool.execute_command('python -c "import sys; print(len(sys.stdin.read()))"')
+        result = multi_pattern_tool.bash('python -c "import sys; print(len(sys.stdin.read()))"')
         assert result.success == 1
         assert result.result.strip() == "0"
 
@@ -255,7 +255,7 @@ class TestBashToolWorkspaceIsolation:
 
     def test_commands_run_in_workspace(self, multi_pattern_tool, temp_workspace):
         (temp_workspace / "scripts" / "pwd_test.py").write_text("import os\nprint(os.getcwd())\n")
-        result = multi_pattern_tool.execute_command("python scripts/pwd_test.py")
+        result = multi_pattern_tool.bash("python scripts/pwd_test.py")
         assert result.success == 1
         assert str(temp_workspace) in result.result or temp_workspace.name in result.result
 
@@ -274,7 +274,7 @@ class TestBashToolExtraEnv:
             "print(f\"DIR={os.environ.get('MY_TOOL_DIR', 'NOT_SET')}\")\n"
         )
 
-        result = tool.execute_command("python scripts/env_test.py")
+        result = tool.bash("python scripts/env_test.py")
         assert result.success == 1
         assert "NAME=demo" in result.result
         assert f"DIR={temp_workspace}" in result.result
@@ -289,26 +289,26 @@ class TestBashToolExtraEnv:
         (temp_workspace / "scripts" / "env_test.py").write_text(
             "import os\nprint(f\"SKILL_NAME={os.environ.get('SKILL_NAME', 'MISSING')}\")\n"
         )
-        result = tool.execute_command("python scripts/env_test.py")
+        result = tool.bash("python scripts/env_test.py")
         assert result.success == 1
         assert "SKILL_NAME=MISSING" in result.result
 
 
 class TestBashToolEdgeCases:
     def test_quoted_command(self, wildcard_tool):
-        result = wildcard_tool.execute_command("python -c \"print('hello world')\"")
+        result = wildcard_tool.bash("python -c \"print('hello world')\"")
         assert result.success == 1
         assert "hello world" in result.result
 
     def test_arithmetic_command(self, wildcard_tool):
-        result = wildcard_tool.execute_command('python -c "print(1+2)"')
+        result = wildcard_tool.bash('python -c "print(1+2)"')
         assert result.success == 1
         assert "3" in result.result
 
     def test_invalid_shlex_syntax_returns_error(self, wildcard_tool):
-        # Unclosed quote: ``execute_command`` calls ``shlex.split`` and reports
+        # Unclosed quote: ``bash`` calls ``shlex.split`` and reports
         # the syntax error rather than crashing.
-        result = wildcard_tool.execute_command('python -c "unclosed')
+        result = wildcard_tool.bash('python -c "unclosed')
         assert result.success == 0
         assert "syntax" in result.error.lower() or "not allowed" in result.error.lower()
 
@@ -322,7 +322,7 @@ class TestBashToolTimeout:
         )
         (temp_workspace / "scripts" / "sleep_test.py").write_text("import time\ntime.sleep(10)\nprint('Done')\n")
 
-        result = tool.execute_command("python scripts/sleep_test.py")
+        result = tool.bash("python scripts/sleep_test.py")
         assert result.success == 0
         assert "timed out" in result.error.lower()
 
@@ -335,7 +335,7 @@ class TestBashToolOutputLimit:
         monkeypatch.setattr(bash_tool_module, "MAX_OUTPUT_SIZE", 50)
 
         tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["python:*"])
-        result = tool.execute_command("python -c \"print('X' * 500)\"")
+        result = tool.bash("python -c \"print('X' * 500)\"")
         assert result.success == 1
         assert "truncated" in result.result
         # Truncation marker tells us the source was longer than the cap.
@@ -358,14 +358,14 @@ class TestBashToolOutputOffload:
         )
 
     def test_small_output_returned_inline_and_no_residual_file(self, offload_tool, offload_dir):
-        result = offload_tool.execute_command("python -c \"print('hi')\"")
+        result = offload_tool.bash("python -c \"print('hi')\"")
         assert result.success == 1
         assert result.result.strip() == "hi"
         # Small output is read back and the temp file deleted — nothing lingers.
         assert list(offload_dir.glob("*")) == []
 
     def test_empty_output_leaves_no_file(self, offload_tool, offload_dir):
-        result = offload_tool.execute_command('python -c "pass"')
+        result = offload_tool.bash('python -c "pass"')
         assert result.success == 1
         assert (result.result or "") == ""
         assert list(offload_dir.glob("*")) == []
@@ -375,7 +375,7 @@ class TestBashToolOutputOffload:
         from datus.utils.tool_archive import build_archived_marker, parse_archived_marker
 
         monkeypatch.setattr(bash_tool_module, "BASH_ARCHIVE_THRESHOLD", 100)
-        result = offload_tool.execute_command("python -c \"print('Y' * 5000)\"")
+        result = offload_tool.bash("python -c \"print('Y' * 5000)\"")
         assert result.success == 1
         # The file kept on disk holds the complete output.
         kept = list(offload_dir.glob("*_bash_*.txt"))
@@ -392,7 +392,7 @@ class TestBashToolOutputOffload:
         from datus.utils.tool_archive import is_archived_output
 
         monkeypatch.setattr(bash_tool_module, "BASH_ARCHIVE_THRESHOLD", 100)
-        result = offload_tool.execute_command("python -c \"import sys; sys.stdout.write('Z'*5000); sys.exit(2)\"")
+        result = offload_tool.bash("python -c \"import sys; sys.stdout.write('Z'*5000); sys.exit(2)\"")
         assert result.success == 0
         assert "exited with code 2" in result.error
         assert is_archived_output(result.result)
@@ -401,7 +401,7 @@ class TestBashToolOutputOffload:
     def test_no_provider_falls_back_to_in_memory(self, temp_workspace, offload_dir):
         """Without a provider the tool truncates in memory and writes no file."""
         tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["*"])
-        result = tool.execute_command("python -c \"print('hello')\"")
+        result = tool.bash("python -c \"print('hello')\"")
         assert result.success == 1
         assert result.result.strip() == "hello"
         assert not offload_dir.exists() or list(offload_dir.glob("*")) == []
@@ -412,6 +412,6 @@ class TestBashToolOutputOffload:
             allowed_patterns=["*"],
             output_dir_provider=lambda: None,
         )
-        result = tool.execute_command("python -c \"print('ok')\"")
+        result = tool.bash("python -c \"print('ok')\"")
         assert result.success == 1
         assert result.result.strip() == "ok"

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -937,7 +937,7 @@ class TestFilesystemZoneProfileMatrix:
         The zone gate returns ``False`` here so the category-level
         ``default=ASK`` (or any explicit ``filesystem_tools.write_file`` rule)
         takes over. The user choosing "Allow once" lets the call proceed; the
-        cache key is category-level, matching how ``bash_tools.execute_command``
+        cache key is category-level, matching how ``bash_tools.bash``
         ASK works.
         """
         hooks, _, project = self._build(mock_broker, tmp_path, profile="normal")

--- a/tests/unit_tests/utils/test_tool_archive.py
+++ b/tests/unit_tests/utils/test_tool_archive.py
@@ -1,0 +1,87 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the shared disk-archive primitive.
+
+The archive helpers moved from ``datus.agent.node.compact_archive`` to
+``datus.utils.tool_archive`` so both the compact pass and the bash tool can
+share them. These tests cover the relocated primitives and the round-trip
+between :func:`build_archived_marker` and :func:`parse_archived_marker`.
+"""
+
+import pytest
+
+from datus.utils.tool_archive import (
+    ARCHIVED_MARKER,
+    ToolArchive,
+    build_archived_marker,
+    is_archived_output,
+    is_error_output,
+    make_single_line_preview,
+    parse_archived_marker,
+)
+
+
+@pytest.mark.ci
+class TestMarkerRoundTrip:
+    def test_build_then_parse(self):
+        marker = build_archived_marker("/tmp/000001_output_ab.txt", "the preview text")
+        assert marker.startswith(ARCHIVED_MARKER)
+        parsed = parse_archived_marker(marker)
+        assert parsed == {"path": "/tmp/000001_output_ab.txt", "preview": "the preview text"}
+
+    def test_is_archived_output(self):
+        assert is_archived_output(build_archived_marker("/tmp/x.txt", "p"))
+        assert not is_archived_output('{"success": 1, "result": "hi"}')
+        assert not is_archived_output(None)
+
+    def test_parse_non_marker_returns_none(self):
+        assert parse_archived_marker("not a marker") is None
+        assert parse_archived_marker(None) is None
+
+    def test_parse_write_failure_fallback_path(self):
+        marker = build_archived_marker("<unavailable: archive write failed>", "preview here")
+        parsed = parse_archived_marker(marker)
+        assert parsed["path"] == "<unavailable: archive write failed>"
+        assert parsed["preview"] == "preview here"
+
+
+@pytest.mark.ci
+class TestSingleLinePreview:
+    def test_flattens_newlines_and_truncates(self):
+        assert make_single_line_preview("a\nb\r\nc", 100) == "a b  c"
+        assert make_single_line_preview("x" * 50, 10) == "x" * 10
+
+
+@pytest.mark.ci
+class TestIsErrorOutput:
+    def test_funcresult_success_zero_is_error(self):
+        assert is_error_output('{"success": 0, "error": "boom"}')
+
+    def test_success_one_not_error(self):
+        assert not is_error_output('{"success": 1, "result": "ok"}')
+
+    def test_non_json_traceback_is_error(self):
+        assert is_error_output("Traceback (most recent call last): ...")
+
+
+@pytest.mark.ci
+class TestToolArchive:
+    def test_archive_writes_file_and_returns_marker(self, tmp_path):
+        archive = ToolArchive("proj", "sess", base_dir=tmp_path, preview_chars=20)
+        marker = archive.archive("full content here that is fairly long", 3, "output")
+        parsed = parse_archived_marker(marker)
+        assert parsed is not None
+        written = tmp_path / "000003_output_"  # filename prefix
+        files = list(tmp_path.glob("000003_output_*.txt"))
+        assert len(files) == 1
+        assert str(files[0]).startswith(str(written))
+        assert files[0].read_text() == "full content here that is fairly long"
+
+    def test_archive_rejects_bad_kind(self, tmp_path):
+        from datus.utils.exceptions import DatusException
+
+        archive = ToolArchive("proj", "sess", base_dir=tmp_path)
+        with pytest.raises(DatusException):
+            archive.archive("x", 0, "bogus")

--- a/tests/unit_tests/utils/test_tool_archive.py
+++ b/tests/unit_tests/utils/test_tool_archive.py
@@ -23,7 +23,6 @@ from datus.utils.tool_archive import (
 )
 
 
-@pytest.mark.ci
 class TestMarkerRoundTrip:
     def test_build_then_parse(self):
         marker = build_archived_marker("/tmp/000001_output_ab.txt", "the preview text")
@@ -47,14 +46,12 @@ class TestMarkerRoundTrip:
         assert parsed["preview"] == "preview here"
 
 
-@pytest.mark.ci
 class TestSingleLinePreview:
     def test_flattens_newlines_and_truncates(self):
         assert make_single_line_preview("a\nb\r\nc", 100) == "a b  c"
         assert make_single_line_preview("x" * 50, 10) == "x" * 10
 
 
-@pytest.mark.ci
 class TestIsErrorOutput:
     def test_funcresult_success_zero_is_error(self):
         assert is_error_output('{"success": 0, "error": "boom"}')
@@ -66,18 +63,17 @@ class TestIsErrorOutput:
         assert is_error_output("Traceback (most recent call last): ...")
 
 
-@pytest.mark.ci
-class TestToolArchive:
+class TestToolArchivePrimitives:
     def test_archive_writes_file_and_returns_marker(self, tmp_path):
         archive = ToolArchive("proj", "sess", base_dir=tmp_path, preview_chars=20)
         marker = archive.archive("full content here that is fairly long", 3, "output")
-        parsed = parse_archived_marker(marker)
-        assert parsed is not None
-        written = tmp_path / "000003_output_"  # filename prefix
         files = list(tmp_path.glob("000003_output_*.txt"))
         assert len(files) == 1
-        assert str(files[0]).startswith(str(written))
         assert files[0].read_text() == "full content here that is fairly long"
+        # Marker points at the written file and carries a bounded preview.
+        parsed = parse_archived_marker(marker)
+        assert parsed["path"] == str(files[0])
+        assert parsed["preview"] == "full content here th"  # preview_chars=20
 
     def test_archive_rejects_bad_kind(self, tmp_path):
         from datus.utils.exceptions import DatusException


### PR DESCRIPTION
## Why

Follow-ups to the bash stdin-hang fix (#1092), covering output handling, live feedback, and naming:

1. **Memory + context bloat** — bash output was buffered in memory (`capture_output`) and hard-truncated at 50K, with only a terse `Command exited with code N` surfaced while the real stdout/stderr sat unused. A large output both bloated memory and polluted the model context.
2. **No live progress** — no tool showed elapsed time while running; a long bash looked frozen until it completed.
3. **Terse compact display** — bash showed only the last output line.
4. **Verbose name/header** — the tool was `execute_command` and the header read `execute_command(command: "sleep 5")`.

## Solution

- **Memory-safe disk offload**: bash streams the child's stdout/stderr straight to a file under the session data dir (same location minor compact uses) instead of `capture_output`; after exit it decides by file size — small output is read back and the temp file deleted, oversized output (>8000 chars) stays on disk and the model gets a `[DATUS_ARCHIVED]` preview+path marker (recoverable via `read_file`, no permission prompt since the session data dir is a read-only whitelist anchor). No offload dir wired (MCP/standalone) → in-memory `MAX_OUTPUT_SIZE` fallback. `ToolArchive` + marker helpers moved to `datus/utils/tool_archive.py` (shared by the compact pass and bash without an inverted `tools -> agent.node` dep); `compact_archive.py` is now a re-export shim. `agentic_node` wires a lazy `output_dir_provider` closure (session id resolved at execute time).
- **Running indicator (all tools)**: the PROCESSING frame now shows `· running Ns` (integer seconds), recomputed each repaint.
- **Compact display**: bash shows the first 3 output lines + `… +N lines (ctrl+o to expand)` (claude-style); failures show the real stderr reason with boilerplate prefixes stripped; verbose renders the full `result` payload.
- **Rename `execute_command` → `bash`**: model-facing tool name, permission rule (`bash_tools.bash`), registry/formatter keys, and renderer renamed; the `command` parameter is unchanged, matching the Claude Code `bash(command=...)` signature the Claude/Codex models know. Header now reads `bash("sleep 5")` (positional, no `command:` prefix); the running frame matches.

Key decisions/tradeoffs: offload threshold 8000 chars (between compact's 1000 and the old 50K hard cap); stderr merged into the stdout file (`stderr=STDOUT`), preserving real interleaving order at the cost of an explicit `[stderr]` section; a small bash result envelope may be re-archived by minor compact (harmless, sub-threshold).

## Test Cases

All deterministic unit tests (no real LLM/network):

- `tests/unit_tests/tools/func_tool/test_bash_tool.py`: disk-offload paths (small→inline + no residual file, empty→no file, oversized→marker + full file kept, non-zero exit + oversized→`success=0` + marker, no-provider→in-memory truncation); positional `bash(...)` behavior.
- `tests/unit_tests/utils/test_tool_archive.py` (new): relocated marker/`ToolArchive` round-trip, error-preview widening, bad-kind rejection.
- `tests/unit_tests/cli/action_display/test_tool_content.py` / `test_renderers.py`: `format_running_duration` boundaries; multi-line bash compact (3 lines + `… +N lines`) and archived-preview rendering; single-line tools unchanged; `bash(...)` header has no `command:` prefix; PROCESSING frame shows `running Ns`.
- Existing `test_compact_archive.py` passes unchanged via the re-export shim.

Impacted unit tests pass; diff coverage 92%. (Local acceptance-harness integration failures are environmental — an invalid local `.datus/config.yml` `default_datasource` and missing pre-built KB data — unrelated to this diff.)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Shell tool output can now be shown in a compact multi-line preview, with overflow lines clearly indicated.
  * Long command results are now stored outside the main response when needed, helping preserve more output for later viewing.
  * Running tool actions now display clearer argument summaries and elapsed-time indicators.

* **Bug Fixes**
  * Improved handling of large or archived command output so previews are more readable and less likely to be truncated unexpectedly.
  * Updated shell tool naming and permission prompts to match the current command execution experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell tool results can now be rendered as a compact multi-line preview with a clear overflow line when output is folded.
  * Large outputs may be archived/offloaded and surfaced via a preview for easier later viewing.
  * Running tool actions now show improved argument summaries along with an elapsed-time indicator.
* **Bug Fixes**
  * Improved display and formatting for archived or oversized shell output so previews are more readable and less prone to unexpected truncation.
  * Updated shell tool naming and permission prompting to align with the current `bash` experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->