### PR TITLE
[Doc] Add user documentation for the unified web tool group

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -1011,6 +1011,42 @@ flow_groups:
         gaps:
           - https://github.com/Datus-ai/Datus-agent/issues/910
 
+      - id: extension.web_tools
+        title: Web search and fetch tools
+        priority: p1
+        quality_sensitive: false
+        docs:
+          - docs/configuration/web_tool.md
+        entrypoints:
+          - "Tool: web_search"
+          - "Tool: web_fetch"
+        contracts:
+          - The unified web tool group resolves provider configuration and exposes web_search/web_fetch to agents per permission policy.
+          - web_search/web_fetch results render through the canonical web_result schema regardless of backend (Tavily / Anthropic / OpenAI hosted).
+        coverage:
+          pr_acceptance:
+            status: covered
+            nodeids:
+              - tests/unit_tests/tools/func_tool/test_web_tool.py
+              - tests/unit_tests/schemas/test_web_result.py
+              - tests/unit_tests/agent/node/test_agentic_node_web_tools.py
+          merge_queue:
+            status: covered
+            nodeids:
+              - tests/unit_tests/tools/func_tool/test_web_tool.py
+              - tests/unit_tests/schemas/test_web_result.py
+              - tests/unit_tests/agent/node/test_agentic_node_web_tools.py
+          nightly:
+            status: external
+            notes: >
+              Live web_search/web_fetch require real provider credentials (Tavily / Anthropic / OpenAI
+              hosted) and network egress, classified as an external dependency. Provider-agnostic result
+              parsing, rendering, and tool wiring/permission exposure are covered deterministically.
+          weekly_benchmark:
+            status: not_applicable
+        gaps:
+          - https://github.com/Datus-ai/Datus-agent/issues/910
+
   quality_and_ops:
     description: Validation, observability, provider compatibility, benchmark, and release-confidence operations.
     flows:

--- a/docs/configuration/web_tool.md
+++ b/docs/configuration/web_tool.md
@@ -1,0 +1,130 @@
+# Web Tools
+
+During a chat session the agent can reach the public web through a single pair of tools:
+
+| Tool | Purpose |
+|---|---|
+| `web_search` | Search the web and return ranked results with snippets |
+| `web_fetch` | Fetch one URL and return its readable text content |
+
+The typical flow pairs them: `web_search` finds candidate pages (latest SQL dialect syntax, an error message, a product changelog), then `web_fetch` pulls the full text of the most promising URL. Both tools return the same result structure regardless of which backend served the request, so downstream behavior never depends on your LLM provider.
+
+## Backend selection
+
+The agent always sees the same two tools; what serves them is chosen automatically per active LLM provider:
+
+- **Vendor-native** — if the active provider's API ships a built-in web search capability, Datus injects the vendor's hosted tool and skips the local implementation. No setup is needed.
+- **Local fallback** — for every other provider:
+    - `web_search` calls the [Tavily](https://tavily.com) search API — requires an API key (see below).
+    - `web_fetch` downloads the page directly over HTTP and extracts the main text — no key, no third-party API.
+
+Current support by provider:
+
+| Provider | `web_search` | `web_fetch` |
+|---|---|---|
+| OpenAI (official `api.openai.com`) | Vendor-native | Local |
+| ChatGPT Codex (official `chatgpt.com` backend) | Vendor-native | Local |
+| Claude / Anthropic (official `api.anthropic.com`) | Vendor-native | Local |
+| Everything else (DeepSeek, Qwen, self-hosted, OpenAI/Claude-compatible relays, …) | Local (Tavily) | Local |
+
+Two caveats:
+
+- Vendor-native search requires the **official** endpoint. If the provider entry points at a custom `base_url` (a relay, proxy, or self-hosted gateway), the hosted tool cannot be relied on and Datus falls back to the local Tavily backend automatically.
+- `web_fetch` currently always runs on the local backend, for every provider.
+
+Switching models with `/model` mid-session re-resolves the backends immediately.
+
+## Setup
+
+Only the local `web_search` backend needs configuration — a Tavily API key, resolved in this order:
+
+1. `agent.document.tavily_api_key` in `agent.yml` (supports `${ENV_VAR}` substitution)
+2. The `TAVILY_API_KEY` environment variable
+
+```yaml title="agent.yml"
+agent:
+  document:
+    tavily_api_key: ${TAVILY_API_KEY}
+```
+
+Without a key (and without vendor-native search), `web_search` is simply not exposed to the agent — a note is written to the log. `web_fetch` is always available.
+
+## Tool reference
+
+### `web_search`
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `keywords` | list of strings | required | Search queries, e.g. `["StarRocks materialized view syntax"]` |
+| `max_results` | int | `5` | Maximum results to return (1–20) |
+| `include_domains` | list of strings | none | Restrict results to specific domains, e.g. `["docs.snowflake.com"]` |
+
+Result:
+
+```json
+{
+  "query": "StarRocks materialized view syntax",
+  "result_count": 5,
+  "results": [
+    {"title": "...", "url": "...", "snippet": "...", "age": "..."}
+  ]
+}
+```
+
+### `web_fetch`
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `url` | string | required | Absolute `http(s)` URL to fetch |
+| `max_chars` | int | `20000` | Truncate the extracted text to this many characters |
+
+Result:
+
+```json
+{
+  "url": "...",
+  "title": "...",
+  "content": "...",
+  "truncated": false,
+  "char_count": 12345
+}
+```
+
+`truncated` reports whether `content` was cut off at `max_chars`; the agent can re-fetch with a larger limit when it needs the tail of a long page.
+
+## Limits and safety
+
+The local `web_fetch` backend enforces:
+
+- **Public targets only (SSRF protection)** — requests to `localhost`, `*.local` / `*.internal` hostnames, private/loopback/link-local IP ranges, and cloud metadata addresses are refused.
+- **HTML / plain text only** — other content types (PDFs, images, binaries) are rejected with an explanatory error.
+- **10 MiB response cap** — responses that declare a larger body are refused before download.
+- **30-second timeout** per request, following redirects.
+- **Boilerplate stripping** — scripts, styles, navigation, headers/footers are removed; only the main text is returned.
+
+## Permissions
+
+Both tools belong to the `web_tool` permission category and are **allowed by default** in every built-in profile: they only read the public web and send nothing derived from your databases. To require confirmation or disable them, add a rule under `agent.permissions`:
+
+```yaml title="agent.yml"
+agent:
+  permissions:
+    rules:
+      - tool: web_tool
+        pattern: "*"          # or a single tool: web_search / web_fetch
+        permission: deny      # allow | ask | deny
+```
+
+## Relation to `web_search_document`
+
+Do not confuse `web_tool.web_search` with [`web_search_document`](../knowledge_base/platform_doc.md): the latter belongs to the knowledge-base platform-documentation tool group and serves as a web fallback when local document search comes up empty. Both use Tavily and share the same API-key configuration, but they are separate tools with separate permission categories.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `web_search` never appears in the tool list | No Tavily key resolvable and no vendor-native search — set `agent.document.tavily_api_key` or `TAVILY_API_KEY`. |
+| `Web search is unavailable: set agent.document.tavily_api_key or TAVILY_API_KEY.` | Same as above — the key disappeared at call time. |
+| `Refusing to fetch non-public URL target (SSRF protection)` | The URL points at localhost / a private network. Intentional; only public web targets are fetchable. |
+| `Unsupported content-type '...'` | The URL is not an HTML/text page. Point `web_fetch` at a readable page instead. |
+| `Response too large ... exceeds the 10,485,760-byte web_fetch limit.` | The page body exceeds 10 MiB. Fetch a smaller page (e.g. a specific article rather than an archive). |

--- a/docs/configuration/web_tool.zh.md
+++ b/docs/configuration/web_tool.zh.md
@@ -1,0 +1,130 @@
+# Web 工具
+
+在 chat 会话中，agent 通过一对统一的工具访问公共互联网：
+
+| 工具 | 用途 |
+|---|---|
+| `web_search` | 搜索互联网，返回带摘要的排序结果 |
+| `web_fetch` | 抓取单个 URL，返回其可读的正文文本 |
+
+典型用法是两者配合：先用 `web_search` 找到候选页面（最新的 SQL 方言语法、某条报错信息、产品 changelog），再用 `web_fetch` 拉取最有价值那个 URL 的全文。无论请求由哪个后端处理，两个工具都返回相同的结果结构，下游行为不依赖你所用的 LLM provider。
+
+## 后端选择
+
+Agent 看到的永远是同样的两个工具；由谁来处理请求则按当前激活的 LLM provider 自动决定：
+
+- **厂商原生** —— 如果当前 provider 的 API 自带 web 搜索能力，Datus 会自动注入厂商的托管工具，并跳过本地实现。无需任何配置。
+- **本地回退** —— 其他所有 provider：
+    - `web_search` 调用 [Tavily](https://tavily.com) 搜索 API —— 需要 API key（见下文）。
+    - `web_fetch` 直接通过 HTTP 下载页面并抽取正文 —— 无需 key，不经过任何第三方 API。
+
+各 provider 的当前支持情况：
+
+| Provider | `web_search` | `web_fetch` |
+|---|---|---|
+| OpenAI（官方 `api.openai.com`） | 厂商原生 | 本地 |
+| ChatGPT Codex（官方 `chatgpt.com` 后端） | 厂商原生 | 本地 |
+| Claude / Anthropic（官方 `api.anthropic.com`） | 厂商原生 | 本地 |
+| 其他所有（DeepSeek、Qwen、自建服务、OpenAI/Claude 兼容中转等） | 本地（Tavily） | 本地 |
+
+两点说明：
+
+- 厂商原生搜索仅在**官方**端点上生效。如果 provider 配置指向自定义 `base_url`（中转、代理或自建网关），托管工具无法保证可用，Datus 会自动回退到本地 Tavily 后端。
+- `web_fetch` 目前对所有 provider 都走本地后端。
+
+会话中用 `/model` 切换模型会立即重新解析后端。
+
+## 配置
+
+只有本地 `web_search` 后端需要配置 —— 一个 Tavily API key，按以下顺序解析：
+
+1. `agent.yml` 中的 `agent.document.tavily_api_key`（支持 `${ENV_VAR}` 环境变量替换）
+2. 环境变量 `TAVILY_API_KEY`
+
+```yaml title="agent.yml"
+agent:
+  document:
+    tavily_api_key: ${TAVILY_API_KEY}
+```
+
+没有 key（且没有厂商原生搜索）时，`web_search` 不会暴露给 agent，日志中会有一条提示。`web_fetch` 始终可用。
+
+## 工具参考
+
+### `web_search`
+
+| 参数 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `keywords` | 字符串列表 | 必填 | 搜索关键词，如 `["StarRocks materialized view syntax"]` |
+| `max_results` | int | `5` | 返回结果数上限（1–20） |
+| `include_domains` | 字符串列表 | 无 | 限定结果域名，如 `["docs.snowflake.com"]` |
+
+返回结果：
+
+```json
+{
+  "query": "StarRocks materialized view syntax",
+  "result_count": 5,
+  "results": [
+    {"title": "...", "url": "...", "snippet": "...", "age": "..."}
+  ]
+}
+```
+
+### `web_fetch`
+
+| 参数 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `url` | string | 必填 | 要抓取的绝对 `http(s)` URL |
+| `max_chars` | int | `20000` | 抽取文本的截断长度（字符数） |
+
+返回结果：
+
+```json
+{
+  "url": "...",
+  "title": "...",
+  "content": "...",
+  "truncated": false,
+  "char_count": 12345
+}
+```
+
+`truncated` 表示 `content` 是否在 `max_chars` 处被截断；当 agent 需要长页面的后半部分时，可以用更大的上限重新抓取。
+
+## 限制与安全
+
+本地 `web_fetch` 后端强制执行以下约束：
+
+- **仅限公网目标（SSRF 防护）** —— 拒绝访问 `localhost`、`*.local` / `*.internal` 主机名、私有/回环/链路本地 IP 段以及云 metadata 地址。
+- **仅支持 HTML / 纯文本** —— 其他内容类型（PDF、图片、二进制）会返回带说明的错误。
+- **10 MiB 响应体上限** —— 声明超过此大小的响应在下载前即被拒绝。
+- **单次请求 30 秒超时**，自动跟随重定向。
+- **去除页面噪音** —— 脚本、样式、导航、页眉页脚会被剥离，只返回正文文本。
+
+## 权限
+
+两个工具同属 `web_tool` 权限类别，在所有内置 profile 中**默认允许**：它们只读取公共互联网，不会发送任何来自你数据库的数据。如需改为确认后执行或禁用，在 `agent.permissions` 下添加规则：
+
+```yaml title="agent.yml"
+agent:
+  permissions:
+    rules:
+      - tool: web_tool
+        pattern: "*"          # 也可以只写单个工具：web_search / web_fetch
+        permission: deny      # allow | ask | deny
+```
+
+## 与 `web_search_document` 的区别
+
+不要把 `web_tool.web_search` 和 [`web_search_document`](../knowledge_base/platform_doc.zh.md) 混淆：后者属于知识库平台文档工具组，是本地文档检索无结果时的 Web 兜底搜索。两者都使用 Tavily、共享同一份 API key 配置，但它们是不同的工具，权限类别也各自独立。
+
+## 常见问题排查
+
+| 现象 | 原因 / 处理 |
+|---|---|
+| 工具列表里始终没有 `web_search` | 未解析到 Tavily key 且无厂商原生搜索 —— 配置 `agent.document.tavily_api_key` 或 `TAVILY_API_KEY`。 |
+| `Web search is unavailable: set agent.document.tavily_api_key or TAVILY_API_KEY.` | 同上 —— 调用时 key 不可用。 |
+| `Refusing to fetch non-public URL target (SSRF protection)` | URL 指向 localhost / 私有网络。这是有意为之，只允许抓取公网目标。 |
+| `Unsupported content-type '...'` | URL 不是 HTML/文本页面。请让 `web_fetch` 指向可读的网页。 |
+| `Response too large ... exceeds the 10,485,760-byte web_fetch limit.` | 页面响应体超过 10 MiB。请改抓更小的页面（例如具体文章而非归档页）。 |

--- a/docs/knowledge_base/platform_doc.md
+++ b/docs/knowledge_base/platform_doc.md
@@ -171,6 +171,8 @@ To expose these tools in custom nodes or subagents, include `platform_doc_tools`
 
 **Recommended call order**: `list_document_nav` → `get_document` → `search_document` → `web_search_document` (fallback).
 
+`web_search_document` is not the same tool as the general-purpose `web_search` from the [web tool group](../configuration/web_tool.md) — they share the Tavily key configuration but have separate permission categories.
+
 **`get_document` expects one document at a time**. Pass a single hierarchy path like:
 
 ```text

--- a/docs/knowledge_base/platform_doc.zh.md
+++ b/docs/knowledge_base/platform_doc.zh.md
@@ -172,6 +172,8 @@ datus-agent platform-doc --platform starrocks --github-ref 4.0.5
 如需在自定义节点或子代理中启用这些工具，请在工具配置里加入 `platform_doc_tools`（或具体的 `platform_doc_search_tools.*`）。
 **推荐调用顺序**：`list_document_nav` → `get_document` → `search_document` → `web_search_document`（兜底）。
 
+`web_search_document` 与 [Web 工具组](../configuration/web_tool.zh.md)中的通用 `web_search` 不是同一个工具 —— 两者共享 Tavily key 配置，但权限类别各自独立。
+
 **`get_document` 一次只取一篇文档**，示例：
 
 ```text

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Workflow: configuration/workflow.md
       - Benchmark: configuration/benchmark.md
       - SQL Policy: configuration/sql_policy.md
+      - Web Tools: configuration/web_tool.md
       - Services:
         - Datasources: configuration/datasources.md
         - Semantic Layer: configuration/semantic_layer.md


### PR DESCRIPTION
## Why

The unified `web_tool` group (`web_tool.web_search` / `web_tool.web_fetch`, introduced in #1050) had no user documentation. Users had no way to learn which providers serve the tools natively vs. via the local Tavily/httpx backends, how to configure the Tavily API key, what the result schemas look like, or what safety limits apply. The only "web search" content in the docs was `web_search_document` (the knowledge-base platform-doc fallback), which is a different tool and easy to confuse with `web_tool.web_search`.

## Solution

Add a bilingual "Web Tools" page under the Configuration section (`docs/configuration/web_tool.md` + `web_tool.zh.md`) covering:

- **Backend selection** — a per-provider table (OpenAI / ChatGPT Codex / Claude serve `web_search` vendor-natively on their official endpoints; everything else falls back to local Tavily) plus the two behavioral caveats verified from code: vendor-native search is gated on the official endpoint hostname (custom `base_url` relays fall back to Tavily), and `web_fetch` currently always runs on the local httpx backend.
- **Setup** — Tavily key resolution order (`agent.document.tavily_api_key` → `TAVILY_API_KEY`); without a key `web_search` is not exposed while `web_fetch` stays available.
- **Tool reference** — parameters and the provider-agnostic result schemas for both tools.
- **Limits and safety** — SSRF protection, HTML/text-only content types, 10 MiB body cap, 30 s timeout, boilerplate stripping.
- **Permissions** — the `web_tool` category defaults to ALLOW; example rule to tighten it.
- **Disambiguation + troubleshooting** — relation to `web_search_document` and a table of common errors.

Supporting changes: a `Web Tools` nav entry in `mkdocs.yml` (Configuration group), and a one-line cross-reference in `platform_doc.md(.zh.md)` clarifying that `web_search_document` is a separate tool with its own permission category.

Vendor API version identifiers are intentionally kept out of the docs; behavior is described at the provider level only.

## Test Cases

None — documentation-only change (Markdown + mkdocs nav), no runtime code touched. `ci/run-pr-tests.py` passes 204/204 with 100% diff coverage; `ci/audit_tests.py --diff-only` reports no test files in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [x] release/0.3.7
## Summary by CodeRabbit

* **Documentation**
  * Added new English and Chinese docs for Web Tools, covering web search and page fetching, setup, permissions, safety limits, and troubleshooting.
  * Clarified the difference between general web search and platform document search.
  * Added the new Web Tools page to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Web Tools documentation (English + Chinese) describing `web_search` and `web_fetch`, including configuration, tool availability by provider, and required API key behavior.
  * Documented `web_fetch` safety/limits (such as content handling, size cap, and timeouts) plus result truncation details.
  * Clarified the distinction between `web_search_document` (platform document ingestion/search) and general `web_search`.
  * Updated documentation navigation to include the new Web Tools page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->