### PR TITLE
[Doc] Add 0.3.7 release notes and bump version to 0.3.7

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,38 @@
 
 ## 0.3
 
+### 0.3.7
+
+**New Features**
+
+- **Unified Web Search and Fetch Tools** - Added `web_tool.web_search` / `web_tool.web_fetch` so the agent can search the web and fetch page content. The backend is selected automatically by the current model provider (Claude native `web_search`/`web_fetch`, OpenAI hosted search, or local Tavily), and results are normalized into one shared structure, so CLI/TUI rendering and the API / `datus -p` event payloads stay consistent regardless of the model. For example, Claude and GPT models prefer their own built-in search tools, models without a built-in search tool fall back to the local Tavily configuration, and without that configuration search is unavailable. [#1050](https://github.com/Datus-ai/Datus-agent/pull/1050) [#1068](https://github.com/Datus-ai/Datus-agent/pull/1068) [#1070](https://github.com/Datus-ai/Datus-agent/pull/1070) [#1081](https://github.com/Datus-ai/Datus-agent/pull/1081) [docs](https://docs.datus.ai/0.3/configuration/web_tool/)
+
+**Enhancements**
+
+- **Unified `execute_sql` Database Tool** - The previously separate `read_query` / `execute_ddl` / `execute_write` tools are merged into a single `execute_sql` that classifies each statement type and authorizes accordingly: read-only queries (SELECT/SHOW/EXPLAIN) pass automatically, while writes and DDL go through permission confirmation (auto-executed only when the permission mode is `dangerous`). The previous restriction on DDL statement types is also lifted, so statements like `CREATE DATABASE` / `TRUNCATE` / `MERGE` can run once confirmed. [#1062](https://github.com/Datus-ai/Datus-agent/pull/1062)
+- **`list_tables` Returns Qualified Names** - List items changed from bare `table_name` to `qualified_name` (`[db.][schema.]table`), completing only the namespace levels the caller did not specify, which makes it easier to build valid follow-up query references across databases/schemas. [#1078](https://github.com/Datus-ai/Datus-agent/pull/1078)
+- **Improved OSI Metric Generation and the AskMetrics Semantic Pipeline** - OSI semantic models are consolidated at the business-domain level, `describe_table` now syncs and displays a table-level semantic profile, and `ask_metrics` gains stronger metric discovery, cross-table join control, and cumulative/rolling metric querying. [#1061](https://github.com/Datus-ai/Datus-agent/pull/1061) [#1055](https://github.com/Datus-ai/Datus-agent/pull/1055) [docs](https://docs.datus.ai/0.3/adapters/osi_semantic_adapter/)
+- **build-kb / init Scan All Text Files** - `/build-kb` and `/init` no longer scan by a fixed extension whitelist; text files are detected by content, so extension-less or uncommon-suffix text files are included, while binaries and oversized files (>~1MB) are skipped automatically. [#1059](https://github.com/Datus-ai/Datus-agent/pull/1059)
+- **Readable Permission Prompts** - Tool arguments in permission confirmations are now rendered as markdown blocks (SQL as highlighted code blocks, nested structures as JSON blocks), making it much clearer what you are being asked to approve. [#1069](https://github.com/Datus-ai/Datus-agent/pull/1069)
+
+**Bug Fixes**
+
+- **Tool Failure Display and `write_file` Extensions** - Fixed failed tool executions still showing a green ✓ under the Claude native / Codex backends (now correctly shown as ✗); also removed the `write_file` extension whitelist so files like `.sh` / `.tf` can be written. [#1077](https://github.com/Datus-ai/Datus-agent/pull/1077)
+- **catalog/list Scoped to the Datasource's Configured Databases** - `GET /api/v1/catalog/list` no longer lists every database on the server instance; it returns only the databases actually bound to the datasource. [#1064](https://github.com/Datus-ai/Datus-agent/pull/1064)
+- **Runtime DB Context for Semantic Adapters** - The selected catalog/database/schema now travels through the API and agent as runtime DB context, and semantic adapter configuration plus SemanticTools are rebuilt automatically when the context switches. [#1066](https://github.com/Datus-ai/Datus-agent/pull/1066)
+- **CLI Suppresses LiteLLM Console Logs** - LiteLLM INFO logs are now written to the Datus log file instead of leaking into the TUI. [#1071](https://github.com/Datus-ai/Datus-agent/pull/1071)
+
+**Upgrade Notes**
+
+- **Database SQL Tool Consolidation** - `read_query` / `execute_ddl` / `execute_write` are no longer exposed as separate agent/MCP tools; they are unified into a single `execute_sql`. Custom subagent tool whitelists or scripts referencing the old tool names must migrate to `execute_sql`. [#1062](https://github.com/Datus-ai/Datus-agent/pull/1062)
+
+**Internal**
+
+- **Web Frontend Proxies `delete_file`** - `delete_file` in web sessions is now proxied to the browser side for execution, consistent with `write_file` / `edit_file`, instead of running on the server filesystem. [#1080](https://github.com/Datus-ai/Datus-agent/pull/1080)
+- **Metric Retrieval Hook and uid Column** - `tb_metrics` gains a `uid` column and a new metric retrieval hook so the SaaS Semantic Hub can track metric consumption; no end-user impact. [#1072](https://github.com/Datus-ai/Datus-agent/pull/1072)
+- **Benchmark Provenance** - The Claude native execution loop now preserves structured tool results for benchmark provenance. [#1056](https://github.com/Datus-ai/Datus-agent/pull/1056)
+- **Testing and Release** - Added a MetricFlow nightly integration test, fixed nightly/UT issues, and completed 0.3.6 release-note doc and link fixes plus release preparation. [#1076](https://github.com/Datus-ai/Datus-agent/pull/1076) [#1067](https://github.com/Datus-ai/Datus-agent/pull/1067) [#1065](https://github.com/Datus-ai/Datus-agent/pull/1065) [#1057](https://github.com/Datus-ai/Datus-agent/pull/1057) [#1054](https://github.com/Datus-ai/Datus-agent/pull/1054)
+
 ### 0.3.6
 
 **Enhancements**

--- a/docs/release_notes.zh.md
+++ b/docs/release_notes.zh.md
@@ -2,6 +2,31 @@
 
 ## 0.3
 
+### 0.3.7
+
+**新功能**
+
+- **统一的 Web 搜索与抓取工具** - 新增 `web_tool.web_search` / `web_tool.web_fetch` 工具，agent 可联网搜索并抓取网页正文。后端按当前模型 provider 自动选择（Claude 原生 `web_search`/`web_fetch`、OpenAI hosted search、本地 Tavily），并统一归一化为同一套结果结构，无论用哪个模型，CLI/TUI 展示与 API、`datus -p` 的事件载荷都保持一致。例如 Claude 和 GPT 模型都会优先调用自己的搜索工具，没有内置搜索工具的模型降级到本地 Tavily 配置，如果仍然没有配置则没有搜索能力。[#1050](https://github.com/Datus-ai/Datus-agent/pull/1050) [#1068](https://github.com/Datus-ai/Datus-agent/pull/1068) [#1070](https://github.com/Datus-ai/Datus-agent/pull/1070) [#1081](https://github.com/Datus-ai/Datus-agent/pull/1081) [文档](https://docs.datus.ai/0.3/zh/configuration/web_tool/)
+
+**增强**
+
+- **统一的 `execute_sql` 数据库工具** - 原先分散的 `read_query` / `execute_ddl` / `execute_write` 合并为单个 `execute_sql`，按语句类型自动判定并授权：只读查询（SELECT/SHOW/EXPLAIN）自动放行，写入与 DDL 走权限确认（在 permission mode 为 dangerous 时才会自动执行）。同时解除了对 DDL 语句类型的预先限制，确认后即可执行 `CREATE DATABASE` / `TRUNCATE` / `MERGE` 等语句。[#1062](https://github.com/Datus-ai/Datus-agent/pull/1062)
+- **`list_tables` 返回限定名** - 列表项由裸 `table_name` 改为 `qualified_name`（`[db.][schema.]table`），只补全调用方未指定的命名空间层级，便于在跨 db/schema 场景中构造合法的后续查询引用。[#1078](https://github.com/Datus-ai/Datus-agent/pull/1078)
+- **完善 OSI 指标生成与 AskMetrics 语义指标链路** - 将 OSI 语义模型收敛为业务域级别，新增 describe_table 时的表级 semantic profile 同步/展示，并增强 ask_metrics 查询时的指标发现、跨表 join 控制及累计/滚动指标查询能力。[#1061](https://github.com/Datus-ai/Datus-agent/pull/1061) [#1055](https://github.com/Datus-ai/Datus-agent/pull/1055) [文档](https://docs.datus.ai/0.3/zh/adapters/osi_semantic_adapter/)
+- **build-kb / init 扫描全部文本文件** - `/build-kb` 与 `/init` 不再按固定后缀白名单扫描，改为按内容识别文本文件，无扩展名或少见后缀的文本也能纳入，二进制与超大文件（>~1MB）自动跳过。[#1059](https://github.com/Datus-ai/Datus-agent/pull/1059)
+- **权限确认弹窗可读化** - 权限确认时的工具参数改为按 markdown 分块渲染（SQL 用代码块高亮、嵌套结构用 JSON 块），能更清晰的看到需要确认的内容。[#1069](https://github.com/Datus-ai/Datus-agent/pull/1069)
+
+**Bug 修复**
+
+- **工具失败展示与 write_file 扩展名** - 修复 Claude 原生 / Codex 后端下工具执行失败仍显示绿色 ✓ 的问题（现正确显示 ✗）；同时解除 `write_file` 的扩展名白名单限制，可写出 `.sh` / `.tf` 等文件。[#1077](https://github.com/Datus-ai/Datus-agent/pull/1077)
+- **catalog/list 按 datasource 配置的 database 限定** - `GET /api/v1/catalog/list` 不再列出服务器实例上的全部 database，只返回 datasource 实际绑定的 database。[#1064](https://github.com/Datus-ai/Datus-agent/pull/1064)
+- **语义适配器运行时 DB 上下文** - 选中的 catalog/database/schema 会作为运行时 DB 上下文贯穿 API 与 agent，语义适配器配置与 SemanticTools 会随上下文切换自动重建。[#1066](https://github.com/Datus-ai/Datus-agent/pull/1066)
+- **CLI 抑制 LiteLLM 控制台日志** - LiteLLM 的 INFO 日志改写入 Datus 日志文件，不再泄漏到 TUI 界面。[#1071](https://github.com/Datus-ai/Datus-agent/pull/1071)
+
+**升级说明**
+
+- **数据库 SQL 工具合并** - `read_query` / `execute_ddl` / `execute_write` 不再作为独立的 agent/MCP 工具暴露，统一为单个 `execute_sql`；自定义 subagent 工具白名单或脚本若引用了旧工具名，需迁移到 `execute_sql`。[#1062](https://github.com/Datus-ai/Datus-agent/pull/1062)
+
 ### 0.3.6
 
 **增强**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Project basic information configuration, required.
 [project]
 name = "datus-agent"
-version = "0.3.3"
+version = "0.3.7"
 description = "AI-powered SQL Agent for data engineering (Compiled Version)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -683,7 +683,7 @@ wheels = [
 
 [[package]]
 name = "datus-agent"
-version = "0.3.3"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Why

Prepare the 0.3.7 release: the release notes for 0.3.7 were not yet in the docs site, and the project version in `pyproject.toml` still pointed to an older version.

## Solution

- Add the 0.3.7 section to `docs/release_notes.md` (English) and `docs/release_notes.zh.md` (Chinese), following the existing section structure (New Features / Enhancements / Bug Fixes / Upgrade Notes / Internal). Covers the unified `web_tool.web_search` / `web_tool.web_fetch` group, the `execute_sql` consolidation, `list_tables` qualified names, OSI/AskMetrics improvements, permission prompt rendering, and related fixes, with PR links throughout.
- Replace the "docs pending" placeholder for the web tool with links to the new `configuration/web_tool` docs page (zh/en).
- Bump `version` in `pyproject.toml` to `0.3.7` and refresh `uv.lock` via `uv lock`.

## Test Cases

Docs-and-version-only change, no runtime behavior affected. Verified locally with the PR CI harness (`ci/run-pr-tests.py`): 204/204 tests passed, diff coverage 100%.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [x] release/0.3.7