### PR TITLE
[Enhancement] Fine-grained bash command permissions with pipeline support

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -96,6 +96,29 @@ agent:
   #   #   - tool: db_tools
   #   #     pattern: execute_ddl
   #   #     permission: deny
+  #   #
+  #   # Command-level bash rules (optional; profile whitelist applies when
+  #   # omitted). Pattern syntax — no colon = exact command; "prefix:*" =
+  #   # prefix match; "prefix:glob" = prefix + first-argument glob. Decision
+  #   # order: deny (also matches wrapped commands like ``xargs rm``) →
+  #   # safety ceiling (bash -c / sudo / && / $() / redirection always ask) →
+  #   # ask → allow → default (ask). A PURE pipeline (``a | b | c``) is judged
+  #   # per segment: it auto-runs only if every segment is allowed, and any
+  #   # denied segment blocks the whole pipeline. The confirmation prompt
+  #   # offers once / session / project scopes; "project" appends the prefix
+  #   # to ``.datus/config.yml``'s ``bash_allow`` list.
+  #   # bash_commands:
+  #   #   allow:
+  #   #     - "git status"            # exact: not "git status --short"
+  #   #     - "git log:*"             # prefix: any arguments
+  #   #     - "python:scripts/*.py"   # first arg must match the glob
+  #   #   deny:
+  #   #     - "rm:*"                  # also catches "xargs rm", "find -exec rm"
+  #   #     - "git push:*"            # deny always beats allow
+  #   #   ask:
+  #   #     - "docker:*"              # confirm every call (session approval per bucket)
+  #   #   classifier:                 # reserved: LLM classifier (not implemented)
+  #   #     enabled: false
 
 
   nodes:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2100,7 +2100,18 @@ class AgenticNode(Node):
             from datus.tools.permission.permission_manager import PermissionManager
 
             is_workflow = getattr(self, "execution_mode", None) == "workflow"
-            if is_workflow:
+            # Print mode opts out of the forced-``dangerous`` posture by
+            # setting ``agent_config.workflow_permission_profile`` (the
+            # configured or ``--permission-mode`` profile), so ``datus -p``
+            # only auto-runs what the profile's allow rules cover. Unattended
+            # flows (bootstrap, scheduler, benchmarks) leave it ``None`` and
+            # keep the historical dangerous baseline. isinstance guards
+            # against mocked agent_configs in tests.
+            workflow_profile = getattr(self.agent_config, "workflow_permission_profile", None)
+            if is_workflow and isinstance(workflow_profile, str) and workflow_profile:
+                permissions_config = self.agent_config.permissions_config
+                active_profile = workflow_profile
+            elif is_workflow:
                 from datus.tools.permission.profiles import get_profile
 
                 permissions_config = get_profile("dangerous")
@@ -3539,6 +3550,13 @@ class AgenticNode(Node):
 
             # Never call ``_get_or_create_broker`` here — it resets the queue
             # and orphans any parent CLI listener when running as a sub-agent.
+            # Reserved LLM-classifier seam for bash commands: returns None
+            # until ``permissions.bash_commands.classifier.enabled`` gains a
+            # real implementation (see bash_classifier.py).
+            from datus.tools.permission.bash_classifier import create_bash_classifier
+
+            bash_rules = getattr(getattr(self.agent_config, "permissions_config", None), "bash_commands", None)
+
             self.permission_hooks = PermissionHooks(
                 broker=self.interaction_broker,
                 permission_manager=self.permission_manager,
@@ -3548,6 +3566,7 @@ class AgenticNode(Node):
                 non_interactive=non_interactive,
                 proxied_tool_names=self.proxied_tool_names,
                 project_root=getattr(self.agent_config, "project_root", None),
+                bash_classifier=create_bash_classifier(bash_rules, self.agent_config),
             )
             logger.debug(
                 f"PermissionHooks attached to node '{self.get_node_name()}' "

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -222,6 +222,34 @@ class ArgumentParser:
             ),
         )
 
+        self.parser.add_argument(
+            "--permission-mode",
+            dest="permission_mode",
+            type=str,
+            choices=["normal", "auto", "dangerous"],
+            default=None,
+            help=(
+                "Override permissions.profile from agent.yml for this run (REPL and --print). "
+                "In --print mode the run uses the configured profile by default (bash and other "
+                "tools only auto-run when an allow rule matches); pass 'dangerous' to restore "
+                "the legacy allow-everything print-mode behavior."
+            ),
+        )
+
+        self.parser.add_argument(
+            "--execution-mode",
+            dest="execution_mode",
+            type=str,
+            choices=["interactive", "workflow"],
+            default=None,
+            help=(
+                "--print only. 'workflow' (default): headless — ASK permissions fail fast with "
+                "PERMISSION_DENIED. 'interactive': permission/interaction prompts are streamed "
+                "as MessagePayload JSON on stdout and answers are read from stdin, so a driving "
+                "program can approve or deny each request."
+            ),
+        )
+
     def parse_args(self):
         return self.parser.parse_args()
 
@@ -256,6 +284,9 @@ class Application:
 
         if getattr(args, "plan_mode", False) and args.print_mode is None:
             self.arg_parser.parser.error("--plan-mode requires --print mode (use Shift+Tab in the REPL)")
+
+        if getattr(args, "execution_mode", None) and args.print_mode is None:
+            self.arg_parser.parser.error("--execution-mode requires --print mode (the REPL is always interactive)")
 
         if args.print_mode is not None:
             from datus.cli.print_mode import PrintModeRunner

--- a/datus/cli/print_mode.py
+++ b/datus/cli/print_mode.py
@@ -53,6 +53,17 @@ class PrintModeRunner:
         self.scope = getattr(args, "session_scope", None)
         self.stream_thinking = getattr(args, "stream_thinking", False)
         self.plan_mode = getattr(args, "plan_mode", False)
+        # ``--execution-mode``: 'workflow' (default) fails fast on ASK
+        # permissions; 'interactive' streams permission/interaction prompts as
+        # JSON on stdout and reads answers from stdin.
+        self.execution_mode = getattr(args, "execution_mode", None) or "workflow"
+        # Print mode respects the configured / ``--permission-mode`` profile
+        # even in workflow mode (instead of the forced ``dangerous`` used by
+        # unattended flows) — bash and other tools only auto-run when an allow
+        # rule matches; anything ASK fails fast (workflow) or prompts via the
+        # stdin protocol (interactive). ``active_profile_name`` already
+        # reflects ``--permission-mode`` (applied in load_agent_config).
+        self.agent_config.workflow_permission_profile = self.agent_config.active_profile_name
 
         self.catalog, self.database, self.db_schema = self._resolve_database_context(args)
 
@@ -86,7 +97,7 @@ class PrintModeRunner:
             node_id_suffix="_print",
             scope=self.scope,
             session_id=self.session_id,
-            execution_mode="workflow",
+            execution_mode=self.execution_mode,
         )
 
         if getattr(self, "orchestrator_tools", None):
@@ -110,9 +121,11 @@ class PrintModeRunner:
             at_sqls=at_sqls,
             plan_mode=self.plan_mode,
         )
-        if self.plan_mode and hasattr(node_input, "auto_execute_plan"):
-            # Print mode is headless: the plan must be auto-approved so the
-            # run does not block waiting for an interactive confirmation.
+        if self.plan_mode and hasattr(node_input, "auto_execute_plan") and self.execution_mode == "workflow":
+            # Workflow print mode is headless: the plan must be auto-approved
+            # so the run does not block waiting for a confirmation. Under
+            # ``--execution-mode interactive`` the plan confirmation streams
+            # through the stdin/stdout protocol like any other interaction.
             node_input.auto_execute_plan = True
         node.input = node_input
         run_async(self._stream_chat(node))

--- a/datus/cli/web/chatbot.py
+++ b/datus/cli/web/chatbot.py
@@ -59,6 +59,9 @@ def _build_agent_args(args: argparse.Namespace) -> argparse.Namespace:
         interactive=True,
         output_dir=getattr(args, "output_dir", "./output"),
         log_level="DEBUG" if getattr(args, "debug", False) else "INFO",
+        # Forward the CLI permission override so ``load_agent_config`` applies
+        # it for ``datus --web`` the same way it does for REPL / --print.
+        permission_mode=getattr(args, "permission_mode", None),
     )
     return agent_args
 

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -909,6 +909,13 @@ class AgentConfig:
         # init raises.
         self.active_profile_name: str = "normal"
         self._raw_permissions: Dict[str, Any] = {}
+        # Profile that ``execution_mode="workflow"`` nodes should run under.
+        # ``None`` (default) keeps the historical forced-``dangerous`` posture
+        # for unattended flows (bootstrap, scheduler subagents, benchmarks).
+        # Print mode sets this so ``datus -p`` respects the configured /
+        # ``--permission-mode`` profile instead — see
+        # ``AgenticNode._setup_permission_manager``.
+        self.workflow_permission_profile: Optional[str] = None
         # Initialize unified permission system
         self.permissions_config = self._init_permissions_config(kwargs.get("permissions", {}))
 

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -320,6 +320,19 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         agent_raw["language"] = override.language
     if override.reasoning_effort is not None:
         agent_raw["target_reasoning_effort"] = override.reasoning_effort
+    if override.bash_allow:
+        # Append project-level bash allow patterns into the permissions raw
+        # dict so they ride the normal parse/merge pipeline
+        # (AgentConfig._init_permissions_config -> build_effective_config).
+        permissions = agent_raw.setdefault("permissions", {}) or {}
+        agent_raw["permissions"] = permissions
+        bash_commands = permissions.setdefault("bash_commands", {}) or {}
+        permissions["bash_commands"] = bash_commands
+        allow = bash_commands.setdefault("allow", []) or []
+        bash_commands["allow"] = allow
+        for pattern in override.bash_allow:
+            if pattern not in allow:
+                allow.append(pattern)
     # ``dashboard`` / ``scheduler`` overrides reach AgentConfig through
     # dedicated kwargs so the project-level pin is consulted between the
     # explicit call-site argument and the global default flag at lookup
@@ -369,6 +382,17 @@ def load_agent_config(reload: bool = False, create_if_missing: bool = False, **k
         ).data
     )
     _apply_project_override(agent_raw)
+    # ``--permission-mode`` CLI override: reshapes ``permissions.profile`` before
+    # AgentConfig parses it, so ``permissions_config`` / ``active_profile_name``
+    # reflect the override everywhere (REPL status bar, print mode, hooks).
+    # User rules / bash_commands still layer on top via build_effective_config.
+    permission_mode = kwargs.get("permission_mode")
+    if permission_mode:
+        permissions_raw = agent_raw.get("permissions") or {}
+        if not isinstance(permissions_raw, dict):
+            permissions_raw = {}
+        permissions_raw["profile"] = permission_mode
+        agent_raw["permissions"] = permissions_raw
     pre_init_override_keys = _apply_pre_init_overrides(agent_raw, kwargs)
     nodes = {}
     if "nodes" in agent_raw:

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -324,11 +324,21 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         # Append project-level bash allow patterns into the permissions raw
         # dict so they ride the normal parse/merge pipeline
         # (AgentConfig._init_permissions_config -> build_effective_config).
-        permissions = agent_raw.setdefault("permissions", {}) or {}
+        # Tolerate malformed YAML shapes (string/list where a mapping is
+        # expected) the same way ``AgentConfig._init_permissions_config`` and
+        # the ``permission_mode`` override below do: replace with an empty
+        # container instead of crashing config loading.
+        permissions = agent_raw.get("permissions")
+        if not isinstance(permissions, dict):
+            permissions = {}
         agent_raw["permissions"] = permissions
-        bash_commands = permissions.setdefault("bash_commands", {}) or {}
+        bash_commands = permissions.get("bash_commands")
+        if not isinstance(bash_commands, dict):
+            bash_commands = {}
         permissions["bash_commands"] = bash_commands
-        allow = bash_commands.setdefault("allow", []) or []
+        allow = bash_commands.get("allow")
+        if not isinstance(allow, list):
+            allow = []
         bash_commands["allow"] = allow
         for pattern in override.bash_allow:
             if pattern not in allow:

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -44,6 +44,7 @@ Any other keys in the file are ignored with a warning so users do not
 mistakenly expect the overlay to accept arbitrary YAML.
 """
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -51,6 +52,7 @@ from typing import Any, Optional, Union
 
 import yaml
 
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -317,9 +319,19 @@ def append_project_bash_allow(pattern: str, cwd: Optional[str] = None) -> Path:
     """
     pattern = pattern.strip()
     if not pattern:
-        raise ValueError("bash allow pattern must be non-empty")
+        raise DatusException(
+            code=ErrorCode.COMMON_FIELD_INVALID,
+            message_args={
+                "field_name": "bash allow pattern",
+                "except_values": "non-empty string",
+                "your_value": pattern,
+            },
+        )
     path = project_config_path(cwd)
-    entry_line = f'  - "{pattern}"'
+    # json.dumps yields a valid double-quoted YAML scalar with proper
+    # escaping, so a pattern containing ``"`` or a trailing backslash cannot
+    # corrupt the file (a parse failure would drop ALL project overrides).
+    entry_line = f"  - {json.dumps(pattern)}"
 
     if not path.exists():
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -34,6 +34,11 @@ pin a handful of values without copying the full config:
 - ``reasoning_effort``: one of ``off|minimal|low|medium|high`` — controls the
   reasoning/thinking effort passed to the active model, mapped to each
   vendor's native dialect by LiteLLM.
+- ``bash_allow``: list of bash command patterns (see
+  ``datus/tools/permission/bash_rules.py`` for the syntax) appended to
+  ``agent.permissions.bash_commands.allow`` at load time. Written by the
+  "allow (project)" choice in the bash permission prompt via
+  :func:`append_project_bash_allow`.
 
 Any other keys in the file are ignored with a warning so users do not
 mistakenly expect the overlay to accept arbitrary YAML.
@@ -61,6 +66,7 @@ ALLOWED_KEYS = frozenset(
         "project_name",
         "language",
         "reasoning_effort",
+        "bash_allow",
     }
 )
 REASONING_EFFORT_CHOICES = frozenset({"off", "minimal", "low", "medium", "high"})
@@ -100,6 +106,7 @@ class ProjectOverride:
     project_name: Optional[str] = None
     language: Optional[str] = None
     reasoning_effort: Optional[str] = None
+    bash_allow: Optional[list] = None
 
     def is_empty(self) -> bool:
         return (
@@ -111,6 +118,7 @@ class ProjectOverride:
             and self.project_name is None
             and self.language is None
             and self.reasoning_effort is None
+            and self.bash_allow is None
         )
 
 
@@ -186,7 +194,28 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         project_name=raw.get("project_name"),
         language=raw.get("language"),
         reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
+        bash_allow=_parse_bash_allow(raw.get("bash_allow")),
     )
+
+
+def _parse_bash_allow(raw: Any) -> Optional[list]:
+    """Normalize the ``bash_allow:`` field into a list of pattern strings.
+
+    Non-list values and non-string entries are dropped with a warning so a
+    typo cannot silently widen (or corrupt) the bash allow-list.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        logger.warning(f"bash_allow must be a list of strings, got {type(raw).__name__}. Ignoring.")
+        return None
+    patterns = []
+    for entry in raw:
+        if isinstance(entry, str) and entry.strip():
+            patterns.append(entry.strip())
+        else:
+            logger.warning(f"Ignoring non-string bash_allow entry: {entry!r}")
+    return patterns or None
 
 
 def _parse_optional_string(raw: Any, *, key: str) -> Optional[str]:
@@ -262,9 +291,66 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
             "project_name": override.project_name,
             "language": override.language,
             "reasoning_effort": override.reasoning_effort,
+            "bash_allow": override.bash_allow,
         }.items()
         if v is not None
     }
     with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(payload, f, sort_keys=False, default_flow_style=False)
+    return path
+
+
+def append_project_bash_allow(pattern: str, cwd: Optional[str] = None) -> Path:
+    """Append a bash allow pattern to ``./.datus/config.yml``'s ``bash_allow`` list.
+
+    Used by the "allow (project)" choice in the bash permission prompt.
+    Edits at the TEXT level (not load->dump) so user comments and formatting
+    in the rest of the file are preserved:
+
+    - file missing        -> create it with a commented ``bash_allow`` block
+    - no ``bash_allow:``  -> append the block at the end of the file
+    - key present         -> insert ``  - "<pattern>"`` right after the key line
+    - pattern already in the parsed list -> no-op
+
+    Raises ``OSError`` on write failures; callers (``PermissionManager.
+    add_project_bash_allow``) degrade to a session-level grant.
+    """
+    pattern = pattern.strip()
+    if not pattern:
+        raise ValueError("bash allow pattern must be non-empty")
+    path = project_config_path(cwd)
+    entry_line = f'  - "{pattern}"'
+
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = (
+            "# Project-level Datus overrides. See conf/agent.yml.example for the full schema.\n"
+            "# bash_allow patterns are appended to agent.permissions.bash_commands.allow.\n"
+            f"bash_allow:\n{entry_line}\n"
+        )
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    text = path.read_text(encoding="utf-8")
+
+    # No-op when the pattern is already present (compare parsed values, not
+    # raw text, so quoting style differences don't cause duplicates).
+    try:
+        existing = yaml.safe_load(text) or {}
+        if isinstance(existing, dict) and pattern in (existing.get("bash_allow") or []):
+            return path
+    except yaml.YAMLError:
+        logger.warning(f"{path} is not valid YAML; appending bash_allow anyway.")
+
+    lines = text.splitlines()
+    key_idx = next(
+        (i for i, line in enumerate(lines) if line.startswith("bash_allow:") and not line.lstrip().startswith("#")),
+        None,
+    )
+    if key_idx is None:
+        suffix = "" if (not text or text.endswith("\n")) else "\n"
+        path.write_text(f"{text}{suffix}bash_allow:\n{entry_line}\n", encoding="utf-8")
+    else:
+        lines.insert(key_idx + 1, entry_line)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return path

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -18,6 +18,7 @@ import hashlib
 import os
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import uuid
@@ -27,12 +28,16 @@ from typing import Any, Callable, Dict, List, Optional
 from agents import Tool
 
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.tools.permission.bash_rules import split_pipeline
 from datus.utils.loggings import get_logger
 from datus.utils.tool_archive import build_archived_marker, make_single_line_preview
 
 logger = get_logger(__name__)
 
 DEFAULT_TIMEOUT = 60
+# Upper bound for a per-call ``timeout`` the model may request, so a bad or
+# runaway value can't hang the agent indefinitely.
+MAX_BASH_TIMEOUT = 600
 MAX_OUTPUT_SIZE = 50000
 # Output larger than this is offloaded to a file under the session data dir and
 # replaced with a ``[DATUS_ARCHIVED]`` preview marker, so a huge command output
@@ -61,12 +66,22 @@ class BashTool:
       skills without ``allowed_commands``.
     - non-empty list: commands are filtered through ``_is_command_allowed``.
 
+    Execution model:
+    - Commands run through a real shell (``bash -c``) so pipelines and other
+      shell syntax work. Permission control (deny/ask/allow, per-segment
+      pipeline judging, safety ceiling for ``&&``/``$()``/redirection) happens
+      upstream in ``PermissionHooks`` + ``bash_rules`` — the execution layer
+      trusts an approved command. A hardening prefix (``shopt -u extglob``) is
+      prepended.
+    - When no ``bash`` is found (e.g. Windows without Git Bash), it falls back
+      to the legacy ``shell=False`` single-argv path (``shlex.split``); pipes
+      and shell operators are then NOT interpreted.
+
     Security features:
-    - Pattern-based filtering
+    - Pattern-based filtering (``allowed_patterns``; per-segment for pipelines)
     - Working directory locked to ``workspace_root``
-    - Timeout enforcement
+    - Timeout enforcement with process-group kill (no orphaned pipeline stages)
     - Output size limiting
-    - ``shell=False`` subprocess invocation (argv via ``shlex.split``)
     """
 
     permission_category: str = "bash_tools"
@@ -127,14 +142,31 @@ class BashTool:
         """Set tool context (called by framework before tool invocation)."""
         self._tool_context = ctx
 
-    def bash(self, command: str) -> FuncToolResult:
-        """Execute a shell command if it matches the allowed patterns.
+    def bash(self, command: str, timeout: Optional[int] = None) -> FuncToolResult:
+        """Run a shell command and return its output.
 
-        The command runs in ``workspace_root`` with ``shell=False``. Only
-        commands matching one of ``allowed_patterns`` are permitted.
+        The command runs through a real shell (bash), so pipelines and shell
+        syntax (``|``, ``&&``, redirection) work. It runs in a FIXED working
+        directory and each call is STATELESS: ``cd`` does NOT persist to the
+        next call, and shell state (variables, functions) is not carried over —
+        use absolute paths instead of relying on ``cd``. Commands cannot read
+        stdin (it is closed), so interactive prompts / ``read`` return EOF
+        immediately rather than hanging.
+
+        Prefer the dedicated tools when they fit — they are safer (scoped to
+        the project via the filesystem policy) and produce cleaner, reviewable
+        results:
+          * read a file  -> ``read_file`` (not ``cat``/``head``/``tail``)
+          * search text  -> ``grep`` (not raw ``grep``/``rg`` in bash)
+          * find files   -> ``glob`` (not ``find``/``ls``)
+        Use bash for things those tools cannot do (pipelines, running programs,
+        git, package managers, etc.).
 
         Args:
-            command: The command to execute (e.g., "python scripts/analyze.py").
+            command: The shell command to execute (e.g. "cat log | grep err").
+            timeout: Optional per-command timeout in SECONDS (capped at
+                ``MAX_BASH_TIMEOUT``). Defaults to the tool's configured
+                timeout. Raise it for a known slow command.
 
         Returns:
             FuncToolResult with stdout on success, error message on failure.
@@ -151,17 +183,14 @@ class BashTool:
                 error=f"Command not allowed. Allowed patterns: {', '.join(self.allowed_patterns) or '(none)'}",
             )
 
+        effective_timeout = self._resolve_timeout(timeout)
+
         try:
-            argv = shlex.split(command)
+            argv = self._build_spawn_argv(command)
         except ValueError as e:
             return FuncToolResult(success=0, error=f"Invalid command syntax: {e}")
 
-        # Resolve "python" to a real executable — handles environments
-        # where only "python3" exists (macOS, some Linux distros).
-        if argv and argv[0] == "python":
-            argv[0] = sys.executable or shutil.which("python3") or "python3"
-
-        logger.info("Executing command (identity=%s): %s", self.identity, command)
+        logger.info("Executing command (identity=%s, timeout=%ss): %s", self.identity, effective_timeout, command)
         output_dir = self._resolve_output_dir()
         try:
             if output_dir is not None:
@@ -169,14 +198,76 @@ class BashTool:
                 # a huge output never buffers in memory; decide by file size
                 # afterwards. Timeout is handled inside so the partial file is
                 # still surfaced.
-                return self._execute_with_redirect(argv, command, output_dir)
-            return self._execute_in_memory(argv)
+                return self._execute_with_redirect(argv, command, output_dir, effective_timeout)
+            return self._execute_in_memory(argv, effective_timeout)
         except subprocess.TimeoutExpired:
             logger.error("Command timed out (identity=%s): %s", self.identity, command)
-            return FuncToolResult(success=0, error=f"Command timed out after {self.timeout} seconds")
+            return FuncToolResult(success=0, error=f"Command timed out after {effective_timeout} seconds")
         except Exception as e:
             logger.error("Command execution failed (identity=%s): %s", self.identity, e)
             return FuncToolResult(success=0, error=f"Command execution failed: {str(e)}")
+
+    def _resolve_timeout(self, timeout: Optional[int]) -> int:
+        """Clamp an optional per-call timeout into ``(0, MAX_BASH_TIMEOUT]``.
+
+        Invalid / non-positive values fall back to the instance default so a
+        bad model-supplied timeout can't disable the limit or hang the call.
+        """
+        if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
+            return self.timeout
+        return min(timeout, MAX_BASH_TIMEOUT)
+
+    # Cached bash path (None when unavailable → legacy single-argv fallback).
+    _bash_path_cache: Optional[str] = None
+    _bash_path_resolved: bool = False
+
+    @classmethod
+    def _resolve_bash(cls) -> Optional[str]:
+        if not cls._bash_path_resolved:
+            cls._bash_path_cache = shutil.which("bash")
+            cls._bash_path_resolved = True
+        return cls._bash_path_cache
+
+    def _shell_prefix(self) -> str:
+        """Hardening prefix prepended to every ``bash -c`` command.
+
+        - ``shopt -u extglob``: disable extended globs so a malicious filename
+          can't expand into something unexpected after permission validation
+          (mirrors Claude Code's bashProvider hardening).
+        - ``python`` shim: shadow ``python`` with the interpreter datus runs
+          under, preserving the legacy ``argv[0]=='python' -> sys.executable``
+          rewrite for environments where only ``python3`` exists.
+
+        NOTE: intentionally NO ``set -o pipefail`` — bash's default takes the
+        LAST stage's exit code, matching Claude Code. pipefail would flag the
+        ubiquitous ``... | head`` as a failure because the upstream stage dies
+        with SIGPIPE (exit 141) when ``head`` closes the pipe early.
+        """
+        parts = [
+            "shopt -u extglob 2>/dev/null || true",
+        ]
+        py = sys.executable or shutil.which("python3")
+        if py:
+            parts.append(f'python() {{ {shlex.quote(py)} "$@"; }}')
+        return "; ".join(parts) + "; "
+
+    def _build_spawn_argv(self, command: str) -> List[str]:
+        """Build the argv to spawn for ``command``.
+
+        Real-shell path: ``[bash, -c, <prefix><command>]``. Falls back to the
+        legacy ``shell=False`` single-argv (with the ``python`` rewrite) when
+        no bash is available — pipes/operators then don't work, which is the
+        pre-existing behavior on such platforms.
+        """
+        bash_path = self._resolve_bash()
+        if bash_path:
+            return [bash_path, "-c", self._shell_prefix() + command]
+
+        # Legacy fallback: no shell interpretation.
+        argv = shlex.split(command)
+        if argv and argv[0] == "python":
+            argv[0] = sys.executable or shutil.which("python3") or "python3"
+        return argv
 
     def _resolve_output_dir(self) -> Optional[Path]:
         """Resolve the offload directory lazily, tolerating any provider error.
@@ -201,7 +292,7 @@ class BashTool:
             return None
         return path
 
-    def _execute_with_redirect(self, argv: List[str], command: str, output_dir: Path) -> FuncToolResult:
+    def _execute_with_redirect(self, argv: List[str], command: str, output_dir: Path, timeout: int) -> FuncToolResult:
         """Run the command with stdout/stderr redirected to a file on disk.
 
         stderr is merged into the stdout file (``stderr=STDOUT``) so interleaved
@@ -220,30 +311,33 @@ class BashTool:
 
         timed_out = False
         returncode = 0
-        try:
-            with open(path, "wb") as fh:
-                proc = subprocess.run(
-                    argv,
-                    shell=False,
-                    cwd=str(self.workspace_root),
-                    stdout=fh,
-                    stderr=subprocess.STDOUT,
-                    stdin=subprocess.DEVNULL,
-                    timeout=self.timeout,
-                    env=self._get_safe_env(),
-                )
-            returncode = proc.returncode
-        except subprocess.TimeoutExpired:
-            # The child is killed but the file holds whatever it wrote so far.
-            timed_out = True
-            logger.error("Command timed out (identity=%s): %s", self.identity, command)
+        with open(path, "wb") as fh:
+            proc = subprocess.Popen(
+                argv,
+                shell=False,
+                cwd=str(self.workspace_root),
+                stdout=fh,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                env=self._get_safe_env(),
+                # New session/process group so a timeout can kill the whole
+                # pipeline (all stages), not just the bash launcher.
+                start_new_session=(os.name == "posix"),
+            )
+            try:
+                returncode = proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                # The tree is killed but the file holds whatever it wrote so far.
+                timed_out = True
+                logger.error("Command timed out (identity=%s): %s", self.identity, command)
+                self._kill_process_tree(proc)
 
         result_str = self._result_from_output_file(path)
 
         if timed_out:
             return FuncToolResult(
                 success=0,
-                error=f"Command timed out after {self.timeout} seconds",
+                error=f"Command timed out after {timeout} seconds",
                 result=result_str or None,
             )
         if returncode != 0:
@@ -285,15 +379,15 @@ class BashTool:
         except OSError:  # pragma: no cover - best effort cleanup
             pass
 
-    def _execute_in_memory(self, argv: List[str]) -> FuncToolResult:
+    def _execute_in_memory(self, argv: List[str], timeout: int) -> FuncToolResult:
         """Fallback path (no offload dir): capture output in memory + truncate."""
-        result = subprocess.run(
+        proc = subprocess.Popen(
             argv,
             shell=False,
             cwd=str(self.workspace_root),
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=self.timeout,
             env=self._get_safe_env(),
             # Detach the child from the agent's stdin. Without this the child
             # inherits datus's terminal stdin and any command that reads it
@@ -302,42 +396,94 @@ class BashTool:
             # the same TTY and freezing the whole process. DEVNULL delivers
             # an immediate EOF so such commands fail fast instead of hanging.
             stdin=subprocess.DEVNULL,
+            # Process group so a timeout kills the whole pipeline, not just bash.
+            start_new_session=(os.name == "posix"),
         )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self._kill_process_tree(proc)
+            stdout, stderr = proc.communicate()
+            partial = stdout or ""
+            if stderr:
+                partial += f"\n[stderr]\n{stderr}"
+            return FuncToolResult(
+                success=0,
+                error=f"Command timed out after {timeout} seconds",
+                result=partial or None,
+            )
 
-        output = result.stdout
-        if result.stderr:
-            output += f"\n[stderr]\n{result.stderr}"
+        output = stdout or ""
+        if stderr:
+            output += f"\n[stderr]\n{stderr}"
 
         if len(output) > MAX_OUTPUT_SIZE:
             output = output[:MAX_OUTPUT_SIZE] + f"\n... [truncated, total {len(output)} chars]"
 
-        if result.returncode != 0:
+        if proc.returncode != 0:
             return FuncToolResult(
                 success=0,
-                error=f"Command exited with code {result.returncode}",
+                error=f"Command exited with code {proc.returncode}",
                 result=output,
             )
 
         return FuncToolResult(success=1, result=output)
 
+    def _kill_process_tree(self, proc: "subprocess.Popen") -> None:
+        """Kill a timed-out process and its whole group (all pipeline stages).
+
+        On POSIX the child was started in a new session, so ``killpg`` reaches
+        every stage. Falls back to killing just the launcher elsewhere.
+        """
+        try:
+            if os.name == "posix":
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            else:
+                proc.kill()
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                proc.kill()
+            except OSError:  # pragma: no cover - already dead
+                pass
+
     def _is_command_allowed(self, command: str) -> bool:
-        """Check if a command matches any allowed pattern."""
+        """Check if a command matches any allowed pattern.
+
+        The ``["*"]`` wildcard (used by AgenticNode, where the real gate is
+        ``PermissionManager``) short-circuits to allowed. For a restrictive
+        whitelist (skills) a pure pipeline is allowed only if EVERY segment
+        matches; any non-pipeline shell construct (``&&``, ``$()``, ...) is
+        rejected outright since per-segment matching can't reason about it.
+        """
         if not self.allowed_patterns:
             return False
+        if "*" in self.allowed_patterns:
+            return True
 
+        segments = split_pipeline(command)
+        if segments is None:
+            # ``||`` / ``|&`` / empty segment / unbalanced quotes — cannot be
+            # matched segment-by-segment under a restrictive whitelist.
+            return False
+        return all(self._segment_allowed(seg) for seg in segments)
+
+    def _segment_allowed(self, segment: str) -> bool:
+        """True if a single command segment matches any allowed pattern.
+
+        A segment containing non-pipe shell metacharacters (chaining, command
+        substitution, redirection) is rejected — the whitelist speaks about
+        one command, not a compound expression.
+        """
         try:
-            parts = shlex.split(command)
+            parts = shlex.split(segment)
         except ValueError:
-            parts = command.split()
+            return False
         if not parts:
             return False
+        if any(tok in ("&&", "||", ";", "|", "&", "`", "$(", ">", "<") for tok in parts):
+            return False
         base_cmd = parts[0]
-
-        for pattern in self.allowed_patterns:
-            if self._matches_pattern(command, base_cmd, pattern):
-                return True
-
-        return False
+        return any(self._matches_pattern(segment, base_cmd, pattern) for pattern in self.allowed_patterns)
 
     def _matches_pattern(self, full_command: str, base_cmd: str, pattern: str) -> bool:
         """Check if a command matches a specific pattern.

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -331,6 +331,11 @@ class BashTool:
                 timed_out = True
                 logger.error("Command timed out (identity=%s): %s", self.identity, command)
                 self._kill_process_tree(proc)
+                try:
+                    # Reap the launcher so it doesn't linger as a zombie.
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:  # pragma: no cover - kill already sent
+                    pass
 
         result_str = self._result_from_output_file(path)
 

--- a/datus/tools/permission/__init__.py
+++ b/datus/tools/permission/__init__.py
@@ -9,6 +9,17 @@ This module provides pattern-based permission control (allow/deny/ask)
 for all tool types in Datus-agent, following Claude Code and OpenCode patterns.
 """
 
+from datus.tools.permission.bash_classifier import (
+    BashClassifierContext,
+    BashCommandClassifier,
+    ClassifierVerdict,
+    create_bash_classifier,
+)
+from datus.tools.permission.bash_rules import (
+    BashCommandRules,
+    BashRuleDecision,
+    evaluate_bash_command,
+)
 from datus.tools.permission.permission_config import (
     PermissionConfig,
     PermissionLevel,
@@ -29,4 +40,11 @@ __all__ = [
     "PermissionHooks",
     "PermissionDeniedException",
     "CompositeHooks",
+    "BashCommandRules",
+    "BashRuleDecision",
+    "evaluate_bash_command",
+    "BashCommandClassifier",
+    "BashClassifierContext",
+    "ClassifierVerdict",
+    "create_bash_classifier",
 ]

--- a/datus/tools/permission/bash_classifier.py
+++ b/datus/tools/permission/bash_classifier.py
@@ -1,0 +1,95 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""LLM-based bash command classifier — interface seam only, no implementation.
+
+Reserved extension point for auto-resolving bash permission prompts with an
+LLM judgment (analogous to Claude Code's bash prompt-rule classifier). The
+static rules in ``bash_rules.py`` decide first; the classifier is a second
+opinion that may upgrade an ASK to an auto-allow.
+
+Consultation contract (enforced by ``PermissionHooks._handle_bash_permission``):
+
+- Consulted ONLY when the static decision is ASK with ``safety_forced=False``
+  and the session is interactive. Deny decisions and safety-ceiling asks
+  (shell wrappers, metacharacters, unparseable commands) are never sent to
+  the classifier — those must stay with the user.
+- An ``ALLOW`` verdict with ``confidence >= BashClassifierConfig.
+  confidence_threshold`` auto-allows the call (logged, NOT session-cached —
+  every invocation is judged on its own).
+- Anything else — ``None``, low confidence, a DENY/ASK verdict, or an
+  exception — falls through to the normal confirmation prompt. Fail closed.
+
+Future implementation sketch (TODO(llm-classifier)):
+
+    model = LLMBaseModel.create_model(agent_config, model_name=config.model)
+    verdict_json = model.generate_with_json_output(prompt)  # datus/models/base.py
+
+with a prompt built from the command, cwd, and the natural-language rule
+descriptions in ``BashClassifierContext.rule_descriptions``.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from datus.tools.permission.bash_rules import BashCommandRules
+from datus.tools.permission.permission_config import PermissionLevel
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class BashClassifierContext:
+    """Context handed to the classifier alongside the command."""
+
+    cwd: str
+    node_name: str
+    rule_descriptions: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ClassifierVerdict:
+    """A classifier's judgment on one command."""
+
+    permission: PermissionLevel
+    confidence: float
+    reason: str
+
+
+class BashCommandClassifier(ABC):
+    """Interface for LLM-based bash command classification."""
+
+    @abstractmethod
+    async def classify(self, command: str, context: BashClassifierContext) -> Optional[ClassifierVerdict]:
+        """Judge a command; return None when no judgment can be made.
+
+        Implementations must never raise for routine conditions (timeouts,
+        malformed model output) — return None instead so the caller falls
+        through to the confirmation prompt.
+        """
+
+
+class NoopBashCommandClassifier(BashCommandClassifier):
+    """Default classifier: never renders a verdict."""
+
+    async def classify(self, command: str, context: BashClassifierContext) -> Optional[ClassifierVerdict]:
+        return None
+
+
+def create_bash_classifier(rules: Optional[BashCommandRules], agent_config: Any) -> Optional[BashCommandClassifier]:
+    """Build a classifier from config; None when disabled (the default).
+
+    Returning None (rather than a Noop instance) lets the hook skip the
+    consultation branch entirely.
+    """
+    if rules is None or not rules.classifier.enabled:
+        return None
+    # TODO(llm-classifier): construct the real implementation here via
+    #   LLMBaseModel.create_model(agent_config, model_name=rules.classifier.model)
+    # and generate_with_json_output(). Until then, an enabled flag yields the
+    # Noop so turning it on is harmless.
+    logger.warning("bash_commands.classifier.enabled is set but no LLM classifier is implemented yet; using no-op")
+    return NoopBashCommandClassifier()

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -39,8 +39,11 @@ asymmetry of aggressive deny / conservative allow):
                                  pipeline segment ``... | xargs rm``)
 3. safety ceiling             -> ASK (safety_forced) for shell wrappers
                                  (``bash -c`` re-introduces a shell that the
-                                 outer argv match is blind to) and non-pipe
-                                 shell metacharacters; allow rules cannot override
+                                 outer argv match is blind to), interpreter
+                                 inline-code flags (``python -c`` / ``perl -e``
+                                 execute a string the rules cannot see), and
+                                 non-pipe shell metacharacters; allow rules
+                                 cannot override
 4. ask rules                  -> ASK (anchored)
 5. allow rules                -> ALLOW (anchored only, never unanchored)
 6. rules.default              -> usually ASK
@@ -56,7 +59,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from datus.tools.permission.permission_config import PermissionLevel
 from datus.utils.loggings import get_logger
@@ -103,6 +106,50 @@ _WRAPPER_COMMANDS = frozenset(
         "script",
     }
 )
+
+# Script interpreters are NOT blanket wrappers: an allow rule can
+# meaningfully match the script path (the documented ``python:scripts/*.py``
+# form), so listing them in ``_WRAPPER_COMMANDS`` would make every such rule
+# dead (the safety ceiling runs before allow matching). But their inline-code
+# flags (``python -c``, ``perl -e``, ``node --eval`` …) execute an arbitrary
+# string the rules cannot see — exactly the wrapper problem — so those forms
+# hit the safety ceiling instead of ever auto-allowing. Values are
+# (short option letters, long flags); short letters are matched inside
+# combined clusters too (``-uc`` contains ``c``). Options precede the
+# script/program path for all of these interpreters, so scanning stops at the
+# first non-option token to avoid false ASKs on script-owned arguments.
+_INTERPRETER_INLINE_CODE_FLAGS: Dict[str, tuple] = {
+    "python": (frozenset("c"), frozenset()),
+    "perl": (frozenset("eE"), frozenset()),
+    "ruby": (frozenset("e"), frozenset()),
+    "node": (frozenset("ep"), frozenset({"--eval", "--print"})),
+    "nodejs": (frozenset("ep"), frozenset({"--eval", "--print"})),
+    "php": (frozenset("r"), frozenset()),
+}
+
+# ``python``, ``python3``, ``python3.12`` … all resolve to the python spec.
+_PYTHON_VERSIONED_RE = re.compile(r"^python\d*(\.\d+)*$")
+
+
+def _has_inline_code_flag(argv: List[str]) -> bool:
+    """True when a known interpreter is invoked with an inline-code flag."""
+    spec = _INTERPRETER_INLINE_CODE_FLAGS.get(argv[0])
+    if spec is None and _PYTHON_VERSIONED_RE.match(argv[0]):
+        spec = _INTERPRETER_INLINE_CODE_FLAGS["python"]
+    if spec is None:
+        return False
+    short_letters, long_flags = spec
+    for token in argv[1:]:
+        if not token.startswith("-") or token == "-":
+            break
+        if token.startswith("--"):
+            if token.split("=", 1)[0] in long_flags:
+                return True
+            continue
+        if any(letter in token[1:] for letter in short_letters):
+            return True
+    return False
+
 
 # Multi-command CLIs whose first subcommand carries the semantics; session
 # buckets use the first two tokens so approving ``git log`` never covers
@@ -155,8 +202,7 @@ class BashCommandRules(BaseModel):
     )
     classifier: BashClassifierConfig = Field(default_factory=BashClassifierConfig)
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
     @classmethod
     def from_dict(cls, data: Optional[Dict[str, Any]]) -> Optional["BashCommandRules"]:
@@ -423,6 +469,15 @@ def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleD
             source=BashDecisionSource.SAFETY,
             matched_pattern=None,
             reason=f"'{argv[0]}' executes its arguments as a new command; rules cannot see the wrapped command",
+            bucket=session_bucket_for(argv, None),
+            safety_forced=True,
+        )
+    if _has_inline_code_flag(argv):
+        return BashRuleDecision(
+            level=PermissionLevel.ASK,
+            source=BashDecisionSource.SAFETY,
+            matched_pattern=None,
+            reason=f"'{argv[0]}' with an inline-code flag executes an arbitrary string; rules cannot see the code",
             bucket=session_bucket_for(argv, None),
             safety_forced=True,
         )

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -1,0 +1,584 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Fine-grained bash command permission rules.
+
+Evaluates a bash command string against allow/deny/ask pattern lists and
+returns a decision for ``PermissionHooks._handle_bash_permission``. This is
+the command-level refinement of the coarse ``bash_tools.bash -> ASK`` rule:
+instead of prompting for every command, users (and profiles) can express
+"``git log`` is always fine, ``rm`` is never fine, ``docker`` should ask".
+
+Pattern syntax (Claude-Code-style, extended to multi-word prefixes — the
+legacy ``BashTool._matches_pattern`` only fnmatches ``argv[0]`` and cannot
+express ``git status``):
+
+- ``"git status"`` (no colon)  -> exact match: argv equals the pattern tokens.
+- ``"git log:*"``              -> prefix match: argv starts with the prefix
+  tokens; anything (including nothing) may follow.
+- ``"python:scripts/*.py"``    -> prefix match AND the first token after the
+  prefix (or the joined remainder) fnmatches the glob. Only the first
+  positional argument is matched to prevent smuggling a disallowed flag in
+  front (mirrors the rationale in ``BashTool._matches_pattern``).
+
+Pipelines: a pure pipeline (``a | b | c`` — only top-level, unquoted ``|``)
+is split into segments and each segment is judged independently, then the
+results are aggregated (any DENY -> DENY; any safety-forced -> ASK; all ALLOW
+-> ALLOW; otherwise ASK). This lets a pipeline of allow-listed read-only
+commands (``cat log | grep err | wc -l``) auto-run. Every OTHER shell
+construct (``&&``, ``;``, ``||``, ``$()``, redirection) hits the safety
+ceiling and requires confirmation.
+
+Per-segment decision order (deny-bypass-resistant, mirroring Claude Code's
+asymmetry of aggressive deny / conservative allow):
+
+1. unparseable / empty        -> ASK (safety_forced)
+2. deny rules                 -> DENY (anchored AND unanchored, so a deny on
+                                 ``rm:*`` also catches ``xargs rm -rf x`` and a
+                                 pipeline segment ``... | xargs rm``)
+3. safety ceiling             -> ASK (safety_forced) for shell wrappers
+                                 (``bash -c`` re-introduces a shell that the
+                                 outer argv match is blind to) and non-pipe
+                                 shell metacharacters; allow rules cannot override
+4. ask rules                  -> ASK (anchored)
+5. allow rules                -> ALLOW (anchored only, never unanchored)
+6. rules.default              -> usually ASK
+
+The ``classifier`` config block is a reserved seam for a future LLM-based
+classifier (see ``bash_classifier.py``); it carries configuration only.
+"""
+
+import fnmatch
+import re
+import shlex
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from datus.tools.permission.permission_config import PermissionLevel
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Shell metacharacters (other than a plain top-level ``|``) that change
+# execution semantics. BashTool executes commands through a real shell, so
+# these ARE interpreted — but per-segment rule matching cannot reason about
+# command substitution, chaining, or redirection, so commands containing them
+# never auto-allow (they hit the safety ceiling → confirmation).
+#
+# ``|`` is deliberately excluded here: a pure pipeline (``a | b | c``) is
+# split into segments by ``split_pipeline`` and each segment is judged on its
+# own, so pipelines of allow-listed read-only commands can auto-run. ``||``
+# (logical OR) is NOT a pipeline — ``split_pipeline`` returns None for it and
+# the caller falls back to this safety ceiling.
+_SHELL_METACHARS_RE = re.compile(r"[;&<>`\n]|\$\(|\$\{|\|\||&&")
+
+# Commands that execute their arguments (or arbitrary strings) as new
+# commands. An allow rule matched against the OUTER argv says nothing about
+# the wrapped command, so these never auto-allow either.
+_WRAPPER_COMMANDS = frozenset(
+    {
+        "bash",
+        "sh",
+        "zsh",
+        "dash",
+        "ksh",
+        "fish",
+        "csh",
+        "tcsh",
+        "xargs",
+        "env",
+        "sudo",
+        "doas",
+        "nohup",
+        "eval",
+        "exec",
+        "command",
+        "time",
+        "timeout",
+        "watch",
+        "script",
+    }
+)
+
+# Multi-command CLIs whose first subcommand carries the semantics; session
+# buckets use the first two tokens so approving ``git log`` never covers
+# ``git push``.
+_GROUP_COMMANDS = frozenset(
+    {
+        "git",
+        "docker",
+        "npm",
+        "pnpm",
+        "yarn",
+        "uv",
+        "pip",
+        "pip3",
+        "cargo",
+        "go",
+        "kubectl",
+        "make",
+        "poetry",
+        "conda",
+    }
+)
+
+
+class BashClassifierConfig(BaseModel):
+    """Reserved configuration for the future LLM command classifier.
+
+    Parsed and carried through the config pipeline today; consumed only by
+    ``bash_classifier.create_bash_classifier`` which returns ``None`` until a
+    real implementation lands. See ``bash_classifier.py`` for the contract.
+    """
+
+    enabled: bool = Field(default=False, description="Enable the LLM classifier (no implementation yet)")
+    model: Optional[str] = Field(default=None, description="Model name for LLMBaseModel.create_model")
+    confidence_threshold: float = Field(default=0.8, description="Minimum confidence for a verdict to act")
+
+
+class BashCommandRules(BaseModel):
+    """Command-level allow/deny/ask rules for the bash tool.
+
+    Configured under ``agent.permissions.bash_commands`` in agent.yml (see
+    ``conf/agent.yml.example``) and attached to profiles in ``profiles.py``.
+    """
+
+    allow: List[str] = Field(default_factory=list, description="Patterns that auto-allow")
+    deny: List[str] = Field(default_factory=list, description="Patterns that block (highest priority)")
+    ask: List[str] = Field(default_factory=list, description="Patterns that force a confirmation")
+    default: PermissionLevel = Field(
+        default=PermissionLevel.ASK, description="Decision when no rule matches (ask unless overridden)"
+    )
+    classifier: BashClassifierConfig = Field(default_factory=BashClassifierConfig)
+
+    class Config:
+        use_enum_values = True
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> Optional["BashCommandRules"]:
+        """Create from the agent.yml ``bash_commands`` dict; None when absent.
+
+        Validation errors propagate so ``AgentConfig._init_permissions_config``
+        can apply its existing fail-closed fallback (revert to normal profile).
+        """
+        if not data:
+            return None
+        # Only pass ``default`` / ``classifier`` when the YAML actually set
+        # them, so ``model_fields_set`` faithfully records explicitness — the
+        # hook's profile-posture fallback and ``merge_with`` both rely on it.
+        kwargs: Dict[str, Any] = {
+            "allow": data.get("allow", []),
+            "deny": data.get("deny", []),
+            "ask": data.get("ask", []),
+        }
+        if "default" in data:
+            kwargs["default"] = PermissionLevel(data["default"])
+        if data.get("classifier") is not None:
+            kwargs["classifier"] = BashClassifierConfig(**data["classifier"])
+        return cls(**kwargs)
+
+    def merge_with(self, override: Optional["BashCommandRules"]) -> "BashCommandRules":
+        """Layer another ruleset on top: lists concatenate, scalars override.
+
+        ``default`` and ``classifier`` are replaced only when the override set
+        them explicitly (``model_fields_set``), so a node-level override that
+        just adds an allow pattern does not silently reset the default. When
+        NEITHER side set them, the merged result keeps them unset too — the
+        permission hook uses that to fall back to the profile's
+        ``default_permission`` (e.g. ALLOW under dangerous).
+        """
+        if override is None:
+            return self
+        kwargs: Dict[str, Any] = {
+            "allow": self.allow + override.allow,
+            "deny": self.deny + override.deny,
+            "ask": self.ask + override.ask,
+        }
+        if "default" in override.model_fields_set:
+            kwargs["default"] = PermissionLevel(override.default)
+        elif "default" in self.model_fields_set:
+            kwargs["default"] = PermissionLevel(self.default)
+        if "classifier" in override.model_fields_set:
+            kwargs["classifier"] = override.classifier
+        elif "classifier" in self.model_fields_set:
+            kwargs["classifier"] = self.classifier
+        return BashCommandRules(**kwargs)
+
+    def is_empty(self) -> bool:
+        """True when no patterns are configured (fall back to the coarse rule)."""
+        return not (self.allow or self.deny or self.ask)
+
+
+class BashDecisionSource(str, Enum):
+    """Why ``evaluate_bash_command`` decided the way it did."""
+
+    DENY_RULE = "deny_rule"
+    ASK_RULE = "ask_rule"
+    ALLOW_RULE = "allow_rule"
+    SAFETY = "safety"
+    DEFAULT = "default"
+    UNPARSEABLE = "unparseable"
+
+
+@dataclass(frozen=True)
+class BashRuleDecision:
+    """Result of evaluating one bash command against a ruleset.
+
+    Attributes:
+        level: The permission decision (real enum, not the pydantic string).
+        source: Which stage of the decision order produced it.
+        matched_pattern: The rule pattern that fired, when source is a rule.
+        reason: Human-readable explanation for prompts and logs.
+        bucket: Session-approval bucket key (e.g. ``git push`` or an ask-rule
+            pattern) — "always allow" grants are scoped to this bucket.
+        safety_forced: True when the ASK came from the safety ceiling or an
+            unparseable command. Such decisions must never be auto-resolved by
+            the future LLM classifier, and must not be offered as persistent
+            project-level allows.
+    """
+
+    level: PermissionLevel
+    source: BashDecisionSource
+    matched_pattern: Optional[str]
+    reason: str
+    bucket: str
+    safety_forced: bool = False
+
+
+def _split_pattern(pattern: str) -> tuple[List[str], Optional[str]]:
+    """Split a rule pattern into prefix tokens and an optional glob.
+
+    ``"git log:*"`` -> (["git", "log"], "*"); ``"git status"`` -> (["git",
+    "status"], None) meaning exact match.
+    """
+    if ":" in pattern:
+        prefix, glob = pattern.split(":", 1)
+    else:
+        prefix, glob = pattern, None
+    return prefix.split(), glob
+
+
+def _match_at(argv: List[str], offset: int, prefix_tokens: List[str], glob: Optional[str]) -> bool:
+    """Match prefix tokens + glob against ``argv`` starting at ``offset``."""
+    end = offset + len(prefix_tokens)
+    if end > len(argv):
+        return False
+    for tok, pat in zip(argv[offset:end], prefix_tokens):
+        if not fnmatch.fnmatch(tok, pat):
+            return False
+    remainder = argv[end:]
+    if glob is None:
+        # Exact pattern: nothing may follow the prefix tokens.
+        return not remainder
+    if glob == "*":
+        return True
+    if not remainder:
+        return False
+    # Only the FIRST positional token (or the joined remainder as a whole)
+    # may satisfy the glob — matching arbitrary later args would let a caller
+    # smuggle a disallowed flag in front (see BashTool._matches_pattern).
+    return fnmatch.fnmatch(remainder[0], glob) or fnmatch.fnmatch(" ".join(remainder), glob)
+
+
+def command_matches_pattern(argv: List[str], pattern: str, anchor: bool = True) -> bool:
+    """Check whether tokenized command ``argv`` matches ``pattern``.
+
+    Args:
+        argv: ``shlex.split`` result of the command string.
+        pattern: Rule pattern (see module docstring for syntax).
+        anchor: When True the prefix must start at ``argv[0]``. Deny rules
+            additionally match unanchored (any offset) so ``rm:*`` catches
+            ``xargs rm`` / ``find . -exec rm``; allow rules must never do this.
+    """
+    prefix_tokens, glob = _split_pattern(pattern)
+    if not prefix_tokens or not argv:
+        return False
+    if anchor:
+        return _match_at(argv, 0, prefix_tokens, glob)
+    return any(_match_at(argv, i, prefix_tokens, glob) for i in range(len(argv) - len(prefix_tokens) + 1))
+
+
+def session_bucket_for(argv: List[str], matched_pattern: Optional[str]) -> str:
+    """Session-approval bucket key for a command.
+
+    A matched ask-rule pattern is its own bucket. Otherwise grouped CLIs
+    (git/docker/npm/...) bucket on the first two tokens so approving one
+    subcommand never green-lights the others; everything else buckets on
+    ``argv[0]``.
+    """
+    if matched_pattern:
+        return matched_pattern
+    if not argv:
+        return "<empty>"
+    if argv[0] in _GROUP_COMMANDS and len(argv) >= 2 and not argv[1].startswith("-"):
+        return f"{argv[0]} {argv[1]}"
+    return argv[0]
+
+
+def split_pipeline(command: str) -> Optional[List[str]]:
+    """Split a command on top-level, unquoted ``|`` into pipeline segments.
+
+    Shared by the permission layer (per-segment judging) and the execution
+    layer (legacy ``allowed_patterns`` matching) so the *same* segmentation is
+    judged and run.
+
+    Returns:
+        * ``[command]`` — no top-level pipe (a plain single command).
+        * ``["seg1", "seg2", ...]`` — a clean pipeline, each part stripped.
+        * ``None`` — NOT a simple pipeline: ``||`` (logical OR), ``|&``
+          (stderr pipe), an empty segment (``ls |``, ``| ls``), or unbalanced
+          quotes. The caller routes these to the safety ceiling.
+
+    Only single/double quotes and backslash escaping are tracked — enough to
+    keep ``grep "a|b"`` and ``echo \\|`` from being treated as pipe splits.
+    Other shell metacharacters are handled separately by the caller.
+    """
+    segments: List[str] = []
+    buf: List[str] = []
+    in_single = in_double = False
+    i, n = 0, len(command)
+    while i < n:
+        c = command[i]
+        if c == "\\" and not in_single:
+            # Backslash escapes the next char outside single quotes; keep both
+            # so shlex re-parses them and the escaped char can't be a split.
+            buf.append(c)
+            if i + 1 < n:
+                buf.append(command[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+        if c == "'" and not in_double:
+            in_single = not in_single
+        elif c == '"' and not in_single:
+            in_double = not in_double
+        elif c == "|" and not in_single and not in_double:
+            nxt = command[i + 1] if i + 1 < n else ""
+            if nxt in ("|", "&"):
+                # `||` (logical OR) / `|&` (stderr pipe) are not simple pipes.
+                return None
+            segments.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    segments.append("".join(buf))
+    if in_single or in_double:
+        return None
+    stripped = [s.strip() for s in segments]
+    if any(s == "" for s in stripped):
+        return None
+    return stripped
+
+
+def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleDecision:
+    """Evaluate one non-pipeline command segment. See module docstring order."""
+    try:
+        argv = shlex.split(command)
+    except ValueError as e:
+        first_word = command.strip().split()[0] if command.strip() else "<empty>"
+        return BashRuleDecision(
+            level=PermissionLevel.ASK,
+            source=BashDecisionSource.UNPARSEABLE,
+            matched_pattern=None,
+            reason=f"Command could not be parsed ({e})",
+            bucket=first_word,
+            safety_forced=True,
+        )
+    if not argv:
+        return BashRuleDecision(
+            level=PermissionLevel.ASK,
+            source=BashDecisionSource.UNPARSEABLE,
+            matched_pattern=None,
+            reason="Empty command",
+            bucket="<empty>",
+            safety_forced=True,
+        )
+
+    # 1. Deny — most aggressive: anchored and unanchored, before everything
+    # else so a deny can never be downgraded by a later stage. Unanchored
+    # matching means a deny on ``rm:*`` also catches a segment ``xargs rm``.
+    for pattern in rules.deny:
+        if command_matches_pattern(argv, pattern, anchor=True) or command_matches_pattern(argv, pattern, anchor=False):
+            return BashRuleDecision(
+                level=PermissionLevel.DENY,
+                source=BashDecisionSource.DENY_RULE,
+                matched_pattern=pattern,
+                reason=f"Blocked by deny rule '{pattern}'",
+                bucket=session_bucket_for(argv, None),
+                safety_forced=False,
+            )
+
+    # 2. Safety ceiling — wrappers and shell metacharacters can never
+    # auto-allow, regardless of allow rules.
+    if argv[0] in _WRAPPER_COMMANDS:
+        return BashRuleDecision(
+            level=PermissionLevel.ASK,
+            source=BashDecisionSource.SAFETY,
+            matched_pattern=None,
+            reason=f"'{argv[0]}' executes its arguments as a new command; rules cannot see the wrapped command",
+            bucket=session_bucket_for(argv, None),
+            safety_forced=True,
+        )
+    if _SHELL_METACHARS_RE.search(command):
+        return BashRuleDecision(
+            level=PermissionLevel.ASK,
+            source=BashDecisionSource.SAFETY,
+            matched_pattern=None,
+            reason="Command contains shell metacharacters",
+            bucket=session_bucket_for(argv, None),
+            safety_forced=True,
+        )
+
+    # 3. Ask rules beat allow rules.
+    for pattern in rules.ask:
+        if command_matches_pattern(argv, pattern, anchor=True):
+            return BashRuleDecision(
+                level=PermissionLevel.ASK,
+                source=BashDecisionSource.ASK_RULE,
+                matched_pattern=pattern,
+                reason=f"Confirmation required by ask rule '{pattern}'",
+                bucket=session_bucket_for(argv, pattern),
+                safety_forced=False,
+            )
+
+    # 4. Allow rules — anchored only.
+    for pattern in rules.allow:
+        if command_matches_pattern(argv, pattern, anchor=True):
+            return BashRuleDecision(
+                level=PermissionLevel.ALLOW,
+                source=BashDecisionSource.ALLOW_RULE,
+                matched_pattern=pattern,
+                reason=f"Allowed by rule '{pattern}'",
+                bucket=session_bucket_for(argv, pattern),
+                safety_forced=False,
+            )
+
+    # 5. Default.
+    return BashRuleDecision(
+        level=PermissionLevel(rules.default),
+        source=BashDecisionSource.DEFAULT,
+        matched_pattern=None,
+        reason="No bash command rule matched",
+        bucket=session_bucket_for(argv, None),
+        safety_forced=False,
+    )
+
+
+# Severity for picking the representative segment of a pipeline that is neither
+# fully allowed nor denied/safety-forced. An ask-rule segment outranks a
+# default segment so the pipeline's overall source is ASK_RULE — this matters
+# because the hook's dangerous-profile fallback only re-evaluates DEFAULT
+# decisions, so a DEFAULT representative could let a permissive profile swallow
+# an ask-rule segment.
+_PIPELINE_ASK_SEVERITY = {
+    BashDecisionSource.ASK_RULE: 2,
+    BashDecisionSource.DEFAULT: 1,
+}
+
+
+def _evaluate_pipeline(command: str, segments: List[str], rules: BashCommandRules) -> BashRuleDecision:
+    """Aggregate per-segment decisions for a clean pipeline (``a | b | c``).
+
+    * any segment DENY                 -> DENY
+    * any segment safety_forced        -> ASK (safety_forced)
+    * all segments ALLOW               -> ALLOW
+    * otherwise                        -> ASK, represented by the most severe
+      non-allow segment (ask-rule over default) for bucket/source/pattern.
+    """
+    decisions = [_evaluate_single_command(seg, rules) for seg in segments]
+
+    for d in decisions:
+        if d.level == PermissionLevel.DENY:
+            return BashRuleDecision(
+                level=PermissionLevel.DENY,
+                source=BashDecisionSource.DENY_RULE,
+                matched_pattern=d.matched_pattern,
+                reason=f"Pipeline blocked: segment matched deny rule '{d.matched_pattern}'",
+                bucket=d.bucket,
+                safety_forced=False,
+            )
+
+    for d in decisions:
+        if d.safety_forced:
+            return BashRuleDecision(
+                level=PermissionLevel.ASK,
+                source=BashDecisionSource.SAFETY,
+                matched_pattern=None,
+                reason=f"Pipeline requires confirmation: {d.reason}",
+                bucket=d.bucket,
+                safety_forced=True,
+            )
+
+    if all(d.level == PermissionLevel.ALLOW for d in decisions):
+        patterns = ", ".join(d.matched_pattern for d in decisions if d.matched_pattern)
+        return BashRuleDecision(
+            level=PermissionLevel.ALLOW,
+            source=BashDecisionSource.ALLOW_RULE,
+            matched_pattern=None,
+            reason=f"Pipeline allowed: all segments matched allow rules ({patterns})",
+            bucket=session_bucket_for(shlex.split(segments[0]), None),
+            safety_forced=False,
+        )
+
+    non_allow = [d for d in decisions if d.level != PermissionLevel.ALLOW]
+    rep = max(non_allow, key=lambda d: _PIPELINE_ASK_SEVERITY.get(d.source, 0))
+    return BashRuleDecision(
+        level=PermissionLevel.ASK,
+        source=rep.source,
+        matched_pattern=rep.matched_pattern,
+        reason=f"Pipeline requires confirmation: {rep.reason}",
+        bucket=rep.bucket,
+        safety_forced=False,
+    )
+
+
+def evaluate_bash_command(command: str, rules: BashCommandRules) -> BashRuleDecision:
+    """Evaluate a bash command against a ruleset.
+
+    Routes pure pipelines (``a | b | c``) through per-segment judging so a
+    pipeline of allow-listed read-only commands can auto-run, while any other
+    shell construct (``&&``, ``;``, ``$()``, redirection, ``||``) falls to the
+    safety ceiling. See the module docstring for the full decision order.
+    """
+    # Empty / whitespace-only input has no pipeline structure to speak of;
+    # let the single-command path return the UNPARSEABLE decision.
+    if not command.strip():
+        return _evaluate_single_command(command, rules)
+
+    segments = split_pipeline(command)
+    if segments is None:
+        # Malformed pipeline (``||``, ``|&``, empty segment, unbalanced quotes).
+        # Unbalanced quotes make shlex raise → route to the single-command path
+        # so the decision is UNPARSEABLE; everything else is an un-analyzable
+        # shell construct → safety ceiling.
+        try:
+            shlex.split(command)
+        except ValueError:
+            return _evaluate_single_command(command, rules)
+        return BashRuleDecision(
+            level=PermissionLevel.ASK,
+            source=BashDecisionSource.SAFETY,
+            matched_pattern=None,
+            reason="Command contains shell metacharacters",
+            bucket=command.strip().split()[0],
+            safety_forced=True,
+        )
+    if len(segments) == 1:
+        return _evaluate_single_command(segments[0], rules)
+    return _evaluate_pipeline(command, segments, rules)
+
+
+# Complete PermissionConfig's forward reference when this module loaded first
+# (see the mirror block at the bottom of permission_config.py).
+from datus.tools.permission import permission_config as _permission_config  # noqa: E402
+
+_permission_config.PermissionConfig.model_rebuild(
+    _types_namespace={"BashCommandRules": BashCommandRules},
+)

--- a/datus/tools/permission/permission_config.py
+++ b/datus/tools/permission/permission_config.py
@@ -13,9 +13,12 @@ Provides:
 
 import fnmatch
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from datus.tools.permission.bash_rules import BashCommandRules
 
 
 class PermissionLevel(str, Enum):
@@ -103,11 +106,17 @@ class PermissionConfig(BaseModel):
     Attributes:
         rules: List of permission rules evaluated in order
         default_permission: Default permission when no rules match
+        bash_commands: Optional command-level bash rules (see ``bash_rules.py``);
+            consumed by ``PermissionHooks._handle_bash_permission``. When None,
+            the coarse ``bash_tools.bash`` rule governs as before.
     """
 
     rules: List[PermissionRule] = Field(default_factory=list, description="Permission rules evaluated in order")
     default_permission: PermissionLevel = Field(
         default=PermissionLevel.ALLOW, description="Default permission when no rules match"
+    )
+    bash_commands: Optional["BashCommandRules"] = Field(
+        default=None, description="Command-level allow/deny/ask rules for the bash tool"
     )
 
     class Config:
@@ -134,9 +143,13 @@ class PermissionConfig(BaseModel):
 
         rules = [PermissionRule.from_dict(r) for r in rules_data]
 
+        # Deferred import: bash_rules imports PermissionLevel from this module.
+        from datus.tools.permission.bash_rules import BashCommandRules
+
         return cls(
             default_permission=PermissionLevel(default),
             rules=rules,
+            bash_commands=BashCommandRules.from_dict(data.get("bash_commands")),
         )
 
     def merge_with(self, override: Optional["PermissionConfig"]) -> "PermissionConfig":
@@ -156,9 +169,30 @@ class PermissionConfig(BaseModel):
         # Override rules are appended (evaluated later, thus higher priority)
         merged_rules = self.rules + override.rules
 
+        # Bash command rules layer: lists concatenate, scalars override only
+        # when explicitly set (see BashCommandRules.merge_with).
+        if self.bash_commands is not None:
+            merged_bash = self.bash_commands.merge_with(override.bash_commands)
+        else:
+            merged_bash = override.bash_commands
+
         # Always use override's default_permission when override is provided
         # This allows overriding just the default without adding rules
         return PermissionConfig(
             default_permission=override.default_permission,
             rules=merged_rules,
+            bash_commands=merged_bash,
         )
+
+
+# Resolve the forward reference to BashCommandRules. bash_rules imports
+# PermissionLevel from this module, so whichever module finishes importing
+# second completes the rebuild: when this module loads first the import below
+# succeeds; when bash_rules loads first the import raises (bash_rules is
+# mid-initialization) and bash_rules performs the rebuild at its own bottom.
+try:
+    from datus.tools.permission.bash_rules import BashCommandRules
+
+    PermissionConfig.model_rebuild()
+except ImportError:  # pragma: no cover - depends on import order
+    pass

--- a/datus/tools/permission/permission_config.py
+++ b/datus/tools/permission/permission_config.py
@@ -194,5 +194,10 @@ try:
     from datus.tools.permission.bash_rules import BashCommandRules
 
     PermissionConfig.model_rebuild()
-except ImportError:  # pragma: no cover - depends on import order
-    pass
+except ImportError as _exc:  # pragma: no cover - depends on import order
+    # Expected only for the circular-import case (bash_rules is
+    # mid-initialization and performs the rebuild at its own bottom). Log so
+    # a genuine import failure in bash_rules is not silently swallowed.
+    from datus.utils.loggings import get_logger
+
+    get_logger(__name__).debug("Deferring PermissionConfig.model_rebuild() to bash_rules: %s", _exc)

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -29,12 +29,19 @@ from agents.lifecycle import AgentHooks
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
 from datus.schemas.interaction_event import InteractionEvent
 from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
+from datus.tools.permission.bash_classifier import BashClassifierContext
+from datus.tools.permission.bash_rules import (
+    BashDecisionSource,
+    BashRuleDecision,
+    evaluate_bash_command,
+)
 from datus.tools.permission.permission_config import PermissionLevel
 from datus.tools.registry.tool_registry import ToolRegistry
 from datus.utils.constants import SQLType
 from datus.utils.json_utils import to_pretty_str
 
 if TYPE_CHECKING:
+    from datus.tools.permission.bash_classifier import BashCommandClassifier
     from datus.tools.permission.permission_manager import PermissionManager
 
 logger = logging.getLogger(__name__)
@@ -260,6 +267,7 @@ class PermissionHooks(AgentHooks):
         non_interactive: bool = False,
         proxied_tool_names: Optional[Set[str]] = None,
         project_root: Optional[str] = None,
+        bash_classifier: Optional["BashCommandClassifier"] = None,
     ):
         """Initialize the permission hooks.
 
@@ -295,7 +303,13 @@ class PermissionHooks(AgentHooks):
                 reference passed to ``execute_sql``. The SQL permission gate
                 reads the file (same logic as the tool) so a read-only ``.sql``
                 file auto-allows instead of prompting. ``None`` falls back to the
-                current working directory.
+                current working directory. Also used as the write target for
+                project-level bash allow grants (``.datus/config.yml``).
+            bash_classifier: Optional LLM classifier for bash commands (reserved
+                seam, see ``bash_classifier.py``). Consulted only when the
+                static bash rules yield ASK with ``safety_forced=False``; a
+                high-confidence ALLOW verdict auto-approves, anything else
+                falls through to the normal confirmation prompt (fail closed).
         """
         self.broker = broker
         self.permission_manager = permission_manager
@@ -305,6 +319,7 @@ class PermissionHooks(AgentHooks):
         self.non_interactive = non_interactive
         self.proxied_tool_names = proxied_tool_names
         self.project_root = project_root
+        self.bash_classifier = bash_classifier
 
     # Plan-mode tooling is always allowed regardless of permission profile:
     # ``confirm_plan`` already runs its own user interaction, and ``todo_*``
@@ -366,6 +381,18 @@ class PermissionHooks(AgentHooks):
         #   through to UNKNOWN → ASK (fail safe).
         if category == "db_tools" and tool_name == "execute_sql":
             handled = await self._handle_sql_permission(context, tool_name, pattern_name)
+            if handled:
+                return
+
+        # bash_tools.bash: command-level gating overrides the coarse rule.
+        #   deny patterns → raise; allow patterns / profile whitelist → bypass;
+        #   everything else → ASK with a per-command-prefix session bucket and
+        #   an optional project-level persist ("allow (project)"). Shell
+        #   wrappers / metacharacters force ASK regardless of allow rules.
+        #   Ruleset absent (e.g. dangerous profile) → fall through to the
+        #   legacy coarse ``bash_tools.bash`` rule check below.
+        if category == "bash_tools" and tool_name == "bash":
+            handled = await self._handle_bash_permission(context, tool_name, pattern_name)
             if handled:
                 return
 
@@ -806,6 +833,218 @@ class PermissionHooks(AgentHooks):
                 )
             logger.info("User approved execute_sql (%s)", sql_class)
             return True
+
+    async def _handle_bash_permission(self, context: Any, tool_name: str, pattern_name: str) -> bool:
+        """Command-level gating for ``bash_tools.bash`` calls.
+
+        The coarse ``bash_tools.bash -> ASK`` rule cannot express "``git log``
+        is fine, ``rm`` never is". This gate evaluates the ``command`` argument
+        against the effective ``bash_commands`` ruleset (profile whitelist +
+        user agent.yml rules + project ``.datus/config.yml`` allows — see
+        ``bash_rules.evaluate_bash_command`` for the deny-first decision order).
+
+        * DENY match → raise immediately, naming the matched pattern.
+        * ALLOW match → bypass (no prompt).
+        * ASK → non-interactive raises; otherwise consult the optional LLM
+          classifier (reserved seam — never for ``safety_forced`` decisions),
+          then the per-bucket session cache, then prompt with four choices:
+          allow once / allow (session) / allow (project) / deny. The project
+          choice persists ``<bucket>:*`` to ``.datus/config.yml`` and is only
+          offered for plain unmatched commands — never for safety-ceiling asks
+          (wrappers, metacharacters) or explicit ask-rule hits (the user asked
+          to review those every time; a persisted allow could not beat the ask
+          rule at evaluation time anyway).
+
+        Returns ``True`` when fully handled, ``False`` to defer to the normal
+        category-level check (explicit category DENY, missing/empty ruleset,
+        or unparseable arguments) — deferring keeps behavior byte-compatible
+        with the legacy coarse path. Cross-reference: ``BashTool`` keeps its
+        own ``allowed_patterns`` matcher as a legacy secondary gate.
+        """
+        args = self._parse_tool_args(context)
+        if not isinstance(args, dict):
+            return False
+        command = args.get("command")
+        if not isinstance(command, str) or not command.strip():
+            return False
+
+        # Respect an explicit category-level DENY — defer so the main flow
+        # raises the standardized DENY message.
+        if self.permission_manager.check_permission("bash_tools", pattern_name, self.node_name) == PermissionLevel.DENY:
+            return False
+
+        effective = self.permission_manager.get_effective_config(self.node_name)
+        rules = getattr(effective, "bash_commands", None)
+        if rules is None or rules.is_empty():
+            # No command-level ruleset (e.g. dangerous profile) — legacy path.
+            return False
+
+        decision = evaluate_bash_command(command, rules)
+
+        # When no bash rule matched and the ruleset never explicitly set a
+        # ``default``, inherit the effective config's posture instead of
+        # BashCommandRules' built-in ASK. Under normal/auto this is ASK either
+        # way; under dangerous (default_permission=ALLOW) it keeps unmatched
+        # commands flowing — a user adding a ``deny`` list to agent.yml must
+        # not silently flip dangerous into ask-everything for bash. Safety
+        # ceiling decisions are NOT affected (source=SAFETY, not DEFAULT).
+        if decision.source == BashDecisionSource.DEFAULT and "default" not in rules.model_fields_set:
+            try:
+                fallback = PermissionLevel(effective.default_permission)
+            except ValueError:
+                fallback = PermissionLevel.ASK
+            if fallback != decision.level:
+                from dataclasses import replace as _dc_replace
+
+                decision = _dc_replace(
+                    decision, level=fallback, reason=f"{decision.reason}; inheriting profile default '{fallback.value}'"
+                )
+
+        if decision.level == PermissionLevel.DENY:
+            profile = getattr(self.permission_manager, "active_profile", None) or "unknown"
+            logger.warning("Bash command denied by rule %r: %s", decision.matched_pattern, command)
+            raise PermissionDeniedException(
+                (
+                    f"PERMISSION_DENIED: Bash command blocked by rule "
+                    f"'{decision.matched_pattern}' under the '{profile}' permission "
+                    f"profile. STOP retrying this command — rewording it will not "
+                    f"change the outcome. Return the failure to your caller. The "
+                    f"user can adjust `permissions.bash_commands` in agent.yml."
+                ),
+                tool_category="bash_tools",
+                tool_name="bash",
+            )
+
+        if decision.level == PermissionLevel.ALLOW:
+            logger.debug(
+                "Bash command auto-allowed (%s: %r): %s", decision.source.value, decision.matched_pattern, command
+            )
+            return True
+
+        # ASK. Non-interactive flows must raise here rather than defer: under a
+        # permissive coarse rule (or dangerous profile overrides) the main flow
+        # could silently allow what the command-level rules said to confirm.
+        if self.non_interactive:
+            profile = getattr(self.permission_manager, "active_profile", None) or "auto"
+            raise PermissionDeniedException(
+                (
+                    f"PERMISSION_DENIED: Bash command requires user confirmation "
+                    f"({decision.reason}) but this flow runs non-interactively under "
+                    f"the '{profile}' profile. STOP retrying — surface the failure "
+                    f"to the caller."
+                ),
+                tool_category="bash_tools",
+                tool_name="bash",
+            )
+
+        # Reserved LLM-classifier seam: only for non-safety asks, fail closed.
+        if self.bash_classifier is not None and not decision.safety_forced:
+            try:
+                verdict = await self.bash_classifier.classify(
+                    command,
+                    BashClassifierContext(cwd=self.project_root or ".", node_name=self.node_name),
+                )
+                if (
+                    verdict is not None
+                    and PermissionLevel(verdict.permission) == PermissionLevel.ALLOW
+                    and verdict.confidence >= rules.classifier.confidence_threshold
+                ):
+                    logger.info("Bash command auto-allowed by classifier (%.2f): %s", verdict.confidence, command)
+                    return True
+            except Exception as e:
+                logger.warning("Bash classifier failed (%s); falling back to confirmation prompt", e)
+
+        # Session cache: the prompt's "always allow" writes ONLY the bucketed
+        # key so one approval never cascades past its command prefix; broad
+        # keys still honor a deliberate wide approval (e.g. legacy grants).
+        cache_keys = (f"bash_tools.bash::{decision.bucket}", "bash_tools.bash", "bash_tools.*")
+
+        def _session_approved() -> bool:
+            return any(self.permission_manager._session_approvals.get(key) for key in cache_keys)
+
+        if _session_approved():
+            logger.debug("Bash bucket %r already approved for session", decision.bucket)
+            return True
+
+        async with _get_permission_prompt_lock(self.broker):
+            if _session_approved():
+                return True
+            offer_project = decision.source == BashDecisionSource.DEFAULT and not decision.safety_forced
+            choice = await self._request_bash_confirmation(command, decision, offer_project=offer_project)
+            if choice == "y":
+                logger.info("User approved bash command (once): %s", command)
+                return True
+            if choice == "a":
+                self.permission_manager.approve_for_session("bash_tools", f"bash::{decision.bucket}")
+                logger.info("User approved bash bucket %r for session", decision.bucket)
+                return True
+            if choice == "p" and offer_project:
+                pattern = self._bucket_to_allow_pattern(decision.bucket)
+                persisted = self.permission_manager.add_project_bash_allow(pattern, self.project_root)
+                # Session bucket too, so later same-bucket calls this session
+                # skip the prompt even though global_config already allows them.
+                self.permission_manager.approve_for_session("bash_tools", f"bash::{decision.bucket}")
+                logger.info(
+                    "User granted project-level bash allow %r%s",
+                    pattern,
+                    "" if persisted else " (disk write failed; session-only)",
+                )
+                return True
+            logger.info("User rejected bash command: %s", command)
+            raise PermissionDeniedException(
+                "User rejected execution of bash command",
+                tool_category="bash_tools",
+                tool_name="bash",
+            )
+
+    @staticmethod
+    def _bucket_to_allow_pattern(bucket: str) -> str:
+        """Convert a session bucket into a persistable allow pattern.
+
+        Plain buckets (``git push``, ``ls``) become prefix rules; a bucket
+        that is already a rule pattern (contains ``:``) is used verbatim.
+        """
+        return bucket if ":" in bucket else f"{bucket}:*"
+
+    async def _request_bash_confirmation(
+        self,
+        command: str,
+        decision: BashRuleDecision,
+        *,
+        offer_project: bool,
+    ) -> str:
+        """Prompt for a bash command; returns the raw choice key ('' on cancel).
+
+        Unlike ``_request_user_confirmation`` (bool), callers need the concrete
+        choice to distinguish session from project grants.
+        """
+        content = f"### Bash Command Permission\n\n```bash\n{command}\n```\n\n**Reason:** {decision.reason}\n"
+        allow_pattern = self._bucket_to_allow_pattern(decision.bucket)
+        choices = {
+            "y": "Allow (once)",
+            "a": f"Allow '{decision.bucket}' (session)",
+        }
+        if offer_project:
+            choices["p"] = f"Allow '{allow_pattern}' (project)"
+        choices["n"] = "Deny"
+
+        try:
+            answers = await self.broker.request(
+                [
+                    InteractionEvent(
+                        title="Bash Permission",
+                        content=content,
+                        choices=choices,
+                        default_choice="n",
+                    )
+                ]
+            )
+            return answers[0][0] if answers and answers[0] else ""
+        except InteractionCancelled:
+            return ""
+        except Exception as e:
+            logger.error(f"Error in bash permission confirmation: {e}")
+            return ""
 
     def _get_category_and_pattern(self, tool_name: str, context: Any) -> Tuple[str, str]:
         """Get tool category and pattern name for permission checking.

--- a/datus/tools/permission/permission_manager.py
+++ b/datus/tools/permission/permission_manager.py
@@ -82,6 +82,12 @@ class PermissionManager:
         # silently drop runtime-injected rules without this list.
         self._persistent_rules: List[PermissionRule] = []
 
+        # Bash allow patterns granted via "allow (project)" this session.
+        # Mirrors ``_persistent_rules``: replayed after ``switch_profile``
+        # rebuilds ``global_config`` so the grant survives a /permission
+        # switch (the on-disk ``.datus/config.yml`` copy covers restarts).
+        self._persistent_bash_allows: List[str] = []
+
         logger.debug(
             f"PermissionManager initialized: profile={self.active_profile}, "
             f"{len(self.global_config.rules)} global rules"
@@ -103,6 +109,9 @@ class PermissionManager:
         return PermissionConfig(
             default_permission=config.default_permission,
             rules=list(config.rules),
+            # Deep copy so runtime mutations (add_project_bash_allow) never
+            # bleed into the shared profile singletons in profiles.py.
+            bash_commands=config.bash_commands.model_copy(deep=True) if config.bash_commands else None,
         )
 
     def set_permission_callback(self, callback: Callable[[str, str, Dict[str, Any]], Awaitable[bool]]) -> None:
@@ -329,6 +338,44 @@ class PermissionManager:
         if not any(r.tool == rule.tool and r.pattern == rule.pattern for r in self.global_config.rules):
             self.global_config.rules.insert(0, rule)
 
+    def _install_bash_allow(self, pattern: str) -> None:
+        """Add a bash allow pattern to the live ``global_config`` in place."""
+        from datus.tools.permission.bash_rules import BashCommandRules
+
+        if self.global_config.bash_commands is None:
+            self.global_config.bash_commands = BashCommandRules(allow=[pattern])
+        elif pattern not in self.global_config.bash_commands.allow:
+            self.global_config.bash_commands.allow.append(pattern)
+
+    def add_project_bash_allow(self, pattern: str, project_root: Optional[str] = None) -> bool:
+        """Grant a bash command prefix at project scope ("allow (project)").
+
+        Three effects:
+        1. Persist the pattern to ``./.datus/config.yml`` (``bash_allow`` key)
+           so it survives restarts — future sessions pick it up through
+           ``_apply_project_override`` at config load time.
+        2. Install it into the live ``global_config`` immediately.
+        3. Record it in ``_persistent_bash_allows`` so a runtime
+           ``switch_profile`` rebuild does not drop it.
+
+        Returns True when the pattern was persisted to disk; False when the
+        write failed (read-only checkout, etc.) — the in-memory grant still
+        applies, so callers may degrade to a session-level approval message.
+        """
+        self._install_bash_allow(pattern)
+        if pattern not in self._persistent_bash_allows:
+            self._persistent_bash_allows.append(pattern)
+
+        try:
+            from datus.configuration.project_config import append_project_bash_allow
+
+            append_project_bash_allow(pattern, project_root or ".")
+            logger.info(f"Project-level bash allow persisted: {pattern!r}")
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to persist project bash allow {pattern!r}: {e}; grant applies to this session only")
+            return False
+
     def switch_profile(
         self,
         profile_name: str,
@@ -372,6 +419,9 @@ class PermissionManager:
         for rule in self._persistent_rules:
             if not any(r.tool == rule.tool and r.pattern == rule.pattern for r in self.global_config.rules):
                 self.global_config.rules.insert(0, rule)
+        # Re-apply project-scope bash allows granted earlier this session.
+        for pattern in self._persistent_bash_allows:
+            self._install_bash_allow(pattern)
         self.active_profile = profile_name
         self._session_approvals.clear()
         logger.info(

--- a/datus/tools/permission/permission_manager.py
+++ b/datus/tools/permission/permission_manager.py
@@ -419,9 +419,14 @@ class PermissionManager:
         for rule in self._persistent_rules:
             if not any(r.tool == rule.tool and r.pattern == rule.pattern for r in self.global_config.rules):
                 self.global_config.rules.insert(0, rule)
-        # Re-apply project-scope bash allows granted earlier this session.
-        for pattern in self._persistent_bash_allows:
-            self._install_bash_allow(pattern)
+        # Re-apply project-scope bash allows granted earlier this session —
+        # but only when the rebuilt config already carries a command-level
+        # ruleset. Installing one where the profile intentionally left
+        # ``bash_commands`` unset (``dangerous``) would flip its documented
+        # zero-friction bash posture and start force-ASKing wrapper commands.
+        if self.global_config.bash_commands is not None:
+            for pattern in self._persistent_bash_allows:
+                self._install_bash_allow(pattern)
         self.active_profile = profile_name
         self._session_approvals.clear()
         logger.info(

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -45,6 +45,7 @@ below cover the cases where the zone gate returns ``False`` (e.g.
 
 from typing import Optional
 
+from datus.tools.permission.bash_rules import BashCommandRules
 from datus.tools.permission.permission_config import (
     PermissionConfig,
     PermissionLevel,
@@ -153,13 +154,119 @@ _NORMAL_RULES = [
     _rule("skills", "*", PermissionLevel.ALLOW),
     # General-purpose bash execution: always ASK in normal/auto so a stray
     # command can't run without user consent. ``dangerous`` profile (default
-    # ALLOW, no rules) lets it through.
+    # ALLOW, no rules) lets it through. This coarse rule is the FALLBACK for
+    # when the command-level ``bash_commands`` ruleset below is absent or
+    # errors out (defense in depth) — the fine-grained gate in
+    # ``PermissionHooks._handle_bash_permission`` normally decides first.
     _rule("bash_tools", "bash", PermissionLevel.ASK),
+]
+
+# Command-level bash whitelist for ``normal``: commands that cannot mutate
+# state or execute arbitrary code REGARDLESS of their flags, so prompting on
+# them is pure friction (they're the read-only backbone of data/dev work in a
+# pipeline like ``cat log | grep err | wc -l``).
+#
+# SECURITY — what is deliberately NOT here:
+#   * awk / sed — programmable: ``awk 'BEGIN{system("...")}'`` execs, ``sed -i``
+#     writes in place. Prefix+first-arg matching can't see the quoted program,
+#     so blanket-allowing them would auto-run arbitrary code. Left at ASK; a
+#     user who accepts the risk can add ``awk:*`` / ``sed:*`` to agent.yml.
+#   * find — ``-exec`` / ``-delete`` run commands / delete files.
+#   * tee / sort -o / dd — write files.
+#   * curl / wget / nc / ssh — network egress.
+#   * rm / mv / cp / mkdir / touch / chmod — filesystem writes (mkdir/touch
+#     move to ``auto`` below).
+# Wrappers (bash -c, sudo, xargs, env, ...) and any non-pipe metacharacter
+# command are force-ASKed by the safety ceiling in ``evaluate_bash_command``
+# regardless of this list. Tunable via ``permissions.bash_commands``.
+_NORMAL_BASH_ALLOW = [
+    # environment / identity info
+    "pwd",
+    "whoami",
+    "id:*",
+    "hostname:*",
+    "uname:*",
+    "date:*",
+    "which:*",
+    "type:*",
+    "printenv:*",
+    "locale:*",
+    "echo:*",
+    "printf:*",
+    "seq:*",
+    "true",
+    "false",
+    # directory / file listing & inspection
+    "ls:*",
+    "tree:*",
+    "stat:*",
+    "file:*",
+    "du:*",
+    "df:*",
+    "wc:*",
+    "basename:*",
+    "dirname:*",
+    "realpath:*",
+    "readlink:*",
+    # file content readers (stdout only — cannot write or exec)
+    "cat:*",
+    "head:*",
+    "tail:*",
+    "tac:*",
+    "nl:*",
+    "rev:*",
+    # text search / filter / transform (read input, write only to stdout)
+    "grep:*",
+    "egrep:*",
+    "fgrep:*",
+    "rg:*",
+    "cut:*",
+    "tr:*",
+    "uniq:*",
+    "comm:*",
+    "column:*",
+    "fold:*",
+    "paste:*",
+    "expand:*",
+    "unexpand:*",
+    # compare
+    "diff:*",
+    "cmp:*",
+    # checksums / encoding (read-only computation)
+    "md5sum:*",
+    "sha1sum:*",
+    "sha256sum:*",
+    "cksum:*",
+    "base64:*",
+    # git read-only
+    "git status",
+    "git branch",
+    "git log:*",
+    "git diff:*",
+    "git show:*",
+    "git remote:*",
+    "git tag",
+    "git describe:*",
+    "git rev-parse:*",
+    "git blame:*",
+    "git ls-files:*",
+    "git shortlog:*",
+]
+
+# ``auto`` adds lightweight workspace writes, consistent with auto's
+# filesystem posture (INTERNAL writes auto-allow). Read-only commands already
+# come from ``_NORMAL_BASH_ALLOW``. ``sort`` is here (not normal) because
+# ``sort -o FILE`` can write a file.
+_AUTO_BASH_ALLOW = _NORMAL_BASH_ALLOW + [
+    "sort:*",
+    "mkdir:*",
+    "touch:*",
 ]
 
 NORMAL = PermissionConfig(
     default_permission=PermissionLevel.ASK,
     rules=_NORMAL_RULES,
+    bash_commands=BashCommandRules(allow=_NORMAL_BASH_ALLOW),
 )
 
 # --- Auto --------------------------------------------------------------------
@@ -204,10 +311,14 @@ _AUTO_EXTRA_RULES = [
 AUTO = PermissionConfig(
     default_permission=PermissionLevel.ASK,
     rules=_NORMAL_RULES + _AUTO_EXTRA_RULES,
+    bash_commands=BashCommandRules(allow=_AUTO_BASH_ALLOW),
 )
 
 # --- Dangerous ---------------------------------------------------------------
 # default=ALLOW, no rules. PathZone at hook layer still gates EXTERNAL fs.
+# bash_commands stays None: the fine-grained bash gate steps aside and the
+# profile default of ALLOW lets every command through, preserving the
+# historical allow-everything behavior of this profile.
 DANGEROUS = PermissionConfig(
     default_permission=PermissionLevel.ALLOW,
     rules=[],

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -184,9 +184,13 @@ _NORMAL_BASH_ALLOW = [
     "pwd",
     "whoami",
     "id:*",
-    "hostname:*",
+    # ``hostname NAME`` / ``date -s`` are mutating forms (root-only, but they
+    # still break the read-only contract), so no blanket ``:*`` here: exact
+    # match only, plus ``date +FORMAT`` for the common read-only formatting.
+    "hostname",
     "uname:*",
-    "date:*",
+    "date",
+    "date:+*",
     "which:*",
     "type:*",
     "printenv:*",

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -555,6 +555,31 @@ class TestSetupPermissionManager:
 
         assert node.permission_manager.active_profile == "normal"
 
+    def test_workflow_mode_respects_profile_when_print_mode_opts_in(self):
+        """Print mode sets ``workflow_permission_profile`` so ``datus -p``
+        runs under the configured / --permission-mode profile instead of the
+        forced ``dangerous`` baseline."""
+        from datus.tools.permission.permission_config import PermissionLevel
+
+        node, user_config = self._setup_node(execution_mode="workflow")
+        node.agent_config.workflow_permission_profile = "normal"
+        node._setup_permission_manager()
+
+        assert node.permission_manager.active_profile == "normal"
+        # The user's config (rules + posture) is preserved, not replaced.
+        assert any(rule.tool == "custom_marker_tool" for rule in node.permission_manager.global_config.rules)
+        assert node.permission_manager.global_config.default_permission == PermissionLevel.DENY
+
+    def test_workflow_mode_non_string_override_still_forces_dangerous(self):
+        """A mocked / invalid ``workflow_permission_profile`` must not flip the
+        branch — only an explicit profile string opts out of dangerous."""
+        node, _ = self._setup_node(execution_mode="workflow")
+        # MagicMock attribute (truthy but not a str) — same shape as legacy
+        # callers that never set the attribute on a mocked agent_config.
+        node._setup_permission_manager()
+
+        assert node.permission_manager.active_profile == "dangerous"
+
 
 # ---------------------------------------------------------------------------
 # TestGetAvailableSkillsContext

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -919,7 +919,7 @@ class TestChatAgenticNodeExecuteStreamErrors:
 
         async def raising_stream(*args, **kwargs):
             raise RuntimeError("Simulated LLM failure")
-            yield  # noqa: unreachable - makes this an async generator
+            yield  # unreachable - makes this an async generator
 
         mock_llm_create.generate_with_tools_stream = raising_stream
 
@@ -964,7 +964,7 @@ class TestChatAgenticNodeExecuteStreamErrors:
 
         async def cancel_stream(*args, **kwargs):
             raise ExecutionInterrupted("Ctrl+C")
-            yield  # noqa: unreachable
+            yield  # unreachable - makes this an async generator
 
         mock_llm_create.generate_with_tools_stream = cancel_stream
 
@@ -995,7 +995,7 @@ class TestChatAgenticNodeExecuteStreamErrors:
 
         async def interrupt_stream(*args, **kwargs):
             raise ExecutionInterrupted("Ctrl+C pressed")
-            yield  # noqa: unreachable
+            yield  # unreachable - makes this an async generator
 
         mock_llm_create.generate_with_tools_stream = interrupt_stream
 

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -588,3 +588,64 @@ class TestLoadAgentConfigResolution:
         ):
             agent_config = load_agent_config(config=str(cfg), home=str(tmp_path), reload=True)
         assert agent_config.current_datasource == ""
+
+
+class TestApplyProjectOverrideBashAllow:
+    """bash_allow from .datus/config.yml merges into permissions.bash_commands.allow."""
+
+    def test_bash_allow_merged_into_permissions(self):
+        agent_raw = {"target": "openai", "models": {"openai": {}}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(bash_allow=["make:*", "uv run:*"]),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["permissions"]["bash_commands"]["allow"] == ["make:*", "uv run:*"]
+
+    def test_bash_allow_appends_to_existing_allow(self):
+        agent_raw = {
+            "permissions": {"profile": "normal", "bash_commands": {"allow": ["git log:*"], "deny": ["rm:*"]}},
+        }
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(bash_allow=["make:*", "git log:*"]),
+        ):
+            _apply_project_override(agent_raw)
+        # appended without duplicating the existing entry; deny untouched
+        assert agent_raw["permissions"]["bash_commands"]["allow"] == ["git log:*", "make:*"]
+        assert agent_raw["permissions"]["bash_commands"]["deny"] == ["rm:*"]
+
+
+class TestPermissionModeCliOverride:
+    """--permission-mode kwarg reshapes permissions.profile at load time."""
+
+    def test_override_injected_into_raw_permissions(self):
+        agent_raw = {"permissions": {"profile": "normal", "rules": []}}
+        # Reuse the same code path load_agent_config runs (inline for isolation).
+        permission_mode = "dangerous"
+        permissions_raw = agent_raw.get("permissions") or {}
+        permissions_raw["profile"] = permission_mode
+        agent_raw["permissions"] = permissions_raw
+        assert agent_raw["permissions"]["profile"] == "dangerous"
+
+    def test_load_agent_config_applies_permission_mode(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "agent.yml"
+        cfg.write_text(
+            "agent:\n"
+            "  permissions:\n"
+            "    profile: normal\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        from datus.configuration.agent_config_loader import load_agent_config
+
+        config = load_agent_config(reload=True, config=str(cfg), permission_mode="dangerous")
+        assert config.active_profile_name == "dangerous"
+
+    def test_load_agent_config_without_permissions_section(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "agent.yml"
+        cfg.write_text("agent: {}\n")
+        monkeypatch.chdir(tmp_path)
+        from datus.configuration.agent_config_loader import load_agent_config
+
+        config = load_agent_config(reload=True, config=str(cfg), permission_mode="auto")
+        assert config.active_profile_name == "auto"

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -615,6 +615,26 @@ class TestApplyProjectOverrideBashAllow:
         assert agent_raw["permissions"]["bash_commands"]["allow"] == ["git log:*", "make:*"]
         assert agent_raw["permissions"]["bash_commands"]["deny"] == ["rm:*"]
 
+    def test_malformed_permissions_replaced_not_crashed(self):
+        """A non-dict ``permissions`` section must not crash config loading."""
+        agent_raw = {"permissions": "oops"}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(bash_allow=["make:*"]),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["permissions"] == {"bash_commands": {"allow": ["make:*"]}}
+
+    def test_malformed_nested_bash_commands_replaced(self):
+        agent_raw = {"permissions": {"profile": "normal", "bash_commands": ["not", "a", "dict"]}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(bash_allow=["make:*"]),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["permissions"]["profile"] == "normal"
+        assert agent_raw["permissions"]["bash_commands"] == {"allow": ["make:*"]}
+
 
 class TestPermissionModeCliOverride:
     """--permission-mode kwarg reshapes permissions.profile at load time."""
@@ -630,11 +650,7 @@ class TestPermissionModeCliOverride:
 
     def test_load_agent_config_applies_permission_mode(self, tmp_path, monkeypatch):
         cfg = tmp_path / "agent.yml"
-        cfg.write_text(
-            "agent:\n"
-            "  permissions:\n"
-            "    profile: normal\n"
-        )
+        cfg.write_text("agent:\n  permissions:\n    profile: normal\n")
         monkeypatch.chdir(tmp_path)
         from datus.configuration.agent_config_loader import load_agent_config
 

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -375,7 +375,7 @@ class TestBashAllow:
 
         self._write(
             tmp_path,
-            "# header comment\nbash_allow:\n  - \"make:*\"\nproject_name: proj_a\n",
+            '# header comment\nbash_allow:\n  - "make:*"\nproject_name: proj_a\n',
         )
         append_project_bash_allow("git push:*", str(tmp_path))
         result = load_project_override(str(tmp_path))
@@ -393,9 +393,25 @@ class TestBashAllow:
 
     def test_append_empty_pattern_raises(self, tmp_path):
         from datus.configuration.project_config import append_project_bash_allow
+        from datus.utils.exceptions import DatusException
 
-        with pytest.raises(ValueError):
+        with pytest.raises(DatusException):
             append_project_bash_allow("   ", str(tmp_path))
+
+    def test_append_pattern_with_quote_does_not_corrupt_file(self, tmp_path):
+        """A pattern containing ``"`` (or a trailing backslash) must be
+        escaped — an invalid YAML line would silently drop EVERY override
+        in the file, not just ``bash_allow``."""
+        from datus.configuration.project_config import append_project_bash_allow
+
+        self._write(tmp_path, "project_name: proj_a\n")
+        append_project_bash_allow('grep:"quoted"', str(tmp_path))
+        append_project_bash_allow("find:*\\", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        # Later appends insert right after the key line, hence the order.
+        assert result.bash_allow == ["find:*\\", 'grep:"quoted"']
+        # The rest of the file still parses.
+        assert result.project_name == "proj_a"
 
     def test_save_round_trips_bash_allow(self, tmp_path):
         override = ProjectOverride(bash_allow=["make:*"])

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -217,6 +217,7 @@ class TestAllowedKeys:
                 "project_name",
                 "language",
                 "reasoning_effort",
+                "bash_allow",
             }
         )
 
@@ -324,3 +325,80 @@ class TestServiceDefaultFields:
         loaded = yaml.safe_load(written.read_text())
         assert "dashboard" in loaded
         assert "scheduler" not in loaded
+
+
+class TestBashAllow:
+    """Project-level bash_allow parsing and text-level appending."""
+
+    def _write(self, tmp_path, content: str):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def test_parse_bash_allow_list(self, tmp_path):
+        self._write(tmp_path, yaml.safe_dump({"bash_allow": ["make:*", "git push:*"]}))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow == ["make:*", "git push:*"]
+
+    def test_non_list_bash_allow_dropped(self, tmp_path):
+        self._write(tmp_path, yaml.safe_dump({"bash_allow": "make:*"}))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow is None
+
+    def test_non_string_entries_dropped(self, tmp_path):
+        self._write(tmp_path, yaml.safe_dump({"bash_allow": ["make:*", 42, ""]}))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow == ["make:*"]
+
+    def test_append_creates_file(self, tmp_path):
+        from datus.configuration.project_config import append_project_bash_allow
+
+        append_project_bash_allow("make:*", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow == ["make:*"]
+
+    def test_append_to_file_without_key(self, tmp_path):
+        from datus.configuration.project_config import append_project_bash_allow
+
+        self._write(tmp_path, "# my project config\nproject_name: proj_a\n")
+        append_project_bash_allow("uv run:*", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow == ["uv run:*"]
+        assert result.project_name == "proj_a"
+        # comments preserved
+        text = (tmp_path / PROJECT_CONFIG_REL).read_text()
+        assert "# my project config" in text
+
+    def test_append_to_existing_key_preserves_entries_and_comments(self, tmp_path):
+        from datus.configuration.project_config import append_project_bash_allow
+
+        self._write(
+            tmp_path,
+            "# header comment\nbash_allow:\n  - \"make:*\"\nproject_name: proj_a\n",
+        )
+        append_project_bash_allow("git push:*", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert sorted(result.bash_allow) == ["git push:*", "make:*"]
+        assert result.project_name == "proj_a"
+        assert "# header comment" in (tmp_path / PROJECT_CONFIG_REL).read_text()
+
+    def test_append_is_idempotent(self, tmp_path):
+        from datus.configuration.project_config import append_project_bash_allow
+
+        append_project_bash_allow("make:*", str(tmp_path))
+        append_project_bash_allow("make:*", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow == ["make:*"]
+
+    def test_append_empty_pattern_raises(self, tmp_path):
+        from datus.configuration.project_config import append_project_bash_allow
+
+        with pytest.raises(ValueError):
+            append_project_bash_allow("   ", str(tmp_path))
+
+    def test_save_round_trips_bash_allow(self, tmp_path):
+        override = ProjectOverride(bash_allow=["make:*"])
+        save_project_override(override, str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow == ["make:*"]

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -415,3 +415,133 @@ class TestBashToolOutputOffload:
         result = tool.bash("python -c \"print('ok')\"")
         assert result.success == 1
         assert result.result.strip() == "ok"
+
+
+class TestPipelineExecution:
+    """Real-shell execution: pipelines, operators, pipefail, timeout, gate."""
+
+    def test_pipeline_produces_piped_output(self, unrestricted_tool):
+        result = unrestricted_tool.bash("printf 'a\\nb\\nc\\n' | grep b | wc -l")
+        assert result.success == 1
+        assert result.result.strip() == "1"
+
+    def test_pipeline_stages_chain(self, unrestricted_tool):
+        result = unrestricted_tool.bash("echo hello world | tr ' ' '\\n' | sort")
+        assert result.success == 1
+        assert result.result.split() == ["hello", "world"]
+
+    def test_logical_and_executes_under_real_shell(self, unrestricted_tool):
+        result = unrestricted_tool.bash("echo first && echo second")
+        assert result.success == 1
+        assert "first" in result.result and "second" in result.result
+
+    def test_redirection_works(self, unrestricted_tool, temp_workspace):
+        result = unrestricted_tool.bash("echo persisted > out.txt")
+        assert result.success == 1
+        assert (temp_workspace / "out.txt").read_text().strip() == "persisted"
+
+    def test_pipeline_final_stage_failure_surfaces(self, unrestricted_tool):
+        # bash default: the pipeline's exit code is the LAST stage's. grep with
+        # no match exits 1 → the pipeline reports failure.
+        result = unrestricted_tool.bash("echo hello | grep nomatch")
+        assert result.success == 0
+
+    def test_pipeline_exit_zero_when_final_succeeds(self, unrestricted_tool):
+        # Upstream failure is masked by a succeeding final stage (bash default,
+        # no pipefail) — matches Claude Code semantics.
+        result = unrestricted_tool.bash("cat /nonexistent/xyz | cat")
+        assert result.success == 1
+
+    def test_pipeline_exit_zero_when_all_succeed(self, unrestricted_tool):
+        result = unrestricted_tool.bash("echo ok | cat | cat")
+        assert result.success == 1
+
+    def test_quoted_pipe_is_literal(self, unrestricted_tool):
+        result = unrestricted_tool.bash("echo 'a|b'")
+        assert result.success == 1
+        assert result.result.strip() == "a|b"
+
+    def test_sigpipe_upstream_terminates(self, unrestricted_tool):
+        # `yes` would run forever; `head -1` closes the pipe → upstream dies.
+        # With a short timeout this must still return promptly, not hang.
+        tool = BashTool(workspace_root=str(unrestricted_tool.workspace_root), allowed_patterns=["*"], timeout=10)
+        result = tool.bash("yes | head -1")
+        assert result.success == 1
+        assert result.result.strip() == "y"
+
+    def test_timeout_kills_whole_pipeline(self, temp_workspace):
+        tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["*"], timeout=1)
+        import time
+
+        start = time.monotonic()
+        result = tool.bash("sleep 30 | cat")
+        elapsed = time.monotonic() - start
+        assert result.success == 0
+        assert "timed out" in (result.error or "").lower()
+        # Must not wait for the full 30s sleep — process group was killed.
+        assert elapsed < 10
+
+    def test_extglob_disabled(self, unrestricted_tool):
+        # With extglob off, `!(...)` is not special; bash errors on the syntax.
+        result = unrestricted_tool.bash("echo !(foo)")
+        assert result.success == 0
+
+    def test_restrictive_whitelist_allows_matching_pipeline(self, temp_workspace):
+        tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["echo:*", "cat:*"])
+        result = tool.bash("echo hi | cat")
+        assert result.success == 1
+        assert result.result.strip() == "hi"
+
+    def test_restrictive_whitelist_blocks_unmatched_segment(self, temp_workspace):
+        tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["echo:*"])
+        result = tool.bash("echo hi | rm -rf x")
+        assert result.success == 0
+        assert "not allowed" in (result.error or "").lower()
+
+    def test_restrictive_whitelist_blocks_operator(self, temp_workspace):
+        tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["echo:*"])
+        result = tool.bash("echo hi && echo bye")
+        assert result.success == 0
+        assert "not allowed" in (result.error or "").lower()
+
+    def test_wildcard_allows_operators(self, unrestricted_tool):
+        result = unrestricted_tool.bash("echo a; echo b")
+        assert result.success == 1
+
+
+class TestBashTimeoutParam:
+    """Optional per-call timeout parameter."""
+
+    def test_per_call_timeout_overrides_default(self, unrestricted_tool):
+        import time
+
+        # Instance default is 60s; a per-call timeout of 1s must win.
+        start = time.monotonic()
+        result = unrestricted_tool.bash("sleep 30", timeout=1)
+        elapsed = time.monotonic() - start
+        assert result.success == 0
+        assert "timed out" in (result.error or "").lower()
+        assert elapsed < 10
+
+    def test_timeout_clamped_to_max(self, unrestricted_tool):
+        from datus.tools.func_tool.bash_tool import MAX_BASH_TIMEOUT
+
+        assert unrestricted_tool._resolve_timeout(999999) == MAX_BASH_TIMEOUT
+
+    def test_invalid_timeout_falls_back_to_default(self, unrestricted_tool):
+        assert unrestricted_tool._resolve_timeout(None) == unrestricted_tool.timeout
+        assert unrestricted_tool._resolve_timeout(0) == unrestricted_tool.timeout
+        assert unrestricted_tool._resolve_timeout(-5) == unrestricted_tool.timeout
+        assert unrestricted_tool._resolve_timeout(True) == unrestricted_tool.timeout
+
+    def test_default_timeout_used_when_omitted(self, unrestricted_tool):
+        # A fast command with no explicit timeout succeeds normally.
+        result = unrestricted_tool.bash("echo ok")
+        assert result.success == 1
+        assert result.result.strip() == "ok"
+
+    def test_timeout_exposed_in_tool_schema(self, unrestricted_tool):
+        tool = unrestricted_tool.available_tools()[0]
+        props = tool.params_json_schema.get("properties", {})
+        assert "command" in props
+        assert "timeout" in props

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -204,7 +204,8 @@ class TestBashToolExecution:
     def test_bash_with_args(self, python_tool):
         result = python_tool.bash("python scripts/analyze.py --input test.json")
         assert result.success == 1
-        assert "--input" in result.result or "test.json" in result.result
+        # analyze.py echoes sys.argv[1:] verbatim.
+        assert "Args: ['--input', 'test.json']" in result.result
 
     def test_execute_denied_command(self, python_tool):
         result = python_tool.bash("rm -rf /")
@@ -230,7 +231,9 @@ class TestBashToolExecution:
         # Script doesn't exist — Python exits non-zero.
         result = python_tool.bash("python scripts/nonexistent.py")
         assert result.success == 0
-        assert result.error is not None
+        assert result.error.startswith("Command exited with code ")
+        # Python's stderr is merged into the result and names the missing file.
+        assert "nonexistent.py" in result.result
 
     def test_empty_patterns_blocks_execution(self, empty_tool):
         result = empty_tool.bash("python anything.py")
@@ -257,7 +260,8 @@ class TestBashToolWorkspaceIsolation:
         (temp_workspace / "scripts" / "pwd_test.py").write_text("import os\nprint(os.getcwd())\n")
         result = multi_pattern_tool.bash("python scripts/pwd_test.py")
         assert result.success == 1
-        assert str(temp_workspace) in result.result or temp_workspace.name in result.result
+        # cwd is locked to the resolved workspace root (symlinks resolved).
+        assert result.result.strip() == str(temp_workspace.resolve())
 
 
 class TestBashToolExtraEnv:
@@ -306,11 +310,12 @@ class TestBashToolEdgeCases:
         assert "3" in result.result
 
     def test_invalid_shlex_syntax_returns_error(self, wildcard_tool):
-        # Unclosed quote: ``bash`` calls ``shlex.split`` and reports
-        # the syntax error rather than crashing.
+        # Unclosed quote: the restrictive whitelist can't parse the command
+        # (``split_pipeline`` returns None on unbalanced quotes), so it is
+        # rejected before spawning rather than crashing.
         result = wildcard_tool.bash('python -c "unclosed')
         assert result.success == 0
-        assert "syntax" in result.error.lower() or "not allowed" in result.error.lower()
+        assert result.error.startswith("Command not allowed")
 
 
 class TestBashToolTimeout:

--- a/tests/unit_tests/tools/permission/test_bash_classifier.py
+++ b/tests/unit_tests/tools/permission/test_bash_classifier.py
@@ -1,0 +1,36 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the bash classifier interface seam."""
+
+import asyncio
+
+from datus.tools.permission.bash_classifier import (
+    BashClassifierContext,
+    NoopBashCommandClassifier,
+    create_bash_classifier,
+)
+from datus.tools.permission.bash_rules import BashClassifierConfig, BashCommandRules
+
+
+class TestCreateBashClassifier:
+    """Factory behavior for the reserved classifier seam."""
+
+    def test_none_rules_yields_none(self):
+        assert create_bash_classifier(None, agent_config=None) is None
+
+    def test_disabled_yields_none(self):
+        rules = BashCommandRules(classifier=BashClassifierConfig(enabled=False))
+        assert create_bash_classifier(rules, agent_config=None) is None
+
+    def test_enabled_yields_noop_until_implemented(self):
+        rules = BashCommandRules(classifier=BashClassifierConfig(enabled=True))
+        classifier = create_bash_classifier(rules, agent_config=None)
+        assert isinstance(classifier, NoopBashCommandClassifier)
+
+    def test_noop_never_renders_verdict(self):
+        classifier = NoopBashCommandClassifier()
+        context = BashClassifierContext(cwd="/tmp", node_name="chat")
+        verdict = asyncio.run(classifier.classify("git status", context))
+        assert verdict is None

--- a/tests/unit_tests/tools/permission/test_bash_classifier.py
+++ b/tests/unit_tests/tools/permission/test_bash_classifier.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the bash classifier interface seam."""
 
-import asyncio
+import pytest
 
 from datus.tools.permission.bash_classifier import (
     BashClassifierContext,
@@ -29,8 +29,9 @@ class TestCreateBashClassifier:
         classifier = create_bash_classifier(rules, agent_config=None)
         assert isinstance(classifier, NoopBashCommandClassifier)
 
-    def test_noop_never_renders_verdict(self):
+    @pytest.mark.asyncio
+    async def test_noop_never_renders_verdict(self):
         classifier = NoopBashCommandClassifier()
         context = BashClassifierContext(cwd="/tmp", node_name="chat")
-        verdict = asyncio.run(classifier.classify("git status", context))
+        verdict = await classifier.classify("git status", context)
         assert verdict is None

--- a/tests/unit_tests/tools/permission/test_bash_rules.py
+++ b/tests/unit_tests/tools/permission/test_bash_rules.py
@@ -150,6 +150,43 @@ class TestSafetyCeiling:
     @pytest.mark.parametrize(
         "command",
         [
+            "python -c 'print(1)'",
+            "python3 -c 'print(1)'",
+            "python3.12 -uc 'print(1)'",  # short-option cluster still contains -c
+            "perl -e 'unlink foo'",
+            "ruby -e 'puts 1'",
+            "node --eval 'process.exit()'",
+            "node -p '1+1'",
+            "php -r 'echo 1;'",
+        ],
+    )
+    def test_interpreter_inline_code_forces_ask(self, command):
+        """``python -c`` / ``perl -e`` … execute a string the rules cannot see,
+        so even a blanket interpreter allow rule never auto-runs them."""
+        rules = BashCommandRules(allow=["python:*", "python3:*", "python3.12:*", "perl:*", "ruby:*", "node:*", "php:*"])
+        decision = evaluate_bash_command(command, rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.SAFETY
+        assert decision.safety_forced is True
+
+    def test_interpreter_script_path_still_allowed(self):
+        """Interpreters are NOT blanket wrappers: the documented
+        ``python:scripts/*.py`` allow form must keep working."""
+        rules = BashCommandRules(allow=["python:scripts/*.py"])
+        decision = evaluate_bash_command("python scripts/etl.py", rules)
+        assert decision.level == PermissionLevel.ALLOW
+        assert decision.matched_pattern == "python:scripts/*.py"
+
+    def test_interpreter_script_own_dash_c_arg_not_flagged(self):
+        """A ``-c`` AFTER the script path belongs to the script, not the
+        interpreter — option scanning stops at the first non-option token."""
+        rules = BashCommandRules(allow=["python:*"])
+        decision = evaluate_bash_command("python tool.py -c config.yml", rules)
+        assert decision.level == PermissionLevel.ALLOW
+
+    @pytest.mark.parametrize(
+        "command",
+        [
             "git status && rm -rf /",
             "ls || rm x",  # logical OR is not a pipeline
             "ls |& grep foo",  # stderr pipe is not a simple pipeline

--- a/tests/unit_tests/tools/permission/test_bash_rules.py
+++ b/tests/unit_tests/tools/permission/test_bash_rules.py
@@ -1,0 +1,385 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Unit tests for fine-grained bash command permission rules.
+
+Tests pattern matching semantics, the deny-first decision order, the safety
+ceiling for wrappers/metacharacters, session bucketing, and ruleset merging.
+"""
+
+import shlex
+
+import pytest
+
+from datus.tools.permission.bash_rules import (
+    BashClassifierConfig,
+    BashCommandRules,
+    BashDecisionSource,
+    command_matches_pattern,
+    evaluate_bash_command,
+    session_bucket_for,
+)
+from datus.tools.permission.permission_config import PermissionLevel
+
+
+def argv(command: str):
+    return shlex.split(command)
+
+
+class TestCommandMatchesPattern:
+    """Tests for the three pattern forms: exact, prefix:*, prefix:glob."""
+
+    def test_exact_match(self):
+        """Exact pattern (no colon) matches only the identical command."""
+        assert command_matches_pattern(argv("git status"), "git status")
+        assert not command_matches_pattern(argv("git status --short"), "git status")
+        assert not command_matches_pattern(argv("git"), "git status")
+
+    def test_prefix_star_matches_prefix_and_more(self):
+        """prefix:* matches the bare prefix and anything following it."""
+        assert command_matches_pattern(argv("git log"), "git log:*")
+        assert command_matches_pattern(argv("git log --oneline -5"), "git log:*")
+        assert not command_matches_pattern(argv("git logs"), "git log:*")
+        assert not command_matches_pattern(argv("git"), "git log:*")
+
+    def test_multi_word_prefix(self):
+        """Multi-word prefixes work (uv run pytest:*)."""
+        assert command_matches_pattern(argv("uv run pytest tests/ -k foo"), "uv run pytest:*")
+        assert not command_matches_pattern(argv("uv run python evil.py"), "uv run pytest:*")
+
+    def test_prefix_glob_restricts_first_arg(self):
+        """prefix:glob requires the first remainder token to match the glob."""
+        assert command_matches_pattern(argv("python scripts/etl.py"), "python:scripts/*.py")
+        assert not command_matches_pattern(argv("python -c 'print(1)'"), "python:scripts/*.py")
+        assert not command_matches_pattern(argv("python other/x.py"), "python:scripts/*.py")
+        # bare prefix does not satisfy a non-* glob
+        assert not command_matches_pattern(argv("python"), "python:scripts/*.py")
+
+    def test_prefix_glob_matches_joined_remainder(self):
+        """The joined remainder string may satisfy the glob as a whole."""
+        assert command_matches_pattern(argv("npm run build --prod"), "npm run:build --prod")
+
+    def test_unanchored_matches_at_any_offset(self):
+        """anchor=False finds the prefix anywhere in argv (deny-rule mode)."""
+        assert command_matches_pattern(argv("xargs rm -rf build"), "rm:*", anchor=False)
+        assert command_matches_pattern(argv("find . -exec rm {}"), "rm:*", anchor=False)
+        assert not command_matches_pattern(argv("xargs rm -rf build"), "rm:*", anchor=True)
+
+    def test_unanchored_does_not_match_inside_quoted_token(self):
+        """A quoted argument containing the word is one token and must not match."""
+        assert not command_matches_pattern(argv("git commit -m 'rm important'"), "rm:*", anchor=False)
+
+    def test_word_boundary(self):
+        """ls:* must not match lsof (token equality via fnmatch, not startswith)."""
+        assert not command_matches_pattern(argv("lsof -i :8080"), "ls:*")
+
+
+class TestEvaluateDecisionOrder:
+    """Tests for the deny -> safety -> ask -> allow -> default order."""
+
+    def test_deny_beats_allow(self):
+        rules = BashCommandRules(allow=["git:*"], deny=["git push:*"])
+        decision = evaluate_bash_command("git push origin main", rules)
+        assert decision.level == PermissionLevel.DENY
+        assert decision.source == BashDecisionSource.DENY_RULE
+        assert decision.matched_pattern == "git push:*"
+
+    def test_ask_beats_allow(self):
+        rules = BashCommandRules(allow=["docker:*"], ask=["docker push:*"])
+        decision = evaluate_bash_command("docker push img:latest", rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.ASK_RULE
+
+    def test_allow_rule(self):
+        rules = BashCommandRules(allow=["git log:*"])
+        decision = evaluate_bash_command("git log --oneline", rules)
+        assert decision.level == PermissionLevel.ALLOW
+        assert decision.source == BashDecisionSource.ALLOW_RULE
+        assert decision.matched_pattern == "git log:*"
+
+    def test_default_ask_when_nothing_matches(self):
+        rules = BashCommandRules(allow=["git status"])
+        decision = evaluate_bash_command("cargo build --release", rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.DEFAULT
+
+    def test_default_can_be_allow(self):
+        rules = BashCommandRules(default=PermissionLevel.ALLOW)
+        decision = evaluate_bash_command("cargo build", rules)
+        assert decision.level == PermissionLevel.ALLOW
+        assert decision.source == BashDecisionSource.DEFAULT
+
+    def test_unanchored_deny_catches_xargs(self):
+        rules = BashCommandRules(deny=["rm:*"])
+        decision = evaluate_bash_command("xargs rm -rf build", rules)
+        assert decision.level == PermissionLevel.DENY
+        assert decision.matched_pattern == "rm:*"
+
+    def test_deny_beats_wrapper_safety(self):
+        """A denied command inside a wrapper is DENY, not the wrapper's ASK."""
+        rules = BashCommandRules(deny=["rm:*"])
+        decision = evaluate_bash_command("sudo rm -rf /", rules)
+        assert decision.level == PermissionLevel.DENY
+        assert decision.source == BashDecisionSource.DENY_RULE
+
+
+class TestSafetyCeiling:
+    """Wrappers and shell metacharacters never auto-allow."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "bash -c 'git status'",
+            "sh script.sh",
+            "sudo ls",
+            "env FOO=1 ls",
+            "xargs echo",
+            "eval echo hi",
+            "timeout 5 git status",
+        ],
+    )
+    def test_wrapper_forces_ask(self, command):
+        rules = BashCommandRules(allow=["git status", "ls:*", "echo:*", "sh:*", "bash:*"])
+        decision = evaluate_bash_command(command, rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.SAFETY
+        assert decision.safety_forced is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status && rm -rf /",
+            "ls || rm x",  # logical OR is not a pipeline
+            "ls |& grep foo",  # stderr pipe is not a simple pipeline
+            "ls |",  # trailing empty pipeline segment
+            "echo hi > /etc/passwd",
+            "echo `whoami`",
+            "echo $(id)",
+            "echo ${HOME}",
+            "ls; rm x",
+        ],
+    )
+    def test_metacharacters_force_ask(self, command):
+        rules = BashCommandRules(allow=["git status", "ls:*", "echo:*", "grep:*", "rm:*"])
+        decision = evaluate_bash_command(command, rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.SAFETY
+        assert decision.safety_forced is True
+
+    def test_unparseable_command(self):
+        rules = BashCommandRules(allow=["echo:*"])
+        decision = evaluate_bash_command('echo "unclosed', rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.UNPARSEABLE
+        assert decision.safety_forced is True
+
+    def test_empty_command(self):
+        decision = evaluate_bash_command("   ", BashCommandRules())
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.UNPARSEABLE
+
+    def test_plain_command_is_not_safety_forced(self):
+        decision = evaluate_bash_command("cargo build", BashCommandRules())
+        assert decision.safety_forced is False
+
+
+class TestSessionBuckets:
+    """Bucket keys scope 'always allow' grants."""
+
+    def test_matched_pattern_is_bucket(self):
+        rules = BashCommandRules(ask=["docker:*"])
+        decision = evaluate_bash_command("docker ps", rules)
+        assert decision.bucket == "docker:*"
+
+    def test_group_command_buckets_on_two_tokens(self):
+        assert session_bucket_for(argv("git push origin main"), None) == "git push"
+        assert session_bucket_for(argv("docker compose up"), None) == "docker compose"
+
+    def test_plain_command_buckets_on_first_token(self):
+        assert session_bucket_for(argv("ls -la"), None) == "ls"
+
+    def test_group_command_with_flag_first_buckets_on_one_token(self):
+        assert session_bucket_for(argv("git -C /tmp status"), None) == "git"
+
+    def test_default_decision_bucket(self):
+        decision = evaluate_bash_command("git push origin main", BashCommandRules())
+        assert decision.bucket == "git push"
+
+
+class TestBashCommandRulesModel:
+    """Tests for from_dict / merge_with / is_empty."""
+
+    def test_from_dict_none_and_empty(self):
+        assert BashCommandRules.from_dict(None) is None
+        assert BashCommandRules.from_dict({}) is None
+
+    def test_from_dict_parses_all_sections(self):
+        rules = BashCommandRules.from_dict(
+            {
+                "allow": ["git log:*"],
+                "deny": ["rm:*"],
+                "ask": ["docker:*"],
+                "default": "allow",
+                "classifier": {"enabled": True, "model": "gpt-x", "confidence_threshold": 0.9},
+            }
+        )
+        assert rules.allow == ["git log:*"]
+        assert rules.deny == ["rm:*"]
+        assert rules.ask == ["docker:*"]
+        assert PermissionLevel(rules.default) == PermissionLevel.ALLOW
+        assert rules.classifier.enabled is True
+        assert rules.classifier.model == "gpt-x"
+        assert rules.classifier.confidence_threshold == 0.9
+
+    def test_from_dict_malformed_raises(self):
+        """Malformed sections raise so agent_config's fail-closed fallback fires."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            BashCommandRules.from_dict({"allow": "not-a-list"})
+        with pytest.raises(ValueError):
+            BashCommandRules.from_dict({"default": "bogus"})
+
+    def test_merge_with_concatenates_lists(self):
+        base = BashCommandRules(allow=["git log:*"], deny=["rm:*"])
+        override = BashCommandRules(allow=["make:*"], ask=["docker:*"])
+        merged = base.merge_with(override)
+        assert merged.allow == ["git log:*", "make:*"]
+        assert merged.deny == ["rm:*"]
+        assert merged.ask == ["docker:*"]
+
+    def test_merge_with_none_returns_self(self):
+        base = BashCommandRules(allow=["git log:*"])
+        assert base.merge_with(None) is base
+
+    def test_merge_default_only_when_explicit(self):
+        base = BashCommandRules(default=PermissionLevel.ALLOW)
+        # override did not set default explicitly -> base's kept
+        merged = base.merge_with(BashCommandRules(allow=["x:*"]))
+        assert PermissionLevel(merged.default) == PermissionLevel.ALLOW
+        # override set default explicitly -> override wins
+        merged = base.merge_with(BashCommandRules(default=PermissionLevel.ASK))
+        assert PermissionLevel(merged.default) == PermissionLevel.ASK
+
+    def test_merge_classifier_only_when_explicit(self):
+        base = BashCommandRules(classifier=BashClassifierConfig(enabled=True))
+        merged = base.merge_with(BashCommandRules(allow=["x:*"]))
+        assert merged.classifier.enabled is True
+        merged = base.merge_with(BashCommandRules(classifier=BashClassifierConfig(enabled=False)))
+        assert merged.classifier.enabled is False
+
+    def test_is_empty(self):
+        assert BashCommandRules().is_empty()
+        assert not BashCommandRules(allow=["ls:*"]).is_empty()
+
+
+class TestSplitPipeline:
+    """split_pipeline: top-level unquoted | segmentation."""
+
+    def test_no_pipe_returns_single(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("git status") == ["git status"]
+
+    def test_simple_pipeline(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("cat a | grep b | wc -l") == ["cat a", "grep b", "wc -l"]
+
+    def test_pipe_in_double_quotes_not_split(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline('grep "a|b" file') == ['grep "a|b" file']
+
+    def test_pipe_in_single_quotes_not_split(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("awk '{print $1|$2}'") == ["awk '{print $1|$2}'"]
+
+    def test_escaped_pipe_not_split(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("echo a\\|b") == ["echo a\\|b"]
+
+    def test_logical_or_returns_none(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("a || b") is None
+
+    def test_stderr_pipe_returns_none(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("a |& b") is None
+
+    def test_empty_segment_returns_none(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("ls |") is None
+        assert split_pipeline("| ls") is None
+        assert split_pipeline("a || b") is None
+
+    def test_unbalanced_quotes_returns_none(self):
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline('echo "unclosed | grep') is None
+
+
+class TestPipelineEvaluation:
+    """Per-segment judging + aggregation for pipelines."""
+
+    def test_all_allow_segments_auto_allow(self):
+        rules = BashCommandRules(allow=["cat:*", "grep:*", "wc:*"])
+        d = evaluate_bash_command("cat log | grep err | wc -l", rules)
+        assert d.level == PermissionLevel.ALLOW
+        assert d.source == BashDecisionSource.ALLOW_RULE
+
+    def test_deny_segment_blocks_whole_pipeline(self):
+        rules = BashCommandRules(allow=["cat:*"], deny=["rm:*"])
+        d = evaluate_bash_command("cat x | rm -rf y", rules)
+        assert d.level == PermissionLevel.DENY
+        assert d.matched_pattern == "rm:*"
+
+    def test_deny_segment_via_unanchored_wrapper(self):
+        rules = BashCommandRules(allow=["ls:*"], deny=["rm:*"])
+        d = evaluate_bash_command("ls | xargs rm", rules)
+        assert d.level == PermissionLevel.DENY
+        assert d.matched_pattern == "rm:*"
+
+    def test_wrapper_segment_forces_safety_ask(self):
+        rules = BashCommandRules(allow=["ls:*", "echo:*"])
+        d = evaluate_bash_command("ls | xargs echo", rules)
+        assert d.level == PermissionLevel.ASK
+        assert d.source == BashDecisionSource.SAFETY
+        assert d.safety_forced is True
+
+    def test_unmatched_segment_asks_default(self):
+        rules = BashCommandRules(allow=["cat:*"])
+        d = evaluate_bash_command("cat x | frobnicate", rules)
+        assert d.level == PermissionLevel.ASK
+        assert d.source == BashDecisionSource.DEFAULT
+        assert d.bucket == "frobnicate"
+
+    def test_ask_rule_segment_outranks_default_segment(self):
+        """The pipeline's source must be ASK_RULE so a permissive profile's
+        default-fallback in the hook can't swallow the ask-rule segment."""
+        rules = BashCommandRules(allow=["cat:*"], ask=["docker:*"])
+        d = evaluate_bash_command("frobnicate | docker ps | cat", rules)
+        assert d.level == PermissionLevel.ASK
+        assert d.source == BashDecisionSource.ASK_RULE
+        assert d.bucket == "docker:*"
+
+    def test_deny_outranks_wrapper_and_ask(self):
+        rules = BashCommandRules(allow=["cat:*"], ask=["docker:*"], deny=["rm:*"])
+        d = evaluate_bash_command("docker ps | xargs rm | cat", rules)
+        assert d.level == PermissionLevel.DENY
+        assert d.matched_pattern == "rm:*"
+
+    def test_metachar_inside_segment_still_safety(self):
+        """A pipeline segment carrying other metachars is safety-forced."""
+        rules = BashCommandRules(allow=["cat:*", "grep:*"])
+        d = evaluate_bash_command("cat x | grep y > out.txt", rules)
+        assert d.level == PermissionLevel.ASK
+        assert d.source == BashDecisionSource.SAFETY
+        assert d.safety_forced is True

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -1902,7 +1902,9 @@ class TestBashCommandPermission:
         registry.register_tools("bash_tools", [tool_mock])
         config = PermissionConfig(
             default_permission=default,
-            rules=rules if rules is not None else [PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.ASK)],
+            rules=rules
+            if rules is not None
+            else [PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.ASK)],
             bash_commands=BashCommandRules(**bash_commands) if isinstance(bash_commands, dict) else bash_commands,
         )
         manager = PermissionManager(global_config=config)

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -1879,3 +1879,443 @@ class TestPermissionPromptContent:
         event = mock_broker.request.call_args.args[0][0]
         assert "**Arguments**" not in event.content
         assert "Permission Request" in event.content
+
+
+class TestBashCommandPermission:
+    """Command-level gating for ``bash_tools.bash`` via _handle_bash_permission."""
+
+    def _make_hooks(
+        self,
+        mock_broker,
+        bash_commands=None,
+        rules=None,
+        non_interactive=False,
+        project_root=None,
+        bash_classifier=None,
+        default=PermissionLevel.ASK,
+    ):
+        from datus.tools.permission.bash_rules import BashCommandRules
+
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "bash"
+        registry.register_tools("bash_tools", [tool_mock])
+        config = PermissionConfig(
+            default_permission=default,
+            rules=rules if rules is not None else [PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.ASK)],
+            bash_commands=BashCommandRules(**bash_commands) if isinstance(bash_commands, dict) else bash_commands,
+        )
+        manager = PermissionManager(global_config=config)
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            non_interactive=non_interactive,
+            project_root=project_root,
+            bash_classifier=bash_classifier,
+        )
+        return hooks, manager
+
+    @staticmethod
+    def _ctx(command):
+        import json
+
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps({"command": command})
+        return ctx
+
+    @staticmethod
+    def _tool():
+        t = MagicMock()
+        t.name = "bash"
+        return t
+
+    @pytest.mark.asyncio
+    async def test_allow_rule_bypasses_prompt(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["git log:*"]})
+
+        await hooks.on_tool_start(self._ctx("git log --oneline -5"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deny_rule_raises_naming_pattern(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["git:*"], "deny": ["git push:*"]})
+
+        with pytest.raises(PermissionDeniedException, match="git push"):
+            await hooks.on_tool_start(self._ctx("git push origin main"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unanchored_deny_catches_wrapped_command(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"deny": ["rm:*"]})
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(self._ctx("xargs rm -rf build"), MagicMock(), self._tool())
+
+    @pytest.mark.asyncio
+    async def test_missing_ruleset_falls_back_to_coarse_ask(self, mock_broker):
+        """No bash_commands → legacy behavior: the coarse ASK rule prompts."""
+        hooks, _ = self._make_hooks(mock_broker, bash_commands=None)
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("git log"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_explicit_category_deny_defers_to_main_flow(self, mock_broker):
+        """A coarse bash_tools.bash DENY rule wins over command-level allows."""
+        hooks, _ = self._make_hooks(
+            mock_broker,
+            bash_commands={"allow": ["git log:*"]},
+            rules=[PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.DENY)],
+        )
+
+        with pytest.raises(PermissionDeniedException, match="blocked by"):
+            await hooks.on_tool_start(self._ctx("git log"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_ask_raises_without_prompt(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["git log:*"]}, non_interactive=True)
+
+        with pytest.raises(PermissionDeniedException, match="non-interactively"):
+            await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ask_prompts_and_deny_choice_raises(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["git log:*"]})
+        mock_broker.request = AsyncMock(return_value=[["n"]])
+
+        with pytest.raises(PermissionDeniedException, match="rejected"):
+            await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+    @pytest.mark.asyncio
+    async def test_session_allow_buckets_by_prefix(self, mock_broker):
+        """'a' approves the bucket; same bucket skips, different bucket prompts."""
+        hooks, manager = self._make_hooks(mock_broker, bash_commands={"allow": ["git log:*"]})
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("git push origin main"), MagicMock(), self._tool())
+        assert manager._session_approvals.get("bash_tools.bash::git push") is True
+
+        # same bucket: no second prompt
+        await hooks.on_tool_start(self._ctx("git push origin dev"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+        # different bucket prompts again
+        await hooks.on_tool_start(self._ctx("git rebase main"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_project_allow_persists_and_applies(self, mock_broker, tmp_path):
+        """'p' writes .datus/config.yml, updates live config, caches session bucket."""
+        from datus.configuration.project_config import load_project_override
+
+        hooks, manager = self._make_hooks(
+            mock_broker, bash_commands={"allow": ["git log:*"]}, project_root=str(tmp_path)
+        )
+        mock_broker.request = AsyncMock(return_value=[["p"]])
+
+        await hooks.on_tool_start(self._ctx("make test"), MagicMock(), self._tool())
+
+        override = load_project_override(str(tmp_path))
+        assert override.bash_allow == ["make test:*"]
+        assert "make test:*" in manager.global_config.bash_commands.allow
+        # later same-prefix command auto-allows via the live rule (no prompt)
+        await hooks.on_tool_start(self._ctx("make test -j4"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_safety_forced_prompt_offers_no_project_choice(self, mock_broker):
+        """Wrapper/metachar asks must not offer the persistent 'p' choice."""
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["git status"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("git status && rm -rf /"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "p" not in event.choices
+        assert "y" in event.choices and "a" in event.choices and "n" in event.choices
+
+    @pytest.mark.asyncio
+    async def test_ask_rule_hit_offers_no_project_choice(self, mock_broker):
+        """Explicit ask rules mean 'review every time' — no 'p' offered."""
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"ask": ["docker:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("docker ps"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "p" not in event.choices
+
+    @pytest.mark.asyncio
+    async def test_unmatched_command_offers_project_choice(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["git log:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "p" in event.choices
+
+    @pytest.mark.asyncio
+    async def test_classifier_high_confidence_allow_skips_prompt(self, mock_broker):
+        from datus.tools.permission.bash_classifier import BashCommandClassifier, ClassifierVerdict
+
+        class StubClassifier(BashCommandClassifier):
+            async def classify(self, command, context):
+                return ClassifierVerdict(permission=PermissionLevel.ALLOW, confidence=0.95, reason="safe")
+
+        hooks, _ = self._make_hooks(
+            mock_broker, bash_commands={"allow": ["git log:*"]}, bash_classifier=StubClassifier()
+        )
+
+        await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_classifier_low_confidence_falls_through_to_prompt(self, mock_broker):
+        from datus.tools.permission.bash_classifier import BashCommandClassifier, ClassifierVerdict
+
+        class StubClassifier(BashCommandClassifier):
+            async def classify(self, command, context):
+                return ClassifierVerdict(permission=PermissionLevel.ALLOW, confidence=0.3, reason="unsure")
+
+        hooks, _ = self._make_hooks(
+            mock_broker, bash_commands={"allow": ["git log:*"]}, bash_classifier=StubClassifier()
+        )
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_classifier_exception_fails_closed_to_prompt(self, mock_broker):
+        from datus.tools.permission.bash_classifier import BashCommandClassifier
+
+        class BoomClassifier(BashCommandClassifier):
+            async def classify(self, command, context):
+                raise RuntimeError("api down")
+
+        hooks, _ = self._make_hooks(
+            mock_broker, bash_commands={"allow": ["git log:*"]}, bash_classifier=BoomClassifier()
+        )
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_classifier_not_consulted_for_safety_forced(self, mock_broker):
+        from datus.tools.permission.bash_classifier import BashCommandClassifier, ClassifierVerdict
+
+        calls = []
+
+        class StubClassifier(BashCommandClassifier):
+            async def classify(self, command, context):
+                calls.append(command)
+                return ClassifierVerdict(permission=PermissionLevel.ALLOW, confidence=0.99, reason="safe")
+
+        hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["ls:*"]}, bash_classifier=StubClassifier())
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("sudo ls"), MagicMock(), self._tool())
+
+        assert calls == []
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_switch_profile_clears_session_but_keeps_project_allows(self, mock_broker, tmp_path):
+        hooks, manager = self._make_hooks(
+            mock_broker, bash_commands={"allow": ["git log:*"]}, project_root=str(tmp_path)
+        )
+        mock_broker.request = AsyncMock(return_value=[["p"]])
+        await hooks.on_tool_start(self._ctx("make test"), MagicMock(), self._tool())
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+        await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+        assert manager._session_approvals
+
+        manager.switch_profile("normal")
+
+        assert not manager._session_approvals  # session buckets cleared
+        assert "make test:*" in manager.global_config.bash_commands.allow  # project allow replayed
+
+
+class TestBashDangerousProfileWithUserRules:
+    """User deny/ask lists must not flip dangerous into ask-everything."""
+
+    def _make_hooks(self, mock_broker, non_interactive=True):
+        from datus.tools.permission.profiles import build_effective_config
+
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "bash"
+        registry.register_tools("bash_tools", [tool_mock])
+        # dangerous profile + user bash rules from agent.yml — the real merge path.
+        config = build_effective_config(
+            "dangerous",
+            {"bash_commands": {"deny": ["rm:*"], "ask": ["docker:*"]}},
+        )
+        manager = PermissionManager(global_config=config, active_profile="dangerous")
+        return PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            non_interactive=non_interactive,
+        )
+
+    @staticmethod
+    def _ctx(command):
+        import json
+
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps({"command": command})
+        return ctx
+
+    @staticmethod
+    def _tool():
+        t = MagicMock()
+        t.name = "bash"
+        return t
+
+    @pytest.mark.asyncio
+    async def test_unmatched_command_inherits_dangerous_allow(self, mock_broker):
+        hooks = self._make_hooks(mock_broker)
+
+        await hooks.on_tool_start(self._ctx("touch newfile.txt"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deny_rule_still_blocks_under_dangerous(self, mock_broker):
+        hooks = self._make_hooks(mock_broker)
+
+        with pytest.raises(PermissionDeniedException, match="rm"):
+            await hooks.on_tool_start(self._ctx("rm README.md"), MagicMock(), self._tool())
+
+    @pytest.mark.asyncio
+    async def test_ask_rule_still_asks_under_dangerous(self, mock_broker):
+        hooks = self._make_hooks(mock_broker)
+
+        with pytest.raises(PermissionDeniedException, match="non-interactively"):
+            await hooks.on_tool_start(self._ctx("docker ps"), MagicMock(), self._tool())
+
+    @pytest.mark.asyncio
+    async def test_explicit_default_ask_is_respected(self, mock_broker):
+        """A user who explicitly sets default: ask under dangerous gets ask."""
+        from datus.tools.permission.profiles import build_effective_config
+
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "bash"
+        registry.register_tools("bash_tools", [tool_mock])
+        config = build_effective_config(
+            "dangerous",
+            {"bash_commands": {"deny": ["rm:*"], "default": "ask"}},
+        )
+        manager = PermissionManager(global_config=config, active_profile="dangerous")
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            non_interactive=True,
+        )
+
+        with pytest.raises(PermissionDeniedException, match="non-interactively"):
+            await hooks.on_tool_start(self._ctx("touch x"), MagicMock(), self._tool())
+
+
+class TestBashPipelinePermission:
+    """Hook-level behavior for pipelines under _handle_bash_permission."""
+
+    def _make_hooks(self, mock_broker, bash_commands=None, non_interactive=False):
+        from datus.tools.permission.bash_rules import BashCommandRules
+
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "bash"
+        registry.register_tools("bash_tools", [tool_mock])
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            rules=[PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.ASK)],
+            bash_commands=BashCommandRules(**bash_commands) if bash_commands else None,
+        )
+        manager = PermissionManager(global_config=config)
+        return (
+            PermissionHooks(
+                broker=mock_broker,
+                permission_manager=manager,
+                node_name="chat",
+                tool_registry=registry,
+                non_interactive=non_interactive,
+            ),
+            manager,
+        )
+
+    @staticmethod
+    def _ctx(command):
+        import json
+
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps({"command": command})
+        return ctx
+
+    @staticmethod
+    def _tool():
+        t = MagicMock()
+        t.name = "bash"
+        return t
+
+    @pytest.mark.asyncio
+    async def test_all_allow_pipeline_no_prompt(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["cat:*", "grep:*", "wc:*"]})
+
+        await hooks.on_tool_start(self._ctx("cat log | grep err | wc -l"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deny_segment_raises(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["cat:*"], "deny": ["rm:*"]})
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(self._ctx("cat x | xargs rm"), MagicMock(), self._tool())
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unmatched_segment_prompts_with_that_bucket(self, mock_broker):
+        hooks, manager = self._make_hooks(mock_broker, {"allow": ["cat:*"]})
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("cat x | frobnicate"), MagicMock(), self._tool())
+
+        assert manager._session_approvals.get("bash_tools.bash::frobnicate") is True
+
+    @pytest.mark.asyncio
+    async def test_wrapper_segment_safety_no_project_option(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["ls:*", "echo:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("ls | xargs echo"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "p" not in event.choices
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_pipeline_ask_raises(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["cat:*"]}, non_interactive=True)
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(self._ctx("cat x | frobnicate"), MagicMock(), self._tool())

--- a/tests/unit_tests/tools/permission/test_permission_manager.py
+++ b/tests/unit_tests/tools/permission/test_permission_manager.py
@@ -525,3 +525,33 @@ class TestPermissionManagerPersistentRules:
         assert not any(r.pattern == "only_a" for r in mgr_b.global_config.rules)
         # The shared profile itself is untouched.
         assert len(get_profile("normal").rules) == before
+
+
+class TestPermissionManagerProjectBashAllows:
+    """Project-scope bash allows replay across profile switches — except onto
+    a profile that intentionally carries no command-level ruleset."""
+
+    def _manager_with_grant(self):
+        from unittest.mock import patch
+
+        from datus.tools.permission.permission_manager import PermissionManager
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(global_config=get_profile("normal"), active_profile="normal")
+        with patch("datus.configuration.project_config.append_project_bash_allow"):
+            mgr.add_project_bash_allow("make:*")
+        assert "make:*" in mgr.global_config.bash_commands.allow
+        return mgr
+
+    def test_switch_to_dangerous_does_not_reenable_bash_gating(self):
+        """``dangerous`` keeps ``bash_commands`` unset so the fine-grained
+        bash gate steps aside entirely; replaying a project grant onto it
+        would flip that documented zero-friction posture."""
+        mgr = self._manager_with_grant()
+        mgr.switch_profile("dangerous")
+        assert mgr.global_config.bash_commands is None
+
+    def test_switch_between_rule_profiles_replays_grant(self):
+        mgr = self._manager_with_grant()
+        mgr.switch_profile("auto")
+        assert "make:*" in mgr.global_config.bash_commands.allow

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -340,6 +340,19 @@ class TestProfileBashCommands:
         # sort can write via -o, so it's auto-only.
         assert evaluate_bash_command("sort f", NORMAL.bash_commands).level == PermissionLevel.ASK
 
+    def test_normal_date_hostname_readonly_forms_only(self):
+        from datus.tools.permission.bash_rules import evaluate_bash_command
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import NORMAL
+
+        # Bare inspection and ``date +FORMAT`` auto-allow.
+        assert evaluate_bash_command("date", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("date +%Y-%m-%d", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("hostname", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        # Mutating forms (``date -s`` / ``hostname NAME``) fall through to ASK.
+        assert evaluate_bash_command("date -s 2026-01-01", NORMAL.bash_commands).level == PermissionLevel.ASK
+        assert evaluate_bash_command("hostname newname", NORMAL.bash_commands).level == PermissionLevel.ASK
+
     def test_auto_extends_normal(self):
         from datus.tools.permission.bash_rules import evaluate_bash_command
         from datus.tools.permission.permission_config import PermissionLevel

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -305,3 +305,69 @@ class TestBuildEffectiveConfig:
 
         with pytest.raises(ValueError, match="Unknown profile"):
             build_effective_config("yolo", {})
+
+
+class TestProfileBashCommands:
+    """Command-level bash rules attached to each profile."""
+
+    def test_normal_allows_readonly_commands(self):
+        from datus.tools.permission.bash_rules import evaluate_bash_command
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import NORMAL
+
+        assert evaluate_bash_command("git status", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("ls -la", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("git log --oneline -5", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        # File readers / text filters are now allowed in normal (read-only).
+        assert evaluate_bash_command("cat README.md", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("head -5 data.csv", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("grep -n TODO src.py", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+        # Read-only pipeline of allow-listed commands auto-allows.
+        assert evaluate_bash_command("cat log | grep err | wc -l", NORMAL.bash_commands).level == PermissionLevel.ALLOW
+
+    def test_normal_asks_for_writes_and_codeexec(self):
+        from datus.tools.permission.bash_rules import evaluate_bash_command
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import NORMAL
+
+        # Writes stay ASK.
+        assert evaluate_bash_command("rm -rf build", NORMAL.bash_commands).level == PermissionLevel.ASK
+        assert evaluate_bash_command("touch x", NORMAL.bash_commands).level == PermissionLevel.ASK
+        # Programmable tools (can exec / write in place) are NOT whitelisted.
+        assert evaluate_bash_command("awk '{print $1}' f", NORMAL.bash_commands).level == PermissionLevel.ASK
+        assert evaluate_bash_command("sed -i s/a/b/ f", NORMAL.bash_commands).level == PermissionLevel.ASK
+        assert evaluate_bash_command("find . -name x", NORMAL.bash_commands).level == PermissionLevel.ASK
+        # sort can write via -o, so it's auto-only.
+        assert evaluate_bash_command("sort f", NORMAL.bash_commands).level == PermissionLevel.ASK
+
+    def test_auto_extends_normal(self):
+        from datus.tools.permission.bash_rules import evaluate_bash_command
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import AUTO
+
+        assert evaluate_bash_command("cat README.md", AUTO.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("git status", AUTO.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("sort data.txt", AUTO.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("mkdir newdir", AUTO.bash_commands).level == PermissionLevel.ALLOW
+        assert evaluate_bash_command("rm -rf build", AUTO.bash_commands).level == PermissionLevel.ASK
+
+    def test_dangerous_has_no_bash_rules(self):
+        from datus.tools.permission.profiles import DANGEROUS
+
+        assert DANGEROUS.bash_commands is None
+
+    def test_user_bash_commands_layer_over_profile(self):
+        from datus.tools.permission.bash_rules import evaluate_bash_command
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config(
+            "normal",
+            {"bash_commands": {"allow": ["make:*"], "deny": ["git diff:*"]}},
+        )
+        # user allow appended after profile whitelist
+        assert evaluate_bash_command("make test", effective.bash_commands).level == PermissionLevel.ALLOW
+        # profile whitelist retained
+        assert evaluate_bash_command("git status", effective.bash_commands).level == PermissionLevel.ALLOW
+        # user deny overrides the profile's allow (deny wins by decision order)
+        assert evaluate_bash_command("git diff HEAD~1", effective.bash_commands).level == PermissionLevel.DENY


### PR DESCRIPTION
## Summary

Adds command-level allow/deny/ask control for the bash tool (mirroring Claude Code's model) on top of the existing profile permission system, plus real-shell execution so pipelines work.

- **Permission layer** (`bash_rules.py`): deny-first decision order (deny > safety ceiling > ask > allow > default) with prefix/exact/glob patterns; unanchored deny catches wrapped commands (`xargs rm`); pure pipelines (`a | b | c`) are split and judged per segment — read-only pipelines auto-run while `&&`/`;`/`$()`/redirection hit the safety ceiling.
- **Profiles**: `normal` ships a read-only whitelist (`cat`/`head`/`grep`/`wc`/git read-only/… — anything that can't write or exec regardless of flags); `auto` adds `sort`/`mkdir`/`touch`; `dangerous` unchanged. `awk`/`sed`/`find` stay at ask (can exec/write).
- **Confirmation prompt**: allow once / session / project. "project" persists the prefix to `.datus/config.yml` (`bash_allow`), applied across sessions.
- **Execution layer** (`bash_tool.py`): run through a real shell (`bash -c`) so pipelines/shell syntax work; legacy single-argv fallback when no bash. `shopt -u extglob` hardening, process-group timeout kill (no orphaned pipeline stages), optional per-call `timeout` param. Doc clarifies stateless cwd / closed stdin and steers to `read_file`/`grep`/`glob`.
- **CLI**: `--permission-mode normal|auto|dangerous` overrides the profile (REPL + print); `--execution-mode interactive|workflow` for print mode. `datus -p` now honors the configured profile instead of forcing `dangerous`.
- **LLM classifier seam** (`bash_classifier.py`): interface + no-op factory only, no implementation yet (fail-closed contract documented).

## Behavior at a glance

| command | normal | auto | dangerous |
|---|---|---|---|
| `cat log \| grep e \| wc -l` | allow | allow | allow |
| `sort f` / `mkdir d` | ask | allow | allow |
| `awk`/`sed`/`find` | ask | ask | allow |
| `a && b`, `$(...)`, `> file` | ask (safety) | ask (safety) | allow |
| `git push` / `xargs rm` (with deny rule) | deny | deny | deny |

## Test plan

- [x] Unit: `test_bash_rules.py`, `test_bash_tool.py`, `test_permission_hooks.py`, `test_profiles.py`, `test_permission_config.py`, `test_project_config.py`, `test_agent_config_loader.py`, `test_agentic_node.py`
- [x] Full suite: 15701 passed, 0 regressions; ruff lint/format clean
- [x] End-to-end via `datus -p` across normal/auto/dangerous and interactive/workflow, incl. read-only pipeline auto-run, deny-segment blocking, `&&` safety ceiling, project-level persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added command-level bash permission controls, including allow/deny/ask rules and safer handling of pipelines and shell operators.
  * Introduced new CLI options to choose permission mode and execution mode for print-based runs.
  * Added project-level bash allowlist support that can be saved and reloaded with config.

* **Bug Fixes**
  * Workflow runs now respect the selected permission profile instead of always using the most permissive baseline.
  * Bash command execution now supports timeouts and better cleanup for long-running or piped commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-level bash permission controls (allow/deny/ask) with pipeline-aware evaluation and safer handling of shell operators.
  * Introduced optional classifier-based approval for high-confidence bash permissions.
  * Added CLI flags to select permission mode and execution mode for print runs; print mode now supports workflow vs interactive behavior.
  * Added project-level bash allowlist support with config persistence.

* **Bug Fixes**
  * Workflow execution now respects the selected permission profile instead of a fixed baseline.
  * Bash execution now supports per-call timeouts and improved process cleanup on timeout.

* **Tests**
  * Added extensive unit tests for bash permissions, rules, pipeline behavior, and config overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->