### PR TITLE
[Refactor] ask_metrics: delegate metric_time grouping to the adapter, add retry de-dup

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import csv
 import io
 import json
-import re
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 if TYPE_CHECKING:
@@ -89,6 +88,7 @@ class AskMetricsAgenticNode(AgenticNode):
         self.subject_tree_mode: str = "none"
         self.subject_tree_prompt: str = ""
         self._metric_catalog_cache: Optional[Dict[str, Dict[str, Any]]] = None
+        self._failed_query_signatures: set[tuple] = set()
         self._selected_final_metric_result_id: Optional[str] = None
         self.startup_error: Optional[str] = None
 
@@ -470,12 +470,23 @@ class AskMetricsAgenticNode(AgenticNode):
             )
         normalized_dimensions = None if dimensions is None else self._normalize_string_list(dimensions)
         normalized_order_by = None if order_by is None else self._normalize_string_list(order_by)
-        normalized_dimensions, time_granularity, normalized_order_by = self._apply_window_time_grouping(
-            expanded_metrics,
-            normalized_dimensions,
-            time_granularity,
-            normalized_order_by,
-        )
+        # metric_time grouping is derived from each metric's definition and
+        # applied by the semantic adapter; the node no longer injects it here.
+
+        # De-duplicate deterministic validation failures: once a metric/dimension/
+        # granularity combination has been rejected, do not re-issue the identical
+        # query — return actionable guidance so the planner adjusts instead of looping.
+        signature = self._query_signature(expanded_metrics, normalized_dimensions, time_granularity, where)
+        if signature in self._failed_query_signatures:
+            return FuncToolResult(
+                success=0,
+                error=(
+                    "query_metrics already failed for this metric/dimension/granularity "
+                    "combination. Adjust the metrics, dimensions, or granularity — or split "
+                    "the query into compatible metric groups — instead of retrying identical "
+                    "arguments."
+                ),
+            )
         query_kwargs = {
             "metrics": expanded_metrics,
             "dimensions": normalized_dimensions,
@@ -493,7 +504,36 @@ class AskMetricsAgenticNode(AgenticNode):
         if zero_fill:
             query_kwargs["zero_fill"] = zero_fill
         result = self.semantic_tools.query_metrics(**query_kwargs)
+        if self._is_deterministic_validation_failure(result):
+            self._failed_query_signatures.add(signature)
         return self._apply_query_result_column_aliases(result)
+
+    @staticmethod
+    def _query_signature(
+        metrics: List[str],
+        dimensions: Optional[List[str]],
+        time_granularity: Optional[str],
+        where: Optional[str],
+    ) -> tuple:
+        """Stable key for a query_metrics invocation used to suppress identical retries."""
+        return (
+            tuple(sorted(metrics or [])),
+            tuple(sorted(dimensions or [])),
+            str(time_granularity or "").strip().lower(),
+            str(where or "").strip(),
+        )
+
+    @staticmethod
+    def _is_deterministic_validation_failure(result: FuncToolResult) -> bool:
+        """True when query_metrics failed for a deterministic semantic validation reason.
+
+        Transient/infra failures are excluded so a retry with the same arguments is
+        only suppressed when re-issuing it cannot succeed.
+        """
+        if not isinstance(result, FuncToolResult) or result.success != 0:
+            return False
+        payload = result.result if isinstance(result.result, dict) else {}
+        return payload.get("error_type") == "semantic_validation_error"
 
     def select_final_metric_result(self, result_id: str) -> FuncToolResult:
         """
@@ -560,44 +600,6 @@ class AskMetricsAgenticNode(AgenticNode):
                 self._append_unique(expanded, bundled_metric)
 
         return expanded
-
-    def _apply_window_time_grouping(
-        self,
-        metrics: List[str],
-        dimensions: Optional[List[str]],
-        time_granularity: Optional[str],
-        order_by: Optional[List[str]],
-    ) -> tuple[Optional[List[str]], Optional[str], Optional[List[str]]]:
-        catalog = self._metric_catalog()
-        if not catalog:
-            return dimensions, time_granularity, order_by
-
-        time_dimension = ""
-        inferred_grain = self._normalize_time_grain(time_granularity)
-        for metric_name in metrics:
-            metric = catalog.get(metric_name)
-            if not metric:
-                continue
-            metadata = self._metric_metadata(metric)
-            if not self._is_window_metric(metadata):
-                continue
-            inferred_grain = inferred_grain or self._infer_window_time_grain(metadata)
-            if inferred_grain:
-                time_dimension = f"metric_time__{inferred_grain}"
-                break
-
-        if not time_dimension:
-            return dimensions, time_granularity, order_by
-
-        updated_dimensions = list(dimensions or [])
-        if not any(str(dimension).startswith("metric_time__") for dimension in updated_dimensions):
-            self._append_unique(updated_dimensions, time_dimension)
-
-        updated_order_by = list(order_by or [])
-        if not updated_order_by:
-            updated_order_by = [time_dimension]
-
-        return updated_dimensions, time_granularity or inferred_grain, updated_order_by
 
     @classmethod
     def _window_metric_bundle(
@@ -748,33 +750,6 @@ class AskMetricsAgenticNode(AgenticNode):
         if not metric_kind:
             return True
         return metric_kind in {"aggregate", "measure_proxy", "simple"}
-
-    @classmethod
-    def _infer_window_time_grain(cls, metadata: Dict[str, Any]) -> str:
-        for key in ("time_granularity", "time_grain", "grain_to_date"):
-            grain = cls._normalize_time_grain(cls._metadata_text(metadata, key))
-            if grain:
-                return grain
-
-        time_dimension = cls._metadata_text(metadata, "time_dimension")
-        if time_dimension.startswith("metric_time__"):
-            grain = cls._normalize_time_grain(time_dimension.split("__", 1)[1])
-            if grain:
-                return grain
-
-        window = cls._metadata_text(metadata, "window")
-        if window:
-            parts = re.findall(r"[a-zA-Z]+", window.lower())
-            if parts:
-                return cls._normalize_time_grain(parts[-1])
-        return ""
-
-    @staticmethod
-    def _normalize_time_grain(value: Optional[str]) -> str:
-        grain = str(value or "").strip().lower()
-        if grain.endswith("s"):
-            grain = grain[:-1]
-        return grain if grain in {"day", "week", "month", "quarter", "year"} else ""
 
     @staticmethod
     def _metric_metadata(metric: Dict[str, Any]) -> Dict[str, Any]:

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -1045,6 +1045,17 @@ class SemanticTools:
             return tool_result
 
         except Exception as e:
+            # Surface backend validation rejections as structured planner guidance.
+            # Duck-typed so the tool layer stays decoupled from any specific adapter.
+            payload = getattr(e, "payload", None)
+            if payload is not None and getattr(payload, "error_type", None) == "semantic_validation_error":
+                data = payload.model_dump() if hasattr(payload, "model_dump") else dict(payload)
+                logger.info(f"query_metrics validation rejection: code={data.get('code')}")
+                return FuncToolResult(
+                    success=0,
+                    error=getattr(payload, "message", "") or "query_metrics validation failed",
+                    result=data,
+                )
             logger.error(f"Error querying metrics: {e}")
             return FuncToolResult(
                 success=0,

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -560,64 +560,18 @@ class TestAskMetricsAgenticNode:
 
         node.query_metrics(metrics=["moving_3_month_order_count_avg"], dimensions=[])
 
+        # The node still expands the executable metric bundle; metric_time grouping
+        # is delegated to the semantic adapter and no longer injected here.
         semantic_tools.query_metrics.assert_called_once_with(
             metrics=["order_count", "moving_window_month_count", "moving_3_month_order_count_avg"],
-            dimensions=["metric_time__month"],
+            dimensions=[],
             path=None,
             time_start=None,
             time_end=None,
-            time_granularity="month",
+            time_granularity=None,
             where=None,
             limit=None,
-            order_by=["metric_time__month"],
-            dry_run=False,
-        )
-
-    def test_query_metrics_infers_window_grain_from_metric_time_dimension(self, real_agent_config, mock_llm_create):
-        node, semantic_tools, _ = _make_node(
-            real_agent_config,
-            tree={"Commerce": {"Orders": {"metrics": ["running_order_count"]}}},
-        )
-        semantic_tools.list_metrics.return_value = FuncToolResult(
-            result={
-                "items": [
-                    {
-                        "name": "order_count",
-                        "measures": ["orders.order_id"],
-                        "metadata": {
-                            "dataset": "orders",
-                            "expr": "COUNT(DISTINCT order_id)",
-                            "metric_kind": "aggregate",
-                            "measure": "order_id",
-                        },
-                    },
-                    {
-                        "name": "running_order_count",
-                        "metadata": {
-                            "dataset": "orders",
-                            "time_dimension": "metric_time__month",
-                            "window_aggregation": "sum",
-                            "metric_kind": "cumulative",
-                        },
-                    },
-                ],
-                "has_more": False,
-            }
-        )
-        semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
-
-        node.query_metrics(metrics=["running_order_count"], dimensions=[])
-
-        semantic_tools.query_metrics.assert_called_once_with(
-            metrics=["running_order_count"],
-            dimensions=["metric_time__month"],
-            path=None,
-            time_start=None,
-            time_end=None,
-            time_granularity="month",
-            where=None,
-            limit=None,
-            order_by=["metric_time__month"],
+            order_by=None,
             dry_run=False,
         )
 
@@ -683,6 +637,8 @@ class TestAskMetricsAgenticNode:
             dimensions=["metric_time__month"],
         )
 
+        # Metric bundle expansion is preserved; caller-supplied dimensions pass
+        # through unchanged and grain injection is left to the semantic adapter.
         semantic_tools.query_metrics.assert_called_once_with(
             metrics=[
                 "average_order_amount",
@@ -693,12 +649,56 @@ class TestAskMetricsAgenticNode:
             path=None,
             time_start=None,
             time_end=None,
-            time_granularity="month",
+            time_granularity=None,
             where=None,
             limit=None,
-            order_by=["metric_time__month"],
+            order_by=None,
             dry_run=False,
         )
+
+    def test_query_metrics_dedupes_deterministic_validation_failure(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["order_count"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={"items": [{"name": "order_count", "metadata": {}}], "has_more": False}
+        )
+        semantic_tools.query_metrics.return_value = FuncToolResult(
+            success=0,
+            error="cumulative metric requires metric_time",
+            result={
+                "error_type": "semantic_validation_error",
+                "code": "cumulative_requires_metric_time",
+            },
+        )
+
+        first = node.query_metrics(metrics=["order_count"], dimensions=["product_type"])
+        assert first.success == 0
+        assert semantic_tools.query_metrics.call_count == 1
+
+        # An identical retry after a deterministic validation failure is short-circuited.
+        second = node.query_metrics(metrics=["order_count"], dimensions=["product_type"])
+        assert second.success == 0
+        assert "already failed" in (second.error or "")
+        assert semantic_tools.query_metrics.call_count == 1
+
+    def test_query_metrics_does_not_dedupe_transient_failure(self, real_agent_config, mock_llm_create):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["order_count"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={"items": [{"name": "order_count", "metadata": {}}], "has_more": False}
+        )
+        # A non-validation (infra) failure must not suppress a retry.
+        semantic_tools.query_metrics.return_value = FuncToolResult(
+            success=0, error="Failed to query metrics: connection lost"
+        )
+
+        node.query_metrics(metrics=["order_count"], dimensions=["product_type"])
+        node.query_metrics(metrics=["order_count"], dimensions=["product_type"])
+        assert semantic_tools.query_metrics.call_count == 2
 
     def test_query_metrics_passes_limit_through(self, real_agent_config, mock_llm_create):
         node, semantic_tools, _ = _make_node(


### PR DESCRIPTION
## Why

`ask_metrics` repeatedly called `query_metrics` with arguments MetricFlow rejects for cumulative/derived metrics, and carried a large parallel layer of scaffolding to pre-inject `metric_time` — compensating for a requirement that belongs to the semantic layer. The requirement is fully determined by each metric's definition, so the adapter should own it.

Depends on **Datus-ai/datus-semantic-adapter#38** (adapter injects metric_time + returns structured `SemanticValidationError`). Refs Datus-ai/Datus-agent#1101.

## Solution

- The adapter now derives and injects the required `metric_time` grouping from each metric's own definition, so the node's parallel time-grouping compensation is redundant: remove `_apply_window_time_grouping` / `_infer_window_time_grain` / `_normalize_time_grain`; the `query_metrics` wrapper no longer injects metric_time, grain, or order_by.
- **Kept** the metric-bundle expansion (`_expand_*`): on close reading it exists for *result-column completeness* (the agent must return base + previous-period + derived columns), which the adapter's *hidden* anchor expansion does not cover. This is a deliberately smaller deletion than "remove all scaffolding".
- **Retry de-dup** (`_failed_query_signatures`): after a deterministic semantic validation rejection, an identical `(metrics, dimensions, granularity, where)` query is short-circuited with actionable guidance instead of looping to `max_steps`. Transient/infra failures are not suppressed.
- `semantic_tools.query_metrics` surfaces backend validation rejections as structured planner guidance (duck-typed, so the tool layer stays adapter-agnostic) instead of raw exception text.

Validated end-to-end against live MetricFlow + StarRocks (`baisheng_ask_metrics`, tasks 35/36/46/47/48): `query_metrics` invoked 41x with **zero** `metric_time` rejections.

## Test Cases

`tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py`:
- Updated the two metric-bundle-expansion tests to assert expansion is preserved while metric_time/grain/order_by are no longer injected at the node (delegated to the adapter).
- Removed the pure grain-inference test (behavior moved to the adapter, covered by its integration tests).
- Added de-dup coverage: a deterministic `semantic_validation_error` short-circuits an identical retry; a transient failure does not.

Suite: 48 passed (ask_metrics node), 18 passed (node/schema), 1527 passed (func_tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric query handling so repeated validation failures are no longer retried endlessly, returning a clearer “already failed” response instead.
  * Semantic validation errors now surface structured, user-friendly messages instead of a generic query failure.
  * Time grouping behavior for metric queries is now handled more consistently, reducing unexpected query shaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->