### PR TITLE
[Enhancement] Prepare OSI semantic layer configuration

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2039,7 +2039,6 @@ class AgenticNode(Node):
             "scoped_context",
             "scoped_kb_path",
             "adapter_type",
-            "semantic_adapter",
             "subject_tree_prompt_limit",
             "require_final_result_selection",
             "sql_file_threshold",

--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -122,11 +122,9 @@ class AskMetricsAgenticNode(AgenticNode):
         return self.configured_node_name or self.NODE_NAME
 
     def _resolve_adapter_type(self) -> Optional[str]:
-        adapter_type = self.node_config.get("adapter_type") or self.node_config.get("semantic_adapter") or "metricflow"
-        resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
-        if callable(resolver):
-            return resolver(adapter_type)
-        return adapter_type
+        from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
+        return resolve_semantic_adapter_type(self.agent_config)
 
     def _resolve_subject_tree_prompt_limit(self) -> int:
         raw_limit = self.node_config.get("subject_tree_prompt_limit", self.SUBJECT_TREE_PROMPT_LIMIT)

--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -338,12 +338,13 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
             return
         if not getattr(self, "semantic_tools", None):
             try:
+                from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
                 from datus.tools.func_tool.semantic_tools import SemanticTools
 
                 self.semantic_tools = SemanticTools(
                     agent_config=self.agent_config,
                     sub_agent_name=self.node_config.get("system_prompt"),
-                    adapter_type=self.node_config.get("adapter_type", "metricflow"),
+                    adapter_type=resolve_semantic_adapter_type(self.agent_config),
                     runtime_db_context_provider=self._semantic_runtime_db_context,
                 )
             except Exception as exc:

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -265,7 +265,9 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
 
     def _setup_semantic_tools(self) -> None:
         try:
-            adapter_type = self.node_config.get("adapter_type", "metricflow")
+            from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
+            adapter_type = resolve_semantic_adapter_type(self.agent_config)
             self.semantic_tools = SemanticTools(
                 agent_config=self.agent_config,
                 sub_agent_name=self.node_config.get("system_prompt"),
@@ -296,10 +298,12 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         try:
             if tool_type == "semantic_tools":
                 if not self.semantic_tools:
+                    from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
                     self.semantic_tools = SemanticTools(
                         agent_config=self.agent_config,
                         sub_agent_name=self.node_config.get("system_prompt"),
-                        adapter_type=self.node_config.get("adapter_type", "metricflow"),
+                        adapter_type=resolve_semantic_adapter_type(self.agent_config),
                         runtime_db_context_provider=self._semantic_runtime_db_context,
                     )
                 tool_instance = self.semantic_tools

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -143,6 +143,7 @@ class GenMetricsAgenticNode(AgenticNode):
         logger.info(f"Setup {len(self.tools)} tools for {self.NODE_NAME}: {[tool.name for tool in self.tools]}")
 
     def _make_filesystem_tool(self, **kwargs):
+        from datus.agent.node.semantic_authoring import resolve_authoring_format
         from datus.configuration.inherited_memory_overrides import get_inherited_memory
         from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
 
@@ -170,6 +171,7 @@ class GenMetricsAgenticNode(AgenticNode):
             strict=strict,
             inherited_memory_node=inherited_memory_node,
             session_data_dir=session_data_dir,
+            authoring_format=resolve_authoring_format(self.agent_config),
             **kwargs,
         )
 
@@ -192,7 +194,7 @@ class GenMetricsAgenticNode(AgenticNode):
             self.generation_tools = GenerationTools(
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
-                authoring_format=resolve_authoring_format(self.agent_config, self.node_config),
+                authoring_format=resolve_authoring_format(self.agent_config),
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
@@ -210,7 +212,7 @@ class GenMetricsAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import is_osi_authoring
 
         node_config = getattr(self, "node_config", None) or {}
-        if is_osi_authoring(self.agent_config, node_config) and "skills" not in node_config:
+        if is_osi_authoring(self.agent_config) and "skills" not in node_config:
             logger.info("Skipping default MetricFlow skills for OSI metrics authoring")
             return
         super()._setup_skill_func_tools()
@@ -218,14 +220,10 @@ class GenMetricsAgenticNode(AgenticNode):
     def _setup_semantic_tools(self):
         """Setup semantic tools for metrics querying and exploration."""
         try:
+            from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
-            adapter_type = None
-            if hasattr(self.agent_config, "agentic_nodes") and self.NODE_NAME in self.agent_config.agentic_nodes:
-                node_config = self.agent_config.agentic_nodes[self.NODE_NAME]
-                if isinstance(node_config, dict) and node_config.get("semantic_adapter"):
-                    adapter_type = node_config.get("semantic_adapter")
-            adapter_type = self.agent_config.resolve_semantic_adapter(adapter_type)
+            adapter_type = resolve_semantic_adapter_type(self.agent_config)
 
             # Initialize semantic func tool
             self.semantic_tools = SemanticTools(
@@ -327,10 +325,12 @@ class GenMetricsAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import (
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
+            osi_expression_dialect,
         )
 
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
+        context["osi_expression_dialect"] = osi_expression_dialect(self.agent_config)
 
         # Handle subject_tree context based on whether predefined or query from storage
         if self.subject_tree:
@@ -371,7 +371,7 @@ class GenMetricsAgenticNode(AgenticNode):
         # Select the authoring format (metricflow YAML vs OSI + Datus hints).
         # OSI mode uses a separate template name so the default metricflow
         # template and its latest-version scan are left untouched.
-        authoring_format = resolve_authoring_format(self.agent_config, self.node_config)
+        authoring_format = resolve_authoring_format(self.agent_config)
         if authoring_format == AUTHORING_FORMAT_OSI:
             template_name = osi_template_name(self.NODE_NAME)
             requested = (
@@ -429,7 +429,7 @@ class GenMetricsAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import is_osi_authoring
 
         self._osi_metrics_baseline_artifact_json = None
-        if not is_osi_authoring(self.agent_config, self.node_config):
+        if not is_osi_authoring(self.agent_config):
             return
         try:
             from datus_semantic_osi.profile import load_osi_path, to_core_schema_document
@@ -626,7 +626,7 @@ class GenMetricsAgenticNode(AgenticNode):
         """Ensure generated metric artifacts are published without relying on one LLM tool call."""
         from datus.agent.node.semantic_authoring import is_osi_authoring
 
-        if is_osi_authoring(self.agent_config, self.node_config):
+        if is_osi_authoring(self.agent_config):
             self._finalize_osi_metric_generation(
                 semantic_model_files=semantic_model_files,
                 metric_file=metric_file,

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -325,12 +325,10 @@ class GenMetricsAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import (
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
-            osi_expression_dialect,
         )
 
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
-        context["osi_expression_dialect"] = osi_expression_dialect(self.agent_config)
 
         # Handle subject_tree context based on whether predefined or query from storage
         if self.subject_tree:

--- a/datus/agent/node/gen_report_agentic_node.py
+++ b/datus/agent/node/gen_report_agentic_node.py
@@ -218,8 +218,9 @@ class GenReportAgenticNode(AgenticNode):
     def _setup_semantic_tools(self):
         """Setup semantic tools for report analysis."""
         try:
-            # Get adapter_type from configuration
-            adapter_type = self.node_config.get("adapter_type", "metricflow")
+            from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
+            adapter_type = resolve_semantic_adapter_type(self.agent_config)
             self.semantic_tools = SemanticTools(
                 agent_config=self.agent_config,
                 sub_agent_name=self.node_config.get("system_prompt"),
@@ -256,7 +257,9 @@ class GenReportAgenticNode(AgenticNode):
         try:
             if tool_type == "semantic_tools":
                 if not self.semantic_tools:
-                    adapter_type = self.node_config.get("adapter_type", "metricflow")
+                    from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
+                    adapter_type = resolve_semantic_adapter_type(self.agent_config)
                     self.semantic_tools = SemanticTools(
                         agent_config=self.agent_config,
                         sub_agent_name=self.node_config.get("system_prompt"),

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -305,12 +305,10 @@ class GenSemanticModelAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import (
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
-            osi_expression_dialect,
         )
 
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
-        context["osi_expression_dialect"] = osi_expression_dialect(self.agent_config)
 
         logger.debug(f"Prepared template context: {context}")
         return context

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -183,14 +183,10 @@ class GenSemanticModelAgenticNode(AgenticNode):
     def _setup_semantic_tools(self):
         """Setup semantic function tools (for querying metrics via adapters)."""
         try:
+            from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
-            adapter_type = None
-            if hasattr(self.agent_config, "agentic_nodes") and self.NODE_NAME in self.agent_config.agentic_nodes:
-                node_config = self.agent_config.agentic_nodes[self.NODE_NAME]
-                if isinstance(node_config, dict) and node_config.get("semantic_adapter"):
-                    adapter_type = node_config.get("semantic_adapter")
-            adapter_type = self.agent_config.resolve_semantic_adapter(adapter_type)
+            adapter_type = resolve_semantic_adapter_type(self.agent_config)
 
             # Initialize semantic func tool
             self.semantic_func_tool = SemanticTools(
@@ -230,7 +226,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
             self.generation_tools = GenerationTools(
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
-                authoring_format=resolve_authoring_format(self.agent_config, self.node_config),
+                authoring_format=resolve_authoring_format(self.agent_config),
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
@@ -245,7 +241,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import is_osi_authoring
 
         node_config = getattr(self, "node_config", None) or {}
-        if is_osi_authoring(self.agent_config, node_config) and "skills" not in node_config:
+        if is_osi_authoring(self.agent_config) and "skills" not in node_config:
             logger.info("Skipping default MetricFlow skills for OSI semantic-model authoring")
             return
         super()._setup_skill_func_tools()
@@ -309,10 +305,12 @@ class GenSemanticModelAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import (
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
+            osi_expression_dialect,
         )
 
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
+        context["osi_expression_dialect"] = osi_expression_dialect(self.agent_config)
 
         logger.debug(f"Prepared template context: {context}")
         return context
@@ -344,7 +342,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
         # template's signature parity with the other nodes.
         # OSI mode uses a separate template name so the default metricflow
         # template and its latest-version scan are left untouched.
-        authoring_format = resolve_authoring_format(self.agent_config, self.node_config)
+        authoring_format = resolve_authoring_format(self.agent_config)
         if authoring_format == AUTHORING_FORMAT_OSI:
             template_name = osi_template_name(self.NODE_NAME)
             requested = prompt_version or self.node_config.get("prompt_version")
@@ -571,7 +569,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
             from datus.agent.node.semantic_authoring import is_osi_authoring
 
-            if is_osi_authoring(self.agent_config, self.node_config):
+            if is_osi_authoring(self.agent_config):
                 if not self.generation_tools:
                     logger.error("Generation tools unavailable for OSI semantic sync")
                     return False

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -314,7 +314,9 @@ class GenSQLAgenticNode(AgenticNode):
     def _setup_semantic_tools(self):
         """Setup semantic tools for metric/dimension exploration."""
         try:
-            adapter_type = self.node_config.get("adapter_type", "metricflow")
+            from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
+            adapter_type = resolve_semantic_adapter_type(self.agent_config)
             self.semantic_tools = SemanticTools(
                 agent_config=self.agent_config,
                 sub_agent_name=self.node_config.get("system_prompt"),
@@ -452,7 +454,9 @@ class GenSQLAgenticNode(AgenticNode):
                 tool_instance = self.context_search_tools
             elif tool_type == "semantic_tools":
                 if not self.semantic_tools:
-                    adapter_type = self.node_config.get("adapter_type", "metricflow")
+                    from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
+                    adapter_type = resolve_semantic_adapter_type(self.agent_config)
                     self.semantic_tools = SemanticTools(
                         agent_config=self.agent_config,
                         sub_agent_name=self.node_config.get("system_prompt"),

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -6,18 +6,15 @@
 
 Datus can author semantic assets in two formats:
 
-- ``metricflow`` (default): the LLM writes MetricFlow YAML directly. This is the
-  original behavior and is left untouched.
+- ``metricflow``: the LLM writes MetricFlow YAML directly. This is the original
+  behavior and is left untouched.
 - ``osi``: the LLM writes OSI semantic models + Datus business hints, which the
   Datus OSI compiler later lowers to a backend (e.g. MetricFlow). The LLM never
   writes backend YAML.
 
-The format is resolved (in priority order) from:
-
-1. an explicit per-node/workflow ``authoring_format`` in ``node_config``;
-2. the active semantic adapter (the consumer of the generated assets) -- when it
-   is ``osi``, author OSI;
-3. the ``metricflow`` default.
+The format is resolved from the global active semantic adapter so semantic model
+generation, metric generation, query, and ask flows stay on one semantic layer
+for a project. Legacy node-level semantic format fields are ignored.
 
 OSI mode uses a *separate* prompt template name (``{node}_osi_system``) so the
 default ``{node}_system`` latest-version scan is never affected.
@@ -41,26 +38,17 @@ def resolve_authoring_format(
     agent_config: Any = None,
     node_config: Optional[Dict[str, Any]] = None,
 ) -> str:
-    """Resolve the semantic authoring format. Defaults to ``metricflow``."""
-    if node_config:
-        explicit = node_config.get("authoring_format")
-        if explicit:
-            normalized = str(explicit).strip().lower()
-            if normalized in (AUTHORING_FORMAT_METRICFLOW, AUTHORING_FORMAT_OSI):
-                return normalized
+    """Resolve the semantic authoring format from the global semantic adapter."""
+    del node_config
 
     adapter: Optional[str] = None
-    adapter_type: Optional[str] = None
-    if node_config:
-        adapter_type = node_config.get("semantic_adapter") or node_config.get("adapter_type")
     if agent_config is not None and hasattr(agent_config, "resolve_semantic_adapter"):
         try:
-            adapter = agent_config.resolve_semantic_adapter(adapter_type)
+            adapter = agent_config.resolve_semantic_adapter()
         except Exception as exc:
             logger.debug(
                 "Failed to resolve semantic adapter for authoring format; "
-                "falling back to metricflow. adapter_type=%r agent_config=%r error=%s",
-                adapter_type,
+                "falling back to metricflow. agent_config=%r error=%s",
                 agent_config,
                 exc,
             )
@@ -71,9 +59,29 @@ def resolve_authoring_format(
     return AUTHORING_FORMAT_METRICFLOW
 
 
+def resolve_semantic_adapter_type(agent_config: Any = None) -> str:
+    """Resolve the active semantic adapter, defaulting to MetricFlow."""
+    resolver = getattr(agent_config, "resolve_semantic_adapter", None)
+    if callable(resolver):
+        try:
+            adapter = resolver()
+        except Exception as exc:
+            logger.debug(
+                "Failed to resolve semantic adapter; falling back to metricflow. agent_config=%r error=%s",
+                agent_config,
+                exc,
+            )
+        else:
+            normalized = str(adapter or "").strip().lower()
+            if normalized:
+                return normalized
+    return AUTHORING_FORMAT_METRICFLOW
+
+
 def is_osi_authoring(agent_config: Any = None, node_config: Optional[Dict[str, Any]] = None) -> bool:
     """Return ``True`` when this node should author OSI instead of MetricFlow."""
-    return resolve_authoring_format(agent_config, node_config) == AUTHORING_FORMAT_OSI
+    del node_config
+    return resolve_authoring_format(agent_config) == AUTHORING_FORMAT_OSI
 
 
 def _normalize_model_name(value: Any) -> str:
@@ -104,6 +112,35 @@ def _config_field_value(config: Any, field_name: str) -> Any:
     else:
         return ""
     return "" if callable(value) else value
+
+
+def osi_expression_dialect(agent_config: Any = None) -> str:
+    """Return the OSI expression dialect for the active datasource.
+
+    OSI authoring should follow the physical datasource type because
+    expressions often contain datasource-specific functions. Keep this generic:
+    new datasource types should work without changing an allowlist.
+    """
+    candidates = []
+    if agent_config is not None:
+        try:
+            db_config = agent_config.current_db_config()
+        except Exception:
+            db_config = None
+        if db_config is not None:
+            candidates.append(_config_field_value(db_config, "type"))
+        candidates.extend(
+            [
+                getattr(agent_config, "db_type", ""),
+                getattr(agent_config, "current_datasource", ""),
+            ]
+        )
+
+    for candidate in candidates:
+        dialect = _normalize_model_name(candidate)
+        if dialect:
+            return dialect
+    return "ANSI_SQL"
 
 
 def default_osi_semantic_model_name(agent_config: Any = None) -> str:

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -26,7 +26,6 @@ import re
 from dataclasses import fields, is_dataclass
 from typing import Any, Dict, Optional
 
-from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 AUTHORING_FORMAT_METRICFLOW = "metricflow"
@@ -35,37 +34,11 @@ AUTHORING_FORMAT_OSI = "osi"
 logger = get_logger(__name__)
 
 
-def _safe_resolve_semantic_adapter(agent_config: Any = None, *, context: str) -> Optional[str]:
+def _resolve_semantic_adapter(agent_config: Any = None) -> Optional[str]:
     resolver = getattr(agent_config, "resolve_semantic_adapter", None)
     if not callable(resolver):
         return None
-
-    try:
-        return resolver()
-    except DatusException as exc:
-        if exc.code == ErrorCode.COMMON_CONFIG_ERROR:
-            logger.warning(
-                "Failed to resolve semantic adapter for %s due to configuration error; "
-                "falling back to metricflow. agent_config=%r error=%s",
-                context,
-                agent_config,
-                exc,
-            )
-        else:
-            logger.debug(
-                "Failed to resolve semantic adapter for %s; falling back to metricflow. agent_config=%r error=%s",
-                context,
-                agent_config,
-                exc,
-            )
-    except Exception as exc:
-        logger.debug(
-            "Failed to resolve semantic adapter for %s; falling back to metricflow. agent_config=%r error=%s",
-            context,
-            agent_config,
-            exc,
-        )
-    return None
+    return resolver(None)
 
 
 def resolve_authoring_format(
@@ -75,7 +48,7 @@ def resolve_authoring_format(
     """Resolve the semantic authoring format from the global semantic adapter."""
     del node_config
 
-    adapter = _safe_resolve_semantic_adapter(agent_config, context="authoring format")
+    adapter = _resolve_semantic_adapter(agent_config)
 
     if adapter and str(adapter).strip().lower() == AUTHORING_FORMAT_OSI:
         return AUTHORING_FORMAT_OSI
@@ -84,7 +57,7 @@ def resolve_authoring_format(
 
 def resolve_semantic_adapter_type(agent_config: Any = None) -> str:
     """Resolve the active semantic adapter, defaulting to MetricFlow."""
-    adapter = _safe_resolve_semantic_adapter(agent_config, context="adapter type")
+    adapter = _resolve_semantic_adapter(agent_config)
     normalized = str(adapter or "").strip().lower()
     if normalized:
         return normalized
@@ -125,35 +98,6 @@ def _config_field_value(config: Any, field_name: str) -> Any:
     else:
         return ""
     return "" if callable(value) else value
-
-
-def osi_expression_dialect(agent_config: Any = None) -> str:
-    """Return the OSI expression dialect for the active datasource.
-
-    OSI authoring should follow the physical datasource type because
-    expressions often contain datasource-specific functions. Keep this generic:
-    new datasource types should work without changing an allowlist.
-    """
-    candidates = []
-    if agent_config is not None:
-        try:
-            db_config = agent_config.current_db_config()
-        except Exception:
-            db_config = None
-        if db_config is not None:
-            candidates.append(_config_field_value(db_config, "type"))
-        candidates.extend(
-            [
-                getattr(agent_config, "db_type", ""),
-                getattr(agent_config, "current_datasource", ""),
-            ]
-        )
-
-    for candidate in candidates:
-        dialect = _normalize_model_name(candidate)
-        if dialect:
-            return dialect
-    return "ANSI_SQL"
 
 
 def default_osi_semantic_model_name(agent_config: Any = None) -> str:

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -26,12 +26,46 @@ import re
 from dataclasses import fields, is_dataclass
 from typing import Any, Dict, Optional
 
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 AUTHORING_FORMAT_METRICFLOW = "metricflow"
 AUTHORING_FORMAT_OSI = "osi"
 
 logger = get_logger(__name__)
+
+
+def _safe_resolve_semantic_adapter(agent_config: Any = None, *, context: str) -> Optional[str]:
+    resolver = getattr(agent_config, "resolve_semantic_adapter", None)
+    if not callable(resolver):
+        return None
+
+    try:
+        return resolver()
+    except DatusException as exc:
+        if exc.code == ErrorCode.COMMON_CONFIG_ERROR:
+            logger.warning(
+                "Failed to resolve semantic adapter for %s due to configuration error; "
+                "falling back to metricflow. agent_config=%r error=%s",
+                context,
+                agent_config,
+                exc,
+            )
+        else:
+            logger.debug(
+                "Failed to resolve semantic adapter for %s; falling back to metricflow. agent_config=%r error=%s",
+                context,
+                agent_config,
+                exc,
+            )
+    except Exception as exc:
+        logger.debug(
+            "Failed to resolve semantic adapter for %s; falling back to metricflow. agent_config=%r error=%s",
+            context,
+            agent_config,
+            exc,
+        )
+    return None
 
 
 def resolve_authoring_format(
@@ -41,18 +75,7 @@ def resolve_authoring_format(
     """Resolve the semantic authoring format from the global semantic adapter."""
     del node_config
 
-    adapter: Optional[str] = None
-    if agent_config is not None and hasattr(agent_config, "resolve_semantic_adapter"):
-        try:
-            adapter = agent_config.resolve_semantic_adapter()
-        except Exception as exc:
-            logger.debug(
-                "Failed to resolve semantic adapter for authoring format; "
-                "falling back to metricflow. agent_config=%r error=%s",
-                agent_config,
-                exc,
-            )
-            adapter = None
+    adapter = _safe_resolve_semantic_adapter(agent_config, context="authoring format")
 
     if adapter and str(adapter).strip().lower() == AUTHORING_FORMAT_OSI:
         return AUTHORING_FORMAT_OSI
@@ -61,20 +84,10 @@ def resolve_authoring_format(
 
 def resolve_semantic_adapter_type(agent_config: Any = None) -> str:
     """Resolve the active semantic adapter, defaulting to MetricFlow."""
-    resolver = getattr(agent_config, "resolve_semantic_adapter", None)
-    if callable(resolver):
-        try:
-            adapter = resolver()
-        except Exception as exc:
-            logger.debug(
-                "Failed to resolve semantic adapter; falling back to metricflow. agent_config=%r error=%s",
-                agent_config,
-                exc,
-            )
-        else:
-            normalized = str(adapter or "").strip().lower()
-            if normalized:
-                return normalized
+    adapter = _safe_resolve_semantic_adapter(agent_config, context="adapter type")
+    normalized = str(adapter or "").strip().lower()
+    if normalized:
+        return normalized
     return AUTHORING_FORMAT_METRICFLOW
 
 

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -3,6 +3,7 @@ Service for handling Database Management operations.
 """
 
 import os
+import tempfile
 from typing import List, Optional
 
 from datus_db_core import BaseSqlConnector
@@ -72,6 +73,39 @@ class DatasourceService:
             )
         self.semantic_rag = SemanticModelRAG(self.agent_config, datasource_id=self.current_datasource)
         return self.semantic_rag
+
+    def _active_semantic_adapter(self) -> str:
+        resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
+        if callable(resolver):
+            return str(resolver() or "").strip().lower()
+        return ""
+
+    def _is_osi_semantic_layer(self) -> bool:
+        return self._active_semantic_adapter() == "osi"
+
+    @staticmethod
+    def _validate_osi_semantic_yaml(yaml_content: str, file_path: str) -> tuple[bool, List[str]]:
+        try:
+            from datus_semantic_osi.profile import load_osi_path
+        except ImportError as exc:
+            return False, [f"datus-semantic-osi is required to validate OSI semantic YAML: {exc}"]
+
+        suffix = os.path.splitext(file_path or "")[1] or ".yml"
+        temp_file_path = ""
+        try:
+            with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=suffix, delete=False) as tmp:
+                tmp.write(yaml_content)
+                temp_file_path = tmp.name
+            load_osi_path(temp_file_path, normalize=True)
+            return True, []
+        except Exception as exc:
+            return False, [str(exc)]
+        finally:
+            if temp_file_path:
+                try:
+                    os.unlink(temp_file_path)
+                except OSError:
+                    pass
 
     def _get_database_type(self, database_name: Optional[str] = None) -> tuple[str, str]:
         """
@@ -552,12 +586,20 @@ class DatasourceService:
 
         # Step 4: Sync semantic model to database
         try:
-            sync_result = GenerationHooks._sync_semantic_to_db(
-                semantic_file_path,
-                self.agent_config,
-                include_semantic_objects=True,
-                include_metrics=False,
-            )
+            if self._is_osi_semantic_layer():
+                from datus.tools.func_tool.generation_tools import GenerationTools
+
+                sync_result = GenerationTools(
+                    agent_config=self.agent_config,
+                    authoring_format="osi",
+                ).sync_osi_semantic_to_db(semantic_file_path)
+            else:
+                sync_result = GenerationHooks._sync_semantic_to_db(
+                    semantic_file_path,
+                    self.agent_config,
+                    include_semantic_objects=True,
+                    include_metrics=False,
+                )
             if not sync_result.get("success", False):
                 error_msg = sync_result.get("error", "Unknown error")
                 return Result[dict](
@@ -611,18 +653,21 @@ class DatasourceService:
             # Get semantic file path from result
             semantic_file_path = semantic_model.get("yaml_path", "")
 
-            # Validate using shared utility (deep validation when metricflow is available)
-            from datus.api.utils.semantic_validation import validate_semantic_yaml
+            if self._is_osi_semantic_layer():
+                is_valid, error_messages = self._validate_osi_semantic_yaml(request.yaml, semantic_file_path)
+            else:
+                # Validate using shared utility (deep validation when metricflow is available)
+                from datus.api.utils.semantic_validation import validate_semantic_yaml
 
-            is_valid, error_messages = validate_semantic_yaml(
-                yaml_content=request.yaml,
-                file_path=semantic_file_path,
-                datus_home=self.agent_config.home,
-                datasource=self.agent_config.current_datasource,
-                catalog=request.catalog,
-                database=request.database,
-                db_schema=request.db_schema,
-            )
+                is_valid, error_messages = validate_semantic_yaml(
+                    yaml_content=request.yaml,
+                    file_path=semantic_file_path,
+                    datus_home=self.agent_config.home,
+                    datasource=self.agent_config.current_datasource,
+                    catalog=request.catalog,
+                    database=request.database,
+                    db_schema=request.db_schema,
+                )
 
             if not is_valid:
                 return Result[ValidateSemanticModelData](

--- a/datus/cli/bootstrap_bi_streams.py
+++ b/datus/cli/bootstrap_bi_streams.py
@@ -262,12 +262,9 @@ def _validate_semantic_model_sync(agent_config: AgentConfig, *, scope: str = "al
         return False, f"semantic_tools unavailable: {exc}"
 
     try:
-        adapter_type = None
-        agentic_nodes = getattr(agent_config, "agentic_nodes", None) or {}
-        node_config = agentic_nodes.get("gen_semantic_model", {}) or {}
-        if isinstance(node_config, dict) and node_config.get("semantic_adapter"):
-            adapter_type = node_config.get("semantic_adapter")
-        adapter_type = agent_config.resolve_semantic_adapter(adapter_type)
+        from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
+
+        adapter_type = resolve_semantic_adapter_type(agent_config)
 
         tools = SemanticTools(agent_config=agent_config, adapter_type=adapter_type)
         if not tools.adapter:

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -305,6 +305,9 @@ class GenerationHooks(AgentHooks):
             if not self._result_success(result):
                 logger.info(f"Skipping semantic model sync because generation tool failed: {result}")
                 return
+            if self.generation_evidence.semantic_kb_sync_passed:
+                logger.info("Skipping semantic model hook sync because generation tool already published it")
+                return
 
             file_paths = self._extract_filepaths_from_result(result)
 
@@ -333,6 +336,9 @@ class GenerationHooks(AgentHooks):
         try:
             if not self._result_success(result):
                 logger.info(f"Skipping metric sync because generation tool failed: {result}")
+                return
+            if self.generation_evidence.metric_kb_sync_passed:
+                logger.info("Skipping metric hook sync because generation tool already published it")
                 return
 
             metric_file, semantic_model_file, metric_sqls = self._extract_metric_generation_result(result)

--- a/datus/cli/service_config_app.py
+++ b/datus/cli/service_config_app.py
@@ -58,7 +58,7 @@ logger = get_logger(__name__)
 _BUILTIN_TYPES: Dict[str, Tuple[str, ...]] = {
     "bi_platforms": ("superset", "grafana"),
     "schedulers": ("airflow",),
-    "semantic_layer": ("metricflow",),
+    "semantic_layer": ("metricflow", "osi"),
 }
 
 
@@ -478,7 +478,7 @@ class ServiceConfigApp:
     def _render_footer_hint(self) -> List[Tuple[str, str]]:
         if self._view == _View.LIST:
             if self._tab == _Tab.SEMANTIC:
-                # ``e edit`` is hidden on this tab — metricflow has no
+                # ``e edit`` is hidden on this tab — semantic adapters have no
                 # editable fields. ``d`` / ``p`` work the same as on the
                 # other tabs.
                 base = (

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1489,7 +1489,7 @@ class AgentConfig:
 
         Order: explicit ``adapter_type`` argument -> project-level pin
         (``./.datus/config.yml`` ``semantic:``) -> global ``default: true``
-        flag / single-entry shortcut -> built-in ``metricflow`` fallback when
+        flag / single-entry shortcut -> built-in default fallback when
         no semantic layer is configured. Raises when multiple semantic layers
         are configured without a clear default.
         """
@@ -1525,7 +1525,7 @@ class AgentConfig:
             ErrorCode.COMMON_CONFIG_ERROR,
             message=(
                 "Multiple semantic layers are configured in `agent.services.semantic_layer`, "
-                "set `semantic_adapter` on the semantic node or mark one entry with `default: true`."
+                "mark exactly one entry with `default: true`."
             ),
         )
 
@@ -1547,6 +1547,8 @@ class AgentConfig:
 
         config = self.get_semantic_layer_config(resolved_adapter)
         config.setdefault("type", resolved_adapter)
+        if resolved_adapter == "osi":
+            config.setdefault("execution_backend", "metricflow")
         effective_runtime_db_context = (
             runtime_db_context if runtime_db_context is not None else self.runtime_db_context()
         )
@@ -2305,7 +2307,14 @@ class AgentConfig:
 
     def init_semantic_layer(self, param: Dict[str, Any]):
         if not isinstance(param, dict):
-            return
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    "`agent.services.semantic_layer` must be a mapping such as "
+                    "`semantic_layer: {metricflow: {}}` or `semantic_layer: {osi: {}}`; "
+                    "scalar values like `semantic_layer: osi` are not supported."
+                ),
+            )
 
         self.semantic_layer_configs = {}
         for service_name, raw_config in param.items():

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -240,16 +240,8 @@ def _agent_config_dialect(agent_config: AgentConfig) -> str:
     return value if isinstance(value, str) and value.strip() else "snowflake"
 
 
-def _metrics_node_config(agent_config: AgentConfig) -> dict[str, Any]:
-    nodes = getattr(agent_config, "agentic_nodes", None)
-    if not isinstance(nodes, dict):
-        return {}
-    node_config = nodes.get(METRICS_NODE_NAME) or {}
-    return node_config if isinstance(node_config, dict) else {}
-
-
 def _metrics_authoring_format(agent_config: AgentConfig) -> str:
-    return resolve_authoring_format(agent_config, _metrics_node_config(agent_config))
+    return resolve_authoring_format(agent_config)
 
 
 def _project_relative_path(agent_config: AgentConfig, path_value: str) -> Path:

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -88,11 +88,16 @@ class GenerationTools:
         self,
         agent_config: AgentConfig,
         generation_evidence: Optional[GenerationEvidence] = None,
-        authoring_format: str = "metricflow",
+        authoring_format: Optional[str] = None,
     ):
         self.agent_config = agent_config
         self.generation_evidence = generation_evidence or GenerationEvidence()
-        self.authoring_format = (authoring_format or "metricflow").strip().lower()
+        if authoring_format:
+            self.authoring_format = str(authoring_format).strip().lower()
+        else:
+            from datus.agent.node.semantic_authoring import resolve_authoring_format
+
+            self.authoring_format = resolve_authoring_format(agent_config)
         self.metric_rag = MetricRAG(agent_config)
         self.semantic_rag = SemanticModelRAG(agent_config)
         self.table_semantic_profile_rag = None

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -23,6 +23,13 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
     MetricFlow YAML files are merged structurally.
     """
 
+    def __init__(self, *args, authoring_format: str = "metricflow", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.authoring_format = (authoring_format or "metricflow").strip().lower()
+
+    def _is_metricflow_authoring(self) -> bool:
+        return self.authoring_format == "metricflow"
+
     def write_file(self, path: str, content: str, file_type: str = "") -> FuncToolResult:  # type: ignore[override]
         resolved = self._classify(path)
         policy_error = self._reject_write_policy(resolved)
@@ -34,6 +41,9 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
         if not preprocess_result.success:
             return preprocess_result
         content = str(preprocess_result.result or "")
+
+        if not self._is_metricflow_authoring():
+            return super().write_file(path, content, file_type)
 
         if self._is_metric_file_path(target_path):
             if not self._should_merge_metric_file(target_path):

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -138,13 +138,13 @@ BUILTIN_SUBAGENT_DESCRIPTIONS = {
         "dashboard_slug, app_jsx_path, render_file_count, template_count, tokens_used}."
     ),
     "gen_semantic_model": (
-        "Generate MetricFlow semantic model YAML files from database table structures. "
+        "Generate semantic model YAML files from database table structures. "
         "Use when asked to create or update semantic models, define entities, relationships, or dimensions. "
         "Prompt MUST contain table name(s), e.g. 'orders' or 'orders, customers, products'. "
         "Returns JSON with {response, semantic_models (list of file paths), tokens_used}."
     ),
     "gen_metrics": (
-        "Define and generate MetricFlow metric definitions. "
+        "Define and generate semantic metric definitions. "
         "Three input modes: "
         "(1) SQL-based: provide SQL queries for metric extraction. "
         "(2) Natural language: describe the business metric or calculation rules, "

--- a/docs/adapters/metricflow_semantic_adapter.md
+++ b/docs/adapters/metricflow_semantic_adapter.md
@@ -27,16 +27,6 @@ agent:
         timeout: 300
         config_path: ./conf/agent.yml   # optional advanced override
         default: true
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-
-    gen_metrics:
-      semantic_adapter: metricflow
-
-    ask_metrics:
-      semantic_adapter: metricflow
 ```
 
 `config_path` is optional. In normal use, Datus builds the MetricFlow runtime config from:
@@ -94,7 +84,7 @@ metric:
 
 ## Generation Flow
 
-With `semantic_adapter: metricflow`:
+With MetricFlow as the active semantic layer:
 
 1. `gen_semantic_model` writes MetricFlow semantic model YAML.
 2. `gen_metrics` writes MetricFlow metric YAML.

--- a/docs/adapters/metricflow_semantic_adapter.zh.md
+++ b/docs/adapters/metricflow_semantic_adapter.zh.md
@@ -27,16 +27,6 @@ agent:
         timeout: 300
         config_path: ./conf/agent.yml   # 可选高级覆盖项
         default: true
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-
-    gen_metrics:
-      semantic_adapter: metricflow
-
-    ask_metrics:
-      semantic_adapter: metricflow
 ```
 
 `config_path` 是可选项。正常情况下，Datus 会从以下信息构造 MetricFlow 运行时配置：
@@ -94,7 +84,7 @@ metric:
 
 ## 生成流程
 
-配置 `semantic_adapter: metricflow` 后：
+当 MetricFlow 是 active semantic layer 时：
 
 1. `gen_semantic_model` 写入 MetricFlow semantic model YAML。
 2. `gen_metrics` 写入 MetricFlow metric YAML。

--- a/docs/adapters/osi_semantic_adapter.md
+++ b/docs/adapters/osi_semantic_adapter.md
@@ -46,7 +46,7 @@ The `metricflow` extra installs dependencies required by the MetricFlow executio
 
 ## Configuration
 
-Configure the semantic layer as `osi` in `agent.yml`, and point semantic nodes to `semantic_adapter: osi`.
+Configure the semantic layer as `osi` in `agent.yml`. The selected semantic layer is global for semantic-model, metric, and metric-query workflows.
 
 ```yaml
 agent:
@@ -63,27 +63,17 @@ agent:
 
     semantic_layer:
       osi:
-        execution_backend: metricflow
         default: true
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: osi
-      # authoring_format is optional; semantic_adapter=osi enables OSI authoring.
-      # authoring_format: osi
-
-    gen_metrics:
-      semantic_adapter: osi
-
-    ask_metrics:
-      semantic_adapter: osi
 ```
 
-`datus-agent` resolves the authoring format in this order:
+`execution_backend` defaults to `metricflow`; set it only when you need a different OSI execution backend.
 
-1. Use `authoring_format: osi` when explicitly configured on the node.
-2. Use OSI authoring when the resolved `semantic_adapter` is `osi`.
-3. Otherwise, keep the default MetricFlow authoring path.
+`datus-agent` resolves the authoring format from the active global semantic adapter:
+
+1. Use OSI authoring when `agent.services.semantic_layer.osi` is the active adapter.
+2. Otherwise, keep the MetricFlow authoring path.
+
+Legacy node-level `semantic_adapter` and `authoring_format` fields are ignored.
 
 ## Semantic Model Generation
 

--- a/docs/adapters/osi_semantic_adapter.zh.md
+++ b/docs/adapters/osi_semantic_adapter.zh.md
@@ -46,7 +46,7 @@ pip install -e "../datus-semantic-adapter/datus-semantic-osi[metricflow]"
 
 ## 配置
 
-在 `agent.yml` 里把 semantic layer 配成 `osi`，并让相关节点使用 `semantic_adapter: osi`。
+在 `agent.yml` 里把 semantic layer 配成 `osi`。语义层选择是全局的，会同时作用于 semantic model、metric 和 metric query 工作流。
 
 ```yaml
 agent:
@@ -63,27 +63,17 @@ agent:
 
     semantic_layer:
       osi:
-        execution_backend: metricflow
         default: true
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: osi
-      # authoring_format 可省略；semantic_adapter=osi 时会自动使用 OSI authoring。
-      # authoring_format: osi
-
-    gen_metrics:
-      semantic_adapter: osi
-
-    ask_metrics:
-      semantic_adapter: osi
 ```
 
-`datus-agent` 的 authoring format 解析规则是：
+`execution_backend` 默认是 `metricflow`；只有需要换 OSI 执行后端时才需要显式配置。
 
-1. 如果节点显式配置 `authoring_format: osi`，使用 OSI。
-2. 如果节点使用的 `semantic_adapter` 解析为 `osi`，自动使用 OSI。
-3. 否则保持默认 MetricFlow authoring。
+`datus-agent` 会从全局 active semantic adapter 推导 authoring format：
+
+1. 当 `agent.services.semantic_layer.osi` 是 active adapter 时，使用 OSI authoring。
+2. 否则保持 MetricFlow authoring。
+
+旧的 node 级 `semantic_adapter` 和 `authoring_format` 字段会被忽略。
 
 ## 生成语义模型
 

--- a/docs/adapters/semantic_adapters.md
+++ b/docs/adapters/semantic_adapters.md
@@ -63,19 +63,10 @@ agent:
 
       osi:
         execution_backend: metricflow
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-
-    gen_metrics:
-      semantic_adapter: metricflow
-
-    ask_metrics:
-      semantic_adapter: metricflow
 ```
 
 The key under `services.semantic_layer` must equal the adapter type, for example `metricflow` or `osi`. If a `type:` field is present, it must match the key.
+The selected semantic adapter is global. Legacy node-level `semantic_adapter` and `authoring_format` fields are ignored.
 
 See [Semantic Layer Configuration](../configuration/semantic_layer.md) for selection rules, defaults, and project-level pins.
 

--- a/docs/adapters/semantic_adapters.zh.md
+++ b/docs/adapters/semantic_adapters.zh.md
@@ -63,19 +63,10 @@ agent:
 
       osi:
         execution_backend: metricflow
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-
-    gen_metrics:
-      semantic_adapter: metricflow
-
-    ask_metrics:
-      semantic_adapter: metricflow
 ```
 
 `services.semantic_layer` 下的 key 必须等于 adapter type，例如 `metricflow` 或 `osi`。如果同时写了 `type:` 字段，其值必须与 key 一致。
+语义适配器选择是全局的。旧的 node 级 `semantic_adapter` 和 `authoring_format` 字段会被忽略。
 
 选择规则、默认适配器和项目级 pin 见 [语义层配置](../configuration/semantic_layer.zh.md)。
 

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -336,9 +336,10 @@ The runtime currently reads these commonly used fields from `agentic_nodes` entr
 - `workspace_root`
 - `scoped_context`
 - `subagents`
-- `semantic_adapter` for semantic-model and metrics agents
 - `bi_platform` for dashboard agents
 - `scheduler_service` for scheduler agents
+
+Semantic adapter selection is global under `agent.services.semantic_layer`. Legacy node-level `semantic_adapter` and `authoring_format` fields are ignored.
 
 `scoped_kb_path` is deprecated. New configs use shared global storage with query-time filters instead of per-subagent scoped KB directories.
 
@@ -402,7 +403,6 @@ agent:
     semantic_metrics:
       node_class: gen_metrics
       model: claude
-      semantic_adapter: metricflow
       max_turns: 30
 
     etl_scheduler:

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -294,9 +294,10 @@ codex:
 - `workspace_root`
 - `scoped_context`
 - `subagents`
-- semantic 节点使用的 `semantic_adapter`
 - dashboard agent 使用的 `bi_platform`
 - scheduler 节点使用的 `scheduler_service`
+
+语义适配器选择统一配置在 `agent.services.semantic_layer`。旧的 node 级 `semantic_adapter` 和 `authoring_format` 字段会被忽略。
 
 `scoped_kb_path` 已废弃。新配置使用共享的全局存储，并在查询时应用过滤，而不是为每个 subagent 持有独立 scoped KB 目录。
 
@@ -360,7 +361,6 @@ agent:
     semantic_metrics:
       node_class: gen_metrics
       model: claude
-      semantic_adapter: metricflow
       max_turns: 30
 
     etl_scheduler:

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -66,7 +66,7 @@ agent:
 | Section | Purpose | Selector |
 |---------|---------|----------|
 | `services.datasources` | Database connections used by SQL and KB operations | `--datasource` / current database / default database |
-| `services.semantic_layer` | Semantic adapter configuration such as MetricFlow | `semantic_adapter` |
+| `services.semantic_layer` | Semantic adapter configuration such as MetricFlow or OSI | active/default semantic layer |
 | `services.bi_platforms` | BI platform credentials and dataset materialization config | `bi_platform` |
 | `services.schedulers` | Scheduler service instances such as Airflow | `scheduler_service` |
 

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -66,7 +66,7 @@ agent:
 | 配置段 | 用途 | 选择方式 |
 |--------|------|----------|
 | `services.datasources` | SQL 与知识库操作使用的数据库连接 | `--datasource` / 当前数据库 / 默认数据库 |
-| `services.semantic_layer` | 语义适配器配置，例如 MetricFlow | `semantic_adapter` |
+| `services.semantic_layer` | 语义适配器配置，例如 MetricFlow 或 OSI | active/default semantic layer |
 | `services.bi_platforms` | BI 平台凭据与数据集物化配置 | `bi_platform` |
 | `services.schedulers` | 调度器服务实例，例如 Airflow | `scheduler_service` |
 

--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -87,8 +87,6 @@ agent:
         dags_folder: "${AIRFLOW_DAGS_DIR}"
 
   agentic_nodes:
-    gen_metrics:
-      semantic_adapter: metricflow
     gen_dashboard:
       bi_platform: superset
     scheduler:

--- a/docs/configuration/introduction.zh.md
+++ b/docs/configuration/introduction.zh.md
@@ -69,8 +69,6 @@ agent:
         dags_folder: "${AIRFLOW_DAGS_DIR}"
 
   agentic_nodes:
-    gen_metrics:
-      semantic_adapter: metricflow
     gen_dashboard:
       bi_platform: superset
     scheduler:

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -59,7 +59,7 @@ Comparison is case-insensitive and trims surrounding whitespace.
 - OSI is a peer semantic adapter to MetricFlow.
 - OSI mode authors strict OSI core YAML and stores Datus execution hints in `custom_extensions`.
 - The current OSI execution backend is MetricFlow by default. You normally do not need to set `execution_backend`.
-- Configure `services.semantic_layer.osi: {}` to select this path globally.
+- Configure `services.semantic_layer.osi` and mark it `default: true` to select this path globally when other adapters are also configured. An empty `osi: {}` entry is selected automatically only when it is the sole semantic adapter, or when the current project pins `semantic: osi`.
 
 ## Configuring through the CLI (`/services`)
 

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -1,16 +1,13 @@
 # Semantic Layer Configuration
 
 Semantic adapters are configured under `agent.services.semantic_layer`.
-At least one entry must be configured — running a semantic node with an
-empty `services.semantic_layer` block now raises
-`No semantic layer configured` instead of silently falling back to a
-hard-coded `metricflow` default.
+If the section is omitted or empty, Datus uses its built-in semantic
+adapter default. That default is currently `metricflow`; a future release
+can switch it to `osi` without requiring per-node config changes.
 
-> **Migration note**: previous Datus releases inserted an implicit
-> `metricflow` default when the section was missing. The default now
-> requires an explicit YAML entry. The bundled `conf/agent.yml.example`
-> already ships with `metricflow: {}`, so fresh installs continue to
-> Just Work.
+Semantic layer selection is global for the project. Node-level semantic
+format fields from older configs are ignored; use this section to pin a
+format explicitly.
 
 ## Structure
 
@@ -24,14 +21,8 @@ agent:
         default: true                   # global default — picked when no project pin set
 
       osi:
-        execution_backend: metricflow   # optional OSI authoring adapter
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-
-    gen_metrics:
-      semantic_adapter: metricflow
+        # execution_backend defaults to metricflow and normally does not need
+        # to be configured.
 ```
 
 ## Selection Rules
@@ -40,17 +31,16 @@ agent:
 adapter in this order — identical to BI Dashboard and Scheduler
 resolution:
 
-1. Explicit `adapter_type` argument at the call site (or
-   `semantic_adapter` on the agentic node).
+1. Explicit `adapter_type` argument at service-management call sites.
 2. Project-level pin in `./.datus/config.yml`'s `semantic:` field.
 3. Global `default: true` flag — at most one entry under
    `services.semantic_layer` may carry it; multiple defaults are
    rejected at config load time.
 4. Single-entry shortcut when only one semantic adapter is configured.
-5. Otherwise raise:
-   - `No semantic layer configured ...` when the section is empty.
-   - `Multiple semantic layers are configured ...` when there are
-     multiple without a default.
+5. Built-in default when the section is empty.
+
+Multiple configured semantic adapters without a `default: true` entry are
+rejected as ambiguous.
 
 The key under `services.semantic_layer` **must equal the adapter type**
 (for example `metricflow`). If a `type:` field is present, it must match
@@ -68,8 +58,8 @@ Comparison is case-insensitive and trims surrounding whitespace.
 
 - OSI is a peer semantic adapter to MetricFlow.
 - OSI mode authors strict OSI core YAML and stores Datus execution hints in `custom_extensions`.
-- The current OSI execution backend is MetricFlow, configured with `execution_backend: metricflow`.
-- Use `semantic_adapter: osi` on `gen_semantic_model`, `gen_metrics`, or `ask_metrics` to select this path.
+- The current OSI execution backend is MetricFlow by default. You normally do not need to set `execution_backend`.
+- Configure `services.semantic_layer.osi: {}` to select this path globally.
 
 ## Configuring through the CLI (`/services`)
 

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -1,8 +1,8 @@
 # 语义层配置（Semantic Layer）
 
-语义适配器统一配置在 `agent.services.semantic_layer` 下。**至少要配置一条**——空 section 不再静默 fallback 到 metricflow,而是 raise `No semantic layer configured`。
+语义适配器统一配置在 `agent.services.semantic_layer` 下。如果不配置或配置为空，Datus 使用内置默认语义适配器。当前默认是 `metricflow`；未来可以切到 `osi`，不需要为每个 node 单独改配置。
 
-> **迁移说明**:旧版本会在 section 缺失时隐式注入 metricflow 默认值,新版要求显式写入 yaml 条目。`conf/agent.yml.example` 已经默认带上 `metricflow: {}`,新装用户开箱仍能用。
+语义层选择是项目级全局设置。旧配置里 node 级的语义格式字段会被忽略；需要显式 pin 时，只改这里。
 
 ## 配置结构
 
@@ -16,27 +16,20 @@ agent:
         default: true                   # 全局默认:无 project pin 时被选用
 
       osi:
-        execution_backend: metricflow   # 可选 OSI authoring 适配器
-
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-
-    gen_metrics:
-      semantic_adapter: metricflow
+        # execution_backend 默认是 metricflow，通常不需要配置。
 ```
 
 ## 选择规则
 
 `AgentConfig.resolve_semantic_adapter` 解析活动语义适配器的顺序与 BI Dashboard / Scheduler 完全一致:
 
-1. 调用处显式传入的 `adapter_type`(或 agentic node 上的 `semantic_adapter`)。
+1. 服务管理类调用处显式传入的 `adapter_type`。
 2. `./.datus/config.yml` 中的项目级 pin —— `semantic:` 字段。
 3. YAML 全局 `default: true` 标志:`services.semantic_layer` 中至多一条可标 default,多于一条会在加载阶段直接报错。
 4. 单条快捷:仅有一条 semantic adapter 时,自动使用它。
-5. 否则抛错:
-   - section 为空 → `No semantic layer configured ...`
-   - 多条无 default → `Multiple semantic layers are configured ...`
+5. section 为空时使用内置默认。
+
+如果配置了多条 semantic adapter 但没有 `default: true`，Datus 会认为配置有歧义并报错。
 
 `services.semantic_layer` 下的 key **必须等于 adapter type**(例如 `metricflow`)。如果同时写了 `type:` 字段,其值必须与 key 一致,否则 Datus 会在启动时抛出配置错误。比较时会先 lowercase + trim,因此 `MetricFlow`、` metricflow ` 都会被视为与 `metricflow` 匹配。
 
@@ -51,8 +44,8 @@ agent:
 
 - OSI 是和 MetricFlow 并列的 semantic adapter。
 - OSI 模式编写 strict OSI core YAML，并把 Datus 执行提示放在 `custom_extensions` 中。
-- 当前 OSI 执行后端是 MetricFlow，通过 `execution_backend: metricflow` 配置。
-- 在 `gen_semantic_model`、`gen_metrics` 或 `ask_metrics` 上设置 `semantic_adapter: osi` 即可选择该路径。
+- 当前 OSI 执行后端默认是 MetricFlow，通常不需要设置 `execution_backend`。
+- 配置 `services.semantic_layer.osi: {}` 即可在项目内全局选择 OSI。
 
 ## 通过 CLI 配置（`/services`）
 

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -45,7 +45,7 @@ agent:
 - OSI 是和 MetricFlow 并列的 semantic adapter。
 - OSI 模式编写 strict OSI core YAML，并把 Datus 执行提示放在 `custom_extensions` 中。
 - 当前 OSI 执行后端默认是 MetricFlow，通常不需要设置 `execution_backend`。
-- 配置 `services.semantic_layer.osi: {}` 即可在项目内全局选择 OSI。
+- 配置 `services.semantic_layer.osi` 并标记 `default: true`，可在同时配置其他 adapter 时全局选择 OSI。空的 `osi: {}` 只有在它是唯一 semantic adapter，或当前项目 pin 到 `semantic: osi` 时才会被选中。
 
 ## 通过 CLI 配置（`/services`）
 

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -1505,13 +1505,14 @@ class TestGenMetricsNonInteractiveBridge:
 
     def test_workflow_mode_compose_hooks_is_non_interactive(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.permission.permission_hooks import CompositeHooks, PermissionHooks
 
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         # Workflow mode may now compose CompositeHooks (permission + compact)
         # because multi-turn history is enabled for all modes. Validate the
         # permission gate via ``node.permission_hooks`` instead of the bundle.
         hooks = node._compose_hooks()
-        assert hooks is not None
-        assert node.permission_hooks is not None
+        assert isinstance(hooks, CompositeHooks)
+        assert isinstance(node.permission_hooks, PermissionHooks)
         assert node.permission_hooks.non_interactive is True
         assert node.permission_manager.active_profile == "dangerous"

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -36,6 +36,11 @@ from datus.tools.func_tool.generation_tools import GenerationTools
 from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
 from tests.unit_tests.mock_llm_model import MockToolCall, build_simple_response, build_tool_then_response
 
+
+def _set_global_semantic_adapter(agent_config, adapter: str) -> None:
+    agent_config.resolve_semantic_adapter = MagicMock(return_value=adapter)
+
+
 # ---------------------------------------------------------------------------
 # Initialization Tests
 # ---------------------------------------------------------------------------
@@ -713,8 +718,8 @@ class TestGetSystemPrompt:
             assert version == "1.2", f"Expected explicit version '1.2', got '{version}'"
 
     def test_osi_authoring_uses_osi_prompt_template(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.input = SemanticNodeInput(user_message="Generate OSI metrics", prompt_version="1.2")
 
         with (
@@ -976,8 +981,8 @@ semantic_model:
         reported_semantic_path = f"subject/semantic_models/{datasource}/orders.yml"
         reported_metric_path = f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml"
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.input = SemanticNodeInput(user_message="Generate OSI metrics")
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
@@ -1014,8 +1019,8 @@ semantic_model:
             encoding="utf-8",
         )
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.input = SemanticNodeInput(user_message="Generate OSI metrics")
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
@@ -1038,8 +1043,8 @@ semantic_model:
     def test_osi_final_metric_publish_skips_when_already_synced(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.generation_evidence.mark_kb_sync("metric")
         node.generation_tools.end_metric_generation = MagicMock()
 
@@ -1050,8 +1055,8 @@ semantic_model:
     def test_osi_skipped_status_without_metric_file_returns_cleanly(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.generation_tools.end_metric_generation = MagicMock()
 
         node._finalize_metric_generation(None, None, "skipped")
@@ -1061,8 +1066,8 @@ semantic_model:
     def test_osi_skipped_status_with_metric_file_fails_closed(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
 
         with pytest.raises(RuntimeError, match="status='skipped' with a non-null metric_file"):
             node._finalize_metric_generation(None, "orders_metrics.yml", "skipped")
@@ -1070,8 +1075,8 @@ semantic_model:
     def test_osi_generated_status_without_metric_file_fails_closed(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
 
         with pytest.raises(RuntimeError, match="status='generated' without a metric_file"):
             node._finalize_metric_generation(None, None, "generated")
@@ -1079,8 +1084,8 @@ semantic_model:
     def test_osi_empty_final_response_without_metric_file_is_noop(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.generation_tools.end_metric_generation = MagicMock()
 
         node._finalize_metric_generation(None, None, None)
@@ -1090,8 +1095,8 @@ semantic_model:
     def test_osi_final_metric_publish_requires_generation_tools(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.generation_tools = None
 
         with pytest.raises(RuntimeError, match="generation tools are unavailable"):
@@ -1100,8 +1105,8 @@ semantic_model:
     def test_osi_final_metric_publish_requires_validation_tool(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.semantic_tools = None
 
         with pytest.raises(RuntimeError, match="validate_semantic is unavailable"):
@@ -1111,8 +1116,8 @@ semantic_model:
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.tools.func_tool.base import FuncToolResult
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(
             return_value=FuncToolResult(success=0, error="invalid OSI", result={"valid": False})
@@ -1134,8 +1139,8 @@ semantic_model:
         )
         baseline = json.dumps({"version": "0.2.0.dev0", "semantic_model": [{"name": "shop", "datasets": []}]})
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node._osi_metrics_baseline_artifact_json = baseline
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
@@ -1167,8 +1172,8 @@ semantic_model:
             encoding="utf-8",
         )
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
         delattr(node.semantic_tools, "query_metrics")
@@ -1192,8 +1197,8 @@ semantic_model:
             encoding="utf-8",
         )
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
         node.semantic_tools.query_metrics = MagicMock(return_value=FuncToolResult(success=0, error="compile failed"))
@@ -1216,8 +1221,8 @@ semantic_model:
             encoding="utf-8",
         )
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.input = SemanticNodeInput(
             user_message="SELECT customer_segment, SUM(revenue) FROM orders GROUP BY customer_segment"
         )
@@ -1249,8 +1254,8 @@ semantic_model:
             encoding="utf-8",
         )
 
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.node_config["authoring_format"] = "osi"
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
         node.semantic_tools.query_metrics = MagicMock(

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -33,6 +33,11 @@ from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
 from datus.tools.func_tool import DBFuncTool, FilesystemFuncTool, SemanticDiscoveryTools
 from tests.unit_tests.mock_llm_model import MockToolCall, build_simple_response, build_tool_then_response
 
+
+def _set_global_semantic_adapter(agent_config, adapter: str) -> None:
+    agent_config.resolve_semantic_adapter = MagicMock(return_value=adapter)
+
+
 # ---------------------------------------------------------------------------
 # Initialization Tests
 # ---------------------------------------------------------------------------
@@ -488,8 +493,8 @@ class TestPrepareTemplateContext:
 
 class TestGetSystemPrompt:
     def test_osi_authoring_uses_osi_prompt_template(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create)
-        node.node_config["authoring_format"] = "osi"
 
         with (
             patch("datus.agent.node.semantic_authoring.osi_prompt_version", return_value="osi-latest") as version_mock,
@@ -802,8 +807,8 @@ class TestSaveToDb:
             sync_mock.assert_not_called()
 
     def test_osi_save_to_db_uses_generation_tools_sync(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create)
-        node.node_config["authoring_format"] = "osi"
         datasource = real_agent_config.current_datasource
         semantic_dir = real_agent_config.path_manager.semantic_model_path(datasource)
         semantic_dir.mkdir(parents=True, exist_ok=True)
@@ -817,8 +822,8 @@ class TestSaveToDb:
         assert node.generation_evidence.semantic_kb_sync_passed is True
 
     def test_osi_save_to_db_fails_without_generation_tools(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create)
-        node.node_config["authoring_format"] = "osi"
         datasource = real_agent_config.current_datasource
         semantic_dir = real_agent_config.path_manager.semantic_model_path(datasource)
         semantic_dir.mkdir(parents=True, exist_ok=True)
@@ -828,8 +833,8 @@ class TestSaveToDb:
         assert node._save_to_db(f"subject/semantic_models/{datasource}/orders.yml") is False
 
     def test_osi_save_to_db_reports_sync_failure(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create)
-        node.node_config["authoring_format"] = "osi"
         datasource = real_agent_config.current_datasource
         semantic_dir = real_agent_config.path_manager.semantic_model_path(datasource)
         semantic_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -4,12 +4,13 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_METRICFLOW,
     AUTHORING_FORMAT_OSI,
     default_osi_semantic_model_file,
     default_osi_semantic_model_name,
-    osi_expression_dialect,
     osi_prompt_version,
     osi_template_name,
     resolve_authoring_format,
@@ -24,7 +25,6 @@ class _DbScope:
     database: str = ""
     schema: str = ""
     catalog: str = ""
-    type: str = ""
 
 
 def _agent_config(adapter):
@@ -111,97 +111,36 @@ def test_default_osi_semantic_model_name_uses_agent_scope_fallbacks():
     assert default_osi_semantic_model_file(config) == "subject/semantic_models/default/project_alpha.yml"
 
 
-def test_osi_expression_dialect_follows_datasource_type():
-    config = SimpleNamespace(
-        current_datasource="starrocks",
-        db_type="",
-        current_db_config=lambda: _DbScope(type="starrocks"),
-    )
-
-    assert osi_expression_dialect(config) == "starrocks"
-
-
-def test_osi_expression_dialect_uses_generic_datasource_type_without_allowlist():
-    config = SimpleNamespace(
-        current_datasource="custom",
-        db_type="",
-        current_db_config=lambda: _DbScope(type="Acme Warehouse"),
-    )
-
-    assert osi_expression_dialect(config) == "acme_warehouse"
-
-
-def test_osi_expression_dialect_falls_back_to_ansi_sql_without_datasource_type():
-    config = SimpleNamespace(
-        current_datasource="",
-        db_type="",
-        current_db_config=lambda: _DbScope(),
-    )
-
-    assert osi_expression_dialect(config) == "ANSI_SQL"
-
-
-def test_osi_expression_dialect_uses_agent_fallback_when_db_config_fails():
-    def _boom():
-        raise RuntimeError("datasource not ready")
-
-    config = SimpleNamespace(
-        current_datasource="",
-        db_type="Snowflake",
-        current_db_config=_boom,
-    )
-
-    assert osi_expression_dialect(config) == "snowflake"
-
-
 def test_defaults_to_metricflow_when_unknown():
     assert resolve_authoring_format(None, None) == AUTHORING_FORMAT_METRICFLOW
     assert resolve_authoring_format(_agent_config(None), {}) == AUTHORING_FORMAT_METRICFLOW
 
 
-def test_resolution_is_resilient_to_agent_config_errors():
-    def _boom():
-        raise RuntimeError("no semantic layer")
-
-    bad = SimpleNamespace(resolve_semantic_adapter=_boom)
-    assert resolve_authoring_format(bad, None) == AUTHORING_FORMAT_METRICFLOW
-
-
-def test_resolution_logs_agent_config_errors():
+def test_resolution_propagates_agent_config_errors():
     def _boom(_requested=None):
         raise RuntimeError("no semantic layer")
 
     bad = SimpleNamespace(resolve_semantic_adapter=_boom)
-    with patch("datus.agent.node.semantic_authoring.logger") as mock_logger:
-        assert resolve_authoring_format(bad, {"semantic_adapter": "osi"}) == AUTHORING_FORMAT_METRICFLOW
-
-    mock_logger.debug.assert_called_once()
-    assert "Failed to resolve semantic adapter" in mock_logger.debug.call_args.args[0]
+    with pytest.raises(RuntimeError, match="no semantic layer"):
+        resolve_authoring_format(bad, None)
 
 
-def test_resolution_warns_for_semantic_layer_config_errors():
-    def _boom():
+def test_resolution_propagates_semantic_layer_config_errors():
+    def _boom(_requested=None):
         raise DatusException(ErrorCode.COMMON_CONFIG_ERROR, message="multiple semantic layers")
 
     bad = SimpleNamespace(resolve_semantic_adapter=_boom)
-    with patch("datus.agent.node.semantic_authoring.logger") as mock_logger:
-        assert resolve_authoring_format(bad, None) == AUTHORING_FORMAT_METRICFLOW
-
-    mock_logger.warning.assert_called_once()
-    mock_logger.debug.assert_not_called()
-    assert "configuration error" in mock_logger.warning.call_args.args[0]
+    with pytest.raises(DatusException, match="multiple semantic layers"):
+        resolve_authoring_format(bad, None)
 
 
-def test_adapter_type_resolution_uses_same_error_logging():
-    def _boom():
+def test_adapter_type_resolution_propagates_agent_config_errors():
+    def _boom(_requested=None):
         raise RuntimeError("resolver unavailable")
 
     bad = SimpleNamespace(resolve_semantic_adapter=_boom)
-    with patch("datus.agent.node.semantic_authoring.logger") as mock_logger:
-        assert resolve_semantic_adapter_type(bad) == AUTHORING_FORMAT_METRICFLOW
-
-    mock_logger.debug.assert_called_once()
-    assert mock_logger.debug.call_args.args[1] == "adapter type"
+    with pytest.raises(RuntimeError, match="resolver unavailable"):
+        resolve_semantic_adapter_type(bad)
 
 
 def test_osi_template_name_is_isolated_from_metricflow_template():
@@ -241,26 +180,6 @@ def test_osi_metrics_template_renders_despite_injected_metricflow_version():
     version = osi_prompt_version(None, "gen_metrics", "1.2")
     text = pm.render_template(template_name="gen_metrics_osi_system", version=version)
     assert "OSI" in text
-
-
-def test_osi_templates_render_datasource_expression_dialect():
-    pm = get_prompt_manager()
-
-    semantic_text = pm.render_template(
-        template_name="gen_semantic_model_osi_system",
-        version="1.0",
-        osi_expression_dialect="starrocks",
-    )
-    metrics_text = pm.render_template(
-        template_name="gen_metrics_osi_system",
-        version="1.0",
-        osi_expression_dialect="starrocks",
-    )
-
-    assert "dialect: starrocks" in semantic_text
-    assert "dialect: starrocks" in metrics_text
-    assert "OSI expression dialect for this datasource: `starrocks`" in semantic_text
-    assert "OSI expression dialect for this datasource: `starrocks`" in metrics_text
 
 
 def test_osi_skill_skip_handles_missing_node_config(monkeypatch):

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -9,6 +9,7 @@ from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_OSI,
     default_osi_semantic_model_file,
     default_osi_semantic_model_name,
+    osi_expression_dialect,
     osi_prompt_version,
     osi_template_name,
     resolve_authoring_format,
@@ -21,18 +22,19 @@ class _DbScope:
     database: str = ""
     schema: str = ""
     catalog: str = ""
+    type: str = ""
 
 
 def _agent_config(adapter):
     return SimpleNamespace(resolve_semantic_adapter=lambda requested=None: requested or adapter)
 
 
-def test_explicit_node_config_override_wins():
-    assert resolve_authoring_format(_agent_config("metricflow"), {"authoring_format": "osi"}) == AUTHORING_FORMAT_OSI
+def test_legacy_node_config_fields_are_ignored():
     assert (
-        resolve_authoring_format(_agent_config("osi"), {"authoring_format": "metricflow"})
+        resolve_authoring_format(_agent_config("metricflow"), {"authoring_format": "osi"})
         == AUTHORING_FORMAT_METRICFLOW
     )
+    assert resolve_authoring_format(_agent_config("osi"), {"authoring_format": "metricflow"}) == AUTHORING_FORMAT_OSI
 
 
 def test_derives_from_active_semantic_adapter():
@@ -40,8 +42,11 @@ def test_derives_from_active_semantic_adapter():
     assert resolve_authoring_format(_agent_config("metricflow"), None) == AUTHORING_FORMAT_METRICFLOW
 
 
-def test_derives_from_node_semantic_adapter():
-    assert resolve_authoring_format(_agent_config("metricflow"), {"semantic_adapter": "osi"}) == AUTHORING_FORMAT_OSI
+def test_legacy_node_semantic_adapter_is_ignored():
+    assert (
+        resolve_authoring_format(_agent_config("metricflow"), {"semantic_adapter": "osi"})
+        == AUTHORING_FORMAT_METRICFLOW
+    )
 
 
 def test_default_osi_semantic_model_name_uses_database_scope():
@@ -102,6 +107,36 @@ def test_default_osi_semantic_model_name_uses_agent_scope_fallbacks():
 
     assert default_osi_semantic_model_name(config) == "project_alpha"
     assert default_osi_semantic_model_file(config) == "subject/semantic_models/default/project_alpha.yml"
+
+
+def test_osi_expression_dialect_follows_datasource_type():
+    config = SimpleNamespace(
+        current_datasource="starrocks",
+        db_type="",
+        current_db_config=lambda: _DbScope(type="starrocks"),
+    )
+
+    assert osi_expression_dialect(config) == "starrocks"
+
+
+def test_osi_expression_dialect_uses_generic_datasource_type_without_allowlist():
+    config = SimpleNamespace(
+        current_datasource="custom",
+        db_type="",
+        current_db_config=lambda: _DbScope(type="Acme Warehouse"),
+    )
+
+    assert osi_expression_dialect(config) == "acme_warehouse"
+
+
+def test_osi_expression_dialect_falls_back_to_ansi_sql_without_datasource_type():
+    config = SimpleNamespace(
+        current_datasource="",
+        db_type="",
+        current_db_config=lambda: _DbScope(),
+    )
+
+    assert osi_expression_dialect(config) == "ANSI_SQL"
 
 
 def test_defaults_to_metricflow_when_unknown():
@@ -166,6 +201,26 @@ def test_osi_metrics_template_renders_despite_injected_metricflow_version():
     version = osi_prompt_version(None, "gen_metrics", "1.2")
     text = pm.render_template(template_name="gen_metrics_osi_system", version=version)
     assert "OSI" in text
+
+
+def test_osi_templates_render_datasource_expression_dialect():
+    pm = get_prompt_manager()
+
+    semantic_text = pm.render_template(
+        template_name="gen_semantic_model_osi_system",
+        version="1.0",
+        osi_expression_dialect="starrocks",
+    )
+    metrics_text = pm.render_template(
+        template_name="gen_metrics_osi_system",
+        version="1.0",
+        osi_expression_dialect="starrocks",
+    )
+
+    assert "dialect: starrocks" in semantic_text
+    assert "dialect: starrocks" in metrics_text
+    assert "OSI expression dialect for this datasource: `starrocks`" in semantic_text
+    assert "OSI expression dialect for this datasource: `starrocks`" in metrics_text
 
 
 def test_osi_skill_skip_handles_missing_node_config(monkeypatch):

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -13,8 +13,10 @@ from datus.agent.node.semantic_authoring import (
     osi_prompt_version,
     osi_template_name,
     resolve_authoring_format,
+    resolve_semantic_adapter_type,
 )
 from datus.prompts.prompt_manager import get_prompt_manager
+from datus.utils.exceptions import DatusException, ErrorCode
 
 
 @dataclass
@@ -139,6 +141,19 @@ def test_osi_expression_dialect_falls_back_to_ansi_sql_without_datasource_type()
     assert osi_expression_dialect(config) == "ANSI_SQL"
 
 
+def test_osi_expression_dialect_uses_agent_fallback_when_db_config_fails():
+    def _boom():
+        raise RuntimeError("datasource not ready")
+
+    config = SimpleNamespace(
+        current_datasource="",
+        db_type="Snowflake",
+        current_db_config=_boom,
+    )
+
+    assert osi_expression_dialect(config) == "snowflake"
+
+
 def test_defaults_to_metricflow_when_unknown():
     assert resolve_authoring_format(None, None) == AUTHORING_FORMAT_METRICFLOW
     assert resolve_authoring_format(_agent_config(None), {}) == AUTHORING_FORMAT_METRICFLOW
@@ -162,6 +177,31 @@ def test_resolution_logs_agent_config_errors():
 
     mock_logger.debug.assert_called_once()
     assert "Failed to resolve semantic adapter" in mock_logger.debug.call_args.args[0]
+
+
+def test_resolution_warns_for_semantic_layer_config_errors():
+    def _boom():
+        raise DatusException(ErrorCode.COMMON_CONFIG_ERROR, message="multiple semantic layers")
+
+    bad = SimpleNamespace(resolve_semantic_adapter=_boom)
+    with patch("datus.agent.node.semantic_authoring.logger") as mock_logger:
+        assert resolve_authoring_format(bad, None) == AUTHORING_FORMAT_METRICFLOW
+
+    mock_logger.warning.assert_called_once()
+    mock_logger.debug.assert_not_called()
+    assert "configuration error" in mock_logger.warning.call_args.args[0]
+
+
+def test_adapter_type_resolution_uses_same_error_logging():
+    def _boom():
+        raise RuntimeError("resolver unavailable")
+
+    bad = SimpleNamespace(resolve_semantic_adapter=_boom)
+    with patch("datus.agent.node.semantic_authoring.logger") as mock_logger:
+        assert resolve_semantic_adapter_type(bad) == AUTHORING_FORMAT_METRICFLOW
+
+    mock_logger.debug.assert_called_once()
+    assert mock_logger.debug.call_args.args[1] == "adapter type"
 
 
 def test_osi_template_name_is_isolated_from_metricflow_template():

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -1,11 +1,26 @@
 """Tests for datus.api.services.database_service — datasource management."""
 
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from datus.api.models.base_models import Result
 from datus.api.models.database_models import ListDatabasesInput
+from datus.api.models.table_models import SemanticModelInput, ValidateSemanticModelData
 from datus.api.services.database_service import DatasourceService
 from datus.tools.db_tools.db_manager import DBManager
+
+
+def _service_with_semantic_adapter(adapter: str = "metricflow") -> DatasourceService:
+    svc = DatasourceService.__new__(DatasourceService)
+    svc.agent_config = SimpleNamespace(
+        home="/datus-home",
+        current_datasource="warehouse",
+        resolve_semantic_adapter=lambda: adapter,
+    )
+    return svc
 
 
 class TestDatasourceServiceInit:
@@ -57,6 +72,151 @@ class TestDatabaseServiceGetDatabaseType:
         db_type, ds_id = svc._get_database_type()
         assert db_type == "sqlite"
         assert ds_id == svc.current_db_name
+
+
+class TestSemanticLayerServiceBranches:
+    def test_active_semantic_adapter_normalizes_resolved_name(self):
+        svc = _service_with_semantic_adapter(" OSI ")
+
+        assert svc._active_semantic_adapter() == "osi"
+        assert svc._is_osi_semantic_layer() is True
+
+    def test_active_semantic_adapter_returns_empty_without_resolver(self):
+        svc = DatasourceService.__new__(DatasourceService)
+        svc.agent_config = SimpleNamespace()
+
+        assert svc._active_semantic_adapter() == ""
+        assert svc._is_osi_semantic_layer() is False
+
+    def test_validate_osi_semantic_yaml_success(self, monkeypatch):
+        calls = []
+        package_mod = ModuleType("datus_semantic_osi")
+        profile_mod = ModuleType("datus_semantic_osi.profile")
+
+        def _load_osi_path(path, *, normalize):
+            calls.append((path, normalize))
+
+        profile_mod.load_osi_path = _load_osi_path
+        package_mod.profile = profile_mod
+        monkeypatch.setitem(sys.modules, "datus_semantic_osi", package_mod)
+        monkeypatch.setitem(sys.modules, "datus_semantic_osi.profile", profile_mod)
+
+        is_valid, errors = DatasourceService._validate_osi_semantic_yaml("kind: semantic_model\n", "orders.yml")
+
+        assert is_valid is True
+        assert errors == []
+        assert len(calls) == 1
+        assert calls[0][1] is True
+
+    def test_validate_osi_semantic_yaml_reports_errors_and_ignores_cleanup_failure(self, monkeypatch):
+        package_mod = ModuleType("datus_semantic_osi")
+        profile_mod = ModuleType("datus_semantic_osi.profile")
+
+        def _load_osi_path(path, *, normalize):
+            raise ValueError("bad osi yaml")
+
+        def _raise_os_error(path):
+            raise OSError("busy")
+
+        profile_mod.load_osi_path = _load_osi_path
+        package_mod.profile = profile_mod
+        monkeypatch.setitem(sys.modules, "datus_semantic_osi", package_mod)
+        monkeypatch.setitem(sys.modules, "datus_semantic_osi.profile", profile_mod)
+        monkeypatch.setattr("datus.api.services.database_service.os.unlink", _raise_os_error)
+
+        is_valid, errors = DatasourceService._validate_osi_semantic_yaml("not: osi\n", "orders.yml")
+
+        assert is_valid is False
+        assert errors == ["bad osi yaml"]
+
+    @pytest.mark.asyncio
+    async def test_validate_semantic_model_uses_osi_validator(self):
+        svc = _service_with_semantic_adapter("osi")
+        svc._get_semantic_model = MagicMock(return_value={"yaml_path": "/tmp/orders.yml"})
+        svc._validate_osi_semantic_yaml = MagicMock(return_value=(False, ["missing semantic_models"]))
+        request = SemanticModelInput(table="orders", yaml="kind: semantic_model\n")
+
+        result = await svc.validate_semantic_model(request)
+
+        assert result.success is True
+        assert result.data == ValidateSemanticModelData(valid=False, invalid_message=["missing semantic_models"])
+        svc._validate_osi_semantic_yaml.assert_called_once_with(request.yaml, "/tmp/orders.yml")
+
+    @pytest.mark.asyncio
+    async def test_validate_semantic_model_uses_metricflow_validator(self):
+        svc = _service_with_semantic_adapter("metricflow")
+        svc._get_semantic_model = MagicMock(return_value={"yaml_path": "/tmp/orders.yml"})
+        request = SemanticModelInput(
+            table="orders",
+            yaml="semantic_model:\n  name: orders\n",
+            catalog="cat",
+            database="db",
+            db_schema="schema",
+        )
+
+        with patch("datus.api.utils.semantic_validation.validate_semantic_yaml", return_value=(True, [])) as validate:
+            result = await svc.validate_semantic_model(request)
+
+        assert result.success is True
+        assert result.data == ValidateSemanticModelData(valid=True, invalid_message=None)
+        validate.assert_called_once_with(
+            yaml_content=request.yaml,
+            file_path="/tmp/orders.yml",
+            datus_home="/datus-home",
+            datasource="warehouse",
+            catalog="cat",
+            database="db",
+            db_schema="schema",
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_semantic_model_uses_osi_sync_tool(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi")
+        yaml_file = tmp_path / "orders.yml"
+        svc.validate_semantic_model = AsyncMock(
+            return_value=Result(
+                success=True,
+                data=ValidateSemanticModelData(valid=True, invalid_message=None),
+            )
+        )
+        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        request = SemanticModelInput(table="orders", yaml="kind: semantic_model\n")
+
+        with patch("datus.tools.func_tool.generation_tools.GenerationTools") as tools_cls:
+            tools_cls.return_value.sync_osi_semantic_to_db.return_value = {"success": True}
+            result = await svc.save_semantic_model(request)
+
+        assert result.success is True
+        assert yaml_file.read_text(encoding="utf-8") == request.yaml
+        tools_cls.assert_called_once_with(agent_config=svc.agent_config, authoring_format="osi")
+        tools_cls.return_value.sync_osi_semantic_to_db.assert_called_once_with(str(yaml_file))
+
+    @pytest.mark.asyncio
+    async def test_save_semantic_model_uses_metricflow_sync(self, tmp_path):
+        svc = _service_with_semantic_adapter("metricflow")
+        yaml_file = tmp_path / "orders.yml"
+        svc.validate_semantic_model = AsyncMock(
+            return_value=Result(
+                success=True,
+                data=ValidateSemanticModelData(valid=True, invalid_message=None),
+            )
+        )
+        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        request = SemanticModelInput(table="orders", yaml="semantic_model:\n  name: orders\n")
+
+        with patch(
+            "datus.api.services.database_service.GenerationHooks._sync_semantic_to_db",
+            return_value={"success": True},
+        ) as sync:
+            result = await svc.save_semantic_model(request)
+
+        assert result.success is True
+        sync.assert_called_once_with(
+            str(yaml_file),
+            svc.agent_config,
+            include_semantic_objects=True,
+            include_metrics=False,
+        )
 
 
 class TestGetSemanticModel:

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -435,6 +435,16 @@ class TestHandleEndSemanticModelGeneration:
 
         hooks._process_single_file.assert_not_called()
 
+    async def test_already_synced_by_generation_tool_skips_hook_sync(self, hooks):
+        hooks.generation_evidence.semantic_kb_sync_passed = True
+        hooks._extract_filepaths_from_result = MagicMock()
+        hooks._process_single_file = AsyncMock()
+
+        await hooks._handle_end_semantic_model_generation({"result": {"semantic_model_files": ["/tmp/a.yaml"]}})
+
+        hooks._extract_filepaths_from_result.assert_not_called()
+        hooks._process_single_file.assert_not_called()
+
     async def test_no_file_paths_logs_warning(self, hooks):
         hooks._process_single_file = AsyncMock()
         result = {"result": {}}  # no semantic_model_files
@@ -1673,6 +1683,18 @@ class TestHandleEndMetricGeneration:
         )
 
         await hooks._handle_end_metric_generation(result)
+
+        hooks._extract_metric_generation_result.assert_not_called()
+        hooks._process_single_file.assert_not_called()
+        hooks._process_metric_with_semantic_model.assert_not_called()
+
+    async def test_already_synced_by_generation_tool_skips_hook_sync(self, hooks):
+        hooks.generation_evidence.metric_kb_sync_passed = True
+        hooks._extract_metric_generation_result = MagicMock()
+        hooks._process_single_file = AsyncMock()
+        hooks._process_metric_with_semantic_model = AsyncMock()
+
+        await hooks._handle_end_metric_generation({"result": {"metric_file": "metrics/orders.yml"}})
 
         hooks._extract_metric_generation_result.assert_not_called()
         hooks._process_single_file.assert_not_called()

--- a/tests/unit_tests/cli/test_service_config_app.py
+++ b/tests/unit_tests/cli/test_service_config_app.py
@@ -366,6 +366,7 @@ class TestCursor:
         ("bi_platforms", "superset"),
         ("bi_platforms", "grafana"),
         ("schedulers", "airflow"),
+        ("semantic_layer", "osi"),
         ("semantic_layer", "metricflow"),
     ],
 )
@@ -384,13 +385,10 @@ def test_schedulers_currently_only_airflow():
     assert _BUILTIN_TYPES["schedulers"] == ("airflow",)
 
 
-def test_semantic_layer_currently_only_metricflow():
-    """Lock the semantic picker to ``metricflow`` until another adapter
-    package ships. Removing it would break the sole supported semantic
-    layer entry."""
+def test_semantic_layer_lists_supported_builtin_adapters():
     from datus.cli.service_config_app import _BUILTIN_TYPES
 
-    assert _BUILTIN_TYPES["semantic_layer"] == ("metricflow",)
+    assert _BUILTIN_TYPES["semantic_layer"] == ("metricflow", "osi")
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -424,11 +422,11 @@ class TestSemanticTab:
         flat = "".join(text for _, text in rendered)
         assert "Add new semantic" in flat
 
-    def test_type_picker_for_semantic_lists_metricflow(self):
+    def test_type_picker_for_semantic_lists_supported_adapters(self):
         app = _build_app()
         app._tab = _Tab.SEMANTIC
         app._enter_type_picker()
-        assert app._type_choices == ["metricflow"]
+        assert app._type_choices == ["metricflow", "osi"]
 
     def test_type_picker_enter_emits_save_without_form(self):
         app = _build_app()

--- a/tests/unit_tests/cli/test_service_config_app.py
+++ b/tests/unit_tests/cli/test_service_config_app.py
@@ -536,7 +536,7 @@ class TestEmbeddedPanel:
             panel = app.build_embedded_panel(fut)
             assert isinstance(panel, EmbeddedWizard)
             assert panel.done_future is fut
-            assert app._on_done is not None
+            assert callable(app._on_done)
         finally:
             loop.close()
 

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -756,6 +756,27 @@ class TestAgentConfigServiceSelectors:
         assert config["type"] == "metricflow"
         assert config["datasource"] == "demo"
 
+    def test_build_semantic_adapter_config_defaults_osi_execution_backend_to_metricflow(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            services={
+                "datasources": {
+                    "demo": {
+                        "type": "duckdb",
+                        "uri": "duckdb:///:memory:",
+                        "default": True,
+                    }
+                },
+                "semantic_layer": {"osi": {}},
+            },
+        )
+
+        config = cfg.build_semantic_adapter_config()
+
+        assert config["type"] == "osi"
+        assert config["execution_backend"] == "metricflow"
+        assert config["datasource"] == "demo"
+
     def test_build_semantic_adapter_config_preserves_snowflake_key_pair_fields(self, tmp_path):
         cfg = self._make(
             tmp_path,

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -628,8 +628,7 @@ class TestEnsureSemanticModelsForMetrics:
         config = SimpleNamespace(
             project_root=str(tmp_path),
             current_datasource="warehouse",
-            agentic_nodes={"gen_metrics": {"semantic_adapter": "osi"}},
-            resolve_semantic_adapter=lambda requested=None: requested or "metricflow",
+            resolve_semantic_adapter=lambda requested=None: "osi",
         )
         semantic_rag = MagicMock()
         semantic_rag.get_size.return_value = 0
@@ -674,8 +673,7 @@ class TestEnsureSemanticModelsForMetrics:
         from unittest.mock import patch
 
         config = SimpleNamespace(
-            agentic_nodes={"gen_metrics": {"semantic_adapter": "metricflow"}},
-            resolve_semantic_adapter=lambda requested=None: requested or "metricflow",
+            resolve_semantic_adapter=lambda requested=None: "metricflow",
         )
         records = [{"sql": "SELECT COUNT(*) FROM orders JOIN customers USING (customer_id)", "question": "Orders?"}]
         sql_list = [records[0]["sql"]]

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -146,6 +146,42 @@ metric:
         assert "Refusing to overwrite metric 'order_count'" in result.error
         assert target.read_text(encoding="utf-8") == original
 
+    def test_osi_authoring_skips_metricflow_merge(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+semantic_model:
+  - name: ac_manage
+    datasets:
+      - name: orders
+        source:
+          table: orders
+""".lstrip(),
+            encoding="utf-8",
+        )
+        tool = MetricFilesystemFuncTool(
+            root_path=str(project),
+            current_node="gen_metrics",
+            authoring_format="osi",
+        )
+        incoming = """
+semantic_model:
+  - name: ac_manage
+    datasets:
+      - name: orders
+        source:
+          table: orders
+        fields:
+          - name: amount
+""".lstrip()
+
+        result = tool.write_file("subject/semantic_models/ac_manage/orders.yml", incoming)
+
+        assert result.success == 1
+        assert target.read_text(encoding="utf-8") == incoming
+
     def test_write_file_strict_external_path_is_rejected_before_merge(self, tmp_path, monkeypatch):
         project = tmp_path / "project"
         project.mkdir()

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -489,7 +489,8 @@ class TestStaticHelpers:
         incoming = {"sql_table": "different_table"}
         err = MetricFilesystemFuncTool._merge_stable_scalar(merged, incoming, "sql_table", "orders")
         assert err != ""
-        assert "original_table" in err or "different_table" in err
+        assert "original_table" in err
+        assert "different_table" in err
 
     def test_merge_data_sources_name_conflict_returns_error(self):
         tool = MetricFilesystemFuncTool.__new__(MetricFilesystemFuncTool)


### PR DESCRIPTION
## Summary
- Add global semantic adapter resolution so generation, query, AskMetrics, and BI bootstrap flows use one project-level semantic layer.
- Prepare OSI authoring for semantic-model and metric generation while preserving MetricFlow as the current default when no semantic adapter is configured.
- Update OSI prompts, docs, and tests so datasource dialect follows the active datasource type and node-level semantic-format overrides are ignored.

## Impact
- Existing projects without semantic adapter config continue to resolve to MetricFlow.
- Projects can opt into OSI through semantic adapter configuration without node-level overrides.
- This does not switch the default to OSI yet and does not add query-time compare behavior.

## Validation
- git diff --check
- uv run pytest tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py tests/unit_tests/cli/test_service_config_app.py tests/unit_tests/configuration/test_agent_config.py tests/unit_tests/storage/metric/test_metric_init.py tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
- uv run --with-requirements requirements-docs.txt mkdocs build --strict

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the OSI semantic layer globally.
  * OSI workflows now use the appropriate expression dialect automatically.
  * The CLI now recognizes OSI as a built-in semantic adapter option.

* **Bug Fixes**
  * Semantic authoring and generation now rely on the active global semantic layer instead of node-specific settings.
  * OSI and MetricFlow validation/sync flows now follow the correct path consistently.
  * Non-MetricFlow authoring now preserves OSI-formatted content without unwanted merging.

* **Documentation**
  * Updated configuration guides and adapter docs to reflect the new global semantic-layer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global OSI semantic-layer support for semantic models and related workflows.
  * Expanded the semantic adapter picker to include both MetricFlow and OSI.
* **Bug Fixes**
  * Semantic authoring/format selection now follows the active global semantic layer (legacy per-node semantic fields are ignored).
  * OSI-specific semantic YAML validation and synchronization are enabled.
  * Prevented redundant KB sync work when it was already completed by the generation step.
* **Documentation**
  * Updated semantic adapter, OSI/MetricFlow, and agent configuration guides to reflect global selection and the new OSI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->