### PR TITLE
[Doc] Document semantic SQL history profiler skill

### DIFF
--- a/docs/subagent/gen_semantic_model.md
+++ b/docs/subagent/gen_semantic_model.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The semantic model generation feature helps you create semantic models from database tables through an AI-powered assistant. The authored YAML format is selected by the configured semantic adapter: `metricflow` generates MetricFlow YAML, while `osi` generates strict OSI core YAML. The assistant analyzes your table structure and generates configuration files for the selected adapter.
+The semantic model generation feature helps you create semantic models from database tables through an AI-powered assistant. The YAML format is selected by the configured semantic adapter: `metricflow` generates MetricFlow YAML, while `osi` generates strict OSI core YAML. The assistant analyzes your table structure and generates configuration files for the selected adapter.
 
 ## What is a Semantic Model?
 
@@ -60,11 +60,40 @@ agent:
       model: claude      # Optional: defaults to configured model
       max_turns: 30      # Optional: defaults to 30
       semantic_adapter: metricflow   # Optional when only one semantic layer is configured
+      # Optional: enable historical SQL profiling before YAML generation.
+      # Keep the default MetricFlow semantic-model skill when overriding skills.
+      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
 ```
 
 See [Semantic Layer Configuration](../configuration/semantic_layer.md) for the full set of options.
 
-For OSI authoring, see [OSI Semantic Adapter](../adapters/osi_semantic_adapter.md).
+For OSI generation, see [OSI Semantic Adapter](../adapters/osi_semantic_adapter.md).
+
+### Optional Historical SQL Profiling
+
+`semantic-sql-history-profiler` is an internal skill for `gen_semantic_model`, not a chat command or user-invocable skill. Enable it on the `gen_semantic_model` node when you want semantic-model generation to use historical SQL or success-story SQL as modeling evidence.
+
+When the skill is available and the request includes historical SQL or success-story SQL, the subagent loads it before generating YAML and calls `profile_semantic_model_evidence`. The evidence is used to infer join relationships, commonly filtered or grouped dimensions, aggregate candidates, time fields, compact distribution notes, and relationship reliability hints.
+
+For MetricFlow generation, keep the default MetricFlow semantic-model skill when you override `skills`:
+
+```yaml
+agent:
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: metricflow
+      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
+```
+
+For OSI generation, enable only the profiler unless you intentionally need another skill:
+
+```yaml
+agent:
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: osi
+      skills: "semantic-sql-history-profiler"
+```
 
 **Built-in configurations** (automatically enabled):
 - **Tools**: Database tools, generation tools, and filesystem tools

--- a/docs/subagent/gen_semantic_model.zh.md
+++ b/docs/subagent/gen_semantic_model.zh.md
@@ -2,7 +2,7 @@
 
 ## 概览
 
-语义模型生成功能帮助你通过 AI 助手从数据库表创建语义模型。具体 YAML authoring format 由配置的 semantic adapter 决定：`metricflow` 生成 MetricFlow YAML，`osi` 生成 strict OSI core YAML。助手会分析表结构，并按所选适配器生成配置文件。
+语义模型生成功能帮助你通过 AI 助手从数据库表创建语义模型。具体 YAML 格式由配置的 semantic adapter 决定：`metricflow` 生成 MetricFlow YAML，`osi` 生成 strict OSI core YAML。助手会分析表结构，并按所选适配器生成配置文件。
 
 ## 什么是语义模型？
 
@@ -58,11 +58,40 @@ agent:
       model: claude      # 可选：默认使用已配置的模型
       max_turns: 30      # 可选：默认为 30
       semantic_adapter: metricflow   # 当仅配置了一个 semantic layer 时可省略
+      # 可选：在生成 YAML 前启用历史 SQL profiling。
+      # 覆盖 skills 时，需要同时保留默认的 MetricFlow 语义模型 skill。
+      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
 ```
 
 完整配置项见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
-OSI authoring 见 [OSI 语义适配器](../adapters/osi_semantic_adapter.zh.md)。
+OSI 生成见 [OSI 语义适配器](../adapters/osi_semantic_adapter.zh.md)。
+
+### 可选的历史 SQL Profiling
+
+`semantic-sql-history-profiler` 是 `gen_semantic_model` 使用的内部 skill，不是聊天命令，也不能由用户直接调用。需要让语义模型生成基于历史 SQL 或 success-story SQL 做建模证据分析时，可以在 `gen_semantic_model` 节点上启用它。
+
+当该 skill 可用，并且请求中包含历史 SQL 或 success-story SQL 时，subagent 会在生成 YAML 前加载它，并调用 `profile_semantic_model_evidence`。这些证据会用于推断 JOIN 关系、常见过滤或分组维度、聚合候选、时间字段、简洁的数据分布说明，以及关系可靠性提示。
+
+MetricFlow 生成场景下，如果覆盖 `skills`，需要把默认语义模型 skill 一起列出：
+
+```yaml
+agent:
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: metricflow
+      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
+```
+
+OSI 生成场景下，除非明确需要其他 skill，通常只启用 profiler：
+
+```yaml
+agent:
+  agentic_nodes:
+    gen_semantic_model:
+      semantic_adapter: osi
+      skills: "semantic-sql-history-profiler"
+```
 
 **内置配置**（自动启用）：
 - **工具**：数据库工具、生成工具和文件系统工具


### PR DESCRIPTION
## Summary

- Document the optional `semantic-sql-history-profiler` skill in the `gen_semantic_model` guide.
- Add English and Chinese configuration examples for enabling the profiler with MetricFlow and OSI semantic model generation.
- Clarify that the profiler is an internal `gen_semantic_model` skill that uses historical SQL or success-story SQL as modeling evidence before YAML generation.

## Validation

- `git diff --check`
- `uv run --with-requirements requirements-docs.txt mkdocs build --strict --site-dir /tmp/datus-docs-build-semantic-profiler`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how semantic model YAML formatting is determined in the overview.
  * Added guidance for optional historical SQL profiling when generating semantic models.
  * Included updated configuration examples for MetricFlow and OSI setups.
  * Explained when profiling is used and what evidence it can rely on during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->