### PR TITLE
[Enhancement] Add opt-in FTS metadata retrieval with LanceDB 0.34

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -19,7 +19,7 @@ from datus.models.base import LLMBaseModel
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
 from datus.schemas.batch_events import BatchEvent, BatchStage
 from datus.schemas.node_models import SqlTask
-from datus.storage.kb_retrieval import KbSearchMode, metadata_fts_enabled
+from datus.storage.kb_retrieval import KbSearchMode, metadata_fts_enabled, resolve_kb_search_mode
 from datus.storage.metric.metric_init import init_semantic_yaml_metrics, init_success_story_metrics
 from datus.storage.metric.store import MetricRAG
 from datus.storage.schema_metadata import SchemaWithValueRAG, create_metadata_rag
@@ -419,12 +419,13 @@ class Agent:
             # Initialize corresponding stores
             if component == "metadata":
                 use_fts_metadata = metadata_fts_enabled(self.global_config)
-                search_mode = getattr(self.global_config, "kb_search_mode", KbSearchMode.FTS.value)
+                search_mode = resolve_kb_search_mode(self.global_config)
+                needs_database_storage = (not use_fts_metadata) or search_mode == KbSearchMode.HYBRID
                 if kb_update_strategy == "check":
                     if not os.path.exists(dir_path):
                         raise ValueError("metadata is not built, please run bootstrap_kb with overwrite strategy first")
                     else:
-                        if not use_fts_metadata:
+                        if needs_database_storage:
                             self.global_config.check_init_storage_config("database")
 
                         self.metadata_store = (
@@ -443,7 +444,6 @@ class Agent:
                         results[component] = result
                         continue
 
-                needs_database_storage = (not use_fts_metadata) or search_mode == KbSearchMode.HYBRID.value
                 if needs_database_storage:
                     if kb_update_strategy == "overwrite":
                         self.global_config.save_storage_config("database")
@@ -764,7 +764,7 @@ class Agent:
             self.global_config.check_init_storage_config("metric")
             result = self.benchmark_semantic_layer(benchmark_path, target_task_ids, run_id=run_id)
         else:
-            if getattr(self.global_config, "kb_search_mode", KbSearchMode.FTS.value) == KbSearchMode.HYBRID.value:
+            if resolve_kb_search_mode(self.global_config) == KbSearchMode.HYBRID:
                 self.global_config.check_init_storage_config("database")
             self.global_config.check_init_storage_config("metric")
             result = self.do_benchmark(benchmark_platform, target_task_ids, run_id=run_id)

--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -420,7 +420,7 @@ class Agent:
             if component == "metadata":
                 use_fts_metadata = metadata_fts_enabled(self.global_config)
                 search_mode = resolve_kb_search_mode(self.global_config)
-                needs_database_storage = (not use_fts_metadata) or search_mode == KbSearchMode.HYBRID
+                needs_database_storage = not use_fts_metadata
                 if kb_update_strategy == "check":
                     if not os.path.exists(dir_path):
                         raise ValueError("metadata is not built, please run bootstrap_kb with overwrite strategy first")
@@ -433,6 +433,8 @@ class Agent:
                             if use_fts_metadata
                             else SchemaWithValueRAG(self.global_config)
                         )
+                        if use_fts_metadata:
+                            self.metadata_store.check_ready()
                         result = {
                             "status": "success",
                             "message": f"current metadata is already built, "
@@ -454,6 +456,8 @@ class Agent:
                     if use_fts_metadata
                     else SchemaWithValueRAG(self.global_config)
                 )
+                if use_fts_metadata and kb_update_strategy == "incremental":
+                    self.metadata_store.check_ready()
                 if kb_update_strategy == "overwrite":
                     self.metadata_store.truncate()
 
@@ -764,7 +768,7 @@ class Agent:
             self.global_config.check_init_storage_config("metric")
             result = self.benchmark_semantic_layer(benchmark_path, target_task_ids, run_id=run_id)
         else:
-            if resolve_kb_search_mode(self.global_config) == KbSearchMode.HYBRID:
+            if resolve_kb_search_mode(self.global_config) == KbSearchMode.VECTOR:
                 self.global_config.check_init_storage_config("database")
             self.global_config.check_init_storage_config("metric")
             result = self.do_benchmark(benchmark_platform, target_task_ids, run_id=run_id)

--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -19,9 +19,10 @@ from datus.models.base import LLMBaseModel
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
 from datus.schemas.batch_events import BatchEvent, BatchStage
 from datus.schemas.node_models import SqlTask
+from datus.storage.kb_retrieval import KbSearchMode, metadata_fts_enabled
 from datus.storage.metric.metric_init import init_semantic_yaml_metrics, init_success_story_metrics
 from datus.storage.metric.store import MetricRAG
-from datus.storage.schema_metadata import SchemaWithValueRAG
+from datus.storage.schema_metadata import SchemaWithValueRAG, create_metadata_rag
 from datus.storage.schema_metadata.benchmark_init import init_snowflake_schema
 from datus.storage.schema_metadata.benchmark_init_bird import init_dev_schema
 from datus.storage.schema_metadata.local_init import init_local_schema
@@ -417,28 +418,42 @@ class Agent:
             # db_name = component_dirs[component]``
             # Initialize corresponding stores
             if component == "metadata":
+                use_fts_metadata = metadata_fts_enabled(self.global_config)
+                search_mode = getattr(self.global_config, "kb_search_mode", KbSearchMode.FTS.value)
                 if kb_update_strategy == "check":
                     if not os.path.exists(dir_path):
                         raise ValueError("metadata is not built, please run bootstrap_kb with overwrite strategy first")
                     else:
-                        self.global_config.check_init_storage_config("database")
+                        if not use_fts_metadata:
+                            self.global_config.check_init_storage_config("database")
 
-                        self.metadata_store = SchemaWithValueRAG(self.global_config)
+                        self.metadata_store = (
+                            create_metadata_rag(self.global_config)
+                            if use_fts_metadata
+                            else SchemaWithValueRAG(self.global_config)
+                        )
                         result = {
                             "status": "success",
                             "message": f"current metadata is already built, "
                             f"dir_path={dir_path},"
+                            f"search_mode={search_mode}, "
                             f"schema_size={self.metadata_store.get_schema_size()}, "
                             f"value_size={self.metadata_store.get_value_size()}",
                         }
                         results[component] = result
                         continue
 
-                if kb_update_strategy == "overwrite":
-                    self.global_config.save_storage_config("database")
-                else:
-                    self.global_config.check_init_storage_config("database")
-                self.metadata_store = SchemaWithValueRAG(self.global_config)
+                needs_database_storage = (not use_fts_metadata) or search_mode == KbSearchMode.HYBRID.value
+                if needs_database_storage:
+                    if kb_update_strategy == "overwrite":
+                        self.global_config.save_storage_config("database")
+                    else:
+                        self.global_config.check_init_storage_config("database")
+                self.metadata_store = (
+                    create_metadata_rag(self.global_config)
+                    if use_fts_metadata
+                    else SchemaWithValueRAG(self.global_config)
+                )
                 if kb_update_strategy == "overwrite":
                     self.metadata_store.truncate()
 
@@ -488,6 +503,7 @@ class Agent:
                 result = {
                     "status": "success",
                     "message": f"metadata bootstrap completed, "
+                    f"search_mode={search_mode}, "
                     f"schema_size={self.metadata_store.get_schema_size()}, "
                     f"value_size={self.metadata_store.get_value_size()}",
                 }
@@ -748,7 +764,8 @@ class Agent:
             self.global_config.check_init_storage_config("metric")
             result = self.benchmark_semantic_layer(benchmark_path, target_task_ids, run_id=run_id)
         else:
-            self.global_config.check_init_storage_config("database")
+            if getattr(self.global_config, "kb_search_mode", KbSearchMode.FTS.value) == KbSearchMode.HYBRID.value:
+                self.global_config.check_init_storage_config("database")
             self.global_config.check_init_storage_config("metric")
             result = self.do_benchmark(benchmark_platform, target_task_ids, run_id=run_id)
         end = time.perf_counter()

--- a/datus/agent/plan.py
+++ b/datus/agent/plan.py
@@ -267,10 +267,10 @@ def generate_workflow(
     for node in nodes:
         workflow.add_node(node)
     if task.tables and agent_config is not None:
-        from datus.storage.schema_metadata import SchemaWithValueRAG
+        from datus.storage.schema_metadata import create_metadata_rag
 
         try:
-            rag = SchemaWithValueRAG(agent_config=agent_config)
+            rag = create_metadata_rag(agent_config)
             schemas, values = rag.search_tables(
                 task.tables, task.catalog_name, task.database_name, task.schema_name, dialect=task.database_type
             )

--- a/datus/agent/workflow_runner.py
+++ b/datus/agent/workflow_runner.py
@@ -11,6 +11,7 @@ from datus.configuration.node_type import NodeType
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.base import BaseResult
 from datus.schemas.node_models import SqlTask
+from datus.storage.kb_retrieval import KbSearchMode, resolve_kb_search_mode
 from datus.utils.loggings import get_logger
 from datus.utils.trace_context import build_workflow_trace_context_from_runner
 from datus.utils.traceable_utils import get_trace_reference, optional_traceable
@@ -145,7 +146,7 @@ class WorkflowRunner:
 
     def _ensure_prerequisites(self, sql_task: Optional[SqlTask], check_storage: bool) -> bool:
         if check_storage:
-            if getattr(self.global_config, "kb_search_mode", "fts") == "hybrid":
+            if resolve_kb_search_mode(self.global_config) == KbSearchMode.HYBRID:
                 self.global_config.check_init_storage_config("database")
             self.global_config.check_init_storage_config("metrics")
 

--- a/datus/agent/workflow_runner.py
+++ b/datus/agent/workflow_runner.py
@@ -145,7 +145,8 @@ class WorkflowRunner:
 
     def _ensure_prerequisites(self, sql_task: Optional[SqlTask], check_storage: bool) -> bool:
         if check_storage:
-            self.global_config.check_init_storage_config("database")
+            if getattr(self.global_config, "kb_search_mode", "fts") == "hybrid":
+                self.global_config.check_init_storage_config("database")
             self.global_config.check_init_storage_config("metrics")
 
         if not self.init_or_load_workflow(sql_task):

--- a/datus/agent/workflow_runner.py
+++ b/datus/agent/workflow_runner.py
@@ -146,7 +146,7 @@ class WorkflowRunner:
 
     def _ensure_prerequisites(self, sql_task: Optional[SqlTask], check_storage: bool) -> bool:
         if check_storage:
-            if resolve_kb_search_mode(self.global_config) == KbSearchMode.HYBRID:
+            if resolve_kb_search_mode(self.global_config) == KbSearchMode.VECTOR:
                 self.global_config.check_init_storage_config("database")
             self.global_config.check_init_storage_config("metrics")
 

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -17,7 +17,7 @@ from datus.storage.metric.metric_init import init_success_story_metrics
 from datus.storage.metric.store import MetricRAG
 from datus.storage.reference_sql import ReferenceSqlRAG
 from datus.storage.reference_sql.reference_sql_init import init_reference_sql
-from datus.storage.schema_metadata import SchemaWithValueRAG
+from datus.storage.schema_metadata import create_metadata_rag
 from datus.storage.schema_metadata.local_init import init_local_schema
 from datus.storage.semantic_model.semantic_model_init import (
     init_success_story_semantic_model,
@@ -222,7 +222,7 @@ class KbService:
         emit=None,
     ) -> dict:
         if strategy == "check":
-            store = SchemaWithValueRAG(config)
+            store = create_metadata_rag(config)
             return {
                 "status": "success",
                 "message": f"metadata already built, schema_size={store.get_schema_size()}, "
@@ -230,11 +230,11 @@ class KbService:
             }
 
         if strategy == "overwrite":
-            store = SchemaWithValueRAG(config)
+            store = create_metadata_rag(config)
             store.truncate()
             logger.info("Truncated schema metadata tables for overwrite")
 
-        store = SchemaWithValueRAG(config)
+        store = create_metadata_rag(config)
         db_manager = DBManager(config.datasource_configs)
         init_local_schema(
             store,

--- a/datus/cli/agent_commands.py
+++ b/datus/cli/agent_commands.py
@@ -400,9 +400,9 @@ class AgentCommands:
         # The PDF mentions table_type, but the tool implementation has it fixed to "full".
         # I will omit prompting for it as it won't be used.
 
-        from datus.storage.schema_metadata import SchemaWithValueRAG
+        from datus.storage.schema_metadata import create_metadata_rag
 
-        schema_rag = SchemaWithValueRAG(self.cli.agent_config)
+        schema_rag = create_metadata_rag(self.cli.agent_config)
 
         try:
             with self.console.status("[green]Searching for relevant tables...[/]"):

--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -680,12 +680,12 @@ class TableCompleter(DynamicAtReferenceCompleter):
         self.sub_agent_name = sub_agent_name
 
     def _build_snapshot(self) -> Tuple[Union[List[str], Dict[str, Any]], Dict[str, Any], int]:
-        from datus.storage.schema_metadata.store import SchemaWithValueRAG
+        from datus.storage.schema_metadata import create_metadata_rag
 
         flatten: Dict[str, Any] = {}
         max_level = 0
 
-        storage = SchemaWithValueRAG(self.agent_config, sub_agent_name=self.sub_agent_name or None)
+        storage = create_metadata_rag(self.agent_config, sub_agent_name=self.sub_agent_name or None)
         try:
             schema_table = storage.search_all_schemas(
                 select_fields=[

--- a/datus/cli/background_sync.py
+++ b/datus/cli/background_sync.py
@@ -137,8 +137,8 @@ class BackgroundSchemaSyncManager:
     ) -> None:
         # Defer imports to avoid pulling storage stack into CLI startup
         # when the feature is disabled.
+        from datus.storage.schema_metadata import create_metadata_rag
         from datus.storage.schema_metadata.local_init import init_local_schema_async
-        from datus.storage.schema_metadata.store import SchemaWithValueRAG
 
         try:
             # Drift guard: main thread may have switched datasource again
@@ -154,7 +154,7 @@ class BackgroundSchemaSyncManager:
                 )
                 return
 
-            store = SchemaWithValueRAG(cli.agent_config)
+            store = create_metadata_rag(cli.agent_config)
             if reason == "startup":
                 cache_ready, reason_message = self._embedding_cache_ready_for_noncritical_sync(store)
                 if not cache_ready:

--- a/datus/cli/bootstrap_bi_streams.py
+++ b/datus/cli/bootstrap_bi_streams.py
@@ -85,8 +85,8 @@ async def stream_bi_metadata(
     it crawls the configured datasource end-to-end. We log the requested
     scope on entry so the operator can see what's expected.
     """
+    from datus.storage.schema_metadata import create_metadata_rag
     from datus.storage.schema_metadata.local_init import init_local_schema_async
-    from datus.storage.schema_metadata.store import SchemaWithValueRAG
     from datus.tools.db_tools.db_manager import db_manager_instance
 
     if not table_names:
@@ -95,7 +95,7 @@ async def stream_bi_metadata(
 
     yield message_action(f"Crawling metadata for {len(table_names)} table(s)…")
 
-    metadata_store = SchemaWithValueRAG(agent_config)
+    metadata_store = create_metadata_rag(agent_config)
     db_manager = db_manager_instance(agent_config.datasource_configs)
 
     async def _factory(emit: Callable[[BatchEvent], None]):

--- a/datus/cli/bootstrap_streams.py
+++ b/datus/cli/bootstrap_streams.py
@@ -271,8 +271,8 @@ async def stream_metadata(
     ``pool_size`` are kept at sensible defaults; the simplified ``/bootstrap``
     Schema tab does not expose them.
     """
+    from datus.storage.schema_metadata import create_metadata_rag
     from datus.storage.schema_metadata.local_init import init_local_schema_async
-    from datus.storage.schema_metadata.store import SchemaWithValueRAG
     from datus.tools.db_tools.db_manager import db_manager_instance
 
     if not datasource:
@@ -283,7 +283,7 @@ async def stream_metadata(
 
     yield message_action(f"Crawling schema from datasource `{datasource}` (mode={build_mode})…")
 
-    metadata_store = SchemaWithValueRAG(agent_config)
+    metadata_store = create_metadata_rag(agent_config)
     db_manager = db_manager_instance(agent_config.datasource_configs)
 
     async def _factory(emit):

--- a/datus/cli/interactive_init.py
+++ b/datus/cli/interactive_init.py
@@ -714,7 +714,6 @@ class ReferenceSqlStreamHandler:
 def init_metadata_and_log_result(datasource_name: str, config_path: str, console: Console):
     from datus.configuration.agent_config_loader import load_agent_config
     from datus.storage.schema_metadata.local_init import init_local_schema
-    from datus.storage.schema_metadata.store import SchemaWithValueRAG
     from datus.tools.db_tools.db_manager import db_manager_instance
 
     agent_config = load_agent_config(reload=True, config=config_path)
@@ -724,7 +723,14 @@ def init_metadata_and_log_result(datasource_name: str, config_path: str, console
 
     with console.status(f"→ Initializing metadata for {datasource_name} with path `{storage_path}`..."):
         try:
-            if kb_update_strategy == "overwrite":
+            from datus.storage.kb_retrieval import KbSearchMode, metadata_fts_enabled
+            from datus.storage.schema_metadata import create_metadata_rag
+
+            if metadata_fts_enabled(agent_config) and agent_config.kb_search_mode != KbSearchMode.HYBRID.value:
+                metadata_store = create_metadata_rag(agent_config)
+                if kb_update_strategy == "overwrite":
+                    metadata_store.truncate()
+            elif kb_update_strategy == "overwrite":
                 agent_config.save_storage_config("database")
                 from datus.storage.backend_holder import create_vector_connection
 
@@ -735,10 +741,11 @@ def init_metadata_and_log_result(datasource_name: str, config_path: str, console
                     logger.info("Dropped existing schema_metadata and schema_value tables")
                 finally:
                     db.close()
+                metadata_store = create_metadata_rag(agent_config)
             else:
                 agent_config.check_init_storage_config("database")
+                metadata_store = create_metadata_rag(agent_config)
 
-            metadata_store = SchemaWithValueRAG(agent_config)
             db_manager = db_manager_instance(agent_config.datasource_configs)
             init_local_schema(
                 metadata_store,

--- a/datus/cli/interactive_init.py
+++ b/datus/cli/interactive_init.py
@@ -723,10 +723,10 @@ def init_metadata_and_log_result(datasource_name: str, config_path: str, console
 
     with console.status(f"→ Initializing metadata for {datasource_name} with path `{storage_path}`..."):
         try:
-            from datus.storage.kb_retrieval import KbSearchMode, metadata_fts_enabled
+            from datus.storage.kb_retrieval import metadata_fts_enabled
             from datus.storage.schema_metadata import create_metadata_rag
 
-            if metadata_fts_enabled(agent_config) and agent_config.kb_search_mode != KbSearchMode.HYBRID.value:
+            if metadata_fts_enabled(agent_config):
                 metadata_store = create_metadata_rag(agent_config)
                 if kb_update_strategy == "overwrite":
                     metadata_store.truncate()

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1838,7 +1838,12 @@ class AgentConfig:
         if kwargs.get("search_metrics_rate", ""):
             self.search_metrics_rate = kwargs["search_metrics_rate"]
         if kwargs.get("kb_search_mode", ""):
-            self.kb_search = KbSearchConfig.from_dict({"mode": kwargs["kb_search_mode"]})
+            self.kb_search = KbSearchConfig.from_dict(
+                {
+                    "enabled": getattr(getattr(self, "kb_search", None), "enabled", True),
+                    "mode": kwargs["kb_search_mode"],
+                }
+            )
             self.kb_search_mode = self.kb_search.mode
         if kwargs.get("plan", ""):
             self.workflow_plan = kwargs["plan"]

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -218,25 +218,23 @@ class CompactConfig:
 class KbSearchConfig:
     """Knowledge-base retrieval mode shared by bootstrap and runtime search."""
 
-    enabled: bool = True
-    mode: str = "fts"
+    mode: str = "vector"
 
     @classmethod
     def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "KbSearchConfig":
         if not isinstance(raw, dict):
             raw = {}
-        enabled = _coerce_bool(raw.get("enabled"), True)
-        mode = str(raw.get("mode") or "fts").strip().lower()
-        if mode not in {"fts", "hybrid"}:
+        mode = str(raw.get("mode") or "vector").strip().lower()
+        if mode not in {"vector", "fts"}:
             raise DatusException(
                 code=ErrorCode.COMMON_FIELD_INVALID,
                 message_args={
                     "field_name": "kb.search.mode",
-                    "except_values": {"fts", "hybrid"},
+                    "except_values": {"vector", "fts"},
                     "your_value": mode,
                 },
             )
-        return cls(enabled=enabled, mode=mode)
+        return cls(mode=mode)
 
 
 @dataclass
@@ -1838,12 +1836,7 @@ class AgentConfig:
         if kwargs.get("search_metrics_rate", ""):
             self.search_metrics_rate = kwargs["search_metrics_rate"]
         if kwargs.get("kb_search_mode", ""):
-            self.kb_search = KbSearchConfig.from_dict(
-                {
-                    "enabled": getattr(getattr(self, "kb_search", None), "enabled", True),
-                    "mode": kwargs["kb_search_mode"],
-                }
-            )
+            self.kb_search = KbSearchConfig.from_dict({"mode": kwargs["kb_search_mode"]})
             self.kb_search_mode = self.kb_search.mode
         if kwargs.get("plan", ""):
             self.workflow_plan = kwargs["plan"]

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -215,6 +215,31 @@ class CompactConfig:
 
 
 @dataclass
+class KbSearchConfig:
+    """Knowledge-base retrieval mode shared by bootstrap and runtime search."""
+
+    enabled: bool = True
+    mode: str = "fts"
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "KbSearchConfig":
+        if not isinstance(raw, dict):
+            raw = {}
+        enabled = _coerce_bool(raw.get("enabled"), True)
+        mode = str(raw.get("mode") or "fts").strip().lower()
+        if mode not in {"fts", "hybrid"}:
+            raise DatusException(
+                code=ErrorCode.COMMON_FIELD_INVALID,
+                message_args={
+                    "field_name": "kb.search.mode",
+                    "except_values": {"fts", "hybrid"},
+                    "your_value": mode,
+                },
+            )
+        return cls(enabled=enabled, mode=mode)
+
+
+@dataclass
 class DbConfig:
     path_pattern: str = field(default="", init=True)
     type: str = field(default="", init=True)
@@ -790,6 +815,14 @@ class AgentConfig:
         self.knowledge_base: Dict[str, Any] = (
             _resolve_nested_value(knowledge_base_raw) if isinstance(knowledge_base_raw, dict) else {}
         )
+        kb_raw = kwargs.get("kb", {}) or {}
+        if not isinstance(kb_raw, dict):
+            kb_raw = {}
+        kb_search_raw = kb_raw.get("search")
+        if not isinstance(kb_search_raw, dict) and isinstance(self.knowledge_base.get("search"), dict):
+            kb_search_raw = self.knowledge_base.get("search")
+        self.kb_search = KbSearchConfig.from_dict(_resolve_nested_value(kb_search_raw))
+        self.kb_search_mode = self.kb_search.mode
         # ``filesystem_strict`` is a process-wide safety switch that makes
         # ``FilesystemFuncTool`` fail-closed for EXTERNAL paths (outside the
         # project root) instead of prompting the broker. Set via
@@ -1804,6 +1837,9 @@ class AgentConfig:
             self.schema_linking_rate = kwargs["schema_linking_rate"]
         if kwargs.get("search_metrics_rate", ""):
             self.search_metrics_rate = kwargs["search_metrics_rate"]
+        if kwargs.get("kb_search_mode", ""):
+            self.kb_search = KbSearchConfig.from_dict({"mode": kwargs["kb_search_mode"]})
+            self.kb_search_mode = self.kb_search.mode
         if kwargs.get("plan", ""):
             self.workflow_plan = kwargs["plan"]
         if kwargs.get("action", "") not in ["probe-llm", "generate-dataset", "service", "platform-doc"]:

--- a/datus/main.py
+++ b/datus/main.py
@@ -234,9 +234,9 @@ def create_parser() -> argparse.ArgumentParser:
     bootstrap_parser.add_argument(
         "--kb_search_mode",
         type=str,
-        choices=["fts", "hybrid"],
+        choices=["vector", "fts"],
         default="",
-        help="Knowledge-base search mode for metadata indexing and runtime retrieval (default: config or fts)",
+        help="Knowledge-base search mode for metadata indexing and runtime retrieval (default: config or vector)",
     )
     bootstrap_parser.add_argument(
         "--success_story",

--- a/datus/main.py
+++ b/datus/main.py
@@ -232,6 +232,13 @@ def create_parser() -> argparse.ArgumentParser:
         help="Number of threads to initialize bootstrap-kb, default is 4",
     )
     bootstrap_parser.add_argument(
+        "--kb_search_mode",
+        type=str,
+        choices=["fts", "hybrid"],
+        default="",
+        help="Knowledge-base search mode for metadata indexing and runtime retrieval (default: config or fts)",
+    )
+    bootstrap_parser.add_argument(
         "--success_story",
         type=str,
         default="benchmark/semantic_layer/success_story.csv",

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -566,6 +566,7 @@ class BaseEmbeddingStore(StorageBase):
         top_n: Optional[int] = None,
         where: WhereExpr = None,
         query_type: str = "vector",
+        allow_hybrid_fallback: bool = True,
     ) -> pa.Table:
         table = self._open_existing_table_for_read()
         if table is None:
@@ -578,7 +579,9 @@ class BaseEmbeddingStore(StorageBase):
         self._ensure_table_ready()
 
         if query_type == "hybrid":
-            search_result = self._search_hybrid(query_txt, select_fields, top_n, where)
+            search_result = self._search_hybrid(
+                query_txt, select_fields, top_n, where, allow_fallback=allow_hybrid_fallback
+            )
         else:
             search_result = self._search_vector(query_txt, select_fields, top_n, where)
         if self.vector_column_name in search_result.column_names:
@@ -591,6 +594,7 @@ class BaseEmbeddingStore(StorageBase):
         select_fields: Optional[List[str]] = None,
         top_n: Optional[int] = None,
         where: WhereExpr = None,
+        allow_fallback: bool = True,
     ) -> pa.Table:
         try:
             if not top_n:
@@ -606,6 +610,9 @@ class BaseEmbeddingStore(StorageBase):
                 results = results[:top_n]
             return results
         except Exception as e:
+            if allow_fallback:
+                logger.warning("Hybrid search failed for %s; falling back to vector search: %s", self.table_name, e)
+                return self._search_vector(query_txt, select_fields, top_n, where)
             raise DatusException(
                 ErrorCode.STORAGE_SEARCH_FAILED,
                 message_args={

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -21,6 +21,7 @@ from datus.storage.datasource_scope import (
     datasource_condition,
 )
 from datus.storage.embedding_models import EmbeddingModel
+from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -400,15 +401,39 @@ class BaseEmbeddingStore(StorageBase):
         except Exception as e:
             logger.warning(f"Failed to create vector index for {self.table_name}: {str(e)}")
 
-    def create_fts_index(self, field_names: Union[str, List[str]]):
-        """Create a full-text search index (LanceDB only)."""
+    def create_fts_index(self, fields: Union[str, List[str], FtsSpec]):
+        """Create and verify one native FTS index per configured field."""
         self._ensure_table_ready()
         if not self._supports_runtime_indexing():
             return
+        if isinstance(fields, FtsSpec):
+            spec = fields
+        elif isinstance(fields, str):
+            spec = FtsSpec((FtsField(fields),))
+        else:
+            spec = FtsSpec.from_names(fields)
+
+        remove_legacy = getattr(self.table, "remove_legacy_fts_index", None)
+        if remove_legacy is not None and remove_legacy():
+            logger.info("Removed legacy Tantivy FTS index for %s before rebuilding", self.table_name)
+
         try:
-            self.table.create_fts_index(field_names)
-        except Exception as e:
-            logger.warning(f"Failed to create fts index for {self.table_name} table: {str(e)}")
+            for field in spec.fields:
+                self.table.create_fts_index(field)
+            status_fn = getattr(self.table, "fts_index_status", None)
+            if status_fn is not None:
+                status = status_fn(spec)
+                if status != FtsIndexStatus.READY:
+                    raise RuntimeError(f"FTS index verification returned {status}")
+        except Exception as exc:
+            raise DatusException(
+                ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                message_args={
+                    "operation": "create_fts_index",
+                    "table_name": self.table_name,
+                    "error_message": str(exc),
+                },
+            ) from exc
 
     def store_batch(self, data: List[Dict[str, Any]]):
         """

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -597,7 +597,7 @@ class BaseEmbeddingStore(StorageBase):
                 top_n = self.table.count_rows(where) if where else self.table.count_rows()
             results = self.table.search_hybrid(
                 query_txt,
-                self.vector_source_name,
+                self.vector_column_name,
                 top_n,
                 where=where,
                 select_fields=select_fields,
@@ -606,8 +606,15 @@ class BaseEmbeddingStore(StorageBase):
                 results = results[:top_n]
             return results
         except Exception as e:
-            logger.warning(f"Failed to search hybrid: {str(e)}, use vector search instead")
-            return self._search_vector(query_txt, select_fields, top_n, where)
+            raise DatusException(
+                ErrorCode.STORAGE_SEARCH_FAILED,
+                message_args={
+                    "error_message": str(e),
+                    "query": query_txt,
+                    "where_clause": str(where) if where else "(none)",
+                    "top_n": str(top_n or "all"),
+                },
+            ) from e
 
     def _search_vector(
         self,

--- a/datus/storage/document/doc_init.py
+++ b/datus/storage/document/doc_init.py
@@ -458,12 +458,14 @@ def init_platform_docs(
         )
 
     # Create indices once after all processing is complete
+    indices_ready = True
     if stats.total_chunks > 0:
         try:
             store.create_indices()
         except Exception as e:
             logger.error(f"Failed to create indices: {e}")
             stats.add_error(f"Index error: {str(e)}")
+            indices_ready = False
 
     duration = (datetime.now(timezone.utc) - start_time).total_seconds()
 
@@ -489,7 +491,7 @@ def init_platform_docs(
         source=source,
         total_docs=stats.total_docs,
         total_chunks=stats.total_chunks,
-        success=len(stats.errors) == 0 or stats.total_chunks > 0,
+        success=indices_ready and (len(stats.errors) == 0 or stats.total_chunks > 0),
         errors=stats.errors,
         duration_seconds=duration,
     )

--- a/datus/storage/document/store.py
+++ b/datus/storage/document/store.py
@@ -26,6 +26,7 @@ from datus_storage_base.conditions import And, Condition, WhereExpr, eq, in_
 from datus.storage.base import BaseEmbeddingStore
 from datus.storage.document.schemas import PlatformDocChunk
 from datus.storage.embedding_models import EmbeddingModel, get_document_embedding_model
+from datus.storage.fts import FtsField, FtsSpec
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -388,7 +389,15 @@ class DocumentStore(BaseEmbeddingStore):
         self._ensure_table_ready()
 
         self.create_vector_index(metric="cosine")
-        self.create_fts_index(field_names=["chunk_text", "title", "hierarchy"])
+        self.create_fts_index(
+            FtsSpec(
+                (
+                    FtsField("title", boost=3.0),
+                    FtsField("hierarchy", boost=2.0),
+                    FtsField("chunk_text"),
+                )
+            )
+        )
 
         logger.info(f"Created indices for table '{self.TABLE_NAME}'")
 

--- a/datus/storage/fts.py
+++ b/datus/storage/fts.py
@@ -1,0 +1,69 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Backend-independent full-text index definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class FtsField:
+    """A searchable text field and its index/query configuration."""
+
+    name: str
+    boost: float = 1.0
+    tokenizer: str = "simple"
+    ngram_min_length: int = 2
+    ngram_max_length: int = 2
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("FTS field name must not be empty")
+        if self.boost <= 0:
+            raise ValueError("FTS field boost must be positive")
+        if self.tokenizer not in {"simple", "raw", "whitespace", "ngram"}:
+            raise ValueError(f"Unsupported FTS tokenizer: {self.tokenizer}")
+        if self.tokenizer == "ngram" and not (0 < self.ngram_min_length <= self.ngram_max_length):
+            raise ValueError("Invalid FTS ngram length range")
+
+
+@dataclass(frozen=True)
+class FtsSpec:
+    """The complete FTS contract for one table."""
+
+    fields: tuple[FtsField, ...]
+    version: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.fields:
+            raise ValueError("FTS spec must contain at least one field")
+        names = [field.name for field in self.fields]
+        if len(names) != len(set(names)):
+            raise ValueError("FTS field names must be unique")
+        if self.version < 1:
+            raise ValueError("FTS spec version must be positive")
+
+    @classmethod
+    def from_names(cls, names: Iterable[str], *, version: int = 1) -> "FtsSpec":
+        return cls(tuple(FtsField(name) for name in names), version=version)
+
+    @property
+    def columns(self) -> list[str]:
+        return [field.name for field in self.fields]
+
+    @property
+    def boosts(self) -> list[float]:
+        return [field.boost for field in self.fields]
+
+
+class FtsIndexStatus(StrEnum):
+    READY = "ready"
+    MISSING = "missing"
+    LEGACY = "legacy"
+    VERSION_MISMATCH = "version_mismatch"
+    UNSUPPORTED = "unsupported"

--- a/datus/storage/kb_retrieval/__init__.py
+++ b/datus/storage/kb_retrieval/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from .store import KbSearchMode, MetadataFtsRAG, metadata_fts_enabled
+
+__all__ = ["KbSearchMode", "MetadataFtsRAG", "metadata_fts_enabled"]

--- a/datus/storage/kb_retrieval/__init__.py
+++ b/datus/storage/kb_retrieval/__init__.py
@@ -2,6 +2,6 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from .store import KbSearchMode, MetadataFtsRAG, metadata_fts_enabled
+from .store import KbSearchMode, MetadataFtsRAG, metadata_fts_enabled, resolve_kb_search_mode
 
-__all__ = ["KbSearchMode", "MetadataFtsRAG", "metadata_fts_enabled"]
+__all__ = ["KbSearchMode", "MetadataFtsRAG", "metadata_fts_enabled", "resolve_kb_search_mode"]

--- a/datus/storage/kb_retrieval/store.py
+++ b/datus/storage/kb_retrieval/store.py
@@ -18,9 +18,9 @@ from datus_storage_base.conditions import And, Node, WhereExpr, and_, eq, in_, o
 
 from datus.schemas.base import TABLE_TYPE
 from datus.schemas.node_models import TableSchema, TableValue
-from datus.storage.base import BaseEmbeddingStore, StorageBase
+from datus.storage.base import StorageBase
 from datus.storage.datasource_scope import DATASOURCE_ID_COLUMN, datasource_condition, resolve_datasource_id
-from datus.storage.embedding_models import EmbeddingModel
+from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec
 from datus.tools.db_tools import connector_registry
 from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
@@ -34,8 +34,8 @@ logger = get_logger(__name__)
 
 
 class KbSearchMode(StrEnum):
+    VECTOR = "vector"
     FTS = "fts"
-    HYBRID = "hybrid"
 
 
 def resolve_kb_search_mode(agent_config: Any) -> KbSearchMode:
@@ -44,27 +44,15 @@ def resolve_kb_search_mode(agent_config: Any) -> KbSearchMode:
     kb_search = getattr(agent_config, "kb_search", None)
     mode = getattr(kb_search, "mode", None) if kb_search is not None else None
     if not isinstance(mode, str) or not mode.strip():
-        mode = getattr(agent_config, "kb_search_mode", KbSearchMode.FTS.value)
-    mode = str(mode or KbSearchMode.FTS.value).strip().lower()
-    return KbSearchMode.HYBRID if mode == KbSearchMode.HYBRID.value else KbSearchMode.FTS
+        mode = getattr(agent_config, "kb_search_mode", KbSearchMode.VECTOR.value)
+    mode = str(mode or KbSearchMode.VECTOR.value).strip().lower()
+    return KbSearchMode.FTS if mode == KbSearchMode.FTS.value else KbSearchMode.VECTOR
 
 
 def metadata_fts_enabled(agent_config: Any) -> bool:
-    """Return True when public KB search config enables the metadata retrieval path."""
+    """Return True when the public KB search mode selects the metadata FTS path."""
 
-    kb_search = getattr(agent_config, "kb_search", None)
-    if kb_search is None:
-        return False
-    enabled = getattr(kb_search, "enabled", None)
-    return (
-        isinstance(enabled, bool)
-        and enabled
-        and resolve_kb_search_mode(agent_config)
-        in {
-            KbSearchMode.FTS,
-            KbSearchMode.HYBRID,
-        }
-    )
+    return resolve_kb_search_mode(agent_config) == KbSearchMode.FTS
 
 
 def _search_mode(agent_config: Any) -> KbSearchMode:
@@ -239,31 +227,105 @@ class PlainLanceStore(StorageBase):
             return 0
         return table.count_rows(where)
 
-    def create_indices(self, scalar_columns: Sequence[str], fts_columns: Optional[Sequence[str]] = None) -> None:
+    def create_indices(self, scalar_columns: Sequence[str], fts_spec: Optional[FtsSpec] = None) -> None:
         self._ensure_table_ready()
         for column in scalar_columns:
             try:
                 self.table.create_scalar_index(column)
             except Exception as exc:
                 logger.warning("Failed to create scalar index on %s.%s: %s", self.table_name, column, exc)
-        if fts_columns:
+        if fts_spec is not None:
+            if not getattr(self.table, "supports_fts", lambda: False)():
+                raise DatusException(
+                    ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                    message_args={
+                        "operation": "create_fts_index",
+                        "table_name": self.table_name,
+                        "error_message": "configured vector backend does not support FTS",
+                    },
+                )
+            remove_legacy = getattr(self.table, "remove_legacy_fts_index", None)
+            if remove_legacy is not None and remove_legacy():
+                logger.info("Removed legacy Tantivy FTS index for %s before rebuilding", self.table_name)
             try:
-                self.table.create_fts_index(list(fts_columns))
+                for field in fts_spec.fields:
+                    self.table.create_fts_index(field)
+                self.require_fts_ready(fts_spec)
+            except DatusException:
+                raise
             except Exception as exc:
-                logger.warning("Failed to create FTS index on %s: %s", self.table_name, exc)
+                raise DatusException(
+                    ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                    message_args={
+                        "operation": "create_fts_index",
+                        "table_name": self.table_name,
+                        "error_message": str(exc),
+                    },
+                ) from exc
+
+    def optimize(self) -> None:
+        """Incrementally update existing indices after writes or deletes."""
+
+        self._ensure_table_ready()
+        optimize = getattr(self.table, "optimize", None)
+        if optimize is None:
+            raise DatusException(
+                ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                message_args={
+                    "operation": "optimize_indices",
+                    "table_name": self.table_name,
+                    "error_message": "configured backend does not support incremental index updates",
+                },
+            )
+        try:
+            optimize()
+        except Exception as exc:
+            raise DatusException(
+                ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                message_args={
+                    "operation": "optimize_indices",
+                    "table_name": self.table_name,
+                    "error_message": str(exc),
+                },
+            ) from exc
+
+    def fts_index_status(self, spec: FtsSpec) -> FtsIndexStatus:
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return FtsIndexStatus.MISSING
+        status_fn = getattr(table, "fts_index_status", None)
+        if status_fn is None:
+            return FtsIndexStatus.UNSUPPORTED
+        return status_fn(spec)
+
+    def require_fts_ready(self, spec: FtsSpec) -> None:
+        status = self.fts_index_status(spec)
+        if status != FtsIndexStatus.READY:
+            raise DatusException(
+                ErrorCode.STORAGE_SEARCH_FAILED,
+                message_args={
+                    "error_message": (
+                        f"FTS index for '{self.table_name}' is {status.value}; "
+                        "run bootstrap-kb with --kb_update_strategy overwrite"
+                    ),
+                    "query": "",
+                    "where_clause": "(none)",
+                    "top_n": "0",
+                },
+            )
 
     def search_fts(
         self,
         query_text: str,
         *,
-        fts_columns: Sequence[str],
+        fts_spec: FtsSpec,
         top_n: int,
         where: WhereExpr = None,
         select_fields: Optional[List[str]] = None,
     ) -> pa.Table:
+        self.require_fts_ready(fts_spec)
         table = self._open_existing_table_for_read()
-        if table is None:
-            return self._empty_result(select_fields)
+        assert table is not None
         if table.count_rows(where) == 0:
             return self._empty_result(select_fields)
         if not hasattr(table, "search_fts"):
@@ -276,7 +338,7 @@ class PlainLanceStore(StorageBase):
                     "top_n": str(top_n),
                 },
             )
-        return table.search_fts(query_text, list(fts_columns), top_n, where=where, select_fields=select_fields)
+        return table.search_fts(query_text, fts_spec, top_n, where=where, select_fields=select_fields)
 
 
 class MetadataFactsStore(PlainLanceStore):
@@ -303,7 +365,7 @@ class MetadataFactsStore(PlainLanceStore):
             ),
         )
 
-    def create_indices(self, scalar_columns: Sequence[str] = (), fts_columns: Optional[Sequence[str]] = None) -> None:
+    def create_indices(self, scalar_columns: Sequence[str] = (), fts_spec: Optional[FtsSpec] = None) -> None:
         super().create_indices(
             scalar_columns=scalar_columns
             or [
@@ -319,7 +381,7 @@ class MetadataFactsStore(PlainLanceStore):
 
 
 class KbRetrievalDocumentStore(PlainLanceStore):
-    FTS_COLUMNS = ["title", "search_text", "identifier", "table_name"]
+    FTS_SPEC = FtsSpec((FtsField("search_text", tokenizer="ngram"),), version=1)
 
     def __init__(self, *, project: str):
         super().__init__(
@@ -348,7 +410,7 @@ class KbRetrievalDocumentStore(PlainLanceStore):
             ),
         )
 
-    def create_indices(self, scalar_columns: Sequence[str] = (), fts_columns: Optional[Sequence[str]] = None) -> None:
+    def create_indices(self, scalar_columns: Sequence[str] = (), fts_spec: Optional[FtsSpec] = None) -> None:
         super().create_indices(
             scalar_columns=scalar_columns
             or [
@@ -363,61 +425,8 @@ class KbRetrievalDocumentStore(PlainLanceStore):
                 "table_name",
                 "table_type",
             ],
-            fts_columns=fts_columns or self.FTS_COLUMNS,
+            fts_spec=fts_spec or self.FTS_SPEC,
         )
-
-
-class MetadataRetrievalVectorStorage(BaseEmbeddingStore):
-    """Optional hybrid projection over the same table-level retrieval documents."""
-
-    def __init__(self, embedding_model: EmbeddingModel, **kwargs):
-        super().__init__(
-            table_name="kb_retrieval_vector",
-            embedding_model=embedding_model,
-            schema=pa.schema(
-                [
-                    pa.field("id", pa.string()),
-                    pa.field("doc_id", pa.string()),
-                    pa.field("component_type", pa.string()),
-                    pa.field("entity_type", pa.string()),
-                    pa.field("entity_key", pa.string()),
-                    pa.field("identifier", pa.string()),
-                    pa.field("catalog_name", pa.string()),
-                    pa.field("database_name", pa.string()),
-                    pa.field("schema_name", pa.string()),
-                    pa.field("table_name", pa.string()),
-                    pa.field("table_type", pa.string()),
-                    pa.field("title", pa.string()),
-                    pa.field("search_text", pa.string()),
-                    pa.field("payload_json", pa.string()),
-                    pa.field("content_hash", pa.string()),
-                    pa.field("updated_at", pa.timestamp("ms")),
-                    pa.field("vector", pa.list_(pa.float32(), list_size=embedding_model.dim_size)),
-                ]
-            ),
-            vector_source_name="search_text",
-            vector_column_name="vector",
-            unique_columns=["storage_key"],
-            datasource_scoped=True,
-            **kwargs,
-        )
-
-    def create_indices(self) -> None:
-        self._ensure_table_ready()
-        for column in (
-            "doc_id",
-            "component_type",
-            "entity_type",
-            "entity_key",
-            "identifier",
-            "catalog_name",
-            "database_name",
-            "schema_name",
-            "table_name",
-            "table_type",
-        ):
-            self._create_scalar_index(column)
-        self.create_fts_index(KbRetrievalDocumentStore.FTS_COLUMNS)
 
 
 class MetadataFtsRAG:
@@ -469,44 +478,38 @@ class MetadataFtsRAG:
         self.agent_config = agent_config
         self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self.search_mode = _search_mode(agent_config)
+        if self.search_mode != KbSearchMode.FTS:
+            raise DatusException(
+                ErrorCode.STORAGE_INVALID_ARGUMENT,
+                message_args={"error_message": "MetadataFtsRAG requires kb.search.mode=fts"},
+            )
         self.facts_store = MetadataFactsStore(project=agent_config.project_name)
         self.document_store = KbRetrievalDocumentStore(project=agent_config.project_name)
-        self.vector_store: Optional[MetadataRetrievalVectorStorage] = None
-        if self.search_mode == KbSearchMode.HYBRID:
-            from datus.storage.registry import get_storage
-
-            self.vector_store = get_storage(
-                MetadataRetrievalVectorStorage,
-                "database",
-                project=agent_config.project_name,
-                datasource_id=self.datasource_id,
+        if not getattr(self.document_store.db, "supports_fts", lambda: False)():
+            raise DatusException(
+                ErrorCode.STORAGE_INVALID_ARGUMENT,
+                message_args={
+                    "error_message": (
+                        "kb.search.mode=fts requires an FTS-capable vector backend; "
+                        "use kb.search.mode=vector with the configured backend"
+                    )
+                },
             )
         self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.document_store, "tables")
         self._table_semantic_profiles = None
-        self.last_search_info: Dict[str, Any] = self._search_info(
-            requested_mode=self.search_mode.value,
-            actual_mode="",
-            index_ready=False,
-        )
+        self.last_search_info: Dict[str, Any] = self._search_info(index_status=FtsIndexStatus.MISSING)
 
     @staticmethod
     def _search_info(
         *,
-        requested_mode: str,
-        actual_mode: str,
-        index_ready: bool,
-        fallback: bool = False,
-        vector_row_count: Optional[int] = None,
+        index_status: FtsIndexStatus,
         error_reason: str = "",
     ) -> Dict[str, Any]:
         info: Dict[str, Any] = {
-            "requested_mode": requested_mode,
-            "actual_mode": actual_mode,
-            "index_ready": index_ready,
-            "fallback": fallback,
+            "configured_mode": KbSearchMode.FTS.value,
+            "index_status": index_status.value,
+            "index_version": KbRetrievalDocumentStore.FTS_SPEC.version,
         }
-        if vector_row_count is not None:
-            info["vector_row_count"] = vector_row_count
         if error_reason:
             info["error_reason"] = error_reason
         return info
@@ -544,8 +547,6 @@ class MetadataFtsRAG:
     def truncate(self) -> None:
         self.facts_store.delete_datasource_rows(self.datasource_id)
         self.document_store.delete_datasource_rows(self.datasource_id)
-        if self.vector_store is not None:
-            self.vector_store.delete_datasource_rows(self.datasource_id)
 
     def store_batch(self, schemas: List[Dict[str, Any]], values: List[Dict[str, Any]]) -> None:
         sample_by_identifier = self._sample_rows_by_identifier(values)
@@ -558,19 +559,29 @@ class MetadataFtsRAG:
         self.facts_store.upsert_batch(fact_rows)
         docs = [self._document_row(row) for row in fact_rows]
         self.document_store.upsert_batch(docs)
-        if self.vector_store is not None:
-            vector_rows = [dict(row, id=row["doc_id"]) for row in docs]
-            from datus.storage.datasource_scope import add_datasource_scope_to_rows
 
-            self.vector_store.upsert_batch(
-                add_datasource_scope_to_rows(vector_rows, self.datasource_id), on_column="storage_key"
-            )
+    def after_init(self, build_mode: str = "overwrite") -> None:
+        if build_mode == "incremental":
+            self.check_ready()
+            self.facts_store.optimize()
+            self.document_store.optimize()
+            self.check_ready()
+            return
 
-    def after_init(self) -> None:
         self.facts_store.create_indices()
         self.document_store.create_indices()
-        if self.vector_store is not None:
-            self.vector_store.create_indices()
+        self._record_search_info(index_status=FtsIndexStatus.READY)
+
+    def check_ready(self) -> None:
+        """Fail when FTS data has not been built with the current index spec."""
+
+        try:
+            self.document_store.require_fts_ready(KbRetrievalDocumentStore.FTS_SPEC)
+        except Exception as exc:
+            status = self.document_store.fts_index_status(KbRetrievalDocumentStore.FTS_SPEC)
+            self._record_search_info(index_status=status, error_reason=str(exc))
+            raise
+        self._record_search_info(index_status=FtsIndexStatus.READY)
 
     def get_schema_size(self) -> int:
         return self.facts_store._count_rows(where=self._where(table_type="full"))
@@ -590,143 +601,29 @@ class MetadataFtsRAG:
         schema_name: str = "",
         table_type: TABLE_TYPE = "table",
         top_n: int = 5,
-        query_type: str = "",
     ) -> pa.Table:
-        mode = KbSearchMode.HYBRID if query_type == KbSearchMode.HYBRID.value else self.search_mode
         where = self._where(
             catalog_name=catalog_name,
             database_name=database_name,
             schema_name=schema_name,
             table_type=table_type,
         )
-        if mode == KbSearchMode.HYBRID:
-            if self.vector_store is None:
-                reason = "hybrid_vector_store_unavailable"
-                self._record_search_info(
-                    requested_mode=mode.value,
-                    actual_mode="",
-                    index_ready=False,
-                    fallback=False,
-                    error_reason=reason,
-                )
-                raise DatusException(
-                    ErrorCode.STORAGE_SEARCH_FAILED,
-                    message_args={
-                        "error_message": "Hybrid metadata retrieval requested but vector projection is unavailable",
-                        "query": query_text,
-                        "where_clause": str(where) if where else "(none)",
-                        "top_n": str(top_n),
-                    },
-                )
-
-            try:
-                vector_row_count = self.vector_store._count_rows(where)
-            except Exception as exc:
-                self._record_search_info(
-                    requested_mode=mode.value,
-                    actual_mode="",
-                    index_ready=False,
-                    fallback=False,
-                    error_reason=str(exc),
-                )
-                raise DatusException(
-                    ErrorCode.STORAGE_SEARCH_FAILED,
-                    message_args={
-                        "error_message": str(exc),
-                        "query": query_text,
-                        "where_clause": str(where) if where else "(none)",
-                        "top_n": str(top_n),
-                    },
-                ) from exc
-            if vector_row_count == 0:
-                reason = "hybrid_vector_projection_empty"
-                self._record_search_info(
-                    requested_mode=mode.value,
-                    actual_mode="",
-                    index_ready=False,
-                    fallback=False,
-                    vector_row_count=0,
-                    error_reason=reason,
-                )
-                raise DatusException(
-                    ErrorCode.STORAGE_SEARCH_FAILED,
-                    message_args={
-                        "error_message": "Hybrid metadata retrieval requested but vector projection has no rows",
-                        "query": query_text,
-                        "where_clause": str(where) if where else "(none)",
-                        "top_n": str(top_n),
-                    },
-                )
-
-            try:
-                result = self.vector_store.search(
-                    query_text,
-                    top_n=top_n,
-                    where=where,
-                    query_type=KbSearchMode.HYBRID.value,
-                    select_fields=None,
-                    allow_hybrid_fallback=False,
-                )
-            except DatusException as exc:
-                self._record_search_info(
-                    requested_mode=mode.value,
-                    actual_mode="",
-                    index_ready=True,
-                    fallback=False,
-                    vector_row_count=vector_row_count,
-                    error_reason=str(exc),
-                )
-                raise
-            except Exception as exc:
-                self._record_search_info(
-                    requested_mode=mode.value,
-                    actual_mode="",
-                    index_ready=True,
-                    fallback=False,
-                    vector_row_count=vector_row_count,
-                    error_reason=str(exc),
-                )
-                raise DatusException(
-                    ErrorCode.STORAGE_SEARCH_FAILED,
-                    message_args={
-                        "error_message": str(exc),
-                        "query": query_text,
-                        "where_clause": str(where) if where else "(none)",
-                        "top_n": str(top_n),
-                    },
-                ) from exc
-            self._record_search_info(
-                requested_mode=mode.value,
-                actual_mode=KbSearchMode.HYBRID.value,
-                index_ready=True,
-                fallback=False,
-                vector_row_count=vector_row_count,
-            )
-            return result
-
         try:
             result = self.document_store.search_fts(
                 query_text,
-                fts_columns=KbRetrievalDocumentStore.FTS_COLUMNS,
+                fts_spec=KbRetrievalDocumentStore.FTS_SPEC,
                 top_n=top_n,
                 where=where,
                 select_fields=None,
             )
         except Exception as exc:
+            status = self.document_store.fts_index_status(KbRetrievalDocumentStore.FTS_SPEC)
             self._record_search_info(
-                requested_mode=mode.value,
-                actual_mode="",
-                index_ready=False,
-                fallback=False,
+                index_status=status,
                 error_reason=str(exc),
             )
             raise
-        self._record_search_info(
-            requested_mode=mode.value,
-            actual_mode=KbSearchMode.FTS.value,
-            index_ready=True,
-            fallback=False,
-        )
+        self._record_search_info(index_status=FtsIndexStatus.READY)
         return result
 
     def sample_rows_for_search_results(self, metadata: pa.Table) -> pa.Table:
@@ -738,7 +635,6 @@ class MetadataFtsRAG:
         catalog_name: str = "",
         database_name: str = "",
         schema_name: str = "",
-        query_type: str = "fts",
         table_type: TABLE_TYPE = "table",
         top_n: int = 5,
     ) -> tuple[pa.Table, pa.Table]:
@@ -749,7 +645,6 @@ class MetadataFtsRAG:
             schema_name=schema_name,
             table_type=table_type,
             top_n=top_n,
-            query_type=query_type,
         )
         schemas = self._schema_rows_for_metadata(metadata)
         sample_values = self._sample_rows_for_metadata(schemas)
@@ -918,8 +813,6 @@ class MetadataFtsRAG:
         if where is not None:
             self.facts_store._delete_rows(where)
             self.document_store._delete_rows(where)
-            if self.vector_store is not None:
-                self.vector_store._delete_rows(where)
 
     def refresh_profiles(self, profiles: List[Dict[str, Any]]) -> int:
         updated_docs: List[Dict[str, Any]] = []
@@ -977,16 +870,10 @@ class MetadataFtsRAG:
     def _upsert_documents(self, updated_docs: List[Dict[str, Any]]) -> int:
         if not updated_docs:
             return 0
+        self.document_store.require_fts_ready(KbRetrievalDocumentStore.FTS_SPEC)
         self.document_store.upsert_batch(updated_docs)
-        if self.vector_store is not None:
-            from datus.storage.datasource_scope import add_datasource_scope_to_rows
-
-            vector_rows = [dict(row, id=row["doc_id"]) for row in updated_docs]
-            self.vector_store.upsert_batch(
-                add_datasource_scope_to_rows(vector_rows, self.datasource_id), on_column="storage_key"
-            )
-            self.vector_store.create_indices()
-        self.document_store.create_indices()
+        self.document_store.optimize()
+        self.document_store.require_fts_ready(KbRetrievalDocumentStore.FTS_SPEC)
         return len(updated_docs)
 
     def _schema_rows_for_metadata(self, metadata: pa.Table) -> pa.Table:

--- a/datus/storage/kb_retrieval/store.py
+++ b/datus/storage/kb_retrieval/store.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 import pandas as pd
 import pyarrow as pa
-from datus_storage_base.conditions import And, Node, WhereExpr, and_, eq, or_
+from datus_storage_base.conditions import And, Node, WhereExpr, and_, eq, in_, or_
 
 from datus.schemas.base import TABLE_TYPE
 from datus.schemas.node_models import TableSchema, TableValue
@@ -38,6 +38,17 @@ class KbSearchMode(StrEnum):
     HYBRID = "hybrid"
 
 
+def resolve_kb_search_mode(agent_config: Any) -> KbSearchMode:
+    """Resolve KB retrieval mode from the public kb.search config."""
+
+    kb_search = getattr(agent_config, "kb_search", None)
+    mode = getattr(kb_search, "mode", None) if kb_search is not None else None
+    if not isinstance(mode, str) or not mode.strip():
+        mode = getattr(agent_config, "kb_search_mode", KbSearchMode.FTS.value)
+    mode = str(mode or KbSearchMode.FTS.value).strip().lower()
+    return KbSearchMode.HYBRID if mode == KbSearchMode.HYBRID.value else KbSearchMode.FTS
+
+
 def metadata_fts_enabled(agent_config: Any) -> bool:
     """Return True when public KB search config enables the metadata retrieval path."""
 
@@ -45,22 +56,19 @@ def metadata_fts_enabled(agent_config: Any) -> bool:
     if kb_search is None:
         return False
     enabled = getattr(kb_search, "enabled", None)
-    mode = getattr(kb_search, "mode", None)
     return (
         isinstance(enabled, bool)
         and enabled
-        and isinstance(mode, str)
-        and mode.lower()
+        and resolve_kb_search_mode(agent_config)
         in {
-            KbSearchMode.FTS.value,
-            KbSearchMode.HYBRID.value,
+            KbSearchMode.FTS,
+            KbSearchMode.HYBRID,
         }
     )
 
 
 def _search_mode(agent_config: Any) -> KbSearchMode:
-    mode = str(getattr(agent_config, "kb_search_mode", KbSearchMode.FTS.value) or KbSearchMode.FTS.value).lower()
-    return KbSearchMode.HYBRID if mode == KbSearchMode.HYBRID.value else KbSearchMode.FTS
+    return resolve_kb_search_mode(agent_config)
 
 
 def _utc_now() -> datetime:
@@ -657,6 +665,7 @@ class MetadataFtsRAG:
                     where=where,
                     query_type=KbSearchMode.HYBRID.value,
                     select_fields=None,
+                    allow_hybrid_fallback=False,
                 )
             except DatusException as exc:
                 self._record_search_info(
@@ -984,12 +993,18 @@ class MetadataFtsRAG:
         if metadata.num_rows == 0:
             return self.facts_store._empty_result(self.SCHEMA_SELECT_FIELDS)
 
+        hits = metadata.to_pylist()
+        fact_ids = self._unique_nonempty(hit.get("entity_key") for hit in hits)
+        identifiers = self._unique_nonempty(hit.get("identifier") for hit in hits)
+        fact_by_id, fact_by_identifier = self._fact_lookup_maps(fact_ids=fact_ids, identifiers=identifiers)
         rows: List[Dict[str, Any]] = []
-        for hit in metadata.to_pylist():
-            fact_rows = self._facts_for_hit(hit)
-            if not fact_rows:
+        for hit in hits:
+            fact = fact_by_id.get(str(hit.get("entity_key") or "").strip())
+            if fact is None:
+                fact = fact_by_identifier.get(str(hit.get("identifier") or "").strip())
+            if fact is None:
                 continue
-            schema_row = {field: fact_rows[0].get(field, "") for field in self.SCHEMA_SELECT_FIELDS}
+            schema_row = {field: fact.get(field, "") for field in self.SCHEMA_SELECT_FIELDS}
             for field in self.SCORE_FIELDS:
                 if hit.get(field) is not None:
                     schema_row[field] = hit[field]
@@ -998,43 +1013,57 @@ class MetadataFtsRAG:
             return self.facts_store._empty_result(self.SCHEMA_SELECT_FIELDS)
         return pa.Table.from_pylist(rows)
 
-    def _facts_for_hit(self, hit: Dict[str, Any]) -> List[Dict[str, Any]]:
-        fact_id = str(hit.get("entity_key") or "").strip()
-        if fact_id:
-            rows = self.facts_store._search_all(
-                where=and_(datasource_condition(self.datasource_id), eq("fact_id", fact_id)),
-                select_fields=self.SCHEMA_SELECT_FIELDS,
-                limit=1,
-            ).to_pylist()
-            if rows:
-                return rows
-
-        identifier = str(hit.get("identifier") or "").strip()
-        if not identifier:
-            return []
-        return self.facts_store._search_all(
-            where=and_(datasource_condition(self.datasource_id), eq("identifier", identifier)),
-            select_fields=self.SCHEMA_SELECT_FIELDS,
-            limit=1,
+    def _fact_lookup_maps(
+        self, *, fact_ids: Sequence[str], identifiers: Sequence[str]
+    ) -> tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+        lookup_conditions = []
+        if fact_ids:
+            lookup_conditions.append(in_("fact_id", list(fact_ids)))
+        if identifiers:
+            lookup_conditions.append(in_("identifier", list(identifiers)))
+        if not lookup_conditions:
+            return {}, {}
+        lookup_where = lookup_conditions[0] if len(lookup_conditions) == 1 else or_(*lookup_conditions)
+        rows = self.facts_store._search_all(
+            where=and_(datasource_condition(self.datasource_id), lookup_where),
+            select_fields=["fact_id", *self.SCHEMA_SELECT_FIELDS],
         ).to_pylist()
+        fact_by_id = {str(row.get("fact_id") or ""): row for row in rows if row.get("fact_id")}
+        fact_by_identifier = {str(row.get("identifier") or ""): row for row in rows if row.get("identifier")}
+        return fact_by_id, fact_by_identifier
 
     def _sample_rows_for_metadata(self, metadata: pa.Table) -> pa.Table:
         if metadata.num_rows == 0:
             return self.facts_store._empty_result(self.VALUE_SELECT_FIELDS)
-        identifiers = [row.get("identifier") for row in metadata.to_pylist() if row.get("identifier")]
+        identifiers = self._unique_nonempty(row.get("identifier") for row in metadata.to_pylist())
         if not identifiers:
             return self.facts_store._empty_result(self.VALUE_SELECT_FIELDS)
-        rows = []
-        for identifier in identifiers:
-            rows.extend(
-                self.facts_store._search_all(
-                    where=and_(datasource_condition(self.datasource_id), eq("identifier", identifier)),
-                    select_fields=self.VALUE_SELECT_FIELDS,
-                    limit=1,
-                ).to_pylist()
-            )
-        rows = [row for row in rows if row.get("sample_rows")]
+        rows_by_identifier = {
+            str(row.get("identifier") or ""): row
+            for row in self.facts_store._search_all(
+                where=and_(datasource_condition(self.datasource_id), in_("identifier", list(identifiers))),
+                select_fields=self.VALUE_SELECT_FIELDS,
+            ).to_pylist()
+            if row.get("identifier")
+        }
+        rows = [
+            rows_by_identifier[identifier]
+            for identifier in identifiers
+            if rows_by_identifier.get(identifier, {}).get("sample_rows")
+        ]
         return pa.Table.from_pylist(rows) if rows else self.facts_store._empty_result(self.VALUE_SELECT_FIELDS)
+
+    @staticmethod
+    def _unique_nonempty(values: Sequence[Any]) -> List[str]:
+        result: List[str] = []
+        seen: set[str] = set()
+        for value in values:
+            text = str(value or "").strip()
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            result.append(text)
+        return result
 
     def _sample_rows_by_identifier(self, values: List[Dict[str, Any]]) -> Dict[str, str]:
         result: Dict[str, str] = {}

--- a/datus/storage/kb_retrieval/store.py
+++ b/datus/storage/kb_retrieval/store.py
@@ -1,0 +1,1181 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import datetime, timezone
+from enum import StrEnum
+from threading import Lock
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
+
+import pandas as pd
+import pyarrow as pa
+from datus_storage_base.conditions import And, Node, WhereExpr, and_, eq, or_
+
+from datus.schemas.base import TABLE_TYPE
+from datus.schemas.node_models import TableSchema, TableValue
+from datus.storage.base import BaseEmbeddingStore, StorageBase
+from datus.storage.datasource_scope import DATASOURCE_ID_COLUMN, datasource_condition, resolve_datasource_id
+from datus.storage.embedding_models import EmbeddingModel
+from datus.tools.db_tools import connector_registry
+from datus.utils.constants import DBType
+from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.json_utils import json2csv
+from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from datus.configuration.agent_config import AgentConfig
+
+logger = get_logger(__name__)
+
+
+class KbSearchMode(StrEnum):
+    FTS = "fts"
+    HYBRID = "hybrid"
+
+
+def metadata_fts_enabled(agent_config: Any) -> bool:
+    """Return True when public KB search config enables the metadata retrieval path."""
+
+    kb_search = getattr(agent_config, "kb_search", None)
+    if kb_search is None:
+        return False
+    enabled = getattr(kb_search, "enabled", None)
+    mode = getattr(kb_search, "mode", None)
+    return (
+        isinstance(enabled, bool)
+        and enabled
+        and isinstance(mode, str)
+        and mode.lower()
+        in {
+            KbSearchMode.FTS.value,
+            KbSearchMode.HYBRID.value,
+        }
+    )
+
+
+def _search_mode(agent_config: Any) -> KbSearchMode:
+    mode = str(getattr(agent_config, "kb_search_mode", KbSearchMode.FTS.value) or KbSearchMode.FTS.value).lower()
+    return KbSearchMode.HYBRID if mode == KbSearchMode.HYBRID.value else KbSearchMode.FTS
+
+
+def _utc_now() -> datetime:
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    return now.replace(microsecond=(now.microsecond // 1000) * 1000)
+
+
+def _stable_hash(value: Any) -> str:
+    text = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _as_text(value: Any) -> str:
+    if value in (None, "", [], {}):
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        return str(value)
+
+
+def _normalize_row_text(value: Any) -> str:
+    text = _as_text(value)
+    return " ".join(text.split())
+
+
+def _qualified_name(row: Dict[str, Any]) -> str:
+    parts = [
+        str(row.get("catalog_name") or "").strip(),
+        str(row.get("database_name") or "").strip(),
+        str(row.get("schema_name") or "").strip(),
+        str(row.get("table_name") or "").strip(),
+    ]
+    return ".".join(part for part in parts if part)
+
+
+def _build_where_clause(
+    *,
+    datasource_id: str = "",
+    catalog_name: str = "",
+    database_name: str = "",
+    schema_name: str = "",
+    table_name: str = "",
+    table_type: TABLE_TYPE = "table",
+    extra: Optional[Node] = None,
+) -> Optional[Node]:
+    conditions = []
+    if datasource_id:
+        conditions.append(datasource_condition(datasource_id))
+    if catalog_name:
+        conditions.append(eq("catalog_name", catalog_name))
+    if database_name:
+        conditions.append(eq("database_name", database_name))
+    if schema_name:
+        conditions.append(eq("schema_name", schema_name))
+    if table_name:
+        conditions.append(eq("table_name", table_name))
+    if table_type and table_type != "full":
+        conditions.append(eq("table_type", table_type))
+    if extra is not None:
+        conditions.append(extra)
+    if not conditions:
+        return None
+    return conditions[0] if len(conditions) == 1 else And(conditions)
+
+
+class PlainLanceStore(StorageBase):
+    """Small no-vector LanceDB-backed table store used for KB facts and FTS docs."""
+
+    def __init__(self, *, project: str, table_name: str, schema: pa.Schema, unique_column: str):
+        from datus.storage.backend_holder import create_vector_connection
+
+        super().__init__(db=create_vector_connection(project))
+        self.table_name = table_name
+        self._schema = schema
+        self._unique_column = unique_column
+        self._table_lock = Lock()
+        self._write_lock = Lock()
+        self.table = None
+
+    def _ensure_table_ready(self) -> None:
+        if self.table is not None:
+            return
+        with self._table_lock:
+            if self.table is not None:
+                return
+            try:
+                if self.db.table_exists(self.table_name):
+                    self.table = self.db.open_table(self.table_name)
+                else:
+                    self.table = self.db.create_table(self.table_name, schema=self._schema, exist_ok=True)
+            except Exception as exc:
+                raise DatusException(
+                    ErrorCode.STORAGE_TABLE_OPERATION_FAILED,
+                    message_args={
+                        "operation": "ensure_table",
+                        "table_name": self.table_name,
+                        "error_message": str(exc),
+                    },
+                ) from exc
+
+    def _open_existing_table_for_read(self):
+        if self.table is not None:
+            return self.table
+        if not self.db.table_exists(self.table_name):
+            return None
+        self.table = self.db.open_table(self.table_name)
+        return self.table
+
+    def _empty_result(self, select_fields: Optional[List[str]] = None) -> pa.Table:
+        if select_fields is None:
+            fields = list(self._schema)
+        else:
+            schema_names = set(self._schema.names)
+            fields = [
+                self._schema.field(name) if name in schema_names else pa.field(name, pa.null())
+                for name in select_fields
+            ]
+        return pa.Table.from_arrays([pa.array([], type=field.type) for field in fields], schema=pa.schema(fields))
+
+    def upsert_batch(self, rows: List[Dict[str, Any]]) -> None:
+        if not rows:
+            return
+        self._ensure_table_ready()
+        frame = pd.DataFrame(rows).drop_duplicates(subset=[self._unique_column], keep="last")
+        with self._write_lock:
+            last_error: Exception | None = None
+            for attempt in range(3):
+                try:
+                    self.table.merge_insert(frame, self._unique_column)
+                    return
+                except Exception as exc:
+                    if "Commit conflict" not in str(exc):
+                        raise
+                    last_error = exc
+                    self.table = self.db.refresh_table(self.table_name)
+                    time.sleep(0.05 * (attempt + 1))
+            assert last_error is not None
+            raise last_error
+
+    def delete_datasource_rows(self, datasource_id: str) -> None:
+        self._delete_rows(datasource_condition(datasource_id))
+
+    def _delete_rows(self, where: WhereExpr) -> None:
+        self._ensure_table_ready()
+        if where:
+            self.table.delete(where)
+
+    def _search_all(
+        self,
+        where: WhereExpr = None,
+        select_fields: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+    ) -> pa.Table:
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return self._empty_result(select_fields)
+        row_limit = limit if limit is not None else table.count_rows(where)
+        if row_limit == 0:
+            return self._empty_result(select_fields)
+        return table.search_all(where=where, select_fields=select_fields, limit=row_limit)
+
+    def _count_rows(self, where: WhereExpr = None) -> int:
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return 0
+        return table.count_rows(where)
+
+    def create_indices(self, scalar_columns: Sequence[str], fts_columns: Optional[Sequence[str]] = None) -> None:
+        self._ensure_table_ready()
+        for column in scalar_columns:
+            try:
+                self.table.create_scalar_index(column)
+            except Exception as exc:
+                logger.warning("Failed to create scalar index on %s.%s: %s", self.table_name, column, exc)
+        if fts_columns:
+            try:
+                self.table.create_fts_index(list(fts_columns))
+            except Exception as exc:
+                logger.warning("Failed to create FTS index on %s: %s", self.table_name, exc)
+
+    def search_fts(
+        self,
+        query_text: str,
+        *,
+        fts_columns: Sequence[str],
+        top_n: int,
+        where: WhereExpr = None,
+        select_fields: Optional[List[str]] = None,
+    ) -> pa.Table:
+        table = self._open_existing_table_for_read()
+        if table is None:
+            return self._empty_result(select_fields)
+        if table.count_rows(where) == 0:
+            return self._empty_result(select_fields)
+        if not hasattr(table, "search_fts"):
+            raise DatusException(
+                ErrorCode.STORAGE_SEARCH_FAILED,
+                message_args={
+                    "error_message": f"Backend for '{self.table_name}' does not support FTS search",
+                    "query": query_text,
+                    "where_clause": str(where) if where else "(none)",
+                    "top_n": str(top_n),
+                },
+            )
+        return table.search_fts(query_text, list(fts_columns), top_n, where=where, select_fields=select_fields)
+
+
+class MetadataFactsStore(PlainLanceStore):
+    def __init__(self, *, project: str):
+        super().__init__(
+            project=project,
+            table_name="schema_metadata_facts",
+            unique_column="fact_id",
+            schema=pa.schema(
+                [
+                    pa.field("fact_id", pa.string()),
+                    pa.field(DATASOURCE_ID_COLUMN, pa.string()),
+                    pa.field("identifier", pa.string()),
+                    pa.field("catalog_name", pa.string()),
+                    pa.field("database_name", pa.string()),
+                    pa.field("schema_name", pa.string()),
+                    pa.field("table_name", pa.string()),
+                    pa.field("table_type", pa.string()),
+                    pa.field("definition", pa.string()),
+                    pa.field("sample_rows", pa.string()),
+                    pa.field("content_hash", pa.string()),
+                    pa.field("updated_at", pa.timestamp("ms")),
+                ]
+            ),
+        )
+
+    def create_indices(self, scalar_columns: Sequence[str] = (), fts_columns: Optional[Sequence[str]] = None) -> None:
+        super().create_indices(
+            scalar_columns=scalar_columns
+            or [
+                DATASOURCE_ID_COLUMN,
+                "identifier",
+                "catalog_name",
+                "database_name",
+                "schema_name",
+                "table_name",
+                "table_type",
+            ],
+        )
+
+
+class KbRetrievalDocumentStore(PlainLanceStore):
+    FTS_COLUMNS = ["title", "search_text", "identifier", "table_name"]
+
+    def __init__(self, *, project: str):
+        super().__init__(
+            project=project,
+            table_name="kb_retrieval_document",
+            unique_column="doc_id",
+            schema=pa.schema(
+                [
+                    pa.field("doc_id", pa.string()),
+                    pa.field(DATASOURCE_ID_COLUMN, pa.string()),
+                    pa.field("component_type", pa.string()),
+                    pa.field("entity_type", pa.string()),
+                    pa.field("entity_key", pa.string()),
+                    pa.field("identifier", pa.string()),
+                    pa.field("catalog_name", pa.string()),
+                    pa.field("database_name", pa.string()),
+                    pa.field("schema_name", pa.string()),
+                    pa.field("table_name", pa.string()),
+                    pa.field("table_type", pa.string()),
+                    pa.field("title", pa.string()),
+                    pa.field("search_text", pa.string()),
+                    pa.field("payload_json", pa.string()),
+                    pa.field("content_hash", pa.string()),
+                    pa.field("updated_at", pa.timestamp("ms")),
+                ]
+            ),
+        )
+
+    def create_indices(self, scalar_columns: Sequence[str] = (), fts_columns: Optional[Sequence[str]] = None) -> None:
+        super().create_indices(
+            scalar_columns=scalar_columns
+            or [
+                DATASOURCE_ID_COLUMN,
+                "component_type",
+                "entity_type",
+                "entity_key",
+                "identifier",
+                "catalog_name",
+                "database_name",
+                "schema_name",
+                "table_name",
+                "table_type",
+            ],
+            fts_columns=fts_columns or self.FTS_COLUMNS,
+        )
+
+
+class MetadataRetrievalVectorStorage(BaseEmbeddingStore):
+    """Optional hybrid projection over the same table-level retrieval documents."""
+
+    def __init__(self, embedding_model: EmbeddingModel, **kwargs):
+        super().__init__(
+            table_name="kb_retrieval_vector",
+            embedding_model=embedding_model,
+            schema=pa.schema(
+                [
+                    pa.field("id", pa.string()),
+                    pa.field("doc_id", pa.string()),
+                    pa.field("component_type", pa.string()),
+                    pa.field("entity_type", pa.string()),
+                    pa.field("entity_key", pa.string()),
+                    pa.field("identifier", pa.string()),
+                    pa.field("catalog_name", pa.string()),
+                    pa.field("database_name", pa.string()),
+                    pa.field("schema_name", pa.string()),
+                    pa.field("table_name", pa.string()),
+                    pa.field("table_type", pa.string()),
+                    pa.field("title", pa.string()),
+                    pa.field("search_text", pa.string()),
+                    pa.field("payload_json", pa.string()),
+                    pa.field("content_hash", pa.string()),
+                    pa.field("updated_at", pa.timestamp("ms")),
+                    pa.field("vector", pa.list_(pa.float32(), list_size=embedding_model.dim_size)),
+                ]
+            ),
+            vector_source_name="search_text",
+            vector_column_name="vector",
+            unique_columns=["storage_key"],
+            datasource_scoped=True,
+            **kwargs,
+        )
+
+    def create_indices(self) -> None:
+        self._ensure_table_ready()
+        for column in (
+            "doc_id",
+            "component_type",
+            "entity_type",
+            "entity_key",
+            "identifier",
+            "catalog_name",
+            "database_name",
+            "schema_name",
+            "table_name",
+            "table_type",
+        ):
+            self._create_scalar_index(column)
+        self.create_fts_index(KbRetrievalDocumentStore.FTS_COLUMNS)
+
+
+class MetadataFtsRAG:
+    """No-vector metadata RAG compatible with the schema bootstrap interface."""
+
+    SCHEMA_SELECT_FIELDS = [
+        "identifier",
+        "catalog_name",
+        "database_name",
+        "schema_name",
+        "table_name",
+        "table_type",
+        "definition",
+    ]
+    VALUE_SELECT_FIELDS = [
+        "identifier",
+        "catalog_name",
+        "database_name",
+        "schema_name",
+        "table_name",
+        "table_type",
+        "sample_rows",
+    ]
+    SCORE_FIELDS = ["_score", "_relevance_score", "_distance"]
+    SEARCH_SELECT_FIELDS = [
+        "doc_id",
+        "entity_key",
+        "identifier",
+        "catalog_name",
+        "database_name",
+        "schema_name",
+        "table_name",
+        "table_type",
+        "title",
+        "payload_json",
+        "_score",
+        "_relevance_score",
+        "_distance",
+    ]
+
+    def __init__(
+        self,
+        agent_config: "AgentConfig",
+        sub_agent_name: Optional[str] = None,
+        datasource_id: Optional[str] = None,
+    ):
+        from datus.storage.rag_scope import _build_sub_agent_filter
+
+        self.agent_config = agent_config
+        self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
+        self.search_mode = _search_mode(agent_config)
+        self.facts_store = MetadataFactsStore(project=agent_config.project_name)
+        self.document_store = KbRetrievalDocumentStore(project=agent_config.project_name)
+        self.vector_store: Optional[MetadataRetrievalVectorStorage] = None
+        if self.search_mode == KbSearchMode.HYBRID:
+            from datus.storage.registry import get_storage
+
+            self.vector_store = get_storage(
+                MetadataRetrievalVectorStorage,
+                "database",
+                project=agent_config.project_name,
+                datasource_id=self.datasource_id,
+            )
+        self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.document_store, "tables")
+        self._table_semantic_profiles = None
+        self.last_search_info: Dict[str, Any] = self._search_info(
+            requested_mode=self.search_mode.value,
+            actual_mode="",
+            index_ready=False,
+        )
+
+    @staticmethod
+    def _search_info(
+        *,
+        requested_mode: str,
+        actual_mode: str,
+        index_ready: bool,
+        fallback: bool = False,
+        vector_row_count: Optional[int] = None,
+        error_reason: str = "",
+    ) -> Dict[str, Any]:
+        info: Dict[str, Any] = {
+            "requested_mode": requested_mode,
+            "actual_mode": actual_mode,
+            "index_ready": index_ready,
+            "fallback": fallback,
+        }
+        if vector_row_count is not None:
+            info["vector_row_count"] = vector_row_count
+        if error_reason:
+            info["error_reason"] = error_reason
+        return info
+
+    def _record_search_info(self, **kwargs: Any) -> None:
+        self.last_search_info = self._search_info(**kwargs)
+
+    def _sub_agent_conditions(self) -> list:
+        conditions = [datasource_condition(self.datasource_id)]
+        if self._sub_agent_filter:
+            conditions.append(self._sub_agent_filter)
+        return conditions
+
+    def _where(
+        self,
+        *,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_name: str = "",
+        table_type: TABLE_TYPE = "table",
+    ) -> Optional[Node]:
+        base = _build_where_clause(
+            datasource_id=self.datasource_id,
+            catalog_name=catalog_name,
+            database_name=database_name,
+            schema_name=schema_name,
+            table_name=table_name,
+            table_type=table_type,
+        )
+        if self._sub_agent_filter is None:
+            return base
+        return self._sub_agent_filter if base is None else and_(base, self._sub_agent_filter)
+
+    def truncate(self) -> None:
+        self.facts_store.delete_datasource_rows(self.datasource_id)
+        self.document_store.delete_datasource_rows(self.datasource_id)
+        if self.vector_store is not None:
+            self.vector_store.delete_datasource_rows(self.datasource_id)
+
+    def store_batch(self, schemas: List[Dict[str, Any]], values: List[Dict[str, Any]]) -> None:
+        sample_by_identifier = self._sample_rows_by_identifier(values)
+        fact_rows = [
+            self._fact_row(schema, sample_by_identifier.get(schema.get("identifier", ""), "")) for schema in schemas
+        ]
+        fact_rows = [row for row in fact_rows if row.get("identifier") and row.get("table_name")]
+        if not fact_rows:
+            return
+        self.facts_store.upsert_batch(fact_rows)
+        docs = [self._document_row(row) for row in fact_rows]
+        self.document_store.upsert_batch(docs)
+        if self.vector_store is not None:
+            vector_rows = [dict(row, id=row["doc_id"]) for row in docs]
+            from datus.storage.datasource_scope import add_datasource_scope_to_rows
+
+            self.vector_store.upsert_batch(
+                add_datasource_scope_to_rows(vector_rows, self.datasource_id), on_column="storage_key"
+            )
+
+    def after_init(self) -> None:
+        self.facts_store.create_indices()
+        self.document_store.create_indices()
+        if self.vector_store is not None:
+            self.vector_store.create_indices()
+
+    def get_schema_size(self) -> int:
+        return self.facts_store._count_rows(where=self._where(table_type="full"))
+
+    def get_value_size(self) -> int:
+        rows = self.facts_store._search_all(
+            where=self._where(table_type="full"),
+            select_fields=["sample_rows"],
+        ).to_pylist()
+        return sum(1 for row in rows if row.get("sample_rows"))
+
+    def search_table(
+        self,
+        query_text: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_type: TABLE_TYPE = "table",
+        top_n: int = 5,
+        query_type: str = "",
+    ) -> pa.Table:
+        mode = KbSearchMode.HYBRID if query_type == KbSearchMode.HYBRID.value else self.search_mode
+        where = self._where(
+            catalog_name=catalog_name,
+            database_name=database_name,
+            schema_name=schema_name,
+            table_type=table_type,
+        )
+        if mode == KbSearchMode.HYBRID:
+            if self.vector_store is None:
+                reason = "hybrid_vector_store_unavailable"
+                self._record_search_info(
+                    requested_mode=mode.value,
+                    actual_mode="",
+                    index_ready=False,
+                    fallback=False,
+                    error_reason=reason,
+                )
+                raise DatusException(
+                    ErrorCode.STORAGE_SEARCH_FAILED,
+                    message_args={
+                        "error_message": "Hybrid metadata retrieval requested but vector projection is unavailable",
+                        "query": query_text,
+                        "where_clause": str(where) if where else "(none)",
+                        "top_n": str(top_n),
+                    },
+                )
+
+            try:
+                vector_row_count = self.vector_store._count_rows(where)
+            except Exception as exc:
+                self._record_search_info(
+                    requested_mode=mode.value,
+                    actual_mode="",
+                    index_ready=False,
+                    fallback=False,
+                    error_reason=str(exc),
+                )
+                raise DatusException(
+                    ErrorCode.STORAGE_SEARCH_FAILED,
+                    message_args={
+                        "error_message": str(exc),
+                        "query": query_text,
+                        "where_clause": str(where) if where else "(none)",
+                        "top_n": str(top_n),
+                    },
+                ) from exc
+            if vector_row_count == 0:
+                reason = "hybrid_vector_projection_empty"
+                self._record_search_info(
+                    requested_mode=mode.value,
+                    actual_mode="",
+                    index_ready=False,
+                    fallback=False,
+                    vector_row_count=0,
+                    error_reason=reason,
+                )
+                raise DatusException(
+                    ErrorCode.STORAGE_SEARCH_FAILED,
+                    message_args={
+                        "error_message": "Hybrid metadata retrieval requested but vector projection has no rows",
+                        "query": query_text,
+                        "where_clause": str(where) if where else "(none)",
+                        "top_n": str(top_n),
+                    },
+                )
+
+            try:
+                result = self.vector_store.search(
+                    query_text,
+                    top_n=top_n,
+                    where=where,
+                    query_type=KbSearchMode.HYBRID.value,
+                    select_fields=None,
+                )
+            except DatusException as exc:
+                self._record_search_info(
+                    requested_mode=mode.value,
+                    actual_mode="",
+                    index_ready=True,
+                    fallback=False,
+                    vector_row_count=vector_row_count,
+                    error_reason=str(exc),
+                )
+                raise
+            except Exception as exc:
+                self._record_search_info(
+                    requested_mode=mode.value,
+                    actual_mode="",
+                    index_ready=True,
+                    fallback=False,
+                    vector_row_count=vector_row_count,
+                    error_reason=str(exc),
+                )
+                raise DatusException(
+                    ErrorCode.STORAGE_SEARCH_FAILED,
+                    message_args={
+                        "error_message": str(exc),
+                        "query": query_text,
+                        "where_clause": str(where) if where else "(none)",
+                        "top_n": str(top_n),
+                    },
+                ) from exc
+            self._record_search_info(
+                requested_mode=mode.value,
+                actual_mode=KbSearchMode.HYBRID.value,
+                index_ready=True,
+                fallback=False,
+                vector_row_count=vector_row_count,
+            )
+            return result
+
+        try:
+            result = self.document_store.search_fts(
+                query_text,
+                fts_columns=KbRetrievalDocumentStore.FTS_COLUMNS,
+                top_n=top_n,
+                where=where,
+                select_fields=None,
+            )
+        except Exception as exc:
+            self._record_search_info(
+                requested_mode=mode.value,
+                actual_mode="",
+                index_ready=False,
+                fallback=False,
+                error_reason=str(exc),
+            )
+            raise
+        self._record_search_info(
+            requested_mode=mode.value,
+            actual_mode=KbSearchMode.FTS.value,
+            index_ready=True,
+            fallback=False,
+        )
+        return result
+
+    def sample_rows_for_search_results(self, metadata: pa.Table) -> pa.Table:
+        return self._sample_rows_for_metadata(metadata)
+
+    def search_similar(
+        self,
+        query_text: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        query_type: str = "fts",
+        table_type: TABLE_TYPE = "table",
+        top_n: int = 5,
+    ) -> tuple[pa.Table, pa.Table]:
+        metadata = self.search_table(
+            query_text,
+            catalog_name=catalog_name,
+            database_name=database_name,
+            schema_name=schema_name,
+            table_type=table_type,
+            top_n=top_n,
+            query_type=query_type,
+        )
+        schemas = self._schema_rows_for_metadata(metadata)
+        sample_values = self._sample_rows_for_metadata(schemas)
+        return schemas, sample_values
+
+    def get_schema(
+        self, table_name: str, catalog_name: str = "", database_name: str = "", schema_name: str = ""
+    ) -> pa.Table:
+        return self.facts_store._search_all(
+            where=self._where(
+                catalog_name=catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+                table_name=table_name,
+                table_type="full",
+            ),
+            select_fields=[
+                "catalog_name",
+                "database_name",
+                "schema_name",
+                "table_name",
+                "table_type",
+                "definition",
+            ],
+        )
+
+    def search_all_schemas(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_type: TABLE_TYPE = "full",
+        select_fields: Optional[List[str]] = None,
+    ) -> pa.Table:
+        return self.facts_store._search_all(
+            where=self._where(
+                catalog_name=catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+                table_type=table_type,
+            ),
+            select_fields=select_fields,
+        )
+
+    def search_all_value(
+        self, catalog_name: str = "", database_name: str = "", schema_name: str = "", table_type: TABLE_TYPE = "full"
+    ) -> pa.Table:
+        return self.facts_store._search_all(
+            where=self._where(
+                catalog_name=catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+                table_type=table_type,
+            ),
+            select_fields=[
+                "identifier",
+                "catalog_name",
+                "database_name",
+                "schema_name",
+                "table_name",
+                "table_type",
+                "sample_rows",
+            ],
+        )
+
+    def search_tables(
+        self,
+        tables: list[str],
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        dialect: str = DBType.SQLITE,
+    ) -> tuple[List[TableSchema], List[TableValue]]:
+        conditions = []
+        for full_table in tables:
+            cat, db, sch, table = self._parse_table_name(
+                full_table,
+                catalog_name=catalog_name,
+                database_name=database_name,
+                schema_name=schema_name,
+                dialect=dialect,
+            )
+            condition = self._where(
+                catalog_name=cat,
+                database_name=db,
+                schema_name=sch,
+                table_name=table,
+                table_type="full",
+            )
+            if condition is not None:
+                conditions.append(condition)
+        where = None if not conditions else conditions[0] if len(conditions) == 1 else or_(*conditions)
+        rows = self.facts_store._search_all(where=where).to_pylist()
+        schema_rows = [
+            {
+                "identifier": row.get("identifier", ""),
+                "catalog_name": row.get("catalog_name", ""),
+                "database_name": row.get("database_name", ""),
+                "schema_name": row.get("schema_name", ""),
+                "table_name": row.get("table_name", ""),
+                "table_type": row.get("table_type", ""),
+                "definition": row.get("definition", ""),
+            }
+            for row in rows
+        ]
+        value_rows = [
+            {
+                "identifier": row.get("identifier", ""),
+                "catalog_name": row.get("catalog_name", ""),
+                "database_name": row.get("database_name", ""),
+                "schema_name": row.get("schema_name", ""),
+                "table_name": row.get("table_name", ""),
+                "table_type": row.get("table_type", ""),
+                "sample_rows": row.get("sample_rows", ""),
+            }
+            for row in rows
+            if row.get("sample_rows")
+        ]
+        schema_table = (
+            pa.Table.from_pylist(schema_rows)
+            if schema_rows
+            else self.facts_store._empty_result(
+                [
+                    "identifier",
+                    "catalog_name",
+                    "database_name",
+                    "schema_name",
+                    "table_name",
+                    "table_type",
+                    "definition",
+                ]
+            )
+        )
+        value_table = (
+            pa.Table.from_pylist(value_rows)
+            if value_rows
+            else self.facts_store._empty_result(
+                [
+                    "identifier",
+                    "catalog_name",
+                    "database_name",
+                    "schema_name",
+                    "table_name",
+                    "table_type",
+                    "sample_rows",
+                ]
+            )
+        )
+        return TableSchema.from_arrow(schema_table), TableValue.from_arrow(value_table)
+
+    def remove_data(
+        self,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        table_name: str = "",
+        table_type: TABLE_TYPE = "table",
+    ) -> None:
+        where = self._where(
+            catalog_name=catalog_name,
+            database_name=database_name,
+            schema_name=schema_name,
+            table_name=table_name,
+            table_type=table_type,
+        )
+        if where is not None:
+            self.facts_store._delete_rows(where)
+            self.document_store._delete_rows(where)
+            if self.vector_store is not None:
+                self.vector_store._delete_rows(where)
+
+    def refresh_profiles(self, profiles: List[Dict[str, Any]]) -> int:
+        updated_docs: List[Dict[str, Any]] = []
+        for profile in profiles:
+            table_name = str(profile.get("table_name") or "").strip()
+            if not table_name:
+                continue
+            rows = self.facts_store._search_all(
+                where=self._where(
+                    catalog_name=str(profile.get("catalog_name") or ""),
+                    database_name=str(profile.get("database_name") or ""),
+                    schema_name=str(profile.get("schema_name") or ""),
+                    table_name=table_name,
+                    table_type="full",
+                )
+            ).to_pylist()
+            for fact in rows:
+                updated_docs.append(self._document_row(fact, profile=profile))
+        return self._upsert_documents(updated_docs)
+
+    def refresh_tables(self, table_refs: List[Dict[str, Any]]) -> int:
+        """Rebuild metadata retrieval documents for tables using currently stored profiles."""
+
+        updated_docs: List[Dict[str, Any]] = []
+        seen_fact_ids: set[str] = set()
+        for table_ref in table_refs:
+            table_name = str(table_ref.get("table_name") or "").strip()
+            if not table_name:
+                continue
+            rows = self.facts_store._search_all(
+                where=self._where(
+                    catalog_name=str(table_ref.get("catalog_name") or ""),
+                    database_name=str(table_ref.get("database_name") or ""),
+                    schema_name=str(table_ref.get("schema_name") or ""),
+                    table_name=table_name,
+                    table_type="full",
+                )
+            ).to_pylist()
+            for fact in rows:
+                fact_id = self._fact_id(fact)
+                if fact_id in seen_fact_ids:
+                    continue
+                seen_fact_ids.add(fact_id)
+                updated_docs.append(self._document_row(fact))
+        return self._upsert_documents(updated_docs)
+
+    def refresh_all_tables(self) -> int:
+        """Rebuild every metadata retrieval document for this datasource."""
+
+        rows = self.facts_store._search_all(
+            where=self._where(table_type="full"),
+        ).to_pylist()
+        return self._upsert_documents([self._document_row(fact) for fact in rows])
+
+    def _upsert_documents(self, updated_docs: List[Dict[str, Any]]) -> int:
+        if not updated_docs:
+            return 0
+        self.document_store.upsert_batch(updated_docs)
+        if self.vector_store is not None:
+            from datus.storage.datasource_scope import add_datasource_scope_to_rows
+
+            vector_rows = [dict(row, id=row["doc_id"]) for row in updated_docs]
+            self.vector_store.upsert_batch(
+                add_datasource_scope_to_rows(vector_rows, self.datasource_id), on_column="storage_key"
+            )
+            self.vector_store.create_indices()
+        self.document_store.create_indices()
+        return len(updated_docs)
+
+    def _schema_rows_for_metadata(self, metadata: pa.Table) -> pa.Table:
+        if metadata.num_rows == 0:
+            return self.facts_store._empty_result(self.SCHEMA_SELECT_FIELDS)
+
+        rows: List[Dict[str, Any]] = []
+        for hit in metadata.to_pylist():
+            fact_rows = self._facts_for_hit(hit)
+            if not fact_rows:
+                continue
+            schema_row = {field: fact_rows[0].get(field, "") for field in self.SCHEMA_SELECT_FIELDS}
+            for field in self.SCORE_FIELDS:
+                if hit.get(field) is not None:
+                    schema_row[field] = hit[field]
+            rows.append(schema_row)
+        if not rows:
+            return self.facts_store._empty_result(self.SCHEMA_SELECT_FIELDS)
+        return pa.Table.from_pylist(rows)
+
+    def _facts_for_hit(self, hit: Dict[str, Any]) -> List[Dict[str, Any]]:
+        fact_id = str(hit.get("entity_key") or "").strip()
+        if fact_id:
+            rows = self.facts_store._search_all(
+                where=and_(datasource_condition(self.datasource_id), eq("fact_id", fact_id)),
+                select_fields=self.SCHEMA_SELECT_FIELDS,
+                limit=1,
+            ).to_pylist()
+            if rows:
+                return rows
+
+        identifier = str(hit.get("identifier") or "").strip()
+        if not identifier:
+            return []
+        return self.facts_store._search_all(
+            where=and_(datasource_condition(self.datasource_id), eq("identifier", identifier)),
+            select_fields=self.SCHEMA_SELECT_FIELDS,
+            limit=1,
+        ).to_pylist()
+
+    def _sample_rows_for_metadata(self, metadata: pa.Table) -> pa.Table:
+        if metadata.num_rows == 0:
+            return self.facts_store._empty_result(self.VALUE_SELECT_FIELDS)
+        identifiers = [row.get("identifier") for row in metadata.to_pylist() if row.get("identifier")]
+        if not identifiers:
+            return self.facts_store._empty_result(self.VALUE_SELECT_FIELDS)
+        rows = []
+        for identifier in identifiers:
+            rows.extend(
+                self.facts_store._search_all(
+                    where=and_(datasource_condition(self.datasource_id), eq("identifier", identifier)),
+                    select_fields=self.VALUE_SELECT_FIELDS,
+                    limit=1,
+                ).to_pylist()
+            )
+        rows = [row for row in rows if row.get("sample_rows")]
+        return pa.Table.from_pylist(rows) if rows else self.facts_store._empty_result(self.VALUE_SELECT_FIELDS)
+
+    def _sample_rows_by_identifier(self, values: List[Dict[str, Any]]) -> Dict[str, str]:
+        result: Dict[str, str] = {}
+        for item in values:
+            identifier = str(item.get("identifier") or "").strip()
+            if not identifier:
+                continue
+            sample_rows = item.get("sample_rows")
+            if isinstance(sample_rows, list):
+                sample_rows = json2csv(sample_rows)
+            text = _normalize_row_text(sample_rows)
+            if text:
+                result[identifier] = text
+        return result
+
+    def _fact_id(self, row: Dict[str, Any]) -> str:
+        return "|".join(
+            [
+                self.datasource_id,
+                str(row.get("identifier") or ""),
+                str(row.get("table_type") or ""),
+            ]
+        )
+
+    def _doc_id(self, row: Dict[str, Any]) -> str:
+        return "metadata:table:" + self._fact_id(row)
+
+    def _fact_row(self, schema: Dict[str, Any], sample_rows: str = "") -> Dict[str, Any]:
+        row = {
+            "identifier": str(schema.get("identifier") or "").strip(),
+            "catalog_name": str(schema.get("catalog_name") or "").strip(),
+            "database_name": str(schema.get("database_name") or "").strip(),
+            "schema_name": str(schema.get("schema_name") or "").strip(),
+            "table_name": str(schema.get("table_name") or "").strip(),
+            "table_type": str(schema.get("table_type") or "table").strip() or "table",
+            "definition": str(schema.get("definition") or ""),
+            "sample_rows": sample_rows,
+        }
+        row[DATASOURCE_ID_COLUMN] = self.datasource_id
+        row["fact_id"] = self._fact_id(row)
+        row["content_hash"] = _stable_hash(row)
+        row["updated_at"] = _utc_now()
+        return row
+
+    def _document_row(self, fact: Dict[str, Any], profile: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        if profile is None:
+            profile = self._get_profile_for_fact(fact)
+        payload = {
+            "identifier": fact.get("identifier", ""),
+            "catalog_name": fact.get("catalog_name", ""),
+            "database_name": fact.get("database_name", ""),
+            "schema_name": fact.get("schema_name", ""),
+            "table_name": fact.get("table_name", ""),
+            "table_type": fact.get("table_type", ""),
+        }
+        title = _qualified_name(fact) or str(fact.get("table_name") or "")
+        search_parts = [
+            f"table {fact.get('table_name', '')}",
+            f"qualified_name {title}",
+            f"identifier {fact.get('identifier', '')}",
+            f"type {fact.get('table_type', '')}",
+            f"definition {fact.get('definition', '')}",
+        ]
+        if fact.get("sample_rows"):
+            search_parts.append(f"sample_rows {fact.get('sample_rows')}")
+        if profile:
+            search_parts.extend(
+                [
+                    f"semantic_model {profile.get('semantic_model_name', '')}",
+                    f"dataset {profile.get('dataset_name') or profile.get('data_source_name') or ''}",
+                    f"description {profile.get('description', '')}",
+                    f"ai_context {profile.get('ai_context_json', '')}",
+                    f"columns {profile.get('columns_json', '')}",
+                    f"relationships {profile.get('relationships_json', '')}",
+                ]
+            )
+            payload["semantic_profile_applied"] = True
+            payload["semantic_model_name"] = profile.get("semantic_model_name", "")
+            payload["description"] = profile.get("description", "")
+        search_text = _normalize_row_text(" ".join(search_parts))
+        row = {
+            "doc_id": self._doc_id(fact),
+            DATASOURCE_ID_COLUMN: self.datasource_id,
+            "component_type": "metadata",
+            "entity_type": "table",
+            "entity_key": self._fact_id(fact),
+            "identifier": fact.get("identifier", ""),
+            "catalog_name": fact.get("catalog_name", ""),
+            "database_name": fact.get("database_name", ""),
+            "schema_name": fact.get("schema_name", ""),
+            "table_name": fact.get("table_name", ""),
+            "table_type": fact.get("table_type", ""),
+            "title": title,
+            "search_text": search_text,
+            "payload_json": json.dumps(payload, ensure_ascii=False, sort_keys=True),
+            "updated_at": _utc_now(),
+        }
+        row["content_hash"] = _stable_hash({k: v for k, v in row.items() if k not in {"updated_at", "content_hash"}})
+        return row
+
+    def _get_profile_for_fact(self, fact: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if self._table_semantic_profiles is None:
+            try:
+                from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
+
+                self._table_semantic_profiles = TableSemanticProfileRAG(self.agent_config)
+            except Exception as exc:
+                logger.debug("Table semantic profile storage unavailable for metadata docs: %s", exc)
+                self._table_semantic_profiles = False
+        if not self._table_semantic_profiles:
+            return None
+        try:
+            return self._table_semantic_profiles.get_profile(
+                catalog_name=str(fact.get("catalog_name") or ""),
+                database_name=str(fact.get("database_name") or ""),
+                schema_name=str(fact.get("schema_name") or ""),
+                table_name=str(fact.get("table_name") or ""),
+            )
+        except Exception as exc:
+            logger.debug("Failed to load table semantic profile for %s: %s", fact.get("table_name"), exc)
+            return None
+
+    @staticmethod
+    def _parse_table_name(
+        full_table: str,
+        *,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+        dialect: str = DBType.SQLITE,
+    ) -> tuple[str, str, str, str]:
+        parts = full_table.split(".")
+        table_name = parts[-1]
+        if len(parts) == 4:
+            return parts[0], parts[1], parts[2], table_name
+        if len(parts) == 3:
+            if connector_registry.support_catalog(dialect) and not connector_registry.support_schema(dialect):
+                return parts[0], parts[1], "", table_name
+            return catalog_name, parts[0], parts[1], table_name
+        if len(parts) == 2:
+            if not connector_registry.support_schema(dialect):
+                return catalog_name, parts[0], "", table_name
+            return catalog_name, database_name, parts[0], table_name
+        return catalog_name, database_name, schema_name, table_name

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -14,6 +14,7 @@ from datus_storage_base.conditions import WhereExpr, and_, eq, in_, not_
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
 from datus.storage.datasource_scope import datasource_condition, resolve_datasource_id
+from datus.storage.fts import FtsField, FtsSpec
 from datus.storage.knowledge_provenance import enrich_metric_results, is_knowledge_provenance_enabled
 from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore, base_schema_columns
 from datus.utils.loggings import get_logger
@@ -162,7 +163,7 @@ class MetricStorage(BaseSubjectEmbeddingStore):
         self._create_scalar_index("schema_name")
 
         self.create_subject_index()
-        self.create_fts_index(["description", "name"])
+        self.create_fts_index(FtsSpec((FtsField("name", boost=3.0), FtsField("description"))))
 
     def _scope_column_migration_exprs(self) -> Dict[str, str]:
         # Also backfill the Hub uid column on pre-existing metric tables (empty

--- a/datus/storage/reference_sql/store.py
+++ b/datus/storage/reference_sql/store.py
@@ -11,6 +11,7 @@ import yaml
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
 from datus.storage.datasource_scope import datasource_condition, resolve_datasource_id
+from datus.storage.fts import FtsField, FtsSpec
 from datus.storage.knowledge_provenance import enrich_reference_sql_results, is_knowledge_provenance_enabled
 from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore, base_schema_columns
 from datus.utils.loggings import get_logger
@@ -55,7 +56,17 @@ class ReferenceSqlStorage(BaseSubjectEmbeddingStore):
         self._create_scalar_index("filepath")
 
         self.create_subject_index()
-        self.create_fts_index(["sql", "name", "summary", "tags", "search_text"])
+        self.create_fts_index(
+            FtsSpec(
+                (
+                    FtsField("name", boost=3.0),
+                    FtsField("summary", boost=2.0),
+                    FtsField("search_text", boost=2.0),
+                    FtsField("tags", boost=1.5),
+                    FtsField("sql"),
+                )
+            )
+        )
 
     def batch_store_sql(self, sql_items: List[Dict[str, Any]], subject_path_field: str = "subject_path") -> None:
         """Store multiple reference SQL items in batch with subject path processing.

--- a/datus/storage/reference_template/store.py
+++ b/datus/storage/reference_template/store.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.base import EmbeddingModel
 from datus.storage.datasource_scope import datasource_condition, resolve_datasource_id
+from datus.storage.fts import FtsField, FtsSpec
 from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore, base_schema_columns
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -54,7 +55,17 @@ class ReferenceTemplateStorage(BaseSubjectEmbeddingStore):
         self._create_scalar_index("filepath")
 
         self.create_subject_index()
-        self.create_fts_index(["template", "name", "summary", "tags", "search_text"])
+        self.create_fts_index(
+            FtsSpec(
+                (
+                    FtsField("name", boost=3.0),
+                    FtsField("summary", boost=2.0),
+                    FtsField("search_text", boost=2.0),
+                    FtsField("tags", boost=1.5),
+                    FtsField("template"),
+                )
+            )
+        )
 
     def batch_store_templates(
         self, template_items: List[Dict[str, Any]], subject_path_field: str = "subject_path"

--- a/datus/storage/schema_metadata/__init__.py
+++ b/datus/storage/schema_metadata/__init__.py
@@ -6,10 +6,20 @@ from .benchmark_init import init_snowflake_schema
 from .local_init import init_local_schema_async
 from .store import SchemaStorage, SchemaValueStorage, SchemaWithValueRAG
 
+
+def create_metadata_rag(agent_config, sub_agent_name=None, datasource_id=None):
+    from datus.storage.kb_retrieval import MetadataFtsRAG, metadata_fts_enabled
+
+    if metadata_fts_enabled(agent_config):
+        return MetadataFtsRAG(agent_config, sub_agent_name=sub_agent_name, datasource_id=datasource_id)
+    return SchemaWithValueRAG(agent_config, sub_agent_name=sub_agent_name, datasource_id=datasource_id)
+
+
 __all__ = [
     "SchemaStorage",
     "SchemaValueStorage",
     "SchemaWithValueRAG",
+    "create_metadata_rag",
     "init_local_schema_async",
     "init_snowflake_schema",
 ]

--- a/datus/storage/schema_metadata/benchmark_init.py
+++ b/datus/storage/schema_metadata/benchmark_init.py
@@ -63,7 +63,7 @@ def init_snowflake_schema(
                 all_value_tables,
             )
 
-    storage.after_init()
+    storage.after_init(build_mode=build_mode)
 
 
 def process_line(

--- a/datus/storage/schema_metadata/benchmark_init_bird.py
+++ b/datus/storage/schema_metadata/benchmark_init_bird.py
@@ -143,7 +143,7 @@ def init_dev_schema(
         ]
         for future in as_completed(futures):
             future.result()
-    rag.after_init()
+    rag.after_init(build_mode=build_mode)
 
 
 def init_dev_schema_by_db(

--- a/datus/storage/schema_metadata/local_init.py
+++ b/datus/storage/schema_metadata/local_init.py
@@ -113,7 +113,7 @@ def init_local_schema(
         databases = [default_database] if default_database else []
     if not databases:
         logger.info(f"No databases resolved for datasource {ds} ({db_config.type}); skipping schema init.")
-        table_lineage_store.after_init()
+        table_lineage_store.after_init(build_mode=build_mode)
         event_helper.task_completed(total_items=0, completed_items=0)
         return
     logger.info(f"Processing datasource {ds} ({db_config.type}) databases: {databases}")
@@ -155,8 +155,8 @@ def init_local_schema(
                 build_mode=build_mode,
                 event_helper=event_helper,
             )
-    # Create indices after initialization
-    table_lineage_store.after_init()
+    # Build new indices for overwrite, or incrementally index changed fragments.
+    table_lineage_store.after_init(build_mode=build_mode)
     event_helper.task_completed(total_items=0, completed_items=0)
     logger.info("Local schema initialization completed")
 

--- a/datus/storage/schema_metadata/local_init.py
+++ b/datus/storage/schema_metadata/local_init.py
@@ -439,6 +439,7 @@ def store_tables(
     for table in tables:
         if not table.get("database_name"):
             table["database_name"] = database_name
+        table["table_type"] = table_type
         if not table.get("identifier"):
             table["identifier"] = connector.identifier(
                 catalog_name=table["catalog_name"],

--- a/datus/storage/schema_metadata/store.py
+++ b/datus/storage/schema_metadata/store.py
@@ -14,6 +14,7 @@ from datus.schemas.node_models import TableSchema, TableValue
 from datus.storage.base import BaseEmbeddingStore, WhereExpr
 from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
 from datus.storage.embedding_models import EmbeddingModel
+from datus.storage.fts import FtsField, FtsSpec
 from datus.tools.db_tools import connector_registry
 from datus.utils.constants import DBType
 from datus.utils.json_utils import json2csv
@@ -101,7 +102,7 @@ class BaseMetadataStorage(BaseEmbeddingStore):
             query_type=query_type,
         )
 
-    def create_indices(self):
+    def create_indices(self, *, include_fts: bool = True):
         self._ensure_table_ready()
 
         self._create_scalar_index("database_name")
@@ -110,7 +111,17 @@ class BaseMetadataStorage(BaseEmbeddingStore):
         self._create_scalar_index("table_name")
         self._create_scalar_index("table_type")
 
-        self.create_fts_index(["database_name", "schema_name", "table_name", self.vector_source_name])
+        if include_fts:
+            self.create_fts_index(
+                FtsSpec(
+                    (
+                        FtsField("table_name", boost=3.0),
+                        FtsField("schema_name", boost=2.0),
+                        FtsField("database_name", boost=2.0),
+                        FtsField(self.vector_source_name),
+                    )
+                )
+            )
 
     def search_all(
         self,
@@ -300,10 +311,10 @@ class SchemaWithValueRAG:
 
         logger.debug(f"Batch stored {len(schemas)} schemas, {len(final_values)} values")
 
-    def after_init(self):
-        """After init the schema and value, create the indices for the tables."""
-        self.schema_store.create_indices()
-        self.value_store.create_indices()
+    def after_init(self, build_mode: str = "overwrite"):
+        """Create only the indices required by the legacy vector mode."""
+        self.schema_store.create_indices(include_fts=False)
+        self.value_store.create_indices(include_fts=False)
 
     def get_schema_size(self):
         return self.schema_store._count_rows(where=self._add_sub_agent_filter(None))

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -11,6 +11,7 @@ from datus_storage_base.conditions import And, WhereExpr, eq, in_, not_
 
 from datus.storage.base import BaseEmbeddingStore, EmbeddingModel
 from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
+from datus.storage.fts import FtsField, FtsSpec
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -120,7 +121,9 @@ class SemanticModelStorage(BaseEmbeddingStore):
         self._create_scalar_index("table_name")
         self._create_scalar_index("id")
 
-        self.create_fts_index(["description", "name", "fq_name"])
+        self.create_fts_index(
+            FtsSpec((FtsField("name", boost=3.0), FtsField("fq_name", boost=3.0), FtsField("description")))
+        )
 
     def search_objects(
         self,

--- a/datus/storage/table_semantic_profile/store.py
+++ b/datus/storage/table_semantic_profile/store.py
@@ -11,6 +11,7 @@ from datus_storage_base.conditions import And, eq, in_, not_
 
 from datus.storage.base import BaseEmbeddingStore, EmbeddingModel
 from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
+from datus.storage.fts import FtsField, FtsSpec
 from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
@@ -69,7 +70,7 @@ class TableSemanticProfileStorage(BaseEmbeddingStore):
         self._create_scalar_index("format")
         self._create_scalar_index("table_name")
         self._create_scalar_index("physical_table_fq_name")
-        self.create_fts_index(["search_text", "description", "table_name", "physical_table_fq_name"])
+        self.create_fts_index(FtsSpec((FtsField("search_text"),)))
 
 
 class TableSemanticProfileRAG:

--- a/datus/storage/table_semantic_profile/store.py
+++ b/datus/storage/table_semantic_profile/store.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_PROFILE_TABLE_FIELDS = ["catalog_name", "database_name", "schema_name", "table_name"]
+
 
 class TableSemanticProfileStorage(BaseEmbeddingStore):
     """Table-level semantic profile projection used by database tools.
@@ -82,6 +84,7 @@ class TableSemanticProfileRAG:
         from datus.storage.rag_scope import _build_sub_agent_filter
         from datus.storage.registry import get_storage
 
+        self.agent_config = agent_config
         self.datasource_id = resolve_datasource_id(agent_config, datasource_id)
         self.storage: TableSemanticProfileStorage = get_storage(
             TableSemanticProfileStorage,
@@ -98,13 +101,18 @@ class TableSemanticProfileRAG:
         return conditions
 
     def truncate(self) -> None:
+        rows = self._profile_table_refs(where=And(self._sub_agent_conditions()))
         self.storage.delete_datasource_rows(self.datasource_id)
+        self._refresh_metadata_documents_for_tables(rows)
 
     def delete_artifact_rows(self, yaml_path: str) -> None:
         """Delete table profile rows projected from a single YAML artifact."""
         if not yaml_path:
             return
-        self.storage._delete_rows(And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions()))
+        where = And([eq("yaml_path", yaml_path)] + self._sub_agent_conditions())
+        rows = self._profile_table_refs(where=where)
+        self.storage._delete_rows(where)
+        self._refresh_metadata_documents_for_tables(rows)
 
     def delete_artifact_rows_except(self, yaml_path: str, keep_ids: List[str]) -> None:
         """Delete stale table profile rows for one YAML artifact after replacement succeeds."""
@@ -114,9 +122,10 @@ class TableSemanticProfileRAG:
         if not normalized_keep_ids:
             self.delete_artifact_rows(yaml_path)
             return
-        self.storage._delete_rows(
-            And([eq("yaml_path", yaml_path), not_(in_("id", normalized_keep_ids))] + self._sub_agent_conditions())
-        )
+        where = And([eq("yaml_path", yaml_path), not_(in_("id", normalized_keep_ids))] + self._sub_agent_conditions())
+        rows = self._profile_table_refs(where=where)
+        self.storage._delete_rows(where)
+        self._refresh_metadata_documents_for_tables(rows)
 
     def list_artifact_rows(self, yaml_path: str) -> List[Dict[str, Any]]:
         """Return table profile rows projected from a single YAML artifact."""
@@ -210,9 +219,40 @@ class TableSemanticProfileRAG:
 
     def store_batch(self, profiles: List[Dict[str, Any]]) -> None:
         self.storage.store_batch(add_datasource_scope_to_rows(profiles, self.datasource_id))
+        self._refresh_metadata_documents_with_profiles(profiles)
 
     def upsert_batch(self, profiles: List[Dict[str, Any]]) -> None:
         self.storage.upsert_batch(add_datasource_scope_to_rows(profiles, self.datasource_id), on_column="storage_key")
+        self._refresh_metadata_documents_with_profiles(profiles)
+
+    def _profile_table_refs(self, where) -> List[Dict[str, Any]]:
+        try:
+            return self.storage._search_all(where=where, select_fields=_PROFILE_TABLE_FIELDS).to_pylist()
+        except Exception as exc:
+            logger.debug("Failed to load table semantic profile rows before deletion: %s", exc)
+            return []
+
+    def _refresh_metadata_documents_with_profiles(self, profiles: List[Dict[str, Any]]) -> None:
+        if not profiles:
+            return
+        try:
+            from datus.storage.kb_retrieval import MetadataFtsRAG, metadata_fts_enabled
+
+            if metadata_fts_enabled(self.agent_config):
+                MetadataFtsRAG(self.agent_config, datasource_id=self.datasource_id).refresh_profiles(profiles)
+        except Exception as exc:
+            logger.debug("Failed to refresh metadata retrieval documents from table semantic profiles: %s", exc)
+
+    def _refresh_metadata_documents_for_tables(self, table_refs: List[Dict[str, Any]]) -> None:
+        if not table_refs:
+            return
+        try:
+            from datus.storage.kb_retrieval import MetadataFtsRAG, metadata_fts_enabled
+
+            if metadata_fts_enabled(self.agent_config):
+                MetadataFtsRAG(self.agent_config, datasource_id=self.datasource_id).refresh_tables(table_refs)
+        except Exception as exc:
+            logger.debug("Failed to refresh metadata retrieval documents from table semantic profiles: %s", exc)
 
     def create_indices(self) -> None:
         self.storage.create_indices()

--- a/datus/storage/vector/lance_backend.py
+++ b/datus/storage/vector/lance_backend.py
@@ -6,7 +6,10 @@
 
 import os
 import re
+import shutil
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import unquote, urlparse
 
 import lancedb
 import pandas as pd
@@ -18,10 +21,12 @@ from lancedb.embeddings import EmbeddingFunctionConfig
 from lancedb.embeddings.base import EmbeddingFunction as LanceDBEmbeddingFunction
 from lancedb.embeddings.base import TextEmbeddingFunction
 from lancedb.embeddings.registry import register
-from lancedb.query import LanceQueryBuilder
+from lancedb.index import FTS
+from lancedb.query import LanceQueryBuilder, MatchQuery, MultiMatchQuery
 from lancedb.rerankers import LinearCombinationReranker
 from lancedb.table import Table as LanceTable
 
+from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -100,9 +105,9 @@ def _wrap_embedding(model: EmbeddingFunction) -> TextEmbeddingFunction:
     from datus.storage.fastembed_embeddings import FastEmbedEmbeddings
 
     if isinstance(model, FastEmbedEmbeddings):
-        adapter = _LanceFastEmbedAdapter(name=model.name, batch_size=model.batch_size)
+        adapter = _LanceFastEmbedAdapter.create(name=model.name, batch_size=model.batch_size)
     else:
-        adapter = _LanceOpenAIAdapter(
+        adapter = _LanceOpenAIAdapter.create(
             name=getattr(model, "name", ""),
             dim=getattr(model, "dim", None),
             base_url=getattr(model, "base_url", None),
@@ -178,13 +183,22 @@ class LanceVectorTable(VectorTable):
     def search_fts(
         self,
         query_text: str,
-        fts_columns: Union[str, List[str]],
+        fts_spec: Union[FtsSpec, str, List[str]],
         top_n: int,
         where: WhereExpr = None,
         select_fields: Optional[List[str]] = None,
     ) -> pa.Table:
         compiled = build_where(where)
-        query_builder = self._table.search(query=query_text, query_type="fts", fts_columns=fts_columns)
+        if isinstance(fts_spec, str):
+            fts_spec = FtsSpec.from_names([fts_spec])
+        elif isinstance(fts_spec, list):
+            fts_spec = FtsSpec.from_names(fts_spec)
+        if len(fts_spec.fields) == 1:
+            field = fts_spec.fields[0]
+            query = MatchQuery(query_text, field.name, boost=field.boost)
+        else:
+            query = MultiMatchQuery(query_text, fts_spec.columns, boosts=fts_spec.boosts)
+        query_builder = self._table.search(query=query)
         query_builder = self._fill_query(query_builder, select_fields, compiled)
         return query_builder.limit(top_n).to_arrow()
 
@@ -215,8 +229,52 @@ class LanceVectorTable(VectorTable):
     def create_vector_index(self, column: str, metric: str = "cosine", **kwargs) -> None:
         self._table.create_index(metric=metric, vector_column_name=column, **kwargs)
 
-    def create_fts_index(self, field_names: Union[str, List[str]]) -> None:
-        self._table.create_fts_index(field_names=field_names, replace=True)
+    def create_fts_index(self, field: Union[FtsField, str]) -> None:
+        if isinstance(field, str):
+            field = FtsField(field)
+        config = FTS(
+            base_tokenizer=field.tokenizer,
+            ngram_min_length=field.ngram_min_length,
+            ngram_max_length=field.ngram_max_length,
+            stem=False,
+            remove_stop_words=False,
+            ascii_folding=False,
+        )
+        self._table.create_index(field.name, config=config, replace=True)
+
+    def supports_fts(self) -> bool:
+        return True
+
+    def fts_index_status(self, spec: FtsSpec) -> FtsIndexStatus:
+        if self._legacy_fts_path() is not None:
+            return FtsIndexStatus.LEGACY
+        index_by_field = {}
+        for index in self._table.list_indices():
+            index_type = getattr(index, "index_type", "")
+            index_type = getattr(index_type, "value", index_type)
+            if str(index_type).upper() == "FTS":
+                columns = getattr(index, "fields", getattr(index, "columns", []))
+                for column in columns:
+                    index_by_field[column] = index
+        if not set(spec.columns).issubset(index_by_field):
+            return FtsIndexStatus.MISSING
+        for field in spec.fields:
+            details = getattr(index_by_field[field.name], "index_details", {}) or {}
+            if details.get("base_tokenizer") != field.tokenizer:
+                return FtsIndexStatus.VERSION_MISMATCH
+            if field.tokenizer == "ngram" and (
+                details.get("min_ngram_length") != field.ngram_min_length
+                or details.get("max_ngram_length") != field.ngram_max_length
+            ):
+                return FtsIndexStatus.VERSION_MISMATCH
+        return FtsIndexStatus.READY
+
+    def remove_legacy_fts_index(self) -> bool:
+        legacy_path = self._legacy_fts_path()
+        if legacy_path is None:
+            return False
+        shutil.rmtree(legacy_path)
+        return True
 
     def create_scalar_index(self, column: str) -> None:
         self._table.create_scalar_index(column, replace=True)
@@ -230,6 +288,10 @@ class LanceVectorTable(VectorTable):
 
     # -- Maintenance --
 
+    def optimize(self) -> None:
+        """Incrementally add changed fragments to existing indices."""
+        self._table.optimize()
+
     def compact_files(self) -> None:
         self._table.compact_files()
 
@@ -237,6 +299,15 @@ class LanceVectorTable(VectorTable):
         self._table.cleanup_old_versions()
 
     # -- Internal helpers --
+
+    def _legacy_fts_path(self) -> Optional[Path]:
+        uri = str(getattr(self._table, "uri", ""))
+        parsed = urlparse(uri)
+        if parsed.scheme not in {"", "file"}:
+            return None
+        table_path = Path(unquote(parsed.path if parsed.scheme else uri))
+        legacy_path = table_path / "_indices" / "fts"
+        return legacy_path if legacy_path.exists() else None
 
     @staticmethod
     def _fill_query(
@@ -261,6 +332,9 @@ class LanceVectorDatabase(VectorDatabase):
 
     def __init__(self, db_connection: DBConnection) -> None:
         self._db = db_connection
+
+    def supports_fts(self) -> bool:
+        return True
 
     @staticmethod
     def _is_missing_table_error(exc: Exception) -> bool:

--- a/datus/storage/vector/lance_backend.py
+++ b/datus/storage/vector/lance_backend.py
@@ -262,12 +262,30 @@ class LanceVectorDatabase(VectorDatabase):
     def __init__(self, db_connection: DBConnection) -> None:
         self._db = db_connection
 
+    @staticmethod
+    def _is_missing_table_error(exc: Exception) -> bool:
+        if isinstance(exc, FileNotFoundError):
+            return True
+        exc_name = type(exc).__name__.lower()
+        exc_text = str(exc).lower()
+        if "filedoesnotexist" in exc_name or "filedoesnotexist" in exc_text:
+            return True
+        if "tablenotfound" in exc_name:
+            return True
+        if "table not found" in exc_text or "table does not exist" in exc_text:
+            return True
+        if isinstance(exc, ValueError) and ("not found" in exc_text or "does not exist" in exc_text):
+            return True
+        return False
+
     def table_exists(self, table_name: str) -> bool:
         try:
             self._db.open_table(table_name)
             return True
-        except ValueError:
-            return False
+        except Exception as exc:
+            if self._is_missing_table_error(exc):
+                return False
+            raise
 
     def table_names(self, limit: int = 100) -> List[str]:
         return self._db.table_names(limit=limit)

--- a/datus/storage/vector/lance_backend.py
+++ b/datus/storage/vector/lance_backend.py
@@ -164,18 +164,29 @@ class LanceVectorTable(VectorTable):
     def search_hybrid(
         self,
         query_text: str,
-        vector_source_column: str,
+        vector_column: str,
         top_n: int,
         where: WhereExpr = None,
         select_fields: Optional[List[str]] = None,
     ) -> pa.Table:
         compiled = build_where(where)
-        query_builder = self._table.search(
-            query=query_text, query_type="hybrid", vector_column_name=vector_source_column
-        )
+        query_builder = self._table.search(query=query_text, query_type="hybrid", vector_column_name=vector_column)
         query_builder = self._fill_query(query_builder, select_fields, compiled)
         reranker = LinearCombinationReranker()
         return query_builder.limit(top_n * 2).rerank(reranker).to_arrow()
+
+    def search_fts(
+        self,
+        query_text: str,
+        fts_columns: Union[str, List[str]],
+        top_n: int,
+        where: WhereExpr = None,
+        select_fields: Optional[List[str]] = None,
+    ) -> pa.Table:
+        compiled = build_where(where)
+        query_builder = self._table.search(query=query_text, query_type="fts", fts_columns=fts_columns)
+        query_builder = self._fill_query(query_builder, select_fields, compiled)
+        return query_builder.limit(top_n).to_arrow()
 
     def search_all(
         self,

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -3,6 +3,8 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 # -*- coding: utf-8 -*-
+import csv
+import io
 import json
 import os
 import re
@@ -16,6 +18,8 @@ from datus_db_core import BaseSqlConnector, connector_registry
 
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.agent_models import SubAgentConfig
+from datus.storage.kb_retrieval import metadata_fts_enabled
+from datus.storage.schema_metadata import create_metadata_rag
 from datus.storage.schema_metadata.store import SchemaWithValueRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
@@ -166,7 +170,10 @@ class DBFuncTool:
         self.principal: Dict[str, Any] = dict(principal_source) if isinstance(principal_source, dict) else {}
         self.sub_agent_name = sub_agent_name
         self.read_only = read_only
-        self.schema_rag = SchemaWithValueRAG(agent_config, sub_agent_name) if agent_config else None
+        if agent_config and metadata_fts_enabled(agent_config):
+            self.schema_rag = create_metadata_rag(agent_config, sub_agent_name)
+        else:
+            self.schema_rag = SchemaWithValueRAG(agent_config, sub_agent_name) if agent_config else None
         self._field_order = self._determine_field_order()
         self._scoped_patterns = self._load_scoped_patterns(scoped_tables)
 
@@ -177,7 +184,7 @@ class DBFuncTool:
                 self._table_semantic_profiles = TableSemanticProfileRAG(agent_config, sub_agent_name)
             except Exception as exc:
                 logger.debug(f"Failed to initialize table semantic profile storage: {exc}")
-        self.has_schema = self.schema_rag and self.schema_rag.schema_store.table_size() > 0
+        self.has_schema = self._has_schema_storage()
 
         self.has_semantic_models = self._semantic_storage and self._semantic_storage.get_size() > 0
         try:
@@ -187,6 +194,133 @@ class DBFuncTool:
         except Exception:
             self._table_semantic_profiles = None
             self.has_table_semantic_profiles = False
+
+    def _has_schema_storage(self) -> bool:
+        if not self.schema_rag:
+            return False
+        get_schema_size = getattr(self.schema_rag, "get_schema_size", None)
+        if callable(get_schema_size):
+            try:
+                return get_schema_size() > 0
+            except Exception:
+                return False
+        schema_store = getattr(self.schema_rag, "schema_store", None)
+        table_size = getattr(schema_store, "table_size", None)
+        if callable(table_size):
+            try:
+                return table_size() > 0
+            except Exception:
+                return False
+        return False
+
+    @staticmethod
+    def _metadata_search_rows(metadata: Any) -> List[Dict[str, Any]]:
+        rows = metadata.to_pylist()
+        result: List[Dict[str, Any]] = []
+        metadata_fields = [
+            "catalog_name",
+            "database_name",
+            "schema_name",
+            "table_name",
+            "table_type",
+            "identifier",
+        ]
+        for row in rows:
+            payload: Dict[str, Any] = {}
+            payload_json = row.get("payload_json")
+            if payload_json:
+                try:
+                    decoded = json.loads(payload_json)
+                    if isinstance(decoded, dict):
+                        description = decoded.get("description")
+                        if description:
+                            payload["description"] = description
+                except (TypeError, ValueError):
+                    pass
+            for field in metadata_fields:
+                if row.get(field) not in (None, ""):
+                    payload[field] = row[field]
+                else:
+                    payload.setdefault(field, "")
+            result.append(payload)
+        return result
+
+    @staticmethod
+    def _qualified_table_name(row: Dict[str, Any]) -> str:
+        parts = [
+            str(row.get("catalog_name") or "").strip(),
+            str(row.get("database_name") or "").strip(),
+            str(row.get("schema_name") or "").strip(),
+            str(row.get("table_name") or "").strip(),
+        ]
+        qualified_name = ".".join(part for part in parts if part)
+        return qualified_name or str(row.get("identifier") or row.get("table_name") or "").strip()
+
+    @staticmethod
+    def _format_sample_rows(value: Any) -> list[Any]:
+        if value in (None, "", [], {}):
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [value]
+        text = str(value).strip()
+        if not text:
+            return []
+        if text.startswith("[") or text.startswith("{"):
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, list):
+                    return parsed
+                if isinstance(parsed, dict):
+                    return [parsed]
+            except (TypeError, ValueError):
+                pass
+        try:
+            rows = list(csv.DictReader(io.StringIO(text)))
+            if rows:
+                return rows
+        except csv.Error:
+            pass
+        return [text]
+
+    @classmethod
+    def _sample_rows_by_identifier(cls, sample_values: Any) -> Dict[str, list[Any]]:
+        if sample_values is None:
+            return {}
+        if getattr(sample_values, "num_rows", None) == 0:
+            return {}
+        selected_fields = ["identifier", "sample_rows"]
+        available_fields = getattr(sample_values, "column_names", None)
+        if available_fields is not None:
+            selected_fields = [field for field in selected_fields if field in available_fields]
+        if not selected_fields:
+            return {}
+        rows = sample_values.select(selected_fields).to_pylist()
+        result: Dict[str, list[Any]] = {}
+        for row in rows:
+            identifier = str(row.get("identifier") or "").strip()
+            if not identifier:
+                continue
+            sample_rows = cls._format_sample_rows(row.get("sample_rows"))
+            if sample_rows:
+                result[identifier] = sample_rows
+        return result
+
+    @classmethod
+    def _search_table_result_row(
+        cls,
+        metadata_row: Dict[str, Any],
+        sample_rows_by_identifier: Dict[str, list[Any]],
+    ) -> Dict[str, Any]:
+        result: Dict[str, Any] = {"table_name": cls._qualified_table_name(metadata_row)}
+        description = str(metadata_row.get("description") or "").strip()
+        if description:
+            result["description"] = description
+        sample_rows = sample_rows_by_identifier.get(str(metadata_row.get("identifier") or "").strip())
+        if sample_rows:
+            result["sample_rows"] = sample_rows
+        return result
 
     def _init_single_db_connector(self, connector: BaseSqlConnector):
         # Legacy single connector mode
@@ -806,10 +940,10 @@ class DBFuncTool:
         simple_sample_data: bool = True,
     ) -> FuncToolResult:
         """
-        Retrieve table candidates by semantic similarity over stored schema metadata and optional sample rows.
+        Retrieve table candidates from indexed metadata and optional semantic profile text.
         Use this tool when the agent needs tables matching a natural-language description.
         This tool helps find relevant tables by searching through table names, schemas (DDL),
-        and sample data using semantic search.
+        and sample data using configured metadata search.
 
         Use this tool when you need to:
         - Find tables related to a specific business concept or domain
@@ -818,7 +952,7 @@ class DBFuncTool:
         - Understand what tables are available in a datasource
 
         **Application Guidance**:
-        1. If table matches (via definition/description/dimensions/measures/sample_data), use it directly
+        1. If table matches (via description/sample_rows), inspect it with describe_table before writing SQL
         2. If partitioned (e.g., date-based in definition), explore correct partition via describe_table
         3. If no match, use list_tables for broader exploration
 
@@ -832,11 +966,12 @@ class DBFuncTool:
                 Leave empty for MySQL (database = schema), StarRocks, SQLite.
             datasource: Optional datasource to route the search to. Defaults to the current datasource.
             top_n: Maximum number of rows to return after scoping filters.
-            simple_sample_data: If True, sample rows omit catalog/database/schema fields for brevity.
+            simple_sample_data: Deprecated compatibility argument; sample rows are returned inline.
 
         Returns:
             FuncToolResult where:
-                - success=1 with result={"metadata": [...], "sample_data": [...]} (empty lists when no matches).
+                - success=1 with result={"metadata": [...]} (empty list when no matches).
+                  Each metadata item contains table_name, optional description, and optional sample_rows.
                 - success=0 with error text if schema storage is unavailable or lookup fails.
         """
         if not self.has_schema:
@@ -849,33 +984,38 @@ class DBFuncTool:
                 schema_name,
                 datasource,
             )
-            metadata, sample_values = self.schema_rag.search_similar(
-                query_text,
-                catalog_name=catalog,
-                database_name=database or self._reset_database_for_rag(datasource),
-                schema_name=schema_name,
-                table_type="full",
-                top_n=top_n,
-            )
-            result_dict: Dict[str, List[Dict[str, Any]]] = {"metadata": [], "sample_data": []}
+            result_dict: Dict[str, Any] = {"metadata": []}
+            rag_database = database or self._reset_database_for_rag(datasource)
+
+            if metadata_fts_enabled(self.agent_config) and hasattr(self.schema_rag, "search_table"):
+                metadata = self.schema_rag.search_table(
+                    query_text,
+                    catalog_name=catalog,
+                    database_name=rag_database,
+                    schema_name=schema_name,
+                    table_type="full",
+                    top_n=top_n,
+                )
+                sample_rows_for_search_results = getattr(self.schema_rag, "sample_rows_for_search_results", None)
+                sample_values = (
+                    sample_rows_for_search_results(metadata) if callable(sample_rows_for_search_results) else None
+                )
+            else:
+                metadata, sample_values = self.schema_rag.search_similar(
+                    query_text,
+                    catalog_name=catalog,
+                    database_name=rag_database,
+                    schema_name=schema_name,
+                    table_type="full",
+                    top_n=top_n,
+                )
 
             metadata_rows: List[Dict[str, Any]] = []
-            if metadata:
-                metadata_rows = metadata.select(
-                    [
-                        "catalog_name",
-                        "database_name",
-                        "schema_name",
-                        "table_name",
-                        "table_type",
-                        "identifier",
-                        "_distance",
-                    ]
-                ).to_pylist()
+            if metadata is not None and getattr(metadata, "num_rows", 1) != 0:
+                metadata_rows = self._metadata_search_rows(metadata)
             if not metadata_rows:
                 return FuncToolResult(success=1, result=result_dict)
 
-            current_has_semantic = False
             if self.has_semantic_models:
                 for metadata_row in metadata_rows:
                     semantic_model = self._get_semantic_model(
@@ -885,37 +1025,12 @@ class DBFuncTool:
                         metadata_row["table_name"],
                     )
                     if semantic_model:
-                        current_has_semantic = True
-                        metadata_row["semantic_model_name"] = semantic_model["semantic_model_name"]
-                        metadata_row["description"] = semantic_model["description"]
-                        metadata_row["dimensions"] = semantic_model["dimensions"]
-                        metadata_row["measures"] = semantic_model["measures"]
-                        metadata_row["identifiers"] = semantic_model["identifiers"]
-                        # Only enrich the top match to prioritize the most relevant table
-                        break
+                        metadata_row["description"] = semantic_model.get("description", "")
 
-            result_dict["metadata"] = metadata_rows
-            if current_has_semantic:
-                result_dict["sample_data"] = self.compressor.compress([])
-                return FuncToolResult(success=1, result=result_dict)
-
-            sample_rows: List[Dict[str, Any]] = []
-            if sample_values:
-                if simple_sample_data:
-                    selected_fields = ["identifier", "table_type", "sample_rows", "_distance"]
-                else:
-                    selected_fields = [
-                        "identifier",
-                        "catalog_name",
-                        "database_name",
-                        "schema_name",
-                        "table_type",
-                        "table_name",
-                        "sample_rows",
-                        "_distance",
-                    ]
-                sample_rows = sample_values.select(selected_fields).to_pylist()
-            result_dict["sample_data"] = self.compressor.compress(sample_rows)
+            sample_rows_by_identifier = self._sample_rows_by_identifier(sample_values)
+            result_dict["metadata"] = [
+                self._search_table_result_row(metadata_row, sample_rows_by_identifier) for metadata_row in metadata_rows
+            ]
             return FuncToolResult(result=result_dict)
         except Exception as e:
             return FuncToolResult(success=0, error=str(e))

--- a/datus/tools/lineage_graph_tools/schema_lineage.py
+++ b/datus/tools/lineage_graph_tools/schema_lineage.py
@@ -123,7 +123,17 @@ class SchemaLineageTool(BaseTool):
         Returns:
             SchemaLinkingResult: The result of the search
         """
-        return self.store.schema_store.search_top_tables_by_every_schema(
+        schema_store = getattr(self.store, "schema_store", None)
+        if schema_store is None:
+            return SchemaLinkingResult(
+                success=False,
+                error="Schema-by-schema linking requires legacy schema metadata storage",
+                schema_count=0,
+                value_count=0,
+                table_schemas=[],
+                table_values=[],
+            )
+        return schema_store.search_top_tables_by_every_schema(
             input_param.input_text,
             database_name=input_param.database_name,
             catalog_name=input_param.catalog_name,

--- a/datus/tools/lineage_graph_tools/schema_lineage.py
+++ b/datus/tools/lineage_graph_tools/schema_lineage.py
@@ -10,7 +10,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.models.base import LLMBaseModel
 from datus.schemas.node_models import TableSchema, TableValue
 from datus.schemas.schema_linking_node_models import SchemaLinkingInput, SchemaLinkingResult
-from datus.storage.schema_metadata.store import SchemaWithValueRAG
+from datus.storage.schema_metadata import create_metadata_rag
 from datus.tools.base import BaseTool
 from datus.tools.llms_tools.match_schema import MatchSchemaTool
 from datus.utils.loggings import get_logger
@@ -23,7 +23,7 @@ class SchemaLineageTool(BaseTool):
 
     def __init__(
         self,
-        storage: Optional[SchemaWithValueRAG] = None,
+        storage: Optional[Any] = None,
         agent_config: Optional[AgentConfig] = None,
         **kwargs,
     ):
@@ -37,7 +37,7 @@ class SchemaLineageTool(BaseTool):
         if storage:
             self.store = storage
         else:
-            self.store = SchemaWithValueRAG(agent_config)
+            self.store = create_metadata_rag(agent_config)
 
     def validate_input(self, input_data: Dict[str, Any]) -> None:
         """Validate the input data for schema lineage operations.
@@ -72,7 +72,11 @@ class SchemaLineageTool(BaseTool):
 
         # Leave exceptions to the higher-ups to handle.
         if input_param.matching_rate == "from_llm":
-            tool = MatchSchemaTool(model, storage=self.store.schema_store, agent_config=self.agent_config)
+            schema_store = getattr(self.store, "schema_store", None)
+            if schema_store is None:
+                logger.info("LLM schema matching requires legacy schema_store; falling back to metadata search")
+                return self._search_similar_schemas(input_param, input_param.top_n_by_rate())
+            tool = MatchSchemaTool(model, storage=schema_store, agent_config=self.agent_config)
             if not tool:
                 return SchemaLinkingResult(
                     success=False,

--- a/docs/knowledge_base/metadata.md
+++ b/docs/knowledge_base/metadata.md
@@ -47,28 +47,29 @@ datus-agent bootstrap-kb --datasource <your_datasource> --kb_update_strategy [ch
     - `check`: Check the number of data entries currently constructed
     - `overwrite`: Fully overwrite existing data
     - `incremental`: Incremental update: if existing data has changed, update it and append non-existent data
-- `--kb_search_mode`: Optional metadata search mode. The default is `fts`. Use `hybrid` to keep the vector + full-text retrieval path.
+- `--kb_search_mode`: Optional metadata search mode. The default is `vector`; set it to `fts` to build full-text metadata from scratch.
 
 ### Metadata Search Mode
 
-By default, metadata bootstrap stores physical table facts and retrieval documents for full-text search. This avoids generating table embeddings for large catalogs while still allowing `search_table`, autocomplete, schema linking, and `@Table` references to find tables from table names, DDL, sample rows, and attached semantic profiles.
+Metadata search remains on the existing vector store by default, so existing installations do not need to rebuild their data after upgrading.
 
-Set `kb.search.mode` to `hybrid` when you want the previous vector-assisted retrieval path:
+Set `kb.search.mode` to `fts` to use full-text metadata retrieval without generating embeddings:
 
 ```yaml
 kb:
   search:
-    mode: hybrid
+    mode: fts
 ```
 
-The `hybrid` mode requires the database embedding storage configuration and a context generated with `--kb_search_mode hybrid`. If `search_table` is run in `hybrid` mode but the vector projection is missing or empty, the tool returns an explicit retrieval error instead of silently falling back to FTS. The default `fts` mode does not require embeddings.
+The FTS store searches table names, DDL, sample rows, and attached semantic profiles. It does not fall back to vector search. A missing, legacy, or incomplete FTS index produces an explicit error and must be rebuilt with `overwrite`.
 
-To temporarily use the legacy schema metadata path, disable the new metadata search path explicitly:
+After the initial FTS build, `incremental` upserts only new or changed metadata and uses LanceDB `optimize()` to add the changed fragments to the existing index. It does not replace the complete FTS index.
 
-```yaml
-kb:
-  search:
-    enabled: false
+Choose the mode before building metadata. Switching an existing vector installation to FTS requires a full rebuild:
+
+```bash
+datus-agent bootstrap-kb --datasource <your_datasource> --components metadata \
+  --kb_search_mode fts --kb_update_strategy overwrite
 ```
 
 ## Usage Examples

--- a/docs/knowledge_base/metadata.md
+++ b/docs/knowledge_base/metadata.md
@@ -4,7 +4,7 @@
 
 The metadata module is primarily used to enable LLMs to quickly match possible related table definition information and sample data based on user questions.
 
-When you use the `bootstrap-kb` command, we initialize the SQL statements and sample data for creating tables/views/materialized views in the data source you specify into a vector database.
+When you use the `bootstrap-kb` command, we initialize the SQL statements and sample data for creating tables/views/materialized views in the data source you specify into local knowledge-base storage.
 
 This module contains two types of information: **table definition** and **sample data**.
 
@@ -47,6 +47,29 @@ datus-agent bootstrap-kb --datasource <your_datasource> --kb_update_strategy [ch
     - `check`: Check the number of data entries currently constructed
     - `overwrite`: Fully overwrite existing data
     - `incremental`: Incremental update: if existing data has changed, update it and append non-existent data
+- `--kb_search_mode`: Optional metadata search mode. The default is `fts`. Use `hybrid` to keep the vector + full-text retrieval path.
+
+### Metadata Search Mode
+
+By default, metadata bootstrap stores physical table facts and retrieval documents for full-text search. This avoids generating table embeddings for large catalogs while still allowing `search_table`, autocomplete, schema linking, and `@Table` references to find tables from table names, DDL, sample rows, and attached semantic profiles.
+
+Set `kb.search.mode` to `hybrid` when you want the previous vector-assisted retrieval path:
+
+```yaml
+kb:
+  search:
+    mode: hybrid
+```
+
+The `hybrid` mode requires the database embedding storage configuration and a context generated with `--kb_search_mode hybrid`. If `search_table` is run in `hybrid` mode but the vector projection is missing or empty, the tool returns an explicit retrieval error instead of silently falling back to FTS. The default `fts` mode does not require embeddings.
+
+To temporarily use the legacy schema metadata path, disable the new metadata search path explicitly:
+
+```yaml
+kb:
+  search:
+    enabled: false
+```
 
 ## Usage Examples
 

--- a/docs/knowledge_base/metadata.zh.md
+++ b/docs/knowledge_base/metadata.zh.md
@@ -47,28 +47,29 @@ datus-agent bootstrap-kb --datasource <your_datasource> --kb_update_strategy [ch
     - `check`：检查当前构建的数据条目数
     - `overwrite`：完全覆盖现有数据
     - `incremental`：增量更新：如果现有数据已更改，则更新它并追加不存在的数据
-- `--kb_search_mode`：可选的元数据搜索模式。默认值是 `fts`。使用 `hybrid` 可以保留向量 + 全文检索路径。
+- `--kb_search_mode`：可选的元数据搜索模式。默认值是 `vector`；设置为 `fts` 时会从头构建全文检索 metadata。
 
 ### 元数据搜索模式
 
-默认情况下，metadata bootstrap 会存储物理表事实和用于全文检索的 retrieval document。这样在大规模表目录下不需要为每张表生成 embedding，同时 `search_table`、autocomplete、schema linking 和 `@Table` 引用仍然可以基于表名、DDL、样本数据以及附加的 semantic profile 找表。
+metadata 搜索默认继续使用现有 vector store，因此老用户升级后不需要重建数据，检索行为保持不变。
 
-如果需要使用原有的向量辅助检索路径，可以设置 `kb.search.mode` 为 `hybrid`：
+如果要使用不生成 embedding 的全文检索，显式设置 `kb.search.mode` 为 `fts`：
 
 ```yaml
 kb:
   search:
-    mode: hybrid
+    mode: fts
 ```
 
-`hybrid` 模式需要配置 database embedding storage，并且需要使用 `--kb_search_mode hybrid` 生成 context。如果 `search_table` 运行在 `hybrid` 模式，但向量检索投影不存在或为空，工具会返回明确的检索错误，不会静默降级到 FTS。默认的 `fts` 模式不需要 embedding。
+FTS store 会检索表名、DDL、样本数据以及附加的 semantic profile，并且不会回退到 vector。FTS 索引缺失、格式过旧或构建不完整时会直接报错，必须使用 `overwrite` 重新构建。
 
-如果需要临时使用旧的 schema metadata 路径，可以显式关闭新的 metadata search：
+首次构建 FTS 后，`incremental` 只会 upsert 新增或发生变化的 metadata，并通过 LanceDB `optimize()` 将变化的 fragment 增量加入现有索引，不会替换完整 FTS 索引。
 
-```yaml
-kb:
-  search:
-    enabled: false
+必须在构建 metadata 前选定模式。已有 vector 数据切换到 FTS 时需要完整重建：
+
+```bash
+datus-agent bootstrap-kb --datasource <your_datasource> --components metadata \
+  --kb_search_mode fts --kb_update_strategy overwrite
 ```
 
 ## 使用示例

--- a/docs/knowledge_base/metadata.zh.md
+++ b/docs/knowledge_base/metadata.zh.md
@@ -4,7 +4,7 @@
 
 元数据模块主要用于使 LLM 能够根据用户问题快速匹配可能相关的表定义信息和样本数据。
 
-当你使用 `bootstrap-kb` 命令时，我们会将你指定的数据源中创建表/视图/物化视图的 SQL 语句和样本数据初始化到向量数据库中。
+当你使用 `bootstrap-kb` 命令时，我们会将你指定的数据源中创建表/视图/物化视图的 SQL 语句和样本数据初始化到本地知识库存储中。
 
 此模块包含两种类型的信息：**表定义**和**样本数据**。
 
@@ -47,6 +47,29 @@ datus-agent bootstrap-kb --datasource <your_datasource> --kb_update_strategy [ch
     - `check`：检查当前构建的数据条目数
     - `overwrite`：完全覆盖现有数据
     - `incremental`：增量更新：如果现有数据已更改，则更新它并追加不存在的数据
+- `--kb_search_mode`：可选的元数据搜索模式。默认值是 `fts`。使用 `hybrid` 可以保留向量 + 全文检索路径。
+
+### 元数据搜索模式
+
+默认情况下，metadata bootstrap 会存储物理表事实和用于全文检索的 retrieval document。这样在大规模表目录下不需要为每张表生成 embedding，同时 `search_table`、autocomplete、schema linking 和 `@Table` 引用仍然可以基于表名、DDL、样本数据以及附加的 semantic profile 找表。
+
+如果需要使用原有的向量辅助检索路径，可以设置 `kb.search.mode` 为 `hybrid`：
+
+```yaml
+kb:
+  search:
+    mode: hybrid
+```
+
+`hybrid` 模式需要配置 database embedding storage，并且需要使用 `--kb_search_mode hybrid` 生成 context。如果 `search_table` 运行在 `hybrid` 模式，但向量检索投影不存在或为空，工具会返回明确的检索错误，不会静默降级到 FTS。默认的 `fts` 模式不需要 embedding。
+
+如果需要临时使用旧的 schema metadata 路径，可以显式关闭新的 metadata search：
+
+```yaml
+kb:
+  search:
+    enabled: false
+```
 
 ## 使用示例
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "datus-db-core>=0.1.4",
     "datus-storage-base>=0.1.5,<0.2.0",
     "python-dotenv==1.0.0",
-    "pandas==2.1.4",
+    "pandas==2.3.3",
     "sqlalchemy==2.0.23",
     "sqlglot>=26.12.0,<31",
     "pyyaml==6.0.1",
@@ -44,9 +44,8 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.20.0",
     "litellm>=1.67.4.post1,<2",
     "pydantic>=2.11.7,<3.0",
-    "lancedb==0.18.0",
+    "lancedb==0.34.0",
     # This library is required by lancedb
-    # this version is required by pandas 2.1.4
     "pyarrow<19.0.0",
     "rich==14.0.0",
     "prompt_toolkit>=3.0.51",

--- a/tests/integration/storage/test_doc_search.py
+++ b/tests/integration/storage/test_doc_search.py
@@ -59,7 +59,7 @@ def deterministic_document_embedding(monkeypatch):
     """Keep document-search acceptance off real fastembed/model cache state."""
     document_store.cache_clear()
     model = EmbeddingModel(model_name="datus-test-deterministic", dim_size=8)
-    model._model = _DeterministicDocEmbedding()
+    model._model = _DeterministicDocEmbedding.create()
     model.model_initialization_attempted = True
     monkeypatch.setitem(EMBEDDING_MODELS, "document", model)
     yield

--- a/tests/unit_tests/agent/node/test_schema_linking.py
+++ b/tests/unit_tests/agent/node/test_schema_linking.py
@@ -1,12 +1,15 @@
 import os
 import shutil
 import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+import pyarrow as pa
 import pytest
 import yaml
 
 from datus.configuration.agent_config_loader import load_agent_config
-from datus.schemas.schema_linking_node_models import SchemaLinkingInput
+from datus.schemas.schema_linking_node_models import SchemaLinkingInput, SchemaLinkingResult
 from datus.tools.db_tools.config import SQLiteConfig
 from datus.tools.db_tools.sqlite_connector import SQLiteConnector
 from datus.tools.lineage_graph_tools.schema_lineage import SchemaLineageTool
@@ -158,6 +161,86 @@ def test_schema_linking_no_exist(agent_config):
     assert res["success"] is True  # Operation succeeds but returns no results
     assert res["schema_count"] == 0
     assert res["value_count"] == 0
+
+
+def test_search_similar_schemas_by_schema_requires_legacy_schema_store():
+    tool = SchemaLineageTool(storage=object(), agent_config=None)
+    res = tool.search_similar_schemas_by_schema(
+        SchemaLinkingInput(
+            input_text="test query",
+            database_type=DBType.SQLITE,
+            catalog_name="",
+            database_name="",
+            schema_name="",
+            matching_rate="fast",
+            sql_context=None,
+        )
+    )
+
+    assert res["success"] is False
+    assert "legacy schema metadata storage" in res["error"]
+
+
+def test_from_llm_without_legacy_schema_store_falls_back_to_metadata_search():
+    storage = SimpleNamespace(
+        search_similar=MagicMock(return_value=(pa.Table.from_pylist([]), pa.Table.from_pylist([])))
+    )
+    tool = SchemaLineageTool(storage=storage, agent_config=None)
+    res = tool.execute(
+        SchemaLinkingInput(
+            input_text="test query",
+            database_type=DBType.SQLITE,
+            catalog_name="",
+            database_name="",
+            schema_name="",
+            matching_rate="from_llm",
+            sql_context=None,
+        )
+    )
+
+    assert res["success"] is True
+    assert res["schema_count"] == 0
+    storage.search_similar.assert_called_once_with(
+        "test query",
+        top_n=20,
+        catalog_name="",
+        database_name="",
+        schema_name="",
+        table_type="table",
+    )
+
+
+def test_search_similar_schemas_by_schema_delegates_to_legacy_schema_store():
+    expected = SchemaLinkingResult(
+        success=True,
+        error=None,
+        schema_count=0,
+        value_count=0,
+        table_schemas=[],
+        table_values=[],
+    )
+    schema_store = SimpleNamespace(search_top_tables_by_every_schema=MagicMock(return_value=expected))
+    tool = SchemaLineageTool(storage=SimpleNamespace(schema_store=schema_store), agent_config=None)
+    res = tool.search_similar_schemas_by_schema(
+        SchemaLinkingInput(
+            input_text="test query",
+            database_type=DBType.SQLITE,
+            catalog_name="catalog",
+            database_name="db",
+            schema_name="",
+            matching_rate="fast",
+            sql_context=None,
+        ),
+        top_n=7,
+    )
+
+    assert res == expected
+    schema_store.search_top_tables_by_every_schema.assert_called_once_with(
+        "test query",
+        database_name="db",
+        catalog_name="catalog",
+        top_n=7,
+    )
 
 
 def test_get_schema_from_db(schema_lineage_tool: SchemaLineageTool, sqlite_connector: SQLiteConnector):

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -17,6 +17,7 @@ NO MOCK EXCEPT LLM. Uses real AgentConfig (from config dict) and real print capt
 import argparse
 import os
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -953,6 +954,40 @@ class TestBootstrapKbMetadata:
             result = agent.bootstrap_kb()
         assert result["status"] == "success"
 
+    def test_metadata_check_strategy_hybrid_validates_database_storage(self, tmp_path):
+        args = _make_args_ext(components=["metadata"], kb_update_strategy="check", benchmark=None)
+        agent = _make_agent_ext(args=args)
+        agent.global_config.rag_storage_path.return_value = str(tmp_path)
+        agent.global_config.kb_search = SimpleNamespace(enabled=True, mode="hybrid")
+        agent.global_config.kb_search_mode = "hybrid"
+
+        mock_store = MagicMock()
+        mock_store.get_schema_size.return_value = 5
+        mock_store.get_value_size.return_value = 10
+        with patch("datus.agent.agent.create_metadata_rag", return_value=mock_store):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        agent.global_config.check_init_storage_config.assert_called_with("database")
+
+    def test_metadata_incremental_legacy_path_validates_database_storage(self):
+        args = _make_args_ext(components=["metadata"], kb_update_strategy="incremental", benchmark=None)
+        agent = _make_agent_ext(args=args)
+
+        mock_store = MagicMock()
+        mock_store.get_schema_size.return_value = 3
+        mock_store.get_value_size.return_value = 7
+
+        with (
+            patch("datus.agent.agent.SchemaWithValueRAG", return_value=mock_store),
+            patch("datus.agent.agent.init_local_schema"),
+            patch.object(agent, "check_db", return_value={"status": "success"}),
+        ):
+            result = agent.bootstrap_kb()
+
+        assert result["status"] == "success"
+        agent.global_config.check_init_storage_config.assert_called_with("database")
+
     def test_metadata_overwrite_local(self, tmp_path):
         args = _make_args_ext(components=["metadata"], kb_update_strategy="overwrite", benchmark=None)
         agent = _make_agent_ext(args=args)
@@ -1031,6 +1066,28 @@ class TestBootstrapKbMetadata:
             result = agent.bootstrap_kb()
 
         assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# benchmark storage checks
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkStorageChecks:
+    def test_benchmark_hybrid_mode_validates_database_storage(self, tmp_path):
+        args = _make_args_ext(benchmark="baisheng")
+        agent = _make_agent_ext(args=args)
+        agent.global_config.benchmark_path.return_value = str(tmp_path)
+        agent.global_config.kb_search = SimpleNamespace(enabled=True, mode="hybrid")
+        agent.global_config.kb_search_mode = "fts"
+
+        with patch.object(agent, "do_benchmark", return_value={"status": "success"}) as do_benchmark:
+            result = agent.benchmark(run_id="run-1")
+
+        assert result["status"] == "success"
+        agent.global_config.check_init_storage_config.assert_any_call("database")
+        agent.global_config.check_init_storage_config.assert_any_call("metric")
+        do_benchmark.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/test_agent.py
+++ b/tests/unit_tests/agent/test_agent.py
@@ -954,12 +954,12 @@ class TestBootstrapKbMetadata:
             result = agent.bootstrap_kb()
         assert result["status"] == "success"
 
-    def test_metadata_check_strategy_hybrid_validates_database_storage(self, tmp_path):
+    def test_metadata_check_strategy_fts_skips_database_embedding_storage(self, tmp_path):
         args = _make_args_ext(components=["metadata"], kb_update_strategy="check", benchmark=None)
         agent = _make_agent_ext(args=args)
         agent.global_config.rag_storage_path.return_value = str(tmp_path)
-        agent.global_config.kb_search = SimpleNamespace(enabled=True, mode="hybrid")
-        agent.global_config.kb_search_mode = "hybrid"
+        agent.global_config.kb_search = SimpleNamespace(mode="fts")
+        agent.global_config.kb_search_mode = "fts"
 
         mock_store = MagicMock()
         mock_store.get_schema_size.return_value = 5
@@ -968,7 +968,22 @@ class TestBootstrapKbMetadata:
             result = agent.bootstrap_kb()
 
         assert result["status"] == "success"
-        agent.global_config.check_init_storage_config.assert_called_with("database")
+        agent.global_config.check_init_storage_config.assert_not_called()
+        mock_store.check_ready.assert_called_once_with()
+
+    def test_metadata_incremental_fts_requires_existing_ready_index(self):
+        args = _make_args_ext(components=["metadata"], kb_update_strategy="incremental", benchmark=None)
+        agent = _make_agent_ext(args=args)
+        agent.global_config.kb_search = SimpleNamespace(mode="fts")
+        agent.global_config.kb_search_mode = "fts"
+
+        mock_store = MagicMock()
+        mock_store.check_ready.side_effect = RuntimeError("FTS index is missing")
+        with patch("datus.agent.agent.create_metadata_rag", return_value=mock_store):
+            with pytest.raises(RuntimeError, match="FTS index is missing"):
+                agent.bootstrap_kb()
+
+        mock_store.truncate.assert_not_called()
 
     def test_metadata_incremental_legacy_path_validates_database_storage(self):
         args = _make_args_ext(components=["metadata"], kb_update_strategy="incremental", benchmark=None)
@@ -1074,12 +1089,12 @@ class TestBootstrapKbMetadata:
 
 
 class TestBenchmarkStorageChecks:
-    def test_benchmark_hybrid_mode_validates_database_storage(self, tmp_path):
+    def test_benchmark_vector_mode_validates_database_storage(self, tmp_path):
         args = _make_args_ext(benchmark="baisheng")
         agent = _make_agent_ext(args=args)
         agent.global_config.benchmark_path.return_value = str(tmp_path)
-        agent.global_config.kb_search = SimpleNamespace(enabled=True, mode="hybrid")
-        agent.global_config.kb_search_mode = "fts"
+        agent.global_config.kb_search = SimpleNamespace(mode="vector")
+        agent.global_config.kb_search_mode = "vector"
 
         with patch.object(agent, "do_benchmark", return_value={"status": "success"}) as do_benchmark:
             result = agent.benchmark(run_id="run-1")

--- a/tests/unit_tests/agent/test_plan.py
+++ b/tests/unit_tests/agent/test_plan.py
@@ -321,7 +321,7 @@ class TestGenerateWorkflow:
         mock_rag.search_tables.return_value = ([], [])
 
         with _patched_workflow():
-            with patch("datus.storage.schema_metadata.SchemaWithValueRAG", return_value=mock_rag):
+            with patch("datus.storage.schema_metadata.create_metadata_rag", return_value=mock_rag):
                 wf = generate_workflow(task, plan_type="reflection", agent_config=cfg)
 
         assert isinstance(wf, Workflow)
@@ -336,7 +336,7 @@ class TestGenerateWorkflow:
         mock_rag_cls.return_value.search_tables.side_effect = RuntimeError("rag failure")
 
         with _patched_workflow():
-            with patch("datus.storage.schema_metadata.SchemaWithValueRAG", mock_rag_cls):
+            with patch("datus.storage.schema_metadata.create_metadata_rag", mock_rag_cls):
                 wf = generate_workflow(task, plan_type="reflection", agent_config=cfg)
 
         assert isinstance(wf, Workflow)

--- a/tests/unit_tests/agent/test_workflow_runner.py
+++ b/tests/unit_tests/agent/test_workflow_runner.py
@@ -10,7 +10,8 @@ execution paths are mocked.
 """
 
 import argparse
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -324,6 +325,17 @@ class TestFinalizeWorkflow:
 
 
 class TestWorkflowRunnerRun:
+    def test_ensure_prerequisites_hybrid_checks_database_storage(self):
+        cfg = _make_config()
+        cfg.kb_search = SimpleNamespace(enabled=True, mode="hybrid")
+        cfg.kb_search_mode = "fts"
+        runner = _make_runner(config=cfg)
+        runner.init_or_load_workflow = MagicMock(return_value=True)
+
+        assert runner._ensure_prerequisites(_make_sql_task(), check_storage=True) is True
+
+        cfg.check_init_storage_config.assert_has_calls([call("database"), call("metrics")])
+
     def test_run_returns_empty_when_prerequisites_fail(self):
         runner = _make_runner()
         # No task, no checkpoint -> _ensure_prerequisites returns False

--- a/tests/unit_tests/agent/test_workflow_runner.py
+++ b/tests/unit_tests/agent/test_workflow_runner.py
@@ -325,10 +325,10 @@ class TestFinalizeWorkflow:
 
 
 class TestWorkflowRunnerRun:
-    def test_ensure_prerequisites_hybrid_checks_database_storage(self):
+    def test_ensure_prerequisites_vector_checks_database_storage(self):
         cfg = _make_config()
-        cfg.kb_search = SimpleNamespace(enabled=True, mode="hybrid")
-        cfg.kb_search_mode = "fts"
+        cfg.kb_search = SimpleNamespace(mode="vector")
+        cfg.kb_search_mode = "vector"
         runner = _make_runner(config=cfg)
         runner.init_or_load_workflow = MagicMock(return_value=True)
 

--- a/tests/unit_tests/cli/test_agent_commands.py
+++ b/tests/unit_tests/cli/test_agent_commands.py
@@ -187,7 +187,7 @@ class TestCmdSchemaLinking:
         mock_rag = MagicMock()
         mock_rag.search_similar.return_value = (empty_table, empty_table)
 
-        with patch("datus.storage.schema_metadata.SchemaWithValueRAG", return_value=mock_rag):
+        with patch("datus.storage.schema_metadata.create_metadata_rag", return_value=mock_rag):
             with patch.object(agent_commands, "_prompt_db_layers", return_value=("", "testdb", "")):
                 agent_commands.cli.prompt_input = lambda *a, **kw: kw.get("default", "5")
                 agent_commands.cmd_schema_linking("find tables about revenue")
@@ -200,7 +200,7 @@ class TestCmdSchemaLinking:
             "error_code=300019 error_message=Embedding model cache is missing"
         )
 
-        with patch("datus.storage.schema_metadata.SchemaWithValueRAG", return_value=mock_rag):
+        with patch("datus.storage.schema_metadata.create_metadata_rag", return_value=mock_rag):
             with patch.object(agent_commands, "_prompt_db_layers", return_value=("", "testdb", "")):
                 agent_commands.cli.prompt_input = MagicMock(return_value="5")
                 agent_commands.cmd_schema_linking("find tables about revenue")

--- a/tests/unit_tests/cli/test_autocomplete.py
+++ b/tests/unit_tests/cli/test_autocomplete.py
@@ -636,7 +636,7 @@ class TestTableCompleterBuildSnapshotByDbType:
         fake_storage = MagicMock()
         fake_storage.search_all_schemas.return_value = schema_table
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: fake_storage,
         )
 
@@ -692,7 +692,7 @@ class TestTableCompleterBuildSnapshotByDbType:
         fake_storage = MagicMock()
         fake_storage.search_all_schemas.side_effect = RuntimeError("boom")
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: fake_storage,
         )
         tc = self._table_completer(db_type="sqlite")

--- a/tests/unit_tests/cli/test_background_sync.py
+++ b/tests/unit_tests/cli/test_background_sync.py
@@ -90,7 +90,7 @@ class TestScheduleRunsInitAndReloads:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: MagicMock(),
         )
 
@@ -118,7 +118,7 @@ class TestScheduleRunsInitAndReloads:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: MagicMock(),
         )
 
@@ -149,7 +149,7 @@ class TestScheduleCoalesce:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: MagicMock(),
         )
 
@@ -189,7 +189,7 @@ class TestScheduleCancelPrevious:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: MagicMock(),
         )
 
@@ -237,7 +237,7 @@ class TestFailureKeepsOldData:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: MagicMock(),
         )
 
@@ -269,7 +269,7 @@ class TestFailureKeepsOldData:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: fake_store,
         )
 
@@ -302,7 +302,7 @@ class TestDriftGuard:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: MagicMock(),
         )
 
@@ -331,7 +331,7 @@ class TestIsRunningLifecycle:
             fake_init_async,
         )
         monkeypatch.setattr(
-            "datus.storage.schema_metadata.store.SchemaWithValueRAG",
+            "datus.storage.schema_metadata.create_metadata_rag",
             lambda *a, **kw: MagicMock(),
         )
 

--- a/tests/unit_tests/cli/test_bootstrap_bi_streams.py
+++ b/tests/unit_tests/cli/test_bootstrap_bi_streams.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 from typing import AsyncGenerator
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -89,7 +89,7 @@ async def test_stream_bi_metadata_yields_entry_exit_messages(agent_config) -> No
 
     with (
         patch("datus.storage.schema_metadata.local_init.init_local_schema_async", side_effect=_ok),
-        patch("datus.storage.schema_metadata.store.SchemaWithValueRAG"),
+        patch("datus.storage.schema_metadata.create_metadata_rag", return_value=MagicMock()),
         patch("datus.tools.db_tools.db_manager.db_manager_instance"),
     ):
         actions = await _consume(stream_bi_metadata(agent_config, table_names=["t1", "t2"]))
@@ -107,7 +107,7 @@ async def test_stream_bi_metadata_yields_failed_on_helper_exception(agent_config
 
     with (
         patch("datus.storage.schema_metadata.local_init.init_local_schema_async", side_effect=_boom),
-        patch("datus.storage.schema_metadata.store.SchemaWithValueRAG"),
+        patch("datus.storage.schema_metadata.create_metadata_rag", return_value=MagicMock()),
         patch("datus.tools.db_tools.db_manager.db_manager_instance"),
     ):
         actions = await _consume(stream_bi_metadata(agent_config, table_names=["t1"]))

--- a/tests/unit_tests/cli/test_bootstrap_streams.py
+++ b/tests/unit_tests/cli/test_bootstrap_streams.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import List
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -36,6 +37,27 @@ def _make_action(text: str, status: ActionStatus = ActionStatus.SUCCESS) -> Acti
         input_data={"function_name": "probe"},
         status=status,
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_metadata_uses_metadata_rag_factory() -> None:
+    from datus.cli.bootstrap_streams import stream_metadata
+
+    async def _ok(*_args, **_kwargs):
+        return None
+
+    agent_config = SimpleNamespace(current_datasource="", datasource_configs={"local": {}})
+    metadata_store = MagicMock()
+    with (
+        patch("datus.storage.schema_metadata.create_metadata_rag", return_value=metadata_store) as create_metadata_rag,
+        patch("datus.storage.schema_metadata.local_init.init_local_schema_async", side_effect=_ok),
+        patch("datus.tools.db_tools.db_manager.db_manager_instance"),
+    ):
+        actions = [action async for action in stream_metadata(agent_config, datasource="local")]
+
+    create_metadata_rag.assert_called_once_with(agent_config)
+    assert agent_config.current_datasource == "local"
+    assert "finished" in actions[-1].messages.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/cli/test_interactive_init.py
+++ b/tests/unit_tests/cli/test_interactive_init.py
@@ -12,6 +12,7 @@ from datus.cli.interactive_init import (
     ReferenceSqlStreamHandler,
     _format_reference_sql_line,
     do_init_sql_and_log_result,
+    init_metadata_and_log_result,
     overwrite_sql_and_log_result,
     parse_subject_tree,
 )
@@ -272,6 +273,58 @@ class TestInit:
 
                 assert mock_metadata.call_count == 1, "Metadata init should be called when accepted"
                 assert mock_sql.call_count == 1, "SQL init should be called when accepted"
+
+    def test_init_metadata_uses_fts_metadata_store_without_database_cleanup(self):
+        config = MagicMock()
+        config.rag_storage_path.return_value = "/tmp/rag"
+        config.kb_search_mode = "fts"
+        config.datasource_configs = {"test_ns": {"type": "sqlite"}}
+        metadata_store = MagicMock()
+        metadata_store.get_schema_size.return_value = 2
+        metadata_store.get_value_size.return_value = 3
+
+        with (
+            patch("datus.configuration.agent_config_loader.load_agent_config", return_value=config),
+            patch("datus.storage.kb_retrieval.metadata_fts_enabled", return_value=True),
+            patch("datus.storage.schema_metadata.create_metadata_rag", return_value=metadata_store) as create_rag,
+            patch("datus.storage.schema_metadata.local_init.init_local_schema") as init_schema,
+            patch("datus.tools.db_tools.db_manager.db_manager_instance", return_value=MagicMock()) as db_manager,
+        ):
+            init_metadata_and_log_result("test_ns", "/tmp/agent.yml", _make_console())
+
+        assert config.current_datasource == "test_ns"
+        create_rag.assert_called_once_with(config)
+        metadata_store.truncate.assert_called_once_with()
+        config.save_storage_config.assert_not_called()
+        db_manager.assert_called_once_with(config.datasource_configs)
+        init_schema.assert_called_once()
+
+    def test_init_metadata_overwrite_cleans_legacy_vector_tables(self):
+        config = MagicMock()
+        config.rag_storage_path.return_value = "/tmp/rag"
+        config.kb_search_mode = "hybrid"
+        config.project_name = "demo"
+        config.datasource_configs = {"test_ns": {"type": "sqlite"}}
+        metadata_store = MagicMock()
+        db = MagicMock()
+
+        with (
+            patch("datus.configuration.agent_config_loader.load_agent_config", return_value=config),
+            patch("datus.storage.kb_retrieval.metadata_fts_enabled", return_value=True),
+            patch("datus.storage.schema_metadata.create_metadata_rag", return_value=metadata_store) as create_rag,
+            patch("datus.storage.schema_metadata.local_init.init_local_schema") as init_schema,
+            patch("datus.tools.db_tools.db_manager.db_manager_instance", return_value=MagicMock()),
+            patch("datus.storage.backend_holder.create_vector_connection", return_value=db) as create_vector,
+        ):
+            init_metadata_and_log_result("test_ns", "/tmp/agent.yml", _make_console())
+
+        config.save_storage_config.assert_called_once_with("database")
+        create_vector.assert_called_once_with("demo")
+        db.drop_table.assert_any_call("schema_metadata", ignore_missing=True)
+        db.drop_table.assert_any_call("schema_value", ignore_missing=True)
+        db.close.assert_called_once_with()
+        create_rag.assert_called_once_with(config)
+        init_schema.assert_called_once()
 
 
 def _make_console():

--- a/tests/unit_tests/cli/test_interactive_init.py
+++ b/tests/unit_tests/cli/test_interactive_init.py
@@ -299,10 +299,10 @@ class TestInit:
         db_manager.assert_called_once_with(config.datasource_configs)
         init_schema.assert_called_once()
 
-    def test_init_metadata_overwrite_cleans_legacy_vector_tables(self):
+    def test_init_metadata_vector_overwrite_cleans_legacy_vector_tables(self):
         config = MagicMock()
         config.rag_storage_path.return_value = "/tmp/rag"
-        config.kb_search_mode = "hybrid"
+        config.kb_search_mode = "vector"
         config.project_name = "demo"
         config.datasource_configs = {"test_ns": {"type": "sqlite"}}
         metadata_store = MagicMock()
@@ -310,7 +310,7 @@ class TestInit:
 
         with (
             patch("datus.configuration.agent_config_loader.load_agent_config", return_value=config),
-            patch("datus.storage.kb_retrieval.metadata_fts_enabled", return_value=True),
+            patch("datus.storage.kb_retrieval.metadata_fts_enabled", return_value=False),
             patch("datus.storage.schema_metadata.create_metadata_rag", return_value=metadata_store) as create_rag,
             patch("datus.storage.schema_metadata.local_init.init_local_schema") as init_schema,
             patch("datus.tools.db_tools.db_manager.db_manager_instance", return_value=MagicMock()),

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1399,6 +1399,12 @@ class TestAgentConfigKnowledgeBase:
 
         assert cfg.knowledge_base == {}
 
+    def test_kb_config_rejects_non_dict(self, tmp_path):
+        cfg = self._make(tmp_path, kb="bad")
+
+        assert cfg.kb_search == KbSearchConfig(enabled=True, mode="fts")
+        assert cfg.kb_search_mode == "fts"
+
     def test_kb_search_defaults_to_fts(self, tmp_path):
         cfg = self._make(tmp_path)
 
@@ -1425,6 +1431,14 @@ class TestAgentConfigKnowledgeBase:
     def test_kb_search_rejects_vector_only_mode(self, tmp_path):
         with pytest.raises(DatusException):
             self._make(tmp_path, kb={"search": {"mode": "vector"}})
+
+    def test_override_kb_search_mode_preserves_enabled_flag(self, tmp_path):
+        cfg = self._make(tmp_path, kb={"search": {"enabled": False}})
+
+        cfg.override_by_args(kb_search_mode="hybrid")
+
+        assert cfg.kb_search == KbSearchConfig(enabled=False, mode="hybrid")
+        assert cfg.kb_search_mode == "hybrid"
 
 
 class TestAgentConfigChannels:

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1402,43 +1402,43 @@ class TestAgentConfigKnowledgeBase:
     def test_kb_config_rejects_non_dict(self, tmp_path):
         cfg = self._make(tmp_path, kb="bad")
 
-        assert cfg.kb_search == KbSearchConfig(enabled=True, mode="fts")
-        assert cfg.kb_search_mode == "fts"
+        assert cfg.kb_search == KbSearchConfig(mode="vector")
+        assert cfg.kb_search_mode == "vector"
 
-    def test_kb_search_defaults_to_fts(self, tmp_path):
+    def test_kb_search_defaults_to_vector(self, tmp_path):
         cfg = self._make(tmp_path)
 
-        assert cfg.kb_search == KbSearchConfig(enabled=True, mode="fts")
-        assert cfg.kb_search_mode == "fts"
+        assert cfg.kb_search == KbSearchConfig(mode="vector")
+        assert cfg.kb_search_mode == "vector"
         assert not hasattr(cfg, "_metadata_fts_enabled")
 
-    def test_kb_search_can_disable_metadata_fts_path(self, tmp_path):
-        cfg = self._make(tmp_path, kb={"search": {"enabled": "false"}})
+    def test_kb_search_ignores_removed_enabled_flag(self, tmp_path):
+        cfg = self._make(tmp_path, kb={"search": {"enabled": "false", "mode": "fts"}})
 
-        assert cfg.kb_search == KbSearchConfig(enabled=False, mode="fts")
+        assert cfg.kb_search == KbSearchConfig(mode="fts")
         assert cfg.kb_search_mode == "fts"
 
-    def test_kb_search_accepts_top_level_hybrid_mode(self, tmp_path):
-        cfg = self._make(tmp_path, kb={"search": {"mode": "hybrid"}})
+    def test_kb_search_accepts_explicit_fts_mode(self, tmp_path):
+        cfg = self._make(tmp_path, kb={"search": {"mode": "fts"}})
 
-        assert cfg.kb_search_mode == "hybrid"
+        assert cfg.kb_search_mode == "fts"
 
     def test_kb_search_keeps_legacy_knowledge_base_search_compatibility(self, tmp_path):
-        cfg = self._make(tmp_path, knowledge_base={"search": {"mode": "hybrid"}})
+        cfg = self._make(tmp_path, knowledge_base={"search": {"mode": "fts"}})
 
-        assert cfg.kb_search_mode == "hybrid"
+        assert cfg.kb_search_mode == "fts"
 
-    def test_kb_search_rejects_vector_only_mode(self, tmp_path):
+    def test_kb_search_rejects_hybrid_mode(self, tmp_path):
         with pytest.raises(DatusException):
-            self._make(tmp_path, kb={"search": {"mode": "vector"}})
+            self._make(tmp_path, kb={"search": {"mode": "hybrid"}})
 
-    def test_override_kb_search_mode_preserves_enabled_flag(self, tmp_path):
-        cfg = self._make(tmp_path, kb={"search": {"enabled": False}})
+    def test_override_kb_search_mode(self, tmp_path):
+        cfg = self._make(tmp_path)
 
-        cfg.override_by_args(kb_search_mode="hybrid")
+        cfg.override_by_args(kb_search_mode="fts")
 
-        assert cfg.kb_search == KbSearchConfig(enabled=False, mode="hybrid")
-        assert cfg.kb_search_mode == "hybrid"
+        assert cfg.kb_search == KbSearchConfig(mode="fts")
+        assert cfg.kb_search_mode == "fts"
 
 
 class TestAgentConfigChannels:

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -23,6 +23,7 @@ from datus.configuration.agent_config import (
     DatasetDbConfig,
     DbConfig,
     DocumentConfig,
+    KbSearchConfig,
     ModelConfig,
     NodeConfig,
     ServicesConfig,
@@ -1363,7 +1364,7 @@ class TestAgentConfigApiSection:
 
 
 class TestAgentConfigKnowledgeBase:
-    def _make(self, tmp_path, knowledge_base=None):
+    def _make(self, tmp_path, knowledge_base=None, kb=None):
         kwargs = dict(
             nodes={"test": NodeConfig(model="test-model", input=None)},
             home=str(tmp_path / "h"),
@@ -1380,6 +1381,8 @@ class TestAgentConfigKnowledgeBase:
         )
         if knowledge_base is not None:
             kwargs["knowledge_base"] = knowledge_base
+        if kb is not None:
+            kwargs["kb"] = kb
         return AgentConfig(**kwargs)
 
     def test_knowledge_base_config_resolves_nested_env_values(self, tmp_path, monkeypatch):
@@ -1395,6 +1398,33 @@ class TestAgentConfigKnowledgeBase:
         cfg = self._make(tmp_path, knowledge_base="bad")
 
         assert cfg.knowledge_base == {}
+
+    def test_kb_search_defaults_to_fts(self, tmp_path):
+        cfg = self._make(tmp_path)
+
+        assert cfg.kb_search == KbSearchConfig(enabled=True, mode="fts")
+        assert cfg.kb_search_mode == "fts"
+        assert not hasattr(cfg, "_metadata_fts_enabled")
+
+    def test_kb_search_can_disable_metadata_fts_path(self, tmp_path):
+        cfg = self._make(tmp_path, kb={"search": {"enabled": "false"}})
+
+        assert cfg.kb_search == KbSearchConfig(enabled=False, mode="fts")
+        assert cfg.kb_search_mode == "fts"
+
+    def test_kb_search_accepts_top_level_hybrid_mode(self, tmp_path):
+        cfg = self._make(tmp_path, kb={"search": {"mode": "hybrid"}})
+
+        assert cfg.kb_search_mode == "hybrid"
+
+    def test_kb_search_keeps_legacy_knowledge_base_search_compatibility(self, tmp_path):
+        cfg = self._make(tmp_path, knowledge_base={"search": {"mode": "hybrid"}})
+
+        assert cfg.kb_search_mode == "hybrid"
+
+    def test_kb_search_rejects_vector_only_mode(self, tmp_path):
+        with pytest.raises(DatusException):
+            self._make(tmp_path, kb={"search": {"mode": "vector"}})
 
 
 class TestAgentConfigChannels:

--- a/tests/unit_tests/storage/document/test_doc_init.py
+++ b/tests/unit_tests/storage/document/test_doc_init.py
@@ -816,7 +816,7 @@ class TestInitPlatformDocsOverwrite:
     @patch("datus.storage.document.doc_init.LocalFetcher")
     @patch("datus.storage.document.doc_init.document_store")
     def test_index_creation_error_logged(self, mock_store_fn, mock_fetcher_cls, mock_processor_cls):
-        """When create_indices raises, error is captured in stats but result is still success."""
+        """When create_indices raises, bootstrap reports failure."""
         from datus.storage.document.streaming_processor import ProcessingStats
 
         mock_store = MagicMock()
@@ -844,8 +844,7 @@ class TestInitPlatformDocsOverwrite:
 
         mock_store.create_indices.assert_called_once()
         assert any("Index error" in err for err in result.errors)
-        # total_chunks > 0 so success is True despite index error
-        assert result.success is True
+        assert result.success is False
 
     @patch("datus.storage.document.doc_init.StreamingDocProcessor")
     @patch("datus.storage.document.doc_init.LocalFetcher")

--- a/tests/unit_tests/storage/document/test_store.py
+++ b/tests/unit_tests/storage/document/test_store.py
@@ -454,11 +454,10 @@ class TestDocumentStoreCreateIndices:
         doc_store.store_chunks(_make_chunks(3))
         with patch.object(doc_store.table, "create_fts_index", wraps=doc_store.table.create_fts_index) as mock_fts:
             doc_store.create_indices()
-            mock_fts.assert_called_once()
-            args, kwargs = mock_fts.call_args
-            # field_names is passed positionally from base.create_fts_index
-            field_names = kwargs.get("field_names") or args[0]
-            assert set(field_names) == {"chunk_text", "title", "hierarchy"}
+            assert mock_fts.call_count == 3
+            fields = [call.args[0] for call in mock_fts.call_args_list]
+            assert [field.name for field in fields] == ["title", "hierarchy", "chunk_text"]
+            assert [field.boost for field in fields] == [3.0, 2.0, 1.0]
 
 
 # ============================================================

--- a/tests/unit_tests/storage/schema_metadata/test_benchmark_init.py
+++ b/tests/unit_tests/storage/schema_metadata/test_benchmark_init.py
@@ -387,7 +387,7 @@ class TestInitSnowflakeSchema:
         )
 
         # after_init should always be called
-        mock_storage.after_init.assert_called_once()
+        mock_storage.after_init.assert_called_once_with(build_mode="overwrite")
 
     def test_deduplicates_db_ids(self, tmp_path):
         """Should process each db_id only once."""

--- a/tests/unit_tests/storage/schema_metadata/test_local_init.py
+++ b/tests/unit_tests/storage/schema_metadata/test_local_init.py
@@ -814,7 +814,19 @@ class TestInitLocalSchema:
             init_local_schema(mock_store, agent_config, db_manager)
 
         mock_init_other.assert_called_once()
-        mock_store.after_init.assert_called_once()
+        mock_store.after_init.assert_called_once_with(build_mode="overwrite")
+
+    def test_incremental_mode_is_forwarded_to_index_finalization(self):
+        from datus.storage.schema_metadata.local_init import init_local_schema
+
+        mock_store = MagicMock()
+        agent_config, _ = self._make_real_agent_config(db_type="mysql")
+        db_manager, _ = _make_db_manager()
+
+        with patch("datus.storage.schema_metadata.local_init.init_other_three_level_schema"):
+            init_local_schema(mock_store, agent_config, db_manager, build_mode="incremental")
+
+        mock_store.after_init.assert_called_once_with(build_mode="incremental")
 
     def test_sqlite_dispatches_each_database_from_list(self):
         """A datasource serving multiple databases dispatches one init per database."""

--- a/tests/unit_tests/storage/schema_metadata/test_store.py
+++ b/tests/unit_tests/storage/schema_metadata/test_store.py
@@ -4,6 +4,7 @@
 
 """Tests for datus/storage/schema_metadata/store.py — SchemaStorage and _build_where_clause."""
 
+import pyarrow as pa
 import pytest
 from datus_db_core import ConnectorRegistry
 from datus_storage_base.conditions import And, Condition, build_where, eq
@@ -853,6 +854,29 @@ class TestMetadataFtsRAG:
         real_agent_config.kb_search.enabled = False
         assert isinstance(create_metadata_rag(real_agent_config), SchemaWithValueRAG)
 
+    def test_metadata_fts_uses_public_kb_search_as_mode_source(self, real_agent_config):
+        from datus.storage.kb_retrieval import KbSearchMode, metadata_fts_enabled, resolve_kb_search_mode
+
+        real_agent_config.kb_search.enabled = True
+        real_agent_config.kb_search.mode = "hybrid"
+        real_agent_config.kb_search_mode = "fts"
+
+        assert metadata_fts_enabled(real_agent_config) is True
+        assert resolve_kb_search_mode(real_agent_config) == KbSearchMode.HYBRID
+
+    def test_kb_retrieval_text_and_where_helpers_handle_empty_and_structured_values(self):
+        from datus.storage.kb_retrieval.store import _as_text, _build_where_clause
+
+        assert _as_text(None) == ""
+        assert _as_text({"b": 2, "a": 1}) == '{"a": 1, "b": 2}'
+        assert "object" in _as_text(object())
+
+        where = _build_where_clause(catalog_name="cat", table_type="full", extra=eq("region", "north"))
+        clause = build_where(where)
+        assert "catalog_name = 'cat'" in clause
+        assert "region = 'north'" in clause
+        assert _build_where_clause(table_type="full") is None
+
     def test_store_batch_writes_facts_docs_and_samples(self, real_agent_config):
         from datus.schemas.node_models import TableSchema
         from datus.storage.kb_retrieval import MetadataFtsRAG
@@ -885,6 +909,44 @@ class TestMetadataFtsRAG:
         table_schemas = TableSchema.from_arrow(metadata)
         assert table_schemas[0].definition == "CREATE TABLE order_facts (order_id INT, gross_revenue DECIMAL)"
         assert sample_values.num_rows == 1
+
+    def test_metadata_enrichment_uses_batched_fact_lookup(self, real_agent_config, monkeypatch):
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+
+        rag = MetadataFtsRAG(real_agent_config)
+        rag.store_batch(
+            [
+                self._make_schema_row("orders", definition="CREATE TABLE orders (order_id INT)"),
+                self._make_schema_row("customers", definition="CREATE TABLE customers (customer_id INT)"),
+            ],
+            [
+                self._make_value_row("orders", sample_rows=[{"order_id": 1}]),
+                self._make_value_row("customers", sample_rows=[{"customer_id": 1}]),
+            ],
+        )
+        rag.after_init()
+
+        calls = []
+        original_search_all = rag.facts_store._search_all
+
+        def _counting_search_all(*args, **kwargs):
+            calls.append(kwargs.get("where"))
+            return original_search_all(*args, **kwargs)
+
+        monkeypatch.setattr(rag.facts_store, "_search_all", _counting_search_all)
+        metadata = pa.Table.from_pylist(
+            [
+                {"identifier": "db.public.orders", "_score": 2.0},
+                {"identifier": "db.public.customers", "_score": 1.5},
+            ]
+        )
+
+        schemas = rag._schema_rows_for_metadata(metadata)
+        samples = rag._sample_rows_for_metadata(schemas)
+
+        assert [row["table_name"] for row in schemas.to_pylist()] == ["orders", "customers"]
+        assert samples.num_rows == 2
+        assert len(calls) == 2
 
     def test_hybrid_search_fails_when_vector_projection_is_empty(self, real_agent_config):
         from datus.storage.kb_retrieval import MetadataFtsRAG

--- a/tests/unit_tests/storage/schema_metadata/test_store.py
+++ b/tests/unit_tests/storage/schema_metadata/test_store.py
@@ -6,7 +6,7 @@
 
 import pytest
 from datus_db_core import ConnectorRegistry
-from datus_storage_base.conditions import And, Condition, build_where
+from datus_storage_base.conditions import And, Condition, build_where, eq
 
 from datus.storage.embedding_models import get_db_embedding_model
 from datus.storage.schema_metadata import SchemaStorage
@@ -794,3 +794,199 @@ class TestSchemaWithValueRAGTruncate:
         # After truncate, rows for this datasource are deleted (table still exists)
         assert rag.get_schema_size() == 0
         assert rag.get_value_size() == 0
+
+
+# ---------------------------------------------------------------------------
+# MetadataFtsRAG
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataFtsRAG:
+    """Tests for the FTS-first metadata retrieval store."""
+
+    def _make_schema_row(
+        self,
+        table_name: str,
+        *,
+        definition: str,
+        identifier: str = "",
+        database_name: str = "db",
+        schema_name: str = "public",
+    ) -> dict:
+        identifier = identifier or f"{database_name}.{schema_name}.{table_name}"
+        return {
+            "identifier": identifier,
+            "catalog_name": "",
+            "database_name": database_name,
+            "schema_name": schema_name,
+            "table_name": table_name,
+            "table_type": "table",
+            "definition": definition,
+        }
+
+    def _make_value_row(
+        self,
+        table_name: str,
+        *,
+        sample_rows,
+        identifier: str = "",
+        database_name: str = "db",
+        schema_name: str = "public",
+    ) -> dict:
+        identifier = identifier or f"{database_name}.{schema_name}.{table_name}"
+        return {
+            "identifier": identifier,
+            "catalog_name": "",
+            "database_name": database_name,
+            "schema_name": schema_name,
+            "table_name": table_name,
+            "table_type": "table",
+            "sample_rows": sample_rows,
+        }
+
+    def test_create_metadata_rag_defaults_real_config_to_fts_store(self, real_agent_config):
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+        from datus.storage.schema_metadata import SchemaWithValueRAG, create_metadata_rag
+
+        assert isinstance(create_metadata_rag(real_agent_config), MetadataFtsRAG)
+
+        real_agent_config.kb_search.enabled = False
+        assert isinstance(create_metadata_rag(real_agent_config), SchemaWithValueRAG)
+
+    def test_store_batch_writes_facts_docs_and_samples(self, real_agent_config):
+        from datus.schemas.node_models import TableSchema
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+
+        rag = MetadataFtsRAG(real_agent_config)
+        schemas = [
+            self._make_schema_row(
+                "order_facts",
+                definition="CREATE TABLE order_facts (order_id INT, gross_revenue DECIMAL)",
+            )
+        ]
+        values = [
+            self._make_value_row(
+                "order_facts",
+                sample_rows=[{"order_id": 1, "gross_revenue": 10.5}],
+            )
+        ]
+
+        rag.store_batch(schemas, values)
+        rag.after_init()
+
+        assert rag.get_schema_size() == 1
+        assert rag.get_value_size() == 1
+        metadata, sample_values = rag.search_similar("gross revenue", top_n=5, table_type="full")
+        assert "definition" in metadata.column_names
+        assert any(row["table_name"] == "order_facts" for row in metadata.to_pylist())
+        assert rag.last_search_info["requested_mode"] == "fts"
+        assert rag.last_search_info["actual_mode"] == "fts"
+        assert rag.last_search_info["fallback"] is False
+        table_schemas = TableSchema.from_arrow(metadata)
+        assert table_schemas[0].definition == "CREATE TABLE order_facts (order_id INT, gross_revenue DECIMAL)"
+        assert sample_values.num_rows == 1
+
+    def test_hybrid_search_fails_when_vector_projection_is_empty(self, real_agent_config):
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+        from datus.utils.exceptions import DatusException
+
+        real_agent_config.kb_search.mode = "hybrid"
+        real_agent_config.kb_search_mode = "hybrid"
+        rag = MetadataFtsRAG(real_agent_config)
+
+        with pytest.raises(DatusException, match="vector projection has no rows"):
+            rag.search_table("orders", top_n=5, table_type="full")
+
+        assert rag.last_search_info["requested_mode"] == "hybrid"
+        assert rag.last_search_info["actual_mode"] == ""
+        assert rag.last_search_info["index_ready"] is False
+        assert rag.last_search_info["fallback"] is False
+        assert rag.last_search_info["error_reason"] == "hybrid_vector_projection_empty"
+
+    def test_refresh_profiles_adds_semantic_text_to_metadata_document(self, real_agent_config):
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+
+        rag = MetadataFtsRAG(real_agent_config)
+        rag.store_batch(
+            [
+                self._make_schema_row(
+                    "orders",
+                    definition="CREATE TABLE orders (order_id INT, customer_id INT)",
+                )
+            ],
+            [],
+        )
+        rag.after_init()
+
+        updated = rag.refresh_profiles(
+            [
+                {
+                    "id": "orders_profile",
+                    "format": "metricflow",
+                    "physical_table_fq_name": "db.public.orders",
+                    "catalog_name": "",
+                    "database_name": "db",
+                    "schema_name": "public",
+                    "table_name": "orders",
+                    "semantic_model_name": "commerce",
+                    "dataset_name": "orders",
+                    "data_source_name": "orders",
+                    "description": "Customer lifetime value and retention order history",
+                    "ai_context_json": "",
+                    "columns_json": "",
+                    "relationships_json": "",
+                    "custom_extensions_json": "",
+                    "yaml_path": "semantic_models/orders.yml",
+                    "search_text": "Customer lifetime value and retention order history",
+                }
+            ]
+        )
+
+        assert updated == 1
+        results = rag.search_table("lifetime value retention", top_n=5, table_type="full").to_pylist()
+        assert any(row["table_name"] == "orders" for row in results)
+
+    def test_refresh_tables_removes_stale_semantic_text(self, real_agent_config):
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+
+        rag = MetadataFtsRAG(real_agent_config)
+        rag.store_batch(
+            [
+                self._make_schema_row(
+                    "orders",
+                    definition="CREATE TABLE orders (order_id INT, customer_id INT)",
+                )
+            ],
+            [],
+        )
+        rag.after_init()
+        profile = {
+            "id": "orders_profile",
+            "format": "metricflow",
+            "physical_table_fq_name": "db.public.orders",
+            "catalog_name": "",
+            "database_name": "db",
+            "schema_name": "public",
+            "table_name": "orders",
+            "semantic_model_name": "commerce",
+            "dataset_name": "orders",
+            "data_source_name": "orders",
+            "description": "Customer lifetime value and retention order history",
+            "ai_context_json": "",
+            "columns_json": "",
+            "relationships_json": "",
+            "custom_extensions_json": "",
+            "yaml_path": "semantic_models/orders.yml",
+            "search_text": "Customer lifetime value and retention order history",
+        }
+
+        assert rag.refresh_profiles([profile]) == 1
+        assert rag.refresh_tables([profile]) == 1
+
+        docs = rag.document_store._search_all(
+            where=eq("table_name", "orders"),
+            select_fields=["search_text", "payload_json"],
+        ).to_pylist()
+        assert len(docs) == 1
+        assert "lifetime value" not in docs[0]["search_text"]
+        assert "semantic_profile_applied" not in docs[0]["payload_json"]

--- a/tests/unit_tests/storage/schema_metadata/test_store.py
+++ b/tests/unit_tests/storage/schema_metadata/test_store.py
@@ -4,6 +4,8 @@
 
 """Tests for datus/storage/schema_metadata/store.py — SchemaStorage and _build_where_clause."""
 
+from unittest.mock import MagicMock, patch
+
 import pyarrow as pa
 import pytest
 from datus_db_core import ConnectorRegistry
@@ -796,6 +798,18 @@ class TestSchemaWithValueRAGTruncate:
         assert rag.get_schema_size() == 0
         assert rag.get_value_size() == 0
 
+    def test_after_init_vector_mode_does_not_create_fts_indices(self):
+        from datus.storage.schema_metadata.store import SchemaWithValueRAG
+
+        rag = SchemaWithValueRAG.__new__(SchemaWithValueRAG)
+        rag.schema_store = MagicMock()
+        rag.value_store = MagicMock()
+
+        rag.after_init()
+
+        rag.schema_store.create_indices.assert_called_once_with(include_fts=False)
+        rag.value_store.create_indices.assert_called_once_with(include_fts=False)
+
 
 # ---------------------------------------------------------------------------
 # MetadataFtsRAG
@@ -803,7 +817,12 @@ class TestSchemaWithValueRAGTruncate:
 
 
 class TestMetadataFtsRAG:
-    """Tests for the FTS-first metadata retrieval store."""
+    """Tests for the explicitly configured metadata FTS store."""
+
+    @staticmethod
+    def _enable_fts(agent_config) -> None:
+        agent_config.kb_search.mode = "fts"
+        agent_config.kb_search_mode = "fts"
 
     def _make_schema_row(
         self,
@@ -845,24 +864,34 @@ class TestMetadataFtsRAG:
             "sample_rows": sample_rows,
         }
 
-    def test_create_metadata_rag_defaults_real_config_to_fts_store(self, real_agent_config):
+    def test_create_metadata_rag_defaults_to_vector_and_allows_explicit_fts(self, real_agent_config):
         from datus.storage.kb_retrieval import MetadataFtsRAG
         from datus.storage.schema_metadata import SchemaWithValueRAG, create_metadata_rag
 
-        assert isinstance(create_metadata_rag(real_agent_config), MetadataFtsRAG)
-
-        real_agent_config.kb_search.enabled = False
         assert isinstance(create_metadata_rag(real_agent_config), SchemaWithValueRAG)
+
+        self._enable_fts(real_agent_config)
+        assert isinstance(create_metadata_rag(real_agent_config), MetadataFtsRAG)
 
     def test_metadata_fts_uses_public_kb_search_as_mode_source(self, real_agent_config):
         from datus.storage.kb_retrieval import KbSearchMode, metadata_fts_enabled, resolve_kb_search_mode
 
-        real_agent_config.kb_search.enabled = True
-        real_agent_config.kb_search.mode = "hybrid"
-        real_agent_config.kb_search_mode = "fts"
+        self._enable_fts(real_agent_config)
+        real_agent_config.kb_search_mode = "vector"
 
         assert metadata_fts_enabled(real_agent_config) is True
-        assert resolve_kb_search_mode(real_agent_config) == KbSearchMode.HYBRID
+        assert resolve_kb_search_mode(real_agent_config) == KbSearchMode.FTS
+
+    def test_metadata_fts_rejects_backend_without_fts_capability(self, real_agent_config):
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+        from datus.utils.exceptions import DatusException
+
+        self._enable_fts(real_agent_config)
+        database = MagicMock()
+        database.supports_fts.return_value = False
+        with patch("datus.storage.backend_holder.create_vector_connection", return_value=database):
+            with pytest.raises(DatusException, match="FTS-capable vector backend"):
+                MetadataFtsRAG(real_agent_config)
 
     def test_kb_retrieval_text_and_where_helpers_handle_empty_and_structured_values(self):
         from datus.storage.kb_retrieval.store import _as_text, _build_where_clause
@@ -881,6 +910,7 @@ class TestMetadataFtsRAG:
         from datus.schemas.node_models import TableSchema
         from datus.storage.kb_retrieval import MetadataFtsRAG
 
+        self._enable_fts(real_agent_config)
         rag = MetadataFtsRAG(real_agent_config)
         schemas = [
             self._make_schema_row(
@@ -903,16 +933,80 @@ class TestMetadataFtsRAG:
         metadata, sample_values = rag.search_similar("gross revenue", top_n=5, table_type="full")
         assert "definition" in metadata.column_names
         assert any(row["table_name"] == "order_facts" for row in metadata.to_pylist())
-        assert rag.last_search_info["requested_mode"] == "fts"
-        assert rag.last_search_info["actual_mode"] == "fts"
-        assert rag.last_search_info["fallback"] is False
+        assert rag.last_search_info == {
+            "configured_mode": "fts",
+            "index_status": "ready",
+            "index_version": 1,
+        }
         table_schemas = TableSchema.from_arrow(metadata)
         assert table_schemas[0].definition == "CREATE TABLE order_facts (order_id INT, gross_revenue DECIMAL)"
         assert sample_values.num_rows == 1
 
+    def test_incremental_fts_optimizes_only_changed_fragments(self, real_agent_config):
+        from datus.storage.kb_retrieval import MetadataFtsRAG
+
+        self._enable_fts(real_agent_config)
+        rag = MetadataFtsRAG(real_agent_config)
+        rag.store_batch(
+            [
+                self._make_schema_row(
+                    "orders",
+                    definition="CREATE TABLE orders (qqqq INT)",
+                ),
+                self._make_schema_row(
+                    "customers",
+                    definition="CREATE TABLE customers (xxxx INT)",
+                ),
+            ],
+            [],
+        )
+        rag.after_init()
+
+        rag.remove_data(database_name="db", schema_name="public", table_name="orders")
+        rag.remove_data(database_name="db", schema_name="public", table_name="customers")
+        rag.store_batch(
+            [
+                self._make_schema_row(
+                    "orders",
+                    definition="CREATE TABLE orders (zzzz INT)",
+                ),
+                self._make_schema_row(
+                    "inventory",
+                    definition="CREATE TABLE inventory (yyyy INT)",
+                ),
+            ],
+            [],
+        )
+
+        with (
+            patch.object(rag.facts_store.table, "optimize", wraps=rag.facts_store.table.optimize) as facts_optimize,
+            patch.object(
+                rag.document_store.table,
+                "optimize",
+                wraps=rag.document_store.table.optimize,
+            ) as documents_optimize,
+            patch.object(rag.document_store.table, "create_fts_index") as create_fts_index,
+        ):
+            rag.after_init(build_mode="incremental")
+
+        facts_optimize.assert_called_once_with()
+        documents_optimize.assert_called_once_with()
+        create_fts_index.assert_not_called()
+
+        fresh_results = rag.search_table("zzzz", top_n=5, table_type="full").to_pylist()
+        inventory_results = rag.search_table("yyyy", top_n=5, table_type="full").to_pylist()
+        legacy_results = rag.search_table("qqqq", top_n=5, table_type="full").to_pylist()
+        obsolete_results = rag.search_table("xxxx", top_n=5, table_type="full").to_pylist()
+
+        assert any(row["table_name"] == "orders" for row in fresh_results)
+        assert any(row["table_name"] == "inventory" for row in inventory_results)
+        assert all(row["table_name"] != "orders" for row in legacy_results)
+        assert all(row["table_name"] != "customers" for row in obsolete_results)
+
     def test_metadata_enrichment_uses_batched_fact_lookup(self, real_agent_config, monkeypatch):
         from datus.storage.kb_retrieval import MetadataFtsRAG
 
+        self._enable_fts(real_agent_config)
         rag = MetadataFtsRAG(real_agent_config)
         rag.store_batch(
             [
@@ -948,26 +1042,24 @@ class TestMetadataFtsRAG:
         assert samples.num_rows == 2
         assert len(calls) == 2
 
-    def test_hybrid_search_fails_when_vector_projection_is_empty(self, real_agent_config):
+    def test_fts_search_fails_when_index_is_missing(self, real_agent_config):
         from datus.storage.kb_retrieval import MetadataFtsRAG
         from datus.utils.exceptions import DatusException
 
-        real_agent_config.kb_search.mode = "hybrid"
-        real_agent_config.kb_search_mode = "hybrid"
+        self._enable_fts(real_agent_config)
         rag = MetadataFtsRAG(real_agent_config)
 
-        with pytest.raises(DatusException, match="vector projection has no rows"):
+        with pytest.raises(DatusException, match="run bootstrap-kb"):
             rag.search_table("orders", top_n=5, table_type="full")
 
-        assert rag.last_search_info["requested_mode"] == "hybrid"
-        assert rag.last_search_info["actual_mode"] == ""
-        assert rag.last_search_info["index_ready"] is False
-        assert rag.last_search_info["fallback"] is False
-        assert rag.last_search_info["error_reason"] == "hybrid_vector_projection_empty"
+        assert rag.last_search_info["configured_mode"] == "fts"
+        assert rag.last_search_info["index_status"] == "missing"
+        assert "run bootstrap-kb" in rag.last_search_info["error_reason"]
 
     def test_refresh_profiles_adds_semantic_text_to_metadata_document(self, real_agent_config):
         from datus.storage.kb_retrieval import MetadataFtsRAG
 
+        self._enable_fts(real_agent_config)
         rag = MetadataFtsRAG(real_agent_config)
         rag.store_batch(
             [
@@ -980,37 +1072,48 @@ class TestMetadataFtsRAG:
         )
         rag.after_init()
 
-        updated = rag.refresh_profiles(
-            [
-                {
-                    "id": "orders_profile",
-                    "format": "metricflow",
-                    "physical_table_fq_name": "db.public.orders",
-                    "catalog_name": "",
-                    "database_name": "db",
-                    "schema_name": "public",
-                    "table_name": "orders",
-                    "semantic_model_name": "commerce",
-                    "dataset_name": "orders",
-                    "data_source_name": "orders",
-                    "description": "Customer lifetime value and retention order history",
-                    "ai_context_json": "",
-                    "columns_json": "",
-                    "relationships_json": "",
-                    "custom_extensions_json": "",
-                    "yaml_path": "semantic_models/orders.yml",
-                    "search_text": "Customer lifetime value and retention order history",
-                }
-            ]
-        )
+        with (
+            patch.object(
+                rag.document_store.table,
+                "optimize",
+                wraps=rag.document_store.table.optimize,
+            ) as optimize,
+            patch.object(rag.document_store.table, "create_fts_index") as create_fts_index,
+        ):
+            updated = rag.refresh_profiles(
+                [
+                    {
+                        "id": "orders_profile",
+                        "format": "metricflow",
+                        "physical_table_fq_name": "db.public.orders",
+                        "catalog_name": "",
+                        "database_name": "db",
+                        "schema_name": "public",
+                        "table_name": "orders",
+                        "semantic_model_name": "commerce",
+                        "dataset_name": "orders",
+                        "data_source_name": "orders",
+                        "description": "Customer lifetime value and retention order history",
+                        "ai_context_json": "",
+                        "columns_json": "",
+                        "relationships_json": "",
+                        "custom_extensions_json": "",
+                        "yaml_path": "semantic_models/orders.yml",
+                        "search_text": "Customer lifetime value and retention order history",
+                    }
+                ]
+            )
 
         assert updated == 1
+        optimize.assert_called_once_with()
+        create_fts_index.assert_not_called()
         results = rag.search_table("lifetime value retention", top_n=5, table_type="full").to_pylist()
         assert any(row["table_name"] == "orders" for row in results)
 
     def test_refresh_tables_removes_stale_semantic_text(self, real_agent_config):
         from datus.storage.kb_retrieval import MetadataFtsRAG
 
+        self._enable_fts(real_agent_config)
         rag = MetadataFtsRAG(real_agent_config)
         rag.store_batch(
             [

--- a/tests/unit_tests/storage/table_semantic_profile/test_store.py
+++ b/tests/unit_tests/storage/table_semantic_profile/test_store.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 
@@ -68,7 +69,10 @@ def test_get_profile_lowercase_fallback_runs_after_ambiguous_broad_lookup():
 
 def _artifact_rag():
     rag = TableSemanticProfileRAG.__new__(TableSemanticProfileRAG)
+    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(enabled=False, mode="fts"), kb_search_mode="fts")
+    rag.datasource_id = "test_datasource"
     rag.storage = Mock()
+    rag.storage._search_all.return_value = _Rows([])
     rag._sub_agent_conditions = Mock(return_value=[])
     return rag
 
@@ -88,6 +92,7 @@ def test_delete_artifact_rows_uses_sub_agent_scope():
     rag.delete_artifact_rows("semantic/orders.yml")
 
     rag._sub_agent_conditions.assert_called_once_with()
+    rag.storage._search_all.assert_called_once()
     rag.storage._delete_rows.assert_called_once()
 
 
@@ -106,7 +111,34 @@ def test_delete_artifact_rows_except_keeps_current_ids():
     rag.delete_artifact_rows_except("semantic/orders.yml", ["profile:orders"])
 
     rag._sub_agent_conditions.assert_called_once_with()
+    rag.storage._search_all.assert_called_once()
     rag.storage._delete_rows.assert_called_once()
+
+
+def test_delete_artifact_rows_refreshes_metadata_documents_for_deleted_tables():
+    rag = _artifact_rag()
+    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(enabled=True, mode="fts"), kb_search_mode="fts")
+    deleted_rows = [{"catalog_name": "", "database_name": "db", "schema_name": "public", "table_name": "orders"}]
+    rag.storage._search_all.return_value = _Rows(deleted_rows)
+
+    with patch("datus.storage.kb_retrieval.MetadataFtsRAG") as metadata_cls:
+        rag.delete_artifact_rows("semantic/orders.yml")
+
+    metadata_cls.assert_called_once_with(rag.agent_config, datasource_id=rag.datasource_id)
+    metadata_cls.return_value.refresh_tables.assert_called_once_with(deleted_rows)
+
+
+def test_truncate_refreshes_metadata_documents_for_deleted_tables():
+    rag = _artifact_rag()
+    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(enabled=True, mode="fts"), kb_search_mode="fts")
+    deleted_rows = [{"catalog_name": "", "database_name": "db", "schema_name": "public", "table_name": "orders"}]
+    rag.storage._search_all.return_value = _Rows(deleted_rows)
+
+    with patch("datus.storage.kb_retrieval.MetadataFtsRAG") as metadata_cls:
+        rag.truncate()
+
+    rag.storage.delete_datasource_rows.assert_called_once_with("test_datasource")
+    metadata_cls.return_value.refresh_tables.assert_called_once_with(deleted_rows)
 
 
 def test_list_artifact_rows_handles_empty_and_non_empty_paths():

--- a/tests/unit_tests/storage/table_semantic_profile/test_store.py
+++ b/tests/unit_tests/storage/table_semantic_profile/test_store.py
@@ -69,7 +69,7 @@ def test_get_profile_lowercase_fallback_runs_after_ambiguous_broad_lookup():
 
 def _artifact_rag():
     rag = TableSemanticProfileRAG.__new__(TableSemanticProfileRAG)
-    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(enabled=False, mode="fts"), kb_search_mode="fts")
+    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(mode="vector"), kb_search_mode="vector")
     rag.datasource_id = "test_datasource"
     rag.storage = Mock()
     rag.storage._search_all.return_value = _Rows([])
@@ -117,7 +117,7 @@ def test_delete_artifact_rows_except_keeps_current_ids():
 
 def test_delete_artifact_rows_refreshes_metadata_documents_for_deleted_tables():
     rag = _artifact_rag()
-    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(enabled=True, mode="fts"), kb_search_mode="fts")
+    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(mode="fts"), kb_search_mode="fts")
     deleted_rows = [{"catalog_name": "", "database_name": "db", "schema_name": "public", "table_name": "orders"}]
     rag.storage._search_all.return_value = _Rows(deleted_rows)
 
@@ -130,7 +130,7 @@ def test_delete_artifact_rows_refreshes_metadata_documents_for_deleted_tables():
 
 def test_truncate_refreshes_metadata_documents_for_deleted_tables():
     rag = _artifact_rag()
-    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(enabled=True, mode="fts"), kb_search_mode="fts")
+    rag.agent_config = SimpleNamespace(kb_search=SimpleNamespace(mode="fts"), kb_search_mode="fts")
     deleted_rows = [{"catalog_name": "", "database_name": "db", "schema_name": "public", "table_name": "orders"}]
     rag.storage._search_all.return_value = _Rows(deleted_rows)
 

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -554,6 +554,41 @@ class TestSearchRouting:
         assert result.num_rows >= 0
         assert "vector" not in result.column_names
 
+    def test_search_hybrid_success_without_fallback(self, tmp_path):
+        """search() with query_type='hybrid' returns hybrid results when available."""
+        store = self._make_store(tmp_path)
+        table = MagicMock()
+        table.count_rows.return_value = 2
+        table.search_hybrid.return_value = pa.Table.from_pylist(
+            [
+                {"identifier": "id_1", "table_name": "table_1"},
+                {"identifier": "id_2", "table_name": "table_2"},
+            ]
+        )
+        store.table = table
+        store._open_existing_table_for_read = MagicMock(return_value=table)
+        store._ensure_embedding_cache_ready_for_search = MagicMock()
+        store._ensure_table_ready = MagicMock()
+
+        result = store.search("table", query_type="hybrid", top_n=1, allow_hybrid_fallback=False)
+
+        assert result.num_rows == 1
+        assert result.to_pylist()[0]["table_name"] == "table_1"
+
+    def test_search_hybrid_without_fallback_raises(self, tmp_path):
+        """search() with fallback disabled surfaces the hybrid error."""
+        store = self._make_store(tmp_path)
+        table = MagicMock()
+        table.count_rows.return_value = 1
+        table.search_hybrid.side_effect = RuntimeError("fts index missing")
+        store.table = table
+        store._open_existing_table_for_read = MagicMock(return_value=table)
+        store._ensure_embedding_cache_ready_for_search = MagicMock()
+        store._ensure_table_ready = MagicMock()
+
+        with pytest.raises(DatusException, match="fts index missing"):
+            store.search("table", query_type="hybrid", top_n=1, allow_hybrid_fallback=False)
+
 
 # ---------------------------------------------------------------------------
 # table_size

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -6,7 +6,7 @@
 
 import re
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
 import pytest
@@ -865,7 +865,7 @@ class TestCreateFtsIndex:
     """Tests for create_fts_index."""
 
     def test_create_fts_index_no_error(self, tmp_path):
-        """create_fts_index should not raise even if index creation fails."""
+        """create_fts_index creates a verified native index."""
         store = SchemaStorage(get_db_embedding_model())
         store.store_batch(
             [
@@ -884,7 +884,7 @@ class TestCreateFtsIndex:
         assert store.table_size() == 1
 
     def test_create_fts_index_with_multiple_fields(self, tmp_path):
-        """create_fts_index with multiple fields should not raise."""
+        """create_fts_index creates one native index per field."""
         store = SchemaStorage(get_db_embedding_model())
         store.store_batch(
             [
@@ -901,6 +901,28 @@ class TestCreateFtsIndex:
         )
         store.create_fts_index(["database_name", "schema_name", "table_name", "definition"])
         assert store.table_size() == 1
+        indices = store.table._table.list_indices()
+        indexed_fields = {column for index in indices if index.index_type == "FTS" for column in index.columns}
+        assert indexed_fields == {"database_name", "schema_name", "table_name", "definition"}
+
+    def test_create_fts_index_failure_is_not_swallowed(self, tmp_path):
+        store = SchemaStorage(get_db_embedding_model())
+        store.store_batch(
+            [
+                {
+                    "identifier": "id_1",
+                    "catalog_name": "cat",
+                    "database_name": "db",
+                    "schema_name": "sch",
+                    "table_name": "t",
+                    "table_type": "table",
+                    "definition": "CREATE TABLE t (id INT)",
+                }
+            ]
+        )
+        with patch.object(store.table, "create_fts_index", side_effect=RuntimeError("index build failed")):
+            with pytest.raises(DatusException, match="index build failed"):
+                store.create_fts_index(["definition"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/vector/test_lance_backend.py
+++ b/tests/unit_tests/storage/vector/test_lance_backend.py
@@ -188,6 +188,29 @@ class TestLanceVectorDatabase:
         db = LanceVectorDatabase(raw_db)
         assert db.table_exists("missing") is False
 
+    def test_table_exists_false_for_corrupt_lance_table_metadata(self):
+        """table_exists() treats incomplete Lance table directories as missing."""
+        raw_db = MagicMock()
+        raw_db.open_table.side_effect = RuntimeError('FileDoesNotExist("meta.json")')
+        db = LanceVectorDatabase(raw_db)
+        assert db.table_exists("missing") is False
+
+    def test_table_exists_reraises_non_missing_errors(self):
+        raw_db = MagicMock()
+        raw_db.open_table.side_effect = RuntimeError("connection lost")
+        db = LanceVectorDatabase(raw_db)
+
+        with pytest.raises(RuntimeError, match="connection lost"):
+            db.table_exists("my_table")
+
+    def test_table_exists_reraises_meta_json_errors_without_missing_table_signature(self):
+        raw_db = MagicMock()
+        raw_db.open_table.side_effect = RuntimeError("failed to parse meta.json")
+        db = LanceVectorDatabase(raw_db)
+
+        with pytest.raises(RuntimeError, match="failed to parse meta.json"):
+            db.table_exists("my_table")
+
     def test_create_table_passes_kwargs(self):
         """create_table() passes schema to db connection without embedding."""
         raw_db = MagicMock()

--- a/tests/unit_tests/storage/vector/test_lance_backend.py
+++ b/tests/unit_tests/storage/vector/test_lance_backend.py
@@ -7,10 +7,12 @@
 import unittest.mock
 from unittest.mock import MagicMock
 
+import lancedb
 import pyarrow as pa
 import pytest
 from datus_storage_base.conditions import and_, eq, in_
 
+from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec
 from datus.storage.vector.lance_backend import LanceVectorBackend, LanceVectorDatabase, LanceVectorTable
 from datus.utils.exceptions import DatusException
 
@@ -117,6 +119,63 @@ class TestLanceVectorTableSearchOps:
         assert table.count_rows(where=where) == 2
         raw_table.count_rows.assert_called_once_with("(status = 'active' AND role = 'admin')")
 
+    def test_multimatch_searches_independently_indexed_fields(self, tmp_path):
+        raw_table = lancedb.connect(tmp_path).create_table(
+            "multi_fts",
+            data=pa.table(
+                {
+                    "id": [1, 2],
+                    "title": ["orders handbook", "customer handbook"],
+                    "body": ["monthly revenue", "retention cohorts"],
+                }
+            ),
+        )
+        table = LanceVectorTable(raw_table)
+        spec = FtsSpec((FtsField("title", boost=3.0), FtsField("body")))
+        for field in spec.fields:
+            table.create_fts_index(field)
+
+        assert table.fts_index_status(spec) == FtsIndexStatus.READY
+        assert table.search_fts("orders", spec, 5).to_pylist()[0]["id"] == 1
+        assert table.search_fts("retention", spec, 5).to_pylist()[0]["id"] == 2
+
+    def test_ngram_fts_matches_chinese_without_whitespace(self, tmp_path):
+        raw_table = lancedb.connect(tmp_path).create_table(
+            "ngram_fts",
+            data=pa.table({"id": [1, 2], "search_text": ["订单购买分析", "客户流失分析"]}),
+        )
+        table = LanceVectorTable(raw_table)
+        spec = FtsSpec((FtsField("search_text", tokenizer="ngram"),))
+        table.create_fts_index(spec.fields[0])
+
+        assert table.search_fts("购买", spec, 5).to_pylist()[0]["id"] == 1
+
+    def test_fts_status_detects_tokenizer_mismatch(self, tmp_path):
+        raw_table = lancedb.connect(tmp_path).create_table(
+            "mismatched_fts",
+            data=pa.table({"text": ["orders"]}),
+        )
+        table = LanceVectorTable(raw_table)
+        table.create_fts_index(FtsField("text"))
+
+        expected = FtsSpec((FtsField("text", tokenizer="ngram"),))
+        assert table.fts_index_status(expected) == FtsIndexStatus.VERSION_MISMATCH
+
+    def test_legacy_fts_directory_is_detected_and_removed_for_rebuild(self, tmp_path):
+        raw_table = lancedb.connect(tmp_path).create_table(
+            "legacy_fts",
+            data=pa.table({"text": ["orders"]}),
+        )
+        table = LanceVectorTable(raw_table)
+        spec = FtsSpec((FtsField("text"),))
+        legacy_path = tmp_path / "legacy_fts.lance" / "_indices" / "fts"
+        legacy_path.mkdir(parents=True)
+        (legacy_path / "marker").write_text("legacy", encoding="utf-8")
+
+        assert table.fts_index_status(spec) == FtsIndexStatus.LEGACY
+        assert table.remove_legacy_fts_index() is True
+        assert not legacy_path.exists()
+
 
 class TestLanceVectorTableIndexOps:
     """Tests for table-level index operations."""
@@ -129,11 +188,17 @@ class TestLanceVectorTableIndexOps:
         raw_table.create_index.assert_called_once_with(metric="l2", vector_column_name="vec_col", replace=True)
 
     def test_create_fts_index(self):
-        """create_fts_index() delegates to underlying table."""
+        """create_fts_index() uses the unified single-field API."""
         raw_table = MagicMock()
         table = LanceVectorTable(raw_table)
-        table.create_fts_index(["title", "body"])
-        raw_table.create_fts_index.assert_called_once_with(field_names=["title", "body"], replace=True)
+        table.create_fts_index(FtsField("body", tokenizer="ngram"))
+        raw_table.create_index.assert_called_once()
+        args, kwargs = raw_table.create_index.call_args
+        assert args == ("body",)
+        assert kwargs["replace"] is True
+        assert kwargs["config"].base_tokenizer == "ngram"
+        assert kwargs["config"].ngram_min_length == 2
+        assert kwargs["config"].ngram_max_length == 2
 
     def test_create_scalar_index(self):
         """create_scalar_index() delegates to underlying table."""
@@ -141,6 +206,13 @@ class TestLanceVectorTableIndexOps:
         table = LanceVectorTable(raw_table)
         table.create_scalar_index("category")
         raw_table.create_scalar_index.assert_called_once_with("category", replace=True)
+
+    def test_optimize(self):
+        """optimize() incrementally updates the underlying Lance indices."""
+        raw_table = MagicMock()
+        table = LanceVectorTable(raw_table)
+        table.optimize()
+        raw_table.optimize.assert_called_once_with()
 
     def test_compact_files(self):
         """compact_files() delegates to underlying table."""

--- a/tests/unit_tests/tools/db_tools/test_db_func_tools.py
+++ b/tests/unit_tests/tools/db_tools/test_db_func_tools.py
@@ -1382,7 +1382,7 @@ class TestDBFuncToolIntegration:
     def test_search_table_uses_metadata_fts_rag_entrypoint(self, db_func_tool):
         """FTS metadata configs should query the metadata search_table API directly."""
         db_func_tool.agent_config = SimpleNamespace(
-            kb_search=SimpleNamespace(enabled=True, mode="fts"),
+            kb_search=SimpleNamespace(mode="fts"),
             kb_search_mode="fts",
         )
         db_func_tool.has_schema = True
@@ -1390,10 +1390,9 @@ class TestDBFuncToolIntegration:
         db_func_tool.schema_rag.search_table.return_value = self._build_metadata_doc_batch()
         db_func_tool.schema_rag.sample_rows_for_search_results.return_value = self._build_sample_batch()
         db_func_tool.schema_rag.last_search_info = {
-            "requested_mode": "fts",
-            "actual_mode": "fts",
-            "index_ready": True,
-            "fallback": False,
+            "configured_mode": "fts",
+            "index_status": "ready",
+            "index_version": 1,
         }
         db_func_tool.schema_rag.search_similar.side_effect = AssertionError("legacy search should not be called")
 

--- a/tests/unit_tests/tools/db_tools/test_db_func_tools.py
+++ b/tests/unit_tests/tools/db_tools/test_db_func_tools.py
@@ -2,6 +2,7 @@
 Test cases for DBFuncTool class in datus/tools/tools.py
 """
 
+import json
 import os
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -1291,6 +1292,43 @@ class TestDBFuncToolIntegration:
             ]
         )
 
+    def _build_csv_sample_batch(self):
+        return FakeRecordBatch(
+            [
+                {
+                    "identifier": "db1.public.orders",
+                    "table_type": "table",
+                    "sample_rows": "id,total\n1,10\n",
+                }
+            ]
+        )
+
+    def _build_metadata_doc_batch(self):
+        return FakeRecordBatch(
+            [
+                {
+                    "catalog_name": "",
+                    "database_name": "db1",
+                    "schema_name": "public",
+                    "table_name": "orders",
+                    "table_type": "table",
+                    "identifier": "db1.public.orders",
+                    "title": "db1.public.orders",
+                    "payload_json": json.dumps(
+                        {
+                            "identifier": "db1.public.orders",
+                            "catalog_name": "",
+                            "database_name": "db1",
+                            "schema_name": "public",
+                            "table_name": "orders",
+                            "table_type": "table",
+                        }
+                    ),
+                    "_score": 3.5,
+                }
+            ]
+        )
+
     def test_search_table_returns_metadata_and_samples(self, db_func_tool):
         """search_table should emit metadata and sample rows when available."""
         db_func_tool.has_schema = True
@@ -1304,11 +1342,12 @@ class TestDBFuncToolIntegration:
 
         assert result.success == 1
         metadata = result.result["metadata"]
-        samples = result.result["sample_data"]
-        assert metadata[0]["table_name"] == "orders"
-        assert isinstance(samples, dict)
-        assert samples["original_rows"] == 1
-        assert "sample_rows" in samples["compressed_data"]
+        assert "sample_data" not in result.result
+        assert metadata[0] == {
+            "table_name": "db1.public.orders",
+            "sample_rows": [{"id": 1, "total": 10}],
+        }
+        assert "_distance" not in metadata[0]
 
     def test_search_table_enriches_semantic_model(self, db_func_tool):
         """When semantic models exist, metadata rows should include enriched context."""
@@ -1330,13 +1369,69 @@ class TestDBFuncToolIntegration:
 
         assert result.success == 1
         metadata = result.result["metadata"]
+        assert metadata[0]["table_name"] == "db1.public.orders"
         assert metadata[0]["description"] == "Orders summary"
-        assert metadata[0]["dimensions"] == ["order_id"]
-        assert metadata[0]["measures"] == ["total_amount"]
-        # sample_data is a compressed empty dict (semantic early-return fires before sample population)
-        assert isinstance(result.result["sample_data"], dict)
-        assert result.result["sample_data"]["original_rows"] == 0
+        assert metadata[0]["sample_rows"] == [{"id": 1, "total": 10}]
+        assert "semantic_model_name" not in metadata[0]
+        assert "dimensions" not in metadata[0]
+        assert "measures" not in metadata[0]
+        assert "identifiers" not in metadata[0]
+        assert "sample_data" not in result.result
         db_func_tool._get_semantic_model.assert_called_once()
+
+    def test_search_table_uses_metadata_fts_rag_entrypoint(self, db_func_tool):
+        """FTS metadata configs should query the metadata search_table API directly."""
+        db_func_tool.agent_config = SimpleNamespace(
+            kb_search=SimpleNamespace(enabled=True, mode="fts"),
+            kb_search_mode="fts",
+        )
+        db_func_tool.has_schema = True
+        db_func_tool.schema_rag = Mock()
+        db_func_tool.schema_rag.search_table.return_value = self._build_metadata_doc_batch()
+        db_func_tool.schema_rag.sample_rows_for_search_results.return_value = self._build_sample_batch()
+        db_func_tool.schema_rag.last_search_info = {
+            "requested_mode": "fts",
+            "actual_mode": "fts",
+            "index_ready": True,
+            "fallback": False,
+        }
+        db_func_tool.schema_rag.search_similar.side_effect = AssertionError("legacy search should not be called")
+
+        result = db_func_tool.search_table("orders table")
+
+        assert result.success == 1
+        metadata = result.result["metadata"]
+        assert metadata[0]["table_name"] == "db1.public.orders"
+        assert "_score" not in metadata[0]
+        assert "_relevance_score" not in metadata[0]
+        assert "_distance" not in metadata[0]
+        assert metadata[0]["sample_rows"] == [{"id": 1, "total": 10}]
+        assert "sample_data" not in result.result
+        assert "retrieval" not in result.result
+        db_func_tool.schema_rag.search_table.assert_called_once_with(
+            "orders table",
+            catalog_name="",
+            database_name="db1",
+            schema_name="",
+            table_type="full",
+            top_n=5,
+        )
+        db_func_tool.schema_rag.sample_rows_for_search_results.assert_called_once()
+        db_func_tool.schema_rag.search_similar.assert_not_called()
+
+    def test_search_table_parses_csv_sample_rows_inline(self, db_func_tool):
+        """Stored CSV sample rows should be returned inline on the matching metadata item."""
+        db_func_tool.has_schema = True
+        db_func_tool.schema_rag = Mock()
+        db_func_tool.schema_rag.search_similar.return_value = (
+            self._build_metadata_batch(),
+            self._build_csv_sample_batch(),
+        )
+
+        result = db_func_tool.search_table("orders table")
+
+        assert result.success == 1
+        assert result.result["metadata"][0]["sample_rows"] == [{"id": "1", "total": "10"}]
 
     def test_tool_transformation_integration(self, db_func_tool):
         """Test that tools can be transformed properly."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "(python_full_version >= '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.14' and sys_platform != 'darwin')",
@@ -783,7 +783,7 @@ requires-dist = [
     { name = "fastembed", specifier = "==0.4.2" },
     { name = "httpx", extras = ["socks"], specifier = "==0.27.2" },
     { name = "json-repair", specifier = ">=0.47.6" },
-    { name = "lancedb", specifier = "==0.18.0" },
+    { name = "lancedb", specifier = "==0.34.0" },
     { name = "litellm", specifier = ">=1.67.4.post1,<2" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
@@ -795,7 +795,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "packaging", specifier = ">=21.0" },
-    { name = "pandas", specifier = "==2.1.4" },
+    { name = "pandas", specifier = "==2.3.3" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pyarrow", specifier = "<19.0.0" },
     { name = "pydantic", specifier = ">=2.11.7,<3.0" },
@@ -1351,6 +1351,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1361,6 +1362,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1371,6 +1373,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -1778,24 +1781,50 @@ wheels = [
 ]
 
 [[package]]
+name = "lance-namespace"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace-urllib3-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/81/4cf8d0412e1f37b2bfa70d0aeb9c7ae4ab73607534e44d60b55efb485306/lance_namespace-0.9.0.tar.gz", hash = "sha256:f738b641cc615b17323baa4eb47900f184688739ee3d2ea9fe39396b9588e53d", size = 11637, upload-time = "2026-07-01T07:42:41.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/fe/f38747c9610ade83dd9a99a0470b9432b6f21ce4e2bb5524edbe66f626fd/lance_namespace-0.9.0-py3-none-any.whl", hash = "sha256:f785ff10927e4ce0db69986576670fedd37f8a33521e8a4630c6be22db8061b2", size = 13501, upload-time = "2026-07-01T07:42:39.372Z" },
+]
+
+[[package]]
+name = "lance-namespace-urllib3-client"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/32d0e2618549ace857c80a457e5915ef3e1145661baff876c8a5ec27be5b/lance_namespace_urllib3_client-0.9.0.tar.gz", hash = "sha256:cf796fa5307fa4dde91fe4bec2af28b90ba79191852d4394e8fe44276538e40f", size = 235805, upload-time = "2026-07-01T07:42:42.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/ab/c8754da0a1efc817f8480100cfe12b7e04034df834759de8ecf02beff3cc/lance_namespace_urllib3_client-0.9.0-py3-none-any.whl", hash = "sha256:be819c8cffb1e460a3a504dbf52d1ca009560a48e7202b8c4279998e4adf9fe4", size = 405586, upload-time = "2026-07-01T07:42:40.503Z" },
+]
+
+[[package]]
 name = "lancedb"
-version = "0.18.0"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
-    { name = "overrides" },
+    { name = "lance-namespace" },
+    { name = "numpy" },
     { name = "packaging" },
+    { name = "pyarrow" },
     { name = "pydantic" },
-    { name = "pylance" },
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/4f/624fccd169db8840cec877bd66ea2c5df86c5dd75c46587903e95eca28dc/lancedb-0.18.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:c0356bb59ff044eddd824eae098837c44780662ba3f82a1ec45ce242c0a9acaf", size = 28698712, upload-time = "2025-01-14T01:48:54.979Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/b2/5d2c53302cf09368fa653e37e97d37e3b201da9ecbf3bddd0d5e470abc07/lancedb-0.18.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8799534dfafaa51058afb6e6f332129632420b2168532318871a4d683924814e", size = 26819978, upload-time = "2025-01-14T01:45:37.134Z" },
-    { url = "https://files.pythonhosted.org/packages/82/18/5783baf381b631528b3cdedf295897121be6e35b5f155ceb85bab4463789/lancedb-0.18.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9790894911463ee16b6d7b2392fa9c2cfb297be298ce6ff4261fd7a7ff434b0a", size = 32679981, upload-time = "2025-01-14T01:22:14.055Z" },
-    { url = "https://files.pythonhosted.org/packages/57/54/8f206dc39863b263e500fd686d84ffab31c02a502535afe3f2dad0e6032a/lancedb-0.18.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d1176b4d0b57c428c7e91e08576cab711327ac4ba7a8e52ec7bf53eebb945ea3", size = 29625854, upload-time = "2025-01-14T01:22:42.848Z" },
-    { url = "https://files.pythonhosted.org/packages/86/93/449e2ca6e9a5d689bf6635540285f2360a02225a768ccdc26b8b8ba68ff2/lancedb-0.18.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a183d2fb56a242c347acb2dabedd9b691462bf890168f375a70a1c181053f290", size = 32161652, upload-time = "2025-01-14T01:21:40.152Z" },
-    { url = "https://files.pythonhosted.org/packages/55/16/0bbd94b9f90ba553fa097ccebc52a796e488942dc2b73a70bb3688441f30/lancedb-0.18.0-cp39-abi3-win_amd64.whl", hash = "sha256:05c91c1e94df01ea7c511ec60c1898120188671db4c6715c0e66c0462b13a1c1", size = 29825704, upload-time = "2025-01-14T01:35:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f7/5262b9aa593f790757163c0165ab0da1dda054758901bea7e4f02c9cb633/lancedb-0.34.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c462f2e6f933cad659fd0179394eaab578acbc9151fe2ef41bc29b36ecca5058", size = 52654213, upload-time = "2026-07-02T17:13:31.102Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/05ea0d32229ebea695193ff20c15d6ecae25785ad82a9d4723d98832a284/lancedb-0.34.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:48829e88e708947d0520454ab9e4f8efa35f3e3626469eadd3a6e061b89cb223", size = 55434501, upload-time = "2026-07-02T17:13:34.81Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4e/4325c13d5afa93c466428a5a0f168ad4d96f5eb4a77bbe7c5100d39c9897/lancedb-0.34.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:05ba8a5b58e064edfbe5be71b1abf2e411b4eaf295d1a173dcb1a55c5bfb5285", size = 58659359, upload-time = "2026-07-02T17:13:38.424Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/8ca165f1386caf6c4d1c515afd52f345b66432264eecfdfb7fd33eefd9af/lancedb-0.34.0-cp39-abi3-win_amd64.whl", hash = "sha256:51cbc11808f9e3332819b9367c975b3a888541447a8e7bea09c57c852a279153", size = 63530726, upload-time = "2026-07-02T17:13:41.612Z" },
 ]
 
 [[package]]
@@ -2748,15 +2777,6 @@ wheels = [
 ]
 
 [[package]]
-name = "overrides"
-version = "7.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2767,7 +2787,7 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.1.4"
+version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -2775,14 +2795,41 @@ dependencies = [
     { name = "pytz" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/41/eb562668eaf93790762f600536b28c97b45803cba9253cd8e436cda96aef/pandas-2.1.4.tar.gz", hash = "sha256:fcb68203c833cc735321512e13861358079a96c174a61f5116a1de89c58c0ef7", size = 4274800, upload-time = "2023-12-08T15:38:29.713Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/16/64109832ed426d5c3e9f6b791e64a2b78d785823657640afb8f416ed1dc9/pandas-2.1.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:482d5076e1791777e1571f2e2d789e940dedd927325cc3cb6d0800c6304082f6", size = 11357488, upload-time = "2023-12-08T15:37:48.717Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/e0/8d97c7ecd73624f4cd5755578990b3cfbc6bbe350b8e017ede3580173a6f/pandas-2.1.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8a706cfe7955c4ca59af8c7a0517370eafbd98593155b48f10f9811da440248b", size = 10613199, upload-time = "2023-12-08T15:37:51.808Z" },
-    { url = "https://files.pythonhosted.org/packages/54/be/98b894bef9acfc310de70fc03524473a9695981e1e87c7afa56ada08f016/pandas-2.1.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0513a132a15977b4a5b89aabd304647919bc2169eac4c8536afb29c07c23540", size = 14288250, upload-time = "2023-12-08T15:37:55.263Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/5f/076b1ce74f80df0a9db244d30e30c4d4dee45342cbfa5f3e01f64cadf663/pandas-2.1.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9f17f2b6fc076b2a0078862547595d66244db0f41bf79fc5f64a5c4d635bead", size = 11673138, upload-time = "2023-12-08T15:37:59.209Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a8/13dced3276ea4514909a80c8dd08b43ab23007b4949701e3d7ae2a8ccd2d/pandas-2.1.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:45d63d2a9b1b37fa6c84a68ba2422dc9ed018bdaa668c7f47566a01188ceeec1", size = 12389903, upload-time = "2023-12-08T15:38:02.655Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/d9/3741b344f57484b423cd22194025a8489992ad9962196a62721ef9980045/pandas-2.1.4-cp312-cp312-win_amd64.whl", hash = "sha256:f69b0c9bb174a2342818d3e2778584e18c740d56857fc5cdb944ec8bbe4082cf", size = 10498689, upload-time = "2023-12-08T15:38:05.834Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
 ]
 
 [[package]]
@@ -3307,23 +3354,6 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
-]
-
-[[package]]
-name = "pylance"
-version = "0.22.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pyarrow" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/22/ad54cfda2bbf7e217de0cc131e0ed2c879af7728d6331903e44dee8f8dfb/pylance-0.22.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:2c0bb6bf7320e500f0f5948e5b23e4d70d9c84bba15a2db2e877be9637c4dc0c", size = 34412591, upload-time = "2025-01-13T21:25:22.067Z" },
-    { url = "https://files.pythonhosted.org/packages/28/e4/54603e4ad6341240e507cd3b490e34cd0663610b59d5e6ba5a9d317cd421/pylance-0.22.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:341a8cbac762c1f446a05a1513dab1b7930f433a8331b08b0b89a975f3864f6a", size = 31889815, upload-time = "2025-01-13T21:10:24.244Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ed/bf2b5e480d9ec620f261d9b5293ebb494934b42f30af62973df476ef8b7d/pylance-0.22.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29848127701f2188b331ad8399036f1fb79bacf5102fd030bfe9fd30cb02cf5b", size = 38929145, upload-time = "2025-01-13T21:11:43.272Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/6c/069ef2823c7366c529297493719e8a3f6b16a19bbaf42e6f5010307157ec/pylance-0.22.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:cd4cc3dd3772600092685282db8cd4c21eaa68f458445b3107bd01b43afb8f11", size = 36272984, upload-time = "2025-01-13T21:11:57.601Z" },
-    { url = "https://files.pythonhosted.org/packages/50/ff/61e10792edab999d0cc0c89a409446d28bee0f47e157ebc5587c0f8fb332/pylance-0.22.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8999e73ce180c977f91bb4629578d742b1e86fcf53e7d27b14d6d219395c17cd", size = 38322607, upload-time = "2025-01-13T21:11:40.174Z" },
-    { url = "https://files.pythonhosted.org/packages/61/f0/b62b14630af78d468ff7b15cc21576910edbd73114795b49907b39df2841/pylance-0.22.0-cp39-abi3-win_amd64.whl", hash = "sha256:848f1a74dab14dc14bf05569404977cfcba9a95a44e513e5a3b32f1221bfa00f", size = 34216608, upload-time = "2025-01-13T21:24:47.835Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade LanceDB from 0.18 to 0.34 and pandas from 2.1.4 to 2.3.3
- keep metadata retrieval on `vector` by default so existing installations preserve current behavior
- add an explicit `kb.search.mode: fts` path that uses native LanceDB FTS without embeddings, hybrid queries, or vector fallback
- adapt every FTS-backed store to LanceDB 0.34's one-index-per-field model and use `MultiMatchQuery` for weighted multi-field search
- add a dedicated ngram-indexed metadata retrieval document store for Chinese and substring-oriented table discovery
- make FTS creation and readiness checks strict so missing, legacy, incompatible, or unsupported indices fail instead of degrading silently
- use LanceDB incremental reindexing (`optimize()`) for metadata additions, DDL updates, deletes, and semantic-profile refreshes

## Compatibility And Migration

| Scenario | Behavior |
| --- | --- |
| Existing user with no search configuration | Continues using vector metadata retrieval |
| New user selecting FTS | Set `kb.search.mode: fts`, then run an overwrite metadata bootstrap |
| Existing vector user switching to FTS | Must run overwrite; vector data is not migrated or queried |
| Existing ready FTS store using incremental bootstrap | Upserts changed metadata and incrementally indexes changed Lance fragments |
| Missing, legacy, or mismatched FTS index | Fails with an explicit overwrite instruction |
| FTS query with zero matches | Returns an empty result without vector fallback |
| Backend without FTS support | Fails when FTS mode is selected |

Public modes are now `vector` and `fts`. Hybrid metadata retrieval and dual writes are intentionally removed.

## Root Cause

LanceDB 0.34 native FTS accepts one field per index, while several stores passed a field list. Index creation errors were logged and swallowed, and broad search tests could still pass through vector paths. Legacy 0.18 Tantivy indices are also not query-compatible with 0.34.

This change creates and verifies each field index independently, uses native multi-field queries, detects legacy/configuration mismatches, and makes index failures visible to bootstrap and tests.

## Retrieval Benchmark

Local `baisheng/search_stress` metadata retrieval benchmark, 50 cases, 110 tables, `top-k=5`, isolated overwrite bootstraps:

| Metric | FTS | Vector |
| --- | ---: | ---: |
| Hit@5 | 0.92 (46/50) | 0.36 (18/50) |
| MRR | 0.8817 | 0.2483 |
| Recall@5 | 0.8067 | 0.2633 |
| Average search latency | 4.20 ms | 17.21 ms |
| P50 search latency | 3.56 ms | 15.28 ms |

FTS added 28 hits and had no case where vector hit while FTS missed.

## Validation

- `uv lock --check --offline`
- `.venv/bin/ruff check datus tests/unit_tests`
- `uv run pytest tests/unit_tests -o addopts='-s' -o log_cli=false -q --tb=short`
  - `16046 passed, 7 skipped, 1 xfailed`
- real LanceDB tests cover independent multi-field indices, Chinese ngram retrieval, legacy/config mismatch detection, and incremental add/update/delete/profile-refresh behavior
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
