### PR TITLE
[BugFix] Semantic model data overwritten for same-named tables in different databases/schemas

### DIFF
--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -1083,7 +1083,7 @@ class GenerationHooks(AgentHooks):
             if data_source and include_semantic_objects:
                 # --- A. Table Object ---
                 table_obj = {
-                    "id": f"table:{table_name}",
+                    "id": f"table:{table_fq_name}",
                     "kind": "table",
                     "name": table_name,
                     "fq_name": table_fq_name,
@@ -1113,7 +1113,7 @@ class GenerationHooks(AgentHooks):
                     "entity": "",
                 }
                 semantic_objects.append(table_obj)
-                synced_items.append(f"table:{table_name}")
+                synced_items.append(f"table:{table_fq_name}")
 
                 # --- B. Column Objects (Measures & Dimensions & Identifiers) ---
 
@@ -1135,7 +1135,7 @@ class GenerationHooks(AgentHooks):
                         time_granularity = type_params.get("time_granularity", "")
 
                     col_obj = {
-                        "id": f"column:{table_name}.{col_name}",
+                        "id": f"column:{table_fq_name}.{col_name}",
                         "kind": "column",
                         "name": col_name,
                         "fq_name": f"{table_fq_name}.{col_name}",
@@ -1412,6 +1412,9 @@ class GenerationHooks(AgentHooks):
                             f"{', '.join(restore_failures)}"
                         ) from sync_exc
                     raise
+                # Post-commit, best-effort cleanup of shadowed stale rows; never raises.
+                if semantic_objects:
+                    semantic_rag.delete_shadowed_table_rows(semantic_objects)
                 result = {
                     "success": True,
                     "message": (

--- a/datus/storage/catalog_manager.py
+++ b/datus/storage/catalog_manager.py
@@ -58,57 +58,90 @@ class CatalogUpdater:
                 return None
         return None
 
+    @staticmethod
+    def _build_fq_name(old_values: Dict[str, Any]) -> str:
+        """Rebuild the qualified name used in storage ids (empty parts skipped),
+        mirroring the write-side id construction."""
+        parts = [
+            old_values.get("catalog_name", ""),
+            old_values.get("database_name", ""),
+            old_values.get("schema_name", ""),
+            old_values.get("table_name", ""),
+        ]
+        return ".".join(part for part in parts if part)
+
+    def _update_entry_with_fallback(self, entry_id: str, legacy_entry_id: str, changes: Dict[str, Any]) -> bool:
+        """Update by qualified id, falling back to the pre-#1084 simple-name id
+        so edits on legacy rows aren't dropped. Returns True when updated."""
+        try:
+            self._update_entry(entry_id, changes)
+            return True
+        except DatusException as e:
+            if e.code != ErrorCode.STORAGE_ENTRY_NOT_FOUND:
+                raise
+        if legacy_entry_id and legacy_entry_id != entry_id:
+            try:
+                self._update_entry(legacy_entry_id, changes)
+                return True
+            except DatusException as e:
+                if e.code != ErrorCode.STORAGE_ENTRY_NOT_FOUND:
+                    raise
+        logger.warning(f"Semantic entry not found: {entry_id}")
+        return False
+
     def update_semantic_model(self, old_values: Dict[str, Any], update_values: Dict[str, Any]):
+        table_fq_name = self._build_fq_name(old_values)
         table_name = old_values.get("table_name", "")
         semantic_model_name = old_values.get("semantic_model_name", "")
 
         # 1. Update table-level record (description)
         if "description" in update_values:
-            entry_id = f"table:{table_name}"
-            try:
-                self._update_entry(entry_id, {"description": update_values["description"]})
-            except DatusException as e:
-                if e.code == ErrorCode.STORAGE_ENTRY_NOT_FOUND:
-                    logger.warning(f"Table entry not found: {entry_id}")
-                else:
-                    raise
-            else:
+            updated = self._update_entry_with_fallback(
+                f"table:{table_fq_name}",
+                f"table:{table_name}" if table_name else "",
+                {"description": update_values["description"]},
+            )
+            if updated:
                 logger.debug("Updated table-level semantic model description")
 
         # 2. Update column-level records (dimensions, measures, identifiers)
         self._update_columns(
-            table_name,
+            table_fq_name,
             semantic_model_name,
             old_values.get("dimensions"),
             update_values.get("dimensions"),
             "is_dimension",
             {"description", "expr", "column_type", "is_partition", "time_granularity"},
+            legacy_table_name=table_name,
         )
         self._update_columns(
-            table_name,
+            table_fq_name,
             semantic_model_name,
             old_values.get("measures"),
             update_values.get("measures"),
             "is_measure",
             {"description", "expr", "agg", "create_metric", "agg_time_dimension"},
+            legacy_table_name=table_name,
         )
         self._update_columns(
-            table_name,
+            table_fq_name,
             semantic_model_name,
             old_values.get("identifiers"),
             update_values.get("identifiers"),
             "is_entity_key",
             {"description", "expr", "column_type", "entity"},
+            legacy_table_name=table_name,
         )
 
     def _update_columns(
         self,
-        table_name: str,
+        table_fq_name: str,
         semantic_model_name: str,
         old_columns: Any,
         new_columns: Any,
         kind_field: str,
         allowed_fields: set,
+        legacy_table_name: str = "",
     ):
         """Update column-level records by matching old and new values."""
         old_list = self._parse_json_field(old_columns) or []
@@ -137,13 +170,10 @@ class CatalogUpdater:
             if not changed:
                 continue
 
-            entry_id = f"column:{table_name}.{col_name}"
-            try:
-                self._update_entry(entry_id, changed)
-            except DatusException as e:
-                if e.code == ErrorCode.STORAGE_ENTRY_NOT_FOUND:
-                    logger.warning(f"Column entry not found: {entry_id}")
-                else:
-                    raise
-            else:
+            updated = self._update_entry_with_fallback(
+                f"column:{table_fq_name}.{col_name}",
+                f"column:{legacy_table_name}.{col_name}" if legacy_table_name else "",
+                changed,
+            )
+            if updated:
                 logger.debug(f"Updated column '{col_name}' ({kind_field}): {list(changed.keys())}")

--- a/datus/storage/semantic_model/auto_create.py
+++ b/datus/storage/semantic_model/auto_create.py
@@ -191,28 +191,28 @@ def find_missing_semantic_models(
         return []
 
     semantic_rag = SemanticModelRAG(agent_config)
+    try:
+        current_db_config = agent_config.current_db_config()
+    except Exception as e:
+        logger.warning(f"Failed to resolve current db config, checking tables without defaults: {e}")
+        current_db_config = None
     missing = []
 
     for table_fq_name in tables:
-        # Parse table name (may be database.schema.table format)
-        parts = table_fq_name.split(".")
-        table_name = parts[-1]  # Last part is the table name
-
-        # Search for existing semantic model
         try:
-            result = semantic_rag.storage.search_objects(
-                query_text=table_name,
-                kinds=["table"],
-                top_n=5,
+            # Resolve the reference to a hierarchy scope so same-named tables
+            # in different databases/schemas are told apart.
+            target = _resolved_table_target(table_fq_name, agent_config, current_db_config)
+            exists = semantic_rag.table_exists(
+                table_name=target["table_name"],
+                catalog_name=target["catalog_name"],
+                database_name=target["database_name"],
+                schema_name=target["schema_name"],
             )
-
-            # Exact match on table name (case insensitive)
-            exists = any(obj.get("name", "").lower() == table_name.lower() for obj in result)
-
             if not exists:
                 missing.append(table_fq_name)
         except Exception as e:
-            logger.warning(f"Error checking semantic model for {table_name}: {e}")
+            logger.warning(f"Error checking semantic model for {table_fq_name}: {e}")
             missing.append(table_fq_name)
 
     return missing

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -59,6 +59,19 @@ def _normalized_identifier(value: str) -> str:
     return ".".join(parts).lower()
 
 
+def _hierarchy_compatible(want: str, have: str) -> bool:
+    """Whether a stored hierarchy field matches a wanted one.
+
+    Empty on either side is compatible (legacy rows / unqualified references);
+    two populated-but-different values are not.
+    """
+    want_norm = _strip_identifier_quotes(want).lower()
+    have_norm = _strip_identifier_quotes(have).lower()
+    if not want_norm or not have_norm:
+        return True
+    return want_norm == have_norm
+
+
 class SemanticModelStorage(BaseEmbeddingStore):
     """Storage for field-level semantic objects (tables, columns) - excluding metrics."""
 
@@ -363,6 +376,49 @@ class SemanticModelRAG:
             And([eq("yaml_path", yaml_path), not_(in_("id", normalized_keep_ids))] + self._sub_agent_conditions())
         )
 
+    def delete_shadowed_table_rows(self, objects: List[Dict[str, Any]]) -> None:
+        """Best-effort post-commit cleanup of stale rows shadowed by ``objects``.
+
+        For each table scope in ``objects``, delete table/column rows in the
+        exact same scope (empty hierarchy matches only empty — never a wildcard)
+        whose id was not just written, e.g. legacy simple-name ids or
+        cross-yaml_path duplicates. Never raises.
+        """
+        keep_ids = [obj.get("id", "") for obj in objects if obj.get("id")]
+        if not keep_ids:
+            # No ids to preserve — deleting anything could wipe the new rows too.
+            return
+        seen_scopes = set()
+        for obj in objects:
+            if obj.get("kind") != "table":
+                continue
+            scope = (
+                obj.get("table_name", ""),
+                obj.get("catalog_name", ""),
+                obj.get("database_name", ""),
+                obj.get("schema_name", ""),
+            )
+            if not scope[0] or scope in seen_scopes:
+                continue
+            seen_scopes.add(scope)
+            table_name, catalog_name, database_name, schema_name = scope
+            conditions = [
+                in_("kind", ["table", "column"]),
+                eq("table_name", table_name),
+                eq("catalog_name", catalog_name),
+                eq("database_name", database_name),
+                eq("schema_name", schema_name),
+                not_(in_("id", keep_ids)),
+            ]
+            try:
+                self.storage._delete_rows(And(conditions + self._sub_agent_conditions()))
+            except Exception as cleanup_exc:
+                logger.warning(
+                    f"Best-effort cleanup of shadowed semantic rows failed for table "
+                    f"{table_name!r} (catalog={catalog_name!r}, database={database_name!r}, "
+                    f"schema={schema_name!r}): {cleanup_exc}"
+                )
+
     def list_artifact_rows(self, yaml_path: str) -> List[Dict[str, Any]]:
         """Return semantic rows projected from a single YAML artifact."""
         if not yaml_path:
@@ -379,6 +435,38 @@ class SemanticModelRAG:
         if rows:
             self.upsert_batch(rows)
         self.create_indices()
+
+    def table_exists(
+        self,
+        table_name: str,
+        catalog_name: str = "",
+        database_name: str = "",
+        schema_name: str = "",
+    ) -> bool:
+        """Whether a table semantic model exists for the given hierarchy scope.
+
+        Table name matches case-insensitively; hierarchy fields must match when
+        populated on both sides, while an empty value on either side stays
+        compatible (keeps legacy rows and unqualified references working).
+        """
+        if not table_name:
+            return False
+        # eq() is case-sensitive; query realistic case variants, compare client-side.
+        name_variants = list({table_name, table_name.lower(), table_name.upper()})
+        conditions = [eq("kind", "table"), in_("table_name", name_variants)] + self._sub_agent_conditions()
+        candidates = self.storage._search_all(
+            where=And(conditions),
+            select_fields=["table_name", "catalog_name", "database_name", "schema_name"],
+        ).to_pylist()
+        for row in candidates:
+            if (
+                row.get("table_name", "").lower() == table_name.lower()
+                and _hierarchy_compatible(catalog_name, row.get("catalog_name", ""))
+                and _hierarchy_compatible(database_name, row.get("database_name", ""))
+                and _hierarchy_compatible(schema_name, row.get("schema_name", ""))
+            ):
+                return True
+        return False
 
     def get_semantic_model(
         self,

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -452,26 +452,33 @@ class SemanticModelRAG:
         if not table_name:
             return False
         select_fields = ["table_name", "catalog_name", "database_name", "schema_name"]
+        want_name = _normalized_identifier(table_name)
+
+        def _matches(rows: List[Dict[str, Any]]) -> bool:
+            for row in rows:
+                if (
+                    _normalized_identifier(row.get("table_name", "")) == want_name
+                    and _hierarchy_compatible(catalog_name, row.get("catalog_name", ""))
+                    and _hierarchy_compatible(database_name, row.get("database_name", ""))
+                    and _hierarchy_compatible(schema_name, row.get("schema_name", ""))
+                ):
+                    return True
+            return False
+
         # eq() is case-sensitive; query realistic case variants, compare client-side.
         name_variants = list({table_name, table_name.lower(), table_name.upper()})
         conditions = [eq("kind", "table"), in_("table_name", name_variants)] + self._sub_agent_conditions()
-        candidates = self.storage._search_all(where=And(conditions), select_fields=select_fields).to_pylist()
-        if not candidates:
-            # MixedCase stored names (e.g. "Orders") escape the variants filter;
-            # fall back to a narrow-field scan of table rows and compare client-side.
-            candidates = self.storage._search_all(
-                where=And([eq("kind", "table")] + self._sub_agent_conditions()),
-                select_fields=select_fields,
-            ).to_pylist()
-        for row in candidates:
-            if (
-                row.get("table_name", "").lower() == table_name.lower()
-                and _hierarchy_compatible(catalog_name, row.get("catalog_name", ""))
-                and _hierarchy_compatible(database_name, row.get("database_name", ""))
-                and _hierarchy_compatible(schema_name, row.get("schema_name", ""))
-            ):
-                return True
-        return False
+        fast_candidates = self.storage._search_all(where=And(conditions), select_fields=select_fields).to_pylist()
+        if _matches(fast_candidates):
+            return True
+        # No full match yet: MixedCase/quoted stored names (e.g. "Orders") escape
+        # the variants filter, and same-named hits in other scopes must not mask
+        # them. Fall back to a narrow-field scan of all table rows.
+        broad_candidates = self.storage._search_all(
+            where=And([eq("kind", "table")] + self._sub_agent_conditions()),
+            select_fields=select_fields,
+        ).to_pylist()
+        return _matches(broad_candidates)
 
     def get_semantic_model(
         self,

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -451,13 +451,18 @@ class SemanticModelRAG:
         """
         if not table_name:
             return False
+        select_fields = ["table_name", "catalog_name", "database_name", "schema_name"]
         # eq() is case-sensitive; query realistic case variants, compare client-side.
         name_variants = list({table_name, table_name.lower(), table_name.upper()})
         conditions = [eq("kind", "table"), in_("table_name", name_variants)] + self._sub_agent_conditions()
-        candidates = self.storage._search_all(
-            where=And(conditions),
-            select_fields=["table_name", "catalog_name", "database_name", "schema_name"],
-        ).to_pylist()
+        candidates = self.storage._search_all(where=And(conditions), select_fields=select_fields).to_pylist()
+        if not candidates:
+            # MixedCase stored names (e.g. "Orders") escape the variants filter;
+            # fall back to a narrow-field scan of table rows and compare client-side.
+            candidates = self.storage._search_all(
+                where=And([eq("kind", "table")] + self._sub_agent_conditions()),
+                select_fields=select_fields,
+            ).to_pylist()
         for row in candidates:
             if (
                 row.get("table_name", "").lower() == table_name.lower()

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -1473,7 +1473,7 @@ class GenerationTools:
 
                 semantic_objects.append(
                     {
-                        "id": f"table:{table_name}",
+                        "id": f"table:{table_fq_name}",
                         "kind": "table",
                         "name": table_name,
                         "fq_name": table_fq_name,
@@ -1497,7 +1497,7 @@ class GenerationTools:
                         "entity": "",
                     }
                 )
-                synced_items.append(f"table:{table_name}")
+                synced_items.append(f"table:{table_fq_name}")
 
                 primary_keys = getattr(dataset, "primary_key", None) or []
                 if isinstance(primary_keys, str):
@@ -1585,6 +1585,8 @@ class GenerationTools:
                         f"{', '.join(restore_failures)}"
                     ) from sync_exc
                 raise
+            # Post-commit, best-effort cleanup of shadowed stale rows; never raises.
+            self.semantic_rag.delete_shadowed_table_rows(semantic_objects)
             return {
                 "success": True,
                 "message": f"Synced {len(semantic_objects)} OSI semantic object(s): {', '.join(synced_items[:5])}",
@@ -1612,7 +1614,7 @@ class GenerationTools:
         time_granularity: str = "",
     ) -> dict:
         return {
-            "id": f"column:{table_name}.{name}",
+            "id": f"column:{table_fq_name}.{name}",
             "kind": "column",
             "name": name,
             "fq_name": f"{table_fq_name}.{name}",

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -1232,6 +1232,23 @@ class GenerationTools:
         table = getattr(source, "table", None) or getattr(dataset, "name", "")
         return str(table).split(".")[-1]
 
+    def _dataset_db_parts(self, dataset: Any, default_db_parts: dict[str, str]) -> dict[str, str]:
+        """Hierarchy for one dataset: a qualified source table overrides the
+        connection defaults, so same-named tables in different databases keep
+        distinct storage ids (issue #1084)."""
+        from datus.utils.sql_utils import parse_table_name_parts
+
+        source = getattr(dataset, "source", None)
+        table_ref = str(getattr(source, "table", "") or "")
+        if "." not in table_ref:
+            return default_db_parts
+        parsed = parse_table_name_parts(table_ref, dialect=self.agent_config.db_type or "snowflake")
+        return {
+            "catalog_name": parsed.get("catalog_name") or default_db_parts["catalog_name"],
+            "database_name": parsed.get("database_name") or default_db_parts["database_name"],
+            "schema_name": parsed.get("schema_name") or default_db_parts["schema_name"],
+        }
+
     @staticmethod
     def _dataset_lookup(doc: Any) -> dict[str, Any]:
         return {getattr(dataset, "name", ""): dataset for dataset in getattr(doc, "datasets", [])}
@@ -1447,7 +1464,7 @@ class GenerationTools:
                 }
 
             doc = self._load_osi_document(semantic_model_file=semantic_model_path)
-            db_parts = self._current_db_parts(self.agent_config)
+            default_db_parts = self._current_db_parts(self.agent_config)
             semantic_objects: List[dict] = []
             table_profiles: List[dict] = []
             synced_items: List[str] = []
@@ -1457,6 +1474,7 @@ class GenerationTools:
                 if dataset_name not in target_dataset_names:
                     continue
                 table_name = self._dataset_table_name(dataset)
+                db_parts = self._dataset_db_parts(dataset, default_db_parts)
                 fq_parts = [db_parts["catalog_name"], db_parts["database_name"], db_parts["schema_name"], table_name]
                 table_fq_name = ".".join(part for part in fq_parts if part)
                 yaml_path = semantic_model_path

--- a/tests/unit_tests/storage/semantic_model/test_auto_create.py
+++ b/tests/unit_tests/storage/semantic_model/test_auto_create.py
@@ -152,6 +152,18 @@ class TestExtractTableSqlEvidence:
 class TestFindMissingSemanticModels:
     """Tests for find_missing_semantic_models."""
 
+    @staticmethod
+    def _make_config(catalog: str = "", database: str = "mydb", schema: str = "public") -> MagicMock:
+        """Config whose current_db_config returns string hierarchy defaults."""
+        config = MagicMock()
+        config.db_type = "snowflake"
+        db_cfg = MagicMock()
+        db_cfg.catalog = catalog
+        db_cfg.database = database
+        db_cfg.schema = schema
+        config.current_db_config.return_value = db_cfg
+        return config
+
     def test_empty_tables_returns_empty(self):
         """Empty table set should return empty list."""
         from datus.storage.semantic_model.auto_create import find_missing_semantic_models
@@ -165,12 +177,10 @@ class TestFindMissingSemanticModels:
         """When all semantic models exist, should return empty list."""
         from datus.storage.semantic_model.auto_create import find_missing_semantic_models
 
-        config = MagicMock()
+        config = self._make_config()
         mock_rag = MagicMock()
         MockRAG.return_value = mock_rag
-
-        # Simulate existing semantic model
-        mock_rag.storage.search_objects.return_value = [{"name": "users"}]
+        mock_rag.table_exists.return_value = True
 
         result = find_missing_semantic_models({"users"}, config)
         assert result == []
@@ -180,57 +190,78 @@ class TestFindMissingSemanticModels:
         """When semantic models are missing, should return those table names."""
         from datus.storage.semantic_model.auto_create import find_missing_semantic_models
 
-        config = MagicMock()
+        config = self._make_config()
         mock_rag = MagicMock()
         MockRAG.return_value = mock_rag
-
-        # No matching results
-        mock_rag.storage.search_objects.return_value = []
+        mock_rag.table_exists.return_value = False
 
         result = find_missing_semantic_models({"missing_table"}, config)
         assert "missing_table" in result
 
     @patch("datus.storage.semantic_model.store.SemanticModelRAG")
-    def test_case_insensitive_match(self, MockRAG):
-        """Should match table names case-insensitively."""
+    def test_same_name_different_database_checked_by_hierarchy(self, MockRAG):
+        """A qualified reference is resolved to its hierarchy before the existence check."""
         from datus.storage.semantic_model.auto_create import find_missing_semantic_models
 
-        config = MagicMock()
+        config = self._make_config()
         mock_rag = MagicMock()
         MockRAG.return_value = mock_rag
+        mock_rag.table_exists.return_value = False
 
-        mock_rag.storage.search_objects.return_value = [{"name": "USERS"}]
+        result = find_missing_semantic_models({"db2.sales.orders"}, config)
 
-        result = find_missing_semantic_models({"users"}, config)
-        assert result == []
+        assert result == ["db2.sales.orders"]
+        # The qualified parts must reach table_exists so db1/db2 are distinguished.
+        kwargs = mock_rag.table_exists.call_args.kwargs
+        assert kwargs["table_name"] == "orders"
+        assert kwargs["database_name"] == "db2"
+        assert kwargs["schema_name"] == "sales"
 
     @patch("datus.storage.semantic_model.store.SemanticModelRAG")
-    def test_fully_qualified_name_parsed(self, MockRAG):
-        """Should parse fully qualified names (db.schema.table) and use last part."""
+    def test_fully_qualified_name_existing(self, MockRAG):
+        """A qualified reference that exists is not reported as missing."""
         from datus.storage.semantic_model.auto_create import find_missing_semantic_models
 
-        config = MagicMock()
+        config = self._make_config()
         mock_rag = MagicMock()
         MockRAG.return_value = mock_rag
-
-        mock_rag.storage.search_objects.return_value = [{"name": "orders"}]
+        mock_rag.table_exists.return_value = True
 
         result = find_missing_semantic_models({"mydb.public.orders"}, config)
         assert result == []
 
     @patch("datus.storage.semantic_model.store.SemanticModelRAG")
     def test_search_error_treated_as_missing(self, MockRAG):
-        """Search errors should treat the table as missing."""
+        """Existence-check errors should treat the table as missing."""
         from datus.storage.semantic_model.auto_create import find_missing_semantic_models
 
-        config = MagicMock()
+        config = self._make_config()
         mock_rag = MagicMock()
         MockRAG.return_value = mock_rag
-
-        mock_rag.storage.search_objects.side_effect = Exception("Storage error")
+        mock_rag.table_exists.side_effect = Exception("Storage error")
 
         result = find_missing_semantic_models({"error_table"}, config)
         assert "error_table" in result
+
+    @patch("datus.storage.semantic_model.store.SemanticModelRAG")
+    def test_db_config_error_does_not_abort_check(self, MockRAG):
+        """A broken db config falls back to no hierarchy defaults instead of raising."""
+        from datus.storage.semantic_model.auto_create import find_missing_semantic_models
+
+        config = MagicMock()
+        config.db_type = "snowflake"
+        config.current_db_config.side_effect = RuntimeError("no datasource configured")
+        mock_rag = MagicMock()
+        MockRAG.return_value = mock_rag
+        mock_rag.table_exists.return_value = False
+
+        result = find_missing_semantic_models({"db2.sales.orders"}, config)
+
+        assert result == ["db2.sales.orders"]
+        # Qualified parts from the reference itself still reach table_exists.
+        kwargs = mock_rag.table_exists.call_args.kwargs
+        assert kwargs["table_name"] == "orders"
+        assert kwargs["database_name"] == "db2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -993,3 +993,146 @@ class TestSemanticModelRAGArtifactRows:
         rag.delete_artifact_rows.assert_called_once_with("semantic/orders.yml")
         rag.upsert_batch.assert_called_once_with(rows)
         rag.create_indices.assert_called_once_with()
+
+
+# ============================================================
+# Issue #1084: same-named tables in different databases/schemas
+# ============================================================
+
+
+def _fq_table_object(
+    database_name: str,
+    schema_name: str = "public",
+    table_name: str = "orders",
+    description: str = "A table",
+    catalog_name: str = "default",
+) -> dict:
+    """Table object whose id is the fully qualified name, matching the fixed write path."""
+    obj = _make_table_object(
+        table_name,
+        description=description,
+        catalog_name=catalog_name,
+        database_name=database_name,
+        schema_name=schema_name,
+    )
+    # Same construction as the production write path: empty parts skipped.
+    fq = ".".join(p for p in [catalog_name, database_name, schema_name, table_name] if p)
+    obj["id"] = f"table:{fq}"
+    obj["fq_name"] = fq
+    return obj
+
+
+class TestSameNameDifferentDatabaseCollision:
+    """The headline defect: distinct-scope same-named tables must not overwrite each other."""
+
+    def test_fq_ids_keep_both_tables(self, sem_rag):
+        """With fully qualified ids, db1.orders and db2.orders both survive independently."""
+        sem_rag.upsert_batch([_fq_table_object("db1", description="DB1 orders")])
+        sem_rag.upsert_batch([_fq_table_object("db2", description="DB2 orders")])
+
+        assert sem_rag.get_size() == 2
+        r1 = sem_rag.get_semantic_model(database_name="db1", schema_name="public", table_name="orders")
+        r2 = sem_rag.get_semantic_model(database_name="db2", schema_name="public", table_name="orders")
+        assert r1["description"] == "DB1 orders"
+        assert r2["description"] == "DB2 orders"
+
+    def test_simple_ids_collide_and_lose_data(self, sem_rag):
+        """Regression guard: identical simple ids share a storage_key, so the second write wins.
+
+        This is exactly the pre-fix data loss and justifies the qualified-id scheme.
+        """
+        first = _make_table_object("orders", description="DB1", database_name="db1")  # id == table:orders
+        second = _make_table_object("orders", description="DB2", database_name="db2")  # id == table:orders
+        sem_rag.upsert_batch([first])
+        sem_rag.upsert_batch([second])
+
+        assert sem_rag.get_size() == 1
+
+
+class TestSemanticModelRAGTableExists:
+    """Tests for the hierarchy-aware table_exists existence check."""
+
+    def test_absent_table_returns_false(self, sem_rag):
+        assert sem_rag.table_exists("orders") is False
+
+    def test_empty_table_name_returns_false(self, sem_rag):
+        assert sem_rag.table_exists("") is False
+
+    def test_matches_same_hierarchy(self, sem_rag):
+        sem_rag.store_batch([_make_table_object("orders", database_name="db1", schema_name="public")])
+        assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
+
+    def test_same_name_other_database_not_matched(self, sem_rag):
+        sem_rag.store_batch([_make_table_object("orders", database_name="db1", schema_name="public")])
+        assert sem_rag.table_exists("orders", database_name="db2", schema_name="public") is False
+
+    def test_legacy_empty_hierarchy_row_is_compatible(self, sem_rag):
+        """A legacy row stored without hierarchy still satisfies a populated query."""
+        sem_rag.store_batch([_make_table_object("orders", catalog_name="", database_name="", schema_name="")])
+        assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
+
+    def test_case_insensitive_table_name_match(self, sem_rag):
+        """A row stored uppercase (e.g. Snowflake) matches a lowercase reference."""
+        sem_rag.store_batch([_make_table_object("ORDERS", database_name="db1", schema_name="public")])
+        assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
+
+
+class TestSemanticModelRAGDeleteShadowedTableRows:
+    """Tests for delete_shadowed_table_rows cleanup (legacy / cross-yaml duplicates)."""
+
+    def test_removes_legacy_simple_id_row_in_same_scope(self, sem_rag):
+        """A legacy simple-id row is dropped in favour of the freshly written qualified row."""
+        legacy = _make_table_object("orders", description="legacy", database_name="db1", schema_name="public")
+        sem_rag.store_batch([legacy])  # id == table:orders
+        fresh = _fq_table_object("db1", description="fresh")  # id == table:default.db1.public.orders
+        sem_rag.upsert_batch([fresh])
+        assert sem_rag.get_size() == 2  # both coexist until cleanup
+
+        sem_rag.delete_shadowed_table_rows([fresh])
+
+        remaining = sem_rag.search_all()
+        assert len(remaining) == 1
+        assert remaining[0]["description"] == "fresh"
+
+    def test_does_not_touch_other_database_scope(self, sem_rag):
+        """Cleanup for db1 must leave the same-named table in db2 untouched."""
+        db1 = _fq_table_object("db1", description="db1 orders")
+        db2 = _fq_table_object("db2", description="db2 orders")
+        sem_rag.store_batch([db1, db2])
+
+        sem_rag.delete_shadowed_table_rows([db1])
+
+        assert sem_rag.get_size() == 2
+        db2_model = sem_rag.get_semantic_model(database_name="db2", schema_name="public", table_name="orders")
+        assert db2_model["description"] == "db2 orders"
+        db1_model = sem_rag.get_semantic_model(database_name="db1", schema_name="public", table_name="orders")
+        assert db1_model["description"] == "db1 orders"
+
+    def test_empty_hierarchy_scope_is_not_a_wildcard(self, sem_rag):
+        """A fresh row whose hierarchy did not resolve must not delete same-named tables in other databases."""
+        db1 = _fq_table_object("db1", description="db1 orders")
+        db2 = _fq_table_object("db2", description="db2 orders")
+        sem_rag.store_batch([db1, db2])
+        bare = _fq_table_object("", schema_name="", catalog_name="", description="bare")  # id == table:orders
+        sem_rag.upsert_batch([bare])
+        assert sem_rag.get_size() == 3
+
+        sem_rag.delete_shadowed_table_rows([bare])
+
+        # Empty scope matches only empty-hierarchy rows; db1/db2 must survive.
+        assert sem_rag.get_size() == 3
+        db1_model = sem_rag.get_semantic_model(database_name="db1", schema_name="public", table_name="orders")
+        assert db1_model["description"] == "db1 orders"
+        db2_model = sem_rag.get_semantic_model(database_name="db2", schema_name="public", table_name="orders")
+        assert db2_model["description"] == "db2 orders"
+
+    def test_cleanup_failure_does_not_raise(self):
+        """A storage error during cleanup is swallowed (post-commit, best-effort)."""
+        rag = SemanticModelRAG.__new__(SemanticModelRAG)
+        rag.storage = Mock()
+        rag.storage._delete_rows.side_effect = RuntimeError("delete conflict")
+        rag._sub_agent_conditions = Mock(return_value=[])
+
+        rag.delete_shadowed_table_rows([_fq_table_object("db1")])  # must not raise
+
+        rag.storage._delete_rows.assert_called_once()

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -1076,6 +1076,11 @@ class TestSemanticModelRAGTableExists:
         sem_rag.store_batch([_make_table_object("ORDERS", database_name="db1", schema_name="public")])
         assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
 
+    def test_mixed_case_stored_name_matches(self, sem_rag):
+        """A MixedCase stored name that escapes the case-variant filter still matches."""
+        sem_rag.store_batch([_make_table_object("Orders", database_name="db1", schema_name="public")])
+        assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
+
 
 class TestSemanticModelRAGDeleteShadowedTableRows:
     """Tests for delete_shadowed_table_rows cleanup (legacy / cross-yaml duplicates)."""

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -1081,6 +1081,24 @@ class TestSemanticModelRAGTableExists:
         sem_rag.store_batch([_make_table_object("Orders", database_name="db1", schema_name="public")])
         assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
 
+    def test_other_scope_fast_hit_does_not_mask_mixed_case_row(self, sem_rag):
+        """A same-named fast-path hit in another database must not skip the fallback scan."""
+        sem_rag.store_batch(
+            [
+                _make_table_object("orders", database_name="db1", schema_name="public"),
+                _make_table_object("Orders", database_name="db2", schema_name="sales"),
+            ]
+        )
+        # Fast path returns db1's row (hierarchy mismatch); db2's MixedCase row
+        # must still be found via the fallback.
+        assert sem_rag.table_exists("orders", database_name="db2", schema_name="sales") is True
+        assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
+
+    def test_quoted_stored_name_matches(self, sem_rag):
+        """A stored name kept with identifier quotes still matches the bare reference."""
+        sem_rag.store_batch([_make_table_object('"Orders"', database_name="db1", schema_name="public")])
+        assert sem_rag.table_exists("orders", database_name="db1", schema_name="public") is True
+
 
 class TestSemanticModelRAGDeleteShadowedTableRows:
     """Tests for delete_shadowed_table_rows cleanup (legacy / cross-yaml duplicates)."""

--- a/tests/unit_tests/storage/test_catalog_manager.py
+++ b/tests/unit_tests/storage/test_catalog_manager.py
@@ -132,7 +132,7 @@ class TestUpdateColumnsFieldMapping:
         new = [{"name": "col1", "type": "integer", "description": "A column"}]
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
@@ -158,7 +158,7 @@ class TestUpdateColumnsFieldMapping:
         item = [{"name": "col1", "type": "string", "description": "desc", "expr": "x"}]
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=item,
             new_columns=item,
@@ -181,7 +181,7 @@ class TestUpdateColumnsFieldMapping:
         new = [{"name": "col1", "type": "string", "description": "new desc"}]
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
@@ -207,7 +207,7 @@ class TestUpdateColumnsFieldMapping:
         new = [{"name": "col1", "description": "new desc", "type": "string"}]
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
@@ -247,7 +247,7 @@ class TestUpdateColumnsMethod:
         updater.semantic_model_storage = FakeStorage()
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=[{"name": "col1", "description": "old"}],
             new_columns=[{"description": "new"}],  # no 'name'
@@ -271,7 +271,7 @@ class TestUpdateColumnsMethod:
         new = [{"name": "col1", "description": "new desc"}]
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
@@ -296,7 +296,7 @@ class TestUpdateColumnsMethod:
         identical = [{"name": "col1", "description": "same", "type": "string"}]
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=identical,
             new_columns=identical,
@@ -320,7 +320,7 @@ class TestUpdateColumnsMethod:
         new = [{"name": "col1", "description": "new"}]
 
         updater._update_columns(
-            table_name="orders",
+            table_fq_name="orders",
             semantic_model_name="",
             old_columns=old,
             new_columns=new,
@@ -341,7 +341,7 @@ class TestUpdateColumnsMethod:
         updater.semantic_model_storage = FakeStorage()
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=None,
             new_columns=None,
@@ -365,7 +365,7 @@ class TestUpdateColumnsMethod:
         new_json = json.dumps([{"name": "col1", "description": "new"}])
 
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=old_json,
             new_columns=new_json,
@@ -392,7 +392,7 @@ class TestUpdateColumnsMethod:
 
         # Should not raise
         updater._update_columns(
-            table_name="t",
+            table_fq_name="t",
             semantic_model_name="t_model",
             old_columns=old,
             new_columns=new,
@@ -634,3 +634,121 @@ class TestUpdateSemanticModel:
         updater.update_semantic_model(old_values, update_values)
 
         assert any(entry_id == "column:orders.order_id" and v.get("entity") == "transaction" for entry_id, v in calls)
+
+
+# ---------------------------------------------------------------------------
+# Fully qualified id construction (issue #1084)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFqName:
+    """Tests for CatalogUpdater._build_fq_name id reconstruction."""
+
+    def test_empty_hierarchy_returns_bare_table(self):
+        """No catalog/database/schema → fq name equals the table name."""
+        assert CatalogUpdater._build_fq_name({"table_name": "orders"}) == "orders"
+
+    def test_full_hierarchy_joined(self):
+        """All hierarchy parts are joined with dots, in catalog→table order."""
+        old_values = {
+            "catalog_name": "cat",
+            "database_name": "db1",
+            "schema_name": "public",
+            "table_name": "orders",
+        }
+        assert CatalogUpdater._build_fq_name(old_values) == "cat.db1.public.orders"
+
+    def test_partial_hierarchy_skips_empty_parts(self):
+        """Empty middle parts are skipped so no double dots appear."""
+        old_values = {
+            "catalog_name": "",
+            "database_name": "db1",
+            "schema_name": "",
+            "table_name": "orders",
+        }
+        assert CatalogUpdater._build_fq_name(old_values) == "db1.orders"
+
+
+class TestUpdateSemanticModelQualifiedId:
+    """update_semantic_model must target rows by their fully qualified id (issue #1084)."""
+
+    def _make_updater(self):
+        obj = object.__new__(CatalogUpdater)
+        obj.datasource_id = "test_datasource"
+        return obj
+
+    def test_table_entry_id_uses_full_hierarchy(self):
+        """Same-named tables in different databases resolve to distinct entry ids."""
+        updater = self._make_updater()
+        calls = []
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {
+            "database_name": "db2",
+            "schema_name": "sales",
+            "table_name": "orders",
+            "semantic_model_name": "orders_model",
+        }
+        updater.update_semantic_model(old_values, {"description": "new"})
+
+        assert calls[0][0] == "table:db2.sales.orders"
+
+    def test_column_entry_id_uses_full_hierarchy(self):
+        """Column updates also target the qualified id so cross-db columns stay distinct."""
+        updater = self._make_updater()
+        calls = []
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {
+            "database_name": "db2",
+            "schema_name": "sales",
+            "table_name": "orders",
+            "semantic_model_name": "orders_model",
+            "dimensions": [{"name": "region", "description": "old"}],
+        }
+        update_values = {"dimensions": [{"name": "region", "description": "new"}]}
+        updater.update_semantic_model(old_values, update_values)
+
+        assert any(entry_id == "column:db2.sales.orders.region" for entry_id, _ in calls)
+
+    def test_falls_back_to_legacy_simple_id(self):
+        """Rows written before the fq-id scheme (id='table:orders') must still be updatable."""
+        updater = self._make_updater()
+        calls = []
+
+        class FakeStorage:
+            def update_entry(self, entry_id, values):
+                calls.append((entry_id, values))
+                if entry_id in ("table:db1.public.orders", "column:db1.public.orders.region"):
+                    raise DatusException(ErrorCode.STORAGE_ENTRY_NOT_FOUND, message_args={"entry_id": entry_id})
+
+        updater.semantic_model_storage = FakeStorage()
+
+        old_values = {
+            "database_name": "db1",
+            "schema_name": "public",
+            "table_name": "orders",
+            "semantic_model_name": "orders_model",
+            "dimensions": [{"name": "region", "description": "old"}],
+        }
+        update_values = {
+            "description": "new desc",
+            "dimensions": [{"name": "region", "description": "new"}],
+        }
+        updater.update_semantic_model(old_values, update_values)
+
+        # fq id tried first, then the legacy simple id succeeds.
+        assert ("table:db1.public.orders", {"description": "new desc"}) in calls
+        assert ("table:orders", {"description": "new desc"}) in calls
+        assert ("column:db1.public.orders.region", {"description": "new"}) in calls
+        assert ("column:orders.region", {"description": "new"}) in calls

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -1297,6 +1297,62 @@ class TestOsiSync:
         assert '"to_columns": ["customer_id", "store_id"]' in profiles[0]["relationships_json"]
         assert result["table_semantic_profiles"] == 1
 
+    def test_sync_osi_semantic_to_db_distinguishes_same_named_tables_across_databases(self, generation_tools, tmp_path):
+        """Issue #1084 (OSI path): qualified source tables in different databases keep distinct ids."""
+        generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
+            catalog="", database="shop", schema=""
+        )
+        generation_tools.agent_config.db_type = "snowflake"
+        generation_tools.table_semantic_profile_rag = Mock()
+        semantic_file = tmp_path / "orders.yml"
+        semantic_file.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: shop\n"
+            "    datasets:\n"
+            "      - name: orders_db1\n"
+            "        source: db1.public.orders\n"
+            "      - name: orders_db2\n"
+            "        source: db2.sales.orders\n"
+        )
+        doc = SimpleNamespace(
+            datasets=[
+                SimpleNamespace(
+                    name="orders_db1",
+                    description="",
+                    source=SimpleNamespace(table="db1.public.orders"),
+                    primary_key="order_id",
+                    time_dimension=None,
+                    dimensions=[],
+                ),
+                SimpleNamespace(
+                    name="orders_db2",
+                    description="",
+                    source=SimpleNamespace(table="db2.sales.orders"),
+                    primary_key="order_id",
+                    time_dimension=None,
+                    dimensions=[],
+                ),
+            ],
+            relationships=[],
+            metrics=[],
+        )
+
+        with patch.object(generation_tools, "_load_osi_document", return_value=doc):
+            result = generation_tools.sync_osi_semantic_to_db(str(semantic_file))
+
+        assert result["success"] is True
+        objects = generation_tools.semantic_rag.upsert_batch.call_args.args[0]
+        table_ids = [obj["id"] for obj in objects if obj["kind"] == "table"]
+        assert table_ids == ["table:db1.public.orders", "table:db2.sales.orders"]
+        column_ids = [obj["id"] for obj in objects if obj["kind"] == "column"]
+        assert column_ids == ["column:db1.public.orders.order_id", "column:db2.sales.orders.order_id"]
+        tables_by_id = {obj["id"]: obj for obj in objects if obj["kind"] == "table"}
+        assert tables_by_id["table:db1.public.orders"]["database_name"] == "db1"
+        assert tables_by_id["table:db1.public.orders"]["schema_name"] == "public"
+        assert tables_by_id["table:db2.sales.orders"]["database_name"] == "db2"
+        assert tables_by_id["table:db2.sales.orders"]["schema_name"] == "sales"
+
     def test_sync_osi_semantic_to_db_fails_when_table_profile_sync_fails(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
             catalog="default_catalog", database="shop", schema=""


### PR DESCRIPTION
## Why

Fixes #1084.

Semantic model storage ids used only the simple table name (`table:orders`), and the dedup layer's `storage_key` is `{datasource_id}:{id}` — the upsert unique column. A datasource can span multiple databases/schemas, so `db1.public.orders` and `db2.sales.orders` produced the same `storage_key` and the second write silently overwrote the first, losing data. The read side had the same root cause: `find_missing_semantic_models` matched by simple name, so a same-named table in another database was misjudged as "already exists" and its model was never generated.

## Solution

- **Qualified ids**: table/column ids now embed the fully qualified name (`table:catalog.database.schema.table`, empty parts skipped) in both write paths (`generation_hooks`, `generation_tools`), eliminating the `storage_key` collision. In the degenerate single-scope case the fq name equals the simple name, so single-database users see no change.
- **Hierarchy-aware existence check**: `find_missing_semantic_models` resolves each reference to its hierarchy scope and checks via the new `SemanticModelRAG.table_exists` — table name matches case-insensitively; an empty hierarchy value on either side stays compatible (parity with pre-fix behavior for legacy rows and unqualified references), while populated-but-different values are told apart.
- **Best-effort self-healing cleanup**: after a successful upsert, `delete_shadowed_table_rows` removes legacy simple-id rows and cross-`yaml_path` duplicates in the *exact same* scope. Empty hierarchy fields never act as wildcards (a sync whose hierarchy did not resolve can never delete same-named tables in other databases), and the cleanup never raises, so it cannot turn an already-durable sync into a reported failure. No migration script is needed — legacy rows are cleaned on next regeneration.
- **Update-side compatibility**: `CatalogUpdater` rebuilds the qualified entry id from the record's hierarchy fields and falls back to the legacy simple id, so catalog-screen edits on pre-fix rows are not silently dropped.

Reads are unaffected: `get_semantic_model` and search paths filter by business fields (`table_name` + hierarchy), not by `id`, so existing data remains readable throughout.

## Test Cases

Unit tests added/updated (all deterministic, no external calls):

- `tests/unit_tests/storage/semantic_model/test_store.py`
  - headline repro: same-named tables in `db1`/`db2` both survive with qualified ids; regression guard proving simple ids collide and lose data
  - `table_exists`: same/different hierarchy, legacy empty-hierarchy compatibility, case-insensitive match (uppercase-stored vs lowercase reference)
  - `delete_shadowed_table_rows`: cleans legacy simple-id row in the same scope, leaves other databases untouched, empty scope is not a wildcard, storage errors are swallowed (best-effort)
- `tests/unit_tests/storage/semantic_model/test_auto_create.py`: `find_missing_semantic_models` distinguishes qualified references by hierarchy; broken db config degrades gracefully instead of aborting the check
- `tests/unit_tests/storage/test_catalog_manager.py`: qualified entry ids for table/column updates; fallback to legacy simple id

No integration/nightly test added: the change is storage-layer keying/cleanup logic, fully exercisable in unit tier with the real LanceDB-backed store fixture already used by `test_store.py`; the end-to-end generation flow around it is unchanged and covered by the existing acceptance harness (204 passed).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of fully qualified table names so same-named tables in different catalogs, databases, or schemas are updated and tracked correctly.
  * Added safer fallback behavior for older stored entries, reducing missed updates during semantic sync.
  * Cleaned up stale shadow rows after successful writes to keep semantic data more consistent.

* **Tests**
  * Expanded unit coverage for hierarchy-aware table matching, fallback updates, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic sync, catalog updates, and auto-creation checks to use fully-qualified table identifiers, avoiding collisions across different catalogs/databases/schemas.
  * Added fallback behavior when fully-qualified storage entries aren’t found, so updates still apply to legacy rows.
  * Added best-effort post-sync cleanup to remove stale “shadowed” semantic rows within the correct hierarchy scope.

* **Tests**
  * Expanded regression/unit coverage for qualified ID behavior, hierarchy-aware table existence detection, fallback updates, and cleanup correctness (including legacy collisions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->