### PR TITLE
[BugFix] Humanize LLM stream errors before sending to client

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -45,6 +45,7 @@ from datus.api.models.cli_models import (
     UserInteractionInput,
 )
 from datus.api.services.background_drain import track_background_task
+from datus.api.utils.stream_errors import humanize_stream_error
 from datus.tools.sql_policy import SqlPolicyConfig
 from datus.utils.feedback_prompt import build_reaction_feedback_prompt
 from datus.utils.loggings import get_logger
@@ -646,12 +647,13 @@ async def _stream_with_post_hook(
         # outer bare ``raise`` below still re-propagates the original
         # ``exc`` instead of being masked.
         try:
+            error_type, error_message = humanize_stream_error(exc)
             error_event = SSEEvent(
                 id=last_event_id + 1,
                 event="error",
                 data=SSEErrorData(
-                    error=str(exc) or type(exc).__name__,
-                    error_type=type(exc).__name__,
+                    error=error_message,
+                    error_type=error_type,
                     session_id=request.session_id,
                 ),
                 timestamp=now_utc_iso(),

--- a/datus/api/utils/stream_errors.py
+++ b/datus/api/utils/stream_errors.py
@@ -1,0 +1,166 @@
+"""Turn a stream-breaking exception into a client-safe error payload.
+
+The chat SSE stream can die on almost anything the agentic loop touches, but
+the most common culprit is an upstream LLM failure surfaced by litellm. Its
+exceptions stringify to blobs like::
+
+    litellm.InternalServerError: AnthropicException - b'{"type":"error",
+    "error":{"type":"api_error","code":"1234","message":"[1234][\\xe7\\xbd...]"}}'
+
+Sending ``str(exc)`` straight to the browser (as ``SSEErrorData.error``) means
+the user sees that raw, byte-escaped blob. ``humanize_stream_error`` maps the
+exception to a stable machine ``error_type`` (so the frontend can localize) and
+a clean human ``message`` — preferring the provider's own wording when it can
+be decoded, falling back to a generic sentence otherwise. The original
+exception is still logged server-side with a full traceback for debugging.
+"""
+
+import ast
+import json
+import re
+from typing import Optional
+
+# Stable ``error_type`` codes the frontend can map to localized copy. Keyed by
+# litellm/openai exception class names (matched anywhere in the MRO, so
+# provider-specific subclasses still resolve). Each maps to (code, fallback).
+_CLASS_TO_ERROR: dict[str, tuple[str, str]] = {
+    "RateLimitError": (
+        "UPSTREAM_RATE_LIMITED",
+        "The AI service is receiving too many requests right now. Please retry in a moment.",
+    ),
+    "Timeout": ("UPSTREAM_TIMEOUT", "The AI service timed out. Please try again."),
+    "APITimeoutError": ("UPSTREAM_TIMEOUT", "The AI service timed out. Please try again."),
+    "APIConnectionError": (
+        "UPSTREAM_UNAVAILABLE",
+        "Could not reach the AI service. Please check your connection and retry.",
+    ),
+    "ServiceUnavailableError": (
+        "UPSTREAM_UNAVAILABLE",
+        "The AI service is temporarily unavailable. Please try again shortly.",
+    ),
+    "InternalServerError": (
+        "UPSTREAM_ERROR",
+        "The AI service ran into a temporary error. Please try again.",
+    ),
+    "APIError": ("UPSTREAM_ERROR", "The AI service ran into a temporary error. Please try again."),
+    "ContextWindowExceededError": (
+        "CONTEXT_LENGTH_EXCEEDED",
+        "This conversation is too long for the model. Please start a new session or compact it.",
+    ),
+    "AuthenticationError": (
+        "UPSTREAM_AUTH_ERROR",
+        "The AI service rejected the request credentials. Please contact your administrator.",
+    ),
+    "PermissionDeniedError": (
+        "UPSTREAM_AUTH_ERROR",
+        "The AI service rejected the request credentials. Please contact your administrator.",
+    ),
+    "ContentPolicyViolationError": (
+        "CONTENT_POLICY_VIOLATION",
+        "The request was blocked by the AI provider's content policy.",
+    ),
+    "BadRequestError": (
+        "UPSTREAM_BAD_REQUEST",
+        "The AI service rejected the request. Please try again or adjust your input.",
+    ),
+}
+
+_DEFAULT_ERROR: tuple[str, str] = (
+    "INTERNAL_ERROR",
+    "Something went wrong while generating the response. Please try again.",
+)
+
+# Long opaque tokens (request ids, trace ids) embedded in a provider message —
+# stripped so the surfaced sentence stays readable.
+_ID_TOKEN = re.compile(r"\b[0-9a-fA-F]{16,}\b")
+_CJK = re.compile(r"[一-鿿]")
+_BYTES_LITERAL = re.compile(r"b'(?:[^'\\]|\\.)*'|b\"(?:[^\"\\]|\\.)*\"")
+_MAX_LEN = 300
+
+
+def humanize_stream_error(exc: BaseException) -> tuple[str, str]:
+    """Return ``(error_type, message)`` safe to send to the client.
+
+    ``error_type`` is a stable code (see ``_CLASS_TO_ERROR``); ``message`` is a
+    human-readable sentence, preferring the upstream provider's own wording.
+    Never returns a raw byte-escaped blob.
+    """
+    error_type, fallback = _classify(exc)
+    provider_message = _extract_provider_message(exc)
+    message = provider_message or fallback
+    return error_type, _clean(message)
+
+
+def _classify(exc: BaseException) -> tuple[str, str]:
+    for klass in type(exc).__mro__:
+        mapped = _CLASS_TO_ERROR.get(klass.__name__)
+        if mapped:
+            return mapped
+    return _DEFAULT_ERROR
+
+
+def _extract_provider_message(exc: BaseException) -> Optional[str]:
+    """Best-effort: pull the provider's human message out of ``str(exc)``.
+
+    Handles the ``... - b'{...}'`` litellm shape (Python bytes-repr wrapping
+    provider JSON) and bare embedded JSON. Returns None if nothing readable
+    can be recovered.
+    """
+    raw = str(exc)
+    if not raw:
+        return None
+
+    payload = _decode_embedded_payload(raw)
+    if payload is None:
+        return None
+
+    message = payload.get("error", {}).get("message") if isinstance(payload.get("error"), dict) else None
+    message = message or payload.get("message")
+    if not isinstance(message, str) or not message.strip():
+        return None
+
+    return _pick_readable_segment(message)
+
+
+def _decode_embedded_payload(raw: str) -> Optional[dict]:
+    # ``b'...\xe7...'`` — a Python bytes literal; eval it back to bytes and
+    # decode as UTF-8 so escaped multibyte chars become real text.
+    literal = _BYTES_LITERAL.search(raw)
+    if literal:
+        try:
+            decoded = ast.literal_eval(literal.group(0))
+            text = decoded.decode("utf-8", "replace") if isinstance(decoded, bytes) else str(decoded)
+            return json.loads(text)
+        except (ValueError, SyntaxError, json.JSONDecodeError):
+            pass
+
+    # Bare embedded JSON object anywhere in the string.
+    start, end = raw.find("{"), raw.rfind("}")
+    if 0 <= start < end:
+        try:
+            return json.loads(raw[start : end + 1])
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+def _pick_readable_segment(message: str) -> str:
+    """Some providers pack the message as ``[code][human text][request_id]``.
+
+    Pick the most human-readable bracketed segment (CJK first, then longest);
+    fall back to the whole message when there are no brackets.
+    """
+    segments = re.findall(r"\[([^\[\]]+)\]", message)
+    if segments:
+        segments.sort(key=lambda s: (1 if _CJK.search(s) else 0, len(s)), reverse=True)
+        return segments[0]
+    return message
+
+
+def _clean(message: str) -> str:
+    message = _ID_TOKEN.sub("", message)
+    message = re.sub(r"\s+", " ", message).strip(" ,;:")
+    if len(message) > _MAX_LEN:
+        message = message[:_MAX_LEN].rstrip() + "…"
+    return message or _DEFAULT_ERROR[1]

--- a/tests/unit_tests/api/utils/test_stream_errors.py
+++ b/tests/unit_tests/api/utils/test_stream_errors.py
@@ -6,17 +6,16 @@
 
 from datus.api.utils.stream_errors import humanize_stream_error
 
-
 # The exact litellm/AnthropicException shape reported in the field: a Python
 # bytes-repr wrapping provider JSON whose message is byte-escaped Chinese
 # ("网络错误 <id>，请稍后重试。").
 LITELLM_BLOB = (
     "litellm.InternalServerError: AnthropicException - "
-    "b'{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"code\":\"1234\","
-    "\"message\":\"[1234][\\xe7\\xbd\\x91\\xe7\\xbb\\x9c\\xe9\\x94\\x99\\xe8\\xaf\\xaf "
+    'b\'{"type":"error","error":{"type":"api_error","code":"1234",'
+    '"message":"[1234][\\xe7\\xbd\\x91\\xe7\\xbb\\x9c\\xe9\\x94\\x99\\xe8\\xaf\\xaf '
     "20260708110941e974e209bda24c95 \\xef\\xbc\\x8c\\xe8\\xaf\\xb7\\xe7\\xa8\\x8d"
     "\\xe5\\x90\\x8e\\xe9\\x87\\x8d\\xe8\\xaf\\x95\\xe3\\x80\\x82]"
-    "[20260708110941e974e209bda24c95]\"},\"request_id\":\"20260708110941e974e209bda24c95\"}'"
+    '[20260708110941e974e209bda24c95]"},"request_id":"20260708110941e974e209bda24c95"}\''
 )
 
 

--- a/tests/unit_tests/api/utils/test_stream_errors.py
+++ b/tests/unit_tests/api/utils/test_stream_errors.py
@@ -1,0 +1,63 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for datus.api.utils.stream_errors — client-safe error humanization."""
+
+from datus.api.utils.stream_errors import humanize_stream_error
+
+
+# The exact litellm/AnthropicException shape reported in the field: a Python
+# bytes-repr wrapping provider JSON whose message is byte-escaped Chinese
+# ("网络错误 <id>，请稍后重试。").
+LITELLM_BLOB = (
+    "litellm.InternalServerError: AnthropicException - "
+    "b'{\"type\":\"error\",\"error\":{\"type\":\"api_error\",\"code\":\"1234\","
+    "\"message\":\"[1234][\\xe7\\xbd\\x91\\xe7\\xbb\\x9c\\xe9\\x94\\x99\\xe8\\xaf\\xaf "
+    "20260708110941e974e209bda24c95 \\xef\\xbc\\x8c\\xe8\\xaf\\xb7\\xe7\\xa8\\x8d"
+    "\\xe5\\x90\\x8e\\xe9\\x87\\x8d\\xe8\\xaf\\x95\\xe3\\x80\\x82]"
+    "[20260708110941e974e209bda24c95]\"},\"request_id\":\"20260708110941e974e209bda24c95\"}'"
+)
+
+
+# Class names must match litellm's exactly — humanize_stream_error keys off the
+# class name walked over the MRO, mirroring the real exception hierarchy.
+class InternalServerError(Exception):
+    """Stand-in mirroring litellm.InternalServerError's class name."""
+
+
+class RateLimitError(Exception):
+    pass
+
+
+def test_decodes_litellm_blob_to_readable_chinese():
+    error_type, message = humanize_stream_error(InternalServerError(LITELLM_BLOB))
+
+    assert error_type == "UPSTREAM_ERROR"
+    # The byte-escaped Chinese is decoded; the embedded request id is stripped.
+    assert message == "网络错误 ，请稍后重试。"
+    # No raw blob leaks through.
+    assert "\\x" not in message
+    assert "litellm" not in message
+    assert "b'" not in message
+
+
+def test_maps_known_class_to_stable_code():
+    error_type, message = humanize_stream_error(RateLimitError("429 rate limited"))
+
+    assert error_type == "UPSTREAM_RATE_LIMITED"
+    assert message  # non-empty fallback sentence
+    assert "\\x" not in message
+
+
+def test_unknown_exception_falls_back_generically():
+    error_type, message = humanize_stream_error(ValueError("boom"))
+
+    assert error_type == "INTERNAL_ERROR"
+    assert message == "Something went wrong while generating the response. Please try again."
+
+
+def test_never_returns_empty_message():
+    _, message = humanize_stream_error(InternalServerError(""))
+
+    assert message


### PR DESCRIPTION
## Why

When the chat SSE stream dies, the fallback catch in `_stream_with_post_hook` sent `str(exc)` straight to the browser as `SSEErrorData.error`. For the most common failure — an upstream LLM error surfaced by litellm — that string is a raw, byte-escaped blob, so users saw garbled text instead of a reason:

```
litellm.InternalServerError: AnthropicException - b'{"type":"error","error":
{"type":"api_error","code":"1234","message":"[1234][\xe7\xbd\x91\xe7\xbb\x9c...]"}}'
```

The actual human message (`网络错误，请稍后重试。`) was buried under three layers: the litellm exception prefix, a Python `b'...'` bytes-repr, and byte-escaped UTF-8 inside the provider JSON.

## Solution

Fix at the source (backend) rather than reverse-engineering the format in each client.

New `datus/api/utils/stream_errors.py` — `humanize_stream_error(exc) -> (error_type, message)`:

- **`error_type`**: a stable machine code (`UPSTREAM_RATE_LIMITED`, `UPSTREAM_TIMEOUT`, `UPSTREAM_ERROR`, `CONTEXT_LENGTH_EXCEEDED`, `UPSTREAM_AUTH_ERROR`, …) matched over the exception MRO. This lets the frontend localize, following the existing `error_type`-driven `BUSINESS_STREAM_ERROR_TYPES` contract.
- **`message`**: prefers the provider's own wording — decodes the `b'...'` Python bytes-repr → UTF-8 → JSON, extracts the human segment from a `[code][text][request_id]` message, and strips opaque id tokens. Falls back to a generic sentence when nothing readable can be recovered. **Never emits a raw blob.**

`chat_routes.py` now fills `SSEErrorData.error` / `error_type` via this helper. The original exception is still logged server-side with a full traceback (`exc_info=True`), so debugging is unaffected.

For the reported blob, the client now receives a clean `网络错误 ，请稍后重试。`.

## Test Cases

Added `tests/unit_tests/api/utils/test_stream_errors.py` (4 cases):
- decodes the exact field-reported litellm blob to readable Chinese, id stripped, no `\x`/`b'`/`litellm` leaking
- maps a known exception class to its stable code
- unknown exception falls back to `INTERNAL_ERROR` + generic message
- never returns an empty message

All pass; existing `tests/unit_tests/api/routes/test_chat_routes.py` (42) still pass.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming chat errors now return cleaner, user-friendly error messages instead of raw technical exception text.
  * Improved error responses for upstream failures, including rate limits and other provider issues, with more consistent error codes.
  * Removed leaked request IDs and escaped blob content from visible error messages.
* **Tests**
  * Added coverage for readable error formatting, fallback messages, and empty-message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->