### PR TITLE
[BugFix] Strip hex ids adjacent to CJK in stream error cleanup

### DIFF
--- a/datus/api/utils/stream_errors.py
+++ b/datus/api/utils/stream_errors.py
@@ -71,8 +71,10 @@ _DEFAULT_ERROR: tuple[str, str] = (
 )
 
 # Long opaque tokens (request ids, trace ids) embedded in a provider message —
-# stripped so the surfaced sentence stays readable.
-_ID_TOKEN = re.compile(r"\b[0-9a-fA-F]{16,}\b")
+# stripped so the surfaced sentence stays readable. Hex-specific lookarounds
+# (not ``\b``) so ids are stripped even when they touch CJK text: CJK chars are
+# ``\w`` under Unicode, so ``\b`` finds no boundary between "错误" and a hex id.
+_ID_TOKEN = re.compile(r"(?<![0-9a-fA-F])[0-9a-fA-F]{16,}(?![0-9a-fA-F])")
 _CJK = re.compile(r"[一-鿿]")
 _BYTES_LITERAL = re.compile(r"b'(?:[^'\\]|\\.)*'|b\"(?:[^\"\\]|\\.)*\"")
 _MAX_LEN = 300

--- a/tests/unit_tests/api/utils/test_stream_errors.py
+++ b/tests/unit_tests/api/utils/test_stream_errors.py
@@ -41,6 +41,22 @@ def test_decodes_litellm_blob_to_readable_chinese():
     assert "b'" not in message
 
 
+def test_strips_hex_id_touching_cjk_without_spaces():
+    # Some gateways emit "错误<id>，" with no separators. CJK chars are \w under
+    # Unicode, so a \b-anchored pattern would leave the id in place.
+    blob = (
+        "litellm.InternalServerError: AnthropicException - "
+        'b\'{"error":{"type":"api_error",'
+        '"message":"\\xe9\\x94\\x99\\xe8\\xaf\\xaf'  # "错误" directly followed by the id
+        "20260708110941e974e209bda24c95"
+        "\\xef\\xbc\\x8c\\xe8\\xaf\\xb7\\xe7\\xa8\\x8d\\xe5\\x90\\x8e\\xe9\\x87\\x8d\\xe8\\xaf\\x95\\xe3\\x80\\x82\"}}'"
+    )
+    _, message = humanize_stream_error(InternalServerError(blob))
+
+    assert message == "错误，请稍后重试。"
+    assert "20260708110941e974e209bda24c95" not in message
+
+
 def test_maps_known_class_to_stable_code():
     error_type, message = humanize_stream_error(RateLimitError("429 rate limited"))
 


### PR DESCRIPTION
## Why

Follow-up to #1116 (merged). `_ID_TOKEN` in `stream_errors.py` used `\b` word boundaries:

```python
_ID_TOKEN = re.compile(r"\b[0-9a-fA-F]{16,}\b")
```

Under Python's Unicode regex, CJK characters are `\w` word characters, so `\b` finds **no** boundary between a Chinese char and an adjacent hex id. When a gateway emits `错误<id>，` with no separators, the opaque id is left in the user-facing message. (The originally handled cases had spaces around the id, so this went unnoticed.)

Verified:

| input | old `\b` | new lookaround |
|---|---|---|
| `网络错误 <id> ，请稍后重试。` | id stripped ✓ | id stripped ✓ |
| `错误<id>，请稍后重试。` | **id kept ✗** | id stripped ✓ |
| `trace <id> failed` | id stripped ✓ | id stripped ✓ |

## Solution

Switch to hex-specific lookarounds so the match depends only on the hex run, not the surrounding character class:

```python
_ID_TOKEN = re.compile(r"(?<![0-9a-fA-F])[0-9a-fA-F]{16,}(?![0-9a-fA-F])")
```

Change is localized to the `_ID_TOKEN` definition. Behavior is unchanged for space/ascii-delimited ids.

## Test Cases

Added `test_strips_hex_id_touching_cjk_without_spaces` to `tests/unit_tests/api/utils/test_stream_errors.py`, covering a gateway blob where the hex id directly abuts `错误` with no separator. Full file (5 cases) passes; format + lint clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-message cleanup so long request/token IDs are removed more reliably, including cases where they appear next to non-Latin text without spaces.
  * This helps produce cleaner, more user-friendly provider error messages in multilingual contexts.

* **Tests**
  * Added coverage for error messages containing an ID directly adjacent to CJK text to ensure the cleaned output no longer exposes the embedded identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->