### PR TITLE
[Refactor] Derive semantic authoring skills/templates from the active adapter

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -90,6 +90,14 @@ class AgenticNode(Node):
     # empty string in yml to opt out of the defaults.
     DEFAULT_SKILLS: Optional[str] = None
 
+    # Skills whose full content is injected into the system prompt by the host
+    # at render time instead of being advertised in ``<available_skills>`` for
+    # LLM-initiated ``load_skill`` calls. Use for specifications the node needs
+    # on every run (e.g. authoring format specs); optional, conditionally
+    # useful workflows belong in ``DEFAULT_SKILLS``. Subclasses may override
+    # ``_get_required_skills()`` to derive the list from configuration.
+    REQUIRED_SKILLS: Optional[str] = None
+
     # When True, this node's ``SkillFuncTool`` loads skills in *authoring* mode:
     # ``allowed_agents`` scoping on ``load_skill`` is bypassed so the agent can
     # read any skill by name (used by ``gen_skill`` for edit/optimize flows).
@@ -1146,6 +1154,11 @@ class AgenticNode(Node):
 
         # Mount the lazily injected skill/bash/memory tools.
         self._ensure_lazy_tools_mounted()
+
+        # Inject required-skill specifications deterministically. These are
+        # host-mandated (e.g. authoring format specs) and must not depend on
+        # the LLM choosing to call ``load_skill``.
+        base_prompt = self._inject_required_skills(base_prompt)
 
         # Inject available skills XML into system prompt when skill_func_tool is active.
         if self.skill_func_tool:
@@ -2229,6 +2242,68 @@ class AgenticNode(Node):
             )
         except Exception as e:
             logger.error(f"Failed to setup skill func tools: {e}")
+
+    def _get_required_skills(self) -> List[str]:
+        """Return skill names whose content is host-injected into the prompt.
+
+        Defaults to parsing the class-level ``REQUIRED_SKILLS`` string.
+        Subclasses may override to derive the list from configuration (e.g.
+        the active semantic authoring format).
+        """
+        patterns = type(self).REQUIRED_SKILLS
+        if not patterns:
+            return []
+        return [pattern.strip() for pattern in patterns.split(",") if pattern.strip()]
+
+    def _inject_required_skills(self, base_prompt: str) -> str:
+        """Append required-skill content to the system prompt deterministically.
+
+        Required skills carry specifications the node needs on every run, so
+        the host injects them at prompt-build time instead of advertising them
+        in ``<available_skills>`` and hoping the LLM calls ``load_skill``.
+        Permission checks are skipped — the node itself mandates these skills —
+        but ``allowed_agents`` scoping still applies.
+
+        Raises:
+            DatusException: When a required skill cannot be loaded. A missing
+                authoring spec would silently degrade every generation, so this
+                fails fast instead.
+        """
+        required_skills = self._get_required_skills()
+        if not required_skills:
+            return base_prompt
+
+        if not self.skill_manager:
+            from datus.tools.skill_tools.skill_manager import SkillManager
+
+            self.skill_manager = SkillManager(permission_manager=self.permission_manager)
+
+        from xml.sax.saxutils import quoteattr as xml_quoteattr
+
+        sections = []
+        for skill_name in required_skills:
+            success, message, content = self.skill_manager.load_skill(
+                skill_name,
+                self.get_node_name(),
+                check_permission=False,
+                node_class=self.get_node_class_name(),
+            )
+            if not success or not content:
+                from datus.utils.exceptions import DatusException, ErrorCode
+
+                raise DatusException(
+                    code=ErrorCode.COMMON_CONFIG_ERROR,
+                    message_args={
+                        "config_error": (
+                            f"Required skill '{skill_name}' could not be loaded for node "
+                            f"'{self.get_node_name()}': {message}"
+                        )
+                    },
+                )
+            sections.append(f"<required_skill name={xml_quoteattr(skill_name)}>\n{content}\n</required_skill>")
+            logger.info(f"Injected required skill '{skill_name}' into system prompt for '{self.get_node_name()}'")
+
+        return base_prompt + "\n\n" + "\n\n".join(sections)
 
     @staticmethod
     def _merge_skill_patterns(existing_skills: Any, injected_skills: List[str]) -> str:

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -48,9 +48,6 @@ class GenMetricsAgenticNode(AgenticNode):
     NODE_NAME = "gen_metrics"
     result_class = SemanticNodeResult
 
-    # Define-metric workflow scoped to ``gen_metrics`` via SKILL.md allowed_agents.
-    DEFAULT_SKILLS = "gen-metrics, metricflow-semantic-authoring"
-
     def __init__(
         self,
         agent_config: AgentConfig,
@@ -208,14 +205,19 @@ class GenMetricsAgenticNode(AgenticNode):
             logger.error(f"Failed to setup generation tools: {e}")
 
     def _setup_skill_func_tools(self) -> None:
-        """Avoid injecting MetricFlow authoring skills into OSI workflows."""
-        from datus.agent.node.semantic_authoring import is_osi_authoring
+        """Default the optional skill set from the active authoring format."""
+        from datus.agent.node.semantic_authoring import default_optional_skills
 
-        node_config = getattr(self, "node_config", None) or {}
-        if is_osi_authoring(self.agent_config) and "skills" not in node_config:
-            logger.info("Skipping default MetricFlow skills for OSI metrics authoring")
-            return
+        if self.node_config.get("skills") is None:
+            self.node_config["skills"] = default_optional_skills(self.agent_config, self.NODE_NAME)
         super()._setup_skill_func_tools()
+
+    def _get_required_skills(self) -> list:
+        """Host-inject the metric authoring specification skill."""
+        from datus.agent.node.semantic_authoring import required_authoring_skills
+
+        patterns = required_authoring_skills(self.agent_config, self.NODE_NAME)
+        return [pattern.strip() for pattern in patterns.split(",") if pattern.strip()]
 
     def _setup_semantic_tools(self):
         """Setup semantic tools for metrics querying and exploration."""
@@ -325,8 +327,10 @@ class GenMetricsAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import (
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
+            resolve_authoring_format,
         )
 
+        context["authoring_format"] = resolve_authoring_format(self.agent_config)
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
 
@@ -359,28 +363,12 @@ class GenMetricsAgenticNode(AgenticNode):
         Returns:
             System prompt string loaded from the template
         """
-        from datus.agent.node.semantic_authoring import (
-            AUTHORING_FORMAT_OSI,
-            osi_prompt_version,
-            osi_template_name,
-            resolve_authoring_format,
+        # Both authoring formats share one template; the format-specific spec
+        # is injected as a required skill.
+        template_name = f"{self.NODE_NAME}_system"
+        version = (
+            prompt_version or getattr(self.input, "prompt_version", None) or self.node_config.get("prompt_version")
         )
-
-        # Select the authoring format (metricflow YAML vs OSI + Datus hints).
-        # OSI mode uses a separate template name so the default metricflow
-        # template and its latest-version scan are left untouched.
-        authoring_format = resolve_authoring_format(self.agent_config)
-        if authoring_format == AUTHORING_FORMAT_OSI:
-            template_name = osi_template_name(self.NODE_NAME)
-            requested = (
-                prompt_version or getattr(self.input, "prompt_version", None) or self.node_config.get("prompt_version")
-            )
-            version = osi_prompt_version(self.agent_config, self.NODE_NAME, requested)
-        else:
-            template_name = f"{self.NODE_NAME}_system"
-            version = (
-                prompt_version or getattr(self.input, "prompt_version", None) or self.node_config.get("prompt_version")
-            )
 
         try:
             # Prepare template variables

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -43,7 +43,6 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
     NODE_NAME = "gen_semantic_model"
     result_class = SemanticNodeResult
-    DEFAULT_SKILLS = "metricflow-semantic-authoring"
 
     def __init__(
         self,
@@ -237,14 +236,19 @@ class GenSemanticModelAgenticNode(AgenticNode):
             logger.error(f"Failed to setup generation tools: {e}")
 
     def _setup_skill_func_tools(self) -> None:
-        """Avoid injecting MetricFlow authoring skills into OSI workflows."""
-        from datus.agent.node.semantic_authoring import is_osi_authoring
+        """Default the optional skill set from the active authoring format."""
+        from datus.agent.node.semantic_authoring import default_optional_skills
 
-        node_config = getattr(self, "node_config", None) or {}
-        if is_osi_authoring(self.agent_config) and "skills" not in node_config:
-            logger.info("Skipping default MetricFlow skills for OSI semantic-model authoring")
-            return
+        if self.node_config.get("skills") is None:
+            self.node_config["skills"] = default_optional_skills(self.agent_config, self.NODE_NAME)
         super()._setup_skill_func_tools()
+
+    def _get_required_skills(self) -> list:
+        """Host-inject the authoring format specification skill."""
+        from datus.agent.node.semantic_authoring import required_authoring_skills
+
+        patterns = required_authoring_skills(self.agent_config, self.NODE_NAME)
+        return [pattern.strip() for pattern in patterns.split(",") if pattern.strip()]
 
     def _setup_hooks(self):
         """Setup hooks for interactive mode."""
@@ -305,8 +309,10 @@ class GenSemanticModelAgenticNode(AgenticNode):
         from datus.agent.node.semantic_authoring import (
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
+            resolve_authoring_format,
         )
 
+        context["authoring_format"] = resolve_authoring_format(self.agent_config)
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
 
@@ -329,25 +335,12 @@ class GenSemanticModelAgenticNode(AgenticNode):
         Returns:
             System prompt string loaded from the template
         """
-        from datus.agent.node.semantic_authoring import (
-            AUTHORING_FORMAT_OSI,
-            osi_prompt_version,
-            osi_template_name,
-            resolve_authoring_format,
-        )
-
         # ``prompt_version`` kwarg wins over the config default; preserves the
-        # template's signature parity with the other nodes.
-        # OSI mode uses a separate template name so the default metricflow
-        # template and its latest-version scan are left untouched.
-        authoring_format = resolve_authoring_format(self.agent_config)
-        if authoring_format == AUTHORING_FORMAT_OSI:
-            template_name = osi_template_name(self.NODE_NAME)
-            requested = prompt_version or self.node_config.get("prompt_version")
-            version = osi_prompt_version(self.agent_config, self.NODE_NAME, requested)
-        else:
-            template_name = f"{self.NODE_NAME}_system"
-            version = prompt_version or self.node_config.get("prompt_version")
+        # template's signature parity with the other nodes. Both authoring
+        # formats share one template; the format-specific spec is injected as a
+        # required skill.
+        template_name = f"{self.NODE_NAME}_system"
+        version = prompt_version or self.node_config.get("prompt_version")
 
         try:
             # Prepare template variables

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -16,8 +16,9 @@ The format is resolved from the global active semantic adapter so semantic model
 generation, metric generation, query, and ask flows stay on one semantic layer
 for a project. Legacy node-level semantic format fields are ignored.
 
-OSI mode uses a *separate* prompt template name (``{node}_osi_system``) so the
-default ``{node}_system`` latest-version scan is never affected.
+Both formats share one system prompt template per node; the format-specific
+authoring specification is carried by a *required skill* that the node injects
+into the prompt at render time (see ``required_authoring_skills``).
 """
 
 from __future__ import annotations
@@ -26,12 +27,38 @@ import re
 from dataclasses import fields, is_dataclass
 from typing import Any, Dict, Optional
 
-from datus.utils.loggings import get_logger
-
 AUTHORING_FORMAT_METRICFLOW = "metricflow"
 AUTHORING_FORMAT_OSI = "osi"
 
-logger = get_logger(__name__)
+# Authoring specification skills injected into the system prompt on every run,
+# keyed by node name then authoring format. These carry the full YAML format
+# spec, so they are host-injected (``REQUIRED_SKILLS`` semantics) rather than
+# advertised for LLM-initiated ``load_skill``.
+_REQUIRED_AUTHORING_SKILLS: Dict[str, Dict[str, str]] = {
+    "gen_semantic_model": {
+        AUTHORING_FORMAT_METRICFLOW: "metricflow-semantic-authoring",
+        AUTHORING_FORMAT_OSI: "osi-semantic-authoring",
+    },
+    "gen_metrics": {
+        AUTHORING_FORMAT_METRICFLOW: "gen-metrics",
+        AUTHORING_FORMAT_OSI: "osi-metrics-authoring",
+    },
+}
+
+# Optional skills advertised in ``<available_skills>`` for LLM-initiated
+# loading, keyed the same way. These cover conditional workflows (profiling on
+# explicit request, semantic-model repair during metric authoring), so the LLM
+# decides per request whether to load them.
+_OPTIONAL_AUTHORING_SKILLS: Dict[str, Dict[str, str]] = {
+    "gen_semantic_model": {
+        AUTHORING_FORMAT_METRICFLOW: "semantic-sql-history-profiler",
+        AUTHORING_FORMAT_OSI: "semantic-sql-history-profiler",
+    },
+    "gen_metrics": {
+        AUTHORING_FORMAT_METRICFLOW: "metricflow-semantic-authoring",
+        AUTHORING_FORMAT_OSI: "osi-semantic-authoring",
+    },
+}
 
 
 def _resolve_semantic_adapter(agent_config: Any = None) -> Optional[str]:
@@ -159,34 +186,22 @@ def default_osi_semantic_model_file(agent_config: Any = None) -> str:
     return f"subject/semantic_models/{datasource}/{default_osi_semantic_model_name(agent_config)}.yml"
 
 
-def osi_template_name(node_name: str) -> str:
-    """Return the OSI-mode system prompt template name for a generation node."""
-    return f"{node_name}_osi_system"
+def required_authoring_skills(agent_config: Any, node_name: str) -> str:
+    """Return the host-injected authoring spec skill(s) for a generation node.
 
-
-def osi_prompt_version(agent_config: Any, node_name: str, requested: Optional[str]) -> Optional[str]:
-    """Resolve the OSI template version, ignoring versions meant for other templates.
-
-    Callers (e.g. success-story bootstrap) often pin the latest version of the
-    *metricflow* template ``{node}_system`` and inject it as ``prompt_version``.
-    The OSI template ``{node}_osi_system`` versions independently, so an injected
-    metricflow version would not exist here. Honor ``requested`` only when it is a
-    real version of the OSI template; otherwise fall back to its latest (``None``).
+    The result is a comma-separated pattern string in the same shape as
+    ``AgenticNode.REQUIRED_SKILLS``, derived from the active authoring format.
     """
-    if not requested:
-        return None
-    try:
-        from datus.prompts.prompt_manager import get_prompt_manager
+    authoring_format = resolve_authoring_format(agent_config)
+    return _REQUIRED_AUTHORING_SKILLS.get(node_name, {}).get(authoring_format, "")
 
-        available = get_prompt_manager(agent_config=agent_config).list_template_versions(osi_template_name(node_name))
-    except Exception as exc:
-        logger.debug(
-            "Failed to list OSI prompt template versions; falling back to latest. "
-            "node_name=%r template_name=%r agent_config=%r error=%s",
-            node_name,
-            osi_template_name(node_name),
-            agent_config,
-            exc,
-        )
-        available = []
-    return requested if requested in available else None
+
+def default_optional_skills(agent_config: Any, node_name: str) -> str:
+    """Return the default ``<available_skills>`` pattern for a generation node.
+
+    These skills stay LLM-loadable because their workflows are conditional; the
+    active authoring format decides which variants are visible. Users can still
+    override with an explicit ``skills:`` entry in node configuration.
+    """
+    authoring_format = resolve_authoring_format(agent_config)
+    return _OPTIONAL_AUTHORING_SKILLS.get(node_name, {}).get(authoring_format, "")

--- a/datus/prompts/prompt_templates/_semantic_sql_history_profiler_gate.j2
+++ b/datus/prompts/prompt_templates/_semantic_sql_history_profiler_gate.j2
@@ -1,5 +1,11 @@
-## Optional Historical SQL Profiling
-- If `<available_skills>` includes `semantic-sql-history-profiler` and the request includes historical SQL or success-story SQL, call `load_skill("semantic-sql-history-profiler")` before schema sampling, per-table column-usage analysis, ad hoc `execute_sql` sampling, YAML authoring, or any `write_file` call.
-- After loading the skill, call `profile_semantic_model_evidence` before deciding identifiers, relationships, dimensions, time fields, measures, or field descriptions.
-- When historical SQL is provided inline, pass every provided SQL statement via `sql_entries_json` or `sql_queries`; do not choose only representative examples. Use `query_text` only when direct SQL text is unavailable and existing reference SQL must be searched.
-- Use profiler evidence to choose the semantic model shape and to include compact distribution notes in descriptions when useful.
+## Optional SQL History & Distribution Profiling
+- Skip this section entirely when `semantic-sql-history-profiler` is not listed in `<available_skills>`.
+- Call `load_skill("semantic-sql-history-profiler")` ONLY when the user explicitly asks for profiling, statistics, data-distribution analysis, or mining/analyzing historical SQL. Providing SQL alone is NOT a trigger.
+- When triggered:
+  - Load the skill and call `profile_semantic_model_evidence` BEFORE schema sampling, column-usage analysis, ad hoc `execute_sql` sampling, or writing any YAML, and use its evidence when deciding identifiers, relationships, dimensions, time fields, measures, and descriptions.
+  - Inline historical SQL provided → pass EVERY statement via `sql_entries_json` or `sql_queries` (do not truncate to representative examples); default `profile_mode="sql_only"`.
+  - No SQL text but the user asks to mine stored history → search reference SQL via `query_text` and/or `tables`.
+  - The user asks for statistics or data distributions → `profile_mode="lightweight"` with the target `tables`.
+  - The user explicitly allows slow, thorough exploration → `profile_mode="deep"`.
+- When NOT triggered, do not call the profiler. If historical SQL is present in the request, still use it directly as modeling context (joins, filters, groupings) without the profiler tool.
+- Keep distribution notes in descriptions compact; never dump profiler JSON.

--- a/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
@@ -1,0 +1,86 @@
+{% if authoring_format == "osi" %}You are a metric **semantics** expert. Your task is to ADD metrics to an existing strict OSI (Open Semantic Interchange) core semantic model, capturing each metric's business meaning from SQL queries or natural language. The Datus OSI compiler infers backing measures, picks the backend metric kind, and lowers to the execution engine; you never write backend YAML.{% else %}You are a MetricFlow metric definition expert. Your task is to help users define, create, and manage MetricFlow metrics — either from SQL queries or from natural language business descriptions.{% endif %}
+
+The complete metric authoring specification for this run — YAML structure, metric candidate handling rules, and examples — is provided in the `<required_skill>` section appended to this prompt. Follow it exactly.
+
+## Available Tools
+- Native tools: {{ native_tools }}
+{% if mcp_tools and mcp_tools != "None" %}- MCP servers: {{ mcp_tools }}
+{% endif %}{% if has_ask_user_tool %}- `ask_user(questions)`: Ask the user one or more clarification questions when required input is missing or ambiguous. Pass `questions` as an actual array argument, not as a JSON string. Each question can have optional predefined choices (2-10 options). Every question in a single call must be independent.
+{% endif %}
+
+{% if has_ask_user_tool %}## Confirmation Rules
+- Before generating, call `ask_user` to confirm which metric(s) to generate, their business meaning, and calculation logic. When proposing multiple candidates, use `multi_select: true` so the user can pick several.
+- Ask only for information that materially changes the output. Collect all questions into one `ask_user` call. Prefer details inferred from SQL, semantic models, or existing metric files over asking again.
+{% if has_subject_tree %}- If a predefined subject category cannot be chosen confidently from the provided context, include it in the `ask_user` call.
+{% endif %}{% else %}## Clarification Rule
+- If required input is missing or ambiguous, stop and explain what information is needed instead of guessing.
+{% endif %}
+
+{% if has_subject_tree %}## Subject Classification (REQUIRED)
+
+**IMPORTANT**: A predefined classification taxonomy has been configured. You MUST choose ONE category from the list below for every metric. Do NOT create new categories.
+
+**Available Subject Categories:**
+{% for subject in subject_tree %}
+- {{ subject }}
+{% endfor %}
+{% else %}## Subject Classification (REQUIRED)
+
+Every metric MUST include a `subject_tree` classification in the format `{domain}/{layer1}/{layer2}`. Reuse existing classifications when possible; create a new one only when none fit.
+{% if existing_subject_trees %}
+**Existing Subject Categories** (reuse when possible):
+{% for subject in existing_subject_trees %}
+- {{ subject }}
+{% endfor %}
+{% endif %}{% endif %}
+Record the classification as defined in the `<required_skill>` specification{% if authoring_format == "osi" %} (the DATUS `subject_path` extension hint){% else %} (a `locked_metadata.tags` entry `"subject_tree: {domain}/{layer1}/{layer2}"`){% endif %}.
+
+## Workspace
+- Knowledge base directory on disk: {{ knowledge_base_dir }}
+- Use this relative path prefix for semantic model and metric files: `{{ kind_subdir }}/`
+  (resolves to `{{ semantic_model_dir }}` on disk)
+- Restrict filesystem reads/writes/reuse to `{{ kind_subdir }}/...`. Never read, edit, or pass paths from a sibling datasource directory such as `subject/semantic_models/other_datasource/...`.
+{% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
+- OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — this is the OSI core schema dialect label derived from the allowed enum; it may differ from the active datasource connector type. Use this exact value in every `expression.dialects[].dialect`.
+- Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
+- Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`
+{% endif %}
+
+## Workflow
+
+1. **Discover existing assets**: Call `list_metrics()` and build an existing metric catalog. Do not recreate metrics that already exist — but note that "already exists" requires the same aggregation AND the same window/offset semantics; cumulative/window/period-over-period variants of a published base metric are NEW metrics.
+2. **Understand the request**: Confirm scope per the rules above. For provided historical SQL, call `analyze_metric_candidates_from_history` with the existing metric catalog before writing any files, and follow the candidate handling rules in the `<required_skill>` specification.
+3. **Ensure model prerequisites**: Check `check_semantic_object_exists(name, kind='table')` for involved tables{% if authoring_format == "osi" %}. Load the existing OSI model from the target semantic model file to learn dataset names, fields, time fields, and relationships; minimally update it only when something is truly absent{% else %}. If a semantic model is missing, load the `metricflow-semantic-authoring` skill from `<available_skills>` and follow it to create the model{% endif %}.
+4. **Author metrics**: Check `check_semantic_object_exists(name, kind='metric')` for each metric, then write the metric YAML per the `<required_skill>` specification.
+5. **Validate (MUST PASS)**: Call `validate_semantic`. If it fails, fix with `edit_file` and retry until it passes. Do NOT proceed until validation passes.
+6. **Dry-run**: Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric. If the source SQL groups by dimensions or a time grain, dry-run with matching `dimensions` / `time_granularity`; use `get_dimensions` for exact names. Collect each generated SQL into `metric_sqls_json`.
+7. **Publish**: After validation and dry-run pass, call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` ONCE. Do not rely on the final JSON host fallback — it is only a last-resort guard. If no metrics were generated, do NOT call `end_metric_generation`.
+
+## Output Format
+
+**CRITICAL**: Your final response MUST always be a valid JSON object, regardless of whether you called any tools.
+
+{% if authoring_format == "osi" %}```json
+{
+  "semantic_model_file": "{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}",
+  "metric_file": "{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}",
+  "status": "generated",
+  "output": "brief summary"
+}
+```
+
+- `status`: `"generated"` when at least one metric was published; `"skipped"` ONLY when nothing was authored in this batch — then `metric_file` MUST be `null`.
+- Every candidate from the discovery tool MUST end this run either published via `end_metric_generation` or listed in `output` with a concrete blocker. "Covered by an existing base metric" is never a valid blocker for a cumulative/window/period-over-period candidate.
+{% else %}```json
+{
+  "semantic_model_files": ["{{ kind_subdir }}/{table_name}.yml"],
+  "metric_file": "{{ kind_subdir }}/metrics/{table_name}_metrics.yml",
+  "status": "generated",
+  "output": "markdown summary of the metric definition"
+}
+```
+
+- `semantic_model_files`: Paths of semantic model files changed in this run (empty array when none).
+- `status`: `"generated"` (at least one new metric was created and synced) or `"skipped"` (every requested metric already existed — set `metric_file` to `null` in this case).
+{% endif %}
+**DO NOT** return markdown, plain text, or any other format. Return **ONLY** the JSON object.

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
@@ -1,0 +1,73 @@
+{% if authoring_format == "osi" %}You are a semantic modeling expert. Your task is to describe tables as strict **OSI (Open Semantic Interchange) core schema** documents plus Datus business hints. The Datus OSI compiler lowers your OSI core documents to the configured execution backend; you never write backend YAML.{% else %}You are a MetricFlow expert generating semantic model YAML files for one or more database tables.{% endif %}
+
+The complete authoring specification for this run — YAML structure, field classification rules, path conventions, and examples — is provided in the `<required_skill>` section appended to this prompt. Follow it exactly.
+
+## Available Tools
+- Native tools: {{ native_tools }}
+{% if mcp_tools and mcp_tools != "None" %}- MCP servers: {{ mcp_tools }}
+{% endif %}{% if has_ask_user_tool %}- `ask_user(questions)`: Ask the user one or more clarification questions when critical requirements are missing. Each question can have optional predefined choices (2-10 options). Every question in a single call must be independent — do NOT include follow-ups that assume a particular answer to a previous question.
+{% endif %}
+
+## Workspace
+- Knowledge base directory on disk: {{ knowledge_base_dir }}
+- Use this relative path prefix for semantic model files: `{{ kind_subdir }}/`
+  (resolves to `{{ semantic_model_dir }}` on disk)
+{% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
+- OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — this is the OSI core schema dialect label derived from the allowed enum; it may differ from the active datasource connector type. Use this exact value in every `expression.dialects[].dialect`.
+- Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
+- Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`
+{% endif %}
+
+## Workflow
+
+0. **Clarify blocking ambiguity first**
+{% if has_ask_user_tool %}   - If the request does not clearly specify the target table(s), intended scope, or another critical modeling choice that would change the generated YAML (e.g. which column is the grain or the primary time dimension), call `ask_user` before proceeding.
+   - Collect all questions into a single `ask_user` call. Prefer 2-4 concrete options when reasonable.
+   - Do NOT use `ask_user` for information you can reliably derive from DDL, relationship analysis, or existing files.
+{% else %}   - If critical requirements are missing, stop guessing and explain what information is needed.
+{% endif %}
+1. **Inspect the tables**
+   - Use `get_table_ddl` (or `get_multiple_tables_ddl` for several tables) to retrieve complete table structures.
+   - Extract column comments (COMMENT) from DDL and keep them in their ORIGINAL language (e.g. Chinese). DO NOT TRANSLATE.
+   - For multiple tables, discover join relationships with `analyze_table_relationships`.
+
+{% include "_semantic_sql_history_profiler_gate.j2" %}
+
+2. **Check for existing semantic objects**
+   - Use `check_semantic_object_exists(table_name, kind='table')` to verify whether a model already exists.
+   - If it exists, decide whether to update it with `edit_file` or skip.
+
+3. **Author the semantic model YAML**
+   - Follow the `<required_skill>` authoring specification for document structure, field classification, descriptions, and time-dimension rules.
+   - Save files with `write_file` under the path convention defined in the specification. If you forget the `{{ kind_subdir }}/` prefix the host silently normalizes it, but always include it so subsequent `read_file` / `edit_file` use the same path.
+
+4. **Validate (MANDATORY — DO NOT SKIP)**
+   - Call `validate_semantic(scope="semantic_model")`.
+   - If validation fails: analyze the error, fix the YAML with `edit_file` (actually execute the fix — do not just describe it), then call `validate_semantic` again. Repeat until it passes.
+   - **ABSOLUTE RULE**: You MUST NOT return the final JSON response until `validate_semantic` returns success.
+
+5. **Publish (ONLY AFTER VALIDATION PASSES)**
+   - Prefer calling `end_semantic_model_generation(semantic_model_files=[...])` with all generated file paths so publish errors are caught while you can still fix files.
+   - If you forget this tool, the host will use the final JSON `semantic_model_files` to validate and publish before reporting success.
+   - Validation passing is the publish gate; no additional approval step is needed.
+
+## Output Format
+
+**PREREQUISITE**: Only return the final JSON response when all YAML files have been written, `validate_semantic` has returned success, and publishing has completed (or the final JSON names the files for host-side publishing).
+
+**CRITICAL**: Your final response MUST always be a valid JSON object, regardless of whether you called any tools.
+
+```json
+{
+  "semantic_model_files": ["{{ kind_subdir }}/<file>.yml"],
+  "output": "markdown summary of generated semantic models"
+}
+```
+
+- `semantic_model_files`: Array of generated file paths using the `{{ kind_subdir }}/` prefix. Absolute paths are also accepted and left unchanged.
+- `output`: Markdown summary — tables identified, key fields per model, validation status.
+
+**ABSOLUTE RULES**:
+- **DO NOT** return this JSON if validation is still failing.
+- **DO NOT** just describe fixes — actually use `edit_file` to apply them.
+- Return **ONLY** the JSON object — no markdown or plain text around it.

--- a/datus/resources/skills/gen-metrics/SKILL.md
+++ b/datus/resources/skills/gen-metrics/SKILL.md
@@ -4,7 +4,7 @@ description: Generate MetricFlow metrics from natural language business descript
 tags:
   - metrics
   - metricflow
-version: "1.2.0"
+version: "1.3.0"
 user_invocable: false
 disable_model_invocation: false
 allowed_agents:
@@ -88,6 +88,10 @@ Call `analyze_metric_candidates_from_history` with all parsed SQL queries and `e
 12. **Ignore passthrough references** — entries in `identity_metric_references` show existing metrics selected without new business formula; do not generate new metrics for them.
 13. **Do not promote support measures** — a SELECT projection that only supports another final KPI, such as a denominator, row count, or intermediate aggregation, may be added as a semantic-model measure. Do not also wrap it as a top-level business metric unless the user question or candidate plan identifies it as a final KPI.
 14. **Respect `support_measure_candidates`** — these are dependency or comparison measures, not direct metrics. You may add them to a semantic model only if a generated metric needs them, but do not publish a `metric:` block for them.
+15. **Review `llm_review_candidates` critically** — these are possible metric evidence, not confirmed metrics. For each item, decide whether the row-level or ambiguous expression should be lifted into a reusable MetricFlow metric. Generate it only when the SQL, table/column semantics, and user question support that lift; otherwise record it as query-only/detail evidence and do not create a metric.
+16. **Do not assume lifted equivalence** — for candidates with `equivalence: "lifted"` or `requires_validation: true`, do not assume exact equivalence to the historical SQL. Prefer a semantically correct aggregate metric such as `SUM(numerator) / SUM(denominator)` only when that lift is business-valid; otherwise skip the metric.
+17. **One metric per business meaning** — use the candidate's `name` exactly as the published metric name. When a candidate lists `equivalent_names`, those are acceptable aliases for the same metric — publish ONE metric (prefer the candidate `name`), never one per alias.
+18. **Names/questions are naming evidence only** — natural-language fields in the candidate plan (`question`, `name`, `summary`, or `source_context`) never override the SQL expression structure or turn a detail query into a metric by themselves.
 
 **Step 1-batch-c: Business metric principle**
 
@@ -248,6 +252,123 @@ Phase 1 confirms the generation scope; validation plus dry-run are the acceptanc
 7. **Derived metrics are second-stage**: Generate non-derived metrics first, including fixed `period_over_period` direct candidates, validate them, refresh the metric catalog with `list_metrics`, then generate `derived_metric_candidates` only when every referenced metric exists in the refreshed catalog or was generated earlier in the same batch.
 
 8. **Support measures are not always metrics**: Add support measures needed for ratios, expressions, filters, and validation, but do not publish each support measure as a separate metric unless it is itself a requested/final business KPI.
+
+## MetricFlow Metric Structure Reference
+
+**measure_proxy** (simple aggregation):
+```yaml
+metric:
+  name: {metric_name}
+  description: "{description}"
+  type: measure_proxy
+  type_params:
+    measure: {measure_name}
+  locked_metadata:
+    tags:
+      - "{category}"
+      - "subject_tree: {domain}/{layer1}/{layer2}"
+```
+
+For a filtered metric, define a dedicated conditional measure in the semantic model and keep the metric's `type_params.measure` as a string:
+```yaml
+data_source:
+  name: orders
+  measures:
+    - name: completed_order_count
+      description: "Completed order count"
+      agg: SUM
+      expr: "CASE WHEN status = 'completed' THEN 1 ELSE 0 END"
+---
+metric:
+  name: completed_order_count
+  description: "Completed order count"
+  type: measure_proxy
+  type_params:
+    measure: completed_order_count
+```
+
+**ratio** (ratio of two measures):
+```yaml
+metric:
+  name: {metric_name}
+  description: "{description}"
+  type: ratio
+  type_params:
+    numerator: {measure_or_metric_name}
+    denominator: {measure_or_metric_name}
+  locked_metadata:
+    tags:
+      - "subject_tree: {domain}/{layer1}/{layer2}"
+```
+
+**expr** (expression combining measures):
+```yaml
+metric:
+  name: {metric_name}
+  description: "{description}"
+  type: expr
+  type_params:
+    measures:
+      - measure_a
+      - measure_b
+    expr: "{expression}"  # e.g. "(measure_a - measure_b) / measure_a"
+  locked_metadata:
+    tags:
+      - "subject_tree: {domain}/{layer1}/{layer2}"
+```
+
+**derived** (expression combining existing metrics):
+```yaml
+metric:
+  name: {metric_name}
+  description: "{description}"
+  type: derived
+  type_params:
+    metrics:
+      - name: metric_a
+        # Optional: period-over-period comparison
+        alias: metric_a_prev
+        offset_window: 1 week    # compare to 1 week ago (WoW)
+      - name: metric_b
+        offset_to_grain: month   # compare to start of current month (MTD)
+    expr: "{expression}"  # e.g. "metric_a / metric_a_prev"
+  locked_metadata:
+    tags:
+      - "subject_tree: {domain}/{layer1}/{layer2}"
+```
+
+Period-over-period example — a MoM SQL whose final output is `metric_a_mom_delta` should publish a fixed MoM delta metric, not a query-time compare instruction and not a previous-value helper unless that helper is itself the final requested output:
+```yaml
+metric:
+  name: metric_a_mom_delta
+  description: "{metric_a month-over-month delta description}"
+  type: derived
+  type_params:
+    metrics:
+      - name: metric_a
+      - name: metric_a
+        alias: metric_a_prev
+        offset_window: 1 month
+    expr: "metric_a - metric_a_prev"
+```
+
+**cumulative** (running total over time):
+```yaml
+metric:
+  name: {metric_name}
+  description: "{description}"
+  type: cumulative
+  type_params:
+    measure: {measure_name}
+    # Use ONE of:
+    window: {time_window}        # rolling window, e.g. "7 days", "1 month"
+    grain_to_date: month|year    # MTD/YTD - resets at grain boundary
+  locked_metadata:
+    tags:
+      - "subject_tree: {domain}/{layer1}/{layer2}"
+```
+
+Ordinary period-over-period SQL (`LAG`, previous period, DoD/WoW/MoM/QoQ/YoY, delta, or rate) is fixed long-term metric evidence when it is a final business output: monthly YoY is distinct from weekly YoY, MoM rate is distinct from MoM delta, and previous-period value is distinct from a rate. Publish a previous-period metric only when it is itself the requested final output.
 
 ## Important Rules
 

--- a/datus/resources/skills/metricflow-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/metricflow-semantic-authoring/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: metricflow-semantic-authoring
-description: Author MetricFlow semantic model YAML from database tables with validation and Knowledge Base publishing
+description: MetricFlow semantic model authoring specification — YAML structure, field classification, validation, and Knowledge Base publishing
 tags:
   - semantic-model
   - metricflow
-version: "1.0.0"
+version: "2.0.0"
 user_invocable: false
 disable_model_invocation: false
 allowed_agents:
@@ -14,60 +14,210 @@ allowed_agents:
 
 # MetricFlow Semantic Authoring
 
-Create production-ready MetricFlow semantic model YAML for one or more database tables, validate it, and publish it to the Knowledge Base.
+Author production-ready MetricFlow semantic model YAML for one or more database tables, validate it, and publish it to the Knowledge Base.
 
-## Workflow
+## Column analysis
 
-1. **Understand target tables**
-   - Identify the table or tables from the user request.
-   - Use `describe_table` and relationship tools as needed.
-   - Use `ask_user` only when a critical modeling choice cannot be inferred.
-   - If the request includes historical SQL or success-story SQL and the `semantic-sql-history-profiler`
-     skill is available, load that skill and call `profile_semantic_model_evidence` before modeling
-     columns or writing YAML.
-   - Pass every provided historical SQL statement to the profiler via `sql_entries_json` or `sql_queries`;
-     do not truncate to a few representative examples.
+- Use `analyze_column_usage_patterns(table_name)` to discover how columns are used in historical SQL — filter operators, functions, and actual filter examples. This is strongly recommended for every table unless profiler evidence already covers it.
+- When profiler evidence from `profile_semantic_model_evidence` is available, use it as the primary source for join hints, commonly filtered/grouped dimensions, aggregate candidates, and concise usage hints; use `analyze_column_usage_patterns` only as a fallback or to fill a narrow gap.
 
-2. **Model columns**
-   - For historical-SQL requests with profiler evidence, use the profiler output as the primary source
-     for join hints, commonly filtered/grouped dimensions, aggregate candidates, and concise usage hints.
-     Use `analyze_column_usage_patterns` only as a fallback or to fill a narrow gap.
-   - Choose one primary time dimension when a reliable time column exists.
-   - Define `type: TIME` only for a physical DATE/TIME/TIMESTAMP column, or for a SQL expression / `sql_query` alias that is guaranteed to return a DATE/TIME/TIMESTAMP value.
-   - Do not mark numeric surrogate keys such as `*_date_sk`, `*_date_key`, `*_dt_key`, or integer YYYYMMDD keys as `type: TIME`; model them as identifiers or categorical dimensions unless you explicitly convert them to a real date.
-   - If a fact table uses a calendar/date dimension to derive its business date, prefer a `sql_query` data source that joins the date dimension, selects the real date column with a clear alias, and uses that alias as the primary time dimension and measure `agg_time_dimension`.
-   - Define identifiers for primary keys and join keys.
-   - Define measures only for reusable aggregations.
-   - Define dimensions for grouping/filtering fields.
-   - Do not define the same column/name under both `identifiers` and `dimensions`. Use identifiers for
-     primary/join keys and dimensions for grouping/filtering fields.
-   - Use `expr: "1"` for row-count measures with `agg: COUNT`.
-   - For measures, use `agg` for the aggregation type; do not add a `type` field to measure entries.
+## Field classification rules
 
-3. **Write YAML**
-   - Save files under the semantic model directory shown in the system prompt.
-   - Preferred path shape: `subject/semantic_models/<current_datasource>/{table_name}.yml`.
-   - Use paths relative to the filesystem sandbox root.
-   - For multiple related tables, write all relevant semantic model files before validation.
-   - Keep each YAML document to one MetricFlow object type. Semantic model generation should write `data_source:` documents; do not put a top-level `metrics:` list beside `data_source:` in the same document.
-   - If explicit metric definitions are needed, write them through the metrics generation workflow as separate `metric:` documents.
+Classify each column by actual data type and analytical usage, not by display convenience alone:
 
-4. **Validate and fix**
-   - Call `validate_semantic(scope="semantic_model")`.
-   - If validation fails, use `edit_file` to fix the YAML and call `validate_semantic` again.
-   - Repeat until `validate_semantic` succeeds.
+- Put DECIMAL/NUMERIC/INTEGER/FLOAT/DOUBLE or equivalent fields in `measures` when they represent measured quantities, scores, rates, prices, amounts, durations, counts, or percentages and historical SQL uses them in arithmetic, range predicates, numeric ordering, or numeric aggregates such as `AVG`, `SUM`, `MIN`, `MAX`, `STD`, `VARIANCE`, `CORR`, or `COVAR`.
+- Do not model an aggregatable numeric business value as a categorical dimension just because it is selected, displayed, filtered, sorted, or appears in a WHERE clause. A DECIMAL field used by `AVG(<field>)` should be a measure with an appropriate aggregate such as `AVG`.
+- Put text/enums/labels/booleans and numeric-coded category fields in `dimensions` when their values identify groups or labels and averaging or summing the raw value has no business meaning. Explain code semantics (e.g. "status: 1=Active, 2=Inactive") in the description.
+- Put primary keys, foreign keys, unique entity IDs, and opaque IDs in `identifiers`. Do not classify identifiers as measures merely because their physical storage type is integer.
+- Do not define the same column/name under both `identifiers` and `dimensions`.
+- If schema type and SQL usage appear to conflict, prefer concrete SQL usage plus column comments/profiler evidence, and ask only when the modeling choice is business-critical.
+- Define measures only for reusable aggregations. Use `expr: "1"` for row-count measures with `agg: COUNT`. For measures, use `agg` for the aggregation type; do not add a `type` field to measure entries.
 
-5. **Publish**
-   - After validation succeeds, call `end_semantic_model_generation` with all generated semantic model file paths.
-   - This publishes the validated semantic models to the Knowledge Base.
-   - If you miss this tool call, the host will use the final JSON `semantic_model_files` to validate and publish before reporting success.
-   - Validation passing is the publish gate; no additional approval step is needed.
+## Time dimension correctness
 
-## Rules
+- Define `type: TIME` only for a physical DATE/TIME/TIMESTAMP column, or for a `sql_query` alias / SQL expression that is guaranteed to return a DATE/TIME/TIMESTAMP value.
+- Do NOT mark numeric surrogate keys such as `*_date_sk`, `*_date_key`, `*_dt_key`, or integer YYYYMMDD keys as `type: TIME`. Model them as identifiers or categorical dimensions unless you explicitly convert them to a real date.
+- If a fact table derives its business date by joining a calendar/date dimension, prefer a `sql_query` data source that joins the date dimension, selects the real date column with a clear alias, and uses that alias as the primary time dimension.
+- `agg_time_dimension` on measures must point to that real date/time dimension, not a numeric surrogate key.
+- Include a primary time dimension only when a reliable DATE/TIME/TIMESTAMP column or expression exists; never force one.
 
-- Do not publish before `validate_semantic` succeeds.
-- After validation succeeds, prefer publishing directly through `end_semantic_model_generation`; final JSON `semantic_model_files` is the host fallback.
-- Do not manually write Knowledge Base summary files.
-- Keep YAML focused on semantic model definitions; avoid markdown or explanatory prose in YAML files.
-- Keep MetricFlow document boundaries valid: one top-level object type per YAML document.
-- Use existing semantic models when present; edit them only when needed for the requested metrics or relationships.
+## Descriptions
+
+Populate `description` fields for ALL measures, dimensions, and identifiers by COMBINING all available information:
+
+- Start with DDL comments and **preserve their original language — DO NOT TRANSLATE** (Chinese comments stay Chinese).
+- Append usage patterns and filter examples from `analyze_column_usage_patterns`.
+- Append compact observed distribution evidence from `profile_semantic_model_evidence` when available: null rate, numeric ranges and percentiles, date spans/freshness/duration, distinct counts, representative stable values, referential coverage, common filter templates, and enum/code mappings.
+- Describe what a column means first, then add concise observed evidence. Avoid long SQL snippets or procedural query instructions.
+- ALWAYS wrap `description` values in double quotes (`"`). Escape special characters: `"` → `\"`, `\` → `\\`.
+
+Example:
+
+```yaml
+- name: status
+  type: CATEGORICAL
+  expr: status
+  description: "Order status; commonly filtered with =/IN; representative values include paid/refund"
+```
+
+## Multi-table workflow
+
+When the request covers multiple tables:
+
+1. Batch retrieve DDL with `get_multiple_tables_ddl`.
+2. Discover join relationships with `analyze_table_relationships`. The tool uses a three-tier strategy: DDL foreign keys (high confidence), historical SQL JOIN patterns (medium), column name inference (low).
+3. Generate one YAML file per table. Use the `entity` field to reference other tables in **singular form** (`customer`, not `customers`); `type: PRIMARY` for the table's primary key, `type: FOREIGN` for columns that join to other tables. Linked identifiers share the same `name` (one PRIMARY, one FOREIGN).
+4. Write ALL files before validation, then validate them together.
+
+## File paths
+
+- Save files under `subject/semantic_models/<current_datasource>/{table_name}.yml`, relative to the filesystem sandbox root (use the exact prefix shown in the system prompt Workspace section).
+- If a semantic model already exists, update it with `edit_file` instead of rewriting.
+
+## Validate and publish
+
+1. Call `validate_semantic(scope="semantic_model")`. If validation fails, fix the YAML with `edit_file` and validate again; repeat until it passes. Common errors:
+   - PostgreSQL column case sensitivity: wrap uppercase column names in double quotes (e.g., `expr: '"SP_POP_TOTL"'`)
+   - Column not found: check column names match the DDL exactly
+   - Duplicate semantic element name: remove the column from either `identifiers` or `dimensions`
+   - Invalid YAML syntax: check indentation and quoting
+2. Only after validation succeeds, publish via `end_semantic_model_generation` with all generated file paths. Do not publish before validation passes; do not manually write Knowledge Base summary files.
+
+## Document structure rules
+
+- A semantic model file defines `data_source:` document(s). Do NOT add a top-level `metrics:` list to the same YAML document — MetricFlow requires exactly one top-level object type per YAML document. Explicit `metric:` documents belong to the metrics workflow.
+- Do not rely on `create_metric: true` for persisted metrics; runtime metrics are not part of the Knowledge Base metric catalog.
+- All `name` fields follow `^[a-z][a-z0-9_]*[a-z0-9]$` (snake_case, no double underscores).
+- Choose exactly ONE of `sql_table` (schema-qualified) or `sql_query` (databases without schema, or custom joins).
+- Preserve original language everywhere (Chinese text remains Chinese) for optimal vector search.
+
+## MetricFlow semantic model structure specification
+
+```yaml
+data_source:
+  # === Required Fields ===
+  name: string (required)             # Data source name, pattern: ^[a-z][a-z0-9_]*[a-z0-9]$
+
+  # === Optional Metadata Fields ===
+  description: string                 # Data source description
+  display_name: string                # Display name
+  owners:                             # List of owners
+    - email@domain.com
+  tier: string|integer                # Data tier
+
+  # === Data Source Definition (Choose ONE) ===
+  sql_table: schema.table_name        # For databases with schema support (PostgreSQL, Snowflake, Redshift, BigQuery)
+  # OR
+  sql_query: |                        # For databases without schema (SQLite, DuckDB) or custom queries
+    SELECT * FROM table_name
+    WHERE condition = 'value'
+
+  # === Core Components ===
+  measures:                           # Measure definitions (array)
+    - name: string (required)         # Measure name
+      agg: enum (required)            # SUM|MIN|MAX|AVERAGE|COUNT_DISTINCT|COUNT|PERCENTILE|MEDIAN|SUM_BOOLEAN
+      description: string             # Description - put extracted comments here
+      expr: string|integer|boolean    # Expression, defaults to column name
+      agg_time_dimension: string      # Aggregation time dimension
+      agg_params:                     # Aggregation parameters (for PERCENTILE)
+        percentile: number
+        use_discrete_percentile: boolean
+        use_approximate_percentile: boolean
+      create_metric: boolean          # Runtime MetricFlow metric only; not persisted to the Knowledge Base metric catalog
+      create_metric_display_name: string
+      non_additive_dimension:         # Non-additive dimension (snapshot/balance measures)
+        name: string
+        window_choice: MIN|MAX
+        window_groupings: [string]
+
+  dimensions:                         # Dimension definitions (array)
+    - name: string (required)
+      type: enum (required)           # CATEGORICAL|TIME
+      description: string             # Description - put extracted comments/enums here
+      expr: string|boolean
+      is_partition: boolean
+      type_params:                    # Required for TIME type
+        is_primary: boolean           # Exactly one primary time dimension per data_source
+        time_granularity: enum (required)  # DAY|WEEK|MONTH|QUARTER|YEAR
+        time_format: string
+        validity_params:              # For SCD Type 2
+          is_start: boolean
+          is_end: boolean
+
+  identifiers:                        # Identifier definitions (array)
+    - name: string (required)
+      type: enum (required)           # PRIMARY|UNIQUE|FOREIGN|NATURAL
+      description: string
+      expr: string|boolean
+      entity: string                  # Associated entity name (singular form)
+      role: string
+      identifiers:                    # Composite identifiers
+        - name: string
+          expr: string|boolean
+          ref: string
+
+  # === Mutability Configuration ===
+  mutability:
+    type: enum (required)             # IMMUTABLE|APPEND_ONLY|FULL_MUTATION|DS_APPEND_ONLY
+    type_params:
+      min: string
+      max: string
+      update_cron: string
+      along: string
+```
+
+## PostgreSQL column name case sensitivity (CRITICAL for PostgreSQL)
+
+- PostgreSQL converts unquoted identifiers to lowercase. If a column was created with quotes (e.g., `"SP_POP_TOTL"`), it retains uppercase and MUST be quoted when queried.
+- In `expr` fields, wrap uppercase column names with double quotes: wrong `expr: SP_POP_TOTL`, correct `expr: '"SP_POP_TOTL"'`.
+- Check the DDL: if column names contain uppercase letters, they likely need quoting. This applies to measures, dimensions, and identifiers `expr` fields.
+
+## Example
+
+```yaml
+data_source:
+  name: my_transactions
+  description: Transaction data with customer and order details
+  owners:
+    - data-team@company.com
+
+  sql_table: analytics.transactions
+
+  measures:
+    - name: total_amount
+      agg: SUM
+      expr: transaction_amount
+    - name: transaction_count
+      agg: SUM
+      expr: "1"
+    - name: unique_customers
+      agg: COUNT_DISTINCT
+      expr: customer_id
+
+  dimensions:
+    - name: transaction_date
+      type: TIME
+      type_params:
+        is_primary: true
+        time_granularity: DAY
+    - name: payment_method
+      type: CATEGORICAL
+    - name: is_refund
+      type: CATEGORICAL
+      expr: "CASE WHEN amount < 0 THEN 'Yes' ELSE 'No' END"
+      description: "Refund status (1:Refunded, 0:Normal)" # Keep original enums in description
+
+  identifiers:
+    - name: transaction
+      type: PRIMARY
+      expr: transaction_id
+    - name: customer
+      type: FOREIGN
+      expr: customer_id
+    - name: order
+      type: FOREIGN
+      expr: order_id
+
+  mutability:
+    type: APPEND_ONLY
+```

--- a/datus/resources/skills/osi-metrics-authoring/SKILL.md
+++ b/datus/resources/skills/osi-metrics-authoring/SKILL.md
@@ -1,22 +1,28 @@
-You are a metric **semantics** expert. Your task is to ADD metrics to an existing strict OSI (Open Semantic Interchange) core semantic model, capturing each metric's business meaning from SQL queries or natural language.
+---
+name: osi-metrics-authoring
+description: OSI core schema metric authoring specification — metric expression shape, Datus extension hints, window/period-over-period semantics, and skip gates
+tags:
+  - metrics
+  - osi
+version: "1.0.0"
+user_invocable: false
+disable_model_invocation: false
+allowed_agents:
+  - gen_metrics
+---
 
-CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow YAML, `measure_proxy`, `type_params`, `measures:`, `ratio`, `cumulative`, or any execution-engine syntax. The Datus OSI compiler infers backing measures, picks the backend metric kind, and lowers to the execution engine.
-Do NOT write legacy MetricFlow `metric:` blocks.
+# OSI Metrics Authoring
 
-CRITICAL MODEL RULE - **build the model once, then only add metrics**:
+ADD metrics to an existing strict OSI (Open Semantic Interchange) core semantic model, capturing each metric's business meaning from SQL queries or natural language.
+
+CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow YAML, `measure_proxy`, `type_params`, `measures:`, `ratio`, `cumulative`, or any execution-engine syntax. The Datus OSI compiler infers backing measures, picks the backend metric kind, and lowers to the execution engine. Do NOT write legacy MetricFlow `metric:` blocks.
+
+CRITICAL MODEL RULE — **build the model once, then only add metrics**:
 - The datasets and relationships are owned by the semantic-model step and are ALREADY built.
 - The semantic model file is the durable OSI domain document. Load it, preserve existing datasets and relationships, and append metrics under `semantic_model[0].metrics`.
 - A given logical dataset has one canonical definition shared by all metrics. Reuse that dataset by name in each metric's DATUS `dataset` hint.
-- This is the OSI authoring path. Do NOT load or follow MetricFlow `gen-metrics` / `metricflow-semantic-authoring` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
 
-{% set target_model_name = default_osi_semantic_model_name | default('<model_name>', true) %}
-{% set target_model_file = default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) %}
-{% import "_osi_dialect_map.j2" as osi_dialect_map %}
-{% set datasource_type = current_datasource | default('', true) | lower %}
-{% set osi_expression_dialect = osi_dialect_map.expression_dialect(datasource_type) %}
-
-{% if native_tools %}- Native tools: {{ native_tools }}{% endif %}
-{% if mcp_tools %}- MCP servers: {{ mcp_tools }}{% endif %}
+The OSI expression dialect and target semantic model file for the current run are shown in the system prompt Workspace section — use those exact values (`<osi_dialect>` below stands for that dialect).
 
 ## What you produce
 
@@ -25,7 +31,7 @@ Metric definitions inside a valid OSI core document:
 ```yaml
 version: 0.2.0.dev0
 semantic_model:
-  - name: {{ target_model_name }}
+  - name: <target_model_name>
     datasets:
       - name: <existing_dataset_name>
         source: <existing_source>
@@ -39,7 +45,7 @@ semantic_model:
           instructions: "<how AI should use this metric, including grain, conditions, time field, and join caveats>"
         expression:
           dialects:
-            - dialect: {{ osi_expression_dialect }}
+            - dialect: <osi_dialect>
               expression: "COUNT(DISTINCT id)" # aggregate business expression; no OVER/LAG/RANK
         custom_extensions:
           - vendor_name: DATUS
@@ -51,11 +57,11 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
 ## Authoring rules
 
 1. **Reference, don't rebuild.** Every metric's DATUS `dataset` hint must reference an existing dataset of the semantic model. If a needed dataset, field, time field, or relationship is missing, do not invent a conflicting one; note it and minimally update the semantic model only if truly absent.
-2. **Aggregates**: write the natural business expression in OSI core `expression.dialects[0].expression`, e.g. `COUNT(DISTINCT order_id)`, `SUM(amount)`, `AVG(score)`. The OSI expression dialect for this run is `{{ osi_expression_dialect }}`. This is the OSI core schema dialect label, derived from the allowed enum, and may differ from the active datasource connector type. Use this exact value in every `expression.dialects[].dialect`.
+2. **Aggregates**: write the natural business expression in OSI core `expression.dialects[0].expression`, e.g. `COUNT(DISTINCT order_id)`, `SUM(amount)`, `AVG(score)`.
 3. **Conditional aggregates**: keep the CASE inside the expression, e.g. `COUNT(DISTINCT CASE WHEN <condition> THEN id END)`. Preserve literal values exactly.
 4. **Conditional semantics**: encode metric-specific business conditions inside the OSI core metric expression, e.g. `COUNT(DISTINCT CASE WHEN status = 'paid' THEN id END)`. Do NOT create a separate dataset for a metric-only condition. Fixed logical dataset scope belongs in the dataset `source` query plus `description`/`ai_context`. Do NOT bury query-time date ranges into the metric; time ranges are query parameters.
 5. **Ratios**: if the expression is unambiguous, write the division expression. If numerator/denominator cannot be parsed unambiguously, use DATUS hints `{"metric_kind":"ratio","numerator":"...","denominator":"..."}`.
-6. **Time-window metrics - do NOT simplify away.**
+6. **Time-window metrics — do NOT simplify away.**
    - A window/cumulative/offset decoration over an existing metric defines a NEW standalone metric, NOT a reference to its base. Aggregate windows such as `SUM(x) OVER (... UNBOUNDED PRECEDING ...)`, `AVG(x) OVER (ROWS BETWEEN n PRECEDING ...)`, `MIN(x)`/`MAX(x) OVER (...)`, and `LAG(x) OVER (...)` each yield a new metric (e.g. `running_x`, `moving_n_x`, `previous_period_x`) even when the base metric `x` is already published. Never skip such a candidate as "already covered by the base metric".
    - Rolling / cumulative: the OSI core metric expression is the base aggregate itself plus DATUS hints `window` or `grain_to_date`.
    - If `analyze_metric_candidates_from_history` returns a cumulative/window candidate with `window`, `grain_to_date`, `window_aggregation`, `base_metric_name`, or `time_grain`, preserve those structured fields when authoring the metric.
@@ -65,7 +71,7 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
        - name: revenue_l7d
          expression:
            dialects:
-             - dialect: {{ osi_expression_dialect }}
+             - dialect: <osi_dialect>
                expression: "SUM(amount)"
          custom_extensions:
            - vendor_name: DATUS
@@ -79,7 +85,7 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
          description: "Monthly year-over-year revenue growth rate"
          expression:
            dialects:
-             - dialect: {{ osi_expression_dialect }}
+             - dialect: <osi_dialect>
                expression: "SUM(amount)"
          custom_extensions:
            - vendor_name: DATUS
@@ -95,7 +101,7 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
        to_columns: [<primary_or_unique_key_column>]
    ```
    Never put `relationships` inside a dataset. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
-8. **Not metrics**: detail/list queries (`SELECT DISTINCT ...`) and window/ranking (`ROW_NUMBER()`, `RANK() OVER`, TopN per group) are NOT metrics. In `gen_metrics`, SKIP them. Do NOT create a dataset/view here and never force them into a metric. If the discovery tool returns `metric_generation_skips` or rank-like `derived_datasource_recommendations`, treat that SQL as skipped.
+8. **Not metrics**: detail/list queries (`SELECT DISTINCT ...`) and window/ranking (`ROW_NUMBER()`, `RANK() OVER`, TopN per group) are NOT metrics. SKIP them. Do NOT create a dataset/view here and never force them into a metric. If the discovery tool returns `metric_generation_skips` or rank-like `derived_datasource_recommendations`, treat that SQL as skipped.
 9. Use clear English `snake_case` metric names; metric names must be globally unique. Every metric MUST include `description` and `ai_context`. Put the business definition in `description`; put LLM-facing usage guidance in `ai_context.instructions`, including grain, metric-specific conditions, time field, and join caveats.
 
 ## Hard skip gate
@@ -104,46 +110,17 @@ Before writing any YAML, classify the source SQL:
 
 - If the SQL has no aggregate output (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, ratio, rolling/cumulative aggregate, etc.) and primarily returns row-level fields (`SELECT DISTINCT ac_name, ac_code, ...`, list/detail/ranking), then it is not a metric request.
 - For non-metric SQL, do not invent convenience metrics such as `*_count`, `*_avg_duration`, `*_max_sr`, or `*_min_sr` just because the table contains those columns.
-- For non-metric SQL, do not call `write_file`, `validate_semantic`, `query_metrics`, or `end_metric_generation`.
+- For non-metric SQL, do not call `write_file`, `validate_semantic`, `query_metrics`, or `end_metric_generation`. Report `status: "skipped"` with `metric_file: null` in the final JSON.
 - For TopN per group / ranking-window SQL (`ROW_NUMBER`, `RANK`, `DENSE_RANK`) do the same: skip metric generation. A derived dataset/view may be a future modeling task, but it is outside this `gen_metrics` run.
-- Finish with:
-  ```json
-  {
-    "semantic_model_file": "{{ target_model_file }}",
-    "metric_file": null,
-    "status": "skipped",
-    "output": "No metric generated: the SQL is a detail/list query, not an aggregate metric definition."
-  }
-  ```
 
-## Workflow
+## Workflow notes
 
-{% if current_datasource %}
-- Active datasource: `{{ current_datasource }}`
-- OSI expression dialect: `{{ osi_expression_dialect }}`
-{% endif %}
-{% if kind_subdir %}
-- Write OSI core YAML under `{{ kind_subdir }}/...` only.
-{% endif %}
-- Target semantic model name: `{{ target_model_name }}`
-- Target semantic model file: `{{ target_model_file }}`
-- FIRST, load the existing model from `{{ target_model_file }}` to learn dataset names, fields, time fields, and relationships. Call `list_metrics()` to see metrics that already exist.
+- FIRST, load the existing model from the target semantic model file to learn dataset names, fields, time fields, and relationships. Call `list_metrics()` to see metrics that already exist.
 - For provided SQL/history, call `analyze_metric_candidates_from_history` before writing files. Use `direct_metric_candidates` for base metrics and fixed `period_over_period` final metrics; use `derived_metric_candidates` only for second-stage OSI metrics that explicitly depend on published input metrics. If it returns `metric_generation_skips`, skip those SQLs instead of writing metric YAML.
 - Candidate-plan compliance: every candidate in `direct_metric_candidates` and `derived_metric_candidates` (including cumulative, rolling-window, and period_over_period candidates) MUST end this run either published via `end_metric_generation` or listed in your final `output` with a concrete blocker such as a validation failure. "Covered by an existing base metric" is never a valid blocker for a cumulative/window/period_over_period candidate.
-- Status contract: report `status: "skipped"` ONLY when nothing was authored in this batch, and then `metric_file` MUST be null. If any metric was published, report `status: "generated"` and list still-unpublished candidates with their blockers in `output`.
 - Reference, reconcile, reuse: point each metric's DATUS `dataset` hint at an existing dataset. If a metric with the same meaning already exists (`check_semantic_object_exists(name, kind='metric')`), reuse/skip it. "Same meaning" requires the same aggregation AND the same window/offset semantics: a base aggregate never covers its cumulative/rolling/period-over-period variants, so `running_x`/`moving_x`/`previous_x` candidates must still be published when only `x` exists. For a derived metric, make sure its input metrics already exist.
 - From SQL: find the table (FROM), aggregate expression(s), and business conditions vs query-time ranges. Anchor the metric on the aggregated table's existing dataset; encode metric-specific conditions with CASE inside the metric expression.
 - When a required business input is missing or ambiguous, ASK for the business semantics; do not guess.
-- Produce valid OSI core YAML; the Datus OSI compiler validates it against OSI core schema, compiles Datus extensions into IR, and lowers it to the configured backend.
 - Call `validate_semantic(scope="all")` after writing OSI metrics and fix errors until it passes.
 - Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric name before publishing.
-- After validation and dry-run pass, call `end_metric_generation(metric_file="{{ target_model_file }}", semantic_model_file="{{ target_model_file }}", metric_sqls_json="<dry-run SQL JSON>")`.
-- Finish with JSON:
-  ```json
-  {
-    "semantic_model_file": "{{ target_model_file }}",
-    "metric_file": "{{ target_model_file }}",
-    "status": "generated",
-    "output": "<brief summary>"
-  }
-  ```
+- After validation and dry-run pass, call `end_metric_generation(metric_file="<target model file>", semantic_model_file="<target model file>", metric_sqls_json="<dry-run SQL JSON>")`.

--- a/datus/resources/skills/osi-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/osi-semantic-authoring/SKILL.md
@@ -1,29 +1,33 @@
-You are a semantic modeling expert. Your task is to describe tables as strict **OSI (Open Semantic Interchange) core schema** documents plus Datus business hints.
+---
+name: osi-semantic-authoring
+description: OSI core schema semantic model authoring specification — dataset shape, Datus extension hints, relationships, and validation
+tags:
+  - semantic-model
+  - osi
+version: "1.0.0"
+user_invocable: false
+disable_model_invocation: false
+allowed_agents:
+  - gen_semantic_model
+  - gen_metrics
+---
+
+# OSI Semantic Authoring
+
+Describe tables as strict **OSI (Open Semantic Interchange) core schema** documents plus Datus business hints.
 
 CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow `data_source:`, `measures:`, `identifiers:`, `agg_time_dimension`, `create_metric`, or any execution-engine YAML. The Datus OSI compiler lowers OSI core documents to the configured backend.
-This is the OSI authoring path. Do NOT load or follow MetricFlow `metricflow-semantic-authoring` skills if they are visible; their file format is for the legacy MetricFlow authoring path.
 
-The MetricFlow-skill restriction above does not apply to `semantic-sql-history-profiler`.
-{% include "_semantic_sql_history_profiler_gate.j2" %}
-
-
-{% set target_model_name = default_osi_semantic_model_name | default('<model_name>', true) %}
-{% set target_model_file = default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) %}
-{% import "_osi_dialect_map.j2" as osi_dialect_map %}
-{% set datasource_type = current_datasource | default('', true) | lower %}
-{% set osi_expression_dialect = osi_dialect_map.expression_dialect(datasource_type) %}
-
-{% if native_tools %}- Native tools: {{ native_tools }}{% endif %}
-{% if mcp_tools %}- MCP servers: {{ mcp_tools }}{% endif %}
+The OSI expression dialect, target semantic model name, and target semantic model file for the current run are shown in the system prompt Workspace section — use those exact values.
 
 ## What you produce
 
-Produce one valid OSI core document for the current business domain / semantic model scope:
+One valid OSI core document for the current business domain / semantic model scope (`<osi_dialect>` stands for the OSI expression dialect from the system prompt):
 
 ```yaml
 version: 0.2.0.dev0
 semantic_model:
-  - name: {{ target_model_name }}
+  - name: <target_model_name>
     datasets:
       - name: <dataset_name>
         source: <physical_table_view_or_query_name>
@@ -37,7 +41,7 @@ semantic_model:
           - name: <date_or_timestamp_column>
             expression:
               dialects:
-                - dialect: {{ osi_expression_dialect }}
+                - dialect: <osi_dialect>
                   expression: <date_or_timestamp_column>
             dimension:
               is_time: true
@@ -47,7 +51,7 @@ semantic_model:
           - name: <categorical_business_column>
             expression:
               dialects:
-                - dialect: {{ osi_expression_dialect }}
+                - dialect: <osi_dialect>
                   expression: <categorical_business_column>
             dimension:
               is_time: false
@@ -58,7 +62,7 @@ semantic_model:
           - name: <numeric_business_column>
             expression:
               dialects:
-                - dialect: {{ osi_expression_dialect }}
+                - dialect: <osi_dialect>
                   expression: <numeric_business_column>
             dimension:
               is_time: false
@@ -77,7 +81,7 @@ semantic_model:
 ## Authoring rules
 
 1. **Root schema is fixed.** Root keys are only `version` and `semantic_model`. `semantic_model` is a list. Do NOT write top-level `datasets:`, `relationships:`, or `metrics:`.
-2. **Use OSI core dataset shape.** Dataset `source` is a string, not `{table: ...}`. Dataset columns are `fields`, not `dimensions`. Field expressions are `expression.dialects[]`, not `expr`. The OSI expression dialect for this run is `{{ osi_expression_dialect }}`. This is the OSI core schema dialect label, derived from the allowed enum, and may differ from the active datasource connector type. Use this exact value in every `expression.dialects[].dialect`.
+2. **Use OSI core dataset shape.** Dataset `source` is a string, not `{table: ...}`. Dataset columns are `fields`, not `dimensions`. Field expressions are `expression.dialects[]`, not `expr`. Use the exact OSI expression dialect from the system prompt in every `expression.dialects[].dialect`.
 3. **Datus-only hints go into `custom_extensions`.** OSI core does not have top-level dataset `time_dimension`, field `type`, field `granularity`, metric `dataset`, metric `window`, etc. Put those Datus execution hints in `custom_extensions: [{vendor_name: DATUS, data: '<JSON object string>'}]`.
 4. **Semantic model boundary.** One OSI `semantic_model` represents the current business domain / metric domain. Put all related logical datasets needed by the provided SQL history in this semantic model, with relationships declared once under the semantic model object.
 5. **Canonical logical datasets.** A dataset is a logical dataset backed by a table, view, or query. For the same source and row grain, create one canonical dataset that metrics can reference by name. Create a separate dataset only when the logical row grain or fixed business scope is genuinely different. Include the full logical dataset: primary key, primary time field, and all business-meaningful fields.
@@ -88,36 +92,20 @@ semantic_model:
 8. **Time dimension**: mark the primary date/time field with `dimension.is_time: true` and Datus extension `{"type":"time","time_granularity":"day|week|month|quarter|year"}`. Point it at a real date/time column, never a numeric surrogate key.
 9. **Fields**: include every business-meaningful column the user may group or slice by. Populate `description` for ALL non-obvious fields by combining the column comment, sample values, profiler evidence, and external knowledge. Useful profiler evidence may include null rate, numeric ranges/percentiles, date span/freshness/duration, distinct counts, representative stable values, common filter templates, and relationship coverage/fanout. Wrap descriptions in double quotes and keep each description concise.
 10. **Field type classification must follow actual data type and analytical usage.** The DATUS `custom_extensions.data.type` value is not a display hint; it is the semantic field type.
-   - Use `{"type":"numeric"}` for DECIMAL/NUMERIC/INTEGER/FLOAT/DOUBLE or equivalent fields that represent measured quantities, scores, rates, prices, amounts, durations, counts, percentages, or other arithmetic values.
-   - Keep a field `numeric` when historical SQL uses it in arithmetic, range predicates, numeric ordering, or numeric aggregates such as `AVG`, `SUM`, `MIN`, `MAX`, `STD`, `VARIANCE`, `CORR`, or `COVAR`. A numeric field does not become categorical just because it is selected, displayed, filtered, or grouped.
-   - Use `{"type":"categorical"}` for text/enums/labels/booleans and code fields whose values are categories, not quantities. Numeric-coded categories such as status codes, product type codes, or channel codes can be categorical when averaging or summing the code would have no business meaning; explain the code semantics in the description.
-   - Use `{"type":"identifier"}` for primary keys, foreign keys, unique entity IDs, or opaque IDs. Do not classify identifiers as numeric merely because their physical storage type is integer.
-   - Use `{"type":"time","time_granularity":"..."}` only for real date/time values as described above.
-   - If evidence conflicts, prefer the physical column type plus concrete SQL usage. For example, a DECIMAL field used by `AVG(<field>)` or numeric threshold filters must be `numeric`, while an integer status code used only as labels/groups should be `categorical`.
+    - Use `{"type":"numeric"}` for DECIMAL/NUMERIC/INTEGER/FLOAT/DOUBLE or equivalent fields that represent measured quantities, scores, rates, prices, amounts, durations, counts, percentages, or other arithmetic values.
+    - Keep a field `numeric` when historical SQL uses it in arithmetic, range predicates, numeric ordering, or numeric aggregates such as `AVG`, `SUM`, `MIN`, `MAX`, `STD`, `VARIANCE`, `CORR`, or `COVAR`. A numeric field does not become categorical just because it is selected, displayed, filtered, or grouped.
+    - Use `{"type":"categorical"}` for text/enums/labels/booleans and code fields whose values are categories, not quantities. Numeric-coded categories such as status codes, product type codes, or channel codes can be categorical when averaging or summing the code would have no business meaning; explain the code semantics in the description.
+    - Use `{"type":"identifier"}` for primary keys, foreign keys, unique entity IDs, or opaque IDs. Do not classify identifiers as numeric merely because their physical storage type is integer.
+    - Use `{"type":"time","time_granularity":"..."}` only for real date/time values as described above.
+    - If evidence conflicts, prefer the physical column type plus concrete SQL usage. A DECIMAL field used by `AVG(<field>)` or numeric threshold filters must be `numeric`; an integer status code used only as labels/groups should be `categorical`.
 11. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
 12. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
-13. Preserve literal values and column names exactly; do not invent columns.
+13. Preserve literal values and column names exactly; do not invent columns. Keep column comments in their original language — do not translate.
 
-## Workflow
+## Workflow notes
 
-{% if current_datasource %}
-- Active datasource: `{{ current_datasource }}`
-- OSI expression dialect: `{{ osi_expression_dialect }}`
-{% endif %}
-{% if semantic_model_dir %}
-- Write OSI core YAML under `{{ semantic_model_dir }}` only.
-{% endif %}
-- Target semantic model name: `{{ target_model_name }}`
-- Target semantic model file: `{{ target_model_file }}`
+- Write OSI core YAML under the semantic model directory shown in the system prompt only, at the target semantic model file path.
 - Inspect the table schema and comments; map columns to keys, the time field, business fields, and relationships.
 - When a critical modeling choice is ambiguous (which column is the grain, which is the primary time dimension), ASK before generating.
-- Produce valid OSI core YAML; the Datus OSI compiler validates it against OSI core schema, then lowers it to the configured execution backend.
-- Call `validate_semantic(scope="semantic_model")` after writing the OSI semantic model and fix errors until it passes.
-- After validation passes, call `end_semantic_model_generation(semantic_model_files=[...])`. In OSI mode this syncs OSI datasets to Knowledge Base without using MetricFlow YAML.
-- Finish with JSON:
-  ```json
-  {
-    "semantic_model_files": ["{{ target_model_file }}"],
-    "output": "<brief summary>"
-  }
-  ```
+- Call `validate_semantic(scope="semantic_model")` after writing the OSI semantic model and fix errors until it passes. The Datus OSI compiler validates against the OSI core schema, then lowers to the configured execution backend.
+- After validation passes, call `end_semantic_model_generation(semantic_model_files=[...])`. In OSI mode this syncs OSI datasets to the Knowledge Base without using MetricFlow YAML.

--- a/datus/resources/skills/osi-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/osi-semantic-authoring/SKILL.md
@@ -4,7 +4,7 @@ description: OSI core schema semantic model authoring specification — dataset 
 tags:
   - semantic-model
   - osi
-version: "1.0.0"
+version: "1.1.0"
 user_invocable: false
 disable_model_invocation: false
 allowed_agents:
@@ -98,9 +98,11 @@ semantic_model:
     - Use `{"type":"identifier"}` for primary keys, foreign keys, unique entity IDs, or opaque IDs. Do not classify identifiers as numeric merely because their physical storage type is integer.
     - Use `{"type":"time","time_granularity":"..."}` only for real date/time values as described above.
     - If evidence conflicts, prefer the physical column type plus concrete SQL usage. A DECIMAL field used by `AVG(<field>)` or numeric threshold filters must be `numeric`; an integer status code used only as labels/groups should be `categorical`.
-11. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
-12. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
-13. Preserve literal values and column names exactly; do not invent columns. Keep column comments in their original language — do not translate.
+11. **One column, one type model-wide.** A given column name must carry the SAME `type` everywhere it appears across ALL datasets and in `primary_key`. Do not model the same column as `identifier` in one place and `categorical`/`dimension` in another. Decide its role once from its strongest signal: a key/foreign-key/join column is an `identifier` even when it also appears in a `GROUP BY`; a code/label column is `categorical`. If `validate_semantic` reports a column "used as multiple types", fix every occurrence to a SINGLE type and re-validate — never toggle it back and forth between validation attempts.
+12. **Do not model columns no query uses.** Include a field only when the provided SQL selects, filters, groups, joins, or aggregates by it, or it is the dataset primary key or primary time field. A key column present in the DDL but never referenced by any provided SQL should be a plain `identifier` (or the dataset `primary_key`) consistently — do not guess whether it is a dimension. When in doubt about an unused column, omit it rather than introduce an ambiguous type.
+13. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
+14. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
+15. Preserve literal values and column names exactly; do not invent columns. Keep column comments in their original language — do not translate.
 
 ## Workflow notes
 

--- a/datus/resources/skills/semantic-sql-history-profiler/SKILL.md
+++ b/datus/resources/skills/semantic-sql-history-profiler/SKILL.md
@@ -14,15 +14,14 @@ allowed_agents:
 
 # Semantic SQL History Profiler
 
-Use this workflow when the skill is loaded because the user provided historical SQL, success-story SQL, or explicitly asked for profiling. Once loaded, run the profiler before semantic YAML authoring.
+Use this workflow when the skill is loaded because the user explicitly asked for profiling, statistics, data-distribution analysis, or mining/analyzing historical SQL. Providing SQL alone is not a trigger. Once loaded, run the profiler before semantic YAML authoring.
 
 ## Workflow
 
 1. Call `profile_semantic_model_evidence` before writing semantic model YAML.
-   - When historical SQL is provided inline, pass every provided SQL statement via `sql_entries_json` or `sql_queries`; do not choose only representative examples.
+   - When historical SQL is provided inline, pass every provided SQL statement via `sql_entries_json` or `sql_queries`; do not choose only representative examples. Default to `profile_mode="sql_only"`.
    - Use `query_text` only when direct SQL text is unavailable and existing reference SQL must be searched.
-   - Use `profile_mode="sql_only"` when the user wants quick generation.
-   - Use `profile_mode="lightweight"` when sampled field distributions are helpful.
+   - Use `profile_mode="lightweight"` with the target `tables` when the user asks for statistics or field distributions — this also works with no SQL at all (pure bounded distribution profiling).
    - Use `profile_mode="deep"` only when the user explicitly allows a slower exploration.
    - Set conservative bounds such as `max_tables`, `max_columns_per_table`, `top_n`, and `max_profile_seconds`.
 

--- a/docs/subagent/gen_semantic_model.md
+++ b/docs/subagent/gen_semantic_model.md
@@ -60,40 +60,26 @@ agent:
       model: claude      # Optional: defaults to configured model
       max_turns: 30      # Optional: defaults to 30
       semantic_adapter: metricflow   # Optional when only one semantic layer is configured
-      # Optional: enable historical SQL profiling before YAML generation.
-      # Keep the default MetricFlow semantic-model skill when overriding skills.
-      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
 ```
 
 See [Semantic Layer Configuration](../configuration/semantic_layer.md) for the full set of options.
 
 For OSI generation, see [OSI Semantic Adapter](../adapters/osi_semantic_adapter.md).
 
+### Skills (automatic)
+
+Skills are wired automatically from the active semantic adapter — no `skills:` entry is needed:
+
+- The authoring specification skill (`metricflow-semantic-authoring` for MetricFlow, `osi-semantic-authoring` for OSI) is injected into the system prompt on every run.
+- `semantic-sql-history-profiler` is registered by default as an optional skill for both formats.
+
+Set `skills: ""` on the node to opt out of the optional skill set, or list explicit skill names to replace it. Project-level skill overrides under `./.datus/skills/` take precedence over the built-in specifications.
+
 ### Optional Historical SQL Profiling
 
-`semantic-sql-history-profiler` is an internal skill for `gen_semantic_model`, not a chat command or user-invocable skill. Enable it on the `gen_semantic_model` node when you want semantic-model generation to use historical SQL or success-story SQL as modeling evidence.
+`semantic-sql-history-profiler` is an internal skill for `gen_semantic_model`, not a chat command or user-invocable skill. It is available by default and triggers **only when the user explicitly asks** for profiling, statistics, data-distribution analysis, or mining/analyzing historical SQL — providing SQL alone does not trigger it (the SQL is still used directly as modeling context).
 
-When the skill is available and the request includes historical SQL or success-story SQL, the subagent loads it before generating YAML and calls `profile_semantic_model_evidence`. The evidence is used to infer join relationships, commonly filtered or grouped dimensions, aggregate candidates, time fields, compact distribution notes, and relationship reliability hints.
-
-For MetricFlow generation, keep the default MetricFlow semantic-model skill when you override `skills`:
-
-```yaml
-agent:
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
-```
-
-For OSI generation, enable only the profiler unless you intentionally need another skill:
-
-```yaml
-agent:
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: osi
-      skills: "semantic-sql-history-profiler"
-```
+When triggered, the subagent loads the skill before generating YAML and calls `profile_semantic_model_evidence`. The evidence is used to infer join relationships, commonly filtered or grouped dimensions, aggregate candidates, time fields, compact distribution notes, and relationship reliability hints.
 
 **Built-in configurations** (automatically enabled):
 - **Tools**: Database tools, generation tools, and filesystem tools

--- a/docs/subagent/gen_semantic_model.md
+++ b/docs/subagent/gen_semantic_model.md
@@ -68,18 +68,46 @@ For OSI generation, see [OSI Semantic Adapter](../adapters/osi_semantic_adapter.
 
 ### Skills (automatic)
 
-Skills are wired automatically from the active semantic adapter — no `skills:` entry is needed:
+You never configure `skills:` — the assistant picks the right ones from the active semantic adapter:
 
-- The authoring specification skill (`metricflow-semantic-authoring` for MetricFlow, `osi-semantic-authoring` for OSI) is injected into the system prompt on every run.
-- `semantic-sql-history-profiler` is registered by default as an optional skill for both formats.
+- The matching authoring guide (`metricflow-semantic-authoring` or `osi-semantic-authoring`) is always applied.
+- A historical-SQL profiler is available on demand (see below).
 
-Set `skills: ""` on the node to opt out of the optional skill set, or list explicit skill names to replace it. Project-level skill overrides under `./.datus/skills/` take precedence over the built-in specifications.
+To customize: set `skills: ""` to disable the optional profiler, or drop a folder with the same name under `./.datus/skills/` to replace a built-in guide with your own.
 
-### Optional Historical SQL Profiling
+### Triggering historical-SQL profiling
 
-`semantic-sql-history-profiler` is an internal skill for `gen_semantic_model`, not a chat command or user-invocable skill. It is available by default and triggers **only when the user explicitly asks** for profiling, statistics, data-distribution analysis, or mining/analyzing historical SQL — providing SQL alone does not trigger it (the SQL is still used directly as modeling context).
+By default the assistant models a table from its DDL and column comments — fast, no extra steps. When you want it to also mine your historical queries or sample real data distributions, **just ask for it in your request**:
 
-When triggered, the subagent loads the skill before generating YAML and calls `profile_semantic_model_evidence`. The evidence is used to infer join relationships, commonly filtered or grouped dimensions, aggregate candidates, time fields, compact distribution notes, and relationship reliability hints.
+| What you want | Example request |
+|---|---|
+| Model from DDL only (default) | `/gen_semantic_model generate a semantic model for orders` |
+| Use past queries as modeling evidence | `/gen_semantic_model model orders and its joins; analyze these queries first: <paste SQL>` |
+| Sample real value distributions | `/gen_semantic_model model orders and profile its column statistics before writing the model` |
+
+Pasting SQL alone does **not** trigger profiling — the assistant still reads it as context, but only runs the profiler when you explicitly ask to analyze or profile. This keeps everyday generation quick.
+
+When profiling runs, its findings (value ranges, null rates, distinct counts, common filters, join reliability) are folded into the field descriptions. For example, a field the assistant would normally write as:
+
+```yaml
+- name: amount
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: amount
+  dimension:
+    is_time: false
+  description: "Order amount"
+  custom_extensions:
+    - vendor_name: DATUS
+      data: '{"type":"numeric"}'
+```
+
+becomes, after profiling, self-documenting with observed evidence:
+
+```yaml
+  description: "Order amount; observed range 0–9,999, p50 ≈ 120; ~0.3% null"
+```
 
 **Built-in configurations** (automatically enabled):
 - **Tools**: Database tools, generation tools, and filesystem tools

--- a/docs/subagent/gen_semantic_model.zh.md
+++ b/docs/subagent/gen_semantic_model.zh.md
@@ -58,40 +58,26 @@ agent:
       model: claude      # 可选：默认使用已配置的模型
       max_turns: 30      # 可选：默认为 30
       semantic_adapter: metricflow   # 当仅配置了一个 semantic layer 时可省略
-      # 可选：在生成 YAML 前启用历史 SQL profiling。
-      # 覆盖 skills 时，需要同时保留默认的 MetricFlow 语义模型 skill。
-      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
 ```
 
 完整配置项见 [语义层配置](../configuration/semantic_layer.zh.md)。
 
 OSI 生成见 [OSI 语义适配器](../adapters/osi_semantic_adapter.zh.md)。
 
+### Skills（自动装配）
+
+skills 会根据当前激活的 semantic adapter 自动装配，无需配置 `skills:`：
+
+- 建模规范 skill（MetricFlow 对应 `metricflow-semantic-authoring`，OSI 对应 `osi-semantic-authoring`）会在每次运行时注入系统提示词。
+- `semantic-sql-history-profiler` 在两种格式下都默认注册为可选 skill。
+
+如需关闭可选 skill，可在节点上设置 `skills: ""`；也可以列出显式的 skill 名称进行替换。`./.datus/skills/` 下的项目级 skill 会覆盖内置规范。
+
 ### 可选的历史 SQL Profiling
 
-`semantic-sql-history-profiler` 是 `gen_semantic_model` 使用的内部 skill，不是聊天命令，也不能由用户直接调用。需要让语义模型生成基于历史 SQL 或 success-story SQL 做建模证据分析时，可以在 `gen_semantic_model` 节点上启用它。
+`semantic-sql-history-profiler` 是 `gen_semantic_model` 使用的内部 skill，不是聊天命令，也不能由用户直接调用。它默认可用，但**只在用户明确要求**画像、统计、数据分布分析或挖掘/分析历史 SQL 时才会触发——仅提供 SQL 不会触发（这些 SQL 仍会被直接用作建模参考）。
 
-当该 skill 可用，并且请求中包含历史 SQL 或 success-story SQL 时，subagent 会在生成 YAML 前加载它，并调用 `profile_semantic_model_evidence`。这些证据会用于推断 JOIN 关系、常见过滤或分组维度、聚合候选、时间字段、简洁的数据分布说明，以及关系可靠性提示。
-
-MetricFlow 生成场景下，如果覆盖 `skills`，需要把默认语义模型 skill 一起列出：
-
-```yaml
-agent:
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: metricflow
-      skills: "metricflow-semantic-authoring, semantic-sql-history-profiler"
-```
-
-OSI 生成场景下，除非明确需要其他 skill，通常只启用 profiler：
-
-```yaml
-agent:
-  agentic_nodes:
-    gen_semantic_model:
-      semantic_adapter: osi
-      skills: "semantic-sql-history-profiler"
-```
+触发后，subagent 会在生成 YAML 前加载该 skill，并调用 `profile_semantic_model_evidence`。这些证据会用于推断 JOIN 关系、常见过滤或分组维度、聚合候选、时间字段、简洁的数据分布说明，以及关系可靠性提示。
 
 **内置配置**（自动启用）：
 - **工具**：数据库工具、生成工具和文件系统工具

--- a/docs/subagent/gen_semantic_model.zh.md
+++ b/docs/subagent/gen_semantic_model.zh.md
@@ -66,18 +66,46 @@ OSI 生成见 [OSI 语义适配器](../adapters/osi_semantic_adapter.zh.md)。
 
 ### Skills（自动装配）
 
-skills 会根据当前激活的 semantic adapter 自动装配，无需配置 `skills:`：
+你无需配置 `skills:`——助手会根据当前激活的 semantic adapter 自动选择：
 
-- 建模规范 skill（MetricFlow 对应 `metricflow-semantic-authoring`，OSI 对应 `osi-semantic-authoring`）会在每次运行时注入系统提示词。
-- `semantic-sql-history-profiler` 在两种格式下都默认注册为可选 skill。
+- 对应格式的建模规范（`metricflow-semantic-authoring` 或 `osi-semantic-authoring`）始终生效。
+- 一个历史 SQL profiler 按需可用（见下文）。
 
-如需关闭可选 skill，可在节点上设置 `skills: ""`；也可以列出显式的 skill 名称进行替换。`./.datus/skills/` 下的项目级 skill 会覆盖内置规范。
+如需自定义：设置 `skills: ""` 关闭可选 profiler；或在 `./.datus/skills/` 下放一个同名目录，用你自己的规范替换内置的。
 
-### 可选的历史 SQL Profiling
+### 触发历史 SQL profiling
 
-`semantic-sql-history-profiler` 是 `gen_semantic_model` 使用的内部 skill，不是聊天命令，也不能由用户直接调用。它默认可用，但**只在用户明确要求**画像、统计、数据分布分析或挖掘/分析历史 SQL 时才会触发——仅提供 SQL 不会触发（这些 SQL 仍会被直接用作建模参考）。
+默认情况下，助手只根据表的 DDL 和列注释建模——快、无需额外步骤。当你希望它同时挖掘历史查询或采样真实数据分布时，**在请求里直接说出来即可**：
 
-触发后，subagent 会在生成 YAML 前加载该 skill，并调用 `profile_semantic_model_evidence`。这些证据会用于推断 JOIN 关系、常见过滤或分组维度、聚合候选、时间字段、简洁的数据分布说明，以及关系可靠性提示。
+| 你想要 | 请求示例 |
+|---|---|
+| 仅按 DDL 建模（默认） | `/gen_semantic_model 为 orders 生成语义模型` |
+| 用历史查询作为建模证据 | `/gen_semantic_model 为 orders 及其 join 建模；先分析这些查询：<粘贴 SQL>` |
+| 采样真实值分布 | `/gen_semantic_model 为 orders 建模，写模型前先 profile 一下列的统计信息` |
+
+仅粘贴 SQL **不会**触发 profiling——助手仍会把它当作上下文阅读，但只有你明确要求分析或 profile 时才会真正运行 profiler。这让日常生成保持快速。
+
+profiling 运行时，其发现（取值范围、空值率、去重基数、常见过滤、join 可靠性）会被融入字段 description。例如，助手原本会写成：
+
+```yaml
+- name: amount
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: amount
+  dimension:
+    is_time: false
+  description: "订单金额"
+  custom_extensions:
+    - vendor_name: DATUS
+      data: '{"type":"numeric"}'
+```
+
+profiling 后，会带上观测证据、自解释：
+
+```yaml
+  description: "订单金额；观测范围 0–9999，p50 ≈ 120；约 0.3% 为空"
+```
 
 **内置配置**（自动启用）：
 - **工具**：数据库工具、生成工具和文件系统工具

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -884,15 +884,20 @@ class TestBuiltinNodeDefaultSkills:
 
         assert GenTableAgenticNode.DEFAULT_SKILLS == "gen-table"
 
-    def test_gen_metrics_defaults(self):
+    def test_gen_metrics_defaults_derive_from_authoring_format(self):
+        """gen_metrics derives skills dynamically: DEFAULT_SKILLS stays unset, the
+        optional set comes from the authoring format and the spec skill is
+        host-injected via REQUIRED_SKILLS (see test_semantic_authoring.py)."""
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 
-        assert GenMetricsAgenticNode.DEFAULT_SKILLS == "gen-metrics, metricflow-semantic-authoring"
+        assert GenMetricsAgenticNode.DEFAULT_SKILLS is None
+        assert GenMetricsAgenticNode.REQUIRED_SKILLS is None
 
-    def test_gen_semantic_model_defaults(self):
+    def test_gen_semantic_model_defaults_derive_from_authoring_format(self):
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 
-        assert GenSemanticModelAgenticNode.DEFAULT_SKILLS == "metricflow-semantic-authoring"
+        assert GenSemanticModelAgenticNode.DEFAULT_SKILLS is None
+        assert GenSemanticModelAgenticNode.REQUIRED_SKILLS is None
 
     def test_gen_dashboard_leaves_defaults_unset(self):
         """gen_dashboard injects {platform}-dashboard dynamically in setup, not via DEFAULT_SKILLS."""
@@ -1097,3 +1102,59 @@ class TestBashToolToggle:
         node.tools = []
         node._ensure_bash_tool_in_tools()
         assert node.tools == []
+
+
+class TestRequiredSkillsInjection:
+    """``REQUIRED_SKILLS`` host-injection primitive (``_inject_required_skills``)."""
+
+    def _make_node(self, mock_agent_config, skill_manager, required):
+        node = MinimalAgenticNode(
+            node_id="required_skills_node",
+            description="Test node",
+            node_type="chat",
+            agent_config=mock_agent_config,
+        )
+        node.skill_manager = skill_manager
+        node.__class__ = type(
+            "RequiredSkillsNode",
+            (MinimalAgenticNode,),
+            {"REQUIRED_SKILLS": required, "get_node_name": lambda self: "test_node"},
+        )
+        return node
+
+    def test_required_skill_content_is_injected(self, mock_agent_config, skill_manager, monkeypatch):
+        node = self._make_node(mock_agent_config, skill_manager, "sql-analysis")
+        monkeypatch.setattr(node, "_inject_memory_context", lambda p, override_node_name=None: p)
+        monkeypatch.setattr(node, "_inject_response_language", lambda p: p)
+
+        result = node._finalize_system_prompt("base prompt")
+
+        assert '<required_skill name="sql-analysis">' in result
+        assert "SQL analysis techniques" in result
+        assert "</required_skill>" in result
+
+    def test_multiple_required_skills_all_injected(self, mock_agent_config, skill_manager):
+        node = self._make_node(mock_agent_config, skill_manager, "sql-analysis, data-profiler")
+
+        result = node._inject_required_skills("base prompt")
+
+        assert '<required_skill name="sql-analysis">' in result
+        assert '<required_skill name="data-profiler">' in result
+
+    def test_missing_required_skill_raises(self, mock_agent_config, skill_manager):
+        from datus.utils.exceptions import DatusException
+
+        node = self._make_node(mock_agent_config, skill_manager, "no-such-skill")
+
+        with pytest.raises(DatusException, match="no-such-skill"):
+            node._inject_required_skills("base prompt")
+
+    def test_no_required_skills_leaves_prompt_unchanged(self, mock_agent_config, skill_manager):
+        node = self._make_node(mock_agent_config, skill_manager, None)
+
+        assert node._inject_required_skills("base prompt") == "base prompt"
+
+    def test_get_required_skills_parses_comma_separated_string(self, mock_agent_config, skill_manager):
+        node = self._make_node(mock_agent_config, skill_manager, " sql-analysis ,, data-profiler ")
+
+        assert node._get_required_skills() == ["sql-analysis", "data-profiler"]

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -717,23 +717,44 @@ class TestGetSystemPrompt:
             version = call_kwargs.kwargs.get("version")
             assert version == "1.2", f"Expected explicit version '1.2', got '{version}'"
 
-    def test_osi_authoring_uses_osi_prompt_template(self, real_agent_config, mock_llm_create):
+    def test_osi_authoring_uses_shared_template_with_osi_context(self, real_agent_config, mock_llm_create):
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create, execution_mode="workflow")
         node.input = SemanticNodeInput(user_message="Generate OSI metrics", prompt_version="1.2")
 
-        with (
-            patch("datus.agent.node.semantic_authoring.osi_prompt_version", return_value="osi-latest") as version_mock,
-            patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_pm,
-        ):
+        with patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_pm:
             mock_pm.return_value.render_template.return_value = "osi prompt"
 
-            node._get_system_prompt(template_context={})
+            template_context = node._prepare_template_context(node.input)
+            node._get_system_prompt(template_context=template_context)
 
-        version_mock.assert_called_once_with(real_agent_config, "gen_metrics", "1.2")
         call_kwargs = mock_pm.return_value.render_template.call_args.kwargs
-        assert call_kwargs["template_name"] == "gen_metrics_osi_system"
-        assert call_kwargs["version"] == "osi-latest"
+        # Both formats share one template; the format travels in the context and
+        # the pinned prompt_version applies to the shared template.
+        assert call_kwargs["template_name"] == "gen_metrics_system"
+        assert call_kwargs["version"] == "1.2"
+        assert call_kwargs["authoring_format"] == "osi"
+
+    def test_osi_authoring_injects_osi_required_skill(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = _make_node(real_agent_config, mock_llm_create, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate OSI metrics")
+
+        prompt = node._get_system_prompt(template_context=node._prepare_template_context(node.input))
+
+        assert '<required_skill name="osi-metrics-authoring">' in prompt
+        assert "OSI core semantics only" in prompt
+        assert '<required_skill name="gen-metrics">' not in prompt
+
+    def test_metricflow_authoring_injects_gen_metrics_required_skill(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate metrics")
+
+        prompt = node._get_system_prompt(template_context=node._prepare_template_context(node.input))
+
+        assert '<required_skill name="gen-metrics">' in prompt
+        assert "measure_proxy" in prompt
+        assert '<required_skill name="osi-metrics-authoring">' not in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -102,12 +102,32 @@ class TestGenSemanticModelAgenticNodeInit:
         assert "check_semantic_object_exists" in tool_names
         assert "end_semantic_model_generation" in tool_names
 
-        # SemanticDiscoveryTools should be present
+        # SemanticDiscoveryTools should be present; the profiler tool is
+        # registered by default (the optional skill is in the default set).
         assert isinstance(node.semantic_discovery_tools, SemanticDiscoveryTools)
-        assert "profile_semantic_model_evidence" not in tool_names
+        assert "profile_semantic_model_evidence" in tool_names
 
-    def test_semantic_sql_history_profiler_tool_is_skill_gated(self, real_agent_config, mock_llm_create):
-        """Profiler tool is exposed only when the optional skill is configured."""
+    def test_semantic_sql_history_profiler_tool_opt_out(self, real_agent_config, mock_llm_create):
+        """An explicit empty skills entry removes the profiler tool."""
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+
+        original = dict(real_agent_config.agentic_nodes.get("gen_semantic_model", {}))
+        try:
+            real_agent_config.agentic_nodes["gen_semantic_model"] = {
+                **original,
+                "skills": "",
+            }
+            node = GenSemanticModelAgenticNode(
+                agent_config=real_agent_config,
+                execution_mode="workflow",
+            )
+            tool_names = [tool.name for tool in node.tools]
+            assert "profile_semantic_model_evidence" not in tool_names
+        finally:
+            real_agent_config.agentic_nodes["gen_semantic_model"] = original
+
+    def test_semantic_sql_history_profiler_tool_with_explicit_skills(self, real_agent_config, mock_llm_create):
+        """An explicit skills entry naming the profiler keeps the tool exposed."""
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 
         original = dict(real_agent_config.agentic_nodes.get("gen_semantic_model", {}))
@@ -492,22 +512,40 @@ class TestPrepareTemplateContext:
 
 
 class TestGetSystemPrompt:
-    def test_osi_authoring_uses_osi_prompt_template(self, real_agent_config, mock_llm_create):
+    def test_osi_authoring_uses_shared_template_with_osi_context(self, real_agent_config, mock_llm_create):
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create)
 
-        with (
-            patch("datus.agent.node.semantic_authoring.osi_prompt_version", return_value="osi-latest") as version_mock,
-            patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_pm,
-        ):
+        with patch("datus.prompts.prompt_manager.get_prompt_manager") as mock_pm:
             mock_pm.return_value.render_template.return_value = "osi prompt"
 
-            node._get_system_prompt(prompt_version="1.2", template_context={})
+            template_context = node._prepare_template_context(None)
+            node._get_system_prompt(prompt_version="1.2", template_context=template_context)
 
-        version_mock.assert_called_once_with(real_agent_config, "gen_semantic_model", "1.2")
         call_kwargs = mock_pm.return_value.render_template.call_args.kwargs
-        assert call_kwargs["template_name"] == "gen_semantic_model_osi_system"
-        assert call_kwargs["version"] == "osi-latest"
+        # Both formats share one template; the format travels in the context.
+        assert call_kwargs["template_name"] == "gen_semantic_model_system"
+        assert call_kwargs["version"] == "1.2"
+        assert call_kwargs["authoring_format"] == "osi"
+
+    def test_osi_authoring_injects_osi_required_skill(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = _make_node(real_agent_config, mock_llm_create)
+
+        prompt = node._get_system_prompt(template_context=node._prepare_template_context(None))
+
+        assert '<required_skill name="osi-semantic-authoring">' in prompt
+        assert "OSI core semantics only" in prompt
+        assert '<required_skill name="metricflow-semantic-authoring">' not in prompt
+
+    def test_metricflow_authoring_injects_metricflow_required_skill(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create)
+
+        prompt = node._get_system_prompt(template_context=node._prepare_template_context(None))
+
+        assert '<required_skill name="metricflow-semantic-authoring">' in prompt
+        assert "MetricFlow semantic model structure specification" in prompt
+        assert '<required_skill name="osi-semantic-authoring">' not in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -2,21 +2,19 @@
 
 from dataclasses import dataclass
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_METRICFLOW,
     AUTHORING_FORMAT_OSI,
+    default_optional_skills,
     default_osi_semantic_model_file,
     default_osi_semantic_model_name,
-    osi_prompt_version,
-    osi_template_name,
+    required_authoring_skills,
     resolve_authoring_format,
     resolve_semantic_adapter_type,
 )
-from datus.prompts.prompt_manager import get_prompt_manager
 from datus.utils.exceptions import DatusException, ErrorCode
 
 
@@ -143,65 +141,94 @@ def test_adapter_type_resolution_propagates_agent_config_errors():
         resolve_semantic_adapter_type(bad)
 
 
-def test_osi_template_name_is_isolated_from_metricflow_template():
-    # Separate template_name so the default `{node}_system` latest scan is unaffected.
-    assert osi_template_name("gen_metrics") == "gen_metrics_osi_system"
-    assert osi_template_name("gen_semantic_model") == "gen_semantic_model_osi_system"
+@pytest.mark.parametrize(
+    "node_name, adapter, expected",
+    [
+        ("gen_semantic_model", "metricflow", "metricflow-semantic-authoring"),
+        ("gen_semantic_model", "osi", "osi-semantic-authoring"),
+        ("gen_metrics", "metricflow", "gen-metrics"),
+        ("gen_metrics", "osi", "osi-metrics-authoring"),
+        ("unknown_node", "metricflow", ""),
+    ],
+)
+def test_required_authoring_skills_derive_from_format(node_name, adapter, expected):
+    assert required_authoring_skills(_agent_config(adapter), node_name) == expected
 
 
-def test_osi_prompt_version_ignores_injected_metricflow_version():
-    # Bootstrap (init_success_story_metrics) injects the latest *metricflow*
-    # template version (e.g. "1.2"), which is not a version of the OSI template.
-    # It must be ignored (-> None -> latest OSI template), not break rendering.
-    assert osi_prompt_version(None, "gen_metrics", "1.2") is None
-    assert osi_prompt_version(None, "gen_metrics", None) is None
-    # a real OSI template version is honored
-    assert osi_prompt_version(None, "gen_metrics", "1.0") == "1.0"
+@pytest.mark.parametrize(
+    "node_name, adapter, expected",
+    [
+        ("gen_semantic_model", "metricflow", "semantic-sql-history-profiler"),
+        ("gen_semantic_model", "osi", "semantic-sql-history-profiler"),
+        ("gen_metrics", "metricflow", "metricflow-semantic-authoring"),
+        ("gen_metrics", "osi", "osi-semantic-authoring"),
+        ("unknown_node", "osi", ""),
+    ],
+)
+def test_default_optional_skills_derive_from_format(node_name, adapter, expected):
+    assert default_optional_skills(_agent_config(adapter), node_name) == expected
 
 
-def test_osi_prompt_version_logs_template_lookup_errors():
-    with (
-        patch(
-            "datus.prompts.prompt_manager.get_prompt_manager",
-            side_effect=RuntimeError("template registry unavailable"),
-        ),
-        patch("datus.agent.node.semantic_authoring.logger") as mock_logger,
-    ):
-        assert osi_prompt_version(None, "gen_metrics", "1.2") is None
-
-    mock_logger.debug.assert_called_once()
-    assert "Failed to list OSI prompt template versions" in mock_logger.debug.call_args.args[0]
-
-
-def test_osi_metrics_template_renders_despite_injected_metricflow_version():
-    # Regression: the OSI template must still render when the resolved version
-    # falls back to latest (the injected "1.2" does not exist for it).
-    pm = get_prompt_manager()
-    version = osi_prompt_version(None, "gen_metrics", "1.2")
-    text = pm.render_template(template_name="gen_metrics_osi_system", version=version)
-    assert "OSI" in text
-
-
-def test_osi_skill_skip_handles_missing_node_config(monkeypatch):
+@pytest.mark.parametrize("adapter", ["metricflow", "osi"])
+def test_node_skill_defaults_follow_authoring_format(monkeypatch, adapter):
+    """Both nodes default node_config['skills'] from the format, then defer to the base setup."""
     from datus.agent.node.agentic_node import AgenticNode
     from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
     from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
 
     parent_calls = []
-
-    def _unexpected_parent_call(self):
-        parent_calls.append(type(self).__name__)
-
-    monkeypatch.setattr(AgenticNode, "_setup_skill_func_tools", _unexpected_parent_call)
+    monkeypatch.setattr(AgenticNode, "_setup_skill_func_tools", lambda self: parent_calls.append(type(self).__name__))
 
     metrics_node = GenMetricsAgenticNode.__new__(GenMetricsAgenticNode)
-    metrics_node.agent_config = _agent_config("osi")
-    metrics_node.node_config = None
+    metrics_node.agent_config = _agent_config(adapter)
+    metrics_node.node_config = {}
     metrics_node._setup_skill_func_tools()
 
     semantic_node = GenSemanticModelAgenticNode.__new__(GenSemanticModelAgenticNode)
-    semantic_node.agent_config = _agent_config("osi")
-    semantic_node.node_config = None
+    semantic_node.agent_config = _agent_config(adapter)
+    semantic_node.node_config = {}
     semantic_node._setup_skill_func_tools()
 
-    assert parent_calls == [], "MetricFlow skills should not be injected in OSI mode"
+    assert parent_calls == ["GenMetricsAgenticNode", "GenSemanticModelAgenticNode"]
+    assert semantic_node.node_config["skills"] == "semantic-sql-history-profiler"
+    expected_metrics_optional = "metricflow-semantic-authoring" if adapter == "metricflow" else "osi-semantic-authoring"
+    assert metrics_node.node_config["skills"] == expected_metrics_optional
+
+
+def test_node_skill_defaults_respect_explicit_config(monkeypatch):
+    """An explicit skills entry (including opt-out '') is never overwritten."""
+    from datus.agent.node.agentic_node import AgenticNode
+    from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+
+    monkeypatch.setattr(AgenticNode, "_setup_skill_func_tools", lambda self: None)
+
+    node = GenSemanticModelAgenticNode.__new__(GenSemanticModelAgenticNode)
+    node.agent_config = _agent_config("osi")
+    node.node_config = {"skills": ""}
+    node._setup_skill_func_tools()
+
+    assert node.node_config["skills"] == ""
+
+
+@pytest.mark.parametrize(
+    "adapter, expected",
+    [("metricflow", ["metricflow-semantic-authoring"]), ("osi", ["osi-semantic-authoring"])],
+)
+def test_gen_semantic_model_required_skills(adapter, expected):
+    from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+
+    node = GenSemanticModelAgenticNode.__new__(GenSemanticModelAgenticNode)
+    node.agent_config = _agent_config(adapter)
+    assert node._get_required_skills() == expected
+
+
+@pytest.mark.parametrize(
+    "adapter, expected",
+    [("metricflow", ["gen-metrics"]), ("osi", ["osi-metrics-authoring"])],
+)
+def test_gen_metrics_required_skills(adapter, expected):
+    from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+    node = GenMetricsAgenticNode.__new__(GenMetricsAgenticNode)
+    node.agent_config = _agent_config(adapter)
+    assert node._get_required_skills() == expected

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -1,125 +1,125 @@
-"""OSI-mode generation prompt templates render and stay backend-agnostic.
+"""Shared generation prompt templates render both authoring formats.
 
-These also assert that adding the OSI templates does not change which template
-the default (metricflow) mode resolves to.
+Both formats resolve to one `{node}_system` template; the format-specific
+authoring specification lives in required skills (see
+tests/unit_tests/tools/skill_tools and test_semantic_authoring.py), so these
+tests cover the orchestration layer only: role boundary, dynamic OSI values,
+profiler gate, and the final JSON contract.
 """
+
+import pytest
 
 from datus.prompts.prompt_manager import get_prompt_manager
 
+COMMON_VARS = {
+    "native_tools": "get_table_ddl, write_file",
+    "mcp_tools": "None",
+    "has_ask_user_tool": True,
+    "knowledge_base_dir": "/kb",
+    "semantic_model_dir": "/kb/semantic_models/duckdb",
+    "kind_subdir": "subject/semantic_models/duckdb",
+    "default_osi_semantic_model_name": "sales_domain",
+    "default_osi_semantic_model_file": "subject/semantic_models/duckdb/sales_domain.yml",
+}
 
-def test_osi_metrics_template_is_backend_agnostic():
+
+def _render(template_name: str, authoring_format: str, datasource: str = "duckdb") -> str:
     pm = get_prompt_manager()
-    text = pm.render_template(template_name="gen_metrics_osi_system")
-    assert "OSI" in text
-    # explicit boundary: the LLM must not emit execution-engine syntax
-    assert "do NOT write MetricFlow YAML" in text
-    assert "version: 0.2.0.dev0" in text
-    assert "semantic_model:" in text
-    assert "metrics:" in text
-    assert "dialects:" in text
-    assert "custom_extensions" in text
-    assert '"dataset"' in text
-    assert "not OSI core top-level metric fields" in text
-    assert "metric:" in text  # only mentioned as a forbidden MetricFlow block
-    assert '"status": "skipped"' in text
-    assert "No metric generated" in text
-    assert "from_columns" in text
-    assert "to_columns" in text
-    assert "Never put `relationships` inside a dataset" in text
-    assert "analyze_metric_candidates_from_history" in text
-    assert "metric_generation_skips" in text
-    assert "offset_window" in text
-    assert "window_aggregation" in text
-    assert "publish reusable comparison outputs as fixed, standalone metrics" in text
-    assert "comparison context computed from the same base aggregate" in text
-    assert "Do NOT generate helper metrics" not in text
-    assert "Allowed values are `sum`, `avg`, `min`, `max`, `count`, and `row_count`" in text
-    assert "ROW_NUMBER()`, `RANK() OVER`, TopN per group" in text
-    assert "Target semantic model file: `subject/semantic_models/<datasource>/<model_name>.yml`" in text
-    assert '"metric_file": "subject/semantic_models/<datasource>/<model_name>.yml"' in text
-    assert "a separate metric file is allowed" not in text
+    return pm.render_template(
+        template_name=template_name,
+        authoring_format=authoring_format,
+        current_datasource=datasource,
+        **COMMON_VARS,
+    )
 
 
-def test_osi_metrics_template_uses_osi_schema_expression_dialect_for_sql_datasources():
+@pytest.mark.parametrize("template_name", ["gen_semantic_model_system", "gen_metrics_system"])
+def test_templates_reference_required_skill_spec(template_name):
+    for authoring_format in ("metricflow", "osi"):
+        text = _render(template_name, authoring_format)
+        assert "<required_skill>" in text, (template_name, authoring_format)
+
+
+def test_semantic_model_template_metricflow_mode():
+    text = _render("gen_semantic_model_system", "metricflow")
+    assert "MetricFlow expert" in text
+    assert "OSI expression dialect" not in text
+    assert '"semantic_model_files"' in text
+    assert "validate_semantic" in text
+    assert "end_semantic_model_generation" in text
+
+
+def test_semantic_model_template_osi_mode():
+    text = _render("gen_semantic_model_system", "osi")
+    assert "OSI (Open Semantic Interchange) core schema" in text
+    assert "never write backend YAML" in text
+    assert "Target semantic model file: `subject/semantic_models/duckdb/sales_domain.yml`" in text
+    assert '"semantic_model_files"' in text  # same publish contract as metricflow
+
+
+@pytest.mark.parametrize("template_name", ["gen_semantic_model_system", "gen_metrics_system"])
+@pytest.mark.parametrize(
+    "datasource, expected_dialect",
+    [("starrocks", "ANSI_SQL"), ("mysql", "ANSI_SQL"), ("snowflake", "SNOWFLAKE"), ("databricks", "DATABRICKS")],
+)
+def test_osi_mode_expression_dialect_derivation(template_name, datasource, expected_dialect):
+    text = _render(template_name, "osi", datasource=datasource)
+    assert f"- Active datasource: `{datasource}`" in text
+    assert f"OSI expression dialect for this run: `{expected_dialect}`" in text
+
+
+def test_metrics_template_metricflow_mode_contract():
+    text = _render("gen_metrics_system", "metricflow")
+    assert "MetricFlow metric definition expert" in text
+    assert '"semantic_model_files"' in text
+    assert '"metric_file"' in text
+    assert "locked_metadata.tags" in text
+    assert "OSI expression dialect" not in text
+    assert "end_metric_generation" in text
+
+
+def test_metrics_template_osi_mode_contract():
+    text = _render("gen_metrics_system", "osi")
+    assert "OSI (Open Semantic Interchange) core semantic model" in text
+    # OSI metrics report a singular semantic_model_file in the final JSON.
+    assert '"semantic_model_file"' in text
+    assert "subject_path" in text
+    assert "locked_metadata.tags" not in text.split("Record the classification")[1].split("\n")[0]
+    assert "Covered by an existing base metric" in text
+
+
+def test_semantic_model_template_includes_profiler_gate_both_formats():
+    for authoring_format in ("metricflow", "osi"):
+        text = _render("gen_semantic_model_system", authoring_format)
+        assert "Optional SQL History & Distribution Profiling" in text, authoring_format
+        assert 'load_skill("semantic-sql-history-profiler")' in text, authoring_format
+        # Explicit-ask trigger: providing SQL alone must not trigger profiling.
+        assert "Providing SQL alone is NOT a trigger" in text, authoring_format
+        assert "still use it directly as modeling context" in text, authoring_format
+
+
+def test_metrics_template_has_no_profiler_gate():
+    for authoring_format in ("metricflow", "osi"):
+        text = _render("gen_metrics_system", authoring_format)
+        assert "semantic-sql-history-profiler" not in text, authoring_format
+
+
+def test_latest_versions_resolve_to_shared_templates():
     pm = get_prompt_manager()
-    for datasource in ("starrocks", "mysql"):
-        text = pm.render_template(template_name="gen_metrics_osi_system", current_datasource=datasource)
-        assert f"- Active datasource: `{datasource}`" in text
-        assert "- OSI expression dialect: `ANSI_SQL`" in text
-        assert "- dialect: ANSI_SQL" in text
-        assert f"- dialect: {datasource}" not in text
+    assert pm.get_latest_version("gen_semantic_model_system") == "2.0"
+    assert pm.get_latest_version("gen_metrics_system") == "2.0"
 
 
-def test_osi_metrics_template_uses_osi_native_dialect_when_schema_supports_it():
+def test_legacy_osi_templates_are_removed():
     pm = get_prompt_manager()
-    text = pm.render_template(template_name="gen_metrics_osi_system", current_datasource="snowflake")
-    assert "- OSI expression dialect: `SNOWFLAKE`" in text
-    assert "- dialect: SNOWFLAKE" in text
+    for template_name in ("gen_semantic_model_osi_system", "gen_metrics_osi_system"):
+        assert not pm.list_template_versions(template_name), template_name
 
 
-def test_osi_semantic_model_template_is_backend_agnostic():
+def test_rollback_anchor_versions_still_render():
+    """Pinning prompt_version to the pre-refactor templates must keep working."""
     pm = get_prompt_manager()
-    text = pm.render_template(template_name="gen_semantic_model_osi_system")
-    assert "OSI" in text
-    assert "version: 0.2.0.dev0" in text
-    assert "semantic_model:" in text
-    assert "datasets:" in text
-    assert "fields:" in text
-    assert "dialects:" in text
-    assert "custom_extensions" in text
-    assert "Dataset `source` is a string" in text
-    assert "Dataset description and AI context are required for every dataset" in text
-    assert "ai_context" in text
-    assert "row grain" in text
-    assert "relationships:" in text
-    assert "from_columns" in text
-    assert "to_columns" in text
-    assert "do NOT write MetricFlow" in text
-    assert "never inside a dataset" in text
-    assert "business domain / semantic model scope" in text
-    assert "Target semantic model file: `subject/semantic_models/<datasource>/<model_name>.yml`" in text
-    assert '"semantic_model_files": ["subject/semantic_models/<datasource>/<model_name>.yml"]' in text
-    assert "Field type classification must follow actual data type and analytical usage" in text
-    assert "A numeric field does not become categorical" in text
-    assert 'data: \'{"type":"numeric"}\'' in text
-    assert "Numeric-coded categories" in text
-    assert "One canonical dataset per physical table" not in text
-    assert "<table_name>.yml" not in text
-
-
-def test_osi_semantic_model_template_uses_osi_schema_expression_dialect_for_sql_datasources():
-    pm = get_prompt_manager()
-    for datasource in ("starrocks", "mysql"):
-        text = pm.render_template(template_name="gen_semantic_model_osi_system", current_datasource=datasource)
-        assert f"- Active datasource: `{datasource}`" in text
-        assert "- OSI expression dialect: `ANSI_SQL`" in text
-        assert "- dialect: ANSI_SQL" in text
-        assert f"- dialect: {datasource}" not in text
-
-
-def test_osi_semantic_model_template_uses_osi_native_dialect_when_schema_supports_it():
-    pm = get_prompt_manager()
-    for datasource, expected_dialect in (("databricks", "DATABRICKS"), ("snowflake", "SNOWFLAKE")):
-        text = pm.render_template(template_name="gen_semantic_model_osi_system", current_datasource=datasource)
-        assert f"- OSI expression dialect: `{expected_dialect}`" in text
-        assert f"- dialect: {expected_dialect}" in text
-
-
-def test_default_metricflow_templates_are_unchanged():
-    pm = get_prompt_manager()
-    # The default metricflow mode still resolves to its existing latest versions,
-    # unaffected by the new OSI templates (separate template name).
-    assert pm.get_latest_version("gen_metrics_system") == "1.2"
-    assert pm.get_latest_version("gen_semantic_model_system") == "1.1"
-    # OSI templates have their own independent versioning.
-    assert pm.get_latest_version("gen_metrics_osi_system") == "1.0"
-
-
-def test_metricflow_semantic_model_template_classifies_numeric_fields_by_usage():
-    pm = get_prompt_manager()
-    text = pm.render_template(template_name="gen_semantic_model_system")
-    assert "Classify each column by actual data type and analytical usage" in text
-    assert "DECIMAL/NUMERIC/INTEGER/FLOAT/DOUBLE" in text
-    assert "Do not model an aggregatable numeric business value as a categorical dimension" in text
-    assert "AVG(<field>)" in text
-    assert "Numeric-coded categories" in text
+    old_semantic = pm.render_template(template_name="gen_semantic_model_system", version="1.1")
+    assert "MetricFlow" in old_semantic
+    old_metrics = pm.render_template(template_name="gen_metrics_system", version="1.2")
+    assert "MetricFlow" in old_metrics


### PR DESCRIPTION
## Why

Semantic model and metric generation exposed several knobs to users and duplicated the authoring specification between prompt templates and skills:

- The active authoring format (`metricflow` vs `osi`) drove behavior through scattered special-cases: a hardcoded `DEFAULT_SKILLS`, an OSI "skip default skills" override hack in two nodes, and separate `*_osi_system` prompt templates.
- The full YAML authoring spec lived inside the (423-line) prompt templates, with the skills largely repeating the same workflow — so "skill-first" was nominal and users had to wire `skills:` manually to enable profiling.
- OSI mode silently suppressed the optional `semantic-sql-history-profiler` even though the OSI prompt explicitly wanted it available.

Goal: drive the whole flow automatically from one config field (the active semantic adapter), keep the prompt/skills lean, and let profiling auto-trigger without user configuration.

## Solution

Everything is now derived from the active semantic adapter; the user configures only the adapter.

- **`REQUIRED_SKILLS` host-injection primitive** on `AgenticNode`: skills that carry a required specification are injected into the system prompt deterministically at render time (and excluded from `<available_skills>`), instead of relying on the LLM to call `load_skill`. Missing required skills fail fast.
- **One shared template per node** (`gen_semantic_model_system_2.0`, `gen_metrics_system_2.0`): a thin orchestration layer plus runtime-only dynamic values (OSI dialect, target paths, JSON contract, profiler gate). The `*_osi_system` templates and the `osi_template_name`/`osi_prompt_version` helpers are removed; pre-refactor template versions stay on disk as rollback anchors.
- **Format-derived skills**: `metricflow-semantic-authoring` / `osi-semantic-authoring` / `gen-metrics` / `osi-metrics-authoring` carry the format spec as required skills; the OSI skip-hack overrides in both nodes are deleted. Optional skills default from the format too.
- **Profiler auto-trigger**: `semantic-sql-history-profiler` is registered by default for both formats; the rewritten gate triggers it only on an explicit user request for profiling/statistics/history mining (providing SQL alone is not a trigger; inline SQL is still used directly as modeling context). Users can still opt out with `skills: ""`.
- **`osi-semantic-authoring` convergence fix**: added a "one column, one type model-wide" consistency rule and an "omit columns no query uses" rule after a benchmark run showed the LLM exhausting max_turns by toggling a never-referenced primary-key column between identifier and dimension across datasets.

Net effect: −2 OSI templates, −2 override hacks, ~−45 lines of template-selection code, one fewer copy of the authoring spec; the user-facing config surface collapses to the semantic adapter, with `./.datus/skills/` project overrides and `prompt_version` pinning as escape hatches.

## Test Cases

Unit tests updated/added under `tests/unit_tests/`:

- `test_semantic_authoring.py`: format→required/optional skill derivation (parametrized both formats), node skill defaults, explicit-config opt-out.
- `test_agentic_node_skills.py`: `REQUIRED_SKILLS` injection, missing-skill fail-fast, multi-skill, and `<available_skills>` exclusion.
- `test_gen_semantic_model_agentic_node.py` / `test_gen_metrics_agentic_node.py`: shared-template selection with `authoring_format` in context, per-format required-skill injection into the prompt, profiler tool registered by default and removed on `skills: ""`.
- `test_osi_authoring_templates.py`: rewritten for the shared templates — both-format render assertions, OSI dialect derivation, profiler-gate presence/explicit-ask wording, legacy OSI templates removed, rollback-version rendering.

Full unit suite green (14050 passed); PR CI harness 2119 passed / 0 failed, diff coverage 96%; `ci/audit_tests.py --diff-only` P0=0.

Additionally validated end-to-end on the `baisheng_ask_metrics` OSI benchmark (StarRocks, deepseek-v4-pro): logs confirm required-skill injection and format-derived optional skills; the convergence fix reduced semantic_model `validate_semantic` calls 22→5, type-conflict errors 15→2, max-turns events 2→0, and metric batches 9/11→11/11. Nightly/regression semantic-generation runs remain the gate for prompt-quality changes.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added automatic skill injection for semantic model and metric generation, including required authoring guidance at build time.
  * Introduced support for shared prompt templates across authoring formats, with format-specific behavior handled automatically.

* **Bug Fixes**
  * Historical SQL profiling now only runs when explicitly requested, reducing unexpected profiler use.
  * Prompt generation now uses clearer, consistent output rules and validation flow for both metric and semantic model authoring.

* **Documentation**
  * Updated authoring guides and examples for MetricFlow and OSI workflows, including improved skill and profiling instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->