### PR TITLE
[BugFix] func_tool dispatch: reject missing required args instead of crashing

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -178,6 +178,31 @@ def trans_to_function_tool(
                     )
                     args_dict = {k: v for k, v in args_dict.items() if k in valid_params}
 
+            # Reject missing required parameters symmetrically with the extra/
+            # excluded-parameter handling above. Without this, an LLM tool call
+            # that omits a required argument (e.g. ``edit_file`` without
+            # ``path``) reaches ``method_to_call(**args_dict)`` and raises a raw
+            # ``TypeError`` at bind time. That exception is uncaught here and
+            # aborts the whole agent interaction/batch, silently dropping work.
+            # Returning a recoverable error lets the model retry in-turn, the
+            # same as it does for malformed JSON or unsupported parameters.
+            missing_required = {
+                name
+                for name, param in sig.parameters.items()
+                if name != "self"
+                and name not in excluded_param_set
+                and param.default is inspect.Parameter.empty
+                and param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+                and name not in args_dict
+            }
+            if missing_required:
+                params = ", ".join(sorted(missing_required))
+                return {
+                    "success": 0,
+                    "error": f"Missing required parameter(s) for '{method_to_call.__name__}': {params}",
+                    "result": None,
+                }
+
             if inspect.iscoroutinefunction(method_to_call):
                 result = await method_to_call(**args_dict)
             else:

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -124,6 +124,78 @@ class TestTransToFunctionTool:
         assert result["error"] == "Unsupported parameters for this tool: catalog"
 
     @pytest.mark.asyncio
+    async def test_missing_required_parameter_returns_recoverable_error(self):
+        """Omitting a required arg must yield a recoverable error, not a crash.
+
+        Regression: a tool call that drops a required argument (e.g. ``edit_file``
+        without ``path``) previously reached ``method_to_call(**args_dict)`` and
+        raised a raw ``TypeError`` at bind time, aborting the whole agent
+        interaction. The dispatcher now rejects it up front so the model can retry.
+        """
+
+        class FakeTool:
+            def edit_file(self, path: str, old_string: str, new_string: str) -> FuncToolResult:
+                return FuncToolResult(result="edited")
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.edit_file)
+
+        args = json.dumps({"old_string": "a", "new_string": "b"})  # path omitted
+        result = await tool.on_invoke_tool(None, args)
+
+        assert result["success"] == 0
+        assert "Missing required parameter(s)" in result["error"]
+        assert "path" in result["error"]
+        assert "edit_file" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_multiple_required_parameters_are_all_reported(self):
+        class FakeTool:
+            def combine(self, a: str, b: str, c: int = 0) -> FuncToolResult:
+                return FuncToolResult(result="ok")
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.combine)
+
+        result = await tool.on_invoke_tool(None, json.dumps({"c": 5}))  # a, b omitted
+
+        assert result["success"] == 0
+        assert "a" in result["error"] and "b" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_all_required_present_still_runs(self):
+        """The guard must not block a well-formed call (no false positives)."""
+
+        class FakeTool:
+            def edit_file(self, path: str, old_string: str, new_string: str) -> FuncToolResult:
+                return FuncToolResult(result={"path": path})
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.edit_file)
+
+        args = json.dumps({"path": "orders.yml", "old_string": "a", "new_string": "b"})
+        result = await tool.on_invoke_tool(None, args)
+
+        assert result["success"] == 1
+        assert result["result"] == {"path": "orders.yml"}
+
+    @pytest.mark.asyncio
+    async def test_optional_parameters_may_be_omitted(self):
+        """Parameters with defaults are not required and may be omitted."""
+
+        class FakeTool:
+            def search_table(self, query_text: str, top_n: int = 5) -> FuncToolResult:
+                return FuncToolResult(result={"query_text": query_text, "top_n": top_n})
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.search_table)
+
+        result = await tool.on_invoke_tool(None, json.dumps({"query_text": "hello"}))
+
+        assert result["success"] == 1
+        assert result["result"] == {"query_text": "hello", "top_n": 5}
+
+    @pytest.mark.asyncio
     async def test_sync_tool_runs_off_the_event_loop_thread(self):
         """Synchronous tool methods must be offloaded to a worker thread.
 


### PR DESCRIPTION
## Why

An LLM tool call that omits a required argument crashes the entire agent interaction instead of failing gracefully. Observed during OSI metric generation (`baisheng_ask_metrics`, deepseek-v4-pro):

```
batch 10: gen_metrics interaction failed: Error running tool edit_file:
MetricFilesystemFuncTool.edit_file() missing 1 required positional argument: 'path'
```

The whole `gen_metrics` batch aborted and its metrics were silently dropped (run reported 9/11 batches). Fixes #1121.

## Solution

Root cause is in the tool dispatcher (`trans_to_function_tool` → `final_invoker`, `datus/tools/func_tool/base.py`). It already filters out extra/hallucinated params and returns recoverable errors for malformed JSON and unsupported params, but had **no check for missing required params**. When a required arg is absent, `method_to_call(**args_dict)` raises a raw `TypeError` at bind time; that exception is uncaught in the invoker and propagates up to abort the interaction.

Add a missing-required-parameter check symmetric with the existing extra/excluded-parameter handling: a parameter that has no default, is a normal positional/keyword param, and is not host-injected via `excluded_params` must be present — otherwise return `{success: 0, error: "Missing required parameter(s) for '<tool>': <names>"}`. The model can then retry in-turn, exactly as it does for the other malformed-call classes. One dispatcher-level fix covers every func_tool, not just `edit_file`.

## Test Cases

`tests/unit_tests/tools/func_tool/test_base.py` (unit, deterministic, no external calls):

- `test_missing_required_parameter_returns_recoverable_error` — `edit_file` without `path` returns a recoverable error naming the tool and the missing param, instead of raising.
- `test_missing_multiple_required_parameters_are_all_reported` — all missing required names reported.
- `test_all_required_present_still_runs` — no false positive on a well-formed call.
- `test_optional_parameters_may_be_omitted` — params with defaults are not treated as required.

Full `test_base.py` suite green (17 passed); `ci/audit_tests.py --diff-only` P0=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing required tool arguments now return a clear, structured failure instead of crashing the request flow.
  * Error messages now identify which required parameter(s) are missing.

* **Tests**
  * Added coverage for missing required arguments, multiple missing parameters, and successful calls when all required values are present.
  * Confirmed optional parameters with defaults can still be omitted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->