### PR TITLE
[Enhancement] Run web filesystem tools server-side under auto/dangerous profiles

### DIFF
--- a/datus/api/services/action_sse_converter.py
+++ b/datus/api/services/action_sse_converter.py
@@ -6,7 +6,7 @@ chat-history retrieval can share the same conversion logic.
 """
 
 import json
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Set
 
 from datus.agent.node.compact_archive import parse_archived_marker
 from datus.api.models.cli_models import (
@@ -52,14 +52,26 @@ def _extract_function(action: ActionHistory) -> tuple[str, dict]:
     return function_name, arguments
 
 
-def _build_tool_call_content(action: ActionHistory) -> List[IMessageContent]:
-    """Build content for tool call started event."""
+def _build_tool_call_content(
+    action: ActionHistory, proxied_tool_names: Optional[Set[str]] = None
+) -> List[IMessageContent]:
+    """Build content for tool call started event.
+
+    ``proxied_tool_names`` — names of tools the client must execute and
+    report back (see ``apply_proxy_tools``). When provided, the payload
+    carries ``proxied`` so the web client knows whether to run the tool
+    (True) or the server already ran it (False). Omitted for converters
+    without a live node (history retrieval): absent means the client
+    falls back to its legacy heuristic.
+    """
     function_name, arguments = _extract_function(action)
     payload_data = {
         "callToolId": action.action_id,
         "toolName": function_name,
         "toolParams": arguments,
     }
+    if proxied_tool_names is not None:
+        payload_data["proxied"] = function_name in proxied_tool_names
     return [IMessageContent(type="call-tool", payload=payload_data)]
 
 
@@ -442,6 +454,7 @@ def action_to_sse_event(
     is_first_delta: bool = True,
     is_update: bool = False,
     include_final_response: bool = False,
+    proxied_tool_names: Optional[Set[str]] = None,
 ) -> Optional[SSEEvent]:
     """Convert an ActionHistory object to an SSEEvent.
 
@@ -469,6 +482,10 @@ def action_to_sse_event(
         If True, convert node wrapper actions such as chat_response to markdown.
         Streaming callers should only set this when no plain assistant response
         has already been emitted for the turn.
+    proxied_tool_names : Optional[Set[str]]
+        Tool names proxied to the client for execution; stamps ``proxied``
+        on call-tool payloads (see ``_build_tool_call_content``). Pass None
+        when no live node is available (history retrieval).
     """
     try:
         role = action.role
@@ -533,7 +550,7 @@ def action_to_sse_event(
         elif action.action_type == SUBAGENT_COMPLETE_ACTION_TYPE:
             contents = _build_subagent_complete_content(action)
         elif role == ActionRole.TOOL and status == ActionStatus.PROCESSING:
-            contents = _build_tool_call_content(action)
+            contents = _build_tool_call_content(action, proxied_tool_names)
         elif role == ActionRole.TOOL:
             contents = _build_tool_result_content(action)
         elif role == ActionRole.INTERACTION and status == ActionStatus.PROCESSING:

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -606,7 +606,13 @@ class ChatTaskManager:
                     # server-side. The empty set reaches the SSE converter so
                     # call-tool frames carry ``proxied: false`` and the client
                     # knows not to execute them itself.
-                    node.proxied_tool_names = set()
+                    # Mutate in place like ``apply_proxy_tools`` does —
+                    # PermissionHooks may hold a shared reference to the set.
+                    existing_proxied = getattr(node, "proxied_tool_names", None)
+                    if isinstance(existing_proxied, set):
+                        existing_proxied.clear()
+                    else:
+                        node.proxied_tool_names = set()
                     logger.info(
                         "Filesystem tools run server-side for session=%s (profile=%s)", session_id, active_profile
                     )

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -588,9 +588,30 @@ class ChatTaskManager:
             # guard is needed here.
             effective_source = request.source or self._default_source
             if effective_source == "vscode":
+                # VSCode edits the user's *local* filesystem — the client is
+                # always the executor, whatever the permission profile.
                 apply_proxy_tools(node, ["filesystem_tools.*"])
             elif effective_source == "web":
-                apply_proxy_tools(node, ["write_file", "edit_file", "delete_file"])
+                # The active profile (not request.permission_mode) is checked
+                # because a failed ``switch_profile`` silently keeps the
+                # node's original profile — proxying must follow what will
+                # actually gate execution.
+                active_profile = getattr(getattr(node, "permission_manager", None), "active_profile", None)
+                if active_profile in ("auto", "dangerous"):
+                    # These profiles ALLOW workspace writes without asking and
+                    # the web client skips its confirmation UI for them, so a
+                    # browser round-trip buys nothing and only adds failure
+                    # modes (hidden/closed tab, dropped SSE → the proxy-result
+                    # wait timing out after 600s). Run filesystem tools
+                    # server-side. The empty set reaches the SSE converter so
+                    # call-tool frames carry ``proxied: false`` and the client
+                    # knows not to execute them itself.
+                    node.proxied_tool_names = set()
+                    logger.info(
+                        "Filesystem tools run server-side for session=%s (profile=%s)", session_id, active_profile
+                    )
+                else:
+                    apply_proxy_tools(node, ["write_file", "edit_file", "delete_file"])
             elif effective_source:
                 logger.warning("Unsupported source '%s'; skipping proxy shortcut", effective_source)
 
@@ -639,6 +660,7 @@ class ChatTaskManager:
                     is_first_delta=is_first_delta,
                     is_update=bool(is_update),
                     include_final_response=_should_include_final_response(action, assistant_response_sent),
+                    proxied_tool_names=getattr(node, "proxied_tool_names", None),
                 )
                 if sse:
                     # Per-LLM-call usage event: the converter has no access

--- a/tests/unit_tests/api/services/test_action_sse_converter.py
+++ b/tests/unit_tests/api/services/test_action_sse_converter.py
@@ -146,6 +146,25 @@ class TestBuildToolCallContent:
         contents = _build_tool_call_content(action)
         assert contents[0].payload["toolParams"] == {}
 
+    def test_omits_proxied_flag_without_tool_names(self):
+        """History conversion (no live node) must not stamp ``proxied`` at all,
+        so legacy clients keep their own execute-or-not heuristic."""
+        action = _make_action(input={"function_name": "write_file", "arguments": {}})
+        contents = _build_tool_call_content(action)
+        assert "proxied" not in contents[0].payload
+
+    def test_marks_proxied_true_for_client_executed_tool(self):
+        action = _make_action(input={"function_name": "write_file", "arguments": {}})
+        contents = _build_tool_call_content(action, proxied_tool_names={"write_file", "edit_file"})
+        assert contents[0].payload["proxied"] is True
+
+    def test_marks_proxied_false_for_server_executed_tool(self):
+        """An empty proxied set (auto/dangerous web session) stamps False so the
+        client neither shows a confirm bar nor re-executes the tool."""
+        action = _make_action(input={"function_name": "write_file", "arguments": {}})
+        contents = _build_tool_call_content(action, proxied_tool_names=set())
+        assert contents[0].payload["proxied"] is False
+
 
 class TestBuildToolResultContent:
     """Tests for _build_tool_result_content."""
@@ -900,6 +919,20 @@ class TestActionToSSEEvent:
         event = action_to_sse_event(action, event_id=2, message_id="msg-2")
         event = _assert_sse_event(event)
         assert event.data.payload.content[0].type == "call-tool"
+
+    def test_tool_processing_passes_proxied_tool_names_through(self):
+        """The streaming caller's proxied set reaches the call-tool payload."""
+        action = _make_action(
+            role=ActionRole.TOOL,
+            status=ActionStatus.PROCESSING,
+            input={"function_name": "write_file", "arguments": {"path": "a.sql"}},
+        )
+        event = action_to_sse_event(action, event_id=2, message_id="msg-2", proxied_tool_names=set())
+        event = _assert_sse_event(event)
+        assert event.data.payload.content[0].payload["proxied"] is False
+
+        event = action_to_sse_event(action, event_id=3, message_id="msg-3", proxied_tool_names={"write_file"})
+        assert _assert_sse_event(event).data.payload.content[0].payload["proxied"] is True
 
     def test_tool_success_produces_call_tool_result(self):
         """TOOL + SUCCESS maps to call-tool-result content."""

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -426,6 +426,82 @@ class TestChatTaskManagerBehavior:
         assert called_patterns == ["write_file", "edit_file", "delete_file"]
         assert task.status == "completed"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("profile", ["auto", "dangerous"])
+    async def test_run_loop_web_source_skips_proxy_for_auto_and_dangerous(self, real_agent_config, profile):
+        """auto/dangerous web sessions run filesystem tools server-side: no
+        client proxy (which would block on a browser that may be hidden or
+        gone), and an empty proxied set so SSE frames carry proxied=False."""
+        from types import SimpleNamespace
+
+        from datus.api.models.cli_models import StreamChatInput
+
+        class FakeNode:
+            session_id = f"s-web-{profile}"
+            permission_manager = SimpleNamespace(active_profile=profile)
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                return
+                yield  # pragma: no cover - makes this an async generator
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id=f"s-web-{profile}", asyncio_task=MagicMock())
+
+        with patch("datus.api.services.chat_task_manager.apply_proxy_tools") as mock_apply:
+            await manager._run_loop(
+                task,
+                real_agent_config,
+                StreamChatInput(message="hi", source="web", session_id=f"s-web-{profile}"),
+            )
+
+        mock_apply.assert_not_called()
+        assert task.node.proxied_tool_names == set()
+        assert task.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_run_loop_web_source_normal_profile_still_proxies(self, real_agent_config):
+        """A node whose active profile is ``normal`` keeps the client proxy —
+        the confirm UI lives in the browser."""
+        from types import SimpleNamespace
+
+        from datus.api.models.cli_models import StreamChatInput
+
+        class FakeNode:
+            session_id = "s-web-normal"
+            permission_manager = SimpleNamespace(active_profile="normal")
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                return
+                yield  # pragma: no cover - makes this an async generator
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-web-normal", asyncio_task=MagicMock())
+
+        with patch("datus.api.services.chat_task_manager.apply_proxy_tools") as mock_apply:
+            await manager._run_loop(
+                task,
+                real_agent_config,
+                StreamChatInput(message="hi", source="web", session_id="s-web-normal"),
+            )
+
+        mock_apply.assert_called_once()
+        assert mock_apply.call_args.args[1] == ["write_file", "edit_file", "delete_file"]
+        assert task.status == "completed"
+
     def test_include_final_response_rejects_nested_subagent_response(self):
         """Depth>0 sub-agent wrappers must not render as top-level answers."""
         from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -440,6 +440,11 @@ class TestChatTaskManagerBehavior:
             session_id = f"s-web-{profile}"
             permission_manager = SimpleNamespace(active_profile=profile)
 
+            def __init__(self):
+                # Simulate a pre-populated shared set (PermissionHooks may
+                # hold a reference): the skip path must clear it in place.
+                self.proxied_tool_names = {"write_file"}
+
             def get_node_name(self):
                 return "chat"
 
@@ -450,8 +455,11 @@ class TestChatTaskManagerBehavior:
             async def get_last_turn_usage(self):
                 return None
 
+        node = FakeNode()
+        shared_ref = node.proxied_tool_names
+
         manager = ChatTaskManager()
-        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        manager._create_node = lambda *args, **kwargs: node  # type: ignore[method-assign]
         task = ChatTask(session_id=f"s-web-{profile}", asyncio_task=MagicMock())
 
         with patch("datus.api.services.chat_task_manager.apply_proxy_tools") as mock_apply:
@@ -462,7 +470,10 @@ class TestChatTaskManagerBehavior:
             )
 
         mock_apply.assert_not_called()
-        assert task.node.proxied_tool_names == set()
+        # In-place clear, not rebinding — hooks holding the old reference
+        # must observe the emptied set.
+        assert task.node.proxied_tool_names is shared_ref
+        assert shared_ref == set()
         assert task.status == "completed"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Why

Web-sourced `write_file` / `edit_file` / `delete_file` are proxied to the browser unconditionally: the agent loop blocks in `ToolResultChannel.wait_for(call_id, 600s)` until the client executes the tool and POSTs `/chat/tool_result`. Under `auto`/`dangerous` permission modes the web client shows **no confirmation UI** — the browser round-trip buys nothing, and any liveness gap on the client side (hidden/frozen tab, closed laptop, dropped SSE stream, user navigating away mid-turn) turns every file tool call into a 10-minute proxy timeout. This matches user reports of file-tool timeouts with `permissionMode=dangerous`.

## Solution

- **`chat_task_manager`**: for `source=web`, skip `apply_proxy_tools` when the node's **active** permission profile is `auto` or `dangerous` — filesystem tools execute server-side, exactly like the existing `_FS_DEPENDENT_NODES` path (gen_visual_report etc.). The active profile is checked on the node rather than `request.permission_mode` because a failed `switch_profile` silently keeps the original profile, and proxying must follow what actually gates execution. `proxied_tool_names` is cleared **in place** (same convention as `apply_proxy_tools` — PermissionHooks may hold a shared reference). `vscode` keeps the proxy unconditionally — files live on the user's machine. Sub-agents follow automatically: they only proxy when the parent has `proxy_tool_patterns`, which this path never sets.
- **`action_sse_converter`**: call-tool payloads now carry `proxied` when the streaming caller passes the node's `proxied_tool_names` (skipping the proxy leaves an empty set → frames say `proxied: false`). The web client uses the flag to decide whether it must execute the tool (`true`), or the server already ran it (`false` → display-only). The flag is **omitted** in history conversion (no live node), where legacy client heuristics still apply. Side fix: under web+normal, `_FS_DEPENDENT_NODES` server-side writes were redundantly re-executed by the client heuristic; new clients see `proxied: false` and stop.

### Behavior change: `auto` × EXTERNAL-path writes

Previously (proxied), PermissionHooks skipped checks for proxied tools entirely and the auto-mode client executed without asking. Now server-side execution goes through the filesystem zone matrix: `auto` × EXTERNAL(interactive) is **ASK(path)** — the user gets a permission interaction (via the existing InteractionBroker → `user-interaction` SSE frame → web `UserInteraction` component → `/chat/user_interaction`, the same channel auto-mode DB-write ASKs already use) instead of a silent client-side write outside the workspace. `dangerous` bypasses EXTERNAL and is unaffected. This is a deliberate tightening: the zone matrix now actually applies to web file writes.

Rollout is order-independent with the companion web PR (Datus-ai/Datus-saas#598): an old client ignores the flag and redundantly re-executes an already-server-executed write (same content, reported result is logged as late/ignored); a new client with an old backend sees no flag and keeps executing as today.

## Test Cases

`tests/unit_tests/api/services/`:
- `test_action_sse_converter.py`: `proxied` omitted without a tool-name set; `True` for a name in the set; `False` for an empty set; pass-through from `action_to_sse_event` on TOOL/PROCESSING actions.
- `test_chat_task_manager.py`: web + active profile `auto`/`dangerous` → `apply_proxy_tools` not called and a pre-populated `proxied_tool_names` set is cleared **in place** (identity asserted); web + `normal` → proxy applied with the write-tool patterns (existing no-permission-manager test keeps covering the legacy default).

`ci/run-pr-tests.py upstream/main`: impacted unit tests 779 passed (exit 0), diff coverage **100%**. The acceptance-harness failures in the run are local-environment only (this checkout's `.datus/config.yml` sets `default_datasource: finbench`, which the harness config does not know) and unrelated to this diff. `ci/audit_tests.py --diff-only`: P0=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamed tool-call events now include a `proxied` indicator to show whether tool execution was handled locally or delegated.

* **Bug Fixes**
  * Web file actions now follow the active permission profile: in more restrictive profiles, filesystem tools run server-side instead of being proxied.
  * Tool-call streaming frames now consistently carry the correct proxy status.

* **Tests**
  * Added unit tests validating `proxied` flag behavior and permission-profile-driven web execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->