### PR TITLE
[BugFix] Fix --task_db_name parameter being ignored in current_db_name_type

### DIFF
--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1794,7 +1794,7 @@ class AgentConfig:
         if db_name and db_name in datasources:
             return db_name, datasources[db_name].type
         if self._current_datasource and self._current_datasource in datasources:
-            return self._current_datasource, datasources[self._current_datasource].type
+            return db_name or self._current_datasource, datasources[self._current_datasource].type
         if len(datasources) == 1:
             cfg = list(datasources.values())[0]
             return next(iter(datasources)), cfg.type

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1791,10 +1791,14 @@ class AgentConfig:
 
     def current_db_name_type(self, db_name: str) -> tuple[str, str]:
         datasources = self.services.datasources
-        if db_name and db_name in datasources:
-            return db_name, datasources[db_name].type
+        if db_name:
+            if self._current_datasource and self._current_datasource in datasources:
+                return db_name, datasources[self._current_datasource].type
+            if len(datasources) == 1:
+                cfg = list(datasources.values())[0]
+                return db_name, cfg.type
         if self._current_datasource and self._current_datasource in datasources:
-            return db_name or self._current_datasource, datasources[self._current_datasource].type
+            return self._current_datasource, datasources[self._current_datasource].type
         if len(datasources) == 1:
             cfg = list(datasources.values())[0]
             return next(iter(datasources)), cfg.type

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -188,3 +188,17 @@ def test_get_db_name_type_with_custom_db_name(agent_config: AgentConfig):
     db_name, db_type = agent_config.current_db_name_type(db_name="my_custom_db")
     assert db_name == "my_custom_db"
     assert db_type == DBType.SQLITE
+
+
+def test_get_db_name_type_single_datasource_fallback(agent_config: AgentConfig):
+    """When db_name is provided but current_datasource is not set, falls back to single datasource."""
+    agent_config._current_datasource = ""
+    original = dict(agent_config.services.datasources)
+    single_key = next(iter(original))
+    agent_config.services.datasources = {single_key: original[single_key]}
+    try:
+        db_name, db_type = agent_config.current_db_name_type(db_name="custom_db")
+        assert db_name == "custom_db"
+        assert db_type == original[single_key].type
+    finally:
+        agent_config.services.datasources = original

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -164,17 +164,22 @@ def test_init_embedding_models_returns_current_storage_models():
 
 
 def test_get_db_name_type(agent_config: AgentConfig):
+    agent_config.current_datasource = "bird_school"
     db_name, db_type = agent_config.current_db_name_type(db_name="bird_school")
     assert db_name == "bird_school"
     assert db_type == DBType.SQLITE
 
+    agent_config.current_datasource = "local_duckdb"
     db_name, db_type = agent_config.current_db_name_type(db_name="local_duckdb")
     assert db_name == "local_duckdb"
     assert db_type == DBType.DUCKDB
 
+    # Regression: db_name="starrocks" collides with a different datasource key
+    # but must derive the type from current_datasource, not from starrocks
+    agent_config.current_datasource = "bird_school"
     db_name, db_type = agent_config.current_db_name_type(db_name="starrocks")
     assert db_name == "starrocks"
-    assert db_type == "starrocks"
+    assert db_type == DBType.SQLITE
 
 
 def test_get_db_name_type_with_custom_db_name(agent_config: AgentConfig):

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -175,3 +175,11 @@ def test_get_db_name_type(agent_config: AgentConfig):
     db_name, db_type = agent_config.current_db_name_type(db_name="starrocks")
     assert db_name == "starrocks"
     assert db_type == "starrocks"
+
+
+def test_get_db_name_type_with_custom_db_name(agent_config: AgentConfig):
+    """When db_name is not a datasource key, it should be preserved as the database name."""
+    agent_config.current_datasource = "bird_sqlite"
+    db_name, db_type = agent_config.current_db_name_type(db_name="my_custom_db")
+    assert db_name == "my_custom_db"
+    assert db_type == DBType.SQLITE


### PR DESCRIPTION
## Why

When running `datus-agent run --datasource X --task "..." --task_db_name Y`, the `--task_db_name` value is ignored and the datasource name is used as the database name instead. The log showed `database_name='X'` when it should have been `database_name='Y'`. Closes #1126.

## Solution

The `current_db_name_type()` method in `agent_config.py` has a fallback path (line 1797) that returns `self._current_datasource` when `db_name` (from `--task_db_name`) is not a datasource key. This discards the user-provided database name. The fix changes the return value to `db_name or self._current_datasource`, preserving the user's database name.

## Test Cases

Manual verification:
1. Run `datus-agent run --datasource X --task "..." --task_db_name Y` where Y is a valid database name that differs from the datasource name
2. Verify the workflow logs show `database_name='Y'` instead of `database_name='X'`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datasource identification when an explicit database name is provided, ensuring the selected name is preserved in fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database name/type resolution when a provided database name doesn’t match a known datasource key—now preserves the caller’s database name while deriving the database type from the currently selected datasource (including collision and single-datasource fallback scenarios).

* **Tests**
  * Updated and added unit tests covering: datasource key resolution, custom database name handling, deriving type from the current datasource (not the name), and fallback when no current datasource is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->