### PR TITLE
[Enhancement] osi authoring: label expressions with the datasource's own dialect

### DIFF
--- a/datus/prompts/prompt_templates/_osi_dialect_map.j2
+++ b/datus/prompts/prompt_templates/_osi_dialect_map.j2
@@ -1,9 +1,3 @@
 {% macro expression_dialect(datasource_type) -%}
-{{- {
-    'databricks': 'DATABRICKS',
-    'maql': 'MAQL',
-    'mdx': 'MDX',
-    'snowflake': 'SNOWFLAKE',
-    'tableau': 'TABLEAU',
-}.get(datasource_type | default('', true) | lower, 'ANSI_SQL') -}}
+{{- (datasource_type | default('', true) | trim | upper) or 'ANSI_SQL' -}}
 {%- endmacro %}

--- a/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
@@ -44,7 +44,7 @@ Record the classification as defined in the `<required_skill>` specification{% i
   (resolves to `{{ semantic_model_dir }}` on disk)
 - Restrict filesystem reads/writes/reuse to `{{ kind_subdir }}/...`. Never read, edit, or pass paths from a sibling datasource directory such as `subject/semantic_models/other_datasource/...`.
 {% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
-- OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — this is the OSI core schema dialect label derived from the allowed enum; it may differ from the active datasource connector type. Use this exact value in every `expression.dialects[].dialect`.
+- OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
 - Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
 - Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`
 {% endif %}

--- a/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
@@ -43,7 +43,7 @@ Record the classification as defined in the `<required_skill>` specification{% i
 - Use this relative path prefix for semantic model and metric files: `{{ kind_subdir }}/`
   (resolves to `{{ semantic_model_dir }}` on disk)
 - Restrict filesystem reads/writes/reuse to `{{ kind_subdir }}/...`. Never read, edit, or pass paths from a sibling datasource directory such as `subject/semantic_models/other_datasource/...`.
-{% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
+{% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource_dialect | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
 - OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
 - Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
 - Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
@@ -13,7 +13,7 @@ The complete authoring specification for this run — YAML structure, field clas
 - Use this relative path prefix for semantic model files: `{{ kind_subdir }}/`
   (resolves to `{{ semantic_model_dir }}` on disk)
 {% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
-- OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — this is the OSI core schema dialect label derived from the allowed enum; it may differ from the active datasource connector type. Use this exact value in every `expression.dialects[].dialect`.
+- OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
 - Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
 - Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`
 {% endif %}

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
@@ -12,7 +12,7 @@ The complete authoring specification for this run — YAML structure, field clas
 - Knowledge base directory on disk: {{ knowledge_base_dir }}
 - Use this relative path prefix for semantic model files: `{{ kind_subdir }}/`
   (resolves to `{{ semantic_model_dir }}` on disk)
-{% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
+{% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource_dialect | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
 - OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
 - Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
 - Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -23,12 +23,18 @@ COMMON_VARS = {
 }
 
 
-def _render(template_name: str, authoring_format: str, datasource: str = "duckdb") -> str:
+def _render(
+    template_name: str,
+    authoring_format: str,
+    datasource: str = "duckdb",
+    datasource_dialect: str | None = None,
+) -> str:
     pm = get_prompt_manager()
     return pm.render_template(
         template_name=template_name,
         authoring_format=authoring_format,
         current_datasource=datasource,
+        current_datasource_dialect=datasource if datasource_dialect is None else datasource_dialect,
         **COMMON_VARS,
     )
 
@@ -70,15 +76,23 @@ def test_semantic_model_template_osi_mode():
 )
 def test_osi_mode_expression_dialect_derivation(template_name, datasource, expected_dialect):
     # The OSI dialect label is the active datasource's own dialect (uppercased).
-    text = _render(template_name, "osi", datasource=datasource)
-    assert f"- Active datasource: `{datasource}`" in text
+    text = _render(template_name, "osi", datasource_dialect=datasource)
     assert f"OSI expression dialect for this run: `{expected_dialect}`" in text
 
 
 @pytest.mark.parametrize("template_name", ["gen_semantic_model_system", "gen_metrics_system"])
+def test_osi_dialect_label_uses_datasource_type_not_config_name(template_name):
+    # The label is derived from the datasource dialect/type, not the config name:
+    # a snowflake datasource named "prod_wh" must yield SNOWFLAKE, not PROD_WH.
+    text = _render(template_name, "osi", datasource="prod_wh", datasource_dialect="snowflake")
+    assert "- Active datasource: `prod_wh`" in text
+    assert "OSI expression dialect for this run: `SNOWFLAKE`" in text
+
+
+@pytest.mark.parametrize("template_name", ["gen_semantic_model_system", "gen_metrics_system"])
 def test_osi_mode_expression_dialect_falls_back_to_ansi_when_no_datasource(template_name):
-    # With no datasource set, the label falls back to ANSI_SQL.
-    text = _render(template_name, "osi", datasource="")
+    # With no datasource dialect, the label falls back to ANSI_SQL.
+    text = _render(template_name, "osi", datasource="", datasource_dialect="")
     assert "OSI expression dialect for this run: `ANSI_SQL`" in text
 
 

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -60,12 +60,26 @@ def test_semantic_model_template_osi_mode():
 @pytest.mark.parametrize("template_name", ["gen_semantic_model_system", "gen_metrics_system"])
 @pytest.mark.parametrize(
     "datasource, expected_dialect",
-    [("starrocks", "ANSI_SQL"), ("mysql", "ANSI_SQL"), ("snowflake", "SNOWFLAKE"), ("databricks", "DATABRICKS")],
+    [
+        ("starrocks", "STARROCKS"),
+        ("mysql", "MYSQL"),
+        ("postgresql", "POSTGRESQL"),
+        ("snowflake", "SNOWFLAKE"),
+        ("databricks", "DATABRICKS"),
+    ],
 )
 def test_osi_mode_expression_dialect_derivation(template_name, datasource, expected_dialect):
+    # The OSI dialect label is the active datasource's own dialect (uppercased).
     text = _render(template_name, "osi", datasource=datasource)
     assert f"- Active datasource: `{datasource}`" in text
     assert f"OSI expression dialect for this run: `{expected_dialect}`" in text
+
+
+@pytest.mark.parametrize("template_name", ["gen_semantic_model_system", "gen_metrics_system"])
+def test_osi_mode_expression_dialect_falls_back_to_ansi_when_no_datasource(template_name):
+    # With no datasource set, the label falls back to ANSI_SQL.
+    text = _render(template_name, "osi", datasource="")
+    assert "OSI expression dialect for this run: `ANSI_SQL`" in text
 
 
 def test_metrics_template_metricflow_mode_contract():


### PR DESCRIPTION
## Why

OSI expressions are authored in the active datasource's native SQL, so the `expression.dialects[].dialect` label should name that datasource. The previous `_osi_dialect_map` only recognized 5 BI platforms (SNOWFLAKE/DATABRICKS/TABLEAU/MDX/MAQL) and forced every SQL datasource (starrocks, mysql, postgresql, duckdb, ...) to `ANSI_SQL`. That mislabels datasource-native expressions — e.g. a StarRocks model full of `FIND_IN_SET`/`DATEDIFF` was tagged `ANSI_SQL`, which is untrue and hides non-portability.

## Solution

- `_osi_dialect_map.j2`: map any datasource to its uppercased dialect (`starrocks` → `STARROCKS`, `mysql` → `MYSQL`, ...), falling back to `ANSI_SQL` only when no datasource is set. This keeps the previous native mappings (SNOWFLAKE/DATABRICKS/... uppercase unchanged) and extends to all datasources without a hand-maintained list.
- `gen_semantic_model_system_2.0` / `gen_metrics_system_2.0`: instruct the model to author in the datasource's native SQL and use this exact dialect label; drop the "may differ from the active datasource connector type" caveat (the label now matches the datasource).

Pairs with datus-semantic-adapter#42, which derives the sqlglot execution dialect from the datasource (removing hardcoded mysql/starrocks) and opens the OSI core `Dialect` field to accept these labels.

## Test Cases

`tests/unit_tests/prompts/test_osi_authoring_templates.py`: parametrized dialect derivation for starrocks/mysql/postgresql/snowflake/databricks (label = uppercased datasource), plus a separate no-datasource → `ANSI_SQL` fallback test. 23 passed; `ci/audit_tests.py --diff-only` P0=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * OSI expression dialects now reflect the active datasource’s native SQL dialect.
  * Added support for datasource-specific dialect labels, including StarRocks, MySQL, and PostgreSQL.
  * Empty datasource values now default to `ANSI_SQL`.

* **Documentation**
  * Clarified guidance for using the active datasource dialect when authoring expressions and semantic models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OSI expression dialects now follow the active datasource’s native SQL dialect.
  * Dialect labels are now derived from the datasource’s dialect/type (e.g., StarRocks, MySQL, PostgreSQL).
  * If datasource information is missing, the OSI expression dialect defaults to `ANSI_SQL`.
* **Documentation**
  * Updated prompt guidance to instruct authors to write expressions in the datasource’s native SQL and to use the exact dialect value consistently.
* **Tests**
  * Expanded unit tests to validate dialect derivation and the `ANSI_SQL` fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->