### PR TITLE
[BugFix] Keep nightly adapters on checkout sources

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -29,6 +29,10 @@ jobs:
     env:
       DATUS_AGENT_REF: ${{ github.event.inputs.datus_agent_ref || github.ref_name }}
       NIGHTLY_GROUP_FILTER: ${{ github.event.inputs.nightly_group_filter || '' }}
+      # The job deliberately overlays packages from the adapter checkouts after
+      # the locked project sync. Do not let later `uv run` commands restore the
+      # registry builds from uv.lock over those checkout packages.
+      UV_NO_SYNC: "1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -102,9 +106,17 @@ jobs:
                   sha256sum "$file"
                 done
               fi
+
+              for repo in \
+                external/datus-db-adapters \
+                external/datus-bi-adapters \
+                external/datus-scheduler-adapters \
+                external/datus-semantic-adapter; do
+                git -C "$repo" rev-parse HEAD
+              done
             } | sha256sum | awk '{print $1}'
           )"
-          echo "key=${RUNNER_OS}-kb-v4-datus_agent_nightly-${digest}" >> "$GITHUB_OUTPUT"
+          echo "key=${RUNNER_OS}-kb-v5-datus_agent_nightly-${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -147,7 +159,9 @@ jobs:
             ./external/datus-bi-adapters/datus-bi-grafana \
             ./external/datus-scheduler-adapters/datus-scheduler-core \
             ./external/datus-scheduler-adapters/datus-scheduler-airflow
-          uv run playwright install --with-deps chromium
+          uv run --no-sync python ci/verify_nightly_adapter_sources.py \
+            --external-repos-root "$GITHUB_WORKSPACE/external"
+          uv run --no-sync playwright install --with-deps chromium
 
       - name: Ensure Docker runtime
         env:

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Verify that nightly adapter packages came from the checked-out repositories."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+from importlib import metadata
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+EXPECTED_LOCAL_PACKAGES = {
+    "datus-db-core": "datus-db-adapters/datus-db-core",
+    "datus-sqlalchemy": "datus-db-adapters/datus-sqlalchemy",
+    "datus-snowflake": "datus-db-adapters/datus-snowflake",
+    "datus-postgresql": "datus-db-adapters/datus-postgresql",
+    "datus-mysql": "datus-db-adapters/datus-mysql",
+    "datus-clickhouse": "datus-db-adapters/datus-clickhouse",
+    "datus-starrocks": "datus-db-adapters/datus-starrocks",
+    "datus-trino": "datus-db-adapters/datus-trino",
+    "datus-greenplum": "datus-db-adapters/datus-greenplum",
+    "datus-hive": "datus-db-adapters/datus-hive",
+    "datus-spark": "datus-db-adapters/datus-spark",
+    "datus-bi-core": "datus-bi-adapters/datus-bi-core",
+    "datus-bi-superset": "datus-bi-adapters/datus-bi-superset",
+    "datus-bi-grafana": "datus-bi-adapters/datus-bi-grafana",
+    "datus-scheduler-core": "datus-scheduler-adapters/datus-scheduler-core",
+    "datus-scheduler-airflow": "datus-scheduler-adapters/datus-scheduler-airflow",
+    "datus-semantic-core": "datus-semantic-adapter/datus-semantic-core",
+    "datus-semantic-metricflow": "datus-semantic-adapter/datus-semantic-metricflow",
+}
+
+
+def distribution_source_path(package_name: str) -> tuple[Path | None, str | None]:
+    try:
+        dist = metadata.distribution(package_name)
+    except metadata.PackageNotFoundError:
+        return None, "package is not installed"
+
+    direct_url_text = dist.read_text("direct_url.json")
+    if not direct_url_text:
+        return None, "package has no direct_url.json and was likely installed from a registry"
+
+    try:
+        direct_url = json.loads(direct_url_text)
+    except json.JSONDecodeError as exc:
+        return None, f"package has invalid direct_url.json: {exc}"
+
+    source_url = direct_url.get("url")
+    if not isinstance(source_url, str) or not source_url:
+        return None, "package direct_url.json has no source URL"
+
+    parsed = urlparse(source_url)
+    if parsed.scheme != "file" or parsed.netloc not in ("", "localhost"):
+        return None, f"package source is not a local checkout: {source_url}"
+
+    return Path(url2pathname(parsed.path)).resolve(), None
+
+
+def verify_local_sources(external_repos_root: Path) -> list[str]:
+    external_repos_root = external_repos_root.resolve()
+    errors: list[str] = []
+
+    for package_name, relative_path in EXPECTED_LOCAL_PACKAGES.items():
+        expected_path = (external_repos_root / relative_path).resolve()
+        source_path, error = distribution_source_path(package_name)
+        if error:
+            errors.append(f"{package_name}: {error}")
+        elif source_path != expected_path:
+            errors.append(f"{package_name}: expected checkout source {expected_path}, got {source_path}")
+
+    return errors
+
+
+def verify_semantic_adapter_imports() -> list[str]:
+    errors: list[str] = []
+    try:
+        core_models = importlib.import_module("datus_semantic_core.models")
+    except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
+        errors.append(f"datus-semantic-core import failed: {exc}")
+    else:
+        if not hasattr(core_models, "SemanticValidationError"):
+            errors.append("datus-semantic-core is missing SemanticValidationError")
+
+    try:
+        importlib.import_module("datus_semantic_metricflow")
+    except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
+        errors.append(f"datus-semantic-metricflow import failed: {exc}")
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--external-repos-root",
+        type=Path,
+        required=True,
+        help="Directory containing the checked-out adapter repositories.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    errors = verify_local_sources(args.external_repos_root)
+    errors.extend(verify_semantic_adapter_imports())
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+
+    print(f"Verified {len(EXPECTED_LOCAL_PACKAGES)} adapter packages from {args.external_repos_root.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-nightly.yml"
+
+
+def test_nightly_preserves_checkout_packages_after_locked_sync():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'UV_NO_SYNC: "1"' in workflow
+    assert "uv sync --locked" in workflow
+    assert "uv run --no-sync python ci/verify_nightly_adapter_sources.py" in workflow
+    assert "uv run --no-sync playwright install --with-deps chromium" in workflow
+
+
+def test_nightly_kb_cache_tracks_all_adapter_checkouts():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for repo in (
+        "external/datus-db-adapters",
+        "external/datus-bi-adapters",
+        "external/datus-scheduler-adapters",
+        "external/datus-semantic-adapter",
+    ):
+        assert repo in workflow
+
+    assert 'git -C "$repo" rev-parse HEAD' in workflow
+    assert "kb-v5-datus_agent_nightly" in workflow

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "verify_nightly_adapter_sources.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("verify_nightly_adapter_sources", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load verify_nightly_adapter_sources module from {MODULE_PATH}")
+verify_sources = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(verify_sources)
+
+
+class _FakeDistribution:
+    def __init__(self, direct_url: str | None):
+        self.direct_url = direct_url
+
+    def read_text(self, filename: str) -> str | None:
+        assert filename == "direct_url.json"
+        return self.direct_url
+
+
+def _local_distribution(path: Path) -> _FakeDistribution:
+    return _FakeDistribution(json.dumps({"url": path.resolve().as_uri(), "dir_info": {}}))
+
+
+def test_verify_local_sources_accepts_every_expected_checkout(monkeypatch, tmp_path):
+    external_root = tmp_path / "external"
+    distributions = {
+        name: _local_distribution(external_root / relative_path)
+        for name, relative_path in verify_sources.EXPECTED_LOCAL_PACKAGES.items()
+    }
+    monkeypatch.setattr(verify_sources.metadata, "distribution", distributions.__getitem__)
+
+    assert verify_sources.verify_local_sources(external_root) == []
+
+
+def test_verify_local_sources_rejects_registry_package(monkeypatch, tmp_path):
+    external_root = tmp_path / "external"
+    distributions = {
+        name: _local_distribution(external_root / relative_path)
+        for name, relative_path in verify_sources.EXPECTED_LOCAL_PACKAGES.items()
+    }
+    distributions["datus-semantic-core"] = _FakeDistribution(None)
+    monkeypatch.setattr(verify_sources.metadata, "distribution", distributions.__getitem__)
+
+    errors = verify_sources.verify_local_sources(external_root)
+
+    assert errors == ["datus-semantic-core: package has no direct_url.json and was likely installed from a registry"]
+
+
+def test_verify_local_sources_rejects_wrong_checkout(monkeypatch, tmp_path):
+    external_root = tmp_path / "external"
+    distributions = {
+        name: _local_distribution(external_root / relative_path)
+        for name, relative_path in verify_sources.EXPECTED_LOCAL_PACKAGES.items()
+    }
+    distributions["datus-db-core"] = _local_distribution(tmp_path / "somewhere-else")
+    monkeypatch.setattr(verify_sources.metadata, "distribution", distributions.__getitem__)
+
+    errors = verify_sources.verify_local_sources(external_root)
+
+    assert len(errors) == 1
+    assert errors[0].startswith("datus-db-core: expected checkout source ")
+    assert errors[0].endswith(f", got {(tmp_path / 'somewhere-else').resolve()}")
+
+
+def test_verify_semantic_adapter_imports_requires_shared_contract(monkeypatch):
+    modules = {
+        "datus_semantic_core.models": SimpleNamespace(),
+        "datus_semantic_metricflow": SimpleNamespace(),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_semantic_adapter_imports() == [
+        "datus-semantic-core is missing SemanticValidationError"
+    ]


### PR DESCRIPTION
## Summary

- keep packages installed from the four adapter `main` checkouts active for the entire nightly job
- verify all 18 adapter distributions resolve to their expected checkout paths and smoke-import the shared semantic contract
- include adapter checkout SHAs in the knowledge-base cache key so adapter changes rebuild cached test data

## Root cause

Nightly ran `uv sync --locked`, overlaid packages from the checked-out adapter repositories with `uv pip install`, and then invoked `uv run playwright install`. Because `uv run` synchronizes the project environment by default, it restored locked registry builds for core adapter packages. That left the latest checkout of `datus-semantic-metricflow` paired with the published `datus-semantic-core==0.2.0`, which does not contain `SemanticValidationError`. Metric generation then failed and `metrics.lance` was never produced.

The job now sets `UV_NO_SYNC=1` after making the explicit locked sync part of its contract. An early source check fails if any adapter package comes from a registry or the wrong checkout instead of allowing a mixed environment to reach the test-data build.

## Validation

- `uv run pytest -q tests/unit_tests/ci` (169 passed)
- `uv run ruff check ci/verify_nightly_adapter_sources.py tests/unit_tests/ci/test_verify_nightly_adapter_sources.py tests/unit_tests/ci/test_nightly_checkout_contract.py`
- `uv run ruff format --check ci/verify_nightly_adapter_sources.py tests/unit_tests/ci/test_verify_nightly_adapter_sources.py tests/unit_tests/ci/test_nightly_checkout_contract.py`
- `actionlint -shellcheck= .github/workflows/run-nightly.yml`
- `git diff --check`

The complete Docker/provider matrix still requires a workflow dispatch on the self-hosted nightly runner.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly builds to consistently use checked-out adapter packages instead of accidentally restoring registry versions.
  * Added validation to detect incorrect or missing adapter sources before browser setup.
  * Updated knowledge-base caching to refresh when adapter repository revisions change.

* **Tests**
  * Added automated coverage for adapter source validation and nightly workflow configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->