### PR TITLE
[Enhancement] Add public sync_osi_to_db entry for one-call OSI ingest

### DIFF
--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -1768,13 +1768,17 @@ class GenerationTools:
         dataset-only document syncs just its datasets. The result always carries a
         ``synced`` count for uniform accounting across both shapes.
         """
-        if self.extract_osi_metric_names(osi_file_path):
-            result = self._sync_osi_metric_to_db(metric_file=osi_file_path, semantic_model_file=osi_file_path)
-            synced = len(result.get("metric_artifact_ids") or [])
-        else:
-            result = self.sync_osi_semantic_to_db(osi_file_path)
-            synced = int(result.get("semantic_objects") or 0)
-        return {**result, "synced": synced}
+        try:
+            if self.extract_osi_metric_names(osi_file_path):
+                result = self._sync_osi_metric_to_db(metric_file=osi_file_path, semantic_model_file=osi_file_path)
+                synced = len(result.get("metric_artifact_ids") or [])
+            else:
+                result = self.sync_osi_semantic_to_db(osi_file_path)
+                synced = int(result.get("semantic_objects") or 0)
+            return {**result, "synced": synced}
+        except Exception as e:
+            logger.error(f"Error syncing OSI document to DB: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
 
     def _sync_metric_to_db(
         self,

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -1755,6 +1755,27 @@ class GenerationTools:
             logger.error(f"Error syncing OSI metrics to DB: {e}", exc_info=True)
             return {"success": False, "error": str(e)}
 
+    def sync_osi_to_db(self, osi_file_path: str) -> dict:
+        """Sync a complete OSI document (datasets + metrics) into the Knowledge Base.
+
+        Public composition entry for callers that materialize a self-contained OSI
+        file and need it vectorized (e.g. the SaaS Semantic Hub pull) without
+        reaching into the per-kind sync internals.
+
+        A metrics-bearing document is synced in one pass: ``_sync_osi_metric_to_db``
+        already vectorizes the referenced datasets before the metrics when a
+        ``semantic_model_file`` is given, so no separate dataset sync is needed. A
+        dataset-only document syncs just its datasets. The result always carries a
+        ``synced`` count for uniform accounting across both shapes.
+        """
+        if self.extract_osi_metric_names(osi_file_path):
+            result = self._sync_osi_metric_to_db(metric_file=osi_file_path, semantic_model_file=osi_file_path)
+            synced = len(result.get("metric_artifact_ids") or [])
+        else:
+            result = self.sync_osi_semantic_to_db(osi_file_path)
+            synced = int(result.get("semantic_objects") or 0)
+        return {**result, "synced": synced}
+
     def _sync_metric_to_db(
         self,
         metric_file: str,

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -1373,6 +1373,15 @@ class TestOsiSync:
         assert result["success"] is True
         assert result["synced"] == 3
 
+    def test_sync_osi_to_db_returns_error_dict_on_unexpected_failure(self, generation_tools, tmp_path):
+        # Consistent with the delegated syncs: an unexpected raise degrades to an
+        # error dict rather than propagating out of the public entry.
+        osi_file = tmp_path / "shop.yml"
+        osi_file.write_text("version: 0.2.0.dev0\n")
+        with patch.object(generation_tools, "extract_osi_metric_names", side_effect=RuntimeError("bad yaml")):
+            result = generation_tools.sync_osi_to_db(str(osi_file))
+        assert result == {"success": False, "error": "bad yaml"}
+
 
 class TestGenerateSqlSummaryId:
     def test_success(self, generation_tools):

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -1332,6 +1332,47 @@ class TestOsiSync:
         generation_tools.semantic_rag.restore_artifact_rows.assert_called_once()
         generation_tools.table_semantic_profile_rag.restore_artifact_rows.assert_called_once()
 
+    def test_sync_osi_to_db_routes_metric_file_through_metric_sync(self, generation_tools, tmp_path):
+        # A metrics-bearing OSI doc: one pass through _sync_osi_metric_to_db (which
+        # also syncs the referenced datasets); no separate semantic sync call.
+        osi_file = tmp_path / "shop.yml"
+        osi_file.write_text("version: 0.2.0.dev0\n")
+        with (
+            patch.object(generation_tools, "extract_osi_metric_names", return_value=["order_count"]),
+            patch.object(
+                generation_tools,
+                "_sync_osi_metric_to_db",
+                return_value={"success": True, "metric_artifact_ids": ["metric:a", "metric:b"]},
+            ) as metric_sync,
+            patch.object(generation_tools, "sync_osi_semantic_to_db") as semantic_sync,
+        ):
+            result = generation_tools.sync_osi_to_db(str(osi_file))
+
+        metric_sync.assert_called_once_with(metric_file=str(osi_file), semantic_model_file=str(osi_file))
+        semantic_sync.assert_not_called()
+        assert result["success"] is True
+        assert result["synced"] == 2
+
+    def test_sync_osi_to_db_routes_dataset_only_file_through_semantic_sync(self, generation_tools, tmp_path):
+        # A dataset-only OSI doc (no metrics): syncs just the datasets.
+        osi_file = tmp_path / "model.yml"
+        osi_file.write_text("version: 0.2.0.dev0\n")
+        with (
+            patch.object(generation_tools, "extract_osi_metric_names", return_value=[]),
+            patch.object(
+                generation_tools,
+                "sync_osi_semantic_to_db",
+                return_value={"success": True, "semantic_objects": 3},
+            ) as semantic_sync,
+            patch.object(generation_tools, "_sync_osi_metric_to_db") as metric_sync,
+        ):
+            result = generation_tools.sync_osi_to_db(str(osi_file))
+
+        semantic_sync.assert_called_once_with(str(osi_file))
+        metric_sync.assert_not_called()
+        assert result["success"] is True
+        assert result["synced"] == 3
+
 
 class TestGenerateSqlSummaryId:
     def test_success(self, generation_tools):


### PR DESCRIPTION
## Why

Callers that materialize a self-contained OSI document and need it vectorized into the Knowledge Base — notably the SaaS Semantic Hub `pull` (see Datus-backend #345) — had no public one-call entry. They had to compose `sync_osi_semantic_to_db()` **and** the private `_sync_osi_metric_to_db()` themselves. That reaches into per-kind internals (fragile across refactors) and double-syncs the datasets, since `_sync_osi_metric_to_db` already vectorizes the referenced datasets when given a `semantic_model_file`.

## Solution

Add a public `GenerationTools.sync_osi_to_db(osi_file_path)` that ingests a complete OSI file in one call:

- **Metrics-bearing document** → routes through `_sync_osi_metric_to_db(metric_file=…, semantic_model_file=…)`, which already syncs the referenced datasets before the metrics — so a single pass covers both, no redundant dataset sync.
- **Dataset-only document** (no metrics) → routes through `sync_osi_semantic_to_db`.
- Returns the underlying result plus a uniform `synced` count so callers get consistent accounting across both shapes.

No behavior change to the existing `sync_osi_semantic_to_db` / `_sync_osi_metric_to_db`; this is purely a public composition wrapper.

## Test Cases

Added two unit tests in `tests/unit_tests/tools/func_tool/test_generation_tools.py::TestOsiSync`:
- `test_sync_osi_to_db_routes_metric_file_through_metric_sync` — a metrics-bearing file goes through the metric sync only (no separate semantic-sync call), and `synced` reflects the metric count.
- `test_sync_osi_to_db_routes_dataset_only_file_through_semantic_sync` — a dataset-only file goes through the semantic sync, and `synced` reflects the dataset count.

Full `test_generation_tools.py` passes (108 tests); `ruff format`/`ruff check` clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added a unified way to synchronize OSI documents with the database.
  * Automatically detects whether an OSI document contains metrics and selects the appropriate synchronization process.
  * Reports a consistent count of synchronized items.

* **Tests**
  * Added coverage for metric-based and semantic OSI synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified public method to synchronize OSI documents with the database.
  * Automatically detects metric-bearing OSI inputs and routes to the appropriate sync flow.
  * Returns a consistent result including a top-level synchronized-item count.
* **Tests**
  * Added unit tests covering metric-based routing, semantic-only routing, and graceful error reporting when detection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->