### PR TITLE
[Enhancement] Test Agent with latest PostgreSQL storage in nightly

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -73,6 +73,13 @@ jobs:
           ref: main
           path: external/datus-semantic-adapter
 
+      - name: Checkout datus-storage-adapters main
+        uses: actions/checkout@v4
+        with:
+          repository: Datus-ai/datus-storage-adapters
+          ref: main
+          path: external/datus-storage-adapters
+
       - name: Clean up stale temp files
         run: |
           echo "Cleaning stale pytest temp directories..."
@@ -111,12 +118,13 @@ jobs:
                 external/datus-db-adapters \
                 external/datus-bi-adapters \
                 external/datus-scheduler-adapters \
-                external/datus-semantic-adapter; do
+                external/datus-semantic-adapter \
+                external/datus-storage-adapters; do
                 git -C "$repo" rev-parse HEAD
               done
             } | sha256sum | awk '{print $1}'
           )"
-          echo "key=${RUNNER_OS}-kb-v5-datus_agent_nightly-${digest}" >> "$GITHUB_OUTPUT"
+          echo "key=${RUNNER_OS}-kb-v6-datus_agent_nightly-${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -140,7 +148,11 @@ jobs:
             --reinstall-package datus-semantic-core \
             --reinstall-package datus-semantic-metricflow \
             --reinstall-package datus-snowflake \
+            --reinstall-package datus-storage-base \
+            --reinstall-package datus-storage-postgresql \
             pytest-playwright \
+            ./external/datus-storage-adapters/datus-storage-base \
+            "./external/datus-storage-adapters/datus-storage-postgresql[dev]" \
             ./external/datus-semantic-adapter/datus-semantic-core \
             ./external/datus-semantic-adapter/datus-semantic-metricflow \
             ./external/datus-db-adapters/datus-db-core \

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.DATUS_AGENT_REF }}
+          persist-credentials: false
 
       - name: Record Datus-agent checkout
         run: |
@@ -51,6 +52,7 @@ jobs:
           repository: Datus-ai/datus-db-adapters
           ref: main
           path: external/datus-db-adapters
+          persist-credentials: false
 
       - name: Checkout datus-bi-adapters main
         uses: actions/checkout@v4
@@ -58,6 +60,7 @@ jobs:
           repository: Datus-ai/datus-bi-adapters
           ref: main
           path: external/datus-bi-adapters
+          persist-credentials: false
 
       - name: Checkout datus-scheduler-adapters main
         uses: actions/checkout@v4
@@ -65,6 +68,7 @@ jobs:
           repository: Datus-ai/datus-scheduler-adapters
           ref: main
           path: external/datus-scheduler-adapters
+          persist-credentials: false
 
       - name: Checkout datus-semantic-adapter main
         uses: actions/checkout@v4
@@ -72,6 +76,7 @@ jobs:
           repository: Datus-ai/datus-semantic-adapter
           ref: main
           path: external/datus-semantic-adapter
+          persist-credentials: false
 
       - name: Checkout datus-storage-adapters main
         uses: actions/checkout@v4
@@ -79,6 +84,7 @@ jobs:
           repository: Datus-ai/datus-storage-adapters
           ref: main
           path: external/datus-storage-adapters
+          persist-credentials: false
 
       - name: Clean up stale temp files
         run: |

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -62,6 +62,7 @@ default_repo_root() {
 DB_ADAPTERS_ROOT="$(default_repo_root "${DB_ADAPTERS_ROOT:-}" datus-db-adapters)"
 BI_ADAPTERS_ROOT="$(default_repo_root "${BI_ADAPTERS_ROOT:-}" datus-bi-adapters)"
 SCHEDULER_ADAPTERS_ROOT="$(default_repo_root "${SCHEDULER_ADAPTERS_ROOT:-}" datus-scheduler-adapters)"
+STORAGE_ADAPTERS_ROOT="$(default_repo_root "${STORAGE_ADAPTERS_ROOT:-}" datus-storage-adapters)"
 
 POSTGRES_COMPOSE="${POSTGRES_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-postgresql/docker-compose.yml}"
 MYSQL_COMPOSE="${MYSQL_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-mysql/docker-compose.yml}"
@@ -101,6 +102,11 @@ COMPOSE_GROUPS=(
   "Greenplum Adapter Tests"
   "Hive Adapter Tests"
   "Spark Adapter Tests"
+)
+
+DOCKER_GROUPS=(
+  "PostgreSQL Storage Adapter Tests"
+  "${COMPOSE_GROUPS[@]}"
 )
 
 log() {
@@ -419,24 +425,34 @@ will_run_any_compose_suite() {
   return 1
 }
 
+will_run_any_docker_suite() {
+  local group_name
+  for group_name in "${DOCKER_GROUPS[@]}"; do
+    if should_run_group "$group_name"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 require_docker_runtime() {
-  if ! will_run_any_compose_suite; then
+  if ! will_run_any_docker_suite; then
     return 0
   fi
 
   if ! command -v docker >/dev/null 2>&1; then
-    echo "Docker is required for nightly compose-backed suites" | tee -a "$LOG_FILE" >&2
+    echo "Docker is required for Docker-backed nightly suites" | tee -a "$LOG_FILE" >&2
     test_exit_code=127
     return 1
   fi
 
   if ! docker info >/dev/null 2>&1; then
-    echo "Docker daemon is not available for nightly compose-backed suites" | tee -a "$LOG_FILE" >&2
+    echo "Docker daemon is not available for Docker-backed nightly suites" | tee -a "$LOG_FILE" >&2
     test_exit_code=127
     return 1
   fi
 
-  if ! has_docker_compose; then
+  if will_run_any_compose_suite && ! has_docker_compose; then
     echo "Docker Compose is required for nightly compose-backed suites" | tee -a "$LOG_FILE" >&2
     test_exit_code=127
     return 1
@@ -1518,6 +1534,7 @@ log "Nightly process diagnostics: $NIGHTLY_PROCESS_DIAGNOSTICS_FILE"
 log "DB_ADAPTERS_ROOT=$DB_ADAPTERS_ROOT"
 log "BI_ADAPTERS_ROOT=$BI_ADAPTERS_ROOT"
 log "SCHEDULER_ADAPTERS_ROOT=$SCHEDULER_ADAPTERS_ROOT"
+log "STORAGE_ADAPTERS_ROOT=$STORAGE_ADAPTERS_ROOT"
 log "NIGHTLY_HOME=$NIGHTLY_HOME"
 log "DATUS_TEST_PROJECT_NAME=$DATUS_TEST_PROJECT_NAME"
 log "UNIT_TEST_HOME=$UNIT_TEST_HOME"
@@ -1606,6 +1623,7 @@ run_compose_suite "Grafana Nightly Tests" "$GRAFANA_COMPOSE" "postgres:300" "gra
 
 run_compose_suite "Airflow Nightly Tests" "$AIRFLOW_COMPOSE" "airflow:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_scheduler_agentic.py --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
 
+run_logged "PostgreSQL Storage Adapter Tests" env DATUS_TEST_LAYER=nightly uv run --no-sync pytest "$STORAGE_ADAPTERS_ROOT/datus-storage-postgresql/tests" --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "PostgreSQL Adapter Tests" "$POSTGRES_COMPOSE" "postgres:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_postgresql.py tests/integration/adapters/test_semantic_metricflow_postgresql.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_mysql.py tests/integration/adapters/test_semantic_metricflow_mysql.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "ClickHouse Adapter Tests" "$CLICKHOUSE_COMPOSE" "clickhouse:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_clickhouse.py --tb=short --verbose --timeout=300 --timeout-method=thread

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -30,6 +30,8 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-scheduler-airflow": "datus-scheduler-adapters/datus-scheduler-airflow",
     "datus-semantic-core": "datus-semantic-adapter/datus-semantic-core",
     "datus-semantic-metricflow": "datus-semantic-adapter/datus-semantic-metricflow",
+    "datus-storage-base": "datus-storage-adapters/datus-storage-base",
+    "datus-storage-postgresql": "datus-storage-adapters/datus-storage-postgresql",
 }
 
 
@@ -92,6 +94,29 @@ def verify_semantic_adapter_imports() -> list[str]:
     return errors
 
 
+def verify_storage_adapter_imports() -> list[str]:
+    errors: list[str] = []
+    try:
+        fts_contract = importlib.import_module("datus_storage_base.vector.fts")
+    except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
+        errors.append(f"datus-storage-base FTS import failed: {exc}")
+    else:
+        required_names = ("FtsField", "FtsIndexStatus", "FtsSpec", "normalize_fts_spec")
+        missing_names = [name for name in required_names if not hasattr(fts_contract, name)]
+        if missing_names:
+            errors.append(f"datus-storage-base FTS contract is missing: {', '.join(missing_names)}")
+
+    try:
+        vector_adapter = importlib.import_module("datus_storage_postgresql.vector")
+    except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
+        errors.append(f"datus-storage-postgresql vector import failed: {exc}")
+    else:
+        if not hasattr(vector_adapter, "PgvectorBackend"):
+            errors.append("datus-storage-postgresql vector adapter is missing PgvectorBackend")
+
+    return errors
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -107,6 +132,7 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     errors = verify_local_sources(args.external_repos_root)
     errors.extend(verify_semantic_adapter_imports())
+    errors.extend(verify_storage_adapter_imports())
     if errors:
         for error in errors:
             print(f"ERROR: {error}")

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -96,15 +96,33 @@ def verify_semantic_adapter_imports() -> list[str]:
 
 def verify_storage_adapter_imports() -> list[str]:
     errors: list[str] = []
+    required_names = ("FtsField", "FtsIndexStatus", "FtsSpec", "normalize_fts_spec")
+    fts_contract = None
     try:
         fts_contract = importlib.import_module("datus_storage_base.vector.fts")
     except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
         errors.append(f"datus-storage-base FTS import failed: {exc}")
     else:
-        required_names = ("FtsField", "FtsIndexStatus", "FtsSpec", "normalize_fts_spec")
         missing_names = [name for name in required_names if not hasattr(fts_contract, name)]
         if missing_names:
             errors.append(f"datus-storage-base FTS contract is missing: {', '.join(missing_names)}")
+
+    try:
+        agent_fts = importlib.import_module("datus.storage.fts")
+    except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
+        errors.append(f"Datus Agent FTS import failed: {exc}")
+    else:
+        mismatched_names = [
+            name
+            for name in required_names
+            if fts_contract is not None
+            and hasattr(fts_contract, name)
+            and getattr(agent_fts, name, None) is not getattr(fts_contract, name)
+        ]
+        if mismatched_names:
+            errors.append(
+                f"Datus Agent FTS contract does not re-export datus-storage-base: {', '.join(mismatched_names)}"
+            )
 
     try:
         vector_adapter = importlib.import_module("datus_storage_postgresql.vector")

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -404,7 +404,7 @@ class BaseEmbeddingStore(StorageBase):
     def create_fts_index(self, fields: Union[str, List[str], FtsSpec]):
         """Create and verify one native FTS index per configured field."""
         self._ensure_table_ready()
-        if not self._supports_runtime_indexing():
+        if not self._supports_fts_indexing():
             return
         if isinstance(fields, FtsSpec):
             spec = fields
@@ -418,8 +418,7 @@ class BaseEmbeddingStore(StorageBase):
             logger.info("Removed legacy Tantivy FTS index for %s before rebuilding", self.table_name)
 
         try:
-            for field in spec.fields:
-                self.table.create_fts_index(field)
+            self.table.create_fts_index(spec)
             status_fn = getattr(self.table, "fts_index_status", None)
             if status_fn is not None:
                 status = status_fn(spec)
@@ -715,16 +714,16 @@ class BaseEmbeddingStore(StorageBase):
     # -- Convenience methods for subclasses --
 
     def _supports_runtime_indexing(self) -> bool:
-        """Check if the backend supports runtime index creation.
-
-        LanceDB requires explicit index creation after data insertion.
-        Other backends (e.g. pgvector) handle indexing at DDL level
-        and should skip runtime index calls.
-        """
+        """Return whether vector and scalar indexes are managed at runtime."""
         return hasattr(self.table, "create_scalar_index") and type(self.table).__name__.startswith("Lance")
 
+    def _supports_fts_indexing(self) -> bool:
+        """Return whether the backend implements the shared FTS capability."""
+        supports_fts = getattr(self.table, "supports_fts", None)
+        return bool(supports_fts and supports_fts())
+
     def _create_scalar_index(self, column: str) -> None:
-        """Create a scalar index on the given column (LanceDB only)."""
+        """Create a scalar index on the given column."""
         self._ensure_table_ready()
         if not self._supports_runtime_indexing():
             return

--- a/datus/storage/base.py
+++ b/datus/storage/base.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import time
 from datetime import datetime, timezone
 from threading import Lock
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -21,7 +21,7 @@ from datus.storage.datasource_scope import (
     datasource_condition,
 )
 from datus.storage.embedding_models import EmbeddingModel
-from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec
+from datus.storage.fts import FtsIndexStatus, FtsSpecInput, normalize_fts_spec
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -401,17 +401,12 @@ class BaseEmbeddingStore(StorageBase):
         except Exception as e:
             logger.warning(f"Failed to create vector index for {self.table_name}: {str(e)}")
 
-    def create_fts_index(self, fields: Union[str, List[str], FtsSpec]):
+    def create_fts_index(self, fields: FtsSpecInput):
         """Create and verify one native FTS index per configured field."""
         self._ensure_table_ready()
         if not self._supports_fts_indexing():
             return
-        if isinstance(fields, FtsSpec):
-            spec = fields
-        elif isinstance(fields, str):
-            spec = FtsSpec((FtsField(fields),))
-        else:
-            spec = FtsSpec.from_names(fields)
+        spec = normalize_fts_spec(fields)
 
         remove_legacy = getattr(self.table, "remove_legacy_fts_index", None)
         if remove_legacy is not None and remove_legacy():

--- a/datus/storage/fts.py
+++ b/datus/storage/fts.py
@@ -15,7 +15,9 @@ try:
         normalize_fts_spec,
     )
 except ModuleNotFoundError as exc:
-    if exc.name != "datus_storage_base.vector.fts":
+    target_module = "datus_storage_base.vector.fts"
+    missing_module = exc.name or ""
+    if missing_module != target_module and not target_module.startswith(f"{missing_module}."):
         raise
 
     # Remove after datus-storage-base>=0.1.6 is published and required.

--- a/datus/storage/fts.py
+++ b/datus/storage/fts.py
@@ -2,68 +2,92 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Backend-independent full-text index definitions."""
+"""Compatibility exports for the shared storage FTS contract."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import StrEnum
-from typing import Iterable
+try:
+    from datus_storage_base.vector.fts import (
+        FtsField,
+        FtsIndexStatus,
+        FtsSpec,
+        FtsSpecInput,
+        normalize_fts_spec,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "datus_storage_base.vector.fts":
+        raise
+
+    # Remove after datus-storage-base>=0.1.6 is published and required.
+    from dataclasses import dataclass
+    from enum import StrEnum
+    from typing import Iterable, Union
+
+    @dataclass(frozen=True)
+    class FtsField:
+        """A searchable text field and its index/query configuration."""
+
+        name: str
+        boost: float = 1.0
+        tokenizer: str = "simple"
+        ngram_min_length: int = 2
+        ngram_max_length: int = 2
+
+        def __post_init__(self) -> None:
+            if not self.name:
+                raise ValueError("FTS field name must not be empty")
+            if self.boost <= 0:
+                raise ValueError("FTS field boost must be positive")
+            if self.tokenizer not in {"simple", "raw", "whitespace", "ngram"}:
+                raise ValueError(f"Unsupported FTS tokenizer: {self.tokenizer}")
+            if self.tokenizer == "ngram" and not (0 < self.ngram_min_length <= self.ngram_max_length):
+                raise ValueError("Invalid FTS ngram length range")
+
+    @dataclass(frozen=True)
+    class FtsSpec:
+        """The complete FTS contract for one table."""
+
+        fields: tuple[FtsField, ...]
+        version: int = 1
+
+        def __post_init__(self) -> None:
+            if not self.fields:
+                raise ValueError("FTS spec must contain at least one field")
+            names = [field.name for field in self.fields]
+            if len(names) != len(set(names)):
+                raise ValueError("FTS field names must be unique")
+            if self.version < 1:
+                raise ValueError("FTS spec version must be positive")
+
+        @classmethod
+        def from_names(cls, names: Iterable[str], *, version: int = 1) -> "FtsSpec":
+            return cls(tuple(FtsField(name) for name in names), version=version)
+
+        @property
+        def columns(self) -> list[str]:
+            return [field.name for field in self.fields]
+
+        @property
+        def boosts(self) -> list[float]:
+            return [field.boost for field in self.fields]
+
+    class FtsIndexStatus(StrEnum):
+        READY = "ready"
+        MISSING = "missing"
+        LEGACY = "legacy"
+        VERSION_MISMATCH = "version_mismatch"
+        UNSUPPORTED = "unsupported"
+
+    FtsSpecInput = Union[FtsSpec, FtsField, str, Iterable[str]]
+
+    def normalize_fts_spec(value: FtsSpecInput) -> FtsSpec:
+        if isinstance(value, FtsSpec):
+            return value
+        if isinstance(value, FtsField):
+            return FtsSpec((value,))
+        if isinstance(value, str):
+            return FtsSpec((FtsField(value),))
+        return FtsSpec.from_names(value)
 
 
-@dataclass(frozen=True)
-class FtsField:
-    """A searchable text field and its index/query configuration."""
-
-    name: str
-    boost: float = 1.0
-    tokenizer: str = "simple"
-    ngram_min_length: int = 2
-    ngram_max_length: int = 2
-
-    def __post_init__(self) -> None:
-        if not self.name:
-            raise ValueError("FTS field name must not be empty")
-        if self.boost <= 0:
-            raise ValueError("FTS field boost must be positive")
-        if self.tokenizer not in {"simple", "raw", "whitespace", "ngram"}:
-            raise ValueError(f"Unsupported FTS tokenizer: {self.tokenizer}")
-        if self.tokenizer == "ngram" and not (0 < self.ngram_min_length <= self.ngram_max_length):
-            raise ValueError("Invalid FTS ngram length range")
-
-
-@dataclass(frozen=True)
-class FtsSpec:
-    """The complete FTS contract for one table."""
-
-    fields: tuple[FtsField, ...]
-    version: int = 1
-
-    def __post_init__(self) -> None:
-        if not self.fields:
-            raise ValueError("FTS spec must contain at least one field")
-        names = [field.name for field in self.fields]
-        if len(names) != len(set(names)):
-            raise ValueError("FTS field names must be unique")
-        if self.version < 1:
-            raise ValueError("FTS spec version must be positive")
-
-    @classmethod
-    def from_names(cls, names: Iterable[str], *, version: int = 1) -> "FtsSpec":
-        return cls(tuple(FtsField(name) for name in names), version=version)
-
-    @property
-    def columns(self) -> list[str]:
-        return [field.name for field in self.fields]
-
-    @property
-    def boosts(self) -> list[float]:
-        return [field.boost for field in self.fields]
-
-
-class FtsIndexStatus(StrEnum):
-    READY = "ready"
-    MISSING = "missing"
-    LEGACY = "legacy"
-    VERSION_MISMATCH = "version_mismatch"
-    UNSUPPORTED = "unsupported"
+__all__ = ["FtsField", "FtsIndexStatus", "FtsSpec", "FtsSpecInput", "normalize_fts_spec"]

--- a/datus/storage/vector/lance_backend.py
+++ b/datus/storage/vector/lance_backend.py
@@ -8,7 +8,7 @@ import os
 import re
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from urllib.parse import unquote, urlparse
 
 import lancedb
@@ -26,7 +26,7 @@ from lancedb.query import LanceQueryBuilder, MatchQuery, MultiMatchQuery
 from lancedb.rerankers import LinearCombinationReranker
 from lancedb.table import Table as LanceTable
 
-from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec
+from datus.storage.fts import FtsIndexStatus, FtsSpec, FtsSpecInput, normalize_fts_spec
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -183,16 +183,13 @@ class LanceVectorTable(VectorTable):
     def search_fts(
         self,
         query_text: str,
-        fts_spec: Union[FtsSpec, str, List[str]],
+        fts_spec: FtsSpecInput,
         top_n: int,
         where: WhereExpr = None,
         select_fields: Optional[List[str]] = None,
     ) -> pa.Table:
         compiled = build_where(where)
-        if isinstance(fts_spec, str):
-            fts_spec = FtsSpec.from_names([fts_spec])
-        elif isinstance(fts_spec, list):
-            fts_spec = FtsSpec.from_names(fts_spec)
+        fts_spec = normalize_fts_spec(fts_spec)
         if len(fts_spec.fields) == 1:
             field = fts_spec.fields[0]
             query = MatchQuery(query_text, field.name, boost=field.boost)
@@ -229,18 +226,17 @@ class LanceVectorTable(VectorTable):
     def create_vector_index(self, column: str, metric: str = "cosine", **kwargs) -> None:
         self._table.create_index(metric=metric, vector_column_name=column, **kwargs)
 
-    def create_fts_index(self, field: Union[FtsField, str]) -> None:
-        if isinstance(field, str):
-            field = FtsField(field)
-        config = FTS(
-            base_tokenizer=field.tokenizer,
-            ngram_min_length=field.ngram_min_length,
-            ngram_max_length=field.ngram_max_length,
-            stem=False,
-            remove_stop_words=False,
-            ascii_folding=False,
-        )
-        self._table.create_index(field.name, config=config, replace=True)
+    def create_fts_index(self, spec: FtsSpecInput) -> None:
+        for field in normalize_fts_spec(spec).fields:
+            config = FTS(
+                base_tokenizer=field.tokenizer,
+                ngram_min_length=field.ngram_min_length,
+                ngram_max_length=field.ngram_max_length,
+                stem=False,
+                remove_stop_words=False,
+                ascii_folding=False,
+            )
+            self._table.create_index(field.name, config=config, replace=True)
 
     def supports_fts(self) -> bool:
         return True

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-nightly.yml"
+NIGHTLY_SCRIPT = REPO_ROOT / "ci" / "run-nightly-tests.sh"
 
 
 def test_nightly_preserves_checkout_packages_after_locked_sync():
@@ -21,8 +22,32 @@ def test_nightly_kb_cache_tracks_all_adapter_checkouts():
         "external/datus-bi-adapters",
         "external/datus-scheduler-adapters",
         "external/datus-semantic-adapter",
+        "external/datus-storage-adapters",
     ):
         assert repo in workflow
 
     assert 'git -C "$repo" rev-parse HEAD' in workflow
-    assert "kb-v5-datus_agent_nightly" in workflow
+    assert "kb-v6-datus_agent_nightly" in workflow
+
+
+def test_nightly_installs_storage_packages_from_latest_checkout():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "repository: Datus-ai/datus-storage-adapters" in workflow
+    assert "ref: main" in workflow
+    assert "path: external/datus-storage-adapters" in workflow
+    for package_name, package_path in (
+        ("datus-storage-base", "./external/datus-storage-adapters/datus-storage-base"),
+        ("datus-storage-postgresql", '"./external/datus-storage-adapters/datus-storage-postgresql[dev]"'),
+    ):
+        assert f"--reinstall-package {package_name}" in workflow
+        assert package_path in workflow
+
+
+def test_nightly_runs_postgresql_storage_adapter_tests_from_checkout():
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'STORAGE_ADAPTERS_ROOT="$(default_repo_root' in script
+    assert 'run_logged "PostgreSQL Storage Adapter Tests"' in script
+    assert 'uv run --no-sync pytest "$STORAGE_ADAPTERS_ROOT/datus-storage-postgresql/tests"' in script
+    assert '"PostgreSQL Storage Adapter Tests"' in script.split("DOCKER_GROUPS=(", maxsplit=1)[1]

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -87,8 +87,10 @@ def test_verify_semantic_adapter_imports_requires_shared_contract(monkeypatch):
 
 
 def test_verify_storage_adapter_imports_requires_shared_contract(monkeypatch):
+    shared_fts = SimpleNamespace(FtsSpec=object())
     modules = {
-        "datus_storage_base.vector.fts": SimpleNamespace(FtsSpec=object()),
+        "datus_storage_base.vector.fts": shared_fts,
+        "datus.storage.fts": SimpleNamespace(FtsSpec=shared_fts.FtsSpec),
         "datus_storage_postgresql.vector": SimpleNamespace(),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
@@ -97,3 +99,45 @@ def test_verify_storage_adapter_imports_requires_shared_contract(monkeypatch):
         "datus-storage-base FTS contract is missing: FtsField, FtsIndexStatus, normalize_fts_spec",
         "datus-storage-postgresql vector adapter is missing PgvectorBackend",
     ]
+
+
+def test_verify_storage_adapter_imports_requires_agent_to_reexport_shared_contract(monkeypatch):
+    shared_fts = SimpleNamespace(
+        FtsField=object(),
+        FtsIndexStatus=object(),
+        FtsSpec=object(),
+        normalize_fts_spec=object(),
+    )
+    agent_fts = SimpleNamespace(
+        FtsField=shared_fts.FtsField,
+        FtsIndexStatus=object(),
+        FtsSpec=shared_fts.FtsSpec,
+        normalize_fts_spec=shared_fts.normalize_fts_spec,
+    )
+    modules = {
+        "datus_storage_base.vector.fts": shared_fts,
+        "datus.storage.fts": agent_fts,
+        "datus_storage_postgresql.vector": SimpleNamespace(PgvectorBackend=object()),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_storage_adapter_imports() == [
+        "Datus Agent FTS contract does not re-export datus-storage-base: FtsIndexStatus"
+    ]
+
+
+def test_verify_storage_adapter_imports_accepts_agent_shared_contract(monkeypatch):
+    shared_fts = SimpleNamespace(
+        FtsField=object(),
+        FtsIndexStatus=object(),
+        FtsSpec=object(),
+        normalize_fts_spec=object(),
+    )
+    modules = {
+        "datus_storage_base.vector.fts": shared_fts,
+        "datus.storage.fts": shared_fts,
+        "datus_storage_postgresql.vector": SimpleNamespace(PgvectorBackend=object()),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_storage_adapter_imports() == []

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -37,6 +37,13 @@ def test_verify_local_sources_accepts_every_expected_checkout(monkeypatch, tmp_p
     assert verify_sources.verify_local_sources(external_root) == []
 
 
+def test_expected_sources_include_storage_packages():
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-storage-base"] == ("datus-storage-adapters/datus-storage-base")
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-storage-postgresql"] == (
+        "datus-storage-adapters/datus-storage-postgresql"
+    )
+
+
 def test_verify_local_sources_rejects_registry_package(monkeypatch, tmp_path):
     external_root = tmp_path / "external"
     distributions = {
@@ -76,4 +83,17 @@ def test_verify_semantic_adapter_imports_requires_shared_contract(monkeypatch):
 
     assert verify_sources.verify_semantic_adapter_imports() == [
         "datus-semantic-core is missing SemanticValidationError"
+    ]
+
+
+def test_verify_storage_adapter_imports_requires_shared_contract(monkeypatch):
+    modules = {
+        "datus_storage_base.vector.fts": SimpleNamespace(FtsSpec=object()),
+        "datus_storage_postgresql.vector": SimpleNamespace(),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_storage_adapter_imports() == [
+        "datus-storage-base FTS contract is missing: FtsField, FtsIndexStatus, normalize_fts_spec",
+        "datus-storage-postgresql vector adapter is missing PgvectorBackend",
     ]

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -211,7 +211,14 @@ def _copy_california_schools_db(dest_path: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _create_real_agent_config(tmp_path, db_path: str, *, read_only_db: bool) -> AgentConfig:
+def _create_real_agent_config(
+    tmp_path,
+    db_path: str,
+    *,
+    read_only_db: bool,
+    project_name: str | None = None,
+    storage_config: dict | None = None,
+) -> AgentConfig:
     """Create a fully real AgentConfig backed by a real SQLite database.
 
     Includes:
@@ -254,7 +261,7 @@ def _create_real_agent_config(tmp_path, db_path: str, *, read_only_db: bool) -> 
             "schedulers": {},
         },
         "project_root": str(tmp_path / "workspace"),
-        "storage": {},
+        "storage": storage_config or {},
         "agentic_nodes": {
             "chat": {
                 "system_prompt": "chat",
@@ -313,6 +320,8 @@ def _create_real_agent_config(tmp_path, db_path: str, *, read_only_db: bool) -> 
             },
         },
     }
+    if project_name is not None:
+        config_kwargs["project_name"] = project_name
 
     nodes: dict[str, NodeConfig] = {}
     agent_config = AgentConfig(nodes=nodes, **config_kwargs)
@@ -323,12 +332,26 @@ def _create_real_agent_config(tmp_path, db_path: str, *, read_only_db: bool) -> 
 
 
 @pytest.fixture
-def real_agent_config(tmp_path, reset_global_singletons):
+def agent_storage_config():
+    """Use the production default storage configuration unless a suite overrides it."""
+    return {}
+
+
+@pytest.fixture
+def agent_project_name():
+    """Let AgentConfig derive its normal project name unless a suite overrides it."""
+    return None
+
+
+@pytest.fixture
+def real_agent_config(tmp_path, reset_global_singletons, agent_project_name, agent_storage_config):
     """Create a fully real AgentConfig backed by a shared read-only SQLite database."""
     agent_config = _create_real_agent_config(
         tmp_path,
         CALIFORNIA_SCHOOLS_DB,
         read_only_db=True,
+        project_name=agent_project_name,
+        storage_config=agent_storage_config,
     )
 
     yield agent_config
@@ -338,7 +361,7 @@ def real_agent_config(tmp_path, reset_global_singletons):
 
 
 @pytest.fixture
-def mutable_real_agent_config(tmp_path, reset_global_singletons):
+def mutable_real_agent_config(tmp_path, reset_global_singletons, agent_project_name, agent_storage_config):
     """Create a real AgentConfig with a per-test mutable SQLite database copy."""
     db_path = os.path.join(str(tmp_path), "california_schools.sqlite")
     _copy_california_schools_db(db_path)
@@ -347,6 +370,8 @@ def mutable_real_agent_config(tmp_path, reset_global_singletons):
         tmp_path,
         db_path,
         read_only_db=False,
+        project_name=agent_project_name,
+        storage_config=agent_storage_config,
     )
 
 

--- a/tests/unit_tests/storage/conftest.py
+++ b/tests/unit_tests/storage/conftest.py
@@ -60,6 +60,22 @@ def _init_storage_backends(request, tmp_path, storage_test_project):
                 pass
 
 
+@pytest.fixture
+def agent_storage_config(_init_storage_backends):
+    """Keep real AgentConfig fixtures on the backend selected by parameterization."""
+    backend = _init_storage_backends
+    return {
+        "rdb": {"type": backend.rdb_type, **backend.rdb_params},
+        "vector": {"type": backend.vector_type, **backend.vector_params},
+    }
+
+
+@pytest.fixture
+def agent_project_name(storage_test_project):
+    """Use the same safe project identifier for AgentConfig and backend cleanup."""
+    return storage_test_project
+
+
 def pytest_sessionfinish(session, exitstatus):
     """Clean up backend test environments at session end."""
     from tests.unit_tests.storage._backend_discovery import cleanup_test_environments

--- a/tests/unit_tests/storage/document/test_store.py
+++ b/tests/unit_tests/storage/document/test_store.py
@@ -442,28 +442,24 @@ class TestDocumentStoreCreateIndices:
         doc_store.store_chunks(_make_chunks(3))
         with patch.object(doc_store.table, "create_vector_index", wraps=doc_store.table.create_vector_index) as mock_vi:
             doc_store.create_indices()
-            if not type(doc_store.table).__name__.startswith("Lance"):
-                mock_vi.assert_not_called()
-                return
-            mock_vi.assert_called_once()
-            args, kwargs = mock_vi.call_args
-            # First positional arg is the vector column name
-            assert args[0] == "vector"
-            assert kwargs.get("metric") == "cosine"
-            assert kwargs.get("replace") is True
+            expected_call_count = int(type(doc_store.table).__name__.startswith("Lance"))
+            assert mock_vi.call_count == expected_call_count
+            assert [args[0] for args, _ in mock_vi.call_args_list] == ["vector"] * expected_call_count
+            assert [kwargs["metric"] for _, kwargs in mock_vi.call_args_list] == ["cosine"] * expected_call_count
+            assert [kwargs["replace"] for _, kwargs in mock_vi.call_args_list] == [True] * expected_call_count
 
     def test_create_indices_calls_fts_index(self, doc_store):
         """create_indices must delegate to the backend's create_fts_index."""
         doc_store.store_chunks(_make_chunks(3))
         with patch.object(doc_store.table, "create_fts_index", wraps=doc_store.table.create_fts_index) as mock_fts:
             doc_store.create_indices()
-            if not getattr(doc_store.table, "supports_fts", lambda: False)():
-                mock_fts.assert_not_called()
-                return
-            mock_fts.assert_called_once()
-            spec = mock_fts.call_args.args[0]
-            assert [field.name for field in spec.fields] == ["title", "hierarchy", "chunk_text"]
-            assert [field.boost for field in spec.fields] == [3.0, 2.0, 1.0]
+            expected_call_count = int(getattr(doc_store.table, "supports_fts", lambda: False)())
+            specs = [args[0] for args, _ in mock_fts.call_args_list]
+            assert mock_fts.call_count == expected_call_count
+            assert [[field.name for field in spec.fields] for spec in specs] == [
+                ["title", "hierarchy", "chunk_text"]
+            ] * expected_call_count
+            assert [[field.boost for field in spec.fields] for spec in specs] == [[3.0, 2.0, 1.0]] * expected_call_count
 
 
 # ============================================================

--- a/tests/unit_tests/storage/document/test_store.py
+++ b/tests/unit_tests/storage/document/test_store.py
@@ -442,6 +442,9 @@ class TestDocumentStoreCreateIndices:
         doc_store.store_chunks(_make_chunks(3))
         with patch.object(doc_store.table, "create_vector_index", wraps=doc_store.table.create_vector_index) as mock_vi:
             doc_store.create_indices()
+            if not type(doc_store.table).__name__.startswith("Lance"):
+                mock_vi.assert_not_called()
+                return
             mock_vi.assert_called_once()
             args, kwargs = mock_vi.call_args
             # First positional arg is the vector column name
@@ -454,10 +457,13 @@ class TestDocumentStoreCreateIndices:
         doc_store.store_chunks(_make_chunks(3))
         with patch.object(doc_store.table, "create_fts_index", wraps=doc_store.table.create_fts_index) as mock_fts:
             doc_store.create_indices()
-            assert mock_fts.call_count == 3
-            fields = [call.args[0] for call in mock_fts.call_args_list]
-            assert [field.name for field in fields] == ["title", "hierarchy", "chunk_text"]
-            assert [field.boost for field in fields] == [3.0, 2.0, 1.0]
+            if not getattr(doc_store.table, "supports_fts", lambda: False)():
+                mock_fts.assert_not_called()
+                return
+            mock_fts.assert_called_once()
+            spec = mock_fts.call_args.args[0]
+            assert [field.name for field in spec.fields] == ["title", "hierarchy", "chunk_text"]
+            assert [field.boost for field in spec.fields] == [3.0, 2.0, 1.0]
 
 
 # ============================================================

--- a/tests/unit_tests/storage/test_base.py
+++ b/tests/unit_tests/storage/test_base.py
@@ -14,6 +14,7 @@ from datus_storage_base.conditions import eq
 
 from datus.storage.base import BaseEmbeddingStore, StorageBase
 from datus.storage.embedding_models import EmbeddingModel, get_db_embedding_model
+from datus.storage.fts import FtsIndexStatus, FtsSpec
 from datus.storage.schema_metadata import SchemaStorage
 from datus.utils.exceptions import DatusException
 
@@ -899,11 +900,12 @@ class TestCreateFtsIndex:
                 }
             ]
         )
-        store.create_fts_index(["database_name", "schema_name", "table_name", "definition"])
+        if not getattr(store.table, "supports_fts", lambda: False)():
+            pytest.skip("Backend does not implement the shared FTS capability")
+        spec = FtsSpec.from_names(["database_name", "schema_name", "table_name", "definition"])
+        store.create_fts_index(spec)
         assert store.table_size() == 1
-        indices = store.table._table.list_indices()
-        indexed_fields = {column for index in indices if index.index_type == "FTS" for column in index.columns}
-        assert indexed_fields == {"database_name", "schema_name", "table_name", "definition"}
+        assert store.table.fts_index_status(spec) == FtsIndexStatus.READY
 
     def test_create_fts_index_failure_is_not_swallowed(self, tmp_path):
         store = SchemaStorage(get_db_embedding_model())
@@ -920,6 +922,8 @@ class TestCreateFtsIndex:
                 }
             ]
         )
+        if not getattr(store.table, "supports_fts", lambda: False)():
+            pytest.skip("Backend does not implement the shared FTS capability")
         with patch.object(store.table, "create_fts_index", side_effect=RuntimeError("index build failed")):
             with pytest.raises(DatusException, match="index build failed"):
                 store.create_fts_index(["definition"])

--- a/tests/unit_tests/storage/test_fts_contract.py
+++ b/tests/unit_tests/storage/test_fts_contract.py
@@ -1,16 +1,6 @@
 import pytest
 
 from datus.storage.backend_holder import get_vector_backend
-from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec, normalize_fts_spec
-
-
-def test_agent_uses_shared_fts_contract_when_available():
-    shared = pytest.importorskip("datus_storage_base.vector.fts")
-
-    assert FtsField is shared.FtsField
-    assert FtsIndexStatus is shared.FtsIndexStatus
-    assert FtsSpec is shared.FtsSpec
-    assert normalize_fts_spec is shared.normalize_fts_spec
 
 
 def test_real_agent_config_preserves_postgresql_storage_backend(real_agent_config, _init_storage_backends):

--- a/tests/unit_tests/storage/test_fts_contract.py
+++ b/tests/unit_tests/storage/test_fts_contract.py
@@ -1,0 +1,24 @@
+import pytest
+
+from datus.storage.backend_holder import get_vector_backend
+from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec, normalize_fts_spec
+
+
+def test_agent_uses_shared_fts_contract_when_available():
+    shared = pytest.importorskip("datus_storage_base.vector.fts")
+
+    assert FtsField is shared.FtsField
+    assert FtsIndexStatus is shared.FtsIndexStatus
+    assert FtsSpec is shared.FtsSpec
+    assert normalize_fts_spec is shared.normalize_fts_spec
+
+
+def test_real_agent_config_preserves_postgresql_storage_backend(real_agent_config, _init_storage_backends):
+    if _init_storage_backends.vector_type != "postgresql":
+        pytest.skip("Requires the PostgreSQL vector backend")
+
+    from datus_storage_postgresql.vector import PgvectorBackend
+
+    assert real_agent_config._backend_config.rdb.type == "postgresql"
+    assert real_agent_config._backend_config.vector.type == "postgresql"
+    assert isinstance(get_vector_backend(), PgvectorBackend)


### PR DESCRIPTION
## Summary

- check out `Datus-ai/datus-storage-adapters@main` in nightly and install `datus-storage-base` plus `datus-storage-postgresql[dev]` from that checkout after the locked sync
- verify both distributions via `direct_url.json`, smoke-test the shared FTS contract, and include the storage checkout SHA in cache invalidation
- run the complete `datus-storage-postgresql` test suite as a blocking Docker-backed nightly group
- keep storage-parameterized Agent tests on the selected backend when they construct `real_agent_config`, with an explicit runtime assertion for `PgvectorBackend`
- use the `datus-storage-base` FTS contract when available, pass a complete `FtsSpec` through the backend interface, and let Lance expand the spec into native per-field indexes

## Root cause

The storage autouse fixture initially configured PostgreSQL, but `real_agent_config` later constructed `AgentConfig(storage={})`, which overwrote the global backend holder with the SQLite+Lance defaults. Pytest still displayed `[postgresql+postgresql]`, so those cases looked covered while production-path stores were actually using Lance.

Agent and adapter code also defined separate `FtsSpec` classes. The PostgreSQL adapter's strict shared-contract normalization could therefore reject a spec constructed by Agent even though both classes had the same fields.

## Impact

Nightly now exercises the real Agent storage path through `PgvectorBackend` and a PostgreSQL testcontainer, including metadata FTS writes, index creation, search, incremental updates, and datasource isolation. Existing installations locked to `datus-storage-base==0.1.5` retain their vector-default behavior; once 0.1.6 is published and required, the temporary compatibility definition can be removed.

## Dependency

- Depends on Datus-ai/datus-storage-adapters#10 for PostgreSQL DataFrame scalar normalization. Merge that PR first so the nightly checkout of adapter `main` includes the fix.

## Validation

- Agent storage suite with local `datus-storage-base==0.1.6` and patched PostgreSQL adapter source: 4077 passed, 1 skipped
- final cross-repo FTS/PostgreSQL focused suite: 46 passed, 1 skipped
- `datus-storage-postgresql/tests`: 156 passed
- locked `datus-storage-base==0.1.5` Lance/CI compatibility checks passed
- Ruff, workflow YAML parsing, Bash syntax, and `git diff --check` passed

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Nightly CI now runs PostgreSQL storage adapter tests from the latest checked-out sources.
  * Added shared FTS contract compatibility (including spec normalization) and updated backends to use it.
* **Bug Fixes**
  * Knowledge-base caches now invalidate when storage adapter sources change.
  * Docker Compose checks are enforced only when compose-backed suites are enabled.
* **Tests**
  * Expanded nightly checkout/installation/runtime validation and added unit tests for storage adapter source verification and FTS contract behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->