### PR TITLE
[Enhancement] Close PR-harness coverage holes and drop tombstone test assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,8 @@ before_reflection_*.yaml
 coverage.xml
 ci/htmlcov/
 ci/coverage.xml
-ci/test-results.xml
+ci/test-results*.xml
+ci/merge-queue-results.json
 ci/diff-cover.json
 ci/diff-cover-report.*
 ci/pytest-coverage.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Unit tests follow the mapping rule above. The table lists **additional** integra
 | `datus/agent/node/` | `unit_tests/agent/node/test_node.py`, `test_schema_linking.py`, `test_date_parser_*.py` |
 | `datus/cli/repl.py` | `integration/cli/test_cli_commands.py`, `regression/test_regression_web_e2e.py` |
 | `datus/tools/func_tool/` | `integration/tools/test_func_tools_db.py`, `integration/tools/test_mcp_server.py` |
-| `datus/tools/skill_tools/` | `unit_tests/tools/skill_tools/test_skill_*.py` (config, registry_unit, manager_unit, bash_tool, func_tool) |
+| `datus/tools/skill_tools/` | `unit_tests/tools/skill_tools/test_skill_*.py` |
 | `datus/tools/permission/` | `unit_tests/tools/permission/test_permission_*.py` |
 | `datus/mcp_server.py` | `unit_tests/test_mcp_server.py`, `integration/tools/test_mcp_server.py` |
 | `datus/storage/reference_template/` | `unit_tests/storage/reference_template/test_*.py`, `integration/tools/test_reference_template.py` |
@@ -155,3 +155,9 @@ Unit tests follow the mapping rule above. The table lists **additional** integra
 ### Test quality (beyond coverage)
 
 Beyond happy paths, exercise: **input format variants** (all valid shapes, not just the common one); **return-type contracts** (every branch returns the same structure); **cross-component contracts** (consume the producer's real output); **adversarial inputs** for regex/SQL/path sandboxes; **recursive/nested structures** at depth ≥ 3; **spec compliance** for standards (`.gitignore`, SQL dialects).
+
+### No tombstone tests when removing code
+
+When removing code, update or delete the existing tests that covered it. Do **not** add tests asserting that code/functions/strings no longer exist (`not hasattr(...)`, `"xxx" not in source`, import-failure checks) — these pin implementation details, never catch real bugs, and break legitimate future refactors. The proof that a removal is safe is the existing behavioral tests passing, not a new negative assertion.
+
+Exception: when the removal itself is an external contract, add a regression test that asserts the **behavior** does not occur, and note in the test which contract it protects. Qualifying cases: deprecated public APIs/config fields (e.g. a removed YAML key must be silently ignored), security fixes (e.g. secrets must not appear in logs), and removed side effects with real regression risk (`assert_not_called` on a mock).

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -6,7 +6,11 @@ source:
     adapter contract, or release-confidence operation exposed from docs/.
 layers:
   pr_acceptance:
-    description: Fast deterministic PR signal for documented core flows.
+    description: >
+      Fast deterministic PR signal for documented core flows. Only nodeids whose
+      file is listed in PR_ACCEPTANCE_TARGETS (ci/run-pr-tests.py) run on every
+      PR; other nodeids run through the diff-driven impacted unit suite and only
+      execute when the PR touches their mapped source tree.
   merge_queue:
     description: Deterministic pre-merge signal on the merge-group commit.
   nightly:
@@ -888,7 +892,7 @@ flow_groups:
             nodeids:
               - tests/integration/tools/test_skill.py
               - tests/integration/tools/test_skill_execution.py
-              - tests/integration/tools/test_skill_execution.py::TestLocalSkillDiscoveryAndExecutionGate::test_skill_func_tool_exposes_execution_tools
+              - tests/integration/tools/test_skill_execution.py::TestLocalSkillDiscoveryAndExecutionGate::test_skill_func_tool_exposes_load_skill
               - tests/integration/tools/test_skill_execution.py::TestRealLLMSkillExecution::test_agent_invokes_local_skill
             notes: >
               Local skill discovery, permission filtering, and real-LLM skill execution are covered.

--- a/ci/harness/validate_coverage_map.py
+++ b/ci/harness/validate_coverage_map.py
@@ -96,12 +96,17 @@ def class_or_function_exists(repo_root: Path, nodeid: str) -> bool:
         return False
     if not suffix:
         return True
-    first = suffix.split("::", 1)[0]
-    if not first:
-        return True
     text = full_path.read_text(encoding="utf-8", errors="replace")
-    escaped = re.escape(first)
-    return bool(re.search(rf"^\s*(class|(?:async\s+)?def)\s+{escaped}\b", text, flags=re.MULTILINE))
+    for component in suffix.split("::"):
+        # A renamed method inside a surviving class must be caught too, so every
+        # component is checked, with parametrize ids stripped.
+        name = component.split("[", 1)[0]
+        if not name:
+            continue
+        escaped = re.escape(name)
+        if not re.search(rf"^\s*(class|(?:async\s+)?def)\s+{escaped}\b", text, flags=re.MULTILINE):
+            return False
+    return True
 
 
 def iter_flows(coverage_map: dict[str, Any], errors: list[str]) -> list[FlowRef]:

--- a/ci/run-merge-queue-tests.py
+++ b/ci/run-merge-queue-tests.py
@@ -26,8 +26,8 @@ DEFAULT_REPORT = OUT_DIR / "merge-queue-results.json"
 DEFAULT_TIMEOUT_SECONDS = int(os.environ.get("MERGE_QUEUE_TEST_TIMEOUT", "600"))
 PYTEST_BASETEMP_ENV = "DATUS_CI_PYTEST_BASETEMP"
 
-ACCEPTANCE_MARK_EXPR = "acceptance"
-DEFAULT_PR_HARNESS_MARK_EXPR = "acceptance or component or llm_harness"
+ACCEPTANCE_MARK_EXPR = "acceptance and not quarantine"
+DEFAULT_PR_HARNESS_MARK_EXPR = "(acceptance or component or llm_harness) and not quarantine"
 
 
 def log(message: str) -> None:
@@ -137,15 +137,13 @@ def acceptance_integration_targets(targets: Sequence[str]) -> list[str]:
     return [target for target in targets if target.startswith("tests/integration/")]
 
 
-def existing_paths(paths: Sequence[str]) -> list[str]:
-    existing: list[str] = []
-    for item in paths:
-        path = REPO_ROOT / item
-        if path.exists():
-            existing.append(item)
-        else:
-            log(f"Skipping missing path: {item}")
-    return existing
+def missing_paths(paths: Sequence[str]) -> list[str]:
+    """Return targets that do not exist in the checkout.
+
+    A stale entry must fail loudly: silently skipping it would drop merge-queue
+    coverage without any signal in the results.
+    """
+    return [item for item in paths if not (REPO_ROOT / item).exists()]
 
 
 def build_pytest_command(
@@ -213,7 +211,13 @@ def suite_definitions() -> dict[str, dict[str, Any]]:
 
 
 def run_suite(name: str, suite: dict[str, Any], *, timeout: int) -> dict[str, Any]:
-    targets = existing_paths(suite["targets"])
+    targets = list(suite["targets"])
+    stale = missing_paths(targets)
+    if stale:
+        for item in stale:
+            log(f"{name} target missing from checkout: {item}")
+        log("Update PR_ACCEPTANCE_TARGETS in ci/run-pr-tests.py to match the tree")
+        return {"suite": name, "exit_code": 1, "targets": [], "missing": stale}
     if not targets:
         log(f"{name} has no existing targets")
         return {"suite": name, "exit_code": 1, "targets": []}

--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -43,13 +43,14 @@ from typing import Any, TextIO
 import defusedxml.ElementTree as ET
 
 OUT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT_DIR = os.path.dirname(OUT_DIR)
 DEFAULT_JUNIT_XML = os.path.join(OUT_DIR, "test-results.xml")
 DEFAULT_COVERAGE_XML = os.path.join(OUT_DIR, "coverage.xml")
 DEFAULT_COVERAGE_HTML = os.path.join(OUT_DIR, "htmlcov")
 DEFAULT_COVERAGE_DB = os.path.join(OUT_DIR, ".coverage")
 DEFAULT_PYTEST_LOG = os.path.join(OUT_DIR, "pytest-coverage.txt")
 PYTEST_BASETEMP_ENV = "DATUS_CI_PYTEST_BASETEMP"
-PR_HARNESS_MARK_EXPR = "acceptance or component or llm_harness"
+PR_HARNESS_MARK_EXPR = "(acceptance or component or llm_harness) and not quarantine"
 IMPACTED_UNIT_MARK_EXPR = "not acceptance and not component and not llm_harness and not nightly and not quarantine"
 PR_ACCEPTANCE_TARGETS = [
     "tests/unit_tests/agent/node/test_chat_agentic_node.py",
@@ -64,12 +65,15 @@ PR_ACCEPTANCE_TARGETS = [
     "tests/unit_tests/agent/node/test_sql_summary_agentic_node.py",
     "tests/unit_tests/agent/node/test_skill_creator_agentic_node.py",
     "tests/unit_tests/agent/node/test_gen_job_agentic_node.py",
+    "tests/unit_tests/agent/node/test_gen_dashboard_agentic_node.py",
+    "tests/unit_tests/agent/node/test_scheduler_agentic_node.py",
     "tests/unit_tests/api/routes/test_chat_routes.py",
     "tests/unit_tests/api/services/test_kb_service.py",
     "tests/unit_tests/api/test_service.py",
     "tests/unit_tests/cli/test_core_entrypoint_acceptance.py",
     "tests/unit_tests/cli/test_interactive_init.py",
     "tests/unit_tests/cli/web/test_chatbot.py",
+    "tests/unit_tests/ci/test_harness_alignment.py",
     "tests/integration/api/test_api.py",
     "tests/integration/cli/test_cli_commands.py",
     "tests/integration/cli/test_cli_textual.py",
@@ -79,7 +83,6 @@ PR_ACCEPTANCE_TARGETS = [
     "tests/integration/storage/test_platform_doc.py",
     "tests/integration/tools/test_func_tools_db.py",
     "tests/integration/tools/test_mcp_acceptance.py",
-    "tests/integration/tools/test_mcp_server.py",
     "tests/integration/tools/db_tools/test_connector_duckdb.py",
     "tests/unit_tests/storage/test_feedback_store.py",
     "tests/unit_tests/tools/func_tool/test_bi_tools.py",
@@ -685,8 +688,20 @@ def resolve_impacted_unit_tests(base_ref: str) -> list[str]:
     return impacted
 
 
+def missing_acceptance_targets() -> list[str]:
+    """Return PR acceptance targets that do not exist in the checkout."""
+    return [target for target in PR_ACCEPTANCE_TARGETS if not os.path.exists(os.path.join(REPO_ROOT_DIR, target))]
+
+
 def run_tests(base_ref: str = "") -> tuple[int, list[str]]:
     """Run PR acceptance plus impacted unit tests and return the exit code and JUnit XML paths."""
+    stale_targets = missing_acceptance_targets()
+    if stale_targets:
+        for target in stale_targets:
+            log(f"PR acceptance target missing from checkout: {target}")
+        log("Update PR_ACCEPTANCE_TARGETS in ci/run-pr-tests.py to match the tree")
+        return 1, []
+
     _reset_report_outputs()
 
     try:

--- a/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_artifact_agentic_node.py
@@ -554,13 +554,6 @@ class TestAnchorFilePreload:
         node = _make_ask_dashboard_node(real_agent_config)
         assert "Q3 anomalies" in node._artifact_intent_md
 
-    def test_interpretation_not_attribute(self, real_agent_config):
-        """``_artifact_interpretation`` was removed along with the
-        interpretation.json file; the attribute should no longer exist
-        on the node so accidental readers fail loud."""
-        node = _make_ask_report_node(real_agent_config)
-        assert not hasattr(node, "_artifact_interpretation")
-
     def test_missing_intent_degrades_silently_blob_mode(self, real_agent_config):
         """When intent.md is absent from the blob, init still succeeds
         and the cached value stays empty (prompt template branches on

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -1855,20 +1855,6 @@ class TestChatAgenticNodeExecutionMode:
 class TestChatAgenticNodeNoBITools:
     """Verify ChatAgenticNode no longer has BI tools (moved to GenDashboardAgenticNode)."""
 
-    def test_no_bi_func_tool_attribute(self, real_agent_config, mock_llm_create):
-        """Chat node should not have a bi_func_tool attribute."""
-        from datus.agent.node.chat_agentic_node import ChatAgenticNode
-        from datus.configuration.node_type import NodeType
-
-        node = ChatAgenticNode(
-            node_id="test_no_bi",
-            description="Test no BI tools",
-            node_type=NodeType.TYPE_CHAT,
-            agent_config=real_agent_config,
-        )
-
-        assert not hasattr(node, "bi_func_tool")
-
     def test_no_bi_tool_names_in_tools_list(self, real_agent_config, mock_llm_create):
         """Chat node tools list should not contain any BI tool names."""
         from datus.agent.node.chat_agentic_node import ChatAgenticNode
@@ -1901,20 +1887,6 @@ class TestChatAgenticNodeNoBITools:
         tool_names = {tool.name for tool in node.tools}
         assert tool_names.isdisjoint(bi_tool_names), f"Chat node still has BI tools: {tool_names & bi_tool_names}"
 
-    def test_no_setup_bi_tools_method(self, real_agent_config, mock_llm_create):
-        """Chat node should not have _setup_bi_tools method."""
-        from datus.agent.node.chat_agentic_node import ChatAgenticNode
-        from datus.configuration.node_type import NodeType
-
-        node = ChatAgenticNode(
-            node_id="test_no_method",
-            description="Test no BI method",
-            node_type=NodeType.TYPE_CHAT,
-            agent_config=real_agent_config,
-        )
-
-        assert not hasattr(node, "_setup_bi_tools")
-
 
 # ===========================================================================
 # Scheduler Tools Removed from Chat Node Tests
@@ -1923,19 +1895,6 @@ class TestChatAgenticNodeNoBITools:
 
 class TestChatAgenticNodeNoSchedulerTools:
     """Verify ChatAgenticNode no longer has scheduler tools (moved to SchedulerAgenticNode)."""
-
-    def test_no_scheduler_tools_attribute(self, real_agent_config, mock_llm_create):
-        """Chat node should not have a scheduler_tools attribute."""
-        from datus.agent.node.chat_agentic_node import ChatAgenticNode
-
-        node = ChatAgenticNode(
-            node_id="test_no_scheduler",
-            description="Test no scheduler tools",
-            node_type=NodeType.TYPE_CHAT,
-            agent_config=real_agent_config,
-        )
-
-        assert not hasattr(node, "scheduler_tools")
 
     def test_no_scheduler_tool_names_in_tools_list(self, real_agent_config, mock_llm_create):
         """Chat node tools list should not contain any scheduler tool names."""
@@ -1966,16 +1925,3 @@ class TestChatAgenticNodeNoSchedulerTools:
         assert tool_names.isdisjoint(scheduler_tool_names), (
             f"Chat node still has scheduler tools: {tool_names & scheduler_tool_names}"
         )
-
-    def test_no_setup_scheduler_tools_method(self, real_agent_config, mock_llm_create):
-        """Chat node should not have _setup_scheduler_tools method."""
-        from datus.agent.node.chat_agentic_node import ChatAgenticNode
-
-        node = ChatAgenticNode(
-            node_id="test_no_scheduler_method",
-            description="Test no scheduler method",
-            node_type=NodeType.TYPE_CHAT,
-            agent_config=real_agent_config,
-        )
-
-        assert not hasattr(node, "_setup_scheduler_tools")

--- a/tests/unit_tests/ci/harness/test_validate_coverage_map.py
+++ b/tests/unit_tests/ci/harness/test_validate_coverage_map.py
@@ -83,6 +83,21 @@ def test_missing_nodeid_path_is_reported():
     ]
 
 
+def test_class_or_function_exists_checks_every_nodeid_component(tmp_path):
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(
+        "class TestThing:\n    def test_present(self):\n        assert True\n",
+        encoding="utf-8",
+    )
+
+    exists = validate_coverage_map.class_or_function_exists
+
+    assert exists(tmp_path, "test_sample.py::TestThing::test_present")
+    assert exists(tmp_path, "test_sample.py::TestThing::test_present[case-1]")
+    assert not exists(tmp_path, "test_sample.py::TestThing::test_renamed")
+    assert not exists(tmp_path, "test_sample.py::TestGone::test_present")
+
+
 def test_p0_requires_deterministic_pr_or_merge_queue_coverage():
     data = minimal_map()
     flow = data["flow_groups"]["onboarding"]["flows"][0]

--- a/tests/unit_tests/ci/test_harness_alignment.py
+++ b/tests/unit_tests/ci/test_harness_alignment.py
@@ -1,0 +1,94 @@
+"""Guard the alignment between harness marks and the PR acceptance target list.
+
+The PR harness runs two suites with complementary mark filters: the acceptance
+suite runs only files in ``PR_ACCEPTANCE_TARGETS`` with harness marks, while the
+impacted suite excludes harness-marked tests. A harness-marked test in a file
+outside the target list therefore never runs in PR or merge-queue CI. These
+tests fail the acceptance suite on the offending PR itself.
+
+Detection is AST-based (decorators, ``pytestmark``, ``pytest.param`` marks), so
+marks applied dynamically from conftest hooks are not seen; keep harness marks
+literal in the test files.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.acceptance
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "ci" / "run-pr-tests.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("run_pr_tests_for_alignment", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise AssertionError(f"Unable to load run-pr-tests from {MODULE_PATH}")
+run_pr_tests = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(run_pr_tests)
+
+HARNESS_MARKS = ("acceptance", "component", "llm_harness")
+
+
+def _harness_mark_names(path: Path) -> set[str]:
+    """Return harness mark names used as ``pytest.mark.<name>`` expressions in the file.
+
+    String occurrences (e.g. mark names inside test fixtures' source snippets) do
+    not count — only real ``pytest.mark.X`` attribute accesses in the AST.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if not any(mark in text for mark in HARNESS_MARKS):
+        return set()
+
+    found: set[str] = set()
+    for node in ast.walk(ast.parse(text, filename=str(path))):
+        if not isinstance(node, ast.Attribute) or node.attr not in HARNESS_MARKS:
+            continue
+        value = node.value
+        if (
+            isinstance(value, ast.Attribute)
+            and value.attr == "mark"
+            and isinstance(value.value, ast.Name)
+            and value.value.id == "pytest"
+        ):
+            found.add(node.attr)
+    return found
+
+
+def _all_test_files() -> list[Path]:
+    return sorted((REPO_ROOT / "tests").rglob("test_*.py"))
+
+
+def test_acceptance_targets_exist():
+    missing = [target for target in run_pr_tests.PR_ACCEPTANCE_TARGETS if not (REPO_ROOT / target).exists()]
+    assert missing == [], (
+        f"Stale PR_ACCEPTANCE_TARGETS entries (file deleted or renamed): {missing}. "
+        "Update the list in ci/run-pr-tests.py."
+    )
+
+
+def test_harness_marked_files_are_acceptance_targets():
+    targets = set(run_pr_tests.PR_ACCEPTANCE_TARGETS)
+    orphaned = [
+        str(path.relative_to(REPO_ROOT))
+        for path in _all_test_files()
+        if _harness_mark_names(path) and str(path.relative_to(REPO_ROOT)) not in targets
+    ]
+    assert orphaned == [], (
+        f"Files with acceptance/component/llm_harness marks missing from PR_ACCEPTANCE_TARGETS: {orphaned}. "
+        "The acceptance suite skips them (not listed) and the impacted suite excludes them (marked), "
+        "so they never run in PR or merge-queue CI. Add them to the list in ci/run-pr-tests.py."
+    )
+
+
+def test_acceptance_targets_collect_harness_marked_tests():
+    dead_weight = [
+        target for target in run_pr_tests.PR_ACCEPTANCE_TARGETS if not _harness_mark_names(REPO_ROOT / target)
+    ]
+    assert dead_weight == [], (
+        f"PR_ACCEPTANCE_TARGETS entries without any harness mark: {dead_weight}. "
+        "The acceptance suite collects zero tests from them; mark the acceptance-worthy "
+        "tests or drop the entry from ci/run-pr-tests.py."
+    )

--- a/tests/unit_tests/ci/test_run_merge_queue_tests.py
+++ b/tests/unit_tests/ci/test_run_merge_queue_tests.py
@@ -61,6 +61,22 @@ def test_build_pytest_command_includes_marker_junit_and_extra_args(tmp_path, run
     assert ["--timeout=120", "-n", "auto"] == command[-3:]
 
 
+def test_run_suite_fails_loudly_on_missing_target(tmp_path, monkeypatch, run_merge_queue_tests):
+    monkeypatch.setattr(run_merge_queue_tests, "REPO_ROOT", tmp_path)
+    suite = {
+        "targets": ["tests/unit_tests/gone.py"],
+        "mark_expr": "acceptance",
+        "junit_xml": tmp_path / "results.xml",
+        "extra_args": [],
+    }
+
+    result = run_merge_queue_tests.run_suite("acceptance-unit", suite, timeout=10)
+
+    assert result["exit_code"] == 1
+    assert result["missing"] == ["tests/unit_tests/gone.py"]
+    assert result["targets"] == []
+
+
 def test_main_runs_selected_suite_and_writes_report(tmp_path, monkeypatch, run_merge_queue_tests):
     repo_root = tmp_path
     out_dir = repo_root / "ci"

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -246,7 +246,7 @@ def test_run_tests_treats_empty_impacted_collection_as_success(tmp_path, monkeyp
 
 
 def test_pr_harness_marker_expressions_route_component_tests():
-    assert run_pr_tests.PR_HARNESS_MARK_EXPR == "acceptance or component or llm_harness"
+    assert run_pr_tests.PR_HARNESS_MARK_EXPR == "(acceptance or component or llm_harness) and not quarantine"
     assert run_pr_tests.IMPACTED_UNIT_MARK_EXPR == (
         "not acceptance and not component and not llm_harness and not nightly and not quarantine"
     )

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1410,7 +1410,6 @@ class TestAgentConfigKnowledgeBase:
 
         assert cfg.kb_search == KbSearchConfig(mode="vector")
         assert cfg.kb_search_mode == "vector"
-        assert not hasattr(cfg, "_metadata_fts_enabled")
 
     def test_kb_search_ignores_removed_enabled_flag(self, tmp_path):
         cfg = self._make(tmp_path, kb={"search": {"enabled": "false", "mode": "fts"}})


### PR DESCRIPTION
## Why

Two structural gaps in the test harness:

1. **Harness-marked tests could silently drop out of CI.** The PR acceptance suite only runs files listed in `PR_ACCEPTANCE_TARGETS`, while the impacted unit suite explicitly excludes `acceptance`/`component`/`llm_harness` marks. A marked test in an unlisted file therefore never runs in PR **or** merge-queue CI. Two agentic-node acceptance tests (`test_gen_dashboard_agentic_node.py`, `test_scheduler_agentic_node.py`) were already lost this way, and nothing guarded against the next occurrence.
2. **Tombstone assertions.** Several tests asserted that removed private attributes/methods no longer exist (`assert not hasattr(node, "_setup_bi_tools")` etc.). These never catch real bugs, break legitimate refactors, and duplicate the behavioral contracts already covered by the kept tests (tool-list disjointness, config whitelisting).

## Solution

Harness alignment:

- Add the two orphaned files to `PR_ACCEPTANCE_TARGETS`; drop the `test_mcp_server.py` entry that collected zero marked tests (MCP acceptance coverage lives in `test_mcp_acceptance.py`).
- New acceptance-marked guard `tests/unit_tests/ci/test_harness_alignment.py`: AST-scans `tests/` for harness marks (decorators, `pytestmark`, `pytest.param` — string occurrences don't count) and fails the offending PR when marks and the target list drift, when a target goes stale, or when a target collects zero marked tests.
- Both runners now fail loudly with the stale entry named, instead of crashing collection (PR) or silently skipping (merge queue).
- All acceptance mark expressions exclude `quarantine`.
- `validate_coverage_map.py` validates every nodeid component (parametrize ids stripped), not just the first — this immediately caught one rotted method name in `coverage-map.yml`, fixed here. The `pr_acceptance` layer description now documents the two execution paths (always-on target list vs diff-driven impacted suite).
- Stop tracking generated per-suite JUnit XML; cover merge-queue outputs in `.gitignore`.

Test hygiene:

- Remove 5 tombstone tests and 1 tombstone assertion line; the behavioral contracts stay covered by the retained tests in the same classes.
- CLAUDE.md documents the no-tombstone-test rule with its allowed exceptions (deprecated public APIs/config, security fixes, removed side effects), and drops a stale test-file enumeration for `skill_tools`.

## Test Cases

- New: `tests/unit_tests/ci/test_harness_alignment.py` (3 guard tests, acceptance-marked and self-listed in `PR_ACCEPTANCE_TARGETS`).
- New: merge-queue missing-target hard-fail test in `tests/unit_tests/ci/test_run_merge_queue_tests.py`; deep-nodeid validation test in `tests/unit_tests/ci/harness/test_validate_coverage_map.py`.
- Updated: mark-expression assertion in `tests/unit_tests/ci/test_run_pr_tests.py`.
- Verified locally: `tests/unit_tests/ci/` 174 passed; `validate_coverage_map.py --strict` passes; merge-queue rehearsal green (one unrelated local LanceDB-env failure reproduced identically on the base tree); full PR harness `ci/run-pr-tests.py upstream/main`: 762 passed / 0 failed, diff coverage 100%; audit gate P0=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Merge queue and pull request test runs now exclude quarantined tests.
  * Missing or outdated test targets now fail CI clearly instead of being skipped.
  * Coverage mapping validation now checks complete test identifiers, including parameterized tests.
  * Added checks to keep harness-marked tests and acceptance targets aligned.

* **Documentation**
  * Updated testing guidance for required tests and removed-code verification.

* **Chores**
  * Expanded ignored CI result file patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->