### PR TITLE
[BugFix] Fall back to latest built-in gen_sql_system prompt template

### DIFF
--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -683,9 +683,13 @@ class GenSQLAgenticNode(AgenticNode):
             return self._finalize_system_prompt(base_prompt)
 
         except FileNotFoundError:
-            # Template not found - throw DatusException
-            logger.warning(f"Failed to render system prompt '{system_prompt_name}', using the default template instead")
-            base_prompt = pm.render_template(template_name="gen_sql_system", version=prompt_version, **context)
+            # Alias template missing: fall back to the built-in gen_sql_system
+            # at its latest version.
+            logger.warning(
+                f"Failed to render system prompt '{system_prompt_name}' (version={prompt_version}), "
+                "falling back to built-in gen_sql_system"
+            )
+            base_prompt = pm.render_template(template_name="gen_sql_system", version=None, **context)
             return self._finalize_system_prompt(base_prompt)
         except Exception as e:
             # Other template errors - wrap in DatusException

--- a/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_sql_agentic_node.py
@@ -2907,14 +2907,17 @@ class TestGenSQLSystemPromptToolContext:
         assert '"output"' in prompt
         assert "Do not use `tables`, `explanation`, `mode`, or `validation` as final JSON fields." in prompt
 
-    def test_system_prompt_fallback_preserves_prompt_version(self, real_agent_config, mock_llm_create):
+    def test_system_prompt_fallback_uses_latest_builtin_version(self, real_agent_config, mock_llm_create):
+        # Alias template missing: fall back to the built-in gen_sql_system at its
+        # latest version, ignoring the custom prompt_version (which may not exist
+        # for the built-in template).
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode
         from datus.prompts.prompt_manager import PromptManager
 
         real_agent_config.agentic_nodes["custom_alias"] = {
             "system_prompt": "custom_alias",
             "tools": "db_tools.describe_table",
-            "prompt_version": "1.1",
+            "prompt_version": "1.0",
             "max_turns": 5,
         }
         node = GenSQLAgenticNode(
@@ -2942,12 +2945,11 @@ class TestGenSQLSystemPromptToolContext:
         first_call = mock_prompt_manager.render_template.call_args_list[0].kwargs
         second_call = mock_prompt_manager.render_template.call_args_list[1].kwargs
         assert first_call["template_name"] == "custom_alias_system"
-        assert first_call["version"] == "1.1"
+        assert first_call["version"] == "1.0"
         assert second_call["template_name"] == "gen_sql_system"
-        assert second_call["version"] == "1.1"
+        assert second_call["version"] is None
         assert '"sql"' in prompt
         assert '"output"' in prompt
-        assert "Do not use `tables`, `explanation`, `mode`, or `validation` as final JSON fields." in prompt
 
     def test_system_prompt_context_uses_actual_tools(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_sql_agentic_node import GenSQLAgenticNode


### PR DESCRIPTION
## Why

A custom `gen_sql` subagent whose alias prompt template file is missing from the current workspace's template dir (e.g. in SaaS, where the subagent definition is shared across projects but the per-project `{datus_home}/template/` never received the alias template) crashed the whole turn with:

```
Prompt Template file 'gen_sql_system_1.0.j2' not found in user directory (...) or default directory (...)
```

Root cause: when the alias template is missing, `GenSQLAgenticNode._get_system_prompt` falls back to the built-in `gen_sql_system`, but it reused the subagent's `prompt_version` (default `"1.0"`) for that fallback. The built-in `gen_sql_system` only ships `1.1`/`1.2` — there is no `1.0` — so the fallback raised a **second** `FileNotFoundError`, which propagated to the user as a cryptic error instead of degrading gracefully.

## Solution

On the fallback path, render the built-in `gen_sql_system` at its **latest** version (`version=None`) rather than reusing the custom subagent's `prompt_version`, which targets the custom template and may not exist for the built-in one. This keeps the fallback a real safety net.

Note: this is the agent-side hardening only. The underlying SaaS scope mismatch (subagent definitions shared across projects while template files land per-project) is tracked separately; after this fix such a subagent degrades to the built-in prompt instead of erroring.

## Test Cases

Merged the two prior fallback tests in `test_gen_sql_agentic_node.py` into `test_system_prompt_fallback_uses_latest_builtin_version`, which asserts that a missing alias template causes the built-in `gen_sql_system` to be rendered at `version=None` (latest). Full file: 122 passed, 1 skipped; ruff and test-quality audit (P0=0) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior when a configured SQL system prompt template is unavailable.
  * The built-in prompt is now used with its appropriate default version, preventing incompatible custom version values from being carried over.
  * Warning messages now provide clearer details about the missing template and version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->