### PR TITLE
[BugFix] Gateway: skip enabled-but-unconfigured channels instead of crash-looping

### DIFF
--- a/datus/gateway/adapters/feishu.py
+++ b/datus/gateway/adapters/feishu.py
@@ -102,6 +102,10 @@ class FeishuAdapter(ChannelAdapter):
         # Streaming card state — keyed by stream_id for concurrency safety
         self._streams: dict[str, _StreamState] = {}
 
+    def is_configured(self) -> bool:
+        """Feishu needs both an app id and app secret to open its long connection."""
+        return bool(self._app_id and self._app_secret)
+
     def _dispatch_to_loop(self, coro) -> None:
         """Schedule *coro* on the main event loop from a sync SDK callback thread.
 

--- a/datus/gateway/adapters/slack.py
+++ b/datus/gateway/adapters/slack.py
@@ -51,8 +51,20 @@ class SlackAdapter(ChannelAdapter):
         self._web_client: Optional[object] = None
         self._listen_task: Optional[asyncio.Task] = None
 
+    def is_configured(self) -> bool:
+        """Slack needs both an app-level token (xapp-) and a bot token (xoxb-)."""
+        return bool(self._app_token and self._bot_token)
+
     async def start(self) -> None:
         """Connect via Slack Socket Mode."""
+        # Belt-and-braces: the gateway skips unconfigured channels before start(),
+        # but guard here too so a direct start() can't crash-loop on invalid_auth.
+        if not self.is_configured():
+            logger.warning(
+                "Slack adapter '%s' is missing app_token/bot_token; skipping start.",
+                self.channel_id,
+            )
+            return
         try:
             from slack_sdk.socket_mode.aiohttp import SocketModeClient
             from slack_sdk.web.async_client import AsyncWebClient

--- a/datus/gateway/channel/base.py
+++ b/datus/gateway/channel/base.py
@@ -43,6 +43,15 @@ class ChannelAdapter(ABC):
         """
         return False
 
+    def is_configured(self) -> bool:
+        """Whether this adapter has the credentials it needs to start.
+
+        Base default assumes configured; credential-backed adapters override so
+        the gateway can skip an enabled-but-unconfigured channel with a warning
+        instead of crash-looping against the platform (e.g. Slack ``invalid_auth``).
+        """
+        return True
+
     async def dispatch_message(self, msg: InboundMessage) -> None:
         """Forward an inbound message to the bridge for processing."""
         await self._bridge.handle_message(msg, self, self._channel_config)

--- a/datus/gateway/runtime.py
+++ b/datus/gateway/runtime.py
@@ -65,6 +65,15 @@ class DatusGateway:
                 bridge=self._bridge,
                 channel_config=channel_cfg,
             )
+            # Enabled but missing credentials → skip rather than crash-loop against
+            # the platform (e.g. Slack retrying apps.connections.open on invalid_auth).
+            if not adapter.is_configured():
+                logger.warning(
+                    "Channel '%s' (%s) is enabled but not configured (missing credentials); skipping.",
+                    channel_id,
+                    channel_cfg.adapter,
+                )
+                continue
             self._adapters[channel_id] = adapter
 
         if not self._adapters:

--- a/tests/unit_tests/gateway/adapters/test_feishu.py
+++ b/tests/unit_tests/gateway/adapters/test_feishu.py
@@ -133,6 +133,21 @@ def _make_adapter():
     return adapter
 
 
+class TestFeishuIsConfigured:
+    """Feishu needs both app_id and app_secret to be considered configured."""
+
+    def test_configured_with_both_credentials(self):
+        assert _make_adapter().is_configured() is True
+
+    def test_not_configured_when_a_credential_is_missing(self):
+        from datus.gateway.adapters.feishu import FeishuAdapter
+
+        bridge = MagicMock()
+        for cfg in ({"app_id": "x"}, {"app_secret": "x"}, {}):
+            adapter = FeishuAdapter(channel_id="c", config=cfg, bridge=bridge)
+            assert adapter.is_configured() is False
+
+
 def _make_message(text: str = "hello", sql: Optional[str] = None) -> OutboundMessage:
     return OutboundMessage(
         channel_id="test-feishu",

--- a/tests/unit_tests/gateway/adapters/test_slack.py
+++ b/tests/unit_tests/gateway/adapters/test_slack.py
@@ -69,6 +69,19 @@ def _make_socket_request(payload: dict, envelope_id: str = "env-1") -> SimpleNam
     )
 
 
+class TestSlackIsConfigured:
+    """Slack needs both app_token and bot_token to be considered configured."""
+
+    def test_configured_with_both_tokens(self):
+        assert _make_slack_adapter().is_configured() is True
+
+    def test_not_configured_when_a_token_is_missing(self):
+        bridge = MagicMock()
+        for cfg in ({"app_token": "x"}, {"bot_token": "x"}, {}):
+            adapter = SlackAdapter(channel_id="c", config=cfg, bridge=bridge)
+            assert adapter.is_configured() is False
+
+
 # ---------------------------------------------------------------------------
 # Tests: Bot mention detection
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/gateway/adapters/test_slack.py
+++ b/tests/unit_tests/gateway/adapters/test_slack.py
@@ -81,6 +81,14 @@ class TestSlackIsConfigured:
             adapter = SlackAdapter(channel_id="c", config=cfg, bridge=bridge)
             assert adapter.is_configured() is False
 
+    @pytest.mark.asyncio
+    async def test_start_skips_when_unconfigured(self):
+        # Missing tokens → start() returns early without opening a socket (no
+        # invalid_auth loop), even when called directly.
+        adapter = SlackAdapter(channel_id="c", config={}, bridge=MagicMock())
+        await adapter.start()
+        assert adapter._socket_client is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: Bot mention detection

--- a/tests/unit_tests/gateway/test_runtime.py
+++ b/tests/unit_tests/gateway/test_runtime.py
@@ -99,6 +99,11 @@ class TestGatewayStart:
             await gw.start()
         assert "my-slack" not in gw._adapters
 
+    def test_base_adapter_is_configured_by_default(self):
+        # Adapters that don't override is_configured() (no credentials to check)
+        # are treated as configured, so they are never skipped.
+        assert _FakeAdapter("c", {}, bridge=MagicMock()).is_configured() is True
+
     @pytest.mark.asyncio
     async def test_enabled_but_unconfigured_channel_skipped(self):
         """An enabled channel whose adapter isn't configured (missing credentials)

--- a/tests/unit_tests/gateway/test_runtime.py
+++ b/tests/unit_tests/gateway/test_runtime.py
@@ -100,6 +100,25 @@ class TestGatewayStart:
         assert "my-slack" not in gw._adapters
 
     @pytest.mark.asyncio
+    async def test_enabled_but_unconfigured_channel_skipped(self):
+        """An enabled channel whose adapter isn't configured (missing credentials)
+        is skipped, not started — so the gateway never crash-loops on invalid_auth."""
+
+        class _UnconfiguredAdapter(_FakeAdapter):
+            def is_configured(self):
+                return False
+
+        cfg = {"my-slack": {"adapter": "slack", "enabled": True, "extra": {}}}
+        gw = _make_gateway(cfg)
+        with (
+            patch("datus.gateway.runtime.register_builtins"),
+            patch("datus.gateway.runtime.get_adapter_class", return_value=_UnconfiguredAdapter),
+        ):
+            # Only channel is skipped → no adapters → start() returns early (no block).
+            await gw.start()
+        assert gw._adapters == {}
+
+    @pytest.mark.asyncio
     async def test_enabled_channel_instantiated_and_started(self):
         cfg = {
             "my-test": {


### PR DESCRIPTION
## Why

Running the gateway locally with an enabled Slack channel but no valid credentials crash-loops: it keeps calling `apps.connections.open` and getting `invalid_auth`, spamming the log and never settling.

```
The server responded with: {'ok': False, 'error': 'invalid_auth'}
Failed to retrieve WSS URL ... Retrying...
```

The gateway starts every enabled channel regardless of whether its credentials are present.

## Solution

Skip enabled-but-unconfigured channels instead of starting them:

- Add `ChannelAdapter.is_configured()` — base returns `True`; credential-backed adapters override:
  - `SlackAdapter`: requires both `app_token` and `bot_token`.
  - `FeishuAdapter`: requires both `app_id` and `app_secret`.
- `DatusGateway.start()` skips an enabled channel whose adapter reports `is_configured() == False`, with a warning (never added to `_adapters`, so it isn't started or torn down).
- `SlackAdapter.start()` also guards defensively (early return + warning) so a direct caller can't trigger the invalid_auth loop either.

No behaviour change for a properly-configured channel.

## Test Cases

- `tests/unit_tests/gateway/test_runtime.py::TestGatewayStart::test_enabled_but_unconfigured_channel_skipped` — real `start()` skips an enabled channel whose adapter is unconfigured (`_adapters` stays empty, no block).
- `tests/unit_tests/gateway/adapters/test_slack.py::TestSlackIsConfigured` — `is_configured()` true with both tokens, false when either is missing.
- Full gateway unit suite passes (49 tests); `ruff format`/`check` clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled channels with missing credentials are now skipped instead of repeatedly failing to start.
  * Slack connections no longer attempt to initialize when required tokens are absent.
  * Added configuration checks for Slack and Feishu integrations.
  * Improved gateway startup stability for unconfigured channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled channels with missing credentials are now skipped during startup instead of attempting to connect and failing.
  * Slack startup now performs a pre-flight configuration check and exits early when required tokens are absent.
  * Gateway startup now checks each enabled channel adapter’s configuration status before starting it.
* **New Features**
  * Added `is_configured()` reporting for channel adapters (defaulting to configured) to support safer gateway startup.
* **Tests**
  * Added unit tests covering configuration checks and verified that Slack/Feishu unconfigured adapters are not started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->