### PR TITLE
[BugFix] Slack adapter: fail fast on invalid credentials instead of reconnect-looping

### DIFF
--- a/datus/gateway/adapters/slack.py
+++ b/datus/gateway/adapters/slack.py
@@ -77,13 +77,28 @@ class SlackAdapter(ChannelAdapter):
 
         self._web_client = AsyncWebClient(token=self._bot_token)
 
+        # Pre-flight both credentials before opening Socket Mode. slack_sdk's
+        # SocketModeClient.connect() retries invalid_auth indefinitely, so an
+        # invalid/expired token would otherwise spin forever in a reconnect loop
+        # (apps.connections.open → invalid_auth). Fail fast and skip this channel
+        # instead: auth_test validates the bot token, apps_connections_open the
+        # app token.
         try:
             auth_resp = await self._web_client.auth_test()
             data = auth_resp.data if hasattr(auth_resp, "data") else auth_resp
             self._bot_user_id = data.get("user_id", "") if isinstance(data, dict) else ""
-            logger.info("Slack bot user ID: %s", self._bot_user_id)
+            await self._web_client.apps_connections_open(app_token=self._app_token)
         except Exception as e:
-            logger.warning("Failed to get Slack bot user ID: %s", e)
+            logger.error(
+                "Slack adapter '%s' credential check failed (%s); skipping start. "
+                "Verify its bot_token (xoxb-) and app_token (xapp-).",
+                self.channel_id,
+                e,
+            )
+            self._web_client = None
+            return
+
+        logger.info("Slack adapter '%s' authenticated (bot user %s).", self.channel_id, self._bot_user_id)
 
         self._socket_client = SocketModeClient(
             app_token=self._app_token,

--- a/tests/unit_tests/gateway/adapters/test_slack.py
+++ b/tests/unit_tests/gateway/adapters/test_slack.py
@@ -69,6 +69,22 @@ def _make_socket_request(payload: dict, envelope_id: str = "env-1") -> SimpleNam
     )
 
 
+def _fake_slack_sdk_modules(fake_web, fake_socket_client=None):
+    """Fake slack_sdk modules for sys.modules so start()'s in-function imports
+    resolve without the optional slack_sdk package installed (CI runs without it)."""
+    async_client_mod = MagicMock()
+    async_client_mod.AsyncWebClient = MagicMock(return_value=fake_web)
+    aiohttp_mod = MagicMock()
+    aiohttp_mod.SocketModeClient = MagicMock(return_value=fake_socket_client or MagicMock())
+    return {
+        "slack_sdk": MagicMock(),
+        "slack_sdk.web": MagicMock(),
+        "slack_sdk.web.async_client": async_client_mod,
+        "slack_sdk.socket_mode": MagicMock(),
+        "slack_sdk.socket_mode.aiohttp": aiohttp_mod,
+    }
+
+
 class TestSlackIsConfigured:
     """Slack needs both app_token and bot_token to be considered configured."""
 
@@ -101,11 +117,37 @@ class TestSlackIsConfigured:
         fake_web = MagicMock()
         fake_web.auth_test = AsyncMock(side_effect=Exception("invalid_auth"))
         fake_web.apps_connections_open = AsyncMock()
-        with patch("slack_sdk.web.async_client.AsyncWebClient", return_value=fake_web):
+        with patch.dict("sys.modules", _fake_slack_sdk_modules(fake_web)):
             await adapter.start()
         assert adapter._socket_client is None
         assert adapter._web_client is None
         fake_web.apps_connections_open.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_succeeds_with_valid_credentials(self):
+        # Both credentials pass the pre-flight → the Socket Mode client is opened.
+        adapter = SlackAdapter(
+            channel_id="c",
+            config={"app_token": "xapp-ok", "bot_token": "xoxb-ok"},
+            bridge=MagicMock(),
+        )
+        fake_web = MagicMock()
+        fake_web.auth_test = AsyncMock(return_value=SimpleNamespace(data={"user_id": "U_BOT"}))
+        fake_web.apps_connections_open = AsyncMock()
+        fake_socket = MagicMock()
+        fake_socket.connect = AsyncMock()
+        fake_socket.socket_mode_request_listeners = []
+        with patch.dict("sys.modules", _fake_slack_sdk_modules(fake_web, fake_socket)):
+            await adapter.start()
+        try:
+            fake_web.auth_test.assert_awaited_once()
+            fake_web.apps_connections_open.assert_awaited_once_with(app_token="xapp-ok")
+            assert adapter._bot_user_id == "U_BOT"
+            assert adapter._socket_client is fake_socket
+            assert adapter._web_client is fake_web
+        finally:
+            if adapter._listen_task:
+                adapter._listen_task.cancel()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/gateway/adapters/test_slack.py
+++ b/tests/unit_tests/gateway/adapters/test_slack.py
@@ -89,6 +89,24 @@ class TestSlackIsConfigured:
         await adapter.start()
         assert adapter._socket_client is None
 
+    @pytest.mark.asyncio
+    async def test_start_aborts_when_credentials_invalid(self):
+        # Non-empty but invalid tokens: the credential pre-flight raises → start()
+        # aborts instead of entering slack_sdk's invalid_auth reconnect loop.
+        adapter = SlackAdapter(
+            channel_id="c",
+            config={"app_token": "xapp-bad", "bot_token": "xoxb-bad"},
+            bridge=MagicMock(),
+        )
+        fake_web = MagicMock()
+        fake_web.auth_test = AsyncMock(side_effect=Exception("invalid_auth"))
+        fake_web.apps_connections_open = AsyncMock()
+        with patch("slack_sdk.web.async_client.AsyncWebClient", return_value=fake_web):
+            await adapter.start()
+        assert adapter._socket_client is None
+        assert adapter._web_client is None
+        fake_web.apps_connections_open.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Tests: Bot mention detection


### PR DESCRIPTION
## Why

Running locally (or anywhere without valid Slack creds) still crash-loops even after #1135:

```
apps.connections.open ... {'ok': False, 'error': 'invalid_auth'}
Failed to connect ... Retrying...
```

#1135's `is_configured()` guard only skips channels with **missing** tokens. A channel whose tokens are **present but invalid/expired** passes the guard, and `SlackAdapter.start()` then created a `SocketModeClient` whose `connect()` retries `apps.connections.open` on `invalid_auth` indefinitely (slack_sdk's built-in reconnect). The prior `auth_test()` failure was only logged as a warning and start continued anyway.

## Solution

Pre-flight **both** credentials in `SlackAdapter.start()` before opening Socket Mode, and skip the channel (log error + return, no socket client) if either fails:

- `auth_test()` — validates the bot token (`xoxb-`).
- `apps_connections_open(app_token=…)` — validates the app token (`xapp-`), the exact call that was looping.

This makes an invalid/expired token fail fast (one clear error) instead of spinning in a reconnect loop. Properly-configured channels are unaffected. Complements #1135 (missing-token skip) — together they cover both missing and invalid credentials.

Note: the SaaS backend's gateway supervisor drives `adapter.start()` directly (not `DatusGateway.start()`), so this adapter-level guard is what protects that path.

## Test Cases

- `tests/unit_tests/gateway/adapters/test_slack.py::TestSlackIsConfigured::test_start_aborts_when_credentials_invalid` — a present-but-invalid token whose `auth_test()` raises aborts `start()` (`_socket_client`/`_web_client` stay None, no socket opened, `apps_connections_open` not reached).
- Existing `test_start_skips_when_unconfigured` (missing tokens) still passes.
- Full Slack adapter suite: 40 passed; `ruff format`/`check` clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **Bug Fixes**
  * Slack connections now validate both bot and app credentials before starting.
  * Invalid credentials fail fast, preventing incomplete Socket Mode connections.
  * Improved handling ensures failed authentication does not leave connection resources active.

* **Tests**
  * Added coverage confirming startup stops when invalid credentials are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->