### PR TITLE
[Enhancement] Declare AgentConfig.prompt_manager as a typed runtime attribute

### DIFF
--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -7,7 +7,7 @@ import os
 import re
 from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union
 
 from datus.configuration.node_type import NodeType
 from datus.observability.config import ObservabilityConfig
@@ -19,6 +19,10 @@ from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.path_utils import get_files_from_glob_pattern
+
+if TYPE_CHECKING:
+    from datus.prompts.prompt_manager import PromptManager
+    from datus.utils.path_manager import DatusPathManager
 
 # Regex for validating platform/identifier names (no special chars that break paths)
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_\-]+$")
@@ -754,6 +758,24 @@ class AgentConfig:
             self._project_name = _normalize_project_name(str(resolved_project_root))
         self._project_root = resolved_project_root
         self._set_path_manager(self.home)
+
+        # Runtime override for prompt-template resolution, honored by
+        # ``get_prompt_manager()`` ahead of ``path_manager``. ``None`` means "derive
+        # the template dir from ``home``", which is what every CLI run does.
+        #
+        # Hosts whose templates do not live under ``home`` assign one here. The SaaS
+        # backend is the motivating case: its ``home`` is the per-project dir, but
+        # prompt templates are a workspace-level asset shared across the projects in
+        # that workspace, so it attaches a PromptManager anchored one level up.
+        #
+        # Deliberately an instance attribute and NOT a dataclass field — same as
+        # ``path_manager``. Declared fields land in ``dataclasses.asdict()``, which is
+        # what ``DatusService.compute_fingerprint`` hashes; a PromptManager stringifies
+        # to a memory address, so making this a field would churn the fingerprint on
+        # every rebuild and evict the cached service. See the ``model_extras``
+        # normalization below for the same constraint.
+        self.prompt_manager: Optional["PromptManager"] = None
+
         models_raw = kwargs.get("models", {}) or {}
         self.target = kwargs.get("target", "") or ""
         self.models = {name: load_model_config(cfg) for name, cfg in models_raw.items()}
@@ -1911,7 +1933,9 @@ class AgentConfig:
     def _set_path_manager(self, home: str) -> None:
         from datus.utils.path_manager import DatusPathManager, set_current_path_manager
 
-        self.path_manager = DatusPathManager(
+        # Like ``prompt_manager``, an instance attribute rather than a dataclass
+        # field, so it stays out of ``dataclasses.asdict()`` / the fingerprint.
+        self.path_manager: "DatusPathManager" = DatusPathManager(
             home,
             project_name=self._project_name,
             project_root=self._project_root,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ exclude_lines = [
     "if __name__ == .__main__.",
     "raise NotImplementedError",
     "except ImportError",
+    "if TYPE_CHECKING:",
 ]
 show_missing = true
 precision = 2

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2651,3 +2651,90 @@ class TestPluginsEnabledSwitch:
         # The whole ``agent.plugins`` section is ignored when disabled.
         assert cfg.plugin_services == {}
         assert cfg.get_plugin_profile("hello") == {}
+
+
+class TestPromptManagerAttribute:
+    """``AgentConfig.prompt_manager`` — the runtime prompt-template override.
+
+    It is an instance attribute rather than a dataclass field on purpose; these
+    tests pin the two properties that choice buys, so a future refactor that
+    promotes it to a field fails loudly instead of silently degrading the SaaS
+    service cache.
+    """
+
+    @staticmethod
+    def _make(tmp_path):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            skip_init_dirs=True,
+        )
+
+    def test_defaults_to_none(self, tmp_path):
+        """Unset means "derive the template dir from home" — the CLI path."""
+        assert self._make(tmp_path).prompt_manager is None
+
+    def test_get_prompt_manager_falls_back_to_path_manager_when_unset(self, tmp_path):
+        from datus.prompts.prompt_manager import get_prompt_manager
+
+        cfg = self._make(tmp_path)
+        pm = get_prompt_manager(agent_config=cfg)
+
+        assert pm.user_templates_dir == cfg.path_manager.template_dir
+
+    def test_attached_manager_overrides_the_home_derived_one(self, tmp_path):
+        """A host whose templates live outside ``home`` attaches its own manager."""
+        from datus.prompts.prompt_manager import PromptManager, get_prompt_manager
+        from datus.utils.path_manager import DatusPathManager
+
+        cfg = self._make(tmp_path)
+        elsewhere = tmp_path / "elsewhere"
+        cfg.prompt_manager = PromptManager(path_manager=DatusPathManager(str(elsewhere)))
+
+        pm = get_prompt_manager(agent_config=cfg)
+
+        assert pm is cfg.prompt_manager
+        assert pm.user_templates_dir == elsewhere.resolve() / "template"
+        assert pm.user_templates_dir != cfg.path_manager.template_dir
+
+    def test_excluded_from_asdict_so_the_fingerprint_stays_stable(self, tmp_path):
+        """``DatusService.compute_fingerprint`` hashes ``dataclasses.asdict``.
+
+        A PromptManager stringifies to a memory address, so if it ever entered the
+        payload the fingerprint would differ on every rebuild and the cached service
+        would be evicted mid-session.
+        """
+        import dataclasses
+
+        from datus.prompts.prompt_manager import PromptManager
+        from datus.utils.path_manager import DatusPathManager
+
+        cfg = self._make(tmp_path)
+        before = dataclasses.asdict(cfg)
+
+        cfg.prompt_manager = PromptManager(path_manager=DatusPathManager(str(tmp_path / "elsewhere")))
+        after = dataclasses.asdict(cfg)
+
+        assert "prompt_manager" not in after
+        assert "prompt_manager" not in AgentConfig.__dataclass_fields__
+        assert after == before
+
+    def test_survives_deepcopy(self, tmp_path):
+        """Hosts clone the config per request (e.g. chat_task_manager)."""
+        import copy
+
+        from datus.prompts.prompt_manager import PromptManager, get_prompt_manager
+        from datus.utils.path_manager import DatusPathManager
+
+        cfg = self._make(tmp_path)
+        elsewhere = tmp_path / "elsewhere"
+        cfg.prompt_manager = PromptManager(path_manager=DatusPathManager(str(elsewhere)))
+
+        cloned = copy.deepcopy(cfg)
+
+        assert isinstance(cloned.prompt_manager, PromptManager)
+        # A real clone, not a shared reference back into the original config.
+        assert cloned.prompt_manager is not cfg.prompt_manager
+        assert get_prompt_manager(agent_config=cloned).user_templates_dir == elsewhere.resolve() / "template"


### PR DESCRIPTION
## Why

`get_prompt_manager()` documents `agent_config.prompt_manager` as **entry #1** in its resolution order:

```
Resolution order:
1. ``agent_config.prompt_manager`` if already attached
2. A new ``PromptManager`` bound to ``agent_config`` (and its path_manager)
3. Default ``PromptManager()``
```

…but `AgentConfig` never defined the attribute. The extension point added in #518 (*"Replace PromptManager singleton with factory pattern for SaaS multi-tenant isolation"*) only existed inside a `getattr()` lookup — hosts had to graft the attribute on from outside, and nothing told a reader, an IDE, or a type checker that it was there at all.

The SaaS backend is the motivating consumer. `PromptManager` derives its template dir from `AgentConfig.home` (`DatusPathManager.template_dir == home/"template"`), but the backend's `home` is the *per-project* dir while prompt templates are a **workspace-level** asset shared across the projects in that workspace. It therefore attaches a `PromptManager` anchored one level up. That works today purely because Python lets you set an undeclared attribute — which is not a contract anyone can rely on.

## Solution

Declare it in `AgentConfig.__init__`:

```python
self.prompt_manager: Optional["PromptManager"] = None
```

`None` means *"derive the template dir from `home`"* — every CLI run. A host whose templates do not live under `home` assigns its own manager. No behavior changes: `get_prompt_manager()` already treats `None` as "fall through to `path_manager`", which is exactly what an unset attribute did before.

`path_manager` is annotated the same way in `_set_path_manager`, so the two runtime attributes now read alike.

### Why an instance attribute and not a dataclass field

This is the key design decision, and it is deliberate.

`AgentConfig` is a `@dataclass`, so a *declared field* lands in `dataclasses.asdict()` — which is precisely what `DatusService.compute_fingerprint()` hashes:

```python
payload = dataclasses.asdict(agent_config)
serialized = json.dumps(payload, sort_keys=True, default=str)
return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
```

A `PromptManager` has no custom `__repr__`, so `default=str` would stringify it to `<PromptManager object at 0x...>` — a **new memory address on every rebuild**. Promoting `prompt_manager` to a field would therefore churn the fingerprint on every config rebuild and evict the cached `DatusService` mid-session. Keeping it an instance attribute (exactly like `path_manager`) keeps it out of `asdict()` entirely.

The same constraint already governs the `model_extras` normalization a few lines below, which explicitly notes it normalizes to a plain `dict` "so `dataclasses.asdict` serializes cleanly into the AgentConfig fingerprint".

## Test Cases

New `TestPromptManagerAttribute` in `tests/unit_tests/configuration/test_agent_config.py` (5 unit tests, no external deps, no network):

- `test_defaults_to_none` — unset means "derive from `home`".
- `test_get_prompt_manager_falls_back_to_path_manager_when_unset` — the CLI path is unchanged.
- `test_attached_manager_overrides_the_home_derived_one` — an attached manager wins, and its template dir is *not* the `home`-derived one.
- `test_excluded_from_asdict_so_the_fingerprint_stays_stable` — pins the design decision above: `prompt_manager` stays out of `dataclasses.asdict()` and out of `__dataclass_fields__`, and attaching one leaves the payload byte-identical. A future refactor that promotes it to a field fails here instead of silently degrading the service cache.
- `test_survives_deepcopy` — hosts clone the config per request (`chat_task_manager` does `copy.deepcopy(agent_config)` before every agentic loop); the clone keeps its own manager.

Gates run locally on this branch:

- `ruff format` / `ruff check` — clean.
- `ci/audit_tests.py --diff-only upstream/main` — **P0=0, P1=0**.
- `tests/unit_tests/configuration/` + `tests/unit_tests/prompts/` — **489 passed**.
- `ci/run-pr-tests.py` — impacted unit tests **412 passed** (exit 0); diff coverage 66%. The acceptance suite has one failure unrelated to this change: `tests/integration/storage/test_doc_search.py::TestSearchTool::test_delete_docs_by_version` panics inside LanceDB with `DecodeError: expected type URL "/lance.encodings.PageLayout" (got "/lance.encodings21.PageLayout")` — a lance encoding-version mismatch against the pre-built test data. Verified it fails identically on a clean upstream `main` with none of this branch's changes applied.

## Related

The SaaS-side consumer that motivates this attribute: Datus-backend#346 (`fix(config): anchor PromptManager at the workspace template dir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling for prompt managers and path managers.
  * Preserved custom prompt template locations when configurations are copied or reused.
  * Kept prompt manager details from affecting configuration serialization and fingerprinting.
  * Added safeguards to maintain consistent runtime behavior across configuration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration safety and type handling for prompt manager behavior.
  * Prompt template directory now falls back to path-derived settings when a prompt manager isn’t set.
  * An explicitly provided prompt manager now correctly overrides home-derived template locations.
  * Prompt manager is no longer included in configuration serialization/fingerprinting.
* **Tests**
  * Added unit tests covering defaults, overrides, deepcopy persistence, and stable serialization behavior.
* **Chores**
  * Updated coverage reporting to exclude `TYPE_CHECKING` blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->