### PR TITLE
[BugFix] Fix search_table result count display

### DIFF
--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Callable, Dict, List, Optional
 
 from datus.schemas.action_history import ActionHistory, ActionStatus
-from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY
+from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY, search_table_result_counts
 from datus.utils.loggings import get_logger
 from datus.utils.tool_archive import is_archived_output, parse_archived_marker
 
@@ -1030,7 +1030,7 @@ def _build_read_query(action: ActionHistory, verbose: bool) -> ToolCallContent:
 
 
 def _build_search_table(action: ActionHistory, verbose: bool) -> ToolCallContent:
-    """search_table: show metadata + sample_data counts."""
+    """search_table: show table and inline sample-row counts."""
     tc = make_base_content(action)
     if verbose:
         tc.args_lines = extract_args_markup(action)
@@ -1039,14 +1039,8 @@ def _build_search_table(action: ActionHistory, verbose: bool) -> ToolCallContent
     else:
         data = parse_output_data(action.output)
         if data:
-            metadata_count = len(data.get("metadata") or [])
-            sample_data = data.get("sample_data")
-            if isinstance(sample_data, dict):
-                sample_count = sample_data.get("original_rows", 0) or 0
-            elif isinstance(sample_data, list):
-                sample_count = len(sample_data)
-            else:
-                sample_count = 0
+            result = data.get("result", data)
+            metadata_count, sample_count = search_table_result_counts(result)
             tc.compact_result = (
                 f"{metadata_count} {_plural_unit(metadata_count, 'table', 'tables')} "
                 f"and {sample_count} {_plural_unit(sample_count, 'sample row', 'sample rows')}"

--- a/datus/gateway/formatters.py
+++ b/datus/gateway/formatters.py
@@ -7,6 +7,7 @@
 from typing import Callable, Dict, Optional
 
 from datus.gateway.models import Verbose
+from datus.schemas.tool_summary import search_table_result_counts
 
 # Maximum length for any single value in full-mode output
 _MAX_VALUE_LEN = 2000
@@ -112,10 +113,7 @@ class ToolOutputFormatter:
     def _format_search_table_result(result) -> str:
         if not isinstance(result, dict):
             return _format_result_default(result)
-        metadata = result.get("metadata", [])
-        sample_data = result.get("sample_data", result.get("samples", []))
-        meta_count = len(metadata) if isinstance(metadata, list) else 0
-        sample_count = len(sample_data) if isinstance(sample_data, list) else 0
+        meta_count, sample_count = search_table_result_counts(result)
         return f"> metadata: {meta_count}, sample rows: {sample_count}"
 
 

--- a/datus/schemas/tool_summary.py
+++ b/datus/schemas/tool_summary.py
@@ -282,20 +282,28 @@ def _fmt_list_schemas(result: Any) -> str:
     return ""
 
 
+def search_table_result_counts(result: Any) -> tuple[int, int]:
+    """Return table and sample-row counts from the current search_table result shape."""
+    if not isinstance(result, dict):
+        return 0, 0
+
+    metadata = result.get("metadata")
+    if not isinstance(metadata, list):
+        return 0, 0
+
+    sample_count = sum(
+        len(sample_rows)
+        for item in metadata
+        if isinstance(item, dict) and isinstance((sample_rows := item.get("sample_rows")), list)
+    )
+
+    return len(metadata), sample_count
+
+
 def _fmt_search_table(result: Any) -> str:
     if not isinstance(result, dict):
         return ""
-    metadata = result.get("metadata") or []
-    if not isinstance(metadata, list):
-        return ""
-    n = len(metadata)
-    sample = result.get("sample_data")
-    if isinstance(sample, dict):
-        sample_rows = sample.get("original_rows", 0) or 0
-    elif isinstance(sample, list):
-        sample_rows = len(sample)
-    else:
-        sample_rows = 0
+    n, sample_rows = search_table_result_counts(result)
     if n == 0 and sample_rows == 0:
         return "no matches"
     tbl_label = "tbl" if n == 1 else "tbls"

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -381,30 +381,35 @@ class TestBuildSearchTable:
     def test_compact(self):
         a = _make(
             input_data={"function_name": "search_table"},
-            output_data={"metadata": [1, 2], "sample_data": [3]},
-        )
-        tc = _build_search_table(a, verbose=False)
-        assert "2 tables" in tc.compact_result
-        assert "1 sample row" in tc.compact_result
-
-    def test_compact_with_compressed_sample_data(self):
-        a = _make(
-            input_data={"function_name": "search_table"},
             output_data={
-                "metadata": [1, 2],
-                "sample_data": {
-                    "original_rows": 1,
-                    "original_columns": ["sample_rows"],
-                    "is_compressed": False,
-                    "compressed_data": "index,sample_rows\n0,[{'id': 1}]",
-                    "removed_columns": [],
-                    "compression_type": "none",
-                },
+                "metadata": [
+                    {"table_name": "orders", "sample_rows": [{"id": 1}]},
+                    {"table_name": "customers"},
+                ]
             },
         )
         tc = _build_search_table(a, verbose=False)
         assert "2 tables" in tc.compact_result
         assert "1 sample row" in tc.compact_result
+
+    def test_compact_with_func_tool_envelope_and_inline_sample_rows(self):
+        a = _make(
+            input_data={"function_name": "search_table"},
+            output_data={
+                "raw_output": {
+                    "success": 1,
+                    "error": None,
+                    "result": {
+                        "metadata": [
+                            {"table_name": "orders", "sample_rows": [{"id": 1}, {"id": 2}]},
+                            {"table_name": "customers", "sample_rows": [{"id": 3}]},
+                        ]
+                    },
+                }
+            },
+        )
+        tc = _build_search_table(a, verbose=False)
+        assert tc.compact_result == "2 tables and 3 sample rows"
 
     def test_compact_no_data(self):
         a = _make(input_data={"function_name": "search_table"})

--- a/tests/unit_tests/cli/test_action_history_display.py
+++ b/tests/unit_tests/cli/test_action_history_display.py
@@ -3123,7 +3123,11 @@ class TestGetToolOutputPreview:
             ActionRole.TOOL,
             ActionStatus.SUCCESS,
             input_data={"function_name": "search_table"},
-            output_data={"raw_output": '{"metadata": [{"t": 1}, {"t": 2}], "sample_data": [{"r": 1}]}'},
+            output_data={
+                "raw_output": (
+                    '{"metadata": [{"table_name": "orders", "sample_rows": [{"id": 1}]}, {"table_name": "customers"}]}'
+                )
+            },
         )
         tc = _build_search_table(action, verbose=False)
         assert "2 tables" in tc.compact_result

--- a/tests/unit_tests/gateway/test_bridge.py
+++ b/tests/unit_tests/gateway/test_bridge.py
@@ -1211,7 +1211,9 @@ class TestVerboseLevels:
                                 "toolName": "search_table",
                                 "duration": 1.5,
                                 "shortDesc": "",
-                                "result": {"metadata": [1], "sample_data": [1, 2]},
+                                "result": {
+                                    "metadata": [{"table_name": "orders", "sample_rows": [{"id": 1}, {"id": 2}]}]
+                                },
                             },
                         )
                     ],

--- a/tests/unit_tests/gateway/test_formatters.py
+++ b/tests/unit_tests/gateway/test_formatters.py
@@ -23,7 +23,7 @@ RESULT_PAYLOAD = {
     "toolName": "search_table",
     "duration": 1.2,
     "shortDesc": "Found tables",
-    "result": {"metadata": [{"name": "orders"}], "sample_data": [{"id": 1}, {"id": 2}]},
+    "result": {"metadata": [{"table_name": "orders", "sample_rows": [{"id": 1}, {"id": 2}]}]},
 }
 
 
@@ -143,7 +143,13 @@ class TestSearchTableFormatter:
             "callToolId": "t1",
             "toolName": "search_table",
             "duration": 1.0,
-            "result": {"metadata": [1, 2, 3], "sample_data": [1, 2]},
+            "result": {
+                "metadata": [
+                    {"table_name": "orders", "sample_rows": [{"id": 1}, {"id": 2}]},
+                    {"table_name": "customers"},
+                    {"table_name": "products"},
+                ]
+            },
         }
         result = formatter.format_tool_complete(call, res, Verbose.FULL)
         assert "metadata: 3" in result

--- a/tests/unit_tests/schemas/test_tool_summary.py
+++ b/tests/unit_tests/schemas/test_tool_summary.py
@@ -323,8 +323,10 @@ class TestDatabaseFormatters:
             {
                 "success": 1,
                 "result": {
-                    "metadata": [{"table_name": "orders"}, {"table_name": "customers"}],
-                    "sample_data": {"original_rows": 5},
+                    "metadata": [
+                        {"table_name": "orders", "sample_rows": [{"id": i} for i in range(3)]},
+                        {"table_name": "customers", "sample_rows": [{"id": i} for i in range(2)]},
+                    ],
                 },
             },
         )
@@ -333,12 +335,27 @@ class TestDatabaseFormatters:
     def test_search_table_no_samples(self):
         out = _summarize(
             "search_table",
-            {"success": 1, "result": {"metadata": [{"name": "t"}], "sample_data": []}},
+            {"success": 1, "result": {"metadata": [{"table_name": "t"}]}},
         )
         assert out == "1 tbl"
 
+    def test_search_table_with_inline_sample_rows(self):
+        out = _summarize(
+            "search_table",
+            {
+                "success": 1,
+                "result": {
+                    "metadata": [
+                        {"table_name": "orders", "sample_rows": [{"id": 1}, {"id": 2}]},
+                        {"table_name": "customers", "sample_rows": [{"id": 3}]},
+                    ]
+                },
+            },
+        )
+        assert out == "2 tbls, 3 rows"
+
     def test_search_table_empty(self):
-        out = _summarize("search_table", {"success": 1, "result": {"metadata": [], "sample_data": []}})
+        out = _summarize("search_table", {"success": 1, "result": {"metadata": []}})
         assert out == "no matches"
 
 
@@ -1010,7 +1027,10 @@ _LENGTH_CONTRACT_SAMPLES: list[tuple[str, Any]] = [
     ("table_overview", [{"name": str(i)} for i in range(50)]),
     ("list_databases", [str(i) for i in range(99)]),
     ("list_schemas", [str(i) for i in range(99)]),
-    ("search_table", {"metadata": [{"name": str(i)} for i in range(20)], "sample_data": {"original_rows": 999}}),
+    (
+        "search_table",
+        {"metadata": [{"name": str(i), "sample_rows": [{} for _ in range(50)]} for i in range(20)]},
+    ),
     ("transfer_query_result", {"row_count": 99999, "target_table": "very_long_target_table_name"}),
     # bi
     ("list_dashboards", {"items": [{"title": "x"} for _ in range(99)], "total": 999, "has_more": True}),


### PR DESCRIPTION
## Summary

- unwrap the `FuncToolResult.result` envelope before rendering `search_table` results in the CLI
- count tables and inline `metadata[].sample_rows` using the current `search_table` result contract
- share the count logic across CLI compact output, tool summaries, and gateway formatting
- update display fixtures and regression coverage to use the current inline sample-row shape

## Root cause

`search_table` now returns table matches under `result.metadata`, with sample rows embedded in each metadata item. The display paths still read metadata from the outer result envelope or expected the removed top-level `sample_data` field, so successful matches could be rendered as zero tables and zero sample rows.

## User impact

Successful `search_table` calls now report their actual table and sample-row counts consistently across CLI and gateway surfaces.

## Validation

- `532 passed` across the affected CLI, summary, gateway, and DB tool contract tests
- `ruff check` on all changed Python files
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `search_table` result handling for nested tool-result responses.
  * Compact and formatted summaries now accurately count tables and inline sample rows.
  * Updated handling when tables contain no sample rows.

* **Tests**
  * Expanded coverage for nested result payloads and per-table sample rows.
  * Updated formatting checks to validate table and sample-row counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->