### PR TITLE
[Doc] Add metadata FTS user guide

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -499,6 +499,7 @@ flow_groups:
         quality_sensitive: true
         docs:
           - docs/knowledge_base/metadata.md
+          - docs/knowledge_base/metadata_fts.md
           - docs/configuration/storage.md
         entrypoints:
           - CLI bootstrap
@@ -506,6 +507,8 @@ flow_groups:
           - Metadata storage backend
         contracts:
           - Table and column metadata can be initialized, stored, searched, and scoped by datasource.
+          - Metadata bootstrap and runtime retrieval use the configured vector or FTS mode consistently.
+          - FTS reports unsupported, missing, legacy, or incompatible indexes instead of silently falling back.
           - Storage layout remains isolated between projects.
         coverage:
           pr_acceptance:

--- a/docs/knowledge_base/metadata.md
+++ b/docs/knowledge_base/metadata.md
@@ -61,16 +61,14 @@ kb:
     mode: fts
 ```
 
-The FTS store searches table names, DDL, sample rows, and attached semantic profiles. It does not fall back to vector search. A missing, legacy, or incomplete FTS index produces an explicit error and must be rebuilt with `overwrite`.
-
-After the initial FTS build, `incremental` upserts only new or changed metadata and uses LanceDB `optimize()` to add the changed fragments to the existing index. It does not replace the complete FTS index.
-
 Choose the mode before building metadata. Switching an existing vector installation to FTS requires a full rebuild:
 
 ```bash
 datus-agent bootstrap-kb --datasource <your_datasource> --components metadata \
   --kb_search_mode fts --kb_update_strategy overwrite
 ```
+
+For backend requirements, persistent versus one-time configuration, index verification, incremental updates, mode switching, and troubleshooting, see [Metadata Full-text Search](metadata_fts.md).
 
 ## Usage Examples
 

--- a/docs/knowledge_base/metadata.zh.md
+++ b/docs/knowledge_base/metadata.zh.md
@@ -61,16 +61,14 @@ kb:
     mode: fts
 ```
 
-FTS store 会检索表名、DDL、样本数据以及附加的 semantic profile，并且不会回退到 vector。FTS 索引缺失、格式过旧或构建不完整时会直接报错，必须使用 `overwrite` 重新构建。
-
-首次构建 FTS 后，`incremental` 只会 upsert 新增或发生变化的 metadata，并通过 LanceDB `optimize()` 将变化的 fragment 增量加入现有索引，不会替换完整 FTS 索引。
-
 必须在构建 metadata 前选定模式。已有 vector 数据切换到 FTS 时需要完整重建：
 
 ```bash
 datus-agent bootstrap-kb --datasource <your_datasource> --components metadata \
   --kb_search_mode fts --kb_update_strategy overwrite
 ```
+
+关于存储后端要求、持久配置与单次覆盖的区别、索引验证、增量更新、模式切换和故障排查，请参阅[元数据全文检索](metadata_fts.md)。
 
 ## 使用示例
 

--- a/docs/knowledge_base/metadata_fts.md
+++ b/docs/knowledge_base/metadata_fts.md
@@ -1,0 +1,146 @@
+# Metadata Full-text Search
+
+Metadata full-text search (FTS) is an opt-in alternative to vector retrieval for finding relevant tables. It searches the text already present in table metadata and does not generate embeddings for that metadata.
+
+FTS is useful when questions contain recognizable business terms, table or column names, SQL fragments, or other exact text. Keep the default vector mode when users commonly describe a concept with words that do not appear in the metadata.
+
+!!! note "Scope"
+    The setting only changes **metadata retrieval** used for table discovery and schema linking. Metrics, reference SQL, reference templates, platform documents, and other knowledge-base components keep their own retrieval behavior. FTS also searches only sample rows captured during bootstrap; it does not query every source-table row.
+
+## FTS and vector modes
+
+| | `fts` | `vector` |
+|---|---|---|
+| Best for | Keywords, identifiers, SQL text, and exact business terms | Semantic similarity and paraphrased questions |
+| Metadata embeddings | Not generated | Required |
+| Default | No | Yes |
+| Fallback | Does not fall back to vector search | Not applicable |
+
+FTS indexes the following metadata text:
+
+- Table name, qualified name, identifier, and table type
+- Table or view definition (DDL)
+- Sample rows collected by `bootstrap-kb`
+- Attached table semantic profiles, when available, including descriptions, columns, relationships, and AI context
+
+Search results remain scoped to the active datasource and any catalog, database, schema, table type, or subagent restrictions applied by Datus Agent.
+
+## Prerequisites
+
+- Configure the datasource and give its database user permission to read metadata and sample rows.
+- Use an FTS-capable vector storage backend. The built-in LanceDB backend works without additional configuration.
+- If `storage.vector` selects an external adapter, make sure that adapter version supports the Datus FTS contract. Unsupported backends fail explicitly instead of silently using vector search.
+
+## Enable FTS
+
+Add the following setting to the `agent.yml` used by both bootstrap and normal Datus Agent sessions:
+
+```yaml
+kb:
+  search:
+    mode: fts
+```
+
+The default is `vector` when this section is omitted.
+
+`bootstrap-kb` also accepts `--kb_search_mode fts`, but that option overrides the mode only for the current command and is not saved. Persist the YAML setting before using the rebuilt metadata in chat, API, background sync, or agent runs.
+
+## Build the initial index
+
+The first FTS build, or a switch from vector mode, requires a full metadata rebuild:
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy overwrite
+```
+
+`overwrite` replaces metadata only for the selected datasource and creates the FTS index with the current index format. It does not rebuild unrelated knowledge-base components.
+
+To apply a one-time command-line override while testing, add `--kb_search_mode fts` to the command. Remember that subsequent sessions still read the mode from `agent.yml`.
+
+## Verify the index
+
+Run a read-only check with the same configuration:
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy check
+```
+
+A successful result reports `search_mode=fts` together with `schema_size` and `value_size`. The check also verifies that the FTS index exists and matches the current index specification.
+
+After that, use Datus normally. For example, start the CLI, select the datasource, and ask a table-discovery question:
+
+```text
+datus
+/datasource <your_datasource>
+Which table contains customer order status?
+```
+
+Metadata tools and schema linking automatically use the configured FTS path.
+
+## Keep metadata current
+
+After a successful full build, use an incremental update for routine schema changes:
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy incremental
+```
+
+Incremental mode upserts new or changed metadata and updates the existing index. It requires an already-ready FTS index and does not create or repair a missing index.
+
+Run `overwrite` again when:
+
+- Enabling FTS for the first time or switching storage backends
+- Datus reports an index status of `missing`, `legacy`, or `version_mismatch`
+- An earlier build was interrupted or the index is incomplete
+- An upgrade explicitly requires rebuilding the FTS index
+
+## Switch back to vector search
+
+Change the configuration and rebuild metadata so the vector store and embeddings are current:
+
+```yaml
+kb:
+  search:
+    mode: vector
+```
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy overwrite
+```
+
+## Troubleshooting
+
+### The backend does not support FTS
+
+An error mentioning an `FTS-capable vector backend` means the backend selected by `storage.vector` does not expose the required FTS operations. Use the built-in LanceDB backend, install an adapter version with FTS support, or keep `kb.search.mode: vector`.
+
+### The index is missing or incompatible
+
+Errors containing `missing`, `legacy`, or `version_mismatch` are intentionally not hidden by a vector fallback. Rebuild metadata with `--kb_update_strategy overwrite`.
+
+### Incremental update fails on a new installation
+
+Incremental mode only maintains an existing healthy index. Run one `overwrite` build first, then use `incremental` for later changes.
+
+### Bootstrap used FTS but normal sessions still use vector search
+
+If the build command used `--kb_search_mode fts` without updating `agent.yml`, only that command used FTS. Add `kb.search.mode: fts` to the persistent configuration and run the read-only check again.
+
+### Results miss conceptually related tables
+
+FTS ranks text matches; it does not infer semantic similarity. Add clearer business descriptions or semantic profiles to the metadata, search with terms that appear in the schema, or switch back to vector mode for paraphrase-heavy workloads.
+
+!!! tip "Embeddings for other components"
+    FTS avoids embeddings for metadata only. If you also build metrics, reference SQL, documents, or other vector-backed components, keep their embedding configuration and credentials available.

--- a/docs/knowledge_base/metadata_fts.zh.md
+++ b/docs/knowledge_base/metadata_fts.zh.md
@@ -1,0 +1,146 @@
+# 元数据全文检索
+
+元数据全文检索（FTS）是查找相关数据表时可选的一种检索方式。它直接检索表元数据中的文本，不需要为这些元数据生成 embedding。
+
+当用户问题中包含明确的业务词、表名、列名、SQL 片段或其它原文关键词时，FTS 更合适。如果用户经常使用元数据中没有出现的说法来描述业务概念，建议继续使用默认的向量检索。
+
+!!! note "生效范围"
+    此配置只改变表发现和 schema linking 使用的**元数据检索**。指标、Reference SQL、Reference Template、平台文档等其它知识库组件仍使用各自的检索方式。FTS 只会检索 bootstrap 时采集的样本数据，不会扫描数据源中每一行数据。
+
+## FTS 与向量检索的区别
+
+| | `fts` | `vector` |
+|---|---|---|
+| 适合场景 | 关键词、标识符、SQL 文本和明确的业务词 | 语义相似和改写后的自然语言问题 |
+| 元数据 embedding | 不生成 | 需要生成 |
+| 是否为默认值 | 否 | 是 |
+| 检索失败时回退 | 不会自动回退到向量检索 | 不适用 |
+
+FTS 会索引以下元数据文本：
+
+- 表名、完整限定名、唯一标识和表类型
+- 表或视图定义（DDL）
+- `bootstrap-kb` 采集的样本数据
+- 已关联的表语义描述，包括 description、列、关系和 AI context 等信息
+
+检索结果仍受当前 datasource，以及 Datus Agent 应用的 catalog、database、schema、表类型和 subagent 范围限制。
+
+## 前置条件
+
+- 已配置 datasource，且数据库账号有读取元数据和样本数据的权限。
+- 使用支持 FTS 的向量存储后端。内置 LanceDB 无需额外配置即可使用。
+- 如果 `storage.vector` 使用外部适配器，请确认所安装的适配器版本实现了 Datus FTS 接口。不支持 FTS 的后端会直接报错，不会静默切换为向量检索。
+
+## 启用 FTS
+
+在 bootstrap 和日常运行共同使用的 `agent.yml` 中添加：
+
+```yaml
+kb:
+  search:
+    mode: fts
+```
+
+没有此配置时，默认值是 `vector`。
+
+`bootstrap-kb` 也支持 `--kb_search_mode fts`，但该参数只覆盖当前命令，不会保存配置。要让 chat、API、后台同步和后续 agent 运行都使用 FTS，必须把配置写入 `agent.yml`。
+
+## 首次构建索引
+
+首次启用 FTS，或者从向量检索切换到 FTS 时，需要完整重建元数据：
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy overwrite
+```
+
+`overwrite` 只替换当前 datasource 的元数据，并使用当前索引格式创建 FTS 索引，不会重建其它知识库组件。
+
+临时测试时，可以在命令末尾添加 `--kb_search_mode fts`。请注意，后续运行仍会从 `agent.yml` 读取检索模式。
+
+## 验证索引
+
+使用同一份配置执行只读检查：
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy check
+```
+
+检查成功时，结果会包含 `search_mode=fts`、`schema_size` 和 `value_size`，同时确认 FTS 索引存在且符合当前索引规范。
+
+之后可以正常使用 Datus。例如启动 CLI、选择 datasource，然后询问数据表：
+
+```text
+datus
+/datasource <your_datasource>
+哪个表包含客户订单状态？
+```
+
+元数据工具和 schema linking 会自动使用已配置的 FTS 检索路径。
+
+## 日常更新
+
+完成首次完整构建后，日常 schema 变化可以使用增量更新：
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy incremental
+```
+
+增量模式会更新或新增发生变化的元数据，并维护现有索引。它要求 FTS 索引已经处于可用状态，不会创建或修复缺失的索引。
+
+以下情况需要重新执行 `overwrite`：
+
+- 首次启用 FTS，或者切换存储后端
+- Datus 报告索引状态为 `missing`、`legacy` 或 `version_mismatch`
+- 上一次构建被中断，索引不完整
+- 升级说明明确要求重建 FTS 索引
+
+## 切回向量检索
+
+修改配置并重建元数据，确保向量存储和 embedding 都是最新的：
+
+```yaml
+kb:
+  search:
+    mode: vector
+```
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metadata \
+  --kb_update_strategy overwrite
+```
+
+## 故障排查
+
+### 存储后端不支持 FTS
+
+如果错误信息中出现 `FTS-capable vector backend`，说明 `storage.vector` 选择的后端没有提供所需的 FTS 能力。可以使用内置 LanceDB、安装支持 FTS 的适配器版本，或者继续使用 `kb.search.mode: vector`。
+
+### 索引缺失或版本不兼容
+
+如果错误信息中出现 `missing`、`legacy` 或 `version_mismatch`，Datus 不会用向量检索隐藏问题。请使用 `--kb_update_strategy overwrite` 重建元数据。
+
+### 新环境执行 incremental 失败
+
+增量模式只能维护已经存在且状态正常的索引。请先执行一次 `overwrite`，后续更新再使用 `incremental`。
+
+### Bootstrap 使用了 FTS，但日常运行仍在使用向量检索
+
+如果只在构建命令中使用了 `--kb_search_mode fts`，那么只有该命令临时使用 FTS。请将 `kb.search.mode: fts` 写入 `agent.yml`，然后重新执行只读检查。
+
+### 无法找到语义相关但没有相同关键词的表
+
+FTS 按文本匹配排序，不会推断语义相似性。可以为元数据补充更明确的业务描述或表语义信息，使用 schema 中实际出现的词进行检索，或者对大量改写表达的场景切回向量检索。
+
+!!! tip "其它组件仍可能需要 embedding"
+    FTS 只避免为元数据生成 embedding。如果还会构建指标、Reference SQL、文档或其它依赖向量检索的组件，请继续保留这些组件所需的 embedding 配置和凭据。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Introduction: knowledge_base/introduction.md
       - Platform Documentation: knowledge_base/platform_doc.md
       - Metadata: knowledge_base/metadata.md
+      - Metadata Full-text Search: knowledge_base/metadata_fts.md
       - Semantic Models: knowledge_base/semantic_model.md
       - Metrics: knowledge_base/metrics.md
       - Reference SQL: knowledge_base/reference_sql.md
@@ -155,6 +156,7 @@ plugins:
             Knowledge Base: 知识库
             Platform Documentation: 平台文档
             Metadata: 元数据
+            Metadata Full-text Search: 元数据全文检索
             Semantic Models: 语义模型
             Metrics: 指标
             Reference SQL: Reference SQL


### PR DESCRIPTION
## Summary

- add English and Chinese user guides for metadata full-text search
- explain when to choose FTS versus vector retrieval and which metadata fields are indexed
- document persistent configuration, initial index creation, verification, incremental updates, mode switching, and troubleshooting
- link the guide from the existing metadata pages and MkDocs navigation
- include the guide and FTS behavior contracts in the harness coverage map

## Why

Metadata FTS is now available as an opt-in retrieval mode, but users need an end-to-end guide that distinguishes persistent runtime configuration from one-time bootstrap overrides and explains how to build and maintain a valid index.

## User impact

Users can configure metadata FTS, verify that the index is ready, keep it current, recover from missing or incompatible indexes, and switch back to vector retrieval without relying on implementation details.

## Validation

- `mkdocs build --strict`
- `python ci/harness/validate_coverage_map.py --strict` (`error_count: 0`)
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive English and Chinese guidance for metadata full-text search (FTS), including setup, indexing, configuration, mode switching, verification, and troubleshooting.
  * Clarified that FTS is opt-in and applies specifically to knowledge-base metadata.
  * Added `bootstrap-kb` examples and documented backend requirements and consistency expectations.
  * Added the new Metadata Full-text Search pages to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->