### PR TITLE
[Enhancement] Isolate OSI metric authoring from semantic models

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -11,7 +11,6 @@ hooks, and metricflow MCP server integration.
 """
 
 import json
-from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
@@ -109,7 +108,6 @@ class GenMetricsAgenticNode(AgenticNode):
         self.ask_user_tool = None
         self.hooks = None
         self.generation_evidence = GenerationEvidence()
-        self._osi_metrics_baseline_artifact_json: Optional[str] = None
         self.setup_tools()
 
     def get_node_name(self) -> str:
@@ -138,6 +136,14 @@ class GenMetricsAgenticNode(AgenticNode):
             self._setup_ask_user_tool()
 
         logger.info(f"Setup {len(self.tools)} tools for {self.NODE_NAME}: {[tool.name for tool in self.tools]}")
+
+    def _ensure_bash_tool_in_tools(self) -> None:
+        """Keep OSI metric authoring on its metrics-only filesystem surface."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        if is_osi_authoring(self.agent_config):
+            return
+        super()._ensure_bash_tool_in_tools()
 
     def _make_filesystem_tool(self, **kwargs):
         from datus.agent.node.semantic_authoring import resolve_authoring_format
@@ -177,8 +183,9 @@ class GenMetricsAgenticNode(AgenticNode):
         try:
             self.filesystem_func_tool = self._make_filesystem_tool()
 
-            self.tools.extend(self.filesystem_func_tool.available_tools())
-            logger.debug("Added filesystem tools: read_file, write_file, edit_file, glob, grep")
+            filesystem_tools = self.filesystem_func_tool.available_tools()
+            self.tools.extend(filesystem_tools)
+            logger.debug("Added filesystem tools: %s", [tool.name for tool in filesystem_tools])
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 
@@ -188,18 +195,18 @@ class GenMetricsAgenticNode(AgenticNode):
             from datus.agent.node.semantic_authoring import resolve_authoring_format
             from datus.tools.func_tool import trans_to_function_tool
 
+            authoring_format = resolve_authoring_format(self.agent_config)
             self.generation_tools = GenerationTools(
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
-                authoring_format=resolve_authoring_format(self.agent_config),
+                authoring_format=authoring_format,
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
             self.tools.append(trans_to_function_tool(self.generation_tools.end_metric_generation))
-            self.tools.append(trans_to_function_tool(self.generation_tools.end_semantic_model_generation))
-            logger.debug(
-                "Added tools: check_semantic_object_exists, end_metric_generation, end_semantic_model_generation"
-            )
+            if authoring_format != "osi":
+                self.tools.append(trans_to_function_tool(self.generation_tools.end_semantic_model_generation))
+            logger.debug("Added metric generation tools for authoring_format=%s", authoring_format)
 
         except Exception as e:
             logger.error(f"Failed to setup generation tools: {e}")
@@ -408,32 +415,7 @@ class GenMetricsAgenticNode(AgenticNode):
 
     def _build_template_context(self, ctx: StreamRunContext) -> Optional[dict]:
         self._set_metric_queryability_contracts_from_input(ctx.user_input)
-        self._capture_osi_metrics_baseline_artifact()
         return self._prepare_template_context(ctx.user_input)
-
-    def _capture_osi_metrics_baseline_artifact(self) -> None:
-        from datus.agent.node.semantic_authoring import is_osi_authoring
-
-        self._osi_metrics_baseline_artifact_json = None
-        if not is_osi_authoring(self.agent_config):
-            return
-        try:
-            from datus_semantic_osi.profile import load_osi_path, to_core_schema_document
-
-            semantic_model_dir = Path(
-                self.agent_config.path_manager.semantic_model_path(self.agent_config.current_datasource)
-            )
-            if not semantic_model_dir.exists():
-                return
-            doc = load_osi_path(str(semantic_model_dir))
-            baseline = to_core_schema_document(doc)
-            self._osi_metrics_baseline_artifact_json = json.dumps(
-                baseline,
-                ensure_ascii=False,
-                sort_keys=True,
-            )
-        except Exception as exc:
-            logger.info("Skipping OSI metric mutation guard baseline capture: %s", exc)
 
     def _build_success_result(self, ctx: StreamRunContext) -> SemanticNodeResult:
         response_content = ctx.response_content
@@ -743,12 +725,7 @@ class GenMetricsAgenticNode(AgenticNode):
 
         if not getattr(self, "semantic_tools", None):
             raise RuntimeError("Metric generation produced a metric_file, but validate_semantic is unavailable.")
-        validation_checks = ["authoring_quality"]
-        validation_kwargs: Dict[str, Any] = {"checks": validation_checks}
-        if self._osi_metrics_baseline_artifact_json:
-            validation_checks.append("mutation_guard")
-            validation_kwargs["baseline_artifact_json"] = self._osi_metrics_baseline_artifact_json
-        validation_result = self.semantic_tools.validate_semantic(**validation_kwargs)
+        validation_result = self.semantic_tools.validate_semantic(checks=["authoring_quality"])
         self.generation_evidence.record_validation_result(validation_result)
         if not self._tool_succeeded(validation_result):
             raise RuntimeError(
@@ -756,15 +733,6 @@ class GenMetricsAgenticNode(AgenticNode):
             )
 
         abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
-        if isinstance(semantic_model_files, str):
-            semantic_model_file_candidates = [semantic_model_files]
-        else:
-            semantic_model_file_candidates = semantic_model_files or []
-        abs_semantic_model_files = [
-            self._resolve_metric_artifact_path(semantic_model_file, "semantic")
-            for semantic_model_file in semantic_model_file_candidates
-            if semantic_model_file
-        ]
         metric_names = self.generation_tools.extract_osi_metric_names(abs_metric_file)
         if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
             query_metrics = getattr(getattr(self, "semantic_tools", None), "query_metrics", None)
@@ -789,7 +757,7 @@ class GenMetricsAgenticNode(AgenticNode):
 
         publish_result = self.generation_tools.end_metric_generation(
             metric_file=abs_metric_file,
-            semantic_model_files=abs_semantic_model_files,
+            semantic_model_files=[],
         )
         if not self._tool_succeeded(publish_result):
             raise RuntimeError(f"OSI metric KB sync failed: {self._tool_error(publish_result)}")

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -56,7 +56,7 @@ _OPTIONAL_AUTHORING_SKILLS: Dict[str, Dict[str, str]] = {
     },
     "gen_metrics": {
         AUTHORING_FORMAT_METRICFLOW: "metricflow-semantic-authoring",
-        AUTHORING_FORMAT_OSI: "osi-semantic-authoring",
+        AUTHORING_FORMAT_OSI: "",
     },
 }
 

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -18,8 +18,8 @@ from datus.prompts.prompt_manager import PromptManager
 from datus.schemas.artifact_manifest import ARTIFACT_SLUG_RE
 from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.tools.func_tool.database import DBFuncTool
-from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.memory_tools import MemoryFuncTool
+from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
 from datus.tools.func_tool.platform_doc_search import PlatformDocSearchTool
 from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
 from datus.tools.func_tool.semantic_tools import SemanticTools
@@ -38,7 +38,7 @@ VALID_TOOL_METHODS: dict[str, set[str]] = {
     "semantic_tools": set(SemanticTools.all_tools_name()),
     "reference_template_tools": set(ReferenceTemplateTools.all_tools_name()),
     "date_parsing_tools": {"parse_temporal_expressions"},
-    "filesystem_tools": set(FilesystemFuncTool.all_tools_name()),
+    "filesystem_tools": set(MetricFilesystemFuncTool.all_tools_name()),
     "memory_tools": set(MemoryFuncTool.all_tools_name()),
     "platform_doc_tools": set(PlatformDocSearchTool.all_tools_name()),
 }

--- a/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
@@ -53,11 +53,11 @@ Record the classification as defined in the `<required_skill>` specification{% i
 
 1. **Discover existing assets**: Call `list_metrics()` and build an existing metric catalog. Do not recreate metrics that already exist — but note that "already exists" requires the same aggregation AND the same window/offset semantics; cumulative/window/period-over-period variants of a published base metric are NEW metrics.
 2. **Understand the request**: Confirm scope per the rules above. For provided historical SQL, call `analyze_metric_candidates_from_history` with the existing metric catalog before writing any files, and follow the candidate handling rules in the `<required_skill>` specification.
-3. **Ensure model prerequisites**: Check `check_semantic_object_exists(name, kind='table')` for involved tables{% if authoring_format == "osi" %}. Load the existing OSI model from the target semantic model file to learn dataset names, fields, time fields, and relationships; minimally update it only when something is truly absent{% else %}. If a semantic model is missing, load the `metricflow-semantic-authoring` skill from `<available_skills>` and follow it to create the model{% endif %}.
-4. **Author metrics**: Check `check_semantic_object_exists(name, kind='metric')` for each metric, then write the metric YAML per the `<required_skill>` specification.
-5. **Validate (MUST PASS)**: Call `validate_semantic`. If it fails, fix with `edit_file` and retry until it passes. Do NOT proceed until validation passes.
+3. **Ensure model prerequisites**: Check `check_semantic_object_exists(name, kind='table')` for involved tables{% if authoring_format == "osi" %}. The target OSI model must already exist. Load it to learn dataset names, fields, time fields, and relationships. If it is missing, stop and report that `gen_semantic_model` must run first; never create or modify datasets, fields, or relationships in this workflow{% else %}. If a semantic model is missing, load the `metricflow-semantic-authoring` skill from `<available_skills>` and follow it to create the model{% endif %}.
+4. **Author metrics**: Check `check_semantic_object_exists(name, kind='metric')` for each metric, then write the metric YAML per the `<required_skill>` specification{% if authoring_format == "osi" %} using `upsert_osi_metrics`; it creates new metrics and may replace an existing metric by name when an update is required{% endif %}.
+5. **Validate (MUST PASS)**: Call `validate_semantic`. If it fails, {% if authoring_format == "osi" %}fix the metric definitions with another `upsert_osi_metrics` call{% else %}fix with `edit_file`{% endif %} and retry until it passes. Do NOT proceed until validation passes.
 6. **Dry-run**: Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric. If the source SQL groups by dimensions or a time grain, dry-run with matching `dimensions` / `time_granularity`; use `get_dimensions` for exact names. Collect each generated SQL into `metric_sqls_json`.
-7. **Publish**: After validation and dry-run pass, call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` ONCE. Do not rely on the final JSON host fallback — it is only a last-resort guard. If no metrics were generated, do NOT call `end_metric_generation`.
+7. **Publish**: After validation and dry-run pass, call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` ONCE{% if authoring_format == "osi" %}, passing `semantic_model_files=[]` because this workflow did not change semantic objects{% endif %}. Do not rely on the final JSON host fallback — it is only a last-resort guard. If no metrics were generated, do NOT call `end_metric_generation`.
 
 ## Output Format
 
@@ -65,7 +65,7 @@ Record the classification as defined in the `<required_skill>` specification{% i
 
 {% if authoring_format == "osi" %}```json
 {
-  "semantic_model_file": "{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}",
+  "semantic_model_files": [],
   "metric_file": "{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}",
   "status": "generated",
   "output": "brief summary"

--- a/datus/resources/skills/osi-metrics-authoring/SKILL.md
+++ b/datus/resources/skills/osi-metrics-authoring/SKILL.md
@@ -17,9 +17,10 @@ ADD metrics to an existing strict OSI (Open Semantic Interchange) core semantic 
 
 CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow YAML, `measure_proxy`, `type_params`, `measures:`, `ratio`, `cumulative`, or any execution-engine syntax. The Datus OSI compiler infers backing measures, picks the backend metric kind, and lowers to the execution engine. Do NOT write legacy MetricFlow `metric:` blocks.
 
-CRITICAL MODEL RULE — **build the model once, then only add metrics**:
+CRITICAL MODEL RULE — **build the model once, then only upsert metrics**:
 - The datasets and relationships are owned by the semantic-model step and are ALREADY built.
-- The semantic model file is the durable OSI domain document. Load it, preserve existing datasets and relationships, and append metrics under `semantic_model[0].metrics`.
+- The semantic model file is the durable OSI domain document. Load it and use `upsert_osi_metrics` to create or update metrics under `semantic_model[0].metrics`.
+- Never use general filesystem writes to create or modify datasets, fields, or relationships. If the target model is missing, stop and report that `gen_semantic_model` must run first.
 - A given logical dataset has one canonical definition shared by all metrics. Reuse that dataset by name in each metric's DATUS `dataset` hint.
 
 The OSI expression dialect and target semantic model file for the current run are shown in the system prompt Workspace section — use those exact values (`<osi_dialect>` below stands for that dialect).
@@ -56,7 +57,7 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
 
 ## Authoring rules
 
-1. **Reference, don't rebuild.** Every metric's DATUS `dataset` hint must reference an existing dataset of the semantic model. If a needed dataset, field, time field, or relationship is missing, do not invent a conflicting one; note it and minimally update the semantic model only if truly absent.
+1. **Reference, don't rebuild.** Every metric's DATUS `dataset` hint must reference an existing dataset of the semantic model. If a needed dataset, field, time field, or relationship is missing, stop and report the prerequisite; do not modify semantic objects in this workflow.
 2. **Aggregates**: write the natural business expression in OSI core `expression.dialects[0].expression`, e.g. `COUNT(DISTINCT order_id)`, `SUM(amount)`, `AVG(score)`.
 3. **Conditional aggregates**: keep the CASE inside the expression, e.g. `COUNT(DISTINCT CASE WHEN <condition> THEN id END)`. Preserve literal values exactly.
 4. **Conditional semantics**: encode metric-specific business conditions inside the OSI core metric expression, e.g. `COUNT(DISTINCT CASE WHEN status = 'paid' THEN id END)`. Do NOT create a separate dataset for a metric-only condition. Fixed logical dataset scope belongs in the dataset `source` query plus `description`/`ai_context`. Do NOT bury query-time date ranges into the metric; time ranges are query parameters.
@@ -91,16 +92,7 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
            - vendor_name: DATUS
              data: '{"dataset":"orders","time_dimension":"order_date","period_over_period":{"time_grain":"month","offset_window":"1 year","calculation":"percent_change"},"subject_path":["sales","revenue","growth"],"format":"0.00%","unit":"%"}'
      ```
-7. **Joins**: to group or slice by another table, use the existing semantic-model relationships. If the link is truly absent, add one OSI core relationship under the semantic model object:
-   ```yaml
-   relationships:
-     - name: <fact_dataset>_to_<dimension_dataset>
-       from: <fact_or_many_side_dataset>
-       to: <dimension_or_one_side_dataset>
-       from_columns: [<foreign_key_column>]
-       to_columns: [<primary_or_unique_key_column>]
-   ```
-   Never put `relationships` inside a dataset. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `to_dataset`, `to_identifier`, `join_on`, `from_column`, or `to_column`.
+7. **Joins**: to group or slice by another table, use the existing semantic-model relationships. If the link is absent, report that the semantic model must be updated by `gen_semantic_model`; do not add relationships here.
 8. **Not metrics**: detail/list queries (`SELECT DISTINCT ...`) and window/ranking (`ROW_NUMBER()`, `RANK() OVER`, TopN per group) are NOT metrics. SKIP them. Do NOT create a dataset/view here and never force them into a metric. If the discovery tool returns `metric_generation_skips` or rank-like `derived_datasource_recommendations`, treat that SQL as skipped.
 9. Use clear English `snake_case` metric names; metric names must be globally unique. Every metric MUST include `description` and `ai_context`. Put the business definition in `description`; put LLM-facing usage guidance in `ai_context.instructions`, including grain, metric-specific conditions, time field, and join caveats.
 10. **Subject classification (required).** Every metric MUST carry a `subject_path` in its DATUS extension, encoded as an ordered `[domain, layer1, layer2]` list (e.g. `["sales","revenue","growth"]`). Choose the classification exactly as instructed by the **Subject Classification** section of the system prompt — same required categories, same reuse-or-create rule, same `{domain}/{layer1}/{layer2}` hierarchy the MetricFlow path uses; the only difference is the carrier (a DATUS `subject_path` list here, a `locked_metadata.tags` entry there).
@@ -111,17 +103,18 @@ Before writing any YAML, classify the source SQL:
 
 - If the SQL has no aggregate output (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, ratio, rolling/cumulative aggregate, etc.) and primarily returns row-level fields (`SELECT DISTINCT ac_name, ac_code, ...`, list/detail/ranking), then it is not a metric request.
 - For non-metric SQL, do not invent convenience metrics such as `*_count`, `*_avg_duration`, `*_max_sr`, or `*_min_sr` just because the table contains those columns.
-- For non-metric SQL, do not call `write_file`, `validate_semantic`, `query_metrics`, or `end_metric_generation`. Report `status: "skipped"` with `metric_file: null` in the final JSON.
+- For non-metric SQL, do not call `upsert_osi_metrics`, `validate_semantic`, `query_metrics`, or `end_metric_generation`. Report `status: "skipped"` with `metric_file: null` in the final JSON.
 - For TopN per group / ranking-window SQL (`ROW_NUMBER`, `RANK`, `DENSE_RANK`) do the same: skip metric generation. A derived dataset/view may be a future modeling task, but it is outside this `gen_metrics` run.
 
 ## Workflow notes
 
-- FIRST, load the existing model from the target semantic model file to learn dataset names, fields, time fields, and relationships. Call `list_metrics()` to see metrics that already exist.
+- FIRST, load the existing model from the target semantic model file to learn dataset names, fields, time fields, and relationships. If the file is missing, stop and report the prerequisite. Call `list_metrics()` to see metrics that already exist.
 - For provided SQL/history, call `analyze_metric_candidates_from_history` before writing files. Use `direct_metric_candidates` for base metrics and fixed `period_over_period` final metrics; use `derived_metric_candidates` only for second-stage OSI metrics that explicitly depend on published input metrics. If it returns `metric_generation_skips`, skip those SQLs instead of writing metric YAML.
 - Candidate-plan compliance: every candidate in `direct_metric_candidates` and `derived_metric_candidates` (including cumulative, rolling-window, and period_over_period candidates) MUST end this run either published via `end_metric_generation` or listed in your final `output` with a concrete blocker such as a validation failure. "Covered by an existing base metric" is never a valid blocker for a cumulative/window/period_over_period candidate.
-- Reference, reconcile, reuse: point each metric's DATUS `dataset` hint at an existing dataset. If a metric with the same meaning already exists (`check_semantic_object_exists(name, kind='metric')`), reuse/skip it. "Same meaning" requires the same aggregation AND the same window/offset semantics: a base aggregate never covers its cumulative/rolling/period-over-period variants, so `running_x`/`moving_x`/`previous_x` candidates must still be published when only `x` exists. For a derived metric, make sure its input metrics already exist.
+- Reference, reconcile, reuse: point each metric's DATUS `dataset` hint at an existing dataset. If a metric with the same meaning and correct definition already exists (`check_semantic_object_exists(name, kind='metric')`), reuse/skip it. If the user requests an update or the stored definition is incorrect, replace it by name with `upsert_osi_metrics`. "Same meaning" requires the same aggregation AND the same window/offset semantics: a base aggregate never covers its cumulative/rolling/period-over-period variants, so `running_x`/`moving_x`/`previous_x` candidates must still be published when only `x` exists. For a derived metric, make sure its input metrics already exist.
 - From SQL: find the table (FROM), aggregate expression(s), and business conditions vs query-time ranges. Anchor the metric on the aggregated table's existing dataset; encode metric-specific conditions with CASE inside the metric expression.
 - When a required business input is missing or ambiguous, ASK for the business semantics; do not guess.
-- Call `validate_semantic(scope="all")` after writing OSI metrics and fix errors until it passes.
+- Call `upsert_osi_metrics(path="<target model file>", metrics_json="<JSON array of complete OSI metric objects>")` once per coherent metric batch. This tool preserves datasets and relationships, appends new metrics, and replaces existing metrics by name.
+- Call `validate_semantic(scope="all")` after upserting OSI metrics and fix metric errors with another `upsert_osi_metrics` call until validation passes.
 - Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric name before publishing.
-- After validation and dry-run pass, call `end_metric_generation(metric_file="<target model file>", semantic_model_file="<target model file>", metric_sqls_json="<dry-run SQL JSON>")`.
+- After validation and dry-run pass, call `end_metric_generation(metric_file="<target model file>", semantic_model_files=[], metric_sqls_json="<dry-run SQL JSON>")`.

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -379,7 +379,11 @@ class GenerationTools:
         import json
 
         try:
-            if semantic_model_files is None and semantic_model_file:
+            if self._is_osi_authoring():
+                # OSI gen_metrics owns only the metrics collection. Semantic
+                # objects are authored and synced by gen_semantic_model.
+                semantic_model_files = []
+            elif semantic_model_files is None and semantic_model_file:
                 semantic_model_files = [semantic_model_file]
             semantic_model_files = semantic_model_files or []
 

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -149,13 +149,9 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
                     created.append(name)
 
             model["metrics"] = existing_metrics
-            try:
-                from datus_semantic_osi.errors import OSIValidationError
-                from datus_semantic_osi.profile import validate_osi_core_schema
-
-                validate_osi_core_schema(document)
-            except (ImportError, OSIValidationError) as exc:
-                return FuncToolResult(success=0, error=f"Invalid OSI metric update: {exc}")
+            validation_error = self._validate_osi_document(document)
+            if validation_error:
+                return FuncToolResult(success=0, error=f"Invalid OSI metric update: {validation_error}")
 
             serialized = yaml.safe_dump(document, allow_unicode=True, sort_keys=False)
             try:
@@ -177,6 +173,20 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
         key = str(target_path.resolve(strict=False))
         with _OSI_METRIC_PATH_LOCKS_GUARD:
             return _OSI_METRIC_PATH_LOCKS.setdefault(key, threading.RLock())
+
+    @staticmethod
+    def _validate_osi_document(document: Dict[str, Any]) -> Optional[str]:
+        try:
+            from datus_semantic_osi.errors import OSIValidationError
+            from datus_semantic_osi.profile import validate_osi_core_schema
+        except ImportError as exc:
+            return f"OSI schema validator is unavailable: {exc}"
+
+        try:
+            validate_osi_core_schema(document)
+        except OSIValidationError as exc:
+            return str(exc)
+        return None
 
     @staticmethod
     def _atomic_write_text(target_path: Path, content: str) -> None:

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -3,6 +3,10 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import json
+import os
+import stat
+import tempfile
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -13,6 +17,9 @@ from datus.storage.metric.subject_path import normalize_metric_subject_tree_tag
 from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.fs_path_policy import PathZone, ResolvedPath
+
+_OSI_METRIC_PATH_LOCKS: Dict[str, threading.RLock] = {}
+_OSI_METRIC_PATH_LOCKS_GUARD = threading.Lock()
 
 
 class MetricFilesystemFuncTool(FilesystemFuncTool):
@@ -76,17 +83,6 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
         if policy_error is not None:
             return policy_error
 
-        target_path = resolved.resolved
-        if not target_path.exists() or not target_path.is_file():
-            return FuncToolResult(
-                success=0,
-                error=(
-                    "OSI semantic model is required before metric generation. "
-                    "Run gen_semantic_model first, then retry gen_metrics."
-                ),
-                result={"code": "semantic_model_required", "semantic_model_file": resolved.display},
-            )
-
         try:
             incoming_metrics = json.loads(metrics_json)
         except (TypeError, json.JSONDecodeError) as exc:
@@ -105,44 +101,68 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
                 return FuncToolResult(success=0, error=f"metrics_json contains duplicate metric name: {name}")
             incoming_by_name[name] = metric
 
-        try:
-            document = yaml.safe_load(target_path.read_text(encoding="utf-8"))
-        except (OSError, yaml.YAMLError) as exc:
-            return FuncToolResult(success=0, error=f"Cannot load OSI semantic model {resolved.display}: {exc}")
+        target_path = resolved.resolved
+        with self._osi_metric_path_lock(target_path):
+            if not target_path.exists() or not target_path.is_file():
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        "OSI semantic model is required before metric generation. "
+                        "Run gen_semantic_model first, then retry gen_metrics."
+                    ),
+                    result={"code": "semantic_model_required", "semantic_model_file": resolved.display},
+                )
 
-        if not isinstance(document, dict):
-            return FuncToolResult(success=0, error="OSI semantic model root must be a YAML object")
-        models = document.get("semantic_model")
-        if not isinstance(models, list) or len(models) != 1 or not isinstance(models[0], dict):
-            return FuncToolResult(success=0, error="OSI document must contain exactly one semantic_model object")
+            try:
+                document = yaml.safe_load(target_path.read_text(encoding="utf-8"))
+            except (OSError, yaml.YAMLError) as exc:
+                return FuncToolResult(success=0, error=f"Cannot load OSI semantic model {resolved.display}: {exc}")
 
-        model = models[0]
-        existing_metrics = model.get("metrics") or []
-        if not isinstance(existing_metrics, list) or any(not isinstance(metric, dict) for metric in existing_metrics):
-            return FuncToolResult(success=0, error="semantic_model[0].metrics must be a list of metric objects")
+            if not isinstance(document, dict):
+                return FuncToolResult(success=0, error="OSI semantic model root must be a YAML object")
+            models = document.get("semantic_model")
+            if not isinstance(models, list) or len(models) != 1 or not isinstance(models[0], dict):
+                return FuncToolResult(success=0, error="OSI document must contain exactly one semantic_model object")
 
-        metric_indexes: Dict[str, int] = {}
-        for index, metric in enumerate(existing_metrics):
-            name = str(metric.get("name") or "").strip()
-            if name:
-                metric_indexes[name] = index
+            model = models[0]
+            existing_metrics = model["metrics"] if "metrics" in model else []
+            if not isinstance(existing_metrics, list) or any(
+                not isinstance(metric, dict) for metric in existing_metrics
+            ):
+                return FuncToolResult(success=0, error="semantic_model[0].metrics must be a list of metric objects")
 
-        created: List[str] = []
-        updated: List[str] = []
-        for name, metric in incoming_by_name.items():
-            if name in metric_indexes:
-                existing_metrics[metric_indexes[name]] = metric
-                updated.append(name)
-            else:
-                metric_indexes[name] = len(existing_metrics)
-                existing_metrics.append(metric)
-                created.append(name)
+            metric_indexes: Dict[str, int] = {}
+            for index, metric in enumerate(existing_metrics):
+                name = str(metric.get("name") or "").strip()
+                if name:
+                    metric_indexes[name] = index
 
-        model["metrics"] = existing_metrics
-        serialized = yaml.safe_dump(document, allow_unicode=True, sort_keys=False)
-        write_result = super().write_file(path, serialized)
-        if not write_result.success:
-            return write_result
+            created: List[str] = []
+            updated: List[str] = []
+            for name, metric in incoming_by_name.items():
+                if name in metric_indexes:
+                    existing_metrics[metric_indexes[name]] = metric
+                    updated.append(name)
+                else:
+                    metric_indexes[name] = len(existing_metrics)
+                    existing_metrics.append(metric)
+                    created.append(name)
+
+            model["metrics"] = existing_metrics
+            try:
+                from datus_semantic_osi.errors import OSIValidationError
+                from datus_semantic_osi.profile import validate_osi_core_schema
+
+                validate_osi_core_schema(document)
+            except (ImportError, OSIValidationError) as exc:
+                return FuncToolResult(success=0, error=f"Invalid OSI metric update: {exc}")
+
+            serialized = yaml.safe_dump(document, allow_unicode=True, sort_keys=False)
+            try:
+                self._atomic_write_text(target_path, serialized)
+            except OSError as exc:
+                return FuncToolResult(success=0, error=f"Cannot update {resolved.display}: {exc}")
+
         return FuncToolResult(
             result={
                 "message": f"Upserted {len(incoming_by_name)} OSI metric(s)",
@@ -151,6 +171,31 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
                 "updated": updated,
             }
         )
+
+    @staticmethod
+    def _osi_metric_path_lock(target_path: Path) -> threading.RLock:
+        key = str(target_path.resolve(strict=False))
+        with _OSI_METRIC_PATH_LOCKS_GUARD:
+            return _OSI_METRIC_PATH_LOCKS.setdefault(key, threading.RLock())
+
+    @staticmethod
+    def _atomic_write_text(target_path: Path, content: str) -> None:
+        """Replace an existing file atomically while preserving its mode."""
+        fd, temp_name = tempfile.mkstemp(prefix=f".{target_path.name}.", suffix=".tmp", dir=target_path.parent)
+        temp_path = Path(temp_name)
+        try:
+            os.fchmod(fd, stat.S_IMODE(target_path.stat().st_mode))
+            stream = os.fdopen(fd, "w", encoding="utf-8")
+            fd = -1
+            with stream:
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temp_path, target_path)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            temp_path.unlink(missing_ok=True)
 
     def write_file(self, path: str, content: str, file_type: str = "") -> FuncToolResult:  # type: ignore[override]
         resolved = self._classify(path)

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -29,6 +30,127 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
 
     def _is_metricflow_authoring(self) -> bool:
         return self.authoring_format == "metricflow"
+
+    def available_tools(self):
+        """Expose format-specific filesystem mutation tools.
+
+        MetricFlow metric generation still needs the general write/edit surface
+        because metrics can add measures and dimensions to semantic-model files.
+        OSI metric generation owns only ``semantic_model[0].metrics`` and uses a
+        narrow upsert tool so it cannot rewrite datasets or relationships.
+        """
+        if self._is_metricflow_authoring():
+            return super().available_tools()
+
+        from datus.tools.func_tool import trans_to_function_tool
+
+        return [
+            trans_to_function_tool(self.read_file),
+            trans_to_function_tool(self.upsert_osi_metrics),
+            trans_to_function_tool(self.glob),
+            trans_to_function_tool(self.grep),
+        ]
+
+    @staticmethod
+    def all_tools_name() -> List[str]:
+        """Return the complete conditional tool surface for permission routing."""
+        names = FilesystemFuncTool.all_tools_name()
+        if "upsert_osi_metrics" not in names:
+            names.append("upsert_osi_metrics")
+        return names
+
+    def upsert_osi_metrics(self, path: str, metrics_json: str) -> FuncToolResult:
+        """Create or update metrics in an existing OSI semantic-model file.
+
+        The input is a JSON array of OSI metric objects. Existing metrics are
+        replaced by ``name`` and new metrics are appended. The tool reads the
+        live document and only assigns its ``metrics`` collection, so datasets,
+        fields, relationships, and model metadata remain unchanged.
+
+        Args:
+            path: Existing OSI semantic-model YAML file under the project workspace.
+            metrics_json: JSON array containing complete OSI metric objects.
+        """
+        resolved = self._classify(path)
+        policy_error = self._reject_write_policy(resolved)
+        if policy_error is not None:
+            return policy_error
+
+        target_path = resolved.resolved
+        if not target_path.exists() or not target_path.is_file():
+            return FuncToolResult(
+                success=0,
+                error=(
+                    "OSI semantic model is required before metric generation. "
+                    "Run gen_semantic_model first, then retry gen_metrics."
+                ),
+                result={"code": "semantic_model_required", "semantic_model_file": resolved.display},
+            )
+
+        try:
+            incoming_metrics = json.loads(metrics_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            return FuncToolResult(success=0, error=f"metrics_json must be a valid JSON array: {exc}")
+        if not isinstance(incoming_metrics, list) or not incoming_metrics:
+            return FuncToolResult(success=0, error="metrics_json must be a non-empty JSON array")
+
+        incoming_by_name: Dict[str, Dict[str, Any]] = {}
+        for index, metric in enumerate(incoming_metrics):
+            if not isinstance(metric, dict):
+                return FuncToolResult(success=0, error=f"metrics_json[{index}] must be a JSON object")
+            name = str(metric.get("name") or "").strip()
+            if not name:
+                return FuncToolResult(success=0, error=f"metrics_json[{index}].name is required")
+            if name in incoming_by_name:
+                return FuncToolResult(success=0, error=f"metrics_json contains duplicate metric name: {name}")
+            incoming_by_name[name] = metric
+
+        try:
+            document = yaml.safe_load(target_path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            return FuncToolResult(success=0, error=f"Cannot load OSI semantic model {resolved.display}: {exc}")
+
+        if not isinstance(document, dict):
+            return FuncToolResult(success=0, error="OSI semantic model root must be a YAML object")
+        models = document.get("semantic_model")
+        if not isinstance(models, list) or len(models) != 1 or not isinstance(models[0], dict):
+            return FuncToolResult(success=0, error="OSI document must contain exactly one semantic_model object")
+
+        model = models[0]
+        existing_metrics = model.get("metrics") or []
+        if not isinstance(existing_metrics, list) or any(not isinstance(metric, dict) for metric in existing_metrics):
+            return FuncToolResult(success=0, error="semantic_model[0].metrics must be a list of metric objects")
+
+        metric_indexes: Dict[str, int] = {}
+        for index, metric in enumerate(existing_metrics):
+            name = str(metric.get("name") or "").strip()
+            if name:
+                metric_indexes[name] = index
+
+        created: List[str] = []
+        updated: List[str] = []
+        for name, metric in incoming_by_name.items():
+            if name in metric_indexes:
+                existing_metrics[metric_indexes[name]] = metric
+                updated.append(name)
+            else:
+                metric_indexes[name] = len(existing_metrics)
+                existing_metrics.append(metric)
+                created.append(name)
+
+        model["metrics"] = existing_metrics
+        serialized = yaml.safe_dump(document, allow_unicode=True, sort_keys=False)
+        write_result = super().write_file(path, serialized)
+        if not write_result.success:
+            return write_result
+        return FuncToolResult(
+            result={
+                "message": f"Upserted {len(incoming_by_name)} OSI metric(s)",
+                "semantic_model_file": resolved.display,
+                "created": created,
+                "updated": updated,
+            }
+        )
 
     def write_file(self, path: str, content: str, file_type: str = "") -> FuncToolResult:  # type: ignore[override]
         resolved = self._classify(path)

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -13,10 +13,12 @@ tools, template rendering, and action history.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from contextlib import nullcontext
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from agents import FunctionTool, Tool
@@ -140,6 +142,8 @@ BUILTIN_SUBAGENT_DESCRIPTIONS = {
     "gen_semantic_model": (
         "Generate semantic model YAML files from database table structures. "
         "Use when asked to create or update semantic models, define entities, relationships, or dimensions. "
+        "For OSI metric generation, run this task first when the target domain semantic model does not exist, "
+        "wait for it to finish, and only then run gen_metrics; never run both tasks concurrently. "
         "Prompt MUST contain table name(s), e.g. 'orders' or 'orders, customers, products'. "
         "Returns JSON with {response, semantic_models (list of file paths), tokens_used}."
     ),
@@ -150,6 +154,10 @@ BUILTIN_SUBAGENT_DESCRIPTIONS = {
         "(2) Natural language: describe the business metric or calculation rules, "
         "the agent will guide through interactive Q&A to define the metric. "
         "(3) Batch: provide multiple SQL queries for AST-backed metric candidate extraction. "
+        "In OSI mode this task only creates or updates metrics in an existing domain semantic model. "
+        "If it returns code=semantic_model_required, run gen_semantic_model first and retry this task with "
+        "the original prompt. In MetricFlow mode it may create or extend semantic-model prerequisites itself. "
+        "Never run gen_metrics and gen_semantic_model concurrently. "
         "For batch input, if the user provides a CSV file path, YOU (the parent agent) must read the file content first "
         "and include the full content in the prompt — the metrics agent cannot access files outside its workspace. "
         "The metrics agent will preserve final business output expressions and treat base measures as dependencies. "
@@ -235,6 +243,7 @@ class SubAgentTaskTool:
         self._action_bus: Optional["ActionBus"] = None
         self._interaction_broker: Optional["InteractionBroker"] = None
         self._parent_node: Optional["AgenticNode"] = None
+        self._semantic_authoring_locks: Dict[str, asyncio.Lock] = {}
 
     def set_action_bus(self, bus: "ActionBus") -> None:
         """Inject the :class:`ActionBus` for forwarding sub-agent actions."""
@@ -331,12 +340,70 @@ class SubAgentTaskTool:
             return FuncToolResult(success=0, error="Missing required parameter: prompt")
 
         try:
+            normalized_type = type.strip().strip("\"'") if isinstance(type, str) else type
+            semantic_types = {"gen_semantic_model", "gen_metrics"}
+            if normalized_type in semantic_types and normalized_type in self._get_available_types():
+                lock_key = self._semantic_authoring_lock_key()
+                lock = self._semantic_authoring_locks.setdefault(lock_key, asyncio.Lock())
+                async with lock:
+                    if normalized_type == "gen_metrics":
+                        precondition = self._osi_metric_precondition()
+                        if precondition is not None:
+                            return precondition
+                    return await self._execute_node(
+                        normalized_type,
+                        prompt,
+                        description=description,
+                        call_id=call_id,
+                        session_id=session_id,
+                    )
+
             return await self._execute_node(
                 type, prompt, description=description, call_id=call_id, session_id=session_id
             )
         except Exception as e:
             logger.error(f"Task tool execution error (type={type}): {e}")
             return FuncToolResult(success=0, error=f"Task execution failed: {str(e)}")
+
+    def _semantic_authoring_lock_key(self) -> str:
+        """Serialize semantic authoring tasks for one project datasource."""
+        path_manager = getattr(self.agent_config, "path_manager", None)
+        project_root = getattr(path_manager, "project_root", "")
+        datasource = str(getattr(self.agent_config, "current_datasource", "") or "default")
+        return f"{project_root}:{datasource}"
+
+    def _osi_metric_precondition(self) -> Optional[FuncToolResult]:
+        """Require the OSI domain model before starting the metric subagent."""
+        from datus.agent.node.semantic_authoring import (
+            default_osi_semantic_model_file,
+            is_osi_authoring,
+        )
+
+        if not is_osi_authoring(self.agent_config):
+            return None
+
+        path_manager = getattr(self.agent_config, "path_manager", None)
+        project_root = getattr(path_manager, "project_root", None)
+        if project_root is None:
+            return None
+
+        target = Path(project_root) / default_osi_semantic_model_file(self.agent_config)
+        if target.is_file():
+            return None
+
+        return FuncToolResult(
+            success=0,
+            error=(
+                "OSI semantic model is required before metric generation. "
+                "Run gen_semantic_model first, wait for it to finish, then retry gen_metrics."
+            ),
+            result={
+                "code": "semantic_model_required",
+                "required_subagent": "gen_semantic_model",
+                "semantic_model_file": str(target),
+                "retry_subagent": "gen_metrics",
+            },
+        )
 
     # ── node creation ─────────────────────────────────────────────────
 

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+import weakref
 from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
@@ -47,6 +48,8 @@ if TYPE_CHECKING:
     from datus.schemas.base import BaseInput
 
 logger = get_logger(__name__)
+
+_SEMANTIC_AUTHORING_LOCKS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 # Mapping from subagent type string to NodeType constants
 NODE_CLASS_MAP = {
@@ -243,7 +246,6 @@ class SubAgentTaskTool:
         self._action_bus: Optional["ActionBus"] = None
         self._interaction_broker: Optional["InteractionBroker"] = None
         self._parent_node: Optional["AgenticNode"] = None
-        self._semantic_authoring_locks: Dict[str, asyncio.Lock] = {}
 
     def set_action_bus(self, bus: "ActionBus") -> None:
         """Inject the :class:`ActionBus` for forwarding sub-agent actions."""
@@ -343,8 +345,7 @@ class SubAgentTaskTool:
             normalized_type = type.strip().strip("\"'") if isinstance(type, str) else type
             semantic_types = {"gen_semantic_model", "gen_metrics"}
             if normalized_type in semantic_types and normalized_type in self._get_available_types():
-                lock_key = self._semantic_authoring_lock_key()
-                lock = self._semantic_authoring_locks.setdefault(lock_key, asyncio.Lock())
+                lock = self._semantic_authoring_lock()
                 async with lock:
                     if normalized_type == "gen_metrics":
                         precondition = self._osi_metric_precondition()
@@ -370,7 +371,17 @@ class SubAgentTaskTool:
         path_manager = getattr(self.agent_config, "path_manager", None)
         project_root = getattr(path_manager, "project_root", "")
         datasource = str(getattr(self.agent_config, "current_datasource", "") or "default")
-        return f"{project_root}:{datasource}"
+        try:
+            project_key = str(Path(project_root).expanduser().resolve(strict=False))
+        except TypeError:
+            project_key = str(project_root)
+        return f"{project_key}:{datasource}"
+
+    def _semantic_authoring_lock(self) -> asyncio.Lock:
+        """Return the event-loop shared lock for one project datasource."""
+        loop = asyncio.get_running_loop()
+        loop_locks = _SEMANTIC_AUTHORING_LOCKS.setdefault(loop, {})
+        return loop_locks.setdefault(self._semantic_authoring_lock_key(), asyncio.Lock())
 
     def _osi_metric_precondition(self) -> Optional[FuncToolResult]:
         """Require the OSI domain model before starting the metric subagent."""

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -480,7 +480,7 @@ class PermissionHooks(AgentHooks):
     # this set so the profile-aware gate treats it as a write. ``delete_file``
     # belongs here too — it mutates the filesystem just as much as a write
     # and should hit the same INTERNAL × write × normal ASK gate.
-    _FILESYSTEM_WRITE_TOOLS = frozenset({"write_file", "edit_file", "delete_file"})
+    _FILESYSTEM_WRITE_TOOLS = frozenset({"write_file", "edit_file", "delete_file", "upsert_osi_metrics"})
 
     # Subagents that author their own artifact tree (manifest.json,
     # queries/*, render/*.jsx, analysis/*) in one turn — usually 5-10 files

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -287,6 +287,7 @@ _AUTO_EXTRA_RULES = [
     _rule("filesystem_tools", "write_file", PermissionLevel.ALLOW),
     _rule("filesystem_tools", "edit_file", PermissionLevel.ALLOW),
     _rule("filesystem_tools", "delete_file", PermissionLevel.ALLOW),
+    _rule("filesystem_tools", "upsert_osi_metrics", PermissionLevel.ALLOW),
     # plan writes
     _rule("tools", "todo_write", PermissionLevel.ALLOW),
     _rule("tools", "todo_update", PermissionLevel.ALLOW),

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -85,6 +85,23 @@ class TestGenMetricsAgenticNodeInit:
         assert isinstance(node.filesystem_func_tool, FilesystemFuncTool)
         assert isinstance(node.generation_tools, GenerationTools)
 
+    def test_osi_metrics_has_only_metric_mutation_tools(self, real_agent_config, mock_llm_create):
+        """OSI metrics cannot invoke general filesystem or semantic-model authoring tools."""
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate OSI metrics")
+
+        node._get_system_prompt(template_context=node._prepare_template_context(node.input))
+        tool_names = {tool.name for tool in node.tools}
+
+        assert {"read_file", "upsert_osi_metrics", "glob", "grep"}.issubset(tool_names)
+        assert {"write_file", "edit_file", "delete_file", "end_semantic_model_generation", "bash"}.isdisjoint(
+            tool_names
+        )
+        assert "end_metric_generation" in tool_names
+
     def test_metrics_max_turns(self, real_agent_config, mock_llm_create):
         """Test max_turns is read from agentic_nodes config."""
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
@@ -973,7 +990,7 @@ class TestExecuteStreamGenMetricsError:
             semantic_model_files=[str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml")],
         )
 
-    def test_osi_final_metric_publish_uses_semantic_model_files(self, real_agent_config, mock_llm_create):
+    def test_osi_final_metric_publish_does_not_sync_semantic_model_files(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.tools.func_tool.base import FuncToolResult
 
@@ -1017,10 +1034,12 @@ semantic_model:
         node.semantic_tools.query_metrics.assert_called_once_with(metrics=["order_count"], dry_run=True)
         node.generation_tools.end_metric_generation.assert_called_once_with(
             metric_file=str(metric_path),
-            semantic_model_files=[str(semantic_dir / "orders.yml")],
+            semantic_model_files=[],
         )
 
-    def test_osi_final_metric_publish_handles_string_semantic_model_file(self, real_agent_config, mock_llm_create):
+    def test_osi_final_metric_publish_ignores_legacy_string_semantic_model_file(
+        self, real_agent_config, mock_llm_create
+    ):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.tools.func_tool.base import FuncToolResult
 
@@ -1058,7 +1077,7 @@ semantic_model:
 
         node.generation_tools.end_metric_generation.assert_called_once_with(
             metric_file=str(metric_path),
-            semantic_model_files=[str(semantic_dir / "orders.yml")],
+            semantic_model_files=[],
         )
 
     def test_osi_final_metric_publish_skips_when_already_synced(self, real_agent_config, mock_llm_create):
@@ -1147,7 +1166,7 @@ semantic_model:
         with pytest.raises(RuntimeError, match="validate_semantic failed"):
             node._finalize_metric_generation(None, "orders_metrics.yml", "generated")
 
-    def test_osi_final_metric_publish_passes_authoring_checks_and_baseline(self, real_agent_config, mock_llm_create):
+    def test_osi_final_metric_publish_uses_authoring_quality_check(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.tools.func_tool.base import FuncToolResult
 
@@ -1158,11 +1177,8 @@ semantic_model:
             "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: order_count\n",
             encoding="utf-8",
         )
-        baseline = json.dumps({"version": "0.2.0.dev0", "semantic_model": [{"name": "shop", "datasets": []}]})
-
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node._osi_metrics_baseline_artifact_json = baseline
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
         node.semantic_tools.query_metrics = MagicMock(
@@ -1176,10 +1192,7 @@ semantic_model:
             "generated",
         )
 
-        node.semantic_tools.validate_semantic.assert_called_once_with(
-            checks=["authoring_quality", "mutation_guard"],
-            baseline_artifact_json=baseline,
-        )
+        node.semantic_tools.validate_semantic.assert_called_once_with(checks=["authoring_quality"])
 
     def test_osi_final_metric_publish_requires_query_metrics_tool(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -161,7 +161,7 @@ def test_required_authoring_skills_derive_from_format(node_name, adapter, expect
         ("gen_semantic_model", "metricflow", "semantic-sql-history-profiler"),
         ("gen_semantic_model", "osi", "semantic-sql-history-profiler"),
         ("gen_metrics", "metricflow", "metricflow-semantic-authoring"),
-        ("gen_metrics", "osi", "osi-semantic-authoring"),
+        ("gen_metrics", "osi", ""),
         ("unknown_node", "osi", ""),
     ],
 )
@@ -191,7 +191,7 @@ def test_node_skill_defaults_follow_authoring_format(monkeypatch, adapter):
 
     assert parent_calls == ["GenMetricsAgenticNode", "GenSemanticModelAgenticNode"]
     assert semantic_node.node_config["skills"] == "semantic-sql-history-profiler"
-    expected_metrics_optional = "metricflow-semantic-authoring" if adapter == "metricflow" else "osi-semantic-authoring"
+    expected_metrics_optional = "metricflow-semantic-authoring" if adapter == "metricflow" else ""
     assert metrics_node.node_config["skills"] == expected_metrics_optional
 
 

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -255,19 +255,18 @@ class TestConstants:
         assert "platform_doc_tools" not in _USER_FACING_TOOL_CATEGORIES
 
     def test_filesystem_tools_valid_methods_match_runtime_surface(self):
-        """``VALID_TOOL_METHODS["filesystem_tools"]`` is derived from
-        ``FilesystemFuncTool.all_tools_name()`` so it auto-tracks the
-        runtime instead of drifting (``delete_file`` was previously
-        missing from the hand-curated set).
+        """``VALID_TOOL_METHODS["filesystem_tools"]`` tracks the complete
+        general plus OSI metric filesystem surface.
 
         Pin both directions: every name the runtime advertises ends up
         in the saas catalog, and every name in the catalog is a real
         public method on the class.
         """
         from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
+        from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
 
         catalog = VALID_TOOL_METHODS["filesystem_tools"]
-        introspected = set(FilesystemFuncTool.all_tools_name())
+        introspected = set(MetricFilesystemFuncTool.all_tools_name())
         assert catalog == introspected
 
         # The runtime advertises its tool surface in ``available_tools``;
@@ -279,12 +278,14 @@ class TestConstants:
             "write_file",
             "edit_file",
             "delete_file",
+            "upsert_osi_metrics",
             "glob",
             "grep",
         }
         assert introspected == expected_runtime_methods
-        for name in expected_runtime_methods:
+        for name in expected_runtime_methods - {"upsert_osi_metrics"}:
             assert hasattr(FilesystemFuncTool, name), f"FilesystemFuncTool dropped method {name!r}"
+        assert hasattr(MetricFilesystemFuncTool, "upsert_osi_metrics")
         # BaseTool framework methods must NOT show up in the catalog.
         for framework_method in ("set_tool_context", "get_actions", "call_action"):
             assert framework_method not in catalog

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -109,8 +109,8 @@ def test_metrics_template_metricflow_mode_contract():
 def test_metrics_template_osi_mode_contract():
     text = _render("gen_metrics_system", "osi")
     assert "OSI (Open Semantic Interchange) core semantic model" in text
-    # OSI metrics report a singular semantic_model_file in the final JSON.
-    assert '"semantic_model_file"' in text
+    assert '"semantic_model_files": []' in text
+    assert "upsert_osi_metrics" in text
     assert "subject_path" in text
     assert "locked_metadata.tags" not in text.split("Record the classification")[1].split("\n")[0]
     assert "Covered by an existing base metric" in text

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -317,7 +317,7 @@ class TestEndMetricGeneration:
         preflight_mock.assert_not_called()
         sync_mock.assert_called_once_with(str(metric_file), [], {}, replace_metric_artifact=False)
 
-    def test_osi_forwards_all_semantic_model_files_to_sync(self, generation_tools, tmp_path):
+    def test_osi_ignores_semantic_model_files_to_avoid_duplicate_sync(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
         generation_tools.authoring_format = "osi"
         semantic_root = tmp_path / "semantic_models" / "starrocks"
@@ -338,12 +338,7 @@ class TestEndMetricGeneration:
             patch.object(
                 generation_tools,
                 "_sync_osi_metric_to_db",
-                return_value={
-                    "success": True,
-                    "message": "synced",
-                    "semantic_synced": True,
-                    "semantic_model_files_synced": [str(orders_file), str(customers_file)],
-                },
+                return_value={"success": True, "message": "synced"},
             ) as sync_mock,
         ):
             result = generation_tools.end_metric_generation(
@@ -355,11 +350,12 @@ class TestEndMetricGeneration:
         preflight_mock.assert_not_called()
         sync_mock.assert_called_once_with(
             str(metric_file),
-            [str(orders_file), str(customers_file)],
+            [],
             {},
             replace_metric_artifact=False,
         )
-        assert generation_tools.generation_evidence.semantic_kb_sync_passed is True
+        assert result.result["semantic_model_files"] == []
+        assert generation_tools.generation_evidence.semantic_kb_sync_passed is False
 
 
 class TestEndMetricGenerationPreflight:

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -3,11 +3,22 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import yaml
 
 from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
+
+
+def _osi_metric(name, expression):
+    return {
+        "name": name,
+        "description": f"Definition for {name}",
+        "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": expression}]},
+    }
 
 
 class TestMetricFilesystemFuncTool:
@@ -28,27 +39,34 @@ class TestMetricFilesystemFuncTool:
         target.parent.mkdir(parents=True)
         target.write_text(
             """
-version: 0.2.0
+version: 0.2.0.dev0
 semantic_model:
   - name: sales
     description: Sales domain
     datasets:
       - name: orders
-        source:
-          table: orders
+        source: orders
         fields:
           - name: amount
             expression:
-              sql: amount
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: amount
+            dimension:
+              is_time: false
     relationships:
       - name: orders_to_customers
         from: orders
         to: customers
+        from_columns: [customer_id]
+        to_columns: [customer_id]
     metrics:
       - name: revenue
         description: Old definition
         expression:
-          sql: SUM(amount)
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(amount)
 """.lstrip(),
             encoding="utf-8",
         )
@@ -66,13 +84,9 @@ semantic_model:
                     {
                         "name": "revenue",
                         "description": "Corrected definition",
-                        "expression": {"sql": "SUM(net_amount)"},
+                        "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "SUM(net_amount)"}]},
                     },
-                    {
-                        "name": "order_count",
-                        "description": "Number of orders",
-                        "expression": {"sql": "COUNT(*)"},
-                    },
+                    _osi_metric("order_count", "COUNT(*)"),
                 ]
             ),
         )
@@ -89,6 +103,104 @@ semantic_model:
         assert [metric["name"] for metric in after_model["metrics"]] == ["revenue", "order_count"]
         assert after_model["metrics"][0]["description"] == "Corrected definition"
 
+    @pytest.mark.parametrize("invalid_metrics", [{}, ""])
+    def test_upsert_osi_metrics_rejects_present_invalid_metrics_collection(self, tmp_path, invalid_metrics):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+        target.parent.mkdir(parents=True)
+        document = {
+            "version": "0.2.0.dev0",
+            "semantic_model": [{"name": "sales", "datasets": [{"name": "orders", "source": "orders"}]}],
+        }
+        document["semantic_model"][0]["metrics"] = invalid_metrics
+        original = yaml.safe_dump(document, sort_keys=False)
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi")
+
+        result = tool.upsert_osi_metrics(
+            str(target.relative_to(tmp_path)), json.dumps([_osi_metric("revenue", "SUM(amount)")])
+        )
+
+        assert result.success == 0
+        assert "metrics must be a list" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_upsert_osi_metrics_validates_metric_schema_before_writing(self, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+        target.parent.mkdir(parents=True)
+        original = """version: 0.2.0.dev0
+semantic_model:
+  - name: sales
+    datasets:
+      - name: orders
+        source: orders
+"""
+        target.write_text(original, encoding="utf-8")
+        tool = MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi")
+
+        result = tool.upsert_osi_metrics(
+            str(target.relative_to(tmp_path)),
+            json.dumps([{"name": "revenue"}]),
+        )
+
+        assert result.success == 0
+        assert "Invalid OSI metric update" in result.error
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_upsert_osi_metrics_serializes_concurrent_tool_instances(self, tmp_path, monkeypatch):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """version: 0.2.0.dev0
+semantic_model:
+  - name: sales
+    datasets:
+      - name: orders
+        source: orders
+""",
+            encoding="utf-8",
+        )
+        tools = [
+            MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi"),
+            MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi"),
+        ]
+        original_atomic_write = MetricFilesystemFuncTool._atomic_write_text
+        active_writes = 0
+        max_active_writes = 0
+        counter_lock = threading.Lock()
+
+        def slow_atomic_write(path, content):
+            nonlocal active_writes, max_active_writes
+            with counter_lock:
+                active_writes += 1
+                max_active_writes = max(max_active_writes, active_writes)
+            time.sleep(0.02)
+            try:
+                original_atomic_write(path, content)
+            finally:
+                with counter_lock:
+                    active_writes -= 1
+
+        monkeypatch.setattr(MetricFilesystemFuncTool, "_atomic_write_text", staticmethod(slow_atomic_write))
+        barrier = threading.Barrier(2)
+
+        def upsert(tool, metric):
+            barrier.wait()
+            return tool.upsert_osi_metrics(str(target.relative_to(tmp_path)), json.dumps([metric]))
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(
+                executor.map(
+                    upsert,
+                    tools,
+                    [_osi_metric("revenue", "SUM(amount)"), _osi_metric("order_count", "COUNT(*)")],
+                )
+            )
+
+        assert all(result.success == 1 for result in results)
+        assert max_active_writes == 1
+        metrics = yaml.safe_load(target.read_text(encoding="utf-8"))["semantic_model"][0]["metrics"]
+        assert {metric["name"] for metric in metrics} == {"revenue", "order_count"}
+
     def test_upsert_osi_metrics_requires_existing_model(self, tmp_path):
         tool = MetricFilesystemFuncTool(
             root_path=str(tmp_path),
@@ -98,7 +210,7 @@ semantic_model:
 
         result = tool.upsert_osi_metrics(
             "subject/semantic_models/warehouse/sales.yml",
-            json.dumps([{"name": "revenue", "expression": {"sql": "SUM(amount)"}}]),
+            json.dumps([_osi_metric("revenue", "SUM(amount)")]),
         )
 
         assert result.success == 0

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import json
+
 import pytest
 import yaml
 
@@ -9,6 +11,99 @@ from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTo
 
 
 class TestMetricFilesystemFuncTool:
+    def test_osi_available_tools_are_metrics_only(self, tmp_path):
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+        )
+
+        tool_names = {tool.name for tool in tool.available_tools()}
+
+        assert tool_names == {"read_file", "upsert_osi_metrics", "glob", "grep"}
+
+    def test_upsert_osi_metrics_preserves_semantic_objects(self, tmp_path):
+        project = tmp_path / "project"
+        target = project / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """
+version: 0.2.0
+semantic_model:
+  - name: sales
+    description: Sales domain
+    datasets:
+      - name: orders
+        source:
+          table: orders
+        fields:
+          - name: amount
+            expression:
+              sql: amount
+    relationships:
+      - name: orders_to_customers
+        from: orders
+        to: customers
+    metrics:
+      - name: revenue
+        description: Old definition
+        expression:
+          sql: SUM(amount)
+""".lstrip(),
+            encoding="utf-8",
+        )
+        before = yaml.safe_load(target.read_text(encoding="utf-8"))
+        tool = MetricFilesystemFuncTool(
+            root_path=str(project),
+            current_node="gen_metrics",
+            authoring_format="osi",
+        )
+
+        result = tool.upsert_osi_metrics(
+            "subject/semantic_models/warehouse/sales.yml",
+            json.dumps(
+                [
+                    {
+                        "name": "revenue",
+                        "description": "Corrected definition",
+                        "expression": {"sql": "SUM(net_amount)"},
+                    },
+                    {
+                        "name": "order_count",
+                        "description": "Number of orders",
+                        "expression": {"sql": "COUNT(*)"},
+                    },
+                ]
+            ),
+        )
+
+        assert result.success == 1
+        assert result.result["created"] == ["order_count"]
+        assert result.result["updated"] == ["revenue"]
+        after = yaml.safe_load(target.read_text(encoding="utf-8"))
+        before_model = before["semantic_model"][0]
+        after_model = after["semantic_model"][0]
+        assert {key: value for key, value in after_model.items() if key != "metrics"} == {
+            key: value for key, value in before_model.items() if key != "metrics"
+        }
+        assert [metric["name"] for metric in after_model["metrics"]] == ["revenue", "order_count"]
+        assert after_model["metrics"][0]["description"] == "Corrected definition"
+
+    def test_upsert_osi_metrics_requires_existing_model(self, tmp_path):
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+        )
+
+        result = tool.upsert_osi_metrics(
+            "subject/semantic_models/warehouse/sales.yml",
+            json.dumps([{"name": "revenue", "expression": {"sql": "SUM(amount)"}}]),
+        )
+
+        assert result.success == 0
+        assert result.result["code"] == "semantic_model_required"
+
     def test_write_file_merges_existing_semantic_model(self, tmp_path):
         project = tmp_path / "project"
         target = project / "subject" / "semantic_models" / "ac_manage" / "orders.yml"

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -4,7 +4,6 @@
 
 import json
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -146,7 +145,7 @@ semantic_model:
         assert "Invalid OSI metric update" in result.error
         assert target.read_text(encoding="utf-8") == original
 
-    def test_upsert_osi_metrics_serializes_concurrent_tool_instances(self, tmp_path, monkeypatch):
+    def test_upsert_osi_metrics_serializes_concurrent_tool_instances(self, tmp_path):
         target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
         target.parent.mkdir(parents=True)
         target.write_text(
@@ -163,41 +162,26 @@ semantic_model:
             MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi"),
             MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi"),
         ]
-        original_atomic_write = MetricFilesystemFuncTool._atomic_write_text
-        active_writes = 0
-        max_active_writes = 0
-        counter_lock = threading.Lock()
+        relative_path = str(target.relative_to(tmp_path))
+        shared_lock = tools[0]._osi_metric_path_lock(target)
+        assert shared_lock is tools[1]._osi_metric_path_lock(target)
+        second_started = threading.Event()
 
-        def slow_atomic_write(path, content):
-            nonlocal active_writes, max_active_writes
-            with counter_lock:
-                active_writes += 1
-                max_active_writes = max(max_active_writes, active_writes)
-            time.sleep(0.02)
-            try:
-                original_atomic_write(path, content)
-            finally:
-                with counter_lock:
-                    active_writes -= 1
-
-        monkeypatch.setattr(MetricFilesystemFuncTool, "_atomic_write_text", staticmethod(slow_atomic_write))
-        barrier = threading.Barrier(2)
-
-        def upsert(tool, metric):
-            barrier.wait()
-            return tool.upsert_osi_metrics(str(target.relative_to(tmp_path)), json.dumps([metric]))
+        def upsert_from_second_tool():
+            second_started.set()
+            return tools[1].upsert_osi_metrics(relative_path, json.dumps([_osi_metric("order_count", "COUNT(*)")]))
 
         with ThreadPoolExecutor(max_workers=2) as executor:
-            results = list(
-                executor.map(
-                    upsert,
-                    tools,
-                    [_osi_metric("revenue", "SUM(amount)"), _osi_metric("order_count", "COUNT(*)")],
-                )
-            )
+            with shared_lock:
+                second_result = executor.submit(upsert_from_second_tool)
+                assert second_started.wait(timeout=1)
+                assert not second_result.done()
+            results = [
+                second_result.result(),
+                tools[0].upsert_osi_metrics(relative_path, json.dumps([_osi_metric("revenue", "SUM(amount)")])),
+            ]
 
         assert all(result.success == 1 for result in results)
-        assert max_active_writes == 1
         metrics = yaml.safe_load(target.read_text(encoding="utf-8"))["semantic_model"][0]["metrics"]
         assert {metric["name"] for metric in metrics} == {"revenue", "order_count"}
 

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -5,6 +5,7 @@
 import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import Mock
 
 import pytest
 import yaml
@@ -20,6 +21,13 @@ def _osi_metric(name, expression):
     }
 
 
+@pytest.fixture
+def osi_schema_validator(monkeypatch):
+    validator = Mock(return_value=None)
+    monkeypatch.setattr(MetricFilesystemFuncTool, "_validate_osi_document", staticmethod(validator))
+    return validator
+
+
 class TestMetricFilesystemFuncTool:
     def test_osi_available_tools_are_metrics_only(self, tmp_path):
         tool = MetricFilesystemFuncTool(
@@ -32,7 +40,7 @@ class TestMetricFilesystemFuncTool:
 
         assert tool_names == {"read_file", "upsert_osi_metrics", "glob", "grep"}
 
-    def test_upsert_osi_metrics_preserves_semantic_objects(self, tmp_path):
+    def test_upsert_osi_metrics_preserves_semantic_objects(self, tmp_path, osi_schema_validator):
         project = tmp_path / "project"
         target = project / "subject" / "semantic_models" / "warehouse" / "sales.yml"
         target.parent.mkdir(parents=True)
@@ -101,6 +109,7 @@ semantic_model:
         }
         assert [metric["name"] for metric in after_model["metrics"]] == ["revenue", "order_count"]
         assert after_model["metrics"][0]["description"] == "Corrected definition"
+        osi_schema_validator.assert_called_once()
 
     @pytest.mark.parametrize("invalid_metrics", [{}, ""])
     def test_upsert_osi_metrics_rejects_present_invalid_metrics_collection(self, tmp_path, invalid_metrics):
@@ -123,7 +132,7 @@ semantic_model:
         assert "metrics must be a list" in result.error
         assert target.read_text(encoding="utf-8") == original
 
-    def test_upsert_osi_metrics_validates_metric_schema_before_writing(self, tmp_path):
+    def test_upsert_osi_metrics_validates_metric_schema_before_writing(self, tmp_path, osi_schema_validator):
         target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
         target.parent.mkdir(parents=True)
         original = """version: 0.2.0.dev0
@@ -135,6 +144,7 @@ semantic_model:
 """
         target.write_text(original, encoding="utf-8")
         tool = MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi")
+        osi_schema_validator.return_value = "metric expression is required"
 
         result = tool.upsert_osi_metrics(
             str(target.relative_to(tmp_path)),
@@ -145,7 +155,7 @@ semantic_model:
         assert "Invalid OSI metric update" in result.error
         assert target.read_text(encoding="utf-8") == original
 
-    def test_upsert_osi_metrics_serializes_concurrent_tool_instances(self, tmp_path):
+    def test_upsert_osi_metrics_serializes_concurrent_tool_instances(self, tmp_path, osi_schema_validator):
         target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
         target.parent.mkdir(parents=True)
         target.write_text(

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -801,9 +801,13 @@ class TestTaskExecution:
         execute_node.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_semantic_authoring_tasks_are_serialized(self, task_tool, monkeypatch):
+    async def test_semantic_authoring_tasks_are_serialized_across_tool_instances(
+        self, task_tool, monkeypatch, tmp_path
+    ):
         active = 0
         max_active = 0
+        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
+        metrics_tool = SubAgentTaskTool(agent_config=task_tool.agent_config)
 
         async def fake_execute(subagent_type, prompt, **kwargs):
             nonlocal active, max_active
@@ -815,10 +819,12 @@ class TestTaskExecution:
 
         monkeypatch.setattr(task_tool, "_execute_node", fake_execute)
         monkeypatch.setattr(task_tool, "_osi_metric_precondition", lambda: None)
+        monkeypatch.setattr(metrics_tool, "_execute_node", fake_execute)
+        monkeypatch.setattr(metrics_tool, "_osi_metric_precondition", lambda: None)
 
         semantic_result, metrics_result = await asyncio.gather(
             task_tool.task(type="gen_semantic_model", prompt="Generate the sales model"),
-            task_tool.task(type="gen_metrics", prompt="Generate revenue"),
+            metrics_tool.task(type="gen_metrics", prompt="Generate revenue"),
         )
 
         assert semantic_result.success == 1

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -4,6 +4,8 @@
 
 """CI-level tests for SubAgentTaskTool (AgenticNode-based execution)."""
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -12,6 +14,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.configuration.node_type import NodeType
 from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 from datus.schemas.agent_models import ScopedContext
+from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.sub_agent_task_tool import (
     BUILTIN_SUBAGENT_DESCRIPTIONS,
     NODE_CLASS_MAP,
@@ -779,6 +782,49 @@ class TestSubAgentTaskAcceptance:
 
 @pytest.mark.ci
 class TestTaskExecution:
+    @pytest.mark.asyncio
+    async def test_osi_gen_metrics_requires_existing_semantic_model(self, task_tool, tmp_path):
+        task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
+        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
+
+        with patch(
+            "datus.agent.node.semantic_authoring.default_osi_semantic_model_file",
+            return_value="subject/semantic_models/test_db/sales.yml",
+        ):
+            with patch.object(task_tool, "_execute_node") as execute_node:
+                result = await task_tool.task(type="gen_metrics", prompt="Generate revenue")
+
+        assert result.success == 0
+        assert result.result["code"] == "semantic_model_required"
+        assert result.result["required_subagent"] == "gen_semantic_model"
+        assert result.result["retry_subagent"] == "gen_metrics"
+        execute_node.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_semantic_authoring_tasks_are_serialized(self, task_tool, monkeypatch):
+        active = 0
+        max_active = 0
+
+        async def fake_execute(subagent_type, prompt, **kwargs):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return FuncToolResult(result={"subagent_type": subagent_type})
+
+        monkeypatch.setattr(task_tool, "_execute_node", fake_execute)
+        monkeypatch.setattr(task_tool, "_osi_metric_precondition", lambda: None)
+
+        semantic_result, metrics_result = await asyncio.gather(
+            task_tool.task(type="gen_semantic_model", prompt="Generate the sales model"),
+            task_tool.task(type="gen_metrics", prompt="Generate revenue"),
+        )
+
+        assert semantic_result.success == 1
+        assert metrics_result.success == 1
+        assert max_active == 1
+
     @pytest.mark.asyncio
     async def test_execute_gen_sql_success(self, task_tool):
         """Successful gen_sql execution through node."""

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -1032,27 +1032,35 @@ class TestFilesystemZoneProfileMatrix:
     @pytest.mark.asyncio
     async def test_is_write_set_matches_filesystem_tool_surface(self):
         """Guard against drift: the hook's write-set must cover every write
-        method ``FilesystemFuncTool`` actually exposes.
+        method the general or OSI metric filesystem surface actually exposes.
 
         If a new write tool (e.g. ``append_file``) is added without updating
         ``_FILESYSTEM_WRITE_TOOLS``, the normal-profile INTERNAL gate would
         silently regress to bypass for that tool.
         """
         from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
+        from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
 
         fs_tool = FilesystemFuncTool(root_path="/tmp")
         tool_names = {t.name for t in fs_tool.available_tools()}
+        osi_metric_tool = MetricFilesystemFuncTool(
+            root_path="/tmp",
+            current_node="gen_metrics",
+            authoring_format="osi",
+        )
+        osi_metric_tool_names = {t.name for t in osi_metric_tool.available_tools()}
         # Every tool the filesystem surface advertises as a mutation must be
         # declared as a write, so the normal-profile INTERNAL gate doesn't
         # silently bypass it. Read-only tools (``read_file`` / ``glob`` /
         # ``grep``) stay out — they have their own gate path.
-        write_names = {"write_file", "edit_file", "delete_file"}
-        # The hook's declared write-set must equal the writes the tool exposes,
+        write_names = {"write_file", "edit_file", "delete_file", "upsert_osi_metrics"}
+        # The hook's declared write-set must equal the writes these tools expose,
         # not a strict subset. Both directions matter:
         #   - subset breaks the matrix (writes get silently bypassed)
         #   - superset means we ASK on a tool name that doesn't exist
         assert write_names == PermissionHooks._FILESYSTEM_WRITE_TOOLS
-        assert write_names.issubset(tool_names)
+        assert write_names - {"upsert_osi_metrics"} <= tool_names
+        assert "upsert_osi_metrics" in osi_metric_tool_names
 
 
 class TestNonInteractiveMode:

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -156,13 +156,12 @@ class TestAutoProfile:
 
     def test_workspace_writes_allowed(self):
         config = AUTO
-        # ``write_file`` / ``edit_file`` / ``delete_file`` are the full set of
-        # write tools ``FilesystemFuncTool`` exposes today (``create_directory``
-        # / ``move_file`` were removed in the #561 refactor and used to live
-        # here as dead rules — see ``test_dead_filesystem_rules_absent``).
+        # General filesystem writes plus the OSI metrics-only upsert are all
+        # non-interactive under the auto profile.
         assert _resolve(config, "filesystem_tools", "write_file") == PermissionLevel.ALLOW
         assert _resolve(config, "filesystem_tools", "edit_file") == PermissionLevel.ALLOW
         assert _resolve(config, "filesystem_tools", "delete_file") == PermissionLevel.ALLOW
+        assert _resolve(config, "filesystem_tools", "upsert_osi_metrics") == PermissionLevel.ALLOW
 
     def test_bi_write_allowed_delete_asks(self):
         """Auto downgrades NORMAL's DENY on destructives to ASK — user is
@@ -207,17 +206,24 @@ class TestDangerousProfile:
 
 
 class TestFilesystemRuleSurface:
-    """Filesystem rules must match the tool surface exposed by
-    ``FilesystemFuncTool.available_tools``.
+    """Filesystem rules must match the general and OSI metric tool surfaces.
 
     ``#561`` reduced the toolset to five methods (``read_file``,
     ``write_file``, ``edit_file``, ``glob``, ``grep``) but the rule tables
-    kept five stale patterns until this PR. The asserts below lock in that
-    cleanup so a future refactor doesn't silently grow another dead rule.
+    kept five stale patterns until this PR. OSI metric generation additionally
+    exposes ``upsert_osi_metrics``. The asserts below lock in both surfaces.
     """
 
     _DEAD_PATTERNS = ("list_*", "directory_tree", "search_files", "create_directory", "move_file")
-    _LIVE_PATTERNS = ("read_*", "glob", "grep", "write_file", "edit_file", "delete_file")
+    _LIVE_PATTERNS = (
+        "read_*",
+        "glob",
+        "grep",
+        "write_file",
+        "edit_file",
+        "delete_file",
+        "upsert_osi_metrics",
+    )
 
     def test_dead_filesystem_rules_absent(self):
         for cfg in (NORMAL, AUTO):


### PR DESCRIPTION
## Summary

- make OSI `gen_metrics` operate on an existing semantic model through a metrics-only `upsert_osi_metrics` tool
- return a structured `semantic_model_required` precondition when the OSI model does not exist
- serialize `gen_semantic_model` and `gen_metrics` tasks for the same project and datasource
- keep MetricFlow authoring behavior unchanged

## Why

OSI metrics and semantic objects live in the same YAML document, so the metrics agent previously received general filesystem authoring capabilities and the optional OSI semantic-authoring skill. That allowed it to create or rewrite datasets, fields, and relationships while generating metrics. If the parent scheduled semantic-model and metric generation together, both subagents could also write the same file concurrently.

## Changes

- expose only `read_file`, `glob`, `grep`, and `upsert_osi_metrics` to OSI `gen_metrics`
- preserve all non-metric semantic-model content while creating or replacing metrics by name
- remove OSI semantic-model publishing and semantic-authoring tools from `gen_metrics`
- require the existing OSI model before starting metric generation
- serialize semantic authoring task execution and document the required retry flow
- route the new upsert operation through the API tool catalog and permission profiles

## Validation

- 795 targeted unit tests passed
- `ruff check` passed for all changed Python files
- `git diff --check` passed
- clean natural-language `datus-cli --print` run against the `baisheng_ask_metrics` StarRocks data:
  - `gen_semantic_model` completed before `gen_metrics` started, with no overlap
  - all 5 requested OSI metrics were written in one upsert and passed validation plus dry-run
  - the metrics subagent did not call semantic-model authoring tools
- full `baisheng_ask_metrics` regression run completed 48/57 tasks, with all 57 context-generation tasks successful and 29 metrics published

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
## Summary by CodeRabbit

* **New Features**
  * Added OSI metric upsert support for creating and updating metrics in existing semantic models.
  * Added validation to ensure semantic models exist before metric generation.
  * Serialized semantic-model and metric-generation tasks to prevent concurrent execution.

* **Bug Fixes**
  * Prevented metric generation from modifying semantic model objects or syncing unnecessary model files.
  * Improved handling of workflows with no eligible metrics and invalid metric definitions.
  * Updated permissions and tool availability for OSI metric operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OSI metric upsert to filesystem tools with atomic writes, per-path locking, and stronger payload validation.
  * Enforced OSI model-first sequencing: metric generation now requires the semantic model to exist.
  * Prevented concurrent OSI semantic/metric subtasks from running at the same time.

* **Bug Fixes**
  * OSI metric publishing no longer forwards semantic-model files and finalization is skipped when no metrics are produced.
  * Updated OSI output contract to use `semantic_model_files: []`.
  * Tightened OSI semantic validation to only perform `authoring_quality` checks.

* **Documentation**
  * Updated OSI metrics authoring workflow guidance and rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->