### PR TITLE
[Enhancement] Make every TUI surface selectable and copyable

### DIFF
--- a/datus/cli/cli_styles.py
+++ b/datus/cli/cli_styles.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
-from rich.box import ROUNDED
+from rich.box import HORIZONTALS, ROUNDED
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
@@ -111,6 +111,12 @@ def render_user_scrollback_text(message: str, prompt_text: str = USER_SCROLLBACK
 
     The border and background give USER messages a strong visual identity
     that separates them from neighbouring ASSISTANT markdown blocks.
+
+    ``HORIZONTALS`` (top/bottom rules only, space side edges) instead of a
+    fully-boxed style: the TUI's drag-copy extracts rendered characters, so
+    vertical ``│`` edges would land on the clipboard glued to every copied
+    message line. Space edges are stripped by the extraction's rstrip and
+    never pollute a paste.
     """
     text = Text()
     text.append(prompt_text, style=USER_SCROLLBACK_PROMPT_STYLE)
@@ -119,7 +125,7 @@ def render_user_scrollback_text(message: str, prompt_text: str = USER_SCROLLBACK
         text,
         border_style=USER_SCROLLBACK_BORDER_STYLE,
         style=USER_SCROLLBACK_TEXT_STYLE,
-        box=ROUNDED,
+        box=HORIZONTALS,
         padding=(0, 1),
         expand=True,
     )

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -43,7 +43,7 @@ from prompt_toolkit.completion import Completer
 from prompt_toolkit.data_structures import Point
 from prompt_toolkit.document import Document
 from prompt_toolkit.filters import Condition, has_completions, is_done, to_filter
-from prompt_toolkit.formatted_text import FormattedText
+from prompt_toolkit.formatted_text import FormattedText, to_formatted_text
 from prompt_toolkit.history import History
 from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 from prompt_toolkit.keys import Keys
@@ -56,8 +56,9 @@ from prompt_toolkit.layout.containers import (
     ScrollOffsets,
     VSplit,
     Window,
+    to_container,
 )
-from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
+from prompt_toolkit.layout.controls import BufferControl, DummyControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenuControl
 from prompt_toolkit.lexers import Lexer
@@ -70,12 +71,16 @@ from datus.cli.cli_styles import PASTE_COLLAPSE_THRESHOLD
 from datus.cli.tui.clipboard import copy_to_clipboard
 from datus.cli.tui.live_display_state import LiveDisplayState, compute_pinned_max_rows
 from datus.cli.tui.output_buffer import BufferedOutputControl, TUIOutputBuffer, extract_selection_text
+from datus.cli.tui.region_selection import SelectableRegion
 from datus.cli.tui.scrollbar import ScrollbarController, build_scrollbar_window
 from datus.cli.tui.search import SearchState, find_matches
 from datus.cli.tui.selection import (
+    MultiClickTracker,
     SelectionAutoscroll,
     SelectionPoint,
     TranscriptSelection,
+    fragment_plain_text,
+    word_bounds_at,
 )
 from datus.cli.tui.wizard_host import EmbeddedWizard
 from datus.utils.loggings import get_logger
@@ -137,6 +142,36 @@ def _resolve_mouse_support(env: Optional[dict] = None) -> bool:
     if override in {"0", "false", "no", "off"}:
         return False
     return not _is_jediterm(src)
+
+
+def _select_buffer_line(buffer: Buffer) -> None:
+    """Select the whole line under the cursor via the buffer's native selection.
+
+    Triple-click path for buffer-backed inputs: prompt_toolkit's
+    ``BufferControl`` only implements double-click word selection natively,
+    so the third click widens it to the current line here. Uses the same
+    ``selection_state`` machinery, so the highlight paints identically.
+    """
+    document = buffer.document
+    line_start = document.cursor_position - document.cursor_position_col
+    line_length = len(document.current_line)
+    buffer.cursor_position = line_start
+    buffer.start_selection()
+    buffer.cursor_position = line_start + line_length
+
+
+def _buffer_selection_text(buffer: Buffer) -> str:
+    """Plain text covered by a buffer's native selection.
+
+    Mirrors :meth:`prompt_toolkit.document.Document.cut_selection`'s
+    slicing (per-range ``text[from:to]`` joined with ``\\n``) without
+    mutating the buffer or clearing ``selection_state`` — the highlight
+    should stay visible after the copy, like the output pane's.
+    """
+    if buffer.selection_state is None:
+        return ""
+    document = buffer.document
+    return "\n".join(document.text[start:end] for start, end in document.selection_ranges())
 
 
 class DatusApp:
@@ -221,6 +256,24 @@ class DatusApp:
         # extending the selection while auto-scrolling". The actual
         # ticking loop lives in :meth:`_selection_autoscroll_loop`.
         self._selection_autoscroll = SelectionAutoscroll()
+        # Every other text pane gets its own independent software
+        # selection (status bar, todo sidebar, queue preview) so any
+        # visible text can be drag-copied, not just the scrollback.
+        # A drag is confined to the region it started in; beginning a
+        # selection anywhere clears the others (see
+        # :meth:`_clear_other_selections`). Buffer-backed inputs (the
+        # composer, the search field) use prompt_toolkit's native
+        # selection instead and only need copy-on-release, tracked in
+        # ``_selection_buffers``.
+        self._selection_regions: dict[str, SelectableRegion] = {}
+        self._selection_buffers: dict[str, Buffer] = {}
+        # Double-click → word, triple-click → line in the scrollback pane.
+        # Regions carry their own tracker; buffer-backed inputs get one in
+        # :meth:`_install_buffer_copy_handler`.
+        self._output_click_tracker = MultiClickTracker()
+        # Registry keys created by :meth:`_wire_wizard_selection` for the
+        # currently mounted embedded wizard; popped on unmount.
+        self._wizard_selection_names: List[str] = []
 
         # Ctrl+F find-in-scrollback. ``_search_state`` is the shared
         # data structure the renderer (via ``search_provider``) and the
@@ -262,10 +315,14 @@ class DatusApp:
         )
         self._input_area.window.dont_extend_height = to_filter(True)
         self._input_area.buffer.on_text_changed += self._on_buffer_text_changed
+        # The composer already gets native drag-selection from prompt_toolkit's
+        # BufferControl; this wrapper adds copy-on-release + cross-region rules.
+        self._install_buffer_copy_handler("input", self._input_area.control, self._input_area.buffer)
 
+        self._status_region = self._make_selection_region("status", self._safe_status_tokens)
         self._status_window = Window(
             content=FormattedTextControl(
-                text=self._safe_status_tokens,
+                text=self._status_region.render_tokens,
                 focusable=False,
                 show_cursor=False,
             ),
@@ -301,12 +358,15 @@ class DatusApp:
             filter=has_completions & ~is_done,
         )
 
+        hint_body = Window(
+            content=FormattedTextControl(lambda: [("class:hint", self._hint_text)]),
+            height=1,
+            wrap_lines=False,
+        )
+        # Bottom-most row of the layout: off-window releases clamp here.
+        hint_body.content.mouse_handler = self._decoration_mouse_handler
         self._hint_window = ConditionalContainer(
-            content=Window(
-                content=FormattedTextControl(lambda: [("class:hint", self._hint_text)]),
-                height=1,
-                wrap_lines=False,
-            ),
+            content=hint_body,
             filter=Condition(lambda: bool(self._hint_text)),
         )
 
@@ -403,6 +463,22 @@ class DatusApp:
             # no-overflow case by filling the column.
             visible_filter=lambda: True,
         )
+        # The gutter's per-fragment handlers only know the scrollbar. Wrap
+        # the control so an in-flight text-selection drag that ends over
+        # the gutter (terminals clamp off-window releases onto edge
+        # columns like this one) still finalises + copies. The scrollbar's
+        # own drag keeps absolute priority.
+        scrollbar_control = self._scrollbar_window.content.content
+        original_scrollbar_handler = scrollbar_control.mouse_handler
+
+        def _scrollbar_mouse_handler(event: MouseEvent):  # noqa: ANN202
+            if not self._scrollbar_controller.dragging:
+                intercepted = self._inflight_drag_intercept(event)
+                if intercepted is not NotImplemented:
+                    return intercepted
+            return original_scrollbar_handler(event)
+
+        scrollbar_control.mouse_handler = _scrollbar_mouse_handler
 
         # Right-side todo-list sidebar for the pinned output row. Wired via
         # callbacks so non-TUI callers (and tests that pass no todo hooks)
@@ -488,10 +564,16 @@ class DatusApp:
             self._live_state.set_invalidate(self.invalidate)
             self._live_state.set_max_rows_provider(self._pinned_max_rows)
 
-    @staticmethod
-    def _make_separator() -> Window:
-        """Full-width horizontal rule rendered with box-drawing character."""
-        return Window(height=1, char="\u2500", style="class:separator")
+    def _make_separator(self) -> Window:
+        """Full-width horizontal rule rendered with box-drawing character.
+
+        Wired to :meth:`_decoration_mouse_handler` because off-window
+        releases get clamped onto edge rows like these \u2014 the handler
+        closes out any in-flight selection drag so it still copies.
+        """
+        window = Window(height=1, char="\u2500", style="class:separator")
+        window.content.mouse_handler = self._decoration_mouse_handler
+        return window
 
     # Minimum terminal width before the sidebar becomes too narrow to
     # be readable (20% of 60 columns ≈ 12, with a 1-col rule on its
@@ -513,12 +595,14 @@ class DatusApp:
         wired (non-chat dispatch), the filter never reports visible.
         """
 
+        queue_region = self._make_selection_region("queue", self._queue_preview_tokens)
         window = Window(
-            content=FormattedTextControl(self._queue_preview_tokens),
+            content=FormattedTextControl(queue_region.render_tokens),
             height=Dimension(min=1, max=self._QUEUE_PREVIEW_MAX_LINES + 2),
             style="class:queue-preview.box",
             always_hide_cursor=True,
         )
+        window.content.mouse_handler = lambda event: self._region_mouse_dispatch(queue_region, event)
         return ConditionalContainer(content=window, filter=Condition(self._queue_preview_visible))
 
     def _enqueue_pending_input(self, buffer, app) -> bool:
@@ -636,9 +720,10 @@ class DatusApp:
         # visual rows as the column needs — the provider intentionally
         # does NOT truncate content so wrapping is the only way the user
         # sees the full task text on a narrow sidebar.
+        todo_region = self._make_selection_region("todo", tokens_fn)
         sidebar_body = Window(
             content=FormattedTextControl(
-                text=tokens_fn,
+                text=todo_region.render_tokens,
                 focusable=False,
                 show_cursor=False,
             ),
@@ -646,10 +731,13 @@ class DatusApp:
             dont_extend_width=False,
             style="class:todo-sidebar",
         )
+        sidebar_body.content.mouse_handler = lambda event: self._region_mouse_dispatch(todo_region, event)
+        sidebar_rule = Window(width=Dimension.exact(1), char="│", style="class:separator")
+        sidebar_rule.content.mouse_handler = self._decoration_mouse_handler
         return ConditionalContainer(
             content=VSplit(
                 [
-                    Window(width=Dimension.exact(1), char="\u2502", style="class:separator"),
+                    sidebar_rule,
                     sidebar_body,
                 ],
                 width=_sidebar_width,
@@ -922,16 +1010,29 @@ class DatusApp:
                 self._scrollbar_controller._dragging = False  # noqa: SLF001
             return NotImplemented
 
+        # In-flight drag bookkeeping — both the pane's own drag and drags
+        # owned by other regions. Any event proving the button was
+        # released (including releases that happened outside the terminal
+        # window) finalises + copies; foreign drag-moves are confined.
+        intercepted = self._inflight_drag_intercept(event, own_surface="output")
+        if intercepted is not NotImplemented:
+            return intercepted
+
         if et == MouseEventType.MOUSE_DOWN and event.button == MouseButton.LEFT:
             point = self._selection_point_from_event(event)
             if point is not None:
-                self._selection.begin(point)
+                clicks = self._output_click_tracker.register(point.line, point.column)
+                self._clear_other_selections(keep="output")
                 self._selection_autoscroll.disarm()
                 # Disengage sticky-bottom so output growth doesn't yank
                 # the rows out from under the dragging pointer.
                 if self._output_at_bottom:
                     self._output_scroll_offset = self._output_max_scroll()
                     self._output_at_bottom = False
+                if clicks >= 2:
+                    self._select_output_span(point, whole_line=clicks >= 3)
+                else:
+                    self._selection.begin(point)
                 self._app.invalidate()
             return None
 
@@ -954,18 +1055,36 @@ class DatusApp:
             return None
 
         if et == MouseEventType.MOUSE_UP:
-            if self._selection.dragging:
-                self._selection.finish()
-                self._selection_autoscroll.disarm()
-                if not self._selection.is_empty() and self._output_buffer is not None:
-                    text = extract_selection_text(self._output_buffer, self._selection)
-                    if text and copy_to_clipboard(text):
-                        self.show_hint("✓ Copied to clipboard")
-                self._app.invalidate()
-                return None
+            # An in-flight drag never reaches here — the intercept above
+            # finalises it. A bare release with nothing in flight is not
+            # ours to handle.
             return NotImplemented
 
         return NotImplemented
+
+    def _select_output_span(self, point: SelectionPoint, *, whole_line: bool) -> None:
+        """Select (and copy) the word or whole line at ``point`` in the scrollback.
+
+        Multi-click path: the selection is created already-finished so a
+        MOUSE_MOVE with the button still held does not warp it;
+        :meth:`_finalize_output_selection` handles copy + repaint exactly
+        like a drag release would.
+        """
+        if self._output_buffer is None:
+            return
+        snap = self._output_buffer.snapshot()
+        fragments = snap.get_line(point.line) if 0 <= point.line < snap.total else []
+        text = fragment_plain_text(fragments)
+        if whole_line:
+            bounds = (0, len(text)) if text else None
+        else:
+            bounds = word_bounds_at(text, point.column)
+        if bounds is None or bounds[0] >= bounds[1]:
+            self._selection.clear()
+            return
+        self._selection.begin(SelectionPoint(line=point.line, column=bounds[0]))
+        self._selection.update_head(SelectionPoint(line=point.line, column=bounds[1]))
+        self._finalize_output_selection()
 
     def _selection_point_from_event(self, event: MouseEvent) -> Optional[SelectionPoint]:
         """Translate a control-relative MouseEvent into a buffer coordinate.
@@ -1029,19 +1148,19 @@ class DatusApp:
     def _status_mouse_handler(self, event: MouseEvent):  # noqa: ANN201
         """Mouse handler attached to the status bar window.
 
-        Two responsibilities, both gated on whether the user is in the
-        middle of *something* (selection drag or scrollbar drag) —
-        otherwise the status bar is decorative and clicks fall through
-        (``NotImplemented``):
+        Three responsibilities, checked in precedence order:
 
         * **Scrollbar drag forwarding** — when the user is dragging the
           scrollbar and their pointer crosses below the output pane onto
           the status bar, forward the event so scroll keeps following
           the cursor. Releasing on the status bar must also clear the
           scrollbar drag flag.
-        * **Selection autoscroll** — during a selection drag, motion/
-          press on the status bar arms scroll-down. Release here finalises
-          the selection (and copies to clipboard).
+        * **Output-selection autoscroll** — during a scrollback selection
+          drag, motion/press on the status bar arms scroll-down. Release
+          here finalises the selection (and copies to clipboard).
+        * **Status-bar-local selection** — with no drag in flight, the
+          status bar is a selectable region of its own: drag across it to
+          copy the status text.
         """
         et = event.event_type
         if self._scrollbar_controller.dragging:
@@ -1053,22 +1172,200 @@ class DatusApp:
                 self._forward_to_scrollbar(event, row_override="bottom")
                 return None
             return NotImplemented
-        if not self._selection.dragging:
-            return NotImplemented
-        if et in (MouseEventType.MOUSE_DOWN, MouseEventType.MOUSE_MOVE):
-            self._selection_autoscroll.arm(+1)
-            self._app.invalidate()
-            return None
-        if et == MouseEventType.MOUSE_UP:
-            self._selection.finish()
+        if self._selection.dragging:
+            if et == MouseEventType.MOUSE_MOVE and event.button == MouseButton.LEFT:
+                self._selection_autoscroll.arm(+1)
+                self._app.invalidate()
+                return None
+            if self._drag_release_event(event):
+                # MOUSE_UP here, or proof the release happened elsewhere
+                # (fresh press / buttonless move) — close out the drag.
+                self._finalize_output_selection()
+                if et != MouseEventType.MOUSE_DOWN:
+                    return None
+                # A fresh press falls through so it can start a
+                # status-bar selection of its own.
+            else:
+                return NotImplemented
+        return self._region_mouse_dispatch(self._status_region, event)
+
+    # ── Per-region selection plumbing ──────────────────────────────
+
+    def _make_selection_region(self, name: str, tokens_fn: Callable[[], List[Tuple[str, str]]]) -> SelectableRegion:
+        """Create + register an independent selection region for one pane."""
+        region = SelectableRegion(
+            name,
+            tokens_fn,
+            on_begin=lambda: self._clear_other_selections(keep=name),
+            on_copy=self._copy_selection_text,
+            invalidate=lambda: self._app.invalidate(),
+        )
+        self._selection_regions[name] = region
+        return region
+
+    def _copy_selection_text(self, text: str) -> None:
+        """Clipboard + hint plumbing shared by every selection surface."""
+        if text and copy_to_clipboard(text):
+            self.show_hint("✓ Copied to clipboard")
+
+    def _dragging_selection_region(self) -> Optional[SelectableRegion]:
+        """The auxiliary region currently mid-drag, or ``None``."""
+        for region in self._selection_regions.values():
+            if region.selection.dragging:
+                return region
+        return None
+
+    def _clear_other_selections(self, keep: Optional[str] = None) -> None:
+        """Drop every selection except ``keep``'s.
+
+        Selections are independent per region, and exactly one highlight
+        should be visible at a time — beginning a drag anywhere clears
+        the rest. ``keep`` is ``"output"`` for the scrollback pane, a
+        region name for the auxiliary panes, a buffer name for the
+        native-selection inputs, or ``None`` to clear everything
+        (Escape).
+        """
+        if keep != "output":
+            self._selection.clear()
             self._selection_autoscroll.disarm()
-            if not self._selection.is_empty() and self._output_buffer is not None:
-                text = extract_selection_text(self._output_buffer, self._selection)
-                if text and copy_to_clipboard(text):
-                    self.show_hint("✓ Copied to clipboard")
-            self._app.invalidate()
+        for name, region in self._selection_regions.items():
+            if name != keep:
+                region.selection.clear()
+        for name, buffer in self._selection_buffers.items():
+            if name != keep and buffer.selection_state is not None:
+                buffer.exit_selection()
+
+    def _finalize_output_selection(self) -> None:
+        """Close out the scrollback drag; copy the covered text if any."""
+        self._selection.finish()
+        self._selection_autoscroll.disarm()
+        if not self._selection.is_empty() and self._output_buffer is not None:
+            self._copy_selection_text(extract_selection_text(self._output_buffer, self._selection))
+        self._app.invalidate()
+
+    def _region_mouse_dispatch(self, region: SelectableRegion, event: MouseEvent):  # noqa: ANN201
+        """Route a pane's mouse event through the cross-region drag rules.
+
+        The intercept below closes out any in-flight drag (this pane's or
+        a foreign one) and confines foreign drag-moves; everything else
+        falls through to the pane's own selection state machine.
+        """
+        intercepted = self._inflight_drag_intercept(event, own_surface=region)
+        if intercepted is not NotImplemented:
+            return intercepted
+        return region.handle_mouse(event)
+
+    def _inflight_drag_intercept(self, event: MouseEvent, *, own_surface: object = None):  # noqa: ANN201
+        """Shared pre-dispatch for every mouse surface while a drag is in flight.
+
+        prompt_toolkit has no mouse capture: each event goes to whatever
+        window the pointer is over, and a release outside the terminal is
+        either clamped onto an edge cell by the emulator or never
+        delivered at all. Every wired surface runs this first so an
+        in-flight drag can always be closed out (and its text copied):
+
+        * ``MOUSE_UP`` — normal release, wherever it lands. Consumed.
+        * ``MOUSE_MOVE`` without LEFT held — hover after an off-terminal
+          release (terminals in any-event tracking mode report these as
+          soon as the pointer re-enters). Finalise; consumed.
+        * ``MOUSE_DOWN`` — a fresh press proves the previous release was
+          never delivered. Finalise, then return ``NotImplemented`` so
+          the caller can start the interaction the press represents.
+        * ``MOUSE_MOVE`` with LEFT over a **foreign** surface — swallowed:
+          selections stay confined to the surface they started on. The
+          owner (``own_surface`` is ``"output"`` for the scrollback pane,
+          the :class:`SelectableRegion` for region dispatch) gets
+          ``NotImplemented`` so it keeps extending its own selection.
+
+        Returns ``None`` when the event was consumed, ``NotImplemented``
+        when the caller should continue with its own handling.
+        """
+        output_dragging = self._selection.dragging
+        region = self._dragging_selection_region()
+        if not output_dragging and region is None:
+            return NotImplemented
+        if self._drag_release_event(event):
+            if output_dragging:
+                self._finalize_output_selection()
+            elif region is not None:
+                region.finish_drag()
+            return NotImplemented if event.event_type == MouseEventType.MOUSE_DOWN else None
+        owns_drag = (output_dragging and own_surface == "output") or (region is not None and region is own_surface)
+        if owns_drag:
+            return NotImplemented
+        if event.event_type == MouseEventType.MOUSE_MOVE:
             return None
         return NotImplemented
+
+    @staticmethod
+    def _drag_release_event(event: MouseEvent) -> bool:
+        """Whether ``event`` proves the drag button is no longer held.
+
+        A ``MOUSE_UP`` is the obvious case. A ``MOUSE_DOWN`` means a fresh
+        press, so the previous release must have been missed. A
+        ``MOUSE_MOVE`` whose button is not LEFT is a hover — the button
+        was released somewhere we couldn't see (off-terminal, or over a
+        cell without a handler).
+        """
+        et = event.event_type
+        if et in (MouseEventType.MOUSE_UP, MouseEventType.MOUSE_DOWN):
+            return True
+        return et == MouseEventType.MOUSE_MOVE and event.button != MouseButton.LEFT
+
+    def _decoration_mouse_handler(self, event: MouseEvent):  # noqa: ANN201
+        """Mouse handler for decorative surfaces (separators, hint row).
+
+        Terminal emulators clamp off-window mouse coordinates onto the
+        nearest edge cell, which is exactly where these rows sit — a drag
+        released below the app lands its ``MOUSE_UP`` here. Their only
+        mouse duty is to keep such a drag from dangling uncopied.
+        """
+        return self._inflight_drag_intercept(event)
+
+    def _install_buffer_copy_handler(self, name: str, control, buffer: Buffer) -> None:  # noqa: ANN001
+        """Add copy-on-release + cross-region rules to a ``BufferControl``.
+
+        prompt_toolkit's ``BufferControl`` already implements native
+        drag-selection (MOUSE_DOWN moves the cursor, MOUSE_MOVE extends
+        ``buffer.selection_state``, double-click selects a word) and the
+        highlight paints via ``class:selected``. This wrapper adds the
+        write to the system clipboard on release and a triple-click →
+        select-line gesture, without disturbing the native behaviour.
+        """
+        self._selection_buffers[name] = buffer
+        original_handler = control.mouse_handler
+        # prompt_toolkit counts double-clicks on MOUSE_UP, so the tracker
+        # does too — its third rapid UP widens the native word selection
+        # to the whole line.
+        click_tracker = MultiClickTracker()
+
+        def handler(event: MouseEvent):  # noqa: ANN202
+            et = event.event_type
+            intercepted = self._inflight_drag_intercept(event)
+            if intercepted is not NotImplemented:
+                return intercepted
+            if et == MouseEventType.MOUSE_DOWN and event.button == MouseButton.LEFT:
+                self._clear_other_selections(keep=name)
+            result = original_handler(event)
+            if et == MouseEventType.MOUSE_UP:
+                clicks = click_tracker.register(int(event.position.y), int(event.position.x))
+                if clicks >= 3:
+                    _select_buffer_line(buffer)
+                text = _buffer_selection_text(buffer)
+                if text:
+                    self._copy_selection_text(text)
+                    return None
+            return result
+
+        control.mouse_handler = handler
+
+    def _any_selection_active(self) -> bool:
+        """Whether any pane (scrollback, region, or input buffer) has a selection."""
+        if not self._selection.is_empty():
+            return True
+        if any(not region.selection.is_empty() for region in self._selection_regions.values()):
+            return True
+        return any(buffer.selection_state is not None for buffer in self._selection_buffers.values())
 
     def _forward_to_scrollbar(self, event: MouseEvent, *, row_override: Optional[str] = None) -> None:
         """Send ``event`` to :class:`ScrollbarController` from a non-gutter window.
@@ -1122,12 +1419,14 @@ class DatusApp:
             dont_extend_width=True,
             wrap_lines=False,
         )
+        search_control = BufferControl(
+            buffer=self._search_buffer,
+            focusable=True,
+            key_bindings=self._build_search_kb(),
+        )
+        self._install_buffer_copy_handler("search", search_control, self._search_buffer)
         input_window = Window(
-            content=BufferControl(
-                buffer=self._search_buffer,
-                focusable=True,
-                key_bindings=self._build_search_kb(),
-            ),
+            content=search_control,
             height=1,
             wrap_lines=False,
             style="class:search-input",
@@ -1480,6 +1779,10 @@ class DatusApp:
         if panel.key_bindings is not None:
             self._wizard_kb_layer.bindings.extend(panel.key_bindings.bindings)
             self._wizard_kb_layer._clear_cache()
+        # Give the wizard's text panes the same drag/multi-click copy the
+        # rest of the TUI has — the main Application's mouse capture stays
+        # on while a wizard is mounted, so this is the only copy path.
+        self._wire_wizard_selection(panel.container)
         if panel.first_focus is not None:
             try:
                 self._app.layout.focus(panel.first_focus)
@@ -1493,6 +1796,7 @@ class DatusApp:
         # Clear all wizard bindings from the layer.
         self._wizard_kb_layer.bindings.clear()
         self._wizard_kb_layer._clear_cache()
+        self._unwire_wizard_selection()
         target: Optional[Any] = self._stashed_focus
         if target is None:
             target = self._input_area
@@ -1505,6 +1809,92 @@ class DatusApp:
                 logger.debug("unmount_wizard: focus restore failed: %s", exc)
         self._stashed_focus = None
         self._app.invalidate()
+
+    def _wire_wizard_selection(self, container: AnyContainer) -> None:
+        """Give every text control inside an embedded wizard drag-copy support.
+
+        Embedded wizards (ask_user / permission prompts, slash-command
+        pickers) render inside the main Application, so terminal-native
+        selection is unavailable there exactly like everywhere else under
+        mouse capture. Walk the wizard's container tree and wire each
+        display control to its own :class:`SelectableRegion` (drag /
+        double-click word / triple-click line, copy on release), each
+        input control to the copy-on-release wrapper, and each decorative
+        window to the dangling-drag finaliser. Undone by
+        :meth:`_unwire_wizard_selection` when the wizard unmounts.
+        """
+        for window in self._walk_windows(container):
+            control = window.content
+            # An instance-level handler means the wizard wired its own
+            # mouse behaviour — don't fight it.
+            if "mouse_handler" in control.__dict__:
+                continue
+            if isinstance(control, FormattedTextControl):
+                source_text = control.text
+                if self._fragments_carry_mouse_handlers(source_text):
+                    # Click-driven widgets (CheckboxList / RadioList /
+                    # Button rows) embed per-fragment handlers; wiring
+                    # selection over them would steal their clicks.
+                    continue
+                name = f"wizard:{len(self._wizard_selection_names)}"
+                region = self._make_selection_region(name, lambda text=source_text: list(to_formatted_text(text)))
+                original_handler = control.mouse_handler
+
+                def handler(event: MouseEvent, *, _region=region, _orig=original_handler):  # noqa: ANN202
+                    result = self._region_mouse_dispatch(_region, event)
+                    if result is NotImplemented:
+                        # Preserve fragment-embedded handlers / Window
+                        # fallback for events selection doesn't consume.
+                        return _orig(event)
+                    return result
+
+                control.text = region.render_tokens
+                control.mouse_handler = handler
+                self._wizard_selection_names.append(name)
+            elif isinstance(control, BufferControl):
+                name = f"wizard:{len(self._wizard_selection_names)}"
+                self._install_buffer_copy_handler(name, control, control.buffer)
+                self._wizard_selection_names.append(name)
+            elif isinstance(control, DummyControl):
+                # Separator rules etc.: close out in-flight drags whose
+                # release lands on them (same duty as the main layout's
+                # decorative rows).
+                control.mouse_handler = self._decoration_mouse_handler
+
+    @staticmethod
+    def _fragments_carry_mouse_handlers(text: Any) -> bool:
+        """Whether a control's current fragments embed per-fragment handlers.
+
+        Evaluated once at wire time. Returns ``True`` (→ leave the
+        control alone) when inspection fails, so an exotic text callable
+        can never be broken by selection wiring.
+        """
+        try:
+            fragments = to_formatted_text(text)
+        except Exception:
+            return True
+        return any(len(fragment) >= 3 for fragment in fragments)
+
+    @staticmethod
+    def _walk_windows(container: AnyContainer) -> Iterator[Window]:
+        """Yield every :class:`Window` in ``container``'s tree."""
+        stack = [to_container(container)]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, Window):
+                yield node
+                continue
+            try:
+                stack.extend(node.get_children())
+            except Exception:  # pragma: no cover - defensive
+                continue
+
+    def _unwire_wizard_selection(self) -> None:
+        """Drop the selection registrations of the unmounted wizard."""
+        for name in self._wizard_selection_names:
+            self._selection_regions.pop(name, None)
+            self._selection_buffers.pop(name, None)
+        self._wizard_selection_names.clear()
 
     def run_wizard(
         self,
@@ -1940,19 +2330,19 @@ class DatusApp:
             self._scroll_output_down(self._OUTPUT_WHEEL_STEP)
             event.app.invalidate()
 
-        # Escape clears an active selection. The filter gates this so
-        # we never compete with ``DatusCLI``'s Esc → agent-interrupt
-        # binding (registered later on the same KeyBindings instance);
-        # ``eager=True`` lets prompt_toolkit pick this handler over the
-        # interrupt one when both filters are true, which is the
-        # intuitive precedence — clearing the visible highlight is a
-        # local UI concern that the user explicitly asked for.
-        has_selection = Condition(lambda: not self._selection.is_empty())
+        # Escape clears an active selection (in whichever pane holds
+        # one). The filter gates this so we never compete with
+        # ``DatusCLI``'s Esc → agent-interrupt binding (registered later
+        # on the same KeyBindings instance); ``eager=True`` lets
+        # prompt_toolkit pick this handler over the interrupt one when
+        # both filters are true, which is the intuitive precedence —
+        # clearing the visible highlight is a local UI concern that the
+        # user explicitly asked for.
+        has_selection = Condition(self._any_selection_active)
 
         @kb.add("escape", filter=has_selection, eager=True)
         def _clear_selection(event) -> None:  # noqa: ANN001
-            self._selection.clear()
-            self._selection_autoscroll.disarm()
+            self._clear_other_selections(keep=None)
             event.app.invalidate()
 
         # Ctrl+F opens the find-in-scrollback bar. ``eager=True`` jumps

--- a/datus/cli/tui/output_buffer.py
+++ b/datus/cli/tui/output_buffer.py
@@ -46,8 +46,7 @@ from datus.cli.tui.live_display_state import LiveDisplayLine
 from datus.cli.tui.search import SearchState
 from datus.cli.tui.selection import (
     TranscriptSelection,
-    extract_plain_text_between,
-    line_char_count,
+    extract_text_from_lines,
     split_line_for_selection,
 )
 
@@ -602,23 +601,5 @@ def extract_selection_text(
     padding spaces would land on the clipboard and force the user to
     clean them up manually after pasting.
     """
-    rng = selection.range()
-    if rng is None:
-        return ""
     snap = buffer.snapshot()
-    out_lines: List[str] = []
-    start, end = rng
-    for line_idx in range(start.line, end.line + 1):
-        if line_idx < 0 or line_idx >= snap.total:
-            continue
-        fragments = snap.get_line(line_idx)
-        if start.line == end.line:
-            from_col, to_col = start.column, end.column
-        elif line_idx == start.line:
-            from_col, to_col = start.column, line_char_count(fragments)
-        elif line_idx == end.line:
-            from_col, to_col = 0, end.column
-        else:
-            from_col, to_col = 0, line_char_count(fragments)
-        out_lines.append(extract_plain_text_between(fragments, from_col, to_col).rstrip())
-    return "\n".join(out_lines)
+    return extract_text_from_lines(snap.get_line, snap.total, selection)

--- a/datus/cli/tui/region_selection.py
+++ b/datus/cli/tui/region_selection.py
@@ -1,0 +1,230 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Independent mouse text-selection for auxiliary TUI panes.
+
+The scrollback pane already implements software selection (see
+:mod:`datus.cli.tui.selection` and ``DatusApp._output_mouse_handler``); the
+other :class:`~prompt_toolkit.layout.controls.FormattedTextControl`-backed
+panes — status bar, todo sidebar, queue preview — historically ignored
+mouse drags, so their text could not be copied at all while the app owns
+mouse capture. :class:`SelectableRegion` closes that gap: each region owns
+its own :class:`TranscriptSelection` so a drag is always confined to the
+region it started in, and releasing the button copies the highlighted text
+to the system clipboard exactly like the scrollback pane does.
+
+Coordinate contract
+-------------------
+prompt_toolkit's ``Window`` rebases mouse positions into UIContent space
+before calling the control's handler: ``position.y`` is the **logical line
+index** (wrap-aware for ``wrap_lines=True`` windows) and ``position.x`` is
+the **character index** within that line — the same coordinates
+:func:`split_line_for_selection` and :func:`extract_text_from_lines`
+consume. Clicks below the content area are clamped by prompt_toolkit onto
+the last painted row, so no scroll/offset accounting is needed here (these
+panes never scroll).
+
+Blank rows need one caveat: ``Window._copy_body`` only registers
+``rowcol_to_yx`` entries for painted cells, so a fully-empty line would
+make prompt_toolkit fall back to the ``Point(0, 0)`` sentinel and warp a
+drag to the region top. :meth:`SelectableRegion.render_tokens` pads such
+lines with a single space — visually identical, but every visible row
+stays mouse-resolvable. The padding never reaches the clipboard because
+extraction reads the raw (unpadded) lines.
+
+The class has no prompt_toolkit ``Application`` dependency; interaction
+with the rest of the app flows through the ``on_begin`` / ``on_copy`` /
+``invalidate`` callbacks so it can be exercised by unit tests without
+mounting a TUI.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Tuple
+
+from prompt_toolkit.formatted_text.utils import split_lines
+from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
+
+from datus.cli.tui.selection import (
+    MultiClickTracker,
+    SelectionPoint,
+    TranscriptSelection,
+    extract_text_from_lines,
+    fragment_plain_text,
+    split_line_for_selection,
+    word_bounds_at,
+)
+
+_StyledToken = Tuple[str, str]
+
+
+class SelectableRegion:
+    """Mouse-selection + clipboard-copy for one ``tokens_fn``-backed pane.
+
+    ``tokens_fn`` returns the same flat fragment stream the region's
+    ``FormattedTextControl`` renders (``\\n``-separated). The owning app
+    should point the control's ``text`` at :meth:`render_tokens` (so the
+    highlight paints) and route the control's mouse events into
+    :meth:`handle_mouse`.
+
+    Callbacks:
+
+    * ``on_begin`` — fired when a fresh drag starts; the app uses it to
+      clear every *other* region's selection so exactly one highlight is
+      visible at a time.
+    * ``on_copy`` — receives the extracted plain text on drag release; the
+      app wires it to the clipboard + hint plumbing.
+    * ``invalidate`` — request a repaint after any selection state change.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        tokens_fn: Callable[[], List[_StyledToken]],
+        *,
+        on_begin: Optional[Callable[[], None]] = None,
+        on_copy: Optional[Callable[[str], None]] = None,
+        invalidate: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self.name = name
+        self.selection = TranscriptSelection()
+        self._tokens_fn = tokens_fn
+        self._on_begin = on_begin or (lambda: None)
+        self._on_copy = on_copy or (lambda _text: None)
+        self._invalidate = invalidate or (lambda: None)
+        self._click_tracker = MultiClickTracker()
+
+    def lines(self) -> List[List[_StyledToken]]:
+        """Current region content split into per-line fragment lists."""
+        try:
+            tokens = list(self._tokens_fn() or [])
+        except Exception:
+            tokens = []
+        return [list(line) for line in split_lines(tokens)]
+
+    def render_tokens(self) -> List[_StyledToken]:
+        """Fragment stream for the region's ``FormattedTextControl``.
+
+        Identical to the raw ``tokens_fn`` output except that blank lines
+        are padded with a single space (mouse resolvability — see module
+        docstring) and lines intersecting the selection get the
+        ``class:selection`` splice from :func:`split_line_for_selection`.
+        """
+        lines = self.lines()
+        active = not self.selection.is_empty()
+        out: List[_StyledToken] = []
+        last = len(lines) - 1
+        for idx, line in enumerate(lines):
+            if not any(len(f) > 1 and f[1] for f in line):
+                line = [("", " ")]
+            if active:
+                bounds = self.selection.columns_for_line(idx)
+                if bounds is not None:
+                    line = split_line_for_selection(line, bounds[0], bounds[1])
+            out.extend(line)
+            if idx != last:
+                out.append(("", "\n"))
+        return out
+
+    def handle_mouse(self, event: MouseEvent):  # noqa: ANN201
+        """Selection state machine: DOWN begins, MOVE extends, UP copies.
+
+        Rapid same-spot clicks widen the selection instead: a double-click
+        selects (and copies) the word under the pointer, a triple-click the
+        whole line.
+
+        Returns ``None`` when the event was consumed, ``NotImplemented``
+        otherwise (scroll wheel, non-left buttons, moves without an active
+        drag) so ``Window`` fallback behaviour is preserved.
+        """
+        et = event.event_type
+        if et == MouseEventType.MOUSE_DOWN and event.button == MouseButton.LEFT:
+            point = self._point_from_event(event)
+            if point is None:
+                return NotImplemented
+            clicks = self._click_tracker.register(point.line, point.column)
+            self._on_begin()
+            if clicks >= 2:
+                self._select_span(point, whole_line=clicks >= 3)
+                return None
+            self.selection.begin(point)
+            self._invalidate()
+            return None
+        if et == MouseEventType.MOUSE_MOVE and event.button == MouseButton.LEFT:
+            if not self.selection.dragging:
+                return NotImplemented
+            point = self._point_from_event(event)
+            if point is not None:
+                self.selection.update_head(point)
+            self._invalidate()
+            return None
+        if et == MouseEventType.MOUSE_UP:
+            if not self.selection.dragging:
+                return NotImplemented
+            self.finish_drag()
+            return None
+        return NotImplemented
+
+    def _select_span(self, point: SelectionPoint, *, whole_line: bool) -> None:
+        """Select (and copy) the word or whole line at ``point``.
+
+        Multi-click path: the selection is created already-finished (no
+        drag in flight) so a subsequent MOUSE_MOVE with the button still
+        held does not warp it, and :meth:`finish_drag` handles the copy +
+        repaint exactly like a drag release would.
+        """
+        lines = self.lines()
+        fragments = lines[point.line] if 0 <= point.line < len(lines) else []
+        text = fragment_plain_text(fragments)
+        if whole_line:
+            bounds = (0, len(text)) if text else None
+        else:
+            bounds = word_bounds_at(text, point.column)
+        if bounds is None or bounds[0] >= bounds[1]:
+            self.selection.clear()
+            self._invalidate()
+            return
+        self.selection.begin(SelectionPoint(line=point.line, column=bounds[0]))
+        self.selection.update_head(SelectionPoint(line=point.line, column=bounds[1]))
+        self.finish_drag()
+
+    def finish_drag(self) -> None:
+        """Finalise the drag; fire ``on_copy`` when the selection is non-empty.
+
+        Also the entry point for *cross-region* releases: when the user
+        drags out of this region and lets go over another pane, that pane's
+        handler calls this so the drag never dangles.
+        """
+        self.selection.finish()
+        if not self.selection.is_empty():
+            text = self.extract_text()
+            if text:
+                self._on_copy(text)
+        self._invalidate()
+
+    def extract_text(self) -> str:
+        """Plain text covered by the current selection (styles stripped)."""
+        lines = self.lines()
+        return extract_text_from_lines(lambda idx: lines[idx], len(lines), self.selection)
+
+    def _point_from_event(self, event: MouseEvent) -> Optional[SelectionPoint]:
+        """Translate a control-relative event into a region coordinate.
+
+        Lines past the content end are clamped onto the last line so a
+        drag below the region still highlights something visible (matches
+        the output pane's behaviour).
+        """
+        line = int(event.position.y)
+        column = int(event.position.x)
+        if line < 0 or column < 0:
+            return None
+        total = len(self.lines())
+        if total <= 0:
+            return None
+        if line >= total:
+            line = total - 1
+        return SelectionPoint(line=line, column=column)
+
+
+__all__ = ["SelectableRegion"]

--- a/datus/cli/tui/selection.py
+++ b/datus/cli/tui/selection.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 _StyledToken = Tuple[str, str]
 
@@ -364,8 +364,108 @@ def extract_plain_text_between(
     return "".join(out)
 
 
-def _fragment_text(fragments: List[_StyledToken]) -> str:
+def extract_text_from_lines(
+    get_line: Callable[[int], List[_StyledToken]],
+    total: int,
+    selection: TranscriptSelection,
+) -> str:
+    """Plain text covered by ``selection`` over a per-line fragment source.
+
+    Shared by the output pane (``TUIOutputBuffer`` snapshots) and the
+    auxiliary :class:`~datus.cli.tui.region_selection.SelectableRegion`
+    panes. Lines are joined with ``\\n``; style information is stripped and
+    trailing whitespace is removed from each extracted line so background-
+    filled renderables (panels, status segments padded to pane width) don't
+    leak padding spaces onto the clipboard.
+    """
+    rng = selection.range()
+    if rng is None:
+        return ""
+    out_lines: List[str] = []
+    start, end = rng
+    for line_idx in range(start.line, end.line + 1):
+        if line_idx < 0 or line_idx >= total:
+            continue
+        fragments = get_line(line_idx)
+        if start.line == end.line:
+            from_col, to_col = start.column, end.column
+        elif line_idx == start.line:
+            from_col, to_col = start.column, line_char_count(fragments)
+        elif line_idx == end.line:
+            from_col, to_col = 0, end.column
+        else:
+            from_col, to_col = 0, line_char_count(fragments)
+        out_lines.append(extract_plain_text_between(fragments, from_col, to_col).rstrip())
+    return "\n".join(out_lines)
+
+
+def fragment_plain_text(fragments: List[_StyledToken]) -> str:
+    """Concatenated text of a fragment list with styles stripped."""
     return "".join((f[1] if len(f) > 1 else "") for f in fragments)
+
+
+def word_bounds_at(text: str, index: int) -> Optional[Tuple[int, int]]:
+    """Half-open ``[start, end)`` char bounds of the run at ``index``.
+
+    Character classes follow the usual terminal double-click rules:
+    word characters (alphanumeric — including CJK, which Python's
+    ``str.isalnum`` covers — plus underscore), whitespace runs, and
+    punctuation runs each expand over their own class. ``index`` past the
+    end of ``text`` clamps to the last character. ``None`` for empty text.
+    """
+    if not text:
+        return None
+    index = max(0, min(index, len(text) - 1))
+
+    def _cls(ch: str) -> str:
+        if ch.isspace():
+            return "space"
+        if ch.isalnum() or ch == "_":
+            return "word"
+        return "punct"
+
+    cls = _cls(text[index])
+    start = index
+    while start > 0 and _cls(text[start - 1]) == cls:
+        start -= 1
+    end = index + 1
+    while end < len(text) and _cls(text[end]) == cls:
+        end += 1
+    return (start, end)
+
+
+@dataclass
+class MultiClickTracker:
+    """Counts rapid same-spot left clicks: 1 = single, 2 = double, 3 = triple.
+
+    A click chains onto the previous one when it lands on the same line
+    (within ``column_tolerance`` cells) inside ``interval_seconds``. After
+    a triple the next click starts a fresh chain, matching the common
+    single → word → line → single cycle. ``now`` is injectable for tests.
+    """
+
+    interval_seconds: float = 0.4
+    column_tolerance: int = 1
+    _last_time: float = 0.0
+    _last_line: Optional[int] = None
+    _last_column: Optional[int] = None
+    _count: int = 0
+
+    def register(self, line: int, column: int, now: Optional[float] = None) -> int:
+        ts = time.monotonic() if now is None else now
+        same_spot = (
+            self._last_line == line
+            and self._last_column is not None
+            and abs(self._last_column - column) <= self.column_tolerance
+        )
+        if same_spot and (ts - self._last_time) <= self.interval_seconds and self._count < 3:
+            self._count += 1
+        else:
+            self._count = 1
+        self._last_time = ts
+        self._last_line = line
+        self._last_column = column
+        return self._count
 
 
 def _make_fragment(style: str, text: str, trailing: Tuple) -> _StyledToken:
@@ -389,10 +489,14 @@ def _merge_style(existing: str, addition: str) -> str:
 
 __all__ = [
     "COLUMN_TO_LINE_END",
+    "MultiClickTracker",
     "SelectionAutoscroll",
     "SelectionPoint",
     "TranscriptSelection",
     "extract_plain_text_between",
+    "extract_text_from_lines",
+    "fragment_plain_text",
     "line_char_count",
     "split_line_for_selection",
+    "word_bounds_at",
 ]

--- a/tests/unit_tests/cli/test_cli_styles.py
+++ b/tests/unit_tests/cli/test_cli_styles.py
@@ -157,6 +157,42 @@ def _render_renderable(renderable) -> str:
     return re.sub(r"\x1b\[[^m]*m", "", buf.getvalue())
 
 
+class TestRenderUserScrollbackText:
+    def test_copied_message_line_has_no_border_glyphs(self):
+        """Contract: drag-copying a USER message must yield clean text.
+
+        The TUI's selection copy extracts rendered characters, so the panel
+        must not paint vertical border glyphs on the message rows — a fully
+        boxed style would glue ``│`` to both ends of every copied line.
+        Extraction rstrips each line, so space side-edges are fine.
+        """
+        from datus.cli.cli_styles import render_user_scrollback_text
+        from datus.cli.tui.output_buffer import TUIOutputBuffer, extract_selection_text
+        from datus.cli.tui.selection import SelectionPoint, TranscriptSelection
+
+        buf = TUIOutputBuffer()
+        console = Console(file=buf, force_terminal=True, color_system="256", width=30)
+        console.print(render_user_scrollback_text("hello world"))
+
+        selection = TranscriptSelection()
+        selection.begin(SelectionPoint(line=1, column=0))
+        selection.update_head(SelectionPoint(line=1, column=30))
+        selection.finish()
+        assert extract_selection_text(buf, selection) == "  > hello world"
+
+    def test_top_and_bottom_rules_remain(self):
+        from datus.cli.cli_styles import render_user_scrollback_text
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, force_terminal=True, width=30)
+        console.print(render_user_scrollback_text("hello"))
+        import re
+
+        lines = re.sub(r"\x1b\[[^m]*m", "", buf.getvalue()).splitlines()
+        assert "─" in lines[0]
+        assert "─" in lines[2]
+
+
 class TestRenderCompactSummaryPanel:
     def test_contains_summary_token_check_history(self):
         from datus.cli.cli_styles import render_compact_summary_panel

--- a/tests/unit_tests/cli/tui/test_app_region_selection.py
+++ b/tests/unit_tests/cli/tui/test_app_region_selection.py
@@ -1,0 +1,521 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Wiring tests for per-region selection in :class:`DatusApp`.
+
+Every visible pane — status bar, todo sidebar, queue preview, input
+buffers — must be drag-copyable, with each pane's selection independent
+of the others. These tests drive the public mouse handlers with synthetic
+``MouseEvent`` sequences and assert the cross-region contract (mutual
+exclusion, cross-pane release finalisation, clipboard side effects)
+without running the prompt_toolkit Application loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+from prompt_toolkit.application.current import set_app
+from prompt_toolkit.data_structures import Point
+from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
+
+from datus.cli.tui import app as app_mod
+from datus.cli.tui.app import DatusApp
+from datus.cli.tui.output_buffer import TUIOutputBuffer
+
+
+@pytest.fixture
+def captured_clipboard(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    captures: list[str] = []
+    monkeypatch.setattr(app_mod, "copy_to_clipboard", lambda text: captures.append(text) or True)
+    return captures
+
+
+@pytest.fixture
+def tui_app(monkeypatch: pytest.MonkeyPatch) -> DatusApp:
+    buf = TUIOutputBuffer()
+    buf.write("alpha beta\n")
+    buf.write("gamma delta\n")
+
+    app = DatusApp(
+        status_tokens_fn=lambda: [("class:status-bar", "model: gpt-4 | tokens: 12")],
+        dispatch_fn=lambda _text: None,
+        output_buffer=buf,
+        output_line_count_fn=buf.line_count,
+        output_tokens_fn=buf.tokens,
+        todo_tokens_fn=lambda: [("class:todo", "✓ task one\n· task two")],
+        todo_has_items_fn=lambda: True,
+    )
+    monkeypatch.setattr(app, "_output_viewport_rows", lambda: 3)
+    return app
+
+
+def _click(event_type, x, y, button=MouseButton.LEFT):
+    return MouseEvent(
+        position=Point(x=x, y=y),
+        event_type=event_type,
+        button=button,
+        modifiers=frozenset(),
+    )
+
+
+class TestRegionRegistry:
+    def test_all_auxiliary_regions_registered(self, tui_app: DatusApp):
+        assert set(tui_app._selection_regions) == {"status", "todo", "queue"}
+
+    def test_input_and_search_buffers_registered(self, tui_app: DatusApp):
+        assert set(tui_app._selection_buffers) == {"input", "search"}
+
+
+class TestStatusBarSelection:
+    def test_drag_across_status_bar_copies_text(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_UP, x=5, y=0))
+        assert captured_clipboard == ["model"]
+        assert "Copied to clipboard" in tui_app._hint_text
+
+    def test_output_drag_still_owns_status_bar_events(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        """During a scrollback drag the status bar keeps its autoscroll/finalise
+        role — it must NOT start a status-local selection."""
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=2, y=0))
+        assert tui_app._selection_regions["status"].selection.is_empty()
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_UP, x=0, y=0))
+        assert tui_app._selection.dragging is False
+
+
+class TestTodoSidebarSelection:
+    def test_drag_across_sidebar_copies_task_text(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        region = tui_app._selection_regions["todo"]
+        tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_MOVE, x=10, y=1))
+        tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_UP, x=10, y=1))
+        assert captured_clipboard == ["✓ task one\n· task two"]
+
+
+class TestSelectionIndependence:
+    def test_region_drag_clears_output_selection(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        # Finish an output-pane selection first; the highlight persists.
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_UP, x=5, y=0))
+        assert not tui_app._selection.is_empty()
+        # Starting a status-bar drag must drop the scrollback highlight.
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        assert tui_app._selection.is_empty()
+
+    def test_output_drag_clears_region_selection(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_UP, x=5, y=0))
+        assert not tui_app._selection_regions["status"].selection.is_empty()
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        assert tui_app._selection_regions["status"].selection.is_empty()
+
+    def test_region_drag_clears_sibling_region(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        todo = tui_app._selection_regions["todo"]
+        tui_app._region_mouse_dispatch(todo, _click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._region_mouse_dispatch(todo, _click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        tui_app._region_mouse_dispatch(todo, _click(MouseEventType.MOUSE_UP, x=5, y=0))
+        assert not todo.selection.is_empty()
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        assert todo.selection.is_empty()
+
+    def test_region_drag_clears_input_buffer_selection(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        buffer = tui_app._input_area.buffer
+        buffer.text = "select me"
+        buffer.cursor_position = 0
+        buffer.start_selection()
+        buffer.cursor_position = 6
+        assert app_mod._buffer_selection_text(buffer) == "select"
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        assert buffer.selection_state is None
+
+
+class TestCrossRegionRelease:
+    def test_region_drag_released_over_output_pane_finalises_copy(
+        self, tui_app: DatusApp, captured_clipboard: list[str]
+    ):
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        assert tui_app._selection_regions["status"].selection.dragging is True
+        # Pointer wanders up into the scrollback and the button is released
+        # there: the status drag must still close out and copy.
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_UP, x=3, y=1))
+        assert tui_app._selection_regions["status"].selection.dragging is False
+        assert captured_clipboard == ["model"]
+        # The output pane's own selection stays untouched.
+        assert tui_app._selection.is_empty()
+
+    def test_region_drag_move_over_output_pane_does_not_extend(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        head_before = tui_app._selection_regions["status"].selection.head
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=3, y=1))
+        assert tui_app._selection_regions["status"].selection.head == head_before
+        assert tui_app._selection.is_empty()
+
+    def test_output_drag_released_over_sidebar_finalises_copy(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        todo = tui_app._selection_regions["todo"]
+        tui_app._region_mouse_dispatch(todo, _click(MouseEventType.MOUSE_UP, x=0, y=0))
+        assert tui_app._selection.dragging is False
+        assert captured_clipboard == ["alpha"]
+        assert todo.selection.is_empty()
+
+
+class TestInputBufferCopy:
+    def test_release_with_native_selection_copies_text(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        buffer = tui_app._input_area.buffer
+        buffer.text = "SELECT 1 FROM t"
+        buffer.cursor_position = 0
+        buffer.start_selection()
+        buffer.cursor_position = 8
+        handler = tui_app._input_area.control.mouse_handler
+        with set_app(tui_app.application):
+            handler(_click(MouseEventType.MOUSE_UP, x=8, y=0))
+        assert captured_clipboard == ["SELECT 1"]
+        assert "Copied to clipboard" in tui_app._hint_text
+        # The native highlight persists after the copy (still extractable).
+        assert app_mod._buffer_selection_text(buffer) == "SELECT 1"
+
+    def test_release_without_selection_copies_nothing(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        buffer = tui_app._input_area.buffer
+        buffer.text = "plain text"
+        handler = tui_app._input_area.control.mouse_handler
+        with set_app(tui_app.application):
+            handler(_click(MouseEventType.MOUSE_UP, x=2, y=0))
+        assert captured_clipboard == []
+
+    def test_search_buffer_release_copies_selection(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        buffer = tui_app._search_buffer
+        buffer.text = "needle"
+        buffer.cursor_position = 0
+        buffer.start_selection()
+        buffer.cursor_position = 6
+        handler = tui_app._selection_buffers["search"]
+        # The wrapped control handler lives on the search bar's BufferControl;
+        # find it through the registered buffer to avoid poking layout internals.
+        assert handler is buffer
+        search_control = tui_app._search_bar.content.get_children()[1].content
+        with set_app(tui_app.application):
+            search_control.mouse_handler(_click(MouseEventType.MOUSE_UP, x=6, y=0))
+        assert captured_clipboard == ["needle"]
+
+
+class TestOffscreenRelease:
+    """Releases that happen outside the terminal window must still copy.
+
+    prompt_toolkit has no mouse capture and terminals either clamp the
+    release onto an edge cell (which may be a decorative row with no
+    selection logic) or drop it entirely. In the latter case the earliest
+    proof of release is the next event whose button is no longer LEFT —
+    a hover move (any-event tracking) or a fresh press.
+    """
+
+    def test_hover_move_after_lost_release_finalises_output_drag(
+        self, tui_app: DatusApp, captured_clipboard: list[str]
+    ):
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        # Pointer left the window, button released outside, pointer returns:
+        # the terminal reports a buttonless hover move.
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=3, y=1, button=MouseButton.NONE))
+        assert tui_app._selection.dragging is False
+        assert captured_clipboard == ["alpha"]
+
+    def test_hover_move_after_lost_release_finalises_region_drag(
+        self, tui_app: DatusApp, captured_clipboard: list[str]
+    ):
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        handler = tui_app._input_area.control.mouse_handler
+        # Hover re-enters over the input area (a different surface).
+        handler(_click(MouseEventType.MOUSE_MOVE, x=1, y=0, button=MouseButton.NONE))
+        assert tui_app._selection_regions["status"].selection.dragging is False
+        assert captured_clipboard == ["model"]
+
+    def test_release_clamped_onto_separator_finalises_drag(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        # A drag released below the terminal edge clamps onto the bottom
+        # rows — separators and the hint line share this handler.
+        result = tui_app._decoration_mouse_handler(_click(MouseEventType.MOUSE_UP, x=0, y=0))
+        assert result is None
+        assert tui_app._selection.dragging is False
+        assert captured_clipboard == ["alpha"]
+
+    def test_release_clamped_onto_scrollbar_gutter_finalises_drag(
+        self, tui_app: DatusApp, captured_clipboard: list[str]
+    ):
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        gutter_handler = tui_app._scrollbar_window.content.content.mouse_handler
+        gutter_handler(_click(MouseEventType.MOUSE_UP, x=0, y=1))
+        assert tui_app._selection.dragging is False
+        assert captured_clipboard == ["alpha"]
+        # The selection release must not have started a scrollbar drag.
+        assert tui_app._scrollbar_controller.dragging is False
+
+    def test_fresh_press_after_lost_release_copies_then_starts_new_drag(
+        self, tui_app: DatusApp, captured_clipboard: list[str]
+    ):
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        # Release was lost off-screen; the user clicks again in the output
+        # pane. The dangling drag is copied first, then a new one begins.
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=2, y=1))
+        assert captured_clipboard == ["alpha"]
+        assert tui_app._selection.dragging is True
+        anchor = tui_app._selection.anchor
+        assert (anchor.line, anchor.column) == (1, 2)
+
+    def test_hover_during_dangling_drag_on_status_bar_does_not_arm_autoscroll(
+        self, tui_app: DatusApp, captured_clipboard: list[str]
+    ):
+        for _ in range(20):
+            tui_app._output_buffer.write("line\n")
+        tui_app._output_at_bottom = False
+        tui_app._output_scroll_offset = 0
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=4, y=1))
+        # Buttonless hover over the status bar: the release happened
+        # elsewhere — finalise instead of arming downward autoscroll.
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=0, y=0, button=MouseButton.NONE))
+        assert tui_app._selection.dragging is False
+        assert tui_app._selection_autoscroll.direction == 0
+        assert captured_clipboard != []
+
+    def test_scrollbar_own_drag_release_still_works(self, tui_app: DatusApp, monkeypatch: pytest.MonkeyPatch):
+        for _ in range(20):
+            tui_app._output_buffer.write("line\n")
+        monkeypatch.setattr(tui_app, "_output_viewport_rows", lambda: 10)
+        tui_app._scrollbar_controller.handle_event(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        assert tui_app._scrollbar_controller.dragging is True
+        gutter_handler = tui_app._scrollbar_window.content.content.mouse_handler
+        # With no fragments painted (no render), the wrapped control falls
+        # back to NotImplemented — but it must not intercept the event away
+        # from the scrollbar while the scrollbar itself is dragging.
+        gutter_handler(_click(MouseEventType.MOUSE_UP, x=0, y=5))
+        # Forwarded release through the output pane still ends the drag.
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_UP, x=0, y=5))
+        assert tui_app._scrollbar_controller.dragging is False
+
+
+class TestMultiClickApp:
+    def test_output_double_click_copies_word(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=2, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_UP, x=2, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=2, y=0))
+        assert captured_clipboard == ["alpha"]
+        assert "Copied to clipboard" in tui_app._hint_text
+        assert tui_app._selection.dragging is False
+
+    def test_output_triple_click_copies_line(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        for _ in range(2):
+            tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=2, y=1))
+            tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_UP, x=2, y=1))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=2, y=1))
+        assert captured_clipboard == ["gamma", "gamma delta"]
+
+    def test_status_bar_double_click_copies_word(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=8, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_UP, x=8, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=8, y=0))
+        # Status text is "model: gpt-4 | tokens: 12"; char 8 sits in "gpt".
+        assert captured_clipboard == ["gpt"]
+
+    def test_input_triple_click_copies_whole_line(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        buffer = tui_app._input_area.buffer
+        buffer.text = "SELECT 1 FROM t"
+        buffer.cursor_position = 3
+        handler = tui_app._input_area.control.mouse_handler
+        with set_app(tui_app.application):
+            for _ in range(3):
+                handler(_click(MouseEventType.MOUSE_UP, x=3, y=0))
+        assert captured_clipboard[-1] == "SELECT 1 FROM t"
+
+
+def _mount_interaction_wizard(tui_app: DatusApp, **event_kwargs):
+    """Mount a real InteractionApp panel (the ask_user / permission UI)."""
+    import asyncio
+
+    from datus.cli.interaction_app import InteractionApp
+    from datus.schemas.interaction_event import InteractionEvent
+
+    loop = asyncio.new_event_loop()
+    future = loop.create_future()
+    app = InteractionApp([InteractionEvent(**event_kwargs)])
+    panel = app.build_embedded_panel(future)
+    tui_app.mount_wizard(panel)
+    return loop
+
+
+def _wizard_region_with_text(tui_app: DatusApp, needle: str):
+    """Find the mounted wizard region whose content contains ``needle``."""
+    for name in tui_app._wizard_selection_names:
+        region = tui_app._selection_regions.get(name)
+        if region is None:
+            continue
+        lines = region.lines()
+        for row, line in enumerate(lines):
+            text = "".join(f[1] for f in line if len(f) > 1)
+            if needle in text:
+                return region, row
+    return None, -1
+
+
+class TestWizardSelection:
+    """Embedded wizards (ask_user / permission / slash-command pickers)
+    must be drag-copyable like every other pane."""
+
+    def test_interaction_content_is_copyable(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        loop = _mount_interaction_wizard(
+            tui_app,
+            title="Permission",
+            content="DELETE FROM orders WHERE 1=1",
+            content_type="text",
+            choices={"y": "Yes", "n": "No"},
+        )
+        try:
+            region, row = _wizard_region_with_text(tui_app, "DELETE FROM orders")
+            tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_DOWN, x=0, y=row))
+            tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_MOVE, x=200, y=row))
+            tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_UP, x=200, y=row))
+            assert captured_clipboard == ["  DELETE FROM orders WHERE 1=1"]
+        finally:
+            tui_app.unmount_wizard()
+            loop.close()
+
+    def test_interaction_choices_are_copyable(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        loop = _mount_interaction_wizard(
+            tui_app,
+            title="Ask",
+            content="pick one",
+            content_type="text",
+            choices={"a": "Allow always", "d": "Deny"},
+        )
+        try:
+            region, row = _wizard_region_with_text(tui_app, "Allow always")
+            tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_DOWN, x=0, y=row))
+            tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_MOVE, x=200, y=row))
+            tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_UP, x=200, y=row))
+            assert captured_clipboard == ["  1. Allow always"]
+        finally:
+            tui_app.unmount_wizard()
+            loop.close()
+
+    def test_free_text_buffer_gets_copy_wrapper(self, tui_app: DatusApp):
+        loop = _mount_interaction_wizard(
+            tui_app,
+            title="Ask",
+            content="describe it",
+            content_type="text",
+            allow_free_text=True,
+        )
+        try:
+            wizard_buffers = [n for n in tui_app._selection_buffers if n.startswith("wizard:")]
+            assert wizard_buffers != []
+        finally:
+            tui_app.unmount_wizard()
+            loop.close()
+
+    def test_unmount_cleans_wizard_registrations(self, tui_app: DatusApp):
+        loop = _mount_interaction_wizard(
+            tui_app,
+            title="Ask",
+            content="hello",
+            content_type="text",
+            choices={"y": "Yes"},
+        )
+        assert tui_app._wizard_selection_names != []
+        tui_app.unmount_wizard()
+        loop.close()
+        assert tui_app._wizard_selection_names == []
+        assert [n for n in tui_app._selection_regions if n.startswith("wizard:")] == []
+        assert [n for n in tui_app._selection_buffers if n.startswith("wizard:")] == []
+
+    def test_click_driven_widgets_are_left_alone(self, tui_app: DatusApp):
+        """CheckboxList/RadioList-style controls (fragment-embedded mouse
+        handlers) must keep their click behaviour — no selection wiring."""
+        import asyncio
+
+        from prompt_toolkit.key_binding import KeyBindings
+        from prompt_toolkit.layout.containers import HSplit, Window
+        from prompt_toolkit.layout.controls import FormattedTextControl
+
+        from datus.cli.tui.wizard_host import EmbeddedWizard
+
+        clicked: list[str] = []
+
+        def _row_handler(_event):
+            clicked.append("row")
+            return None
+
+        clickable = FormattedTextControl(lambda: [("", "[ ] option a", _row_handler)])
+        plain = FormattedTextControl(lambda: [("", "static label")])
+        container = HSplit([Window(clickable), Window(plain)])
+        loop = asyncio.new_event_loop()
+        panel = EmbeddedWizard(
+            container=container,
+            key_bindings=KeyBindings(),
+            first_focus=None,
+            done_future=loop.create_future(),
+        )
+        tui_app.mount_wizard(panel)
+        try:
+            # The clickable control keeps its class-level fragment dispatch…
+            assert "mouse_handler" not in clickable.__dict__
+            # …while the plain label got selection wiring.
+            assert "mouse_handler" in plain.__dict__
+            region, row = _wizard_region_with_text(tui_app, "static label")
+            assert region.name.startswith("wizard:")
+            assert row == 0
+        finally:
+            tui_app.unmount_wizard()
+            loop.close()
+
+    def test_wizard_selection_clears_output_selection(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        # Finished output-pane selection persists…
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_UP, x=5, y=0))
+        assert not tui_app._selection.is_empty()
+        loop = _mount_interaction_wizard(
+            tui_app,
+            title="Ask",
+            content="pick",
+            content_type="text",
+            choices={"y": "Yes"},
+        )
+        try:
+            region, row = _wizard_region_with_text(tui_app, "Yes")
+            # …until a drag starts inside the wizard.
+            tui_app._region_mouse_dispatch(region, _click(MouseEventType.MOUSE_DOWN, x=0, y=row))
+            assert tui_app._selection.is_empty()
+        finally:
+            tui_app.unmount_wizard()
+            loop.close()
+
+
+class TestEscapeClearsEverything:
+    def test_any_selection_active_and_clear_all(self, tui_app: DatusApp, captured_clipboard: list[str]):
+        assert tui_app._any_selection_active() is False
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        tui_app._status_mouse_handler(_click(MouseEventType.MOUSE_UP, x=5, y=0))
+        assert tui_app._any_selection_active() is True
+        tui_app._clear_other_selections(keep=None)
+        assert tui_app._any_selection_active() is False
+
+    def test_input_buffer_selection_counts_as_active(self, tui_app: DatusApp):
+        buffer = tui_app._input_area.buffer
+        buffer.text = "abc"
+        buffer.cursor_position = 0
+        buffer.start_selection()
+        buffer.cursor_position = 2
+        assert tui_app._any_selection_active() is True
+        tui_app._clear_other_selections(keep=None)
+        assert buffer.selection_state is None

--- a/tests/unit_tests/cli/tui/test_app_selection.py
+++ b/tests/unit_tests/cli/tui/test_app_selection.py
@@ -66,9 +66,8 @@ def test_mouse_down_begins_selection_and_disengages_sticky_bottom(tui_app: Datus
     assert tui_app._output_at_bottom is True
     tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=2, y=0))
     assert tui_app._selection.dragging is True
-    assert tui_app._selection.anchor is not None
-    assert tui_app._selection.anchor.line == 0
-    assert tui_app._selection.anchor.column == 2
+    anchor = tui_app._selection.anchor
+    assert (anchor.line, anchor.column) == (0, 2)
     assert tui_app._output_at_bottom is False
 
 
@@ -76,7 +75,6 @@ def test_drag_extends_selection_head(tui_app: DatusApp):
     tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
     tui_app._output_mouse_handler(_click(MouseEventType.MOUSE_MOVE, x=5, y=1))
     head = tui_app._selection.head
-    assert head is not None
     assert (head.line, head.column) == (1, 5)
 
 
@@ -87,7 +85,8 @@ def test_mouse_up_with_text_writes_to_clipboard(tui_app: DatusApp, captured_clip
     assert captured_clipboard == ["alpha"]
     assert tui_app._selection.dragging is False
     # Selection is preserved post-release so the highlight stays visible.
-    assert tui_app._selection.range() is not None
+    rng = tui_app._selection.range()
+    assert ((rng[0].line, rng[0].column), (rng[1].line, rng[1].column)) == ((0, 0), (0, 5))
 
 
 def test_mouse_up_with_empty_selection_does_not_write_clipboard(tui_app: DatusApp, captured_clipboard: list[str]):
@@ -295,10 +294,10 @@ def test_scroll_wheel_still_works(tui_app: DatusApp):
     # Push a bigger buffer so there's something to scroll past.
     for _ in range(20):
         tui_app._output_buffer.write("line\n")
-    initial_at_bottom = tui_app._output_at_bottom
+    assert tui_app._output_at_bottom is True
     tui_app._output_mouse_handler(_click(MouseEventType.SCROLL_UP, x=0, y=0, button=MouseButton.NONE))
     # Wheel-up disengages sticky-bottom.
-    assert tui_app._output_at_bottom != initial_at_bottom or initial_at_bottom is False
+    assert tui_app._output_at_bottom is False
 
 
 def test_set_output_scroll_offset_disengages_then_reengages_sticky_bottom(tui_app: DatusApp):

--- a/tests/unit_tests/cli/tui/test_region_selection.py
+++ b/tests/unit_tests/cli/tui/test_region_selection.py
@@ -1,0 +1,215 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for :class:`datus.cli.tui.region_selection.SelectableRegion`.
+
+Pure-data tests: the region is driven with synthetic ``MouseEvent``
+sequences and inspected from the outside (selection state, rendered
+fragments, ``on_begin`` / ``on_copy`` callbacks) — no prompt_toolkit
+Application is mounted.
+"""
+
+from __future__ import annotations
+
+from prompt_toolkit.data_structures import Point
+from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
+
+from datus.cli.tui.region_selection import SelectableRegion
+
+
+def _click(event_type, x, y, button=MouseButton.LEFT):
+    return MouseEvent(
+        position=Point(x=x, y=y),
+        event_type=event_type,
+        button=button,
+        modifiers=frozenset(),
+    )
+
+
+def _make_region(tokens, *, name="test"):
+    copied: list[str] = []
+    begun: list[str] = []
+    region = SelectableRegion(
+        name,
+        lambda: tokens,
+        on_begin=lambda: begun.append(name),
+        on_copy=copied.append,
+    )
+    return region, copied, begun
+
+
+class TestMouseStateMachine:
+    def test_down_begins_selection_and_fires_on_begin(self):
+        region, _copied, begun = _make_region([("", "hello world")])
+        result = region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=2, y=0))
+        assert result is None
+        assert region.selection.dragging is True
+        anchor = region.selection.anchor
+        assert (anchor.line, anchor.column) == (0, 2)
+        assert begun == ["test"]
+
+    def test_move_extends_head_while_dragging(self):
+        region, _copied, _begun = _make_region([("", "hello world")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        head = region.selection.head
+        assert (head.line, head.column) == (0, 5)
+
+    def test_up_copies_selected_text(self):
+        region, copied, _begun = _make_region([("", "hello world")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=5, y=0))
+        assert copied == ["hello"]
+        assert region.selection.dragging is False
+        # Highlight persists after the copy (cleared by Escape / next click).
+        assert not region.selection.is_empty()
+
+    def test_click_without_drag_copies_nothing(self):
+        region, copied, _begun = _make_region([("", "hello world")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=3, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=3, y=0))
+        assert copied == []
+        assert region.selection.is_empty()
+
+    def test_move_without_drag_is_not_handled(self):
+        region, _copied, _begun = _make_region([("", "hello")])
+        assert region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=1, y=0)) is NotImplemented
+
+    def test_up_without_drag_is_not_handled(self):
+        region, _copied, _begun = _make_region([("", "hello")])
+        assert region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=1, y=0)) is NotImplemented
+
+    def test_scroll_events_fall_through(self):
+        region, _copied, _begun = _make_region([("", "hello")])
+        event = _click(MouseEventType.SCROLL_UP, x=0, y=0, button=MouseButton.NONE)
+        assert region.handle_mouse(event) is NotImplemented
+
+    def test_right_button_down_is_not_handled(self):
+        region, _copied, _begun = _make_region([("", "hello")])
+        event = _click(MouseEventType.MOUSE_DOWN, x=0, y=0, button=MouseButton.RIGHT)
+        assert region.handle_mouse(event) is NotImplemented
+
+    def test_down_on_empty_region_is_not_handled(self):
+        region, _copied, begun = _make_region([])
+        # split_lines of an empty stream yields a single empty line, so a
+        # click resolves to (0, 0) — dragging over nothing still copies
+        # nothing because extraction of an empty line is empty.
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=0, y=0))
+        assert region.selection.is_empty()
+
+    def test_point_past_last_line_clamps_to_last_line(self):
+        region, _copied, _begun = _make_region([("", "one\ntwo")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=3, y=99))
+        assert (region.selection.head.line, region.selection.head.column) == (1, 3)
+
+
+class TestMultiClick:
+    def test_double_click_selects_and_copies_word(self):
+        region, copied, _begun = _make_region([("", "hello world\nsecond line")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=8, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=8, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=8, y=0))
+        assert copied == ["world"]
+        assert region.selection.dragging is False
+        rng = region.selection.range()
+        assert (rng[0].column, rng[1].column) == (6, 11)
+
+    def test_triple_click_selects_and_copies_line(self):
+        region, copied, _begun = _make_region([("", "hello world\nsecond line")])
+        for _ in range(2):
+            region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=8, y=0))
+            region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=8, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=8, y=0))
+        assert copied == ["world", "hello world"]
+
+    def test_double_click_on_blank_line_copies_nothing(self):
+        region, copied, _begun = _make_region([("", "top\n\nbottom")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=1))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=0, y=1))
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=1))
+        assert copied == []
+        assert region.selection.is_empty()
+
+    def test_fourth_click_starts_fresh_drag(self):
+        region, copied, _begun = _make_region([("", "hello world")])
+        for _ in range(3):
+            region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=2, y=0))
+            region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=2, y=0))
+        # Word + line copies happened; the 4th click begins a normal drag.
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=2, y=0))
+        assert region.selection.dragging is True
+        assert copied == ["hello", "hello world"]
+
+
+class TestExtraction:
+    def test_multiline_extraction_joins_with_newline(self):
+        region, copied, _begun = _make_region([("class:todo", "task one\ntask two\ntask three")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=8, y=2))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=8, y=2))
+        assert copied == ["task one\ntask two\ntask thr"]
+
+    def test_extraction_strips_trailing_padding_spaces(self):
+        region, copied, _begun = _make_region([("", "abc   \ndef")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=3, y=1))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=3, y=1))
+        assert copied == ["abc\ndef"]
+
+    def test_cjk_selection_uses_char_indices(self):
+        # position.x counts characters, not visual cells — two CJK glyphs
+        # are char indices 0 and 1 even though they span 4 cells.
+        region, copied, _begun = _make_region([("", "你好 world")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=2, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=2, y=0))
+        assert copied == ["你好"]
+
+    def test_tokens_fn_exception_yields_empty_content(self):
+        def _boom():
+            raise RuntimeError("provider failed")
+
+        region = SelectableRegion("bad", _boom)
+        assert region.lines() == [[]]
+        assert region.extract_text() == ""
+
+
+class TestRenderTokens:
+    def test_unselected_content_passes_through(self):
+        tokens = [("class:status-bar", "model: gpt"), ("", "\n"), ("class:status-bar", "ctx: 4k")]
+        region, _copied, _begun = _make_region(tokens)
+        rendered = region.render_tokens()
+        assert ("class:status-bar", "model: gpt") in rendered
+        assert ("class:status-bar", "ctx: 4k") in rendered
+
+    def test_selected_range_gains_selection_class(self):
+        region, _copied, _begun = _make_region([("class:x", "hello world")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=5, y=0))
+        rendered = region.render_tokens()
+        assert ("class:x class:selection", "hello") in rendered
+        assert ("class:x", " world") in rendered
+
+    def test_blank_line_padded_with_space(self):
+        # Blank rows must paint at least one cell so prompt_toolkit's
+        # rowcol_to_yx lookup can resolve mouse coordinates on them.
+        region, _copied, _begun = _make_region([("", "top\n\nbottom")])
+        rendered = region.render_tokens()
+        lines: list[list] = [[]]
+        for fragment in rendered:
+            if fragment == ("", "\n"):
+                lines.append([])
+            else:
+                lines[-1].append(fragment)
+        assert lines[1] == [("", " ")]
+
+    def test_padding_never_reaches_clipboard(self):
+        region, copied, _begun = _make_region([("", "top\n\nbottom")])
+        region.handle_mouse(_click(MouseEventType.MOUSE_DOWN, x=0, y=0))
+        region.handle_mouse(_click(MouseEventType.MOUSE_MOVE, x=6, y=2))
+        region.handle_mouse(_click(MouseEventType.MOUSE_UP, x=6, y=2))
+        assert copied == ["top\n\nbottom"]

--- a/tests/unit_tests/cli/tui/test_selection.py
+++ b/tests/unit_tests/cli/tui/test_selection.py
@@ -22,12 +22,14 @@ import pytest
 
 from datus.cli.tui.selection import (
     COLUMN_TO_LINE_END,
+    MultiClickTracker,
     SelectionAutoscroll,
     SelectionPoint,
     TranscriptSelection,
     extract_plain_text_between,
     line_char_count,
     split_line_for_selection,
+    word_bounds_at,
 )
 
 # ── TranscriptSelection state machine ────────────────────────────────
@@ -93,7 +95,7 @@ def test_finish_clears_dragging_but_keeps_selection():
     sel.update_head(SelectionPoint(line=0, column=4))
     sel.finish()
     assert sel.dragging is False
-    assert sel.range() is not None
+    assert sel.range() == (SelectionPoint(line=0, column=0), SelectionPoint(line=0, column=4))
 
 
 def test_clear_removes_anchor_and_head_and_bumps_version():
@@ -266,3 +268,74 @@ def test_autoscroll_direction_flip_resets_clock():
     auto.arm(-1)
     # Flip: next_tick reset to 0, so any now value fires.
     assert auto.due(now=101.0) is True
+
+
+# ── word_bounds_at ─────────────────────────────────────────────
+
+
+def test_word_bounds_middle_of_word():
+    assert word_bounds_at("alpha beta", 2) == (0, 5)
+
+
+def test_word_bounds_second_word():
+    assert word_bounds_at("alpha beta", 7) == (6, 10)
+
+
+def test_word_bounds_underscore_is_word_char():
+    assert word_bounds_at("foo_bar baz", 3) == (0, 7)
+
+
+def test_word_bounds_on_whitespace_selects_space_run():
+    assert word_bounds_at("a   b", 2) == (1, 4)
+
+
+def test_word_bounds_on_punctuation_selects_punct_run():
+    assert word_bounds_at("a --> b", 3) == (2, 5)
+
+
+def test_word_bounds_cjk_run():
+    assert word_bounds_at("你好世界 ok", 1) == (0, 4)
+
+
+def test_word_bounds_index_past_end_clamps_to_last_char():
+    assert word_bounds_at("alpha beta", 99) == (6, 10)
+
+
+def test_word_bounds_empty_text_returns_none():
+    assert word_bounds_at("", 0) is None
+
+
+# ── MultiClickTracker ──────────────────────────────────────────
+
+
+def test_multi_click_counts_single_double_triple():
+    tracker = MultiClickTracker()
+    assert tracker.register(0, 4, now=1.0) == 1
+    assert tracker.register(0, 4, now=1.2) == 2
+    assert tracker.register(0, 4, now=1.4) == 3
+
+
+def test_multi_click_cycles_back_to_single_after_triple():
+    tracker = MultiClickTracker()
+    for expected, now in ((1, 1.0), (2, 1.1), (3, 1.2)):
+        assert tracker.register(0, 4, now=now) == expected
+    assert tracker.register(0, 4, now=1.3) == 1
+
+
+def test_multi_click_timeout_resets_chain():
+    tracker = MultiClickTracker(interval_seconds=0.4)
+    assert tracker.register(0, 4, now=1.0) == 1
+    assert tracker.register(0, 4, now=2.0) == 1
+
+
+def test_multi_click_different_line_resets_chain():
+    tracker = MultiClickTracker()
+    assert tracker.register(0, 4, now=1.0) == 1
+    assert tracker.register(1, 4, now=1.1) == 1
+
+
+def test_multi_click_column_tolerance():
+    tracker = MultiClickTracker(column_tolerance=1)
+    assert tracker.register(0, 4, now=1.0) == 1
+    assert tracker.register(0, 5, now=1.1) == 2  # 1 cell of jitter chains
+    assert tracker.register(0, 8, now=1.2) == 1  # 3 cells away resets


### PR DESCRIPTION
## Why

In full-screen TUI mode the Application owns mouse capture, so terminal-native drag selection is unavailable everywhere. Software selection + copy-to-clipboard existed only for the scrollback pane; every other visible surface could not be copied at all:

- status bar, todo sidebar, and queue preview had no selection logic;
- the composer / Ctrl+F search had native drag highlight but never wrote to the system clipboard;
- embedded wizards (`ask_user` / permission prompts, `/model` `/effort` `/mcp` `/datasource` and other slash-command pickers) had no copy path — e.g. the SQL shown in a permission request could not be copied;
- releasing a drag outside the terminal window left the drag dangling and nothing was copied;
- the USER message panel's `│` box borders were glued onto every copied line.

## Solution

- **`SelectableRegion`** (new `datus/cli/tui/region_selection.py`): reusable software selection for `FormattedTextControl`-backed panes — mouse state machine, `class:selection` highlight splicing, plain-text extraction (blank rows padded for mouse resolvability, padding never reaches the clipboard). Wired to the status bar, todo sidebar, and queue preview. Selections are per-region and mutually exclusive: starting one anywhere clears the others, and a drag is confined to the region it started in.
- **Buffer-backed inputs** (composer, search field) keep prompt_toolkit's native selection; a wrapper adds copy-on-release and a triple-click select-line gesture.
- **Multi-click**: `MultiClickTracker` + `word_bounds_at` implement double-click → word, triple-click → line (CJK-aware, char-index based) in the scrollback and all regions; the 4th click cycles back to a normal drag.
- **Off-terminal releases**: a shared `_inflight_drag_intercept` runs first on every wired surface — `MOUSE_UP` anywhere, a fresh `MOUSE_DOWN`, or a buttonless hover move (mode 1003 any-event tracking) proves the button is up and finalises + copies the in-flight drag. Decorative surfaces (separators, hint row, scrollbar gutter, sidebar rule) participate, since emulators clamp off-window releases onto edge cells.
- **Embedded wizards**: `mount_wizard` walks the wizard's container tree and auto-wires display controls to regions, input buffers to copy-on-release, and separators to the drag finaliser; controls whose fragments embed click handlers (`CheckboxList` / `RadioList` / `Button`) are left untouched so their clicks keep working. All registrations are undone on unmount. No per-wizard code changes needed.
- **USER panel borders**: `render_user_scrollback_text` switches from `ROUNDED` to `HORIZONTALS` (top/bottom rules only) so copied lines carry no border glyphs; extraction's per-line rstrip removes the space side-edges.
- Shared extraction logic consolidated into `selection.extract_text_from_lines`; `output_buffer.extract_selection_text` now delegates to it.

Tradeoff: if a release happens off-terminal and the pointer never returns, no event exists to observe — the copy then fires on the first re-entry event, which is the earliest possible moment.

## Test Cases

Unit tests only — the feature is pure TUI mouse plumbing with no LLM/DB/network surface, so no integration/nightly cases apply. Added ~60 cases across:

- `tests/unit_tests/cli/tui/test_region_selection.py` (new): region state machine, highlight splicing, extraction (CJK char indices, padding never copied), multi-click word/line/cycle.
- `tests/unit_tests/cli/tui/test_app_region_selection.py` (new): per-region wiring, mutual exclusion, cross-region release finalisation, off-screen release recovery (hover / fresh-press / clamped-edge releases), input & search buffer copy, real `InteractionApp` panel content/choices copyable, click-driven widgets left alone, unmount cleanup.
- `tests/unit_tests/cli/tui/test_selection.py`: `MultiClickTracker`, `word_bounds_at`.
- `tests/unit_tests/cli/test_cli_styles.py`: copied USER message line contains no border glyphs (regression guard for the copy contract); top/bottom rules retained.

Local gates: impacted unit suite 3500 passed, diff coverage 95%, `audit_tests.py` P0=0/P1=0, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse text selection and clipboard copying across output, status, queue, todo, input, search, and wizard panes.
  * Added double-click word selection and triple-click line selection.
  * Selections now remain independent across panes and finalize correctly when released outside the originating pane.
  * Pressing Escape clears selections across all supported areas.

* **UI Improvements**
  * User scrollback now displays horizontal borders without vertical edge characters.

* **Bug Fixes**
  * Copied text is cleaner, with styling, borders, and trailing padding removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->