### PR TITLE
[Feature] plugin system: mount external plugin directories via agent.plugin_paths

### DIFF
--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -692,22 +692,28 @@ def _dispatch_plugin_command(argv: "list[str]") -> "int | None":
     # stderr-backed Console (so stdout stays reserved for the plugin's output).
     err_console = Console(stderr=True)
 
+    profile_name, config_path, rest = _split_plugin_globals(argv[1:])
+
     # A managed plugin lives in its own ``~/.datus/plugins/{name}/`` directory;
-    # append it to ``sys.path`` so the entry-point probe can see it. This is
-    # path-only — it does NOT import the plugin package (reading the manifest
-    # never executes plugin code, and the ``cli`` ref is imported only after
-    # every gate below has passed), so the ``plugins_enabled`` master switch
-    # is still honoured before any third-party module-level code runs.
+    # append it to ``sys.path`` so the entry-point probe can see it. Plugins
+    # mounted through ``agent.plugin_paths`` live elsewhere, so when no managed
+    # directory claims the token the configured paths are injected instead.
+    # Both are path-only — they do NOT import the plugin package (reading the
+    # manifest never executes plugin code, and the ``cli`` ref is imported only
+    # after every gate below has passed), so the ``plugins_enabled`` master
+    # switch is still honoured before any third-party module-level code runs.
     if store.plugin_dir(name).is_dir():
         store.activate_name(name)
+    else:
+        from datus.configuration.agent_config_loader import get_plugin_paths
+
+        store.activate_paths(get_plugin_paths(config_path or ""))
 
     # Metadata-only probe: with ``plugins_enabled: false`` the plugin package
     # must not even be imported, so the master switch is checked before
     # ``resolve_code_ref`` runs the plugin's module-level code.
     if not plugin_entry_point_exists(name):
         return None
-
-    profile_name, config_path, rest = _split_plugin_globals(argv[1:])
 
     try:
         from datus.configuration.agent_config_loader import load_agent_config

--- a/datus/cli/plugin_cli.py
+++ b/datus/cli/plugin_cli.py
@@ -300,9 +300,14 @@ def _cmd_activation(console: Console, args: argparse.Namespace) -> int:
     from datus.plugins.registry import plugin_entry_point_exists
 
     # A managed plugin's directory must be on sys.path before the entry-point
-    # probe can see it (metadata-only; no plugin code is imported).
+    # probe can see it (metadata-only; no plugin code is imported). Plugins
+    # mounted through ``agent.plugin_paths`` may equally be inactive (and thus
+    # off sys.path), so those directories are injected too — a disabled plugin
+    # must stay re-enable-able.
     if store.plugin_dir(args.name).is_dir():
         store.activate_name(args.name)
+    else:
+        store.activate_paths(getattr(agent_config, "plugin_paths", None))
 
     if not plugin_entry_point_exists(args.name):
         print_error(console, f"No installed plugin named `{args.name}`. Run `datus plugin list`.")

--- a/datus/cli/plugin_service.py
+++ b/datus/cli/plugin_service.py
@@ -84,7 +84,7 @@ class PluginInfo:
     version: str = ""
     entry: str = ""  # "module:attr" target
     install_type: str = ""  # pip|src|whl|git|zip (managed) or "" (external)
-    source: str = ""  # "managed" (~/.datus/plugins) or "external" (site-packages)
+    source: str = ""  # "managed" (~/.datus/plugins), "path" (agent.plugin_paths) or "external" (site-packages)
     profiles: List[str] = field(default_factory=list)  # configured profile names
     active: Optional[bool] = None  # project activation state (None: unknown)
     active_profiles: Optional[List[str]] = None  # None: all profiles active
@@ -779,12 +779,14 @@ def uninstall(plugin_name: str) -> UninstallResult:
 
 
 def list_plugins(agent_config=None) -> List[PluginInfo]:
-    """Enumerate installed plugins (managed + externally pip-installed).
+    """Enumerate installed plugins (managed + path-mounted + pip-installed).
 
-    Managed plugins are read from ``~/.datus/plugins/*/datus-plugin.json``;
-    externally installed ones are discovered via the ``datus.plugins``
-    entry-point group as a fallback (a name present in both prefers the managed
-    entry). ``agent_config`` (optional) supplies configured profiles and the
+    Managed plugins are read from ``~/.datus/plugins/*/datus-plugin.json``,
+    then ``agent.plugin_paths`` mounts are introspected (one directory = one
+    plugin), and externally installed ones are discovered via the
+    ``datus.plugins`` entry-point group as a fallback (a name present in
+    several sources prefers the earlier one). ``agent_config`` (optional)
+    supplies configured profiles, the ``plugin_paths`` mounts and the
     project's activation state.
     """
     from datus.plugins.registry import iter_plugin_entry_points
@@ -811,6 +813,27 @@ def list_plugins(agent_config=None) -> List[PluginInfo]:
             entry=str(meta.get("entry_point") or ""),
             install_type=str(install_meta.get("type") or ""),
             source="managed",
+        )
+
+    # Path-mounted plugins (agent.plugin_paths) are listed even while inactive
+    # (their entry points may be off sys.path), so they stay visible and
+    # re-enable-able like a disabled managed plugin.
+    extra_paths = getattr(agent_config, "plugin_paths", None) if agent_config is not None else None
+    for name, directory in store.iter_extra_plugin_dirs(extra_paths):
+        if name in by_name:
+            continue
+        try:
+            ident = store.introspect_target(directory)
+        except store.StoreError as exc:
+            logger.debug("plugin_paths entry %s not listable: %s", directory, exc)
+            continue
+        by_name[name] = PluginInfo(
+            name=name,
+            package=str(ident.get("distribution") or ""),
+            version=str(ident.get("version") or ""),
+            entry=str(ident.get("entry_point") or ""),
+            install_type="",
+            source="path",
         )
 
     for ep in iter_plugin_entry_points():

--- a/datus/cli/plugin_service.py
+++ b/datus/cli/plugin_service.py
@@ -417,25 +417,53 @@ def _replace_dir(dest: Path, src_dir: Path) -> None:
         shutil.rmtree(backup, ignore_errors=True)
 
 
-def _refresh(name: str) -> None:
-    """Make a freshly-installed plugin discoverable in this process."""
-    importlib.invalidate_caches()
+def _resolve_dest(name: str, dest_dir: Optional[str]) -> Path:
+    """Destination directory for plugin ``name`` (``dest_dir`` overrides the store)."""
+    return Path(dest_dir).expanduser() if dest_dir else store.plugin_dir(name)
+
+
+def _refresh(name: str, directory: Path) -> None:
+    """Make a freshly-installed plugin discoverable in this process.
+
+    Ensures ``directory`` is on ``sys.path``, then unconditionally drops the
+    import + plugin registry caches. The ``activate_*`` helpers only invalidate
+    when they newly append a directory, so a same-name replace (``--force`` /
+    ``upgrade``) — whose directory is already on ``sys.path`` — would otherwise
+    keep serving the replaced plugin's stale manifest for the rest of the
+    process.
+    """
     try:
-        store.activate_name(name)
+        if directory == store.plugin_dir(name):
+            store.activate_name(name)
+        else:
+            store.activate_paths([str(directory)])
     except Exception as exc:  # noqa: BLE001 - defensive: never crash the install on refresh
         logger.debug("plugin path activation after install failed: %s", exc)
+    importlib.invalidate_caches()
+    try:
+        from datus.plugins.registry import invalidate_plugin_cache
+
+        invalidate_plugin_cache()
+    except Exception as exc:  # noqa: BLE001 - defensive: never crash the install on refresh
+        logger.debug("plugin cache invalidation failed after install: %s", exc)
 
 
 # ── install ────────────────────────────────────────────────────────────────
 
 
-def install(spec: str, force: bool = False) -> InstallResult:
+def install(spec: str, force: bool = False, dest_dir: Optional[str] = None) -> InstallResult:
     """Install a plugin from a ``{type}:{src}`` source into ``~/.datus/plugins/``.
 
     Every non-zip source installs via ``pip install --target`` into the plugin's
     directory; ``zip:`` installs a self-contained wheelhouse bundle. Provenance
     is recorded in ``datus-plugin.json`` for later ``upgrade`` / ``export``. When
     the plugin is already installed, ``force`` replaces it.
+
+    ``dest_dir`` (reserved for future use; not surfaced on the CLI yet) installs
+    the plugin tree into that exact directory instead of
+    ``~/.datus/plugins/{name}/`` — the one-directory-one-plugin layout that
+    ``agent.plugin_paths`` mounts. Such an install is not enumerated by the
+    managed store; mount it via ``agent.plugin_paths`` to use it.
     """
     spec = (spec or "").strip()
     if not spec:
@@ -445,20 +473,27 @@ def install(spec: str, force: bool = False) -> InstallResult:
     except ValueError as exc:
         return InstallResult(ok=False, source=spec, error=str(exc))
 
+    dest_dir = (dest_dir or "").strip() or None
     if itype == "zip":
-        return _install_zip(src, force=force)
-    return _install_via_target(itype, src, force=force)
+        return _install_zip(src, force=force, dest_dir=dest_dir)
+    return _install_via_target(itype, src, force=force, dest_dir=dest_dir)
 
 
 def _install_via_target(
-    itype: str, src: str, force: bool, upgrade: bool = False, expected_name: Optional[str] = None
+    itype: str,
+    src: str,
+    force: bool,
+    upgrade: bool = False,
+    expected_name: Optional[str] = None,
+    dest_dir: Optional[str] = None,
 ) -> InstallResult:
     """Install a ``pip``/``src``/``whl``/``git`` source via ``pip install --target``.
 
     ``expected_name`` pins the plugin identity: when set (an ``upgrade``), an
     installed distribution whose entry-point name differs is rejected so the
     upgrade cannot install a renamed plugin into a new directory while leaving
-    the old one behind.
+    the old one behind. ``dest_dir`` overrides the destination directory (see
+    :func:`install`).
     """
     try:
         pip_spec, ref = _pip_spec_and_ref(itype, src)
@@ -505,20 +540,20 @@ def _install_via_target(
                     f"expected `{expected_name}`. Uninstall `{expected_name}` and install `{name}` explicitly instead."
                 ),
             )
-        dest = store.plugin_dir(name)
+        dest = _resolve_dest(name, dest_dir)
         if dest.exists() and not force:
-            return InstallResult(
-                ok=False,
-                source=src,
-                name=name,
-                error=f"plugin '{name}' is already installed (use --force to replace, or `datus plugin upgrade {name}`)",
+            error = (
+                f"destination directory {dest} already exists (pass force=True to replace)"
+                if dest_dir
+                else f"plugin '{name}' is already installed (use --force to replace, or `datus plugin upgrade {name}`)"
             )
+            return InstallResult(ok=False, source=src, name=name, error=error)
         # Stage metadata into the temp target BEFORE the swap so the committed
         # directory is complete the instant it appears and a metadata failure
         # never leaves the old plugin destroyed.
         store.write_meta(target, _build_dir_meta(info, itype, ref, origin_artifact=None))
         _replace_dir(dest, target)
-        _refresh(name)
+        _refresh(name, dest)
         return InstallResult(
             ok=True,
             source=src,
@@ -532,8 +567,18 @@ def _install_via_target(
         )
 
 
-def _install_zip(src: str, force: bool) -> InstallResult:
-    """Install a plugin from a self-contained wheelhouse ``.zip`` bundle."""
+def _zip_dest_exists_error(name: str, dest: Path, dest_dir: Optional[str]) -> str:
+    """Refusal message for a bundle install whose destination already exists."""
+    if dest_dir:
+        return f"destination directory {dest} already exists (pass force=True to replace)"
+    return f"plugin '{name}' is already installed (use --force to replace)"
+
+
+def _install_zip(src: str, force: bool, dest_dir: Optional[str] = None) -> InstallResult:
+    """Install a plugin from a self-contained wheelhouse ``.zip`` bundle.
+
+    ``dest_dir`` overrides the destination directory (see :func:`install`).
+    """
     bundle = Path(src).expanduser()
     if not bundle.is_file():
         return InstallResult(ok=False, source=src, error=f"bundle not found: {src}")
@@ -549,13 +594,15 @@ def _install_zip(src: str, force: bool) -> InstallResult:
             # Fast pre-check on the manifest's declared name (avoids a wasted
             # install when the plugin is already present and --force is absent).
             declared = manifest["plugin"].get("name")
-            if isinstance(declared, str) and declared and store.plugin_dir(declared).exists() and not force:
-                return InstallResult(
-                    ok=False,
-                    source=src,
-                    name=declared,
-                    error=f"plugin '{declared}' is already installed (use --force to replace)",
-                )
+            if isinstance(declared, str) and declared and not force:
+                pre_dest = _resolve_dest(declared, dest_dir)
+                if pre_dest.exists():
+                    return InstallResult(
+                        ok=False,
+                        source=src,
+                        name=declared,
+                        error=_zip_dest_exists_error(declared, pre_dest, dest_dir),
+                    )
             with tempfile.TemporaryDirectory(prefix="datus-zip-") as tmp:
                 wheels_dir = _extract_and_verify_wheels(zf, manifest, Path(tmp))
                 main_wheel = wheels_dir / manifest["plugin"]["wheel"]
@@ -586,13 +633,13 @@ def _install_zip(src: str, force: bool) -> InstallResult:
                 except StoreError as exc:
                     return InstallResult(ok=False, source=src, label=label, error=str(exc))
                 name = info["name"]
-                dest = store.plugin_dir(name)
+                dest = _resolve_dest(name, dest_dir)
                 if dest.exists() and not force:
                     return InstallResult(
                         ok=False,
                         source=src,
                         name=name,
-                        error=f"plugin '{name}' is already installed (use --force to replace)",
+                        error=_zip_dest_exists_error(name, dest, dest_dir),
                     )
                 # Stage the retained origin bundle + metadata into the temp
                 # target before the swap so the committed directory is complete
@@ -603,7 +650,7 @@ def _install_zip(src: str, force: bool) -> InstallResult:
                     _build_dir_meta(info, "zip", str(bundle.resolve()), origin_artifact=store.ORIGIN_ZIP),
                 )
                 _replace_dir(dest, target)
-                _refresh(name)
+                _refresh(name, dest)
                 return InstallResult(
                     ok=True,
                     source=src,

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -927,6 +927,22 @@ class AgentConfig:
         # Intended for API/web deployments where the agent must not be guided
         # to edit configuration files.
         self.plugins_enabled = _coerce_bool(kwargs.get("plugins_enabled"), True)
+        # ``plugin_paths`` mounts plugin directories living OUTSIDE the managed
+        # store (``~/.datus/plugins``). Each entry is already ONE plugin's
+        # directory — the equivalent of a single ``~/.datus/plugins/{name}/``
+        # subdirectory, not a root containing several — so a shared checkout or
+        # centrally deployed plugin can be used without copying it into the
+        # home store. Merged with the managed store as a union; on a name clash
+        # the managed install wins. ``~``/``$ENV_VAR`` are expanded at
+        # activation time (``datus.plugins.store``).
+        raw_plugin_paths = kwargs.get("plugin_paths")
+        if raw_plugin_paths is not None and not isinstance(raw_plugin_paths, list):
+            logger.warning("agent.plugin_paths must be a list of directories; ignoring %r.", raw_plugin_paths)
+        self.plugin_paths: List[str] = (
+            [p.strip() for p in raw_plugin_paths if isinstance(p, str) and p.strip()]
+            if isinstance(raw_plugin_paths, list)
+            else []
+        )
         # Plugin config: plugin name -> profile name -> profile config dict.
         # Populated from ``agent.plugins`` by ``init_plugin_services``.
         self.plugin_services: Dict[str, Dict[str, Dict[str, Any]]] = {}

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -3,7 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
 
@@ -498,9 +498,10 @@ def load_agent_config(reload: bool = False, create_if_missing: bool = False, **k
     except Exception as e:
         logger.warning(f"Failed to initialize tracing: {e}")
 
-    # Append this project's enabled plugin directories (~/.datus/plugins/<name>/)
-    # to sys.path so their ``datus.plugins`` entry points are discovered before
-    # skills / prompt sections / permissions / tool transformers are collected.
+    # Append this project's enabled plugin directories (~/.datus/plugins/<name>/
+    # unioned with ``agent.plugin_paths`` mounts) to sys.path so their
+    # ``datus.plugins`` entry points are discovered before skills / prompt
+    # sections / permissions / tool transformers are collected.
     # Path-only injection — the plugin package is imported lazily on use.
     try:
         from datus.plugins import store
@@ -508,6 +509,7 @@ def load_agent_config(reload: bool = False, create_if_missing: bool = False, **k
         store.activate(
             agent_config.active_plugin_names(),
             plugins_enabled=getattr(agent_config, "plugins_enabled", True),
+            extra_paths=getattr(agent_config, "plugin_paths", None),
         )
     except Exception as e:  # noqa: BLE001 - a bad plugin dir must never block config load
         logger.debug("plugin sys.path activation failed: %s", e)
@@ -529,3 +531,26 @@ def get_agent_home(config_file: str = "") -> str:
         return "~/.datus"
 
     return raw.get("agent", {}).get("home", "~/.datus")
+
+
+def get_plugin_paths(config_file: str = "") -> List[str]:
+    """Read ``agent.plugin_paths`` from config without instantiating ``AgentConfig``.
+
+    Used by CLI plugin dispatch, which must inject configured plugin
+    directories into ``sys.path`` (path-only) BEFORE the full agent config —
+    and therefore the plugin entry-point probe — runs. Any failure resolves to
+    an empty list: dispatch falls through and the real error surfaces at
+    ``load_agent_config``.
+    """
+    try:
+        config_path = parse_config_path(config_file)
+        with open(config_path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except Exception as e:  # noqa: BLE001 - dispatch probing must never crash
+        logger.debug(f"Error reading plugin_paths from config: {e}")
+        return []
+    agent_raw = raw.get("agent")
+    paths = agent_raw.get("plugin_paths") if isinstance(agent_raw, dict) else None
+    if not isinstance(paths, list):
+        return []
+    return [p.strip() for p in paths if isinstance(p, str) and p.strip()]

--- a/datus/plugins/store.py
+++ b/datus/plugins/store.py
@@ -19,6 +19,12 @@ owns:
   ``importlib.metadata.entry_points()`` scanning ``sys.path``) discovers them,
   then invalidates the import + registry caches
 
+Besides the managed store, ``agent.plugin_paths`` (:class:`AgentConfig`) may
+mount plugin directories living anywhere on disk. Each entry is already ONE
+plugin's directory — the equivalent of a single ``{plugins_root}/{name}/``
+subdirectory, not a root containing several — and is merged with the managed
+store as a union; on a name clash the managed install wins.
+
 Adding a directory to ``sys.path`` makes its ``.dist-info`` discoverable but does
 **not** import the plugin package — manifest reading never executes plugin code,
 and declared code refs are imported lazily by ``resolve_code_ref`` — so callers
@@ -30,6 +36,7 @@ from __future__ import annotations
 
 import configparser
 import json
+import os
 import sys
 from email.parser import Parser
 from pathlib import Path
@@ -152,6 +159,65 @@ def iter_installed() -> List[Dict[str, Any]]:
     return installed
 
 
+# ── Extra plugin paths (agent.plugin_paths) ────────────────────────────────
+
+
+def plugin_name_for_dir(directory: Path) -> Optional[str]:
+    """Best-effort plugin (entry-point) name for one plugin directory.
+
+    Prefers the datus-owned ``datus-plugin.json`` (managed installs); falls
+    back to the ``datus.plugins`` entry point declared by the tree's
+    ``*.dist-info`` (externally built or path-mounted trees). Metadata-only —
+    never imports plugin code and never raises; returns ``None`` when neither
+    source yields a name.
+    """
+    meta = read_meta(directory)
+    if meta is not None:
+        name = meta.get("name")
+        if isinstance(name, str) and name:
+            return name
+    dist_info = _find_plugin_dist_info(directory)
+    if dist_info is None:
+        return None
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    try:
+        parser.read_string((dist_info / "entry_points.txt").read_text(encoding="utf-8", errors="replace"))
+    except (OSError, configparser.Error):
+        return None
+    return next(iter(parser[PLUGIN_ENTRY_POINT_GROUP]), None)
+
+
+def iter_extra_plugin_dirs(extra_paths: Optional[List[str]]) -> List[tuple]:
+    """Resolve ``agent.plugin_paths`` entries to unique ``(name, dir)`` pairs.
+
+    Each entry is expected to be ONE plugin's directory (the same layout as a
+    single ``{plugins_root}/{name}/`` subdirectory). ``~`` and ``$ENV_VAR``
+    are expanded. Entries that are missing, contain no recognizable datus
+    plugin, carry an unsafe/reserved name, or repeat an earlier entry's name
+    are warned about and skipped — a bad path must never block startup.
+    """
+    resolved: List[tuple] = []
+    seen: Set[str] = set()
+    for raw in extra_paths or []:
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        directory = Path(os.path.expandvars(raw.strip())).expanduser()
+        if not directory.is_dir():
+            logger.warning("plugin_paths entry %r is not a directory; skipping.", raw)
+            continue
+        name = plugin_name_for_dir(directory)
+        if name is None or not is_valid_name(name):
+            logger.warning("plugin_paths entry %r contains no recognizable datus plugin; skipping.", raw)
+            continue
+        if name in seen:
+            logger.warning("plugin_paths entry %r duplicates plugin %r; first entry wins.", raw, name)
+            continue
+        seen.add(name)
+        resolved.append((name, directory))
+    return resolved
+
+
 # ── Introspection of a freshly-installed target tree ───────────────────────
 
 
@@ -255,12 +321,19 @@ def _append_to_syspath(directory: Path) -> bool:
     return True
 
 
-def activate(active_names: Optional[Set[str]], plugins_enabled: bool = True) -> List[str]:
+def activate(
+    active_names: Optional[Set[str]],
+    plugins_enabled: bool = True,
+    extra_paths: Optional[List[str]] = None,
+) -> List[str]:
     """Append enabled plugin directories to ``sys.path`` and refresh caches.
 
     ``active_names`` mirrors ``AgentConfig.active_plugin_names()``: ``None`` means
     "no filter" (activate every installed plugin) while a set is the project's
-    activation whitelist. Directories are **appended** (not prepended) so datus'
+    activation whitelist. ``extra_paths`` (``agent.plugin_paths``) mounts
+    additional plugin-level directories, merged with the managed store as a
+    union under the same whitelist; a name claimed by the managed store wins
+    over an extra path. Directories are **appended** (not prepended) so datus'
     own dependencies keep priority over a plugin's vendored copies. When
     ``plugins_enabled`` is false this is a no-op.
 
@@ -270,20 +343,52 @@ def activate(active_names: Optional[Set[str]], plugins_enabled: bool = True) -> 
     """
     if not plugins_enabled:
         return []
-    root = plugins_root()
-    if not root.is_dir():
-        return []
 
     added: List[str] = []
+    managed_names: Set[str] = set()
     for meta in iter_installed():
         name = meta.get("name")
         if not is_valid_name(name):
             continue
+        managed_names.add(name)
         if active_names is not None and name not in active_names:
             continue
         if _append_to_syspath(Path(meta["_dir"])):
             added.append(name)
 
+    for name, directory in iter_extra_plugin_dirs(extra_paths):
+        if name in managed_names:
+            logger.warning(
+                "plugin_paths entry %s duplicates installed plugin %r; the managed install wins.", directory, name
+            )
+            continue
+        if active_names is not None and name not in active_names:
+            continue
+        if _append_to_syspath(directory):
+            added.append(name)
+
+    if added:
+        import importlib
+
+        importlib.invalidate_caches()
+        invalidate_plugin_cache()
+    return added
+
+
+def activate_paths(extra_paths: Optional[List[str]]) -> List[str]:
+    """Append every ``agent.plugin_paths`` directory to ``sys.path``, unfiltered.
+
+    Used by CLI dispatch/management paths that must make a path-mounted plugin's
+    entry point discoverable BEFORE the activation gate runs — the exact mirror
+    of :func:`activate_name` for managed plugins. Path-only (no import), so the
+    ``plugins_enabled`` / per-project activation checks that follow still run
+    before any plugin code executes. Returns the plugin names newly added;
+    refreshes caches when anything was.
+    """
+    added: List[str] = []
+    for name, directory in iter_extra_plugin_dirs(extra_paths):
+        if _append_to_syspath(directory):
+            added.append(name)
     if added:
         import importlib
 
@@ -324,7 +429,10 @@ __all__ = [
     "read_meta",
     "write_meta",
     "iter_installed",
+    "plugin_name_for_dir",
+    "iter_extra_plugin_dirs",
     "introspect_target",
     "activate",
+    "activate_paths",
     "activate_name",
 ]

--- a/datus/utils/path_manager.py
+++ b/datus/utils/path_manager.py
@@ -227,7 +227,9 @@ class DatusPathManager:
         (a ``pip install --target`` tree with its dependencies vendored in) plus
         a ``datus-plugin.json`` metadata file. Enabled plugin directories are
         appended to ``sys.path`` at startup so their ``datus.plugins`` entry
-        points are discovered.
+        points are discovered. ``agent.plugin_paths`` may union in additional
+        plugin-level directories mounted outside this root (one path = one
+        plugin); see :mod:`datus.plugins.store`.
         """
         return self._datus_home / "plugins"
 

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -81,6 +81,30 @@ installed plugin — a `zip:` install returns its retained original bundle
 verbatim, while a `pip`/`src`/`whl`/`git` install is re-packed from its recorded
 source (needs network).
 
+## Mounting plugins from other paths
+
+Besides the managed store, `agent.plugin_paths` in `agent.yml` mounts plugin
+directories living anywhere on disk. Each entry is already **one plugin's
+directory** — the same layout a single `~/.datus/plugins/{name}/` subdirectory
+has (a `pip install --target` tree with the package, its vendored dependencies
+and a `*.dist-info`), not a root containing several plugins:
+
+```yaml
+agent:
+  plugin_paths:
+    - /opt/shared/datus-plugins/airflow          # one path = one plugin
+    - $DATUS_PLUGIN_HOME/hello                   # ~ and $ENV_VAR are expanded
+```
+
+Mounted directories are unioned with `~/.datus/plugins/` at startup and behave
+like installed plugins on every surface: `datus <name>` dispatch, skills,
+prompt sections, bash permissions, and per-project
+[activation](#activating-plugins). On a name clash the managed install under
+`~/.datus/plugins/` wins. `datus plugin list` shows mounted plugins with source
+`path`. This suits plugin trees deployed centrally (one copy shared by several
+machines or projects) that you do not want to copy into every user's home
+store.
+
 ## Configuration
 
 Plugins are configured under `agent.plugins.<name>` in `agent.yml`, where each

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -70,6 +70,26 @@ OS/Python 匹配的机器上构建。
 来源的安装会字节级返回其保留的原始 bundle,而 `pip`/`src`/`whl`/`git` 来源则按记录的
 安装源重新打包(需要网络)。
 
+## 挂载其他路径下的插件 {#plugin-paths}
+
+除受管目录外,`agent.yml` 中的 `agent.plugin_paths` 可以挂载位于磁盘任意位置的插件
+目录。每个条目本身就是**一个插件的目录**——与单个 `~/.datus/plugins/{name}/` 子目录
+的布局相同(即一棵 `pip install --target` 树:插件包、其内嵌依赖和 `*.dist-info`),
+而不是包含多个插件的根目录:
+
+```yaml
+agent:
+  plugin_paths:
+    - /opt/shared/datus-plugins/airflow          # 一个路径 = 一个插件
+    - $DATUS_PLUGIN_HOME/hello                   # 支持 ~ 与 $ENV_VAR 展开
+```
+
+启动时挂载目录与 `~/.datus/plugins/` 取并集,在所有能力面上与已安装插件行为一致:
+`datus <name>` 分发、skills、系统提示词、bash 权限,以及按项目的
+[激活开关](#activating-plugins)。同名冲突时,`~/.datus/plugins/` 下的受管安装优先。
+`datus plugin list` 会以 `path` 来源展示挂载插件。适合集中部署的插件树
+(多台机器或多个项目共享同一份拷贝),无需复制到每个用户的 home 目录。
+
 ## 配置
 
 插件在 `agent.yml` 的 `agent.plugins.<name>` 下配置,`<name>` 之下的每个键是一个

--- a/tests/unit_tests/cli/test_plugin_dispatch.py
+++ b/tests/unit_tests/cli/test_plugin_dispatch.py
@@ -131,6 +131,43 @@ def test_dispatch_unknown_plugin_returns_none(monkeypatch):
     assert _dispatch_plugin_command(["mystery", "x"]) is None
 
 
+def test_dispatch_injects_plugin_paths_when_unmanaged(monkeypatch, tmp_path):
+    """Without a managed dir, ``agent.plugin_paths`` mounts are injected before the probe."""
+    _patch_dispatch(monkeypatch, profile_dict={})
+    monkeypatch.setattr("datus.plugins.store.plugin_dir", lambda name: tmp_path / "absent" / name)
+    seen: dict = {}
+
+    def fake_get_plugin_paths(config_file=""):
+        seen["config"] = config_file
+        return ["/mnt/plugins/hello"]
+
+    monkeypatch.setattr("datus.configuration.agent_config_loader.get_plugin_paths", fake_get_plugin_paths)
+    activated: list = []
+    monkeypatch.setattr("datus.plugins.store.activate_paths", lambda paths: activated.append(paths) or [])
+
+    rc = _dispatch_plugin_command(["hello", "--config", "/tmp/agent.yml", "version"])
+
+    assert rc == 7
+    assert activated == [["/mnt/plugins/hello"]]
+    assert seen["config"] == "/tmp/agent.yml"  # the --config global reaches the pre-load read
+
+
+def test_dispatch_managed_dir_skips_plugin_paths(monkeypatch, tmp_path):
+    """A managed plugin's own directory wins; configured mounts are not read."""
+    _patch_dispatch(monkeypatch, profile_dict={})
+    managed = tmp_path / "plugins" / "hello"
+    managed.mkdir(parents=True)
+    monkeypatch.setattr("datus.plugins.store.plugin_dir", lambda name: managed)
+    monkeypatch.setattr("datus.plugins.store.activate_name", lambda name: False)
+
+    def fail_activate_paths(paths):
+        raise AssertionError("plugin_paths must not be consulted")
+
+    monkeypatch.setattr("datus.plugins.store.activate_paths", fail_activate_paths)
+
+    assert _dispatch_plugin_command(["hello", "version"]) == 7
+
+
 def test_dispatch_missing_manifest_falls_through(monkeypatch):
     """An entry point that exists but has no usable manifest must fall through
     (None) so a same-named legacy handler still gets its chance."""

--- a/tests/unit_tests/cli/test_plugin_service.py
+++ b/tests/unit_tests/cli/test_plugin_service.py
@@ -39,12 +39,22 @@ def _fake_proc(returncode=0, stdout="", stderr=""):
     return subprocess.CompletedProcess(args=["x"], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
-def _write_dist_info(target: Path, *, name, dist, version, entry, requires_python=">=3.12", group="datus.plugins"):
+def _write_dist_info(
+    target: Path,
+    *,
+    name,
+    dist,
+    version,
+    entry,
+    requires_python=">=3.12",
+    group="datus.plugins",
+    manifest_text="manifest_version: 1\n",
+):
     target.mkdir(parents=True, exist_ok=True)
     pkg = target / "datus_demo_plugin"
     pkg.mkdir(parents=True, exist_ok=True)
     (pkg / "__init__.py").write_text("", encoding="utf-8")
-    (pkg / store.MANIFEST_FILENAME).write_text("manifest_version: 1\n", encoding="utf-8")
+    (pkg / store.MANIFEST_FILENAME).write_text(manifest_text, encoding="utf-8")
     dinfo = target / f"{dist.replace('-', '_')}-{version}.dist-info"
     dinfo.mkdir(parents=True, exist_ok=True)
     (dinfo / "entry_points.txt").write_text(f"[{group}]\n{name} = {entry}\n", encoding="utf-8")
@@ -54,7 +64,13 @@ def _write_dist_info(target: Path, *, name, dist, version, entry, requires_pytho
     )
 
 
-def _installer(name="demo", dist="datus-demo-plugin", version="0.1.0", entry="datus_demo_plugin"):
+def _installer(
+    name="demo",
+    dist="datus-demo-plugin",
+    version="0.1.0",
+    entry="datus_demo_plugin",
+    manifest_text="manifest_version: 1\n",
+):
     """Return a fake ``subprocess.run`` that populates the ``--target`` tree."""
     calls = []
 
@@ -62,7 +78,7 @@ def _installer(name="demo", dist="datus-demo-plugin", version="0.1.0", entry="da
         calls.append(cmd)
         if "--target" in cmd:
             target = Path(cmd[cmd.index("--target") + 1])
-            _write_dist_info(target, name=name, dist=dist, version=version, entry=entry)
+            _write_dist_info(target, name=name, dist=dist, version=version, entry=entry, manifest_text=manifest_text)
         return _fake_proc(0)
 
     fake_run.calls = calls
@@ -312,6 +328,62 @@ def test_install_empty_source():
     assert not svc.install("").ok
 
 
+def test_force_reinstall_refreshes_manifest_cache(home, monkeypatch):
+    """A same-name force replace must drop the registry's manifest cache.
+
+    The plugin directory is already on ``sys.path`` after the first install, so
+    the added-only invalidation in the activate helpers never fires — the
+    install path must invalidate unconditionally for the replaced manifest to
+    become visible in-process.
+    """
+    monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+    monkeypatch.setattr(svc.subprocess, "run", _installer())
+    assert svc.install("pip:datus-demo-plugin").ok is True
+    first = registry.load_plugin_manifest("demo")
+    assert first is not None and first.skills is None  # cache primed with the v1 manifest
+
+    monkeypatch.setattr(
+        svc.subprocess,
+        "run",
+        _installer(version="0.2.0", manifest_text="manifest_version: 1\nskills: my_skills\n"),
+    )
+    assert svc.install("pip:datus-demo-plugin", force=True).ok is True
+    second = registry.load_plugin_manifest("demo")
+    assert second is not None and second.skills == "my_skills"
+
+
+# ── install: dest_dir (reserved custom destination) ─────────────────────────
+
+
+def test_install_dest_dir_lands_outside_store(home, tmp_path, monkeypatch):
+    monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+    monkeypatch.setattr(svc.subprocess, "run", _installer())
+    dest = tmp_path / "mounts" / "demo-plugin"
+    result = svc.install("pip:datus-demo-plugin", dest_dir=str(dest))
+    assert result.ok is True, result.error
+    assert result.name == "demo"
+    assert result.plugin_dir == str(dest)
+    meta = store.read_meta(dest)
+    assert meta["name"] == "demo"
+    assert meta["install"]["type"] == "pip"
+    # The managed store is untouched; the custom directory is activated for
+    # this process the way an ``agent.plugin_paths`` mount would be.
+    assert not store.plugin_dir("demo").exists()
+    assert str(dest) in sys.path
+
+
+def test_install_dest_dir_existing_requires_force(home, tmp_path, monkeypatch):
+    monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+    monkeypatch.setattr(svc.subprocess, "run", _installer())
+    dest = tmp_path / "mounts" / "demo-plugin"
+    assert svc.install("pip:datus-demo-plugin", dest_dir=str(dest)).ok is True
+    again = svc.install("pip:datus-demo-plugin", dest_dir=str(dest))
+    assert not again.ok and "already exists" in again.error
+    forced = svc.install("pip:datus-demo-plugin", force=True, dest_dir=str(dest))
+    assert forced.ok is True, forced.error
+    assert store.read_meta(dest)["name"] == "demo"
+
+
 # ── install: zip bundle ──────────────────────────────────────────────────────
 
 
@@ -397,6 +469,21 @@ def test_install_zip_slip_rejected(home, tmp_path, monkeypatch):
     result = svc.install(f"zip:{path}")
     assert not result.ok and "unsafe wheel filename" in result.error
     assert ran == []
+
+
+def test_install_zip_dest_dir_lands_outside_store(home, tmp_path, monkeypatch):
+    bundle = _make_bundle(tmp_path / "b.zip", bundle_deps=False)
+    monkeypatch.setattr(svc.shutil, "which", lambda name: None)
+    monkeypatch.setattr(svc.subprocess, "run", _zip_installer())
+    dest = tmp_path / "mounts" / "demo-plugin"
+    result = svc.install(f"zip:{bundle}", dest_dir=str(dest))
+    assert result.ok is True, result.error
+    assert result.plugin_dir == str(dest)
+    assert (dest / store.ORIGIN_ZIP).is_file()  # original bundle retained in the custom dir
+    assert not store.plugin_dir("demo").exists()
+    # The fast pre-check refuses the occupied custom destination without force.
+    again = svc.install(f"zip:{bundle}", dest_dir=str(dest))
+    assert not again.ok and "already exists" in again.error
 
 
 def test_install_zip_not_found(home):

--- a/tests/unit_tests/cli/test_plugin_service.py
+++ b/tests/unit_tests/cli/test_plugin_service.py
@@ -593,6 +593,56 @@ def test_list_managed_wins_over_external_duplicate(home, monkeypatch):
     assert infos[0].source == "managed" and infos[0].version == "9.9"
 
 
+def test_list_includes_path_mounted_plugins(home, tmp_path, monkeypatch):
+    ext = tmp_path / "ext"
+    _write_dist_info(ext, name="pathdemo", dist="datus-path-plugin", version="1.2.3", entry="datus_demo_plugin")
+    monkeypatch.setattr(registry, "iter_plugin_entry_points", lambda: [])
+    cfg = _FakeConfig(active=None)
+    cfg.plugin_paths = [str(ext)]
+    infos = svc.list_plugins(cfg)
+    assert [i.name for i in infos] == ["pathdemo"]
+    assert infos[0].source == "path"
+    assert infos[0].package == "datus-path-plugin"
+    assert infos[0].version == "1.2.3"
+    assert infos[0].active is True
+
+
+def test_list_path_plugin_listed_while_inactive(home, tmp_path, monkeypatch):
+    ext = tmp_path / "ext"
+    _write_dist_info(ext, name="pathdemo", dist="datus-path-plugin", version="1.2.3", entry="datus_demo_plugin")
+    monkeypatch.setattr(registry, "iter_plugin_entry_points", lambda: [])
+    cfg = _FakeConfig(active=set())  # whitelist present, plugin not in it
+    cfg.plugin_paths = [str(ext)]
+    infos = svc.list_plugins(cfg)
+    assert [i.name for i in infos] == ["pathdemo"]
+    assert infos[0].active is False
+
+
+def test_list_skips_path_entry_with_broken_manifest(home, tmp_path, monkeypatch):
+    ext = tmp_path / "ext"
+    _write_dist_info(ext, name="pathdemo", dist="datus-path-plugin", version="1.2.3", entry="datus_demo_plugin")
+    (ext / "datus_demo_plugin" / store.MANIFEST_FILENAME).unlink()  # introspection now fails
+    monkeypatch.setattr(registry, "iter_plugin_entry_points", lambda: [])
+    cfg = _FakeConfig(active=None)
+    cfg.plugin_paths = [str(ext)]
+    assert svc.list_plugins(cfg) == []
+
+
+def test_list_managed_wins_over_path_duplicate(home, tmp_path, monkeypatch):
+    store.write_meta(
+        store.plugin_dir("demo"),
+        {"name": "demo", "distribution": "managed-dist", "version": "9.9", "install": {"type": "pip"}},
+    )
+    ext = tmp_path / "ext"
+    _write_dist_info(ext, name="demo", dist="path-dist", version="0.1", entry="datus_demo_plugin")
+    monkeypatch.setattr(registry, "iter_plugin_entry_points", lambda: [])
+    cfg = _FakeConfig(active=None)
+    cfg.plugin_paths = [str(ext)]
+    infos = svc.list_plugins(cfg)
+    assert len(infos) == 1
+    assert infos[0].source == "managed" and infos[0].version == "9.9"
+
+
 def test_list_applies_activation_and_profiles(home, monkeypatch):
     store.write_meta(store.plugin_dir("demo"), {"name": "demo", "distribution": "d", "version": "1", "install": {}})
     monkeypatch.setattr(registry, "iter_plugin_entry_points", lambda: [])

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2808,6 +2808,33 @@ class TestPluginsEnabledSwitch:
         assert cfg.get_plugin_profile("hello") == {}
 
 
+class TestPluginPathsConfig:
+    """``agent.plugin_paths`` — extra plugin-level directory mounts."""
+
+    def _make(self, tmp_path, **extra):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            skip_init_dirs=True,
+            **extra,
+        )
+
+    def test_defaults_to_empty(self, tmp_path):
+        assert self._make(tmp_path).plugin_paths == []
+
+    def test_keeps_string_entries_stripped(self, tmp_path):
+        cfg = self._make(tmp_path, plugin_paths=["/opt/plugins/foo", "  ~/dev/bar  ", "", "   ", 42, None])
+        assert cfg.plugin_paths == ["/opt/plugins/foo", "~/dev/bar"]
+
+    def test_non_list_value_ignored_with_warning(self, tmp_path, caplog):
+        with caplog.at_level("WARNING"):
+            cfg = self._make(tmp_path, plugin_paths="/opt/plugins/foo")
+        assert cfg.plugin_paths == []
+        assert "plugin_paths must be a list" in caplog.text
+
+
 class TestPromptManagerAttribute:
     """``AgentConfig.prompt_manager`` — the runtime prompt-template override.
 

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -706,3 +706,47 @@ class TestPermissionModeCliOverride:
 
         config = load_agent_config(reload=True, config=str(cfg), permission_mode="auto")
         assert config.active_profile_name == "auto"
+
+
+# ---------------------------------------------------------------------------
+# get_plugin_paths
+# ---------------------------------------------------------------------------
+
+
+class TestGetPluginPaths:
+    """``get_plugin_paths`` reads ``agent.plugin_paths`` without an AgentConfig."""
+
+    def test_reads_string_entries(self, tmp_path):
+        from datus.configuration.agent_config_loader import get_plugin_paths
+
+        cfg = tmp_path / "agent.yml"
+        cfg.write_text(yaml.safe_dump({"agent": {"plugin_paths": ["/opt/plugins/foo", "  ~/dev/bar ", "", 42, None]}}))
+        assert get_plugin_paths(str(cfg)) == ["/opt/plugins/foo", "~/dev/bar"]
+
+    def test_missing_key_returns_empty(self, tmp_path):
+        from datus.configuration.agent_config_loader import get_plugin_paths
+
+        cfg = tmp_path / "agent.yml"
+        cfg.write_text(yaml.safe_dump({"agent": {}}))
+        assert get_plugin_paths(str(cfg)) == []
+
+    def test_non_list_value_returns_empty(self, tmp_path):
+        from datus.configuration.agent_config_loader import get_plugin_paths
+
+        cfg = tmp_path / "agent.yml"
+        cfg.write_text(yaml.safe_dump({"agent": {"plugin_paths": "/opt/plugins/foo"}}))
+        assert get_plugin_paths(str(cfg)) == []
+
+    def test_unreadable_config_returns_empty(self, tmp_path, monkeypatch):
+        from datus.configuration.agent_config_loader import get_plugin_paths
+
+        monkeypatch.chdir(tmp_path)  # no conf/agent.yml anywhere
+        with patch("datus.configuration.agent_config_loader.Path.home", return_value=tmp_path / "noexist"):
+            assert get_plugin_paths() == []
+
+    def test_invalid_yaml_returns_empty(self, tmp_path):
+        from datus.configuration.agent_config_loader import get_plugin_paths
+
+        cfg = tmp_path / "agent.yml"
+        cfg.write_text("agent: [unbalanced")
+        assert get_plugin_paths(str(cfg)) == []

--- a/tests/unit_tests/plugins/test_store.py
+++ b/tests/unit_tests/plugins/test_store.py
@@ -224,5 +224,108 @@ def test_activate_name_appends_single_dir(home):
     assert store.activate_name("demo") is False  # idempotent
 
 
+# ── extra plugin paths (agent.plugin_paths) ──────────────────────────────────
+
+
+def test_plugin_name_for_dir_prefers_meta(home, tmp_path):
+    target = _write_target(tmp_path / "ext")
+    store.write_meta(target, {"name": "renamed"})
+    assert store.plugin_name_for_dir(target) == "renamed"
+
+
+def test_plugin_name_for_dir_falls_back_to_dist_info(home, tmp_path):
+    target = _write_target(tmp_path / "ext")
+    assert store.plugin_name_for_dir(target) == "demo"
+
+
+def test_plugin_name_for_dir_none_for_plain_dir(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert store.plugin_name_for_dir(plain) is None
+
+
+def test_plugin_name_for_dir_none_when_entry_points_vanish(home, tmp_path, monkeypatch):
+    """A dist-info whose entry_points.txt disappears mid-read resolves to None."""
+    target = _write_target(tmp_path / "ext")
+    dist_info = next(target.glob("*.dist-info"))
+    monkeypatch.setattr(store, "_find_plugin_dist_info", lambda d: dist_info)
+    (dist_info / "entry_points.txt").unlink()
+    assert store.plugin_name_for_dir(target) is None
+
+
+def test_iter_extra_plugin_dirs_skips_bad_entries(home, tmp_path, caplog):
+    first = _write_target(tmp_path / "one")
+    _write_target(tmp_path / "two")  # same entry-point name → duplicate
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    entries = [str(first), str(tmp_path / "two"), str(tmp_path / "missing"), str(plain), "", None]
+    with caplog.at_level("WARNING"):
+        resolved = store.iter_extra_plugin_dirs(entries)
+    assert resolved == [("demo", first)]
+    assert "is not a directory" in caplog.text
+    assert "no recognizable datus plugin" in caplog.text
+    assert "duplicates plugin" in caplog.text
+
+
+def test_iter_extra_plugin_dirs_expands_env_vars(home, tmp_path, monkeypatch):
+    target = _write_target(tmp_path / "ext")
+    monkeypatch.setenv("DATUS_TEST_PLUGIN_HOME", str(tmp_path))
+    assert store.iter_extra_plugin_dirs(["$DATUS_TEST_PLUGIN_HOME/ext"]) == [("demo", target)]
+
+
+def test_iter_extra_plugin_dirs_rejects_reserved_name(home, tmp_path, caplog):
+    target = _write_target(tmp_path / "ext", name="upgrade")
+    with caplog.at_level("WARNING"):
+        assert store.iter_extra_plugin_dirs([str(target)]) == []
+    assert "no recognizable datus plugin" in caplog.text
+
+
+def test_activate_unions_extra_paths_with_store(home, tmp_path):
+    store.write_meta(store.plugin_dir("managed"), {"name": "managed"})
+    ext = _write_target(tmp_path / "ext")  # entry-point name "demo"
+    added = store.activate(None, extra_paths=[str(ext)])
+    assert set(added) == {"managed", "demo"}
+    assert str(store.plugin_dir("managed")) in sys.path
+    assert str(ext) in sys.path
+
+
+def test_activate_extra_paths_respect_whitelist(home, tmp_path):
+    ext = _write_target(tmp_path / "ext")
+    assert store.activate({"other"}, extra_paths=[str(ext)]) == []
+    assert str(ext) not in sys.path
+
+
+def test_activate_extra_path_name_clash_managed_wins(home, tmp_path, caplog):
+    store.write_meta(store.plugin_dir("demo"), {"name": "demo"})
+    ext = _write_target(tmp_path / "ext")  # also claims "demo"
+    with caplog.at_level("WARNING"):
+        added = store.activate(None, extra_paths=[str(ext)])
+    assert added == ["demo"]
+    assert str(store.plugin_dir("demo")) in sys.path
+    assert str(ext) not in sys.path
+    assert "managed install wins" in caplog.text
+
+
+def test_activate_extra_paths_without_managed_root(home, tmp_path):
+    ext = _write_target(tmp_path / "ext")
+    assert not store.plugins_root().is_dir()
+    assert store.activate(None, extra_paths=[str(ext)]) == ["demo"]
+    assert str(ext) in sys.path
+
+
+def test_activate_extra_paths_noop_when_disabled(home, tmp_path):
+    ext = _write_target(tmp_path / "ext")
+    assert store.activate(None, plugins_enabled=False, extra_paths=[str(ext)]) == []
+    assert str(ext) not in sys.path
+
+
+def test_activate_paths_unfiltered_and_idempotent(home, tmp_path):
+    ext = _write_target(tmp_path / "ext")
+    assert store.activate_paths([str(ext)]) == ["demo"]
+    assert str(ext) in sys.path
+    assert store.activate_paths([str(ext)]) == []
+    assert sys.path.count(str(ext)) == 1
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Why

Plugins currently live only in the managed per-user store (`~/.datus/plugins/{name}/`). Teams need to run plugins from directories managed outside that store — shared volumes, read-only deployments, monorepo checkouts, per-project vendoring — without copying them into the store.

Two supporting gaps in the install path are fixed along the way:

- A same-name replace (`--force` / `upgrade`) left the in-process plugin registry cache stale: the `activate_*` helpers only invalidate caches when a directory is *newly* appended to `sys.path`, and a replaced plugin's directory is already there — so a long-lived process kept serving the old manifest.
- `install()` had no way to target a custom destination directory.

## Solution

**`agent.plugin_paths` mounts (main feature)**

- `agent.plugin_paths` in agent.yml mounts plugin-level directories: one entry = ONE plugin's directory (same layout as a managed subdirectory), not a root of many plugins.
- `store.activate(extra_paths=…)` unions mounts with the managed store under the same per-project activation whitelist; on a name clash the managed install wins.
- `store.plugin_name_for_dir` / `iter_extra_plugin_dirs` resolve a mounted directory's plugin name (datus-plugin.json first, dist-info fallback) with `~` / `$ENV_VAR` expansion; bad entries warn and never block startup.
- `store.activate_paths` + loader `get_plugin_paths` provide path-only `sys.path` injection for `datus <plugin>` dispatch and enable/disable, preserving the no-import guarantee: manifest reads never execute plugin code, and a mounted (even currently disabled) plugin stays dispatchable and re-enable-able.
- `datus plugin list` shows mounted plugins with source `path`, visible even while inactive.

**Install-path fixes**

- `_refresh` now unconditionally drops the import + plugin-registry caches after every install, so a same-name `--force`/`upgrade` replace becomes visible in-process instead of serving the stale manifest.
- `install()` gains an internal `dest_dir` parameter (not surfaced on the CLI yet) that installs the plugin tree into an exact directory — the same one-directory-one-plugin layout `plugin_paths` mounts — reserved for custom-destination installs. Destination refusal/`--force` replace semantics and the backup-swap rollback are unchanged.

## Test Cases

Unit tests (CI tier, pip/subprocess fully mocked, no network):

- `tests/unit_tests/plugins/test_store.py` — `plugin_name_for_dir` / `iter_extra_plugin_dirs` (expansion, bad entries, duplicate names) / `activate(extra_paths=…)` union + whitelist + managed-wins / `activate_paths`.
- `tests/unit_tests/cli/test_plugin_service.py` — `dest_dir` installs (custom directory, occupied-destination refusal, force replace, zip bundle path), force-reinstall-refreshes-manifest-cache regression (fails without the `_refresh` fix), `list_plugins` showing path-mounted plugins (active/inactive, broken manifest skipped, managed-wins-duplicate).
- `tests/unit_tests/cli/test_plugin_dispatch.py` — `datus <plugin>` dispatch for path-mounted plugins.
- `tests/unit_tests/configuration/test_agent_config.py` / `test_agent_config_loader.py` — `plugin_paths` parsing (non-list warned + ignored) and loader activation wiring.

No integration/nightly additions: the feature is config parsing + local-filesystem discovery — deterministic, no external services — and is fully exercised at the unit tier. `ci/run-pr-tests.py` (acceptance + impacted unit tests + diff coverage) passes: 16540 passed / 0 failed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mounting plugins from external directories configured in `agent.yml`.
  * Added custom destination directories for plugin installation.
  * Updated plugin listing to include managed, mounted, and externally installed plugins.
  * Mounted plugins now support discovery, activation, dispatch, skills, prompts, and permissions.

* **Documentation**
  * Added English and Chinese documentation for configuring external plugin paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->