### PR TITLE
[Feature] Give web source a datus-only server-side bash for plugin CLIs

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2463,10 +2463,12 @@ class AgenticNode(Node):
         """Create the node's general-purpose :class:`BashTool` instance.
 
         Available to every agentic node when ``agent.bash.enabled`` is
-        ``True`` (the default). ``allowed_patterns=["*"]`` means the tool
-        exposes ``bash`` for any shell command; per-call gating
-        is the responsibility of the ``bash_tools`` ASK rule in the
-        permission profile, not a static pattern whitelist.
+        ``True`` (the default). ``allowed_patterns`` comes from
+        ``agent_config.bash_allowed_patterns``: the default ``["*"]`` exposes
+        ``bash`` for any shell command with per-call gating left to the
+        ``bash_tools`` ASK rule in the permission profile; a restrictive list
+        (e.g. the web front-end's ``["datus*"]``) is enforced as a hard
+        whitelist inside the tool itself.
 
         Only creates the instance — the tool enters ``self.tools`` via
         :meth:`_ensure_bash_tool_in_tools` so subclass ``setup_tools()``
@@ -2484,12 +2486,18 @@ class AgenticNode(Node):
             logger.warning("Skipping bash tool because permission enforcement is unavailable")
             self.bash_tool = None
             return
+        # Non-list values (configs mocked without the attribute, legacy
+        # bootstraps) fall back to the unrestricted default — the AgentConfig
+        # setter already normalizes real config input.
+        allowed_patterns = getattr(self.agent_config, "bash_allowed_patterns", None)
+        if not isinstance(allowed_patterns, list) or not allowed_patterns:
+            allowed_patterns = ["*"]
         try:
             from datus.tools.func_tool.bash_tool import BashTool
 
             self.bash_tool = BashTool(
                 workspace_root=self._resolve_workspace_root(),
-                allowed_patterns=["*"],
+                allowed_patterns=allowed_patterns,
                 # Offload oversized command output to the session data dir (the
                 # same location minor compact uses). Resolved lazily: this method
                 # runs before ``session_id`` is finalized, so the closure reads it

--- a/datus/api/main.py
+++ b/datus/api/main.py
@@ -254,8 +254,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         choices=["web", "vscode"],
         help=(
-            "Default proxy tool source shortcut. 'vscode' -> proxy filesystem_tools.*, "
-            "'web' -> proxy write_file/edit_file/delete_file. "
+            "Default proxy tool source shortcut. 'vscode' -> proxy filesystem_tools.* and no "
+            "server-side bash, 'web' -> proxy write_file/edit_file/delete_file with a "
+            "server-side bash restricted to datus commands. "
             "Overridable per request via ChatInput.source."
         ),
     )

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -272,6 +272,10 @@ class ChatTask:
 
 COMPLETED_TASK_TTL = 300  # seconds to keep completed tasks for resume
 
+# Bash whitelist for web clients: plugin CLIs ("datus <plugin> ...") and the
+# datus binaries themselves are the only commands the server-side bash accepts.
+WEB_BASH_ALLOWED_PATTERNS = ["datus*"]
+
 
 class ChatTaskManager:
     """Per-project manager for active chat tasks.
@@ -314,15 +318,22 @@ class ChatTaskManager:
         # access, so force filesystem strict mode — every node constructed
         # below reads this flag via AgenticNode._resolve_filesystem_strict().
         agent_config.filesystem_strict = True
-        # Remote front-ends (vscode/web) own their own shell: the daemon must
-        # not offer a server-side BashTool. ``project_root`` is intentionally
-        # left untouched — web keeps its configured root, and the read-only
-        # ``AgentConfig.project_root`` property already falls back to the
-        # launch CWD when no root was supplied, so an empty project_root
-        # naturally resolves to the current directory.
+        # vscode owns its own local shell: the daemon must not offer a
+        # server-side BashTool at all. web has no shell of its own, but plugin
+        # CLIs run through bash ("datus <plugin> ..."), so web keeps a
+        # server-side bash restricted to datus-prefixed commands only —
+        # everything else is rejected at the tool layer regardless of the
+        # permission profile. An agent.yml ``bash.enabled: false`` still wins:
+        # patterns never re-enable a disabled tool. ``project_root`` is
+        # intentionally left untouched — web keeps its configured root, and
+        # the read-only ``AgentConfig.project_root`` property already falls
+        # back to the launch CWD when no root was supplied, so an empty
+        # project_root naturally resolves to the current directory.
         effective_source = request.source or self._default_source
-        if effective_source in ("vscode", "web"):
+        if effective_source == "vscode":
             agent_config.bash_tool_enabled = False
+        elif effective_source == "web":
+            agent_config.bash_allowed_patterns = WEB_BASH_ALLOWED_PATTERNS
         # Stash the resolved source on the cloned config so downstream nodes
         # can adapt prompt-side hints to the front-end (e.g. vscode renders
         # the literal "." for the SQL files root because the IDE owns its own

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -126,6 +126,20 @@ def _coerce_bool(value: Any, default: bool) -> bool:
     return bool(value)
 
 
+def _coerce_pattern_list(value: Any) -> List[str]:
+    """Coerce ``bash.allowed_patterns`` into a non-empty list of patterns.
+
+    Missing / malformed values (non-list, empty list, non-string entries only)
+    fall back to ``["*"]`` — the unrestricted default where per-call gating is
+    the permission profile's job. An explicit valid list replaces the default
+    entirely; entries are stripped and blank entries dropped.
+    """
+    if not isinstance(value, list):
+        return ["*"]
+    patterns = [entry.strip() for entry in value if isinstance(entry, str) and entry.strip()]
+    return patterns or ["*"]
+
+
 def _normalize_plugin_activations(raw: Any) -> Dict[str, "PluginActivation"]:
     """Coerce a raw ``active_plugins`` value into ``{name: PluginActivation}``.
 
@@ -905,6 +919,13 @@ class AgentConfig:
         if not isinstance(bash_raw, dict):
             bash_raw = {}
         self._bash_tool_enabled = _coerce_bool(bash_raw.get("enabled"), True)
+        # ``bash.allowed_patterns`` optionally restricts which commands the
+        # general-purpose ``BashTool`` accepts (Claude-Code-style patterns,
+        # see ``BashTool`` docs). Default ``["*"]`` keeps the tool
+        # unrestricted at the execution layer — per-call gating stays with
+        # the permission profile. API front-ends override this at runtime
+        # (e.g. web gets ``["datus*"]``).
+        self._bash_allowed_patterns = _coerce_pattern_list(bash_raw.get("allowed_patterns"))
         # ``compact`` controls the AgenticNode session summarization /
         # archiving subsystem. Defaults preserve the legacy 90% major-compact
         # threshold while enabling the new rule-based minor compact + on-disk
@@ -1155,6 +1176,25 @@ class AgentConfig:
     @bash_tool_enabled.setter
     def bash_tool_enabled(self, value: bool) -> None:
         self._bash_tool_enabled = _coerce_bool(value, True)
+
+    @property
+    def bash_allowed_patterns(self) -> List[str]:
+        """Command patterns the general-purpose ``BashTool`` accepts.
+
+        ``["*"]`` (default): unrestricted at the execution layer — per-call
+        gating is handled by the ``bash_tools`` ASK rule in the permission
+        profile.
+
+        A restrictive list (e.g. ``["datus*"]``) turns the tool into a hard
+        whitelist enforced by ``BashTool._is_command_allowed`` regardless of
+        the active permission profile. Used by the API surface to expose a
+        datus-only bash to web clients.
+        """
+        return self._bash_allowed_patterns
+
+    @bash_allowed_patterns.setter
+    def bash_allowed_patterns(self, value: List[str]) -> None:
+        self._bash_allowed_patterns = _coerce_pattern_list(value)
 
     @property
     def current_datasource(self):

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -28,7 +28,7 @@ from typing import Any, Callable, Dict, List, Optional
 from agents import Tool
 
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
-from datus.tools.permission.bash_rules import split_pipeline
+from datus.tools.permission.bash_rules import contains_shell_metachars, split_pipeline
 from datus.utils.loggings import get_logger
 from datus.utils.tool_archive import build_archived_marker, make_single_line_preview
 
@@ -477,15 +477,24 @@ class BashTool:
 
         A segment containing non-pipe shell metacharacters (chaining, command
         substitution, redirection) is rejected — the whitelist speaks about
-        one command, not a compound expression.
+        one command, not a compound expression. The check runs on the RAW
+        segment string (same regex as the permission safety ceiling), so
+        unspaced forms (``datus x;rm y``, ``datus $(rm y)``) and quoted
+        metacharacters are rejected alike: commands run through a real shell
+        where quoting-aware per-token inspection cannot be made safe.
         """
+        if contains_shell_metachars(segment):
+            return False
         try:
             parts = shlex.split(segment)
         except ValueError:
             return False
         if not parts:
             return False
-        if any(tok in ("&&", "||", ";", "|", "&", "`", "$(", ">", "<") for tok in parts):
+        # Belt-and-suspenders for the one metacharacter the raw check skips:
+        # a stray top-level ``|`` token can't appear (split_pipeline consumed
+        # them), but keep rejecting it in case a caller bypasses the split.
+        if any(tok in ("|", "&&", "||", ";", "&", "`", "$(", ">", "<") for tok in parts):
             return False
         base_cmd = parts[0]
         return any(self._matches_pattern(segment, base_cmd, pattern) for pattern in self.allowed_patterns)
@@ -544,8 +553,18 @@ class BashTool:
         Returns an empty list when no patterns are configured, so callers
         that opt out of bash execution simply omit the tool. Callers that
         want an "unrestricted" tool (gated only by ``PermissionManager``)
-        should pass ``allowed_patterns=["*"]``.
+        should pass ``allowed_patterns=["*"]``. A restrictive whitelist is
+        surfaced in the tool description so the model doesn't waste turns
+        probing disallowed commands.
         """
         if not self.allowed_patterns:
             return []
-        return [trans_to_function_tool(self.bash)]
+        tool = trans_to_function_tool(self.bash)
+        if "*" not in self.allowed_patterns:
+            tool.description = (
+                f"{tool.description}\n\nRestricted mode: only commands matching these patterns "
+                f"are allowed: {', '.join(self.allowed_patterns)}. Any other command "
+                f"(including pipelines mixing in other commands, chaining, command "
+                f"substitution or redirection) is rejected."
+            )
+        return [tool]

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -79,6 +79,20 @@ logger = get_logger(__name__)
 # the caller falls back to this safety ceiling.
 _SHELL_METACHARS_RE = re.compile(r"[;&<>`\n]|\$\(|\$\{|\|\||&&")
 
+
+def contains_shell_metachars(text: str) -> bool:
+    """True when ``text`` contains any non-pipe shell metacharacter.
+
+    Checks the RAW string (quoting is ignored on purpose): neither the
+    permission safety ceiling nor a restrictive execution-layer whitelist can
+    reason about chaining / substitution / redirection, so a quoted
+    metacharacter is treated just as conservatively as an unquoted one.
+    Shared by ``evaluate_bash_command`` (→ forced ASK) and
+    ``BashTool._segment_allowed`` (→ reject).
+    """
+    return bool(_SHELL_METACHARS_RE.search(text))
+
+
 # Commands that execute their arguments (or arbitrary strings) as new
 # commands. An allow rule matched against the OUTER argv says nothing about
 # the wrapped command, so these never auto-allow either.
@@ -557,7 +571,7 @@ def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleD
             bucket=session_bucket_for(argv, None),
             safety_forced=True,
         )
-    if _SHELL_METACHARS_RE.search(command):
+    if contains_shell_metachars(command):
         return BashRuleDecision(
             level=PermissionLevel.ASK,
             source=BashDecisionSource.SAFETY,

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -1103,6 +1103,50 @@ class TestBashToolToggle:
         node._ensure_bash_tool_in_tools()
         assert node.tools == []
 
+    def test_bash_allowed_patterns_passed_through_to_tool(self, mock_agent_config):
+        """``agent_config.bash_allowed_patterns`` reaches the BashTool instance.
+
+        The API surface sets ``["datus*"]`` for web clients; the node must
+        hand it to the tool verbatim so the execution-layer whitelist gates
+        commands regardless of the permission profile.
+        """
+        self._wire_permissions(mock_agent_config)
+        mock_agent_config.bash_allowed_patterns = ["datus*"]
+
+        node = MinimalAgenticNode(
+            node_id="bash_patterns_passthrough",
+            description="Test node",
+            node_type="chat",
+            agent_config=mock_agent_config,
+        )
+
+        from datus.tools.func_tool.bash_tool import BashTool
+
+        assert isinstance(node.bash_tool, BashTool)
+        assert node.bash_tool.allowed_patterns == ["datus*"]
+        assert node.bash_tool._is_command_allowed("datus plugin list") is True
+        assert node.bash_tool._is_command_allowed("rm -rf /") is False
+
+    def test_non_list_bash_patterns_fall_back_to_unrestricted(self, mock_agent_config):
+        """A config without a usable ``bash_allowed_patterns`` (e.g. a Mock
+        or a legacy bootstrap) must not kill the tool — it falls back to the
+        unrestricted default gated by the permission profile."""
+        self._wire_permissions(mock_agent_config)
+        # Mock(spec=AgentConfig) resolves the attribute to a truthy Mock —
+        # exactly the non-list shape the fallback must absorb.
+
+        node = MinimalAgenticNode(
+            node_id="bash_patterns_fallback",
+            description="Test node",
+            node_type="chat",
+            agent_config=mock_agent_config,
+        )
+
+        from datus.tools.func_tool.bash_tool import BashTool
+
+        assert isinstance(node.bash_tool, BashTool)
+        assert node.bash_tool.allowed_patterns == ["*"]
+
 
 class TestRequiredSkillsInjection:
     """``REQUIRED_SKILLS`` host-injection primitive (``_inject_required_skills``)."""

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -1733,10 +1733,12 @@ class TestStartChatModelOverride:
 
 
 class TestStartChatRemoteSourceHardening:
-    """Remote front-ends (vscode/web) must not see a server-side BashTool.
-    ``filesystem_strict`` is always on for the API surface;
-    ``bash_tool_enabled`` is additionally forced off when
-    ``effective_source in {vscode, web}``. ``project_root`` is intentionally
+    """Per-source bash policy for remote front-ends.
+    ``filesystem_strict`` is always on for the API surface. vscode owns its
+    own local shell, so ``bash_tool_enabled`` is forced off; web keeps a
+    server-side bash restricted to datus-prefixed commands
+    (``bash_allowed_patterns = ["datus*"]``) so plugin CLIs
+    ("datus <plugin> ...") stay usable. ``project_root`` is intentionally
     untouched — web keeps its configured root and the read-only property
     falls back to CWD when empty.
     """
@@ -1761,11 +1763,13 @@ class TestStartChatRemoteSourceHardening:
         assert cfg.filesystem_strict is True
         assert cfg.bash_tool_enabled is False
         assert cfg._client_source == "vscode"
+        # vscode never gets a restricted-bash whitelist — the tool is gone.
+        assert cfg.bash_allowed_patterns == ["*"]
         # Source config remains untouched because start_chat deep-copies.
         assert real_agent_config.bash_tool_enabled is True
 
     @pytest.mark.asyncio
-    async def test_web_source_disables_bash_tool(self, real_agent_config, monkeypatch):
+    async def test_web_source_restricts_bash_to_datus_commands(self, real_agent_config, monkeypatch):
         from datus.api.models.cli_models import StreamChatInput
 
         real_agent_config.bash_tool_enabled = True
@@ -1782,8 +1786,56 @@ class TestStartChatRemoteSourceHardening:
 
         cfg = captured["agent_config"]
         assert cfg.filesystem_strict is True
-        assert cfg.bash_tool_enabled is False
+        # web keeps bash for plugin CLIs, but only datus-prefixed commands.
+        assert cfg.bash_tool_enabled is True
+        assert cfg.bash_allowed_patterns == ["datus*"]
         assert cfg._client_source == "web"
+        # Source config remains untouched because start_chat deep-copies.
+        assert real_agent_config.bash_allowed_patterns == ["*"]
+
+    @pytest.mark.asyncio
+    async def test_web_source_respects_yaml_bash_disable(self, real_agent_config, monkeypatch):
+        """An agent.yml ``bash.enabled: false`` still wins under web —
+        restricting patterns must never re-enable a disabled tool."""
+        from datus.api.models.cli_models import StreamChatInput
+
+        real_agent_config.bash_tool_enabled = False
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hi", source="web", session_id="web-yaml-disabled")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+
+        cfg = captured["agent_config"]
+        assert cfg.bash_tool_enabled is False
+        assert cfg.bash_allowed_patterns == ["datus*"]
+
+    @pytest.mark.asyncio
+    async def test_default_source_web_restricts_bash_without_request_source(self, real_agent_config, monkeypatch):
+        """A daemon launched with --source web applies the datus-only bash
+        whitelist to every request that does not override source."""
+        from datus.api.models.cli_models import StreamChatInput
+
+        real_agent_config.bash_tool_enabled = True
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["agent_config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager(default_source="web")
+        request = StreamChatInput(message="hi", session_id="default-web-hardening")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+
+        cfg = captured["agent_config"]
+        assert cfg.bash_tool_enabled is True
+        assert cfg.bash_allowed_patterns == ["datus*"]
 
     @pytest.mark.asyncio
     async def test_default_source_vscode_applies_hardening_without_request_source(self, real_agent_config, monkeypatch):
@@ -1828,6 +1880,7 @@ class TestStartChatRemoteSourceHardening:
         cfg = captured["agent_config"]
         assert cfg.filesystem_strict is True
         assert cfg.bash_tool_enabled is True
+        assert cfg.bash_allowed_patterns == ["*"]
         assert cfg._client_source is None
 
 

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1871,6 +1871,47 @@ class TestAgentConfigBashToolEnabled:
         assert cfg.bash_tool_enabled is True
 
 
+class TestAgentConfigBashAllowedPatterns:
+    """``bash_allowed_patterns`` restricts which commands the general-purpose
+    ``BashTool`` accepts. Sourced from ``agent.bash.allowed_patterns`` in YAML
+    and settable at runtime (the API surface sets ``["datus*"]`` for web
+    clients); default is ``["*"]`` — unrestricted at the execution layer.
+    """
+
+    _make = TestAgentConfigBashToolEnabled._make
+
+    def test_default_unrestricted(self, tmp_path):
+        cfg = self._make(tmp_path)
+        assert cfg.bash_allowed_patterns == ["*"]
+
+    def test_from_yaml_list(self, tmp_path):
+        cfg = self._make(tmp_path, bash={"allowed_patterns": ["datus*", "git status"]})
+        assert cfg.bash_allowed_patterns == ["datus*", "git status"]
+
+    def test_yaml_entries_stripped_and_blanks_dropped(self, tmp_path):
+        cfg = self._make(tmp_path, bash={"allowed_patterns": [" datus* ", "", "   "]})
+        assert cfg.bash_allowed_patterns == ["datus*"]
+
+    @pytest.mark.parametrize("bad_value", ["datus*", 42, {"a": 1}, [], [42, None]])
+    def test_malformed_yaml_falls_back_to_default(self, tmp_path, bad_value):
+        # A non-list value, an empty list, or a list without a single valid
+        # string entry must not silently hide the tool — fall back to the
+        # unrestricted default where the permission profile gates calls.
+        cfg = self._make(tmp_path, bash={"allowed_patterns": bad_value})
+        assert cfg.bash_allowed_patterns == ["*"]
+
+    def test_runtime_setter_overrides(self, tmp_path):
+        cfg = self._make(tmp_path)
+        cfg.bash_allowed_patterns = ["datus*"]
+        assert cfg.bash_allowed_patterns == ["datus*"]
+
+    def test_runtime_setter_rejects_malformed(self, tmp_path):
+        cfg = self._make(tmp_path)
+        cfg.bash_allowed_patterns = ["datus*"]
+        cfg.bash_allowed_patterns = None
+        assert cfg.bash_allowed_patterns == ["*"]
+
+
 class TestAgentConfigTavilyApiKey:
     """``document.tavily_api_key`` resolution prefers the YAML value, falls
     back to ``TAVILY_API_KEY`` env only when the key is absent, and never

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -240,14 +240,17 @@ class TestBashToolExecution:
         assert result.success == 0
         assert "not allowed" in result.error.lower()
 
-    def test_stdin_read_gets_eof_not_hang(self, multi_pattern_tool):
+    def test_stdin_read_gets_eof_not_hang(self, unrestricted_tool):
         """A command reading stdin must receive immediate EOF, never block.
 
         stdin is redirected to DEVNULL; without it the child inherits the
         agent's terminal stdin and hangs until the tool timeout, freezing the
         whole process. Reading stdin here should return an empty string fast.
+        Uses the unrestricted tool: a restrictive whitelist rejects the
+        quoted ``;`` in the inline code, and stdin handling is
+        whitelist-independent.
         """
-        result = multi_pattern_tool.bash('python -c "import sys; print(len(sys.stdin.read()))"')
+        result = unrestricted_tool.bash('python -c "import sys; print(len(sys.stdin.read()))"')
         assert result.success == 1
         assert result.result.strip() == "0"
 
@@ -550,3 +553,87 @@ class TestBashTimeoutParam:
         props = tool.params_json_schema.get("properties", {})
         assert "command" in props
         assert "timeout" in props
+
+
+class TestRestrictedWhitelistHardening:
+    """A restrictive whitelist is a hard security boundary.
+
+    Commands run through a real shell (``bash -c``), so chaining, command
+    substitution and redirection must be rejected even in unspaced or quoted
+    form — per-token inspection cannot be made safe there. Regression tests
+    for the bypass where metacharacters embedded inside a token (``x;rm``)
+    slipped past the token-equality check. The ``["datus*"]`` whitelist is
+    what the API surface hands to web clients (plugin CLIs).
+    """
+
+    @pytest.fixture
+    def datus_tool(self, temp_workspace):
+        return BashTool(workspace_root=str(temp_workspace), allowed_patterns=["datus*"])
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "datus plugin list",
+            "datus hello greet --name x",
+            "datus-api --help",
+            "datus a | datus b",
+        ],
+    )
+    def test_datus_prefixed_commands_allowed(self, datus_tool, command):
+        assert datus_tool._is_command_allowed(command) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rm -rf /",
+            "echo hi",
+            'bash -c "datus x"',
+            "datus a | grep x",
+        ],
+    )
+    def test_non_datus_commands_denied(self, datus_tool, command):
+        assert datus_tool._is_command_allowed(command) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Spaced operator forms (already caught by the token check).
+            "datus x && rm y",
+            "datus x ; rm y",
+            # Unspaced forms — the historical bypass this hardening closes.
+            "datus x&&rm y",
+            "datus x;rm -rf ~",
+            "datus x>f",
+            "datus x<f",
+            "datus $(rm y)",
+            "datus `rm y`",
+            "datus ${HOME}",
+            "datus x\nrm y",
+            # Quoted metacharacters are rejected too: the raw-string check is
+            # deliberately quoting-blind, mirroring the permission safety
+            # ceiling's conservative semantics.
+            'datus query "a;b"',
+        ],
+    )
+    def test_shell_metacharacters_rejected_in_any_form(self, datus_tool, command):
+        assert datus_tool._is_command_allowed(command) is False
+
+    def test_denied_execution_never_spawns_and_reports_patterns(self, datus_tool):
+        result = datus_tool.bash("datus x;rm -rf ~")
+        assert result.success == 0
+        assert "not allowed" in result.error.lower()
+        assert "datus*" in result.error
+
+    def test_wildcard_tool_unaffected_by_hardening(self, unrestricted_tool):
+        # ``["*"]`` short-circuits before the metachar check: compound
+        # commands are gated by the permission hooks, not the execution layer.
+        assert unrestricted_tool._is_command_allowed('echo "a;b" && ls') is True
+
+    def test_restricted_description_lists_patterns(self, datus_tool):
+        tool = datus_tool.available_tools()[0]
+        assert "Restricted mode" in tool.description
+        assert "datus*" in tool.description
+
+    def test_unrestricted_description_has_no_restriction_note(self, unrestricted_tool):
+        tool = unrestricted_tool.available_tools()[0]
+        assert "Restricted mode" not in tool.description


### PR DESCRIPTION
## Why

In API mode (`datus-api`), requests with `source` = `vscode`/`web` unconditionally forced `bash_tool_enabled = False`, so agentic nodes never created a BashTool. But the plugin system runs entirely through the agent's bash tool (`datus <plugin> ...` per the `datus-plugin.yml` manifest contract), which made all plugin CLIs unusable from the web front-end.

## Solution

- **web**: keep a server-side bash restricted to datus-prefixed commands. `ChatTaskManager.start_chat` sets the new `AgentConfig.bash_allowed_patterns = ["datus*"]` on the per-request config clone; `AgenticNode._setup_bash_tool` passes it to `BashTool`, whose existing `allowed_patterns` whitelist enforces it at the execution layer regardless of the active permission profile. Anything non-datus is rejected with `Command not allowed`. The restriction is also surfaced in the tool description so the model doesn't probe disallowed commands.
- **vscode**: unchanged — no server-side bash at all (the IDE owns its local shell).
- `bash_allowed_patterns` is YAML-configurable as `agent.bash.allowed_patterns` (sibling of `bash.enabled`, default `["*"]` preserves current behavior). An explicit `bash.enabled: false` still wins under web — patterns never re-enable a disabled tool.
- **Whitelist hardening (security prerequisite)**: `BashTool._segment_allowed` only rejected shell metacharacters appearing as standalone whitespace-delimited tokens, so unspaced forms (`datus x;rm -rf ~`, `datus $(rm y)`, backticks, redirection) slipped past the whitelist straight into `bash -c`. Since the restrictive whitelist is the only gate under the `dangerous` profile (which bypasses permission hooks), the raw segment is now checked with the permission layer's metacharacter regex, shared via the new public helper `bash_rules.contains_shell_metachars`. Tradeoff: quoted metacharacter arguments (e.g. `--sql "a > b"`) are now rejected under restrictive whitelists too — consistent with the permission safety ceiling's conservative semantics. The `["*"]` wildcard path short-circuits and is unaffected.
- Permission layer untouched: `bash_tools.bash → ASK` still routes through SSE interactions for web, and plugin-declared `datus <name> ...` allow rules keep auto-allowing their own namespace.

## Test Cases

Unit tests (CI tier, no external deps):

- `tests/unit_tests/tools/func_tool/test_bash_tool.py` — new `TestRestrictedWhitelistHardening`: `["datus*"]` allow/deny matrix, injection-bypass regressions (spaced + unspaced `;` `&&` `$()` backtick `${}` `>` `<` newline, quoted metachars), datus-only pipelines, wildcard path unaffected, restricted-mode tool description.
- `tests/unit_tests/api/services/test_chat_task_manager.py` — `TestStartChatRemoteSourceHardening` reworked: web keeps bash with `["datus*"]`, vscode stays disabled, `--source web` daemon default applies per request, YAML `bash.enabled: false` still wins, deep-copy keeps the source config unpolluted.
- `tests/unit_tests/configuration/test_agent_config.py` — new `TestAgentConfigBashAllowedPatterns`: default, YAML parsing, normalization, malformed-value fallback, runtime setter.
- `tests/unit_tests/agent/node/test_agentic_node_skills.py` — pattern pass-through to the BashTool instance and non-list fallback to `["*"]`.

No new integration/nightly tests: the change is config plumbing plus a pure-Python whitelist check, fully exercisable deterministically at the unit tier; existing integration coverage for bash execution and the API chat flow remains valid. Verified locally: `ci/run-pr-tests.py` diff coverage 100%, `ci/audit_tests.py --diff-only` P0=0/P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable command allowlists for Bash tool access.
  * Web-based sessions now allow only approved `datus` commands; VS Code sessions disable server-side Bash access.
  * Restricted Bash mode now clearly communicates its limitations.

* **Bug Fixes**
  * Strengthened protection against shell operators, redirection, command substitution, and other bypass techniques.
  * Invalid allowlist configurations safely fall back to unrestricted defaults.

* **Documentation**
  * Clarified command-source behavior in CLI help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->