### PR TITLE
[Enhancement] Stop todo over-use in /init and scope /build-kb todos to explore fan-out

### DIFF
--- a/datus/resources/skills/build-kb/SKILL.md
+++ b/datus/resources/skills/build-kb/SKILL.md
@@ -8,7 +8,7 @@ tags:
   - metrics
   - reference-sql
   - classify
-version: 1.0.0
+version: 1.1.0
 user_invocable: true
 ---
 
@@ -59,7 +59,7 @@ Gather the raw material **inside the resolved scope**, then classify it into a *
 - **Validated-query SQL corpus → handle here.** Enumerate each `(question, SQL)` pair into a `reference_sql` manifest row directly (per the bullet above). These rows skip Step 2.
 - **Tables + documentation → hand to Step 2 `explore`.** Group them under their domain; these are what the explore subagents investigate.
 
-**Record with todos when the taxonomy is large (> 3 domains):** call `todo_write` with one todo per domain — `title` = domain name (≤ 8 words), `content` = the files + tables it covers plus exploration focus notes. Track each domain's progress with `todo_update` (`pending` → `in_progress` → `completed` / `failed`) in the next steps. Skip todos for small scopes (≤ 3 domains) to avoid noise.
+**Record with todos only when Step 2 will fan out more than one `explore` subagent:** call `todo_write` **once**, with one todo per to-be-explored domain — `title` = domain name (≤ 8 words), `content` = the files + tables it covers plus exploration focus notes. Track each domain's exploration with `todo_update` (`pending` → `in_progress` → `completed` / `failed`) in Step 2. This is the **only** `todo_write` in this skill — Step 3 tracks generation through the confirmed manifest, never through new todos. Skip todos entirely when zero or one domain needs exploring (e.g. the scope is only the SQL corpus) — a single explore call is not worth a sidebar list.
 
 ---
 
@@ -85,7 +85,7 @@ Coverage focuses on **semantic_models, metrics, and knowledge** (plus **referenc
 
 **The validated-query corpus is NOT explored here — you enumerated it directly in Step 1.** The only `reference_sql` refs an explorer should return are SQL it *newly discovers* while investigating tables or docs (e.g. an example query embedded in a Markdown doc). For any such discovered SQL, instruct the explorer to carry the **original natural-language question** (if the doc states one) in the `prompt-seed` — it is the best retrieval key for future questions.
 
-**Concurrency rule:** issue at most **3** `task` calls per batch (3 tool calls in one message), wait for the batch to return, then start the next batch. Set the domain's todo to `in_progress` when you launch it and `completed` when it returns. Tell the user (briefly) how many domains were dropped if you cap anything.
+**Concurrency rule:** issue at most **3** `task` calls per batch (3 tool calls in one message), wait for the batch to return, then start the next batch. If Step 1 created todos, set the domain's todo to `in_progress` when you launch it and `completed` when it returns. Tell the user (briefly) how many domains were dropped if you cap anything.
 
 ---
 
@@ -131,7 +131,7 @@ Once the user confirms or corrects the manifest (or immediately, in the same tur
      - knowledge → run `extract-knowledge` in **lite** mode (do NOT trigger its deep blind-SQL flow); pass the **source (the SQL/doc/table) and the specific fact to mine**, plus the datasource it applies to. Only mine atoms `/init` did not already file — do not duplicate existing `./knowledge/*.md` entries.
 3. **Ordering:** metrics build on semantic models — generate all `semantic_models` items **before** their dependent `metrics` items.
 4. **Dual-route every `(question, SQL)` pair that appears as a `knowledge` row in the manifest — this is required, not optional.** For each such pair: (a) send it to `gen_sql_summary` so the example (with its original question) lands in `reference_sql`, AND (b) feed the same pair to `extract-knowledge` (lite) to mine the non-inferable rule. The example teaches *answer shape* (retrieved later for few-shot); the mined atom teaches *why* (encodings, mandatory filters, term→column mappings). One source, two stores — neither replaces the other. Mine knowledge ONLY for pairs listed as `knowledge` rows in the manifest — whether the user confirmed them, or auto-run carried the manifest through unconfirmed (see Turn Boundary).
-5. **Concurrency ≤ 3:** dispatch heavy `task` calls in batches of at most 3, waiting for each batch. Update each item's todo (`in_progress` → `completed` / `failed`) as you go.
+5. **Concurrency ≤ 3:** dispatch heavy `task` calls in batches of at most 3, waiting for each batch. Do **NOT** create or update todos in this step — the confirmed manifest is the item-level record; narrate per-batch progress briefly and list any failed items in the closing summary.
 
 Do not hand-write semantic_models / metrics / reference_sql YAML yourself — always go through the matching subagent (per storage-classify's Forbidden rules).
 

--- a/datus/resources/skills/init/SKILL.md
+++ b/datus/resources/skills/init/SKILL.md
@@ -6,7 +6,7 @@ tags:
   - workspace
   - project
   - classify
-version: 3.0.0
+version: 3.1.0
 user_invocable: true
 ---
 
@@ -19,7 +19,7 @@ You are initializing a project workspace **lightly**. The goal is a fast, low-co
 
 You **do not** build the vector-indexed stores (`semantic_models`, `metrics`, `reference_sql`) here — those cost tokens, fan out `explore` subagents, and write LanceDB, so they are out of scope for this lightweight pass. There is **no confirmation gate** in this skill: knowledge/memory/AGENTS.md are cheap markdown writes, so just do them.
 
-You run in the main agent context, so you may call `todo_write`/`todo_list`/`todo_read`/`todo_update`, `add_memory`/`edit_memory`, the filesystem tools (`glob`, `grep`, `read_file`, `write_file`, `edit_file`), the database tools (`list_databases`, `list_tables`, `describe_table`, `get_table_ddl`, `search_table`, `execute_sql` for read-only `SELECT` / `SHOW` / `EXPLAIN` probes only), and `load_skill` (to run `extract-knowledge` lite and consult `storage-classify`).
+You run in the main agent context, so you may call `add_memory`/`edit_memory`, the filesystem tools (`glob`, `grep`, `read_file`, `write_file`, `edit_file`), the database tools (`list_databases`, `list_tables`, `describe_table`, `get_table_ddl`, `search_table`, `execute_sql` for read-only `SELECT` / `SHOW` / `EXPLAIN` probes only), and `load_skill` (to run `extract-knowledge` lite and consult `storage-classify`). Do **NOT** use the todo tools (`todo_write` / `todo_update` / `todo_list` / `todo_read`): this is a single-pass, single-turn skill with no subagent fan-out — no later step consumes todos, so writing them only adds sidebar noise.
 
 **Routing authority is `storage-classify`.** This skill decides *what to scan*; for which content lands in `knowledge` vs `memory` vs `AGENTS.md`, follow `storage-classify`'s decision tree (branches 1, 5, 6) — do not re-invent routing here.
 
@@ -53,7 +53,7 @@ Gather the raw material **inside the resolved scope**, then classify it into a *
 
 **Classify** every in-scope file and table into the domain taxonomy. A single domain may contain both files and tables.
 
-**Record with todos when the taxonomy is large (> 3 domains):** call `todo_write` with one todo per domain — `title` = domain name (≤ 8 words), `content` = the files + tables it covers. Skip todos for small projects (≤ 3 domains) to avoid noise.
+Keep the taxonomy in your working context — do **not** record it with todos (see the tool note above); no later step reads them.
 
 ---
 


### PR DESCRIPTION
## Why

The `/init` and `/build-kb` skills over-use the session todo tools, cluttering the sidebar with todo lists on nearly every run:

- `/init` instructed writing one todo per domain whenever the taxonomy exceeded 3 domains, but no later step reads or updates them — in a single-pass, single-turn skill with no subagent fan-out they are write-only noise, left `pending` forever.
- `/build-kb` created per-domain todos in Step 1, then Step 3 said "update **each item's** todo" where the items are Generation Manifest rows that never had todos — nudging the model to `todo_write` a second wave of per-item todos. Since `todo_write` is append-only and session-persisted, running `/init` then `/build-kb` in one session stacks both waves.
- The "> 3 domains" threshold triggers on almost any real project, so the "skip for small scopes" escape hatch rarely applied.

## Solution

Prompt-only changes to the two bundled SKILL.md files:

- **init (v3.0.0 → 3.1.0)**: removed the todo tools from the allowed-tool inventory and added an explicit "do NOT use the todo tools" note with the rationale; replaced the Step 1 "record with todos" rule with "keep the taxonomy in your working context".
- **build-kb (v1.0.0 → 1.1.0)**: todos are now created only when Step 2 will fan out **more than one** `explore` subagent, via a **single** `todo_write` at domain granularity; Step 2 status updates are guarded on the list existing; Step 3 explicitly forbids creating or updating todos — the confirmed manifest is the item-level record, with per-batch progress narrated and failures listed in the closing summary.

Net effect: `/init` never touches todos; `/build-kb` writes at most one domain-level list, only when there is real parallel exploration to track.

## Test Cases

None added — this changes only prompt text in two bundled SKILL.md files; no code path changed. Existing skill-registry / CLI unit tests (254) pass. `ci/run-pr-tests.py` against `datus/main`: 208/209 passed with 100% diff coverage; the single failure (`tests/integration/storage/test_doc_search.py::test_delete_docs_by_version`) is a pre-existing local LanceDB encoding-version panic that also fails on the clean base commit.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the knowledge-base building workflow to track progress only when multiple exploration tasks are dispatched.
  * Improved concurrency guidance, including clearer handling of capped or dropped exploration tasks.
  * Simplified batch progress reporting by removing per-item todo updates.
  * Updated initialization guidance to prohibit todo tools and keep domain taxonomies in working context.
  * Revised skill metadata versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->