### PR TITLE
[BugFix] Deliver @-context to all subagents + replay it in chat history

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -33,7 +33,6 @@ from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.base import BaseInput, BaseResult
 from datus.utils.exceptions import DatusException, ErrorCode
-from datus.utils.json_utils import to_str
 from datus.utils.loggings import get_logger
 from datus.utils.message_utils import build_structured_content
 from datus.utils.node_utils import build_database_context
@@ -851,27 +850,68 @@ class AgenticNode(Node):
 
         ext_know = getattr(user_input, "external_knowledge", "") or ""
         if ext_know:
-            parts.append(f"MUST use these business logic:\n{ext_know}")
+            parts.append(f"## Business knowledge\nMUST apply the following business logic:\n{ext_know}")
 
         schemas = getattr(user_input, "schemas", None)
         if schemas:
             from datus.schemas.node_models import TableSchema
 
-            table_names_str = TableSchema.table_names_to_prompt(schemas)
-            parts.append(
-                "Available tables (MUST use these tables and ONLY use these "
-                f"table names in FROM/JOIN clauses): \n{table_names_str}"
-            )
+            names = TableSchema.table_names_to_prompt(schemas)
+            bullets = "\n".join(f"- {n.strip()}" for n in names.splitlines() if n.strip())
+            parts.append("## Referenced tables\nMUST use ONLY these tables in FROM/JOIN clauses:\n" + bullets)
 
         metrics = getattr(user_input, "metrics", None)
         if metrics:
-            parts.append(f"Metrics: \n{to_str([item.model_dump() for item in metrics])}")
+            lines = []
+            for m in metrics:
+                desc = (getattr(m, "description", "") or "").strip()
+                lines.append(f"- {m.name}: {desc}" if desc else f"- {m.name}")
+            parts.append("## Referenced metrics\n" + "\n".join(lines))
 
         reference_sql = getattr(user_input, "reference_sql", None)
         if reference_sql:
-            parts.append(f"Reference SQL: \n{to_str([item.model_dump() for item in reference_sql])}")
+            blocks = []
+            for r in reference_sql:
+                summary = (getattr(r, "summary", "") or "").strip()
+                sql = (getattr(r, "sql", "") or "").strip()
+                header = f"### {r.name}" + (f" — {summary}" if summary else "")
+                blocks.append(header + (f"\n```sql\n{sql}\n```" if sql else ""))
+            parts.append("## Referenced SQL\n" + "\n\n".join(blocks))
+
+        hint_part = self._render_context_hint_part(getattr(user_input, "context_hints", None))
+        if hint_part:
+            parts.append(hint_part)
 
         return parts
+
+    @staticmethod
+    def _render_context_hint_part(hints: Optional[List[Dict[str, Any]]]) -> str:
+        """Render look-up hints for referenced items that couldn't be pre-loaded.
+
+        Names the item and points the model at the exact tool call so it fetches
+        the detail directly instead of searching the subject tree blindly.
+        """
+        if not hints:
+            return ""
+        tool_by_kind = {"metric": "get_metrics", "reference_sql": "get_reference_sql"}
+        label_by_kind = {"metric": "Metric", "reference_sql": "Reference SQL", "knowledge": "Knowledge"}
+        lines = [
+            "## Referenced items to look up",
+            "The user attached these but their details are not loaded here. Fetch each with the "
+            "indicated tool (using the exact subject_path and name) before answering — do not search blindly:",
+        ]
+        for h in hints:
+            kind = h.get("kind", "")
+            name = h.get("name", "")
+            subject_path = h.get("subject_path", []) or []
+            label = label_by_kind.get(kind, kind or "Item")
+            tool = tool_by_kind.get(kind)
+            if tool:
+                lines.append(f'- {label} "{name}" → call {tool}(subject_path={subject_path}, name="{name}")')
+            else:
+                full = "/".join(list(subject_path) + [name])
+                lines.append(f'- {label} "{name}" (subject path: {full}) → locate it via list_subject_tree')
+        return "\n".join(lines)
 
     def _build_enhanced_message(
         self,

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -47,27 +47,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _maybe_dump_prompt(node_name: str, system_instruction: str, user_prompt: str) -> None:
-    """Append the per-turn system + user prompt to a debug file for inspection.
-
-    Diagnostic only — gated on ``DATUS_PROMPT_DEBUG`` so it is a no-op in normal
-    runs. Set the env var to a file path, or to ``1`` to use the default
-    ``~/.datus/logs/prompt_dump.log``. Never raises.
-    """
-    target = os.environ.get("DATUS_PROMPT_DEBUG")
-    if not target:
-        return
-    try:
-        path = target if target not in ("1", "true", "True") else os.path.expanduser("~/.datus/logs/prompt_dump.log")
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(f"\n{'=' * 80}\n[{datetime.now(timezone.utc).isoformat()}] node={node_name}\n")
-            f.write(f"----- SYSTEM PROMPT -----\n{system_instruction}\n")
-            f.write(f"----- USER PROMPT -----\n{user_prompt}\n")
-    except Exception as exc:  # pragma: no cover - diagnostics must never break a run
-        logger.debug("prompt dump failed: %s", exc)
-
-
 _LANGUAGE_NAME_MAP: Dict[str, str] = {
     "en": "English",
     "zh": "Chinese",
@@ -3155,7 +3134,6 @@ class AgenticNode(Node):
         # argument too late and the first run would execute unwrapped tools.
         self._ensure_tool_transformers()
         self._current_action_history = ctx.action_history_manager
-        _maybe_dump_prompt(self.get_node_name(), ctx.system_instruction, ctx.user_prompt)
         try:
             async for stream_action in self.model.generate_with_tools_stream(
                 prompt=ctx.user_prompt,

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -862,19 +862,41 @@ class AgenticNode(Node):
 
         metrics = getattr(user_input, "metrics", None)
         if metrics:
-            lines = []
+            blocks = []
             for m in metrics:
+                subject_path = getattr(m, "subject_path", []) or []
+                header = f"### {m.name}"
+                if subject_path:
+                    header += f"  (subject_path: {'/'.join(subject_path)})"
+                lines = [header]
                 desc = (getattr(m, "description", "") or "").strip()
-                lines.append(f"- {m.name}: {desc}" if desc else f"- {m.name}")
-            parts.append("## Referenced metrics\n" + "\n".join(lines))
+                if desc:
+                    lines.append(desc)
+                meta = []
+                metric_type = (getattr(m, "metric_type", "") or "").strip()
+                measure_expr = (getattr(m, "measure_expr", "") or "").strip()
+                dimensions = getattr(m, "dimensions", []) or []
+                if metric_type:
+                    meta.append(f"type: {metric_type}")
+                if measure_expr:
+                    meta.append(f"measure: {measure_expr}")
+                if dimensions:
+                    meta.append(f"dimensions: {', '.join(dimensions)}")
+                if meta:
+                    lines.append(" · ".join(meta))
+                blocks.append("\n".join(lines))
+            parts.append("## Referenced metrics\n" + "\n\n".join(blocks))
 
         reference_sql = getattr(user_input, "reference_sql", None)
         if reference_sql:
             blocks = []
             for r in reference_sql:
                 summary = (getattr(r, "summary", "") or "").strip()
-                sql = (getattr(r, "sql", "") or "").strip()
+                subject_path = getattr(r, "subject_path", []) or []
                 header = f"### {r.name}" + (f" — {summary}" if summary else "")
+                if subject_path:
+                    header += f"  (subject_path: {'/'.join(subject_path)})"
+                sql = (getattr(r, "sql", "") or "").strip()
                 blocks.append(header + (f"\n```sql\n{sql}\n```" if sql else ""))
             parts.append("## Referenced SQL\n" + "\n\n".join(blocks))
 

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -48,6 +48,27 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _maybe_dump_prompt(node_name: str, system_instruction: str, user_prompt: str) -> None:
+    """Append the per-turn system + user prompt to a debug file for inspection.
+
+    Diagnostic only — gated on ``DATUS_PROMPT_DEBUG`` so it is a no-op in normal
+    runs. Set the env var to a file path, or to ``1`` to use the default
+    ``~/.datus/logs/prompt_dump.log``. Never raises.
+    """
+    target = os.environ.get("DATUS_PROMPT_DEBUG")
+    if not target:
+        return
+    try:
+        path = target if target not in ("1", "true", "True") else os.path.expanduser("~/.datus/logs/prompt_dump.log")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(f"\n{'=' * 80}\n[{datetime.now(timezone.utc).isoformat()}] node={node_name}\n")
+            f.write(f"----- SYSTEM PROMPT -----\n{system_instruction}\n")
+            f.write(f"----- USER PROMPT -----\n{user_prompt}\n")
+    except Exception as exc:  # pragma: no cover - diagnostics must never break a run
+        logger.debug("prompt dump failed: %s", exc)
+
+
 _LANGUAGE_NAME_MAP: Dict[str, str] = {
     "en": "English",
     "zh": "Chinese",
@@ -3072,6 +3093,7 @@ class AgenticNode(Node):
         # argument too late and the first run would execute unwrapped tools.
         self._ensure_tool_transformers()
         self._current_action_history = ctx.action_history_manager
+        _maybe_dump_prompt(self.get_node_name(), ctx.system_instruction, ctx.user_prompt)
         try:
             async for stream_action in self.model.generate_with_tools_stream(
                 prompt=ctx.user_prompt,

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -815,6 +815,43 @@ class AgenticNode(Node):
 
         return {key: value for key, value in context.items() if value}
 
+    def _render_at_context_parts(self, user_input: Any) -> List[str]:
+        """Render resolved @-referenced context as ordered prompt parts.
+
+        Single source of truth for surfacing @Knowledge / @Table / @Metric /
+        @Sql references to the LLM. Shared by :meth:`_build_enhanced_message`
+        and the deliverable / visual-artifact overrides so a new reference kind
+        is rendered everywhere by editing this one method. Reads every field
+        via ``getattr`` — inputs that don't declare a field (or don't inherit
+        :class:`~datus.schemas.at_context.AtContextInput`) simply contribute
+        nothing.
+        """
+        parts: List[str] = []
+
+        ext_know = getattr(user_input, "external_knowledge", "") or ""
+        if ext_know:
+            parts.append(f"MUST use these business logic:\n{ext_know}")
+
+        schemas = getattr(user_input, "schemas", None)
+        if schemas:
+            from datus.schemas.node_models import TableSchema
+
+            table_names_str = TableSchema.table_names_to_prompt(schemas)
+            parts.append(
+                "Available tables (MUST use these tables and ONLY use these "
+                f"table names in FROM/JOIN clauses): \n{table_names_str}"
+            )
+
+        metrics = getattr(user_input, "metrics", None)
+        if metrics:
+            parts.append(f"Metrics: \n{to_str([item.model_dump() for item in metrics])}")
+
+        reference_sql = getattr(user_input, "reference_sql", None)
+        if reference_sql:
+            parts.append(f"Reference SQL: \n{to_str([item.model_dump() for item in reference_sql])}")
+
+        return parts
+
     def _build_enhanced_message(
         self,
         user_input: Any,
@@ -863,10 +900,6 @@ class AgenticNode(Node):
         if datasource_reminder:
             enhanced_parts.append(datasource_reminder)
 
-        ext_know = getattr(user_input, "external_knowledge", "") or ""
-        if ext_know:
-            enhanced_parts.append(f"MUST use these business logic:\n{ext_know}")
-
         db_type = getattr(self.agent_config, "db_type", "") if self.agent_config else ""
         if db_type and not datasource_reminder:
             # Always resolve empty database via the connector default — the
@@ -890,23 +923,7 @@ class AgenticNode(Node):
             if ctx:
                 enhanced_parts.append(ctx)
 
-        schemas = getattr(user_input, "schemas", None)
-        if schemas:
-            from datus.schemas.node_models import TableSchema
-
-            table_names_str = TableSchema.table_names_to_prompt(schemas)
-            enhanced_parts.append(
-                "Available tables (MUST use these tables and ONLY use these "
-                f"table names in FROM/JOIN clauses): \n{table_names_str}"
-            )
-
-        metrics = getattr(user_input, "metrics", None)
-        if metrics:
-            enhanced_parts.append(f"Metrics: \n{to_str([item.model_dump() for item in metrics])}")
-
-        reference_sql = getattr(user_input, "reference_sql", None)
-        if reference_sql:
-            enhanced_parts.append(f"Reference SQL: \n{to_str([item.model_dump() for item in reference_sql])}")
+        enhanced_parts.extend(self._render_at_context_parts(user_input))
 
         if extra_enhanced_parts:
             enhanced_parts.extend(p for p in extra_enhanced_parts if p)

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -50,7 +50,6 @@ from datus.tools.func_tool._visual_artifact_helpers import (
 )
 from datus.tools.func_tool.semantic_tools import SemanticTools
 from datus.utils.loggings import get_logger
-from datus.utils.message_utils import build_structured_content
 
 logger = get_logger(__name__)
 
@@ -390,6 +389,14 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         return self._finalize_system_prompt(base_prompt)
 
     def _build_enhanced_message(self, user_input: InputT) -> str:
+        """Enrich the user message with catalog/db/schema + @-referenced context.
+
+        Visual-artifact nodes keep a focused override (they don't run the base
+        plan-mode flow); @Table/@Metric/@Sql/@Knowledge references are rendered
+        through the shared :meth:`AgenticNode._render_at_context_parts`.
+        """
+        from datus.utils.message_utils import build_structured_content
+
         parts: List[str] = []
         catalog = getattr(user_input, "catalog", None)
         database = getattr(user_input, "database", None)
@@ -402,6 +409,8 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             parts.append(f"Database context: {database}")
         if db_schema:
             parts.append(f"Schema: {db_schema}")
+
+        parts.extend(self._render_at_context_parts(user_input))
 
         if parts:
             return build_structured_content("\n".join(parts), user_message)

--- a/datus/agent/node/deliverable_node.py
+++ b/datus/agent/node/deliverable_node.py
@@ -27,7 +27,6 @@ from datus.schemas.semantic_agentic_node_models import SemanticNodeResult
 from datus.tools.func_tool import DBFuncTool, FilesystemFuncTool
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
-from datus.utils.message_utils import build_structured_content
 from datus.validation import ValidationHook
 from datus.validation.report import build_retry_prompt
 
@@ -411,11 +410,16 @@ class DeliverableAgenticNode(AgenticNode):
         )
 
     def _build_enhanced_message(self, user_input: Any) -> str:
-        """Enrich the user message with catalog / database / schema context.
+        """Enrich the user message with datasource + @-referenced context.
 
-        Uses ``getattr`` so subclasses with narrower Input schemas (e.g.
-        ``GenDashboardNodeInput`` omits ``catalog`` / ``db_schema``) still work.
+        Renders catalog / database / schema context (deliverable nodes don't
+        run the base plan-mode flow, so this stays a focused override) and
+        appends any @Table/@Metric/@Sql/@Knowledge references via the shared
+        :meth:`AgenticNode._render_at_context_parts`. ``getattr`` keeps it safe
+        for subclasses with narrower Input schemas (e.g. ``GenDashboardNodeInput``
+        omits ``catalog`` / ``db_schema``).
         """
+        from datus.utils.message_utils import build_structured_content
         from datus.utils.node_utils import resolve_database_name_for_prompt
 
         enhanced_parts = []
@@ -444,6 +448,8 @@ class DeliverableAgenticNode(AgenticNode):
                 if db_schema:
                     context_parts.append(f"schema: {db_schema}")
                 enhanced_parts.append(f"Context: {', '.join(context_parts)}")
+
+        enhanced_parts.extend(self._render_at_context_parts(user_input))
 
         if enhanced_parts:
             enhanced_context = "\n\n".join(enhanced_parts)

--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -10,6 +10,8 @@ Used by CLI print mode and interactive REPL to avoid duplicating node creation l
 
 from typing import TYPE_CHECKING, Literal, Optional
 
+from datus.schemas.at_context import apply_at_context
+
 if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
 
@@ -305,11 +307,19 @@ def create_node_input(
     at_tables=None,
     at_metrics=None,
     at_sqls=None,
+    external_knowledge: Optional[str] = None,
     prompt_language: str = "en",
     plan_mode: bool = False,
     source_session_id: Optional[str] = None,
 ):
-    """Create node input based on node type.
+    """Create node input for *node*, then attach resolved @-context uniformly.
+
+    The type dispatch lives in :func:`_build_typed_node_input`; @-context
+    (``at_tables`` / ``at_metrics`` / ``at_sqls`` / ``external_knowledge``) is
+    applied here through the single :func:`apply_at_context` choke point so no
+    per-node branch can forget it. Any input inheriting
+    :class:`~datus.schemas.at_context.AtContextInput` picks the context up;
+    others are skipped silently.
 
     Args:
         user_message: The user's message.
@@ -320,11 +330,44 @@ def create_node_input(
         at_tables: @-referenced tables.
         at_metrics: @-referenced metrics.
         at_sqls: @-referenced SQL queries.
+        external_knowledge: @-referenced supplementary knowledge text.
         prompt_language: Language for prompts (default "en").
         plan_mode: Whether to enable plan mode.
         source_session_id: Source session the feedback node should copy from.
             Only consumed by :class:`FeedbackAgenticNode`.
     """
+    node_input = _build_typed_node_input(
+        user_message=user_message,
+        node=node,
+        catalog=catalog,
+        database=database,
+        db_schema=db_schema,
+        scoped_tables=scoped_tables,
+        prompt_language=prompt_language,
+        plan_mode=plan_mode,
+        source_session_id=source_session_id,
+    )
+    return apply_at_context(
+        node_input,
+        schemas=at_tables,
+        metrics=at_metrics,
+        reference_sql=at_sqls,
+        external_knowledge=external_knowledge,
+    )
+
+
+def _build_typed_node_input(
+    user_message: str,
+    node,
+    catalog: Optional[str] = None,
+    database: Optional[str] = None,
+    db_schema: Optional[str] = None,
+    scoped_tables=None,
+    prompt_language: str = "en",
+    plan_mode: bool = False,
+    source_session_id: Optional[str] = None,
+):
+    """Construct the node-type-specific input object (no @-context wiring)."""
     from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
     from datus.agent.node.gen_job_agentic_node import GenJobAgenticNode
     from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
@@ -414,9 +457,6 @@ def create_node_input(
             catalog=catalog,
             database=database,
             db_schema=db_schema,
-            schemas=at_tables,
-            metrics=at_metrics,
-            reference_sql=at_sqls,
             prompt_language=prompt_language,
             plan_mode=plan_mode,
         )
@@ -466,9 +506,6 @@ def create_node_input(
             catalog=catalog,
             database=database,
             db_schema=db_schema,
-            schemas=at_tables,
-            metrics=at_metrics,
-            reference_sql=at_sqls,
             plan_mode=plan_mode,
         )
 

--- a/datus/agent/node/node_factory.py
+++ b/datus/agent/node/node_factory.py
@@ -308,6 +308,7 @@ def create_node_input(
     at_metrics=None,
     at_sqls=None,
     external_knowledge: Optional[str] = None,
+    context_hints=None,
     prompt_language: str = "en",
     plan_mode: bool = False,
     source_session_id: Optional[str] = None,
@@ -353,6 +354,7 @@ def create_node_input(
         metrics=at_metrics,
         reference_sql=at_sqls,
         external_knowledge=external_knowledge,
+        context_hints=context_hints,
     )
 
 

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -491,6 +491,21 @@ class IUpdateMessagePayload(BaseModel):
 
 
 # SSE Event Data Models
+class AtContextData(BaseModel):
+    """@-referenced context attached to a user message (path identifiers only).
+
+    Mirrors the request's ``*_paths`` fields. Populated by the history API for
+    user messages so the front-end can re-render the referenced tables /
+    metrics / SQL / knowledge as read-only chips. Empty lists when a turn
+    carried no references of that kind.
+    """
+
+    table_paths: List[str] = Field(default_factory=list, description="@Table path identifiers")
+    metric_paths: List[str] = Field(default_factory=list, description="@Metrics path identifiers")
+    sql_paths: List[str] = Field(default_factory=list, description="@Sql path identifiers")
+    knowledge_paths: List[str] = Field(default_factory=list, description="@Knowledge path identifiers")
+
+
 class SSEMessagePayload(BaseModel):
     """Payload for SSE message events."""
 
@@ -499,6 +514,9 @@ class SSEMessagePayload(BaseModel):
     content: List[IMessageContent] = Field(default_factory=list, description="Message content list")
     depth: int = Field(default=0, description="Nesting depth (0=main, 1=sub-agent)")
     parent_action_id: Optional[str] = Field(default=None, description="Parent action ID for sub-agent grouping")
+    at_context: Optional[AtContextData] = Field(
+        default=None, description="@-referenced context for a user message (history replay only)"
+    )
 
 
 class SSEMessageData(BaseModel):

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -12,6 +12,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 from datus.agent.node.chat_agentic_node import ChatAgenticNode
 from datus.api.models.base_models import Result
 from datus.api.models.cli_models import (
+    AtContextData,
     ChatHistoryData,
     ChatSessionData,
     ChatSessionItemInfo,
@@ -250,11 +251,21 @@ class ChatService:
                 if role == "user":
                     content = msg.get("content", "")
                     if content:
+                        at_ctx_raw = msg.get("at_context")
+                        at_context = None
+                        if isinstance(at_ctx_raw, dict):
+                            at_context = AtContextData(
+                                table_paths=at_ctx_raw.get("table_paths") or [],
+                                metric_paths=at_ctx_raw.get("metric_paths") or [],
+                                sql_paths=at_ctx_raw.get("sql_paths") or [],
+                                knowledge_paths=at_ctx_raw.get("knowledge_paths") or [],
+                            )
                         sse_messages.append(
                             SSEMessagePayload(
                                 message_id=str(uuid.uuid4()),
                                 role="user",
                                 content=[IMessageContent(type="markdown", payload={"content": content})],
+                                at_context=at_context,
                             )
                         )
                         event_id += 1

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1103,6 +1103,17 @@ class ChatTaskManager:
         return candidates[0] if len(candidates) == 1 else None
 
     @staticmethod
+    def _none_to_empty(detail: Dict[str, Any]) -> Dict[str, Any]:
+        """Coerce ``None`` values to ``""`` for typed-model construction.
+
+        The path-scoped store returns optional string columns as ``None`` (e.g.
+        a reference SQL with no ``comment`` / ``tags``), but Metric / ReferenceSql
+        declare those as ``str``; ``from_dict``'s ``.get(k, "")`` doesn't catch a
+        present-but-None value, so normalise here.
+        """
+        return {k: ("" if v is None else v) for k, v in detail.items()}
+
+    @staticmethod
     def _split_subject_path(path: str) -> tuple[List[str], str]:
         """Split a subject-tree ref path into ``(subject_path, name)``.
 
@@ -1223,7 +1234,7 @@ class ChatTaskManager:
                 subject_path, name = self._split_subject_path(path)
                 details = rag.get_metrics_detail(subject_path=subject_path, name=name) if name else []
                 if details:
-                    metrics.append(Metric.from_dict(details[0]))
+                    metrics.append(Metric.from_dict(self._none_to_empty(details[0])))
                 else:
                     logger.warning("Unresolved @Metric path '%s'", path)
             except Exception as e:
@@ -1246,7 +1257,7 @@ class ChatTaskManager:
                 subject_path, name = self._split_subject_path(path)
                 details = store.get_reference_sql_detail(subject_path=subject_path, name=name) if name else []
                 if details:
-                    sqls.append(ReferenceSql.from_dict(details[0]))
+                    sqls.append(ReferenceSql.from_dict(self._none_to_empty(details[0])))
                 else:
                     logger.warning("Unresolved @Sql path '%s'", path)
             except Exception as e:

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1154,11 +1154,24 @@ class ChatTaskManager:
         tools use — deliberately NOT the completer's vector search, which is empty
         until the KB is vectorised (and is slated for removal).
         """
-        return (
-            self._resolve_table_paths(agent_config, table_paths),
-            self._resolve_metric_paths(agent_config, metric_paths),
-            self._resolve_sql_paths(agent_config, sql_paths),
+        logger.info(
+            "AT-CONTEXT resolving: table_paths=%s metric_paths=%s sql_paths=%s (project=%s, datasource=%s)",
+            table_paths,
+            metric_paths,
+            sql_paths,
+            getattr(agent_config, "project_name", None),
+            getattr(agent_config, "current_datasource", None),
         )
+        tables = self._resolve_table_paths(agent_config, table_paths)
+        metrics = self._resolve_metric_paths(agent_config, metric_paths)
+        sqls = self._resolve_sql_paths(agent_config, sql_paths)
+        logger.info(
+            "AT-CONTEXT resolved: tables=%s metrics=%s sqls=%s",
+            [t.table_name for t in tables],
+            [m.name for m in metrics],
+            [s.name for s in sqls],
+        )
+        return tables, metrics, sqls
 
     def _resolve_table_paths(self, agent_config: AgentConfig, table_paths: Optional[List[str]]) -> List[TableSchema]:
         tables: List[TableSchema] = []

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1270,7 +1270,11 @@ class ChatTaskManager:
             try:
                 details = rag.get_metrics_detail(subject_path=subject_path, name=name) if rag else []
                 if details:
-                    metrics.append(Metric.from_dict(self._none_to_empty(details[0])))
+                    metric = Metric.from_dict(self._none_to_empty(details[0]))
+                    # Authoritative subject_path from the picked path (the store row
+                    # may omit it), so the prompt can name where the metric lives.
+                    metric.subject_path = subject_path
+                    metrics.append(metric)
                     continue
                 logger.warning("Unresolved @Metric path '%s'; emitting look-up hint", path)
             except Exception as e:
@@ -1299,7 +1303,9 @@ class ChatTaskManager:
             try:
                 details = store.get_reference_sql_detail(subject_path=subject_path, name=name) if store else []
                 if details:
-                    sqls.append(ReferenceSql.from_dict(self._none_to_empty(details[0])))
+                    ref = ReferenceSql.from_dict(self._none_to_empty(details[0]))
+                    ref.subject_path = subject_path
+                    sqls.append(ref)
                     continue
                 logger.warning("Unresolved @Sql path '%s'; emitting look-up hint", path)
             except Exception as e:

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -710,6 +710,11 @@ class ChatTaskManager:
                     if action.role == ActionRole.TOOL and action.status != ActionStatus.PROCESSING:
                         tool_result_seen = True
 
+            # 6.5 Persist this turn's @-context (table/metric/sql/knowledge refs)
+            # so the history API can re-render them. Best-effort and off the
+            # event loop; must never fail the turn.
+            await asyncio.to_thread(self._persist_turn_at_context, agent_config, session_id, request, user_id)
+
             # 7. End event
             token_kwargs: dict = {}
             try:
@@ -779,6 +784,41 @@ class ChatTaskManager:
             # Keep completed task for resume within TTL
             self._completed_tasks[session_id] = task
             self._purge_expired_completed()
+
+    def _persist_turn_at_context(
+        self,
+        agent_config: AgentConfig,
+        session_id: str,
+        request: StreamChatInput,
+        user_id: Optional[str],
+    ) -> None:
+        """Persist the just-completed turn's @-references to the session side table.
+
+        Stores the raw request path identifiers (not the resolved objects) so
+        :meth:`ChatService.get_history` can echo them back for front-end display.
+        No-op when the turn carried no references; failures are swallowed.
+        """
+        context: Dict[str, Any] = {}
+        if request.table_paths:
+            context["table_paths"] = list(request.table_paths)
+        if request.metric_paths:
+            context["metric_paths"] = list(request.metric_paths)
+        if request.sql_paths:
+            context["sql_paths"] = list(request.sql_paths)
+        if request.knowledge_paths:
+            context["knowledge_paths"] = list(request.knowledge_paths)
+        if not context:
+            return
+        try:
+            from datus.models.session_manager import SessionManager
+            from datus.utils.path_manager import get_path_manager
+
+            base_dir = getattr(agent_config, "session_dir", None) or str(
+                get_path_manager(agent_config=agent_config).sessions_dir
+            )
+            SessionManager(session_dir=base_dir, scope=user_id).save_user_message_context(session_id, context)
+        except Exception:
+            logger.debug("Failed to persist turn @-context for session %s", session_id, exc_info=True)
 
     async def _push_event(self, task: ChatTask, event: SSEEvent) -> None:
         """Append an event to the task buffer and notify consumers."""

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -579,12 +579,13 @@ class ChatTaskManager:
             # creation): the metric/reference-sql stores use blocking psycopg
             # connections that must not be driven from the event-loop thread —
             # doing so corrupts the pooled connection ("the connection is lost").
-            at_tables, at_metrics, at_sqls = await asyncio.to_thread(
+            at_tables, at_metrics, at_sqls, at_hints = await asyncio.to_thread(
                 self._resolve_at_context,
                 agent_config,
                 request.table_paths,
                 request.metric_paths,
                 request.sql_paths,
+                request.knowledge_paths,
             )
 
             # 4. Build typed input and assign to node
@@ -594,6 +595,7 @@ class ChatTaskManager:
                 at_tables=at_tables,
                 at_metrics=at_metrics,
                 at_sqls=at_sqls,
+                at_hints=at_hints,
                 catalog=request.catalog,
                 database=request.database,
                 db_schema=request.db_schema,
@@ -1008,6 +1010,7 @@ class ChatTaskManager:
         at_tables: List[TableSchema],
         at_metrics: List[Metric],
         at_sqls: List[ReferenceSql],
+        at_hints: Optional[List[Dict[str, Any]]] = None,
         catalog: Optional[str] = None,
         database: Optional[str] = None,
         db_schema: Optional[str] = None,
@@ -1042,6 +1045,7 @@ class ChatTaskManager:
             at_tables=at_tables,
             at_metrics=at_metrics,
             at_sqls=at_sqls,
+            context_hints=at_hints,
             prompt_language="en",
             plan_mode=plan_mode,
             source_session_id=source_session_id,
@@ -1163,33 +1167,53 @@ class ChatTaskManager:
         table_paths: Optional[List[str]],
         metric_paths: Optional[List[str]],
         sql_paths: Optional[List[str]],
-    ) -> tuple[List[TableSchema], List[Metric], List[ReferenceSql]]:
-        """Resolve @-reference paths to typed objects.
+        knowledge_paths: Optional[List[str]] = None,
+    ) -> tuple[List[TableSchema], List[Metric], List[ReferenceSql], List[Dict[str, Any]]]:
+        """Resolve @-reference paths to typed objects (+ look-up hints).
 
         Tables come from the schema-metadata completer with a name-only fallback.
         Metrics and reference SQL are resolved by EXACT subject path via the same
         non-vector, path-scoped store lookup the get_metrics / get_reference_sql
         tools use — deliberately NOT the completer's vector search, which is empty
         until the KB is vectorised (and is slated for removal).
+
+        Anything that can't be pre-loaded (a metric/sql that didn't resolve, and
+        every @Knowledge ref, which has no store loader) becomes a ``hint`` —
+        ``{kind, name, subject_path}`` — so the prompt can still name it and tell
+        the model which tool to call, instead of dropping it and forcing a blind
+        search.
         """
         logger.info(
-            "AT-CONTEXT resolving: table_paths=%s metric_paths=%s sql_paths=%s (project=%s, datasource=%s)",
+            "AT-CONTEXT resolving: table_paths=%s metric_paths=%s sql_paths=%s knowledge_paths=%s "
+            "(project=%s, datasource=%s)",
             table_paths,
             metric_paths,
             sql_paths,
+            knowledge_paths,
             getattr(agent_config, "project_name", None),
             getattr(agent_config, "current_datasource", None),
         )
         tables = self._resolve_table_paths(agent_config, table_paths)
-        metrics = self._resolve_metric_paths(agent_config, metric_paths)
-        sqls = self._resolve_sql_paths(agent_config, sql_paths)
+        metrics, metric_hints = self._resolve_metric_paths(agent_config, metric_paths)
+        sqls, sql_hints = self._resolve_sql_paths(agent_config, sql_paths)
+        hints = metric_hints + sql_hints + self._knowledge_hints(knowledge_paths)
         logger.info(
-            "AT-CONTEXT resolved: tables=%s metrics=%s sqls=%s",
+            "AT-CONTEXT resolved: tables=%s metrics=%s sqls=%s hints=%s",
             [t.table_name for t in tables],
             [m.name for m in metrics],
             [s.name for s in sqls],
+            [f"{h['kind']}:{h['name']}" for h in hints],
         )
-        return tables, metrics, sqls
+        return tables, metrics, sqls, hints
+
+    def _knowledge_hints(self, knowledge_paths: Optional[List[str]]) -> List[Dict[str, Any]]:
+        """@Knowledge has no store loader yet — surface every ref as a hint."""
+        hints: List[Dict[str, Any]] = []
+        for path in knowledge_paths or []:
+            subject_path, name = self._split_subject_path(path)
+            if name:
+                hints.append({"kind": "knowledge", "name": name, "subject_path": subject_path})
+        return hints
 
     def _resolve_table_paths(self, agent_config: AgentConfig, table_paths: Optional[List[str]]) -> List[TableSchema]:
         tables: List[TableSchema] = []
@@ -1225,48 +1249,60 @@ class ChatTaskManager:
                 logger.warning(f"Failed to resolve table path '{path}': {e}")
         return tables
 
-    def _resolve_metric_paths(self, agent_config: AgentConfig, metric_paths: Optional[List[str]]) -> List[Metric]:
+    def _resolve_metric_paths(
+        self, agent_config: AgentConfig, metric_paths: Optional[List[str]]
+    ) -> tuple[List[Metric], List[Dict[str, Any]]]:
         metrics: List[Metric] = []
+        hints: List[Dict[str, Any]] = []
         if not metric_paths:
-            return metrics
+            return metrics, hints
         try:
             from datus.storage.metric.store import MetricRAG
 
             rag = MetricRAG(agent_config)
         except Exception as exc:
-            logger.warning("MetricRAG unavailable; skipping @Metric resolution: %s", exc)
-            return metrics
+            logger.warning("MetricRAG unavailable; emitting @Metric look-up hints: %s", exc)
+            rag = None
         for path in metric_paths:
+            subject_path, name = self._split_subject_path(path)
+            if not name:
+                continue
             try:
-                subject_path, name = self._split_subject_path(path)
-                details = rag.get_metrics_detail(subject_path=subject_path, name=name) if name else []
+                details = rag.get_metrics_detail(subject_path=subject_path, name=name) if rag else []
                 if details:
                     metrics.append(Metric.from_dict(self._none_to_empty(details[0])))
-                else:
-                    logger.warning("Unresolved @Metric path '%s'", path)
+                    continue
+                logger.warning("Unresolved @Metric path '%s'; emitting look-up hint", path)
             except Exception as e:
-                logger.warning("Failed to resolve metric path '%s': %s", path, e)
-        return metrics
+                logger.warning("Failed to resolve metric path '%s': %s; emitting look-up hint", path, e)
+            hints.append({"kind": "metric", "name": name, "subject_path": subject_path})
+        return metrics, hints
 
-    def _resolve_sql_paths(self, agent_config: AgentConfig, sql_paths: Optional[List[str]]) -> List[ReferenceSql]:
+    def _resolve_sql_paths(
+        self, agent_config: AgentConfig, sql_paths: Optional[List[str]]
+    ) -> tuple[List[ReferenceSql], List[Dict[str, Any]]]:
         sqls: List[ReferenceSql] = []
+        hints: List[Dict[str, Any]] = []
         if not sql_paths:
-            return sqls
+            return sqls, hints
         try:
             from datus.storage.reference_sql.store import ReferenceSqlRAG
 
             store = ReferenceSqlRAG(agent_config)
         except Exception as exc:
-            logger.warning("ReferenceSqlRAG unavailable; skipping @Sql resolution: %s", exc)
-            return sqls
+            logger.warning("ReferenceSqlRAG unavailable; emitting @Sql look-up hints: %s", exc)
+            store = None
         for path in sql_paths:
+            subject_path, name = self._split_subject_path(path)
+            if not name:
+                continue
             try:
-                subject_path, name = self._split_subject_path(path)
-                details = store.get_reference_sql_detail(subject_path=subject_path, name=name) if name else []
+                details = store.get_reference_sql_detail(subject_path=subject_path, name=name) if store else []
                 if details:
                     sqls.append(ReferenceSql.from_dict(self._none_to_empty(details[0])))
-                else:
-                    logger.warning("Unresolved @Sql path '%s'", path)
+                    continue
+                logger.warning("Unresolved @Sql path '%s'; emitting look-up hint", path)
             except Exception as e:
-                logger.warning("Failed to resolve sql path '%s': %s", path, e)
-        return sqls
+                logger.warning("Failed to resolve sql path '%s': %s; emitting look-up hint", path, e)
+            hints.append({"kind": "reference_sql", "name": name, "subject_path": subject_path})
+        return sqls, hints

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -499,6 +499,10 @@ class ChatTaskManager:
         try:
             start_time = datetime.now()
 
+            # Snapshot the turn counter BEFORE the run so the @-context persist
+            # below only fires when this run actually adds a new user turn.
+            pre_turn_number = await asyncio.to_thread(self._max_user_turn_number, agent_config, session_id, user_id)
+
             # 1. Create node.
             #    Runs in thread pool because setup_tools() triggers synchronous
             #    operations (psycopg ConnectionPool creation, PG DDL for table
@@ -713,7 +717,9 @@ class ChatTaskManager:
             # 6.5 Persist this turn's @-context (table/metric/sql/knowledge refs)
             # so the history API can re-render them. Best-effort and off the
             # event loop; must never fail the turn.
-            await asyncio.to_thread(self._persist_turn_at_context, agent_config, session_id, request, user_id)
+            await asyncio.to_thread(
+                self._persist_turn_at_context, agent_config, session_id, request, user_id, pre_turn_number
+            )
 
             # 7. End event
             token_kwargs: dict = {}
@@ -785,17 +791,38 @@ class ChatTaskManager:
             self._completed_tasks[session_id] = task
             self._purge_expired_completed()
 
+    @staticmethod
+    def _session_manager(agent_config: AgentConfig, user_id: Optional[str]):
+        """Build a SessionManager pointed at this run's session dir + scope."""
+        from datus.models.session_manager import SessionManager
+        from datus.utils.path_manager import get_path_manager
+
+        base_dir = getattr(agent_config, "session_dir", None) or str(
+            get_path_manager(agent_config=agent_config).sessions_dir
+        )
+        return SessionManager(session_dir=base_dir, scope=user_id)
+
+    def _max_user_turn_number(self, agent_config: AgentConfig, session_id: str, user_id: Optional[str]) -> int:
+        """Best-effort snapshot of the session's turn counter (0 on any error)."""
+        try:
+            return self._session_manager(agent_config, user_id).get_max_user_turn_number(session_id)
+        except Exception:
+            return 0
+
     def _persist_turn_at_context(
         self,
         agent_config: AgentConfig,
         session_id: str,
         request: StreamChatInput,
         user_id: Optional[str],
+        previous_turn_number: int = -1,
     ) -> None:
         """Persist the just-completed turn's @-references to the session side table.
 
         Stores the raw request path identifiers (not the resolved objects) so
         :meth:`ChatService.get_history` can echo them back for front-end display.
+        ``previous_turn_number`` (captured before the run) gates the write so a
+        run that added no new user turn never mis-attaches to the prior bubble.
         No-op when the turn carried no references; failures are swallowed.
         """
         context: Dict[str, Any] = {}
@@ -810,13 +837,9 @@ class ChatTaskManager:
         if not context:
             return
         try:
-            from datus.models.session_manager import SessionManager
-            from datus.utils.path_manager import get_path_manager
-
-            base_dir = getattr(agent_config, "session_dir", None) or str(
-                get_path_manager(agent_config=agent_config).sessions_dir
+            self._session_manager(agent_config, user_id).save_user_message_context(
+                session_id, context, previous_turn_number=previous_turn_number
             )
-            SessionManager(session_dir=base_dir, scope=user_id).save_user_message_context(session_id, context)
         except Exception:
             logger.debug("Failed to persist turn @-context for session %s", session_id, exc_info=True)
 

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1103,6 +1103,19 @@ class ChatTaskManager:
         return candidates[0] if len(candidates) == 1 else None
 
     @staticmethod
+    def _lookup_subject(flatten: Dict[str, Any], path: str) -> Optional[Dict[str, Any]]:
+        """Resolve a subject-tree ref (metric / reference_sql) tolerating the separator.
+
+        The completer store keys subject paths with ``/`` (``a/b/name``). A web
+        client historically joined them with ``.``; accept either so an
+        older bundle against a newer backend still resolves.
+        """
+        entry = flatten.get(path)
+        if entry is None and "." in path:
+            entry = flatten.get(path.replace(".", "/"))
+        return entry
+
+    @staticmethod
     def _synthesize_table_entry(path: str) -> Optional[Dict[str, Any]]:
         """Build a name-only table entry from a picked path when the store can't resolve it.
 
@@ -1166,18 +1179,22 @@ class ChatTaskManager:
         metrics: List[Metric] = []
         for path in metric_paths or []:
             try:
-                entry = completer.metric_completer.flatten_data.get(path)
+                entry = self._lookup_subject(completer.metric_completer.flatten_data, path)
                 if entry:
                     metrics.append(Metric.from_dict(entry))
+                else:
+                    logger.warning("Unresolved @Metric path '%s'", path)
             except Exception as e:
                 logger.warning(f"Failed to resolve metric path '{path}': {e}")
 
         sqls: List[ReferenceSql] = []
         for path in sql_paths or []:
             try:
-                entry = completer.sql_completer.flatten_data.get(path)
+                entry = self._lookup_subject(completer.sql_completer.flatten_data, path)
                 if entry:
                     sqls.append(ReferenceSql.from_dict(entry))
+                else:
+                    logger.warning("Unresolved @Sql path '%s'", path)
             except Exception as e:
                 logger.warning(f"Failed to resolve sql path '{path}': {e}")
 

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1108,18 +1108,26 @@ class ChatTaskManager:
 
         Order: exact key, then ``.`` -> ``/`` (older web bundles joined subject
         paths with ``.`` while the completer store keys them with ``/``), then a
-        trailing-name match (the picker's subject-path prefix can differ from the
-        store's ``subject_path``). The name match returns a hit only when exactly
-        one entry carries that name, so it never resolves an ambiguous ref.
+        trailing-segment (suffix) match — the picker's subject-path prefix can
+        differ from the store's ``subject_path``, so a query ``b/c`` matches a
+        stored ``a/b/c``. The suffix match uses the full query segment sequence
+        and resolves only when exactly one key ends with it, so given both
+        ``A/b/c`` and ``D/b/c`` a query of ``A/b/c`` hits it exactly while a
+        bare ``b/c`` stays ambiguous and returns None (never a wrong guess).
         """
         entry = flatten.get(path)
         if entry is None and "." in path:
             entry = flatten.get(path.replace(".", "/"))
         if entry is None:
-            want = path.replace(".", "/").rstrip("/").split("/")[-1].strip('"').lower()
-            candidates = [e for e in flatten.values() if str(e.get("name", "")).lower() == want]
-            if len(candidates) == 1:
-                entry = candidates[0]
+            want_segs = [s.strip('"').lower() for s in path.replace(".", "/").split("/") if s.strip()]
+            if want_segs:
+                candidates = [
+                    e
+                    for key, e in flatten.items()
+                    if [s.strip('"').lower() for s in key.split("/") if s.strip()][-len(want_segs) :] == want_segs
+                ]
+                if len(candidates) == 1:
+                    entry = candidates[0]
         return entry
 
     @staticmethod

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -575,9 +575,16 @@ class ChatTaskManager:
             event_id += 1
             event_id = await self._push_degraded_capability_warnings(task, node, event_id)
 
-            # 3. Resolve @-references
-            at_tables, at_metrics, at_sqls = self._resolve_at_context(
-                agent_config, request.table_paths, request.metric_paths, request.sql_paths
+            # 3. Resolve @-references. Run in a worker thread (like node
+            # creation): the metric/reference-sql stores use blocking psycopg
+            # connections that must not be driven from the event-loop thread —
+            # doing so corrupts the pooled connection ("the connection is lost").
+            at_tables, at_metrics, at_sqls = await asyncio.to_thread(
+                self._resolve_at_context,
+                agent_config,
+                request.table_paths,
+                request.metric_paths,
+                request.sql_paths,
             )
 
             # 4. Build typed input and assign to node

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1102,6 +1102,28 @@ class ChatTaskManager:
             candidates.append(entry)
         return candidates[0] if len(candidates) == 1 else None
 
+    @staticmethod
+    def _synthesize_table_entry(path: str) -> Optional[Dict[str, Any]]:
+        """Build a name-only table entry from a picked path when the store can't resolve it.
+
+        Only ``table_name`` is surfaced to the prompt ("Available tables"), so an
+        empty ``definition`` is fine — the node inspects the real DDL via its own
+        ``describe_table``. ``database_name`` is a best-effort guess from the
+        leading segment for display/scoping; it isn't required for resolution.
+        """
+        segs = [s.strip().strip('"') for s in path.split(".") if s.strip()]
+        if not segs:
+            return None
+        return {
+            "identifier": path,
+            "catalog_name": "",
+            "database_name": segs[-2] if len(segs) >= 2 else "",
+            "schema_name": "",
+            "table_name": segs[-1],
+            "table_type": "table",
+            "definition": "",
+        }
+
     def _resolve_at_context(
         self,
         agent_config: AgentConfig,
@@ -1122,15 +1144,22 @@ class ChatTaskManager:
         for path in table_paths or []:
             try:
                 entry = table_flatten.get(path) or self._match_table_entry(table_flatten, path)
-                if entry:
-                    tables.append(TableSchema.from_dict(entry))
-                else:
+                if not entry:
+                    # The @-picker builds table paths from live introspection, so a
+                    # picked table always exists even when the schema-metadata store
+                    # is empty/stale (KB not indexed for this datasource). The prompt
+                    # injection only needs the table NAME (the node's own describe_table
+                    # fetches the DDL), so synthesise a name-only entry rather than
+                    # silently dropping the reference and re-asking the user.
                     logger.warning(
-                        "Unresolved @Table path '%s' (%d indexed tables); sample keys: %s",
+                        "Unresolved @Table path '%s' (%d indexed tables); using name-only reference. Sample keys: %s",
                         path,
                         len(table_flatten),
                         list(table_flatten.keys())[:5],
                     )
+                    entry = self._synthesize_table_entry(path)
+                if entry:
+                    tables.append(TableSchema.from_dict(entry))
             except Exception as e:
                 logger.warning(f"Failed to resolve table path '{path}': {e}")
 

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1104,15 +1104,22 @@ class ChatTaskManager:
 
     @staticmethod
     def _lookup_subject(flatten: Dict[str, Any], path: str) -> Optional[Dict[str, Any]]:
-        """Resolve a subject-tree ref (metric / reference_sql) tolerating the separator.
+        """Resolve a subject-tree ref (metric / reference_sql) resiliently.
 
-        The completer store keys subject paths with ``/`` (``a/b/name``). A web
-        client historically joined them with ``.``; accept either so an
-        older bundle against a newer backend still resolves.
+        Order: exact key, then ``.`` -> ``/`` (older web bundles joined subject
+        paths with ``.`` while the completer store keys them with ``/``), then a
+        trailing-name match (the picker's subject-path prefix can differ from the
+        store's ``subject_path``). The name match returns a hit only when exactly
+        one entry carries that name, so it never resolves an ambiguous ref.
         """
         entry = flatten.get(path)
         if entry is None and "." in path:
             entry = flatten.get(path.replace(".", "/"))
+        if entry is None:
+            want = path.replace(".", "/").rstrip("/").split("/")[-1].strip('"').lower()
+            candidates = [e for e in flatten.values() if str(e.get("name", "")).lower() == want]
+            if len(candidates) == 1:
+                entry = candidates[0]
         return entry
 
     @staticmethod
@@ -1177,24 +1184,36 @@ class ChatTaskManager:
                 logger.warning(f"Failed to resolve table path '{path}': {e}")
 
         metrics: List[Metric] = []
+        metric_flatten = completer.metric_completer.flatten_data
         for path in metric_paths or []:
             try:
-                entry = self._lookup_subject(completer.metric_completer.flatten_data, path)
+                entry = self._lookup_subject(metric_flatten, path)
                 if entry:
                     metrics.append(Metric.from_dict(entry))
                 else:
-                    logger.warning("Unresolved @Metric path '%s'", path)
+                    logger.warning(
+                        "Unresolved @Metric path '%s' (%d indexed metrics); sample keys: %s",
+                        path,
+                        len(metric_flatten),
+                        list(metric_flatten.keys())[:5],
+                    )
             except Exception as e:
                 logger.warning(f"Failed to resolve metric path '{path}': {e}")
 
         sqls: List[ReferenceSql] = []
+        sql_flatten = completer.sql_completer.flatten_data
         for path in sql_paths or []:
             try:
-                entry = self._lookup_subject(completer.sql_completer.flatten_data, path)
+                entry = self._lookup_subject(sql_flatten, path)
                 if entry:
                     sqls.append(ReferenceSql.from_dict(entry))
                 else:
-                    logger.warning("Unresolved @Sql path '%s'", path)
+                    logger.warning(
+                        "Unresolved @Sql path '%s' (%d indexed reference SQL); sample keys: %s",
+                        path,
+                        len(sql_flatten),
+                        list(sql_flatten.keys())[:5],
+                    )
             except Exception as e:
                 logger.warning(f"Failed to resolve sql path '{path}': {e}")
 

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1073,6 +1073,35 @@ class ChatTaskManager:
         )
         return event_id + 1
 
+    @staticmethod
+    def _match_table_entry(flatten: Dict[str, Any], path: str) -> Optional[Dict[str, Any]]:
+        """Best-effort match when the picker's fullName != the metadata-store key.
+
+        The @-picker builds table paths from live introspection (the catalog
+        tree), while the completer indexes the schema-metadata store; the two can
+        differ in catalog presence or schema level (e.g. picker sends
+        ``default_catalog.db.table`` but the store key is ``db.schema.table``).
+        Fall back to matching the trailing components — table name, plus the
+        database when the path carries one. Returns a hit only when exactly one
+        candidate matches, so a genuinely ambiguous name never resolves to the
+        wrong table.
+        """
+        segs = [s.strip().strip('"').lower() for s in path.split(".") if s.strip()]
+        if not segs:
+            return None
+        want_table = segs[-1]
+        want_db = segs[-2] if len(segs) >= 2 else None
+        candidates: List[Dict[str, Any]] = []
+        for entry in flatten.values():
+            if str(entry.get("table_name", "")).lower() != want_table:
+                continue
+            if want_db is not None:
+                entry_db = str(entry.get("database_name", "")).lower()
+                if entry_db and entry_db != want_db:
+                    continue
+            candidates.append(entry)
+        return candidates[0] if len(candidates) == 1 else None
+
     def _resolve_at_context(
         self,
         agent_config: AgentConfig,
@@ -1089,11 +1118,19 @@ class ChatTaskManager:
             return [], [], []
 
         tables: List[TableSchema] = []
+        table_flatten = completer.table_completer.flatten_data
         for path in table_paths or []:
             try:
-                entry = completer.table_completer.flatten_data.get(path)
+                entry = table_flatten.get(path) or self._match_table_entry(table_flatten, path)
                 if entry:
                     tables.append(TableSchema.from_dict(entry))
+                else:
+                    logger.warning(
+                        "Unresolved @Table path '%s' (%d indexed tables); sample keys: %s",
+                        path,
+                        len(table_flatten),
+                        list(table_flatten.keys())[:5],
+                    )
             except Exception as e:
                 logger.warning(f"Failed to resolve table path '{path}': {e}")
 

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1103,32 +1103,19 @@ class ChatTaskManager:
         return candidates[0] if len(candidates) == 1 else None
 
     @staticmethod
-    def _lookup_subject(flatten: Dict[str, Any], path: str) -> Optional[Dict[str, Any]]:
-        """Resolve a subject-tree ref (metric / reference_sql) resiliently.
+    def _split_subject_path(path: str) -> tuple[List[str], str]:
+        """Split a subject-tree ref path into ``(subject_path, name)``.
 
-        Order: exact key, then ``.`` -> ``/`` (older web bundles joined subject
-        paths with ``.`` while the completer store keys them with ``/``), then a
-        trailing-segment (suffix) match — the picker's subject-path prefix can
-        differ from the store's ``subject_path``, so a query ``b/c`` matches a
-        stored ``a/b/c``. The suffix match uses the full query segment sequence
-        and resolves only when exactly one key ends with it, so given both
-        ``A/b/c`` and ``D/b/c`` a query of ``A/b/c`` hits it exactly while a
-        bare ``b/c`` stays ambiguous and returns None (never a wrong guess).
+        The canonical form is ``/``-joined (``Commerce/Orders/aov``). A path that
+        contains no ``/`` is treated as an older ``.``-joined form and converted;
+        a ``/``-joined path is trusted verbatim so a ``.`` inside a leaf name
+        (``v1.2``) is preserved. The last segment is the leaf name.
         """
-        entry = flatten.get(path)
-        if entry is None and "." in path:
-            entry = flatten.get(path.replace(".", "/"))
-        if entry is None:
-            want_segs = [s.strip('"').lower() for s in path.replace(".", "/").split("/") if s.strip()]
-            if want_segs:
-                candidates = [
-                    e
-                    for key, e in flatten.items()
-                    if [s.strip('"').lower() for s in key.split("/") if s.strip()][-len(want_segs) :] == want_segs
-                ]
-                if len(candidates) == 1:
-                    entry = candidates[0]
-        return entry
+        normalized = path if "/" in path else path.replace(".", "/")
+        segs = [s.strip().strip('"') for s in normalized.split("/") if s.strip()]
+        if not segs:
+            return [], ""
+        return segs[:-1], segs[-1]
 
     @staticmethod
     def _synthesize_table_entry(path: str) -> Optional[Dict[str, Any]]:
@@ -1159,17 +1146,32 @@ class ChatTaskManager:
         metric_paths: Optional[List[str]],
         sql_paths: Optional[List[str]],
     ) -> tuple[List[TableSchema], List[Metric], List[ReferenceSql]]:
-        """Resolve @-reference paths to typed objects using a fresh completer."""
+        """Resolve @-reference paths to typed objects.
+
+        Tables come from the schema-metadata completer with a name-only fallback.
+        Metrics and reference SQL are resolved by EXACT subject path via the same
+        non-vector, path-scoped store lookup the get_metrics / get_reference_sql
+        tools use — deliberately NOT the completer's vector search, which is empty
+        until the KB is vectorised (and is slated for removal).
+        """
+        return (
+            self._resolve_table_paths(agent_config, table_paths),
+            self._resolve_metric_paths(agent_config, metric_paths),
+            self._resolve_sql_paths(agent_config, sql_paths),
+        )
+
+    def _resolve_table_paths(self, agent_config: AgentConfig, table_paths: Optional[List[str]]) -> List[TableSchema]:
+        tables: List[TableSchema] = []
+        if not table_paths:
+            return tables
         try:
             completer = AtReferenceCompleter(agent_config)
-            completer.reload_data()
+            completer.table_completer.reload_data()
+            table_flatten = completer.table_completer.flatten_data
         except Exception as exc:
-            logger.warning("Failed to resolve @ references; continuing without context references: %s", exc)
-            return [], [], []
-
-        tables: List[TableSchema] = []
-        table_flatten = completer.table_completer.flatten_data
-        for path in table_paths or []:
+            logger.warning("Table completer unavailable; falling back to name-only @Table refs: %s", exc)
+            table_flatten = {}
+        for path in table_paths:
             try:
                 entry = table_flatten.get(path) or self._match_table_entry(table_flatten, path)
                 if not entry:
@@ -1190,39 +1192,50 @@ class ChatTaskManager:
                     tables.append(TableSchema.from_dict(entry))
             except Exception as e:
                 logger.warning(f"Failed to resolve table path '{path}': {e}")
+        return tables
 
+    def _resolve_metric_paths(self, agent_config: AgentConfig, metric_paths: Optional[List[str]]) -> List[Metric]:
         metrics: List[Metric] = []
-        metric_flatten = completer.metric_completer.flatten_data
-        for path in metric_paths or []:
-            try:
-                entry = self._lookup_subject(metric_flatten, path)
-                if entry:
-                    metrics.append(Metric.from_dict(entry))
-                else:
-                    logger.warning(
-                        "Unresolved @Metric path '%s' (%d indexed metrics); sample keys: %s",
-                        path,
-                        len(metric_flatten),
-                        list(metric_flatten.keys())[:5],
-                    )
-            except Exception as e:
-                logger.warning(f"Failed to resolve metric path '{path}': {e}")
+        if not metric_paths:
+            return metrics
+        try:
+            from datus.storage.metric.store import MetricRAG
 
+            rag = MetricRAG(agent_config)
+        except Exception as exc:
+            logger.warning("MetricRAG unavailable; skipping @Metric resolution: %s", exc)
+            return metrics
+        for path in metric_paths:
+            try:
+                subject_path, name = self._split_subject_path(path)
+                details = rag.get_metrics_detail(subject_path=subject_path, name=name) if name else []
+                if details:
+                    metrics.append(Metric.from_dict(details[0]))
+                else:
+                    logger.warning("Unresolved @Metric path '%s'", path)
+            except Exception as e:
+                logger.warning("Failed to resolve metric path '%s': %s", path, e)
+        return metrics
+
+    def _resolve_sql_paths(self, agent_config: AgentConfig, sql_paths: Optional[List[str]]) -> List[ReferenceSql]:
         sqls: List[ReferenceSql] = []
-        sql_flatten = completer.sql_completer.flatten_data
-        for path in sql_paths or []:
-            try:
-                entry = self._lookup_subject(sql_flatten, path)
-                if entry:
-                    sqls.append(ReferenceSql.from_dict(entry))
-                else:
-                    logger.warning(
-                        "Unresolved @Sql path '%s' (%d indexed reference SQL); sample keys: %s",
-                        path,
-                        len(sql_flatten),
-                        list(sql_flatten.keys())[:5],
-                    )
-            except Exception as e:
-                logger.warning(f"Failed to resolve sql path '{path}': {e}")
+        if not sql_paths:
+            return sqls
+        try:
+            from datus.storage.reference_sql.store import ReferenceSqlRAG
 
-        return tables, metrics, sqls
+            store = ReferenceSqlRAG(agent_config)
+        except Exception as exc:
+            logger.warning("ReferenceSqlRAG unavailable; skipping @Sql resolution: %s", exc)
+            return sqls
+        for path in sql_paths:
+            try:
+                subject_path, name = self._split_subject_path(path)
+                details = store.get_reference_sql_detail(subject_path=subject_path, name=name) if name else []
+                if details:
+                    sqls.append(ReferenceSql.from_dict(details[0]))
+                else:
+                    logger.warning("Unresolved @Sql path '%s'", path)
+            except Exception as e:
+                logger.warning("Failed to resolve sql path '%s': %s", path, e)
+        return sqls

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -1047,13 +1047,44 @@ class SessionManager:
         ")"
     )
 
-    def save_user_message_context(self, session_id: str, context: Dict[str, Any]) -> None:
+    def get_max_user_turn_number(self, session_id: str) -> int:
+        """Return the highest ``user_turn_number`` recorded, or 0 when none/no DB.
+
+        ``user_turn_number`` is session-global and monotonic (assigned by the
+        SDK across every branch), so callers use it to detect whether a run
+        actually persisted a new user turn. Captured before a run and compared
+        after — see :meth:`save_user_message_context`.
+        """
+        self._validate_session_id(session_id)
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if not os.path.exists(db_path):
+            return 0
+        try:
+            with sqlite3.connect(db_path, timeout=5.0) as conn:
+                row = conn.execute(
+                    "SELECT MAX(user_turn_number) FROM message_structure WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+        except sqlite3.OperationalError:
+            return 0
+        return int(row[0]) if row and row[0] is not None else 0
+
+    def save_user_message_context(
+        self, session_id: str, context: Dict[str, Any], previous_turn_number: int = -1
+    ) -> None:
         """Persist a turn's @-context against its ``user_turn_number``.
 
-        Call after the turn's user message is persisted by the SDK. Resolves the
-        turn number as ``MAX(user_turn_number)`` — each API run adds exactly one
-        new user turn, so the newest number is this turn's. No-op when *context*
-        is empty (no references) or the session DB / turn isn't there yet.
+        Call after the turn's user message is persisted by the SDK. The turn is
+        resolved as ``MAX(user_turn_number)``. ``previous_turn_number`` is the
+        value captured *before* the run: the write only happens when the new max
+        strictly exceeds it, so a run that persisted no new user turn (e.g. a
+        node type that emits no user message, or a failed/cancelled turn) can
+        never mis-attach this run's context onto the previous turn's bubble.
+
+        ``user_turn_number`` is session-global monotonic, so a bare ``MAX`` is
+        the right turn even across rewind/fork branches — no ``branch_id``
+        filter is needed. No-op when *context* is empty or the session DB /
+        turn isn't there yet.
         """
         if not context:
             return
@@ -1069,7 +1100,8 @@ class SessionManager:
                     (session_id,),
                 ).fetchone()
                 turn_number = row[0] if row else None
-                if turn_number is None:
+                if turn_number is None or int(turn_number) <= previous_turn_number:
+                    # No new user turn was persisted this run — don't attach.
                     return
                 conn.execute(self._USER_MESSAGE_CONTEXT_DDL)
                 conn.execute(

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -1026,6 +1026,91 @@ class SessionManager:
             "updated_at": to_utc_iso(updated_at) if updated_at else None,
         }
 
+    # ------------------------------------------------------------------
+    # Per-user-turn @-context (table/metric/sql/knowledge references)
+    # ------------------------------------------------------------------
+    #
+    # The SDK's ``agent_messages`` table only stores the enhanced prompt text,
+    # from which structured @-references can't be recovered. This side table —
+    # written by the API layer once a turn is persisted, never read back into
+    # the LLM — lets ``get_history`` echo the exact references a user attached
+    # so the front-end can re-render them. Keyed by ``user_turn_number`` (the
+    # SDK's canonical per-turn id) so it survives gaps (turns with no refs).
+
+    _USER_MESSAGE_CONTEXT_DDL = (
+        "CREATE TABLE IF NOT EXISTS user_message_context ("
+        "session_id TEXT NOT NULL, "
+        "user_turn_number INTEGER NOT NULL, "
+        "context_json TEXT NOT NULL, "
+        "created_at TIMESTAMP, "
+        "PRIMARY KEY (session_id, user_turn_number)"
+        ")"
+    )
+
+    def save_user_message_context(self, session_id: str, context: Dict[str, Any]) -> None:
+        """Persist a turn's @-context against its ``user_turn_number``.
+
+        Call after the turn's user message is persisted by the SDK. Resolves the
+        turn number as ``MAX(user_turn_number)`` — each API run adds exactly one
+        new user turn, so the newest number is this turn's. No-op when *context*
+        is empty (no references) or the session DB / turn isn't there yet.
+        """
+        if not context:
+            return
+        self._validate_session_id(session_id)
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if not os.path.exists(db_path):
+            return
+        payload = json.dumps(context, ensure_ascii=False)
+        try:
+            with sqlite3.connect(db_path, timeout=5.0) as conn:
+                row = conn.execute(
+                    "SELECT MAX(user_turn_number) FROM message_structure WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+                turn_number = row[0] if row else None
+                if turn_number is None:
+                    return
+                conn.execute(self._USER_MESSAGE_CONTEXT_DDL)
+                conn.execute(
+                    "INSERT OR REPLACE INTO user_message_context "
+                    "(session_id, user_turn_number, context_json, created_at) VALUES (?, ?, ?, ?)",
+                    (session_id, int(turn_number), payload, datetime.now(timezone.utc)),
+                )
+                conn.commit()
+        except sqlite3.OperationalError as exc:
+            logger.debug(f"save_user_message_context failed for {session_id}: {exc}")
+
+    @staticmethod
+    def _read_user_message_context(conn: sqlite3.Connection, session_id: str) -> Dict[int, Dict[str, Any]]:
+        """Return ``{user_turn_number: context_dict}`` for a session, ``{}`` if absent."""
+        try:
+            rows = conn.execute(
+                "SELECT user_turn_number, context_json FROM user_message_context WHERE session_id = ?",
+                (session_id,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return {}
+        result: Dict[int, Dict[str, Any]] = {}
+        for turn_number, context_json in rows:
+            try:
+                result[int(turn_number)] = json.loads(context_json) if context_json else {}
+            except (json.JSONDecodeError, TypeError, ValueError):
+                continue
+        return result
+
+    @staticmethod
+    def _read_message_turn_map(conn: sqlite3.Connection, session_id: str) -> Dict[int, int]:
+        """Return ``{agent_messages.id: user_turn_number}`` from message_structure."""
+        try:
+            rows = conn.execute(
+                "SELECT message_id, user_turn_number FROM message_structure WHERE session_id = ?",
+                (session_id,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return {}
+        return {int(mid): int(turn) for mid, turn in rows if mid is not None and turn is not None}
+
     @staticmethod
     def _parse_final_output(actions: List[ActionHistory], current_assistant_group: Dict) -> Optional[ActionHistory]:
         """Try to parse sql/output from the last assistant action's messages and update assistant group.
@@ -1113,20 +1198,28 @@ class SessionManager:
                 cursor = conn.cursor()
                 cursor.execute(
                     """
-                    SELECT message_data, created_at
+                    SELECT id, message_data, created_at
                     FROM agent_messages
                     WHERE session_id = ?
                     ORDER BY created_at, id
                     """,
                     (session_id,),
                 )
+                rows = cursor.fetchall()
+
+                # Side-table @-context (table/metric/sql/knowledge refs) keyed by
+                # user_turn_number, plus the message_id -> turn map to attach each
+                # to the right user bubble. Empty when the session predates the
+                # feature or carried no references.
+                turn_map = self._read_message_turn_map(conn, session_id)
+                context_map = self._read_user_message_context(conn, session_id)
 
                 # Aggregate consecutive assistant messages
                 current_assistant_group = None
                 assistant_progress = []
                 current_actions = []  # Collect ActionHistory objects for detailed view
 
-                for message_data, created_at in cursor.fetchall():
+                for row_id, message_data, created_at in rows:
                     # Normalize SQLite naive UTC timestamp for outward-facing fields.
                     created_at_iso = to_utc_iso(created_at)
                     try:
@@ -1179,14 +1272,18 @@ class SessionManager:
 
                             # Add user message (extract original user input from structured content)
                             content = extract_user_input(message_json.get("content", ""))
-                            messages.append(
-                                {
-                                    "role": "user",
-                                    "content": content,
-                                    "timestamp": created_at_iso,
-                                    "created_at": created_at_iso,
-                                }
-                            )
+                            user_msg: Dict[str, Any] = {
+                                "role": "user",
+                                "content": content,
+                                "timestamp": created_at_iso,
+                                "created_at": created_at_iso,
+                            }
+                            # Attach the turn's resolved @-context (if any) so the
+                            # front-end can re-render referenced tables/metrics/etc.
+                            turn_no = turn_map.get(row_id)
+                            if turn_no is not None and turn_no in context_map:
+                                user_msg["at_context"] = context_map[turn_no]
+                            messages.append(user_msg)
                             continue
 
                         # Handle function calls (tool calls)

--- a/datus/schemas/ask_metrics_agentic_node_models.py
+++ b/datus/schemas/ask_metrics_agentic_node_models.py
@@ -8,10 +8,11 @@ from typing import Any, Dict, Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class AskMetricsNodeInput(BaseInput):
+class AskMetricsNodeInput(AtContextInput):
     """Input model for AskMetricsAgenticNode."""
 
     user_message: str = Field(..., description="User's metric question")

--- a/datus/schemas/at_context.py
+++ b/datus/schemas/at_context.py
@@ -16,7 +16,7 @@ Lives in its own module (not ``base.py``) because the field types come from
 would create a ``base`` <-> ``node_models`` import cycle.
 """
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import AliasChoices, ConfigDict, Field
 
@@ -42,6 +42,14 @@ class AtContextInput(BaseInput):
     external_knowledge: Optional[str] = Field(
         default="", description="@Knowledge / supplementary business evidence supplied with the question"
     )
+    context_hints: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description=(
+            "Referenced items whose full detail could not be pre-loaded. Each hint "
+            "{kind, name, subject_path} tells the model to fetch it via the matching "
+            "tool (get_metrics / get_reference_sql) instead of searching for it."
+        ),
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -53,6 +61,7 @@ def apply_at_context(
     metrics: Optional[List[Metric]] = None,
     reference_sql: Optional[List[ReferenceSql]] = None,
     external_knowledge: Optional[str] = None,
+    context_hints: Optional[List[Dict[str, Any]]] = None,
 ) -> BaseInput:
     """Populate @-context fields on *node_input* in place, returning it.
 
@@ -70,4 +79,6 @@ def apply_at_context(
         node_input.reference_sql = reference_sql
     if external_knowledge is not None and hasattr(node_input, "external_knowledge"):
         node_input.external_knowledge = external_knowledge
+    if context_hints is not None and hasattr(node_input, "context_hints"):
+        node_input.context_hints = context_hints
     return node_input

--- a/datus/schemas/at_context.py
+++ b/datus/schemas/at_context.py
@@ -1,0 +1,73 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Shared @-context carrier for node inputs.
+
+Every ``@Table`` / ``@Metric`` / ``@Sql`` / ``@Knowledge`` reference a user
+attaches to a chat turn is resolved into structured objects and must reach the
+node's prompt via :meth:`AgenticNode._build_enhanced_message`. Declaring these
+fields on a single base (rather than per input model) is what keeps the set
+leak-proof: a new reference kind is added here and to :func:`apply_at_context`
+once, and every subagent input inherits it automatically.
+
+Lives in its own module (not ``base.py``) because the field types come from
+``node_models`` which already imports ``base`` — folding them into ``base``
+would create a ``base`` <-> ``node_models`` import cycle.
+"""
+
+from typing import List, Optional
+
+from pydantic import AliasChoices, ConfigDict, Field
+
+from datus.schemas.base import BaseInput
+from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
+
+
+class AtContextInput(BaseInput):
+    """Base input carrying resolved @-referenced context.
+
+    Consumed uniformly by :meth:`AgenticNode._build_enhanced_message` (which
+    reads each field via ``getattr``), so any node whose input inherits this
+    renders the referenced context without node-specific wiring.
+    """
+
+    schemas: Optional[List[TableSchema]] = Field(default=None, description="@Table referenced table schemas")
+    metrics: Optional[List[Metric]] = Field(default=None, description="@Metric referenced metrics")
+    reference_sql: Optional[List[ReferenceSql]] = Field(
+        default=None,
+        description="@Sql referenced SQL snippets to reuse/adjust",
+        validation_alias=AliasChoices("reference_sql", "historical_sql"),
+    )
+    external_knowledge: Optional[str] = Field(
+        default="", description="@Knowledge / supplementary business evidence supplied with the question"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+def apply_at_context(
+    node_input: BaseInput,
+    *,
+    schemas: Optional[List[TableSchema]] = None,
+    metrics: Optional[List[Metric]] = None,
+    reference_sql: Optional[List[ReferenceSql]] = None,
+    external_knowledge: Optional[str] = None,
+) -> BaseInput:
+    """Populate @-context fields on *node_input* in place, returning it.
+
+    ``hasattr``-guarded per field so inputs that do not carry a given field
+    (or don't inherit :class:`AtContextInput` at all) are silently skipped —
+    this is the single choke point both node-input funnels call, so adding a
+    reference kind never requires touching individual branches. ``None`` args
+    leave the existing value untouched.
+    """
+    if schemas is not None and hasattr(node_input, "schemas"):
+        node_input.schemas = schemas
+    if metrics is not None and hasattr(node_input, "metrics"):
+        node_input.metrics = metrics
+    if reference_sql is not None and hasattr(node_input, "reference_sql"):
+        node_input.reference_sql = reference_sql
+    if external_knowledge is not None and hasattr(node_input, "external_knowledge"):
+        node_input.external_knowledge = external_knowledge
+    return node_input

--- a/datus/schemas/chat_agentic_node_models.py
+++ b/datus/schemas/chat_agentic_node_models.py
@@ -11,15 +11,18 @@ providing structured validation for chat interactions with streaming support.
 
 from typing import Optional
 
-from pydantic import AliasChoices, ConfigDict, Field
+from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
-from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class ChatNodeInput(BaseInput):
+class ChatNodeInput(AtContextInput):
     """
     Input model for ChatAgenticNode interactions.
+
+    @-context fields (``schemas`` / ``metrics`` / ``reference_sql`` /
+    ``external_knowledge``) are inherited from :class:`AtContextInput`.
     """
 
     user_message: str = Field(..., description="User's chat message input")
@@ -35,24 +38,12 @@ class ChatNodeInput(BaseInput):
             "(agent.yml ``agentic_nodes.chat.max_turns``) is used."
         ),
     )
-    external_knowledge: Optional[str] = Field(
-        default="", description="Supplementary description / evidence supplied with the question"
-    )
     workspace_root: Optional[str] = Field(default=None, description="Root directory path for filesystem MCP server")
     prompt_version: Optional[str] = Field(default=None, description="Version for prompt template")
-    schemas: Optional[list[TableSchema]] = Field(default=None, description="Schemas to use")
-    metrics: Optional[list[Metric]] = Field(default=None, description="Metrics to use")
-    reference_sql: Optional[list[ReferenceSql]] = Field(
-        default=None,
-        description="Reference SQL snippets to reuse/adjust",
-        validation_alias=AliasChoices("reference_sql", "historical_sql"),
-    )
     plan_mode: bool = Field(default=False, description="Whether this is a plan mode interaction")
     auto_execute_plan: bool = Field(
         default=False, description="Whether to auto-execute plan without user confirmation (for workflow/benchmark)"
     )
-
-    model_config = ConfigDict(populate_by_name=True)
 
 
 class ChatNodeResult(BaseResult):

--- a/datus/schemas/explore_agentic_node_models.py
+++ b/datus/schemas/explore_agentic_node_models.py
@@ -14,10 +14,11 @@ from typing import List, Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class ExploreNodeInput(BaseInput):
+class ExploreNodeInput(AtContextInput):
     """
     Input model for ExploreAgenticNode interactions.
     """

--- a/datus/schemas/feedback_agentic_node_models.py
+++ b/datus/schemas/feedback_agentic_node_models.py
@@ -14,10 +14,11 @@ from typing import Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class FeedbackNodeInput(BaseInput):
+class FeedbackNodeInput(AtContextInput):
     """Input model for feedback node."""
 
     user_message: str = Field(..., description="Feedback instruction (e.g., 'analyze and archive')")

--- a/datus/schemas/gen_dashboard_agentic_node_models.py
+++ b/datus/schemas/gen_dashboard_agentic_node_models.py
@@ -13,10 +13,11 @@ from typing import Any, Dict, Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class GenDashboardNodeInput(BaseInput):
+class GenDashboardNodeInput(AtContextInput):
     """Input model for GenDashboardAgenticNode."""
 
     user_message: str = Field(..., description="User's dashboard request (required)")

--- a/datus/schemas/gen_report_agentic_node_models.py
+++ b/datus/schemas/gen_report_agentic_node_models.py
@@ -13,10 +13,11 @@ from typing import Any, Dict, Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class GenReportNodeInput(BaseInput):
+class GenReportNodeInput(AtContextInput):
     """
     Input model for GenReportAgenticNode.
 

--- a/datus/schemas/gen_skill_agentic_node_models.py
+++ b/datus/schemas/gen_skill_agentic_node_models.py
@@ -14,10 +14,11 @@ from typing import Literal, Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class SkillCreatorNodeInput(BaseInput):
+class SkillCreatorNodeInput(AtContextInput):
     """
     Input model for SkillCreatorAgenticNode interactions.
     """

--- a/datus/schemas/gen_sql_agentic_node_models.py
+++ b/datus/schemas/gen_sql_agentic_node_models.py
@@ -12,15 +12,18 @@ context support and streaming capabilities.
 
 from typing import Optional
 
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
-from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class GenSQLNodeInput(BaseInput):
+class GenSQLNodeInput(AtContextInput):
     """
     Input model for GenSQLAgenticNode interactions.
+
+    @-context fields (``schemas`` / ``metrics`` / ``reference_sql`` /
+    ``external_knowledge``) are inherited from :class:`AtContextInput`.
     """
 
     user_message: str = Field(..., description="User's input message")
@@ -28,23 +31,15 @@ class GenSQLNodeInput(BaseInput):
     database: Optional[str] = Field(default=None, description="Database name for context")
     db_schema: Optional[str] = Field(default=None, description="Database schema for context")
     max_turns: int = Field(default=30, description="Maximum conversation turns per interaction")
-    external_knowledge: Optional[str] = Field(
-        default="", description="Supplementary description / evidence supplied with the question"
-    )
     workspace_root: Optional[str] = Field(default=None, description="Root directory path for filesystem MCP server")
     prompt_version: Optional[str] = Field(default=None, description="Version for prompt template")
     prompt_language: Optional[str] = Field(default="en", description="Language for prompt template")
-    schemas: Optional[list[TableSchema]] = Field(default=None, description="Table schemas to use")
-    metrics: Optional[list[Metric]] = Field(default=None, description="Metrics to use")
-    reference_sql: Optional[list[ReferenceSql]] = Field(default=None, description="Reference SQL to reference")
     reference_date: Optional[str] = Field(
         default=None,
         description="Pinned reference date for deterministic SQL generation and validation",
     )
     plan_mode: bool = Field(default=False, description="Enable plan mode for multi-step task planning")
     auto_execute_plan: bool = Field(default=False, description="Auto-execute plan without confirmation")
-
-    model_config = ConfigDict(populate_by_name=True)
 
 
 class GenSQLNodeResult(BaseResult):

--- a/datus/schemas/gen_visual_dashboard_models.py
+++ b/datus/schemas/gen_visual_dashboard_models.py
@@ -22,7 +22,8 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 from datus.schemas.gen_visual_report_models import (  # re-use the cross-artifact primitives
     DATA_REF_RE,
     QUERY_SLUG_RE,
@@ -126,7 +127,7 @@ class QueryTemplateMetaFile(BaseModel):
         return self
 
 
-class GenVisualDashboardNodeInput(BaseInput):
+class GenVisualDashboardNodeInput(AtContextInput):
     """Input model for GenVisualDashboardAgenticNode."""
 
     user_message: str = Field(..., description="User's dashboard question (required)")

--- a/datus/schemas/gen_visual_report_models.py
+++ b/datus/schemas/gen_visual_report_models.py
@@ -14,7 +14,8 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 # LLM-supplied slug doubles as the on-disk directory name; constrained
 # to a filesystem-friendly subset so we never need to URL-escape it.
@@ -78,7 +79,7 @@ class QueryResultFile(BaseModel):
         return self
 
 
-class GenVisualReportNodeInput(BaseInput):
+class GenVisualReportNodeInput(AtContextInput):
     """Input model for GenVisualReportAgenticNode."""
 
     user_message: str = Field(..., description="User's analysis question (required)")

--- a/datus/schemas/node_models.py
+++ b/datus/schemas/node_models.py
@@ -316,6 +316,15 @@ class TableValue(BaseTableSchema):
         return self.model_dump()
 
 
+def _coerce_subject_path(value: Any) -> List[str]:
+    """Normalise a subject path to a list of segments (accepts list or '/'-joined str)."""
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value]
+    if isinstance(value, str) and value:
+        return [s for s in value.split("/") if s]
+    return []
+
+
 class Metric(BaseModel):
     """
     Model for metrics information used in SQL generation.
@@ -323,6 +332,12 @@ class Metric(BaseModel):
 
     name: str = Field(..., description="Name of the metric")
     description: str = Field(default="", description="Description of the metric")
+    subject_path: List[str] = Field(
+        default_factory=list, description="Subject-tree hierarchy (excludes the metric name)"
+    )
+    metric_type: str = Field(default="", description="Metric type (simple/derived/ratio/cumulative)")
+    measure_expr: str = Field(default="", description="Underlying measure/aggregation expression")
+    dimensions: List[str] = Field(default_factory=list, description="Available dimensions")
 
     def to_prompt(self, dialect: str = "snowflake") -> str:
         return self.description if self.description else f"Metric: {self.name}"
@@ -331,7 +346,11 @@ class Metric(BaseModel):
     def from_dict(cls, data: Dict[str, Any]) -> Metric:
         return cls(
             name=data.get("name", ""),
-            description=data.get("description", ""),
+            description=data.get("description", "") or "",
+            subject_path=_coerce_subject_path(data.get("subject_path")),
+            metric_type=data.get("metric_type", "") or "",
+            measure_expr=data.get("measure_expr", "") or "",
+            dimensions=list(data.get("dimensions") or []),
         )
 
 
@@ -341,6 +360,9 @@ class ReferenceSql(BaseModel):
     comment: str = Field(default="", description="Comment of the reference SQL table")
     summary: str = Field(default="", description="Summary of the reference SQL table")
     tags: str = Field(default="", description="Tags of the reference SQL table")
+    subject_path: List[str] = Field(
+        default_factory=list, description="Subject-tree hierarchy (excludes the reference SQL name)"
+    )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ReferenceSql:
@@ -350,6 +372,7 @@ class ReferenceSql(BaseModel):
             comment=data.get("comment", ""),
             summary=data.get("summary", ""),
             tags=data.get("tags", ""),
+            subject_path=_coerce_subject_path(data.get("subject_path")),
         )
 
 

--- a/datus/schemas/scheduler_agentic_node_models.py
+++ b/datus/schemas/scheduler_agentic_node_models.py
@@ -13,10 +13,11 @@ from typing import Any, Dict, Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class SchedulerNodeInput(BaseInput):
+class SchedulerNodeInput(AtContextInput):
     """Input model for SchedulerAgenticNode."""
 
     user_message: str = Field(..., description="User's scheduler request (required)")

--- a/datus/schemas/semantic_agentic_node_models.py
+++ b/datus/schemas/semantic_agentic_node_models.py
@@ -13,10 +13,11 @@ from typing import List, Optional
 
 from pydantic import ConfigDict, Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class SemanticNodeInput(BaseInput):
+class SemanticNodeInput(AtContextInput):
     """
     Input model for SemanticAgenticNode interactions.
     """

--- a/datus/schemas/sql_summary_agentic_node_models.py
+++ b/datus/schemas/sql_summary_agentic_node_models.py
@@ -13,10 +13,11 @@ from typing import Optional
 
 from pydantic import Field
 
-from datus.schemas.base import BaseInput, BaseResult
+from datus.schemas.at_context import AtContextInput
+from datus.schemas.base import BaseResult
 
 
-class SqlSummaryNodeInput(BaseInput):
+class SqlSummaryNodeInput(AtContextInput):
     """Input model for SQL summary generation node."""
 
     user_message: str = Field(..., description="User's input message or request")

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -36,6 +36,7 @@ from datus.schemas.action_history import (
     ActionStatus,
 )
 from datus.schemas.agent_models import ScopedContext, SubAgentConfig
+from datus.schemas.at_context import apply_at_context
 from datus.tools.func_tool.base import FuncToolResult
 from datus.utils.constants import SYS_SUB_AGENTS
 from datus.utils.loggings import get_logger
@@ -1074,7 +1075,44 @@ class SubAgentTaskTool:
                     tools.extend(ask_user_tool.available_tools())
 
     def _build_node_input(self, node, prompt: str, db_ctx: Optional[Dict[str, Optional[str]]] = None):
-        """Build the appropriate input object for the given node.
+        """Build the subagent input and attach inherited DB + @-context.
+
+        Delegates type dispatch to :meth:`_build_typed_subagent_input`, then
+        threads the parent node's resolved @-context (schemas / metrics /
+        reference_sql / external_knowledge) through the single
+        :func:`apply_at_context` choke point, so a ``task()``-spawned subagent
+        sees the same @Table/@Metric/@Sql references the parent turn carried.
+        """
+        node_input = self._build_typed_subagent_input(node, prompt, db_ctx=db_ctx)
+        at_ctx = self._parent_at_context()
+        return apply_at_context(
+            node_input,
+            schemas=at_ctx.get("schemas"),
+            metrics=at_ctx.get("metrics"),
+            reference_sql=at_ctx.get("reference_sql"),
+            external_knowledge=at_ctx.get("external_knowledge"),
+        )
+
+    def _parent_at_context(self) -> Dict[str, Any]:
+        """Resolved @-context (schemas/metrics/reference_sql/knowledge) the parent carries.
+
+        Mirrors :meth:`_parent_db_context`: reads the parent node's ``input`` so a
+        subagent inherits the same @-references. Empty when there is no parent or
+        the parent input declares none.
+        """
+        parent = self._parent_node
+        if parent is None:
+            return {}
+        parent_input = getattr(parent, "input", None)
+        return {
+            "schemas": getattr(parent_input, "schemas", None),
+            "metrics": getattr(parent_input, "metrics", None),
+            "reference_sql": getattr(parent_input, "reference_sql", None),
+            "external_knowledge": getattr(parent_input, "external_knowledge", None) or None,
+        }
+
+    def _build_typed_subagent_input(self, node, prompt: str, db_ctx: Optional[Dict[str, Optional[str]]] = None):
+        """Build the node-type-specific subagent input (DB context only, no @-context).
 
         The subagent inherits the parent node's resolved physical ``database`` (and
         ``catalog``/``db_schema`` where supported) via :meth:`_parent_db_context`; without

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -1091,6 +1091,7 @@ class SubAgentTaskTool:
             metrics=at_ctx.get("metrics"),
             reference_sql=at_ctx.get("reference_sql"),
             external_knowledge=at_ctx.get("external_knowledge"),
+            context_hints=at_ctx.get("context_hints"),
         )
 
     def _parent_at_context(self) -> Dict[str, Any]:
@@ -1109,6 +1110,7 @@ class SubAgentTaskTool:
             "metrics": getattr(parent_input, "metrics", None),
             "reference_sql": getattr(parent_input, "reference_sql", None),
             "external_knowledge": getattr(parent_input, "external_knowledge", None) or None,
+            "context_hints": getattr(parent_input, "context_hints", None),
         }
 
     def _build_typed_subagent_input(self, node, prompt: str, db_ctx: Optional[Dict[str, Optional[str]]] = None):

--- a/tests/unit_tests/agent/node/test_at_context_render.py
+++ b/tests/unit_tests/agent/node/test_at_context_render.py
@@ -1,0 +1,38 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for AgenticNode._render_context_hint_part — the look-up hints
+block for @-references whose detail couldn't be pre-loaded."""
+
+from datus.agent.node.agentic_node import AgenticNode
+
+
+def test_empty_hints_render_nothing():
+    assert AgenticNode._render_context_hint_part(None) == ""
+    assert AgenticNode._render_context_hint_part([]) == ""
+
+
+def test_metric_hint_points_at_get_metrics():
+    out = AgenticNode._render_context_hint_part(
+        [{"kind": "metric", "name": "aov", "subject_path": ["Commerce", "Orders"]}]
+    )
+    assert "## Referenced items to look up" in out
+    assert "get_metrics(subject_path=['Commerce', 'Orders'], name=\"aov\")" in out
+
+
+def test_reference_sql_hint_points_at_get_reference_sql():
+    out = AgenticNode._render_context_hint_part(
+        [{"kind": "reference_sql", "name": "raw_customers", "subject_path": ["main"]}]
+    )
+    assert "get_reference_sql(subject_path=['main'], name=\"raw_customers\")" in out
+
+
+def test_knowledge_hint_has_no_tool_call():
+    out = AgenticNode._render_context_hint_part(
+        [{"kind": "knowledge", "name": "gmv", "subject_path": ["Domain", "Glossary"]}]
+    )
+    # No get_* tool exists for knowledge — point at the subject tree instead.
+    assert "get_metrics" not in out and "get_reference_sql" not in out
+    assert "list_subject_tree" in out
+    assert "Domain/Glossary/gmv" in out

--- a/tests/unit_tests/agent/node/test_at_context_render.py
+++ b/tests/unit_tests/agent/node/test_at_context_render.py
@@ -5,7 +5,44 @@
 """Unit tests for AgenticNode._render_context_hint_part — the look-up hints
 block for @-references whose detail couldn't be pre-loaded."""
 
+from types import SimpleNamespace
+
 from datus.agent.node.agentic_node import AgenticNode
+from datus.schemas.node_models import Metric, ReferenceSql
+
+
+def _render(**fields) -> str:
+    """Render at-context parts for a bare input carrying only *fields*."""
+    node = AgenticNode.__new__(AgenticNode)  # bypass __init__; method only reads getattr
+    attrs = {"external_knowledge": "", "schemas": None, "metrics": None, "reference_sql": None, "context_hints": None}
+    attrs.update(fields)
+    return "\n\n".join(node._render_at_context_parts(SimpleNamespace(**attrs)))
+
+
+def test_metric_block_includes_subject_path_and_definition():
+    m = Metric(
+        name="aov",
+        description="avg order value",
+        subject_path=["Commerce", "Orders"],
+        metric_type="ratio",
+        measure_expr="SUM(amount)/COUNT(*)",
+        dimensions=["platform", "country"],
+    )
+    out = _render(metrics=[m])
+    assert "## Referenced metrics" in out
+    assert "subject_path: Commerce/Orders" in out
+    assert "avg order value" in out
+    assert "type: ratio" in out
+    assert "measure: SUM(amount)/COUNT(*)" in out
+    assert "dimensions: platform, country" in out
+
+
+def test_reference_sql_block_includes_subject_path_and_sql():
+    r = ReferenceSql(name="raw_customers", sql="select * from raw_customers", subject_path=["main"])
+    out = _render(reference_sql=[r])
+    assert "## Referenced SQL" in out
+    assert "subject_path: main" in out
+    assert "```sql\nselect * from raw_customers\n```" in out
 
 
 def test_empty_hints_render_nothing():

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2025,3 +2025,16 @@ class TestLookupSubject:
     def test_top_level_name_without_subject_path(self):
         flat = {"raw_customers": {"name": "raw_customers"}}
         assert ChatTaskManager._lookup_subject(flat, "raw_customers")["name"] == "raw_customers"
+
+    def test_name_fallback_when_subject_prefix_differs(self):
+        # Picker sent 'main/raw_customers' but the store keyed it differently.
+        flat = {"jeff_shop_live/main/raw_customers": {"name": "raw_customers", "sql": "select 1"}}
+        entry = ChatTaskManager._lookup_subject(flat, "main/raw_customers")
+        assert entry and entry["name"] == "raw_customers"
+
+    def test_name_fallback_ambiguous_returns_none(self):
+        flat = {"a/raw_customers": {"name": "raw_customers"}, "b/raw_customers": {"name": "raw_customers"}}
+        assert ChatTaskManager._lookup_subject(flat, "x/raw_customers") is None
+
+    def test_empty_store_returns_none(self):
+        assert ChatTaskManager._lookup_subject({}, "main/raw_customers") is None

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2042,6 +2042,9 @@ class TestResolveMetricSqlPaths:
             metrics, hints = mgr._resolve_metric_paths(MagicMock(), ["Commerce/Orders/aov"])
         fake_rag.get_metrics_detail.assert_called_once_with(subject_path=["Commerce", "Orders"], name="aov")
         assert len(metrics) == 1 and metrics[0].name == "aov"
+        # subject_path must survive into the resolved metric (authoritative from
+        # the picked path), so the prompt can name where it lives.
+        assert metrics[0].subject_path == ["Commerce", "Orders"]
         assert hints == []
 
     def test_metric_unresolved_becomes_hint(self):
@@ -2066,6 +2069,7 @@ class TestResolveMetricSqlPaths:
         fake_store.get_reference_sql_detail.assert_called_once_with(subject_path=["main"], name="q")
         assert len(sqls) == 1 and sqls[0].sql == "select 1"
         assert sqls[0].comment == "" and sqls[0].tags == ""
+        assert sqls[0].subject_path == ["main"]
         assert hints == []
 
     def test_metric_none_description_coerced(self):

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -956,20 +956,27 @@ class TestResolveAtContext:
         assert isinstance(metrics, list)
         assert isinstance(sqls, list)
 
-    def test_resolve_at_context_returns_empty_when_completer_fails(self, real_agent_config):
+    def test_table_completer_failure_still_yields_name_only_ref(self, real_agent_config):
+        """A completer failure must not drop a picked @Table — it degrades to a
+        name-only reference so the node still knows which table to inspect."""
         manager = ChatTaskManager()
 
         with patch("datus.api.services.chat_task_manager.AtReferenceCompleter", side_effect=RuntimeError("hf offline")):
-            tables, metrics, sqls = manager._resolve_at_context(
-                real_agent_config,
-                ["db.schema.table"],
-                ["Finance.revenue"],
-                ["Finance.sql"],
-            )
+            tables = manager._resolve_table_paths(real_agent_config, ["db.schema.table"])
 
-        assert tables == []
-        assert metrics == []
-        assert sqls == []
+        assert [t.table_name for t in tables] == ["table"]
+
+    def test_metric_store_failure_degrades_to_empty(self, real_agent_config):
+        """@Metric resolution swallows a store failure and yields no refs."""
+        manager = ChatTaskManager()
+        with patch("datus.storage.metric.store.MetricRAG", side_effect=RuntimeError("store down")):
+            assert manager._resolve_metric_paths(real_agent_config, ["Finance/revenue"]) == []
+
+    def test_sql_store_failure_degrades_to_empty(self, real_agent_config):
+        """@Sql resolution swallows a store failure and yields no refs."""
+        manager = ChatTaskManager()
+        with patch("datus.storage.reference_sql.store.ReferenceSqlRAG", side_effect=RuntimeError("store down")):
+            assert manager._resolve_sql_paths(real_agent_config, ["Finance/sql"]) == []
 
 
 class TestCreateNode:
@@ -2006,53 +2013,55 @@ class TestSynthesizeTableEntry:
         assert ChatTaskManager._synthesize_table_entry("") is None
 
 
-class TestLookupSubject:
-    """_lookup_subject — subject-tree ref resolution tolerating '.'/'/' separators."""
+class TestSplitSubjectPath:
+    """_split_subject_path — (subject_path, name) from a picked ref path."""
 
-    FLAT = {
-        "main/raw_customers": {"name": "raw_customers", "comment": "", "summary": "s", "tags": "", "sql": "select 1"}
-    }
+    def test_slash_joined(self):
+        assert ChatTaskManager._split_subject_path("Commerce/Orders/aov") == (["Commerce", "Orders"], "aov")
 
-    def test_dot_separator_normalizes_to_slash(self):
-        assert ChatTaskManager._lookup_subject(self.FLAT, "main.raw_customers")["name"] == "raw_customers"
+    def test_dot_joined_when_no_slash(self):
+        assert ChatTaskManager._split_subject_path("Commerce.Orders.aov") == (["Commerce", "Orders"], "aov")
 
-    def test_exact_slash_key(self):
-        assert ChatTaskManager._lookup_subject(self.FLAT, "main/raw_customers")["name"] == "raw_customers"
+    def test_slash_present_preserves_dot_in_name(self):
+        assert ChatTaskManager._split_subject_path("A/B/v1.2") == (["A", "B"], "v1.2")
 
-    def test_miss_returns_none(self):
-        assert ChatTaskManager._lookup_subject(self.FLAT, "nope.x") is None
+    def test_single_segment(self):
+        assert ChatTaskManager._split_subject_path("aov") == ([], "aov")
 
-    def test_top_level_name_without_subject_path(self):
-        flat = {"raw_customers": {"name": "raw_customers"}}
-        assert ChatTaskManager._lookup_subject(flat, "raw_customers")["name"] == "raw_customers"
+    def test_empty(self):
+        assert ChatTaskManager._split_subject_path("") == ([], "")
 
-    def test_name_fallback_when_subject_prefix_differs(self):
-        # Picker sent 'main/raw_customers' but the store keyed it differently.
-        flat = {"jeff_shop_live/main/raw_customers": {"name": "raw_customers", "sql": "select 1"}}
-        entry = ChatTaskManager._lookup_subject(flat, "main/raw_customers")
-        assert entry and entry["name"] == "raw_customers"
 
-    def test_name_fallback_ambiguous_returns_none(self):
-        flat = {"a/raw_customers": {"name": "raw_customers"}, "b/raw_customers": {"name": "raw_customers"}}
-        assert ChatTaskManager._lookup_subject(flat, "x/raw_customers") is None
+class TestResolveMetricSqlPaths:
+    """@Metric/@Sql resolve by exact subject path via the non-vector store
+    lookup (same as the get_metrics / get_reference_sql tools)."""
 
-    def test_empty_store_returns_none(self):
-        assert ChatTaskManager._lookup_subject({}, "main/raw_customers") is None
+    def test_metric_uses_path_scoped_detail_lookup(self):
+        mgr = ChatTaskManager()
+        fake_rag = MagicMock()
+        fake_rag.get_metrics_detail.return_value = [{"name": "aov", "description": "avg order value"}]
+        with patch("datus.storage.metric.store.MetricRAG", return_value=fake_rag):
+            out = mgr._resolve_metric_paths(MagicMock(), ["Commerce/Orders/aov"])
+        fake_rag.get_metrics_detail.assert_called_once_with(subject_path=["Commerce", "Orders"], name="aov")
+        assert len(out) == 1 and out[0].name == "aov"
 
-    def test_shared_suffix_exact_query_hits_the_right_one(self):
-        # A/b/c and D/b/c share the trailing 'b/c'. A full, exact query must
-        # resolve to that exact entry (exact-key match, no ambiguity).
-        flat = {"A/b/c": {"name": "c", "sql": "-- A"}, "D/b/c": {"name": "c", "sql": "-- D"}}
-        assert ChatTaskManager._lookup_subject(flat, "A/b/c")["sql"] == "-- A"
-        assert ChatTaskManager._lookup_subject(flat, "D/b/c")["sql"] == "-- D"
+    def test_metric_unresolved_returns_empty(self):
+        mgr = ChatTaskManager()
+        fake_rag = MagicMock()
+        fake_rag.get_metrics_detail.return_value = []
+        with patch("datus.storage.metric.store.MetricRAG", return_value=fake_rag):
+            assert mgr._resolve_metric_paths(MagicMock(), ["A/b/missing"]) == []
 
-    def test_shared_suffix_bare_query_is_ambiguous(self):
-        # A bare 'b/c' (or 'c') suffix-matches both -> no guess.
-        flat = {"A/b/c": {"name": "c"}, "D/b/c": {"name": "c"}}
-        assert ChatTaskManager._lookup_subject(flat, "b/c") is None
-        assert ChatTaskManager._lookup_subject(flat, "c") is None
+    def test_sql_uses_path_scoped_detail_lookup(self):
+        mgr = ChatTaskManager()
+        fake_store = MagicMock()
+        fake_store.get_reference_sql_detail.return_value = [{"name": "q", "sql": "select 1"}]
+        with patch("datus.storage.reference_sql.store.ReferenceSqlRAG", return_value=fake_store):
+            out = mgr._resolve_sql_paths(MagicMock(), ["main/q"])
+        fake_store.get_reference_sql_detail.assert_called_once_with(subject_path=["main"], name="q")
+        assert len(out) == 1 and out[0].sql == "select 1"
 
-    def test_suffix_match_resolves_extra_store_prefix(self):
-        # Picker sends 'main/raw_customers'; store prepended a datasource prefix.
-        flat = {"jeff_shop_live/main/raw_customers": {"name": "raw_customers", "sql": "select 1"}}
-        assert ChatTaskManager._lookup_subject(flat, "main/raw_customers")["sql"] == "select 1"
+    def test_empty_paths_short_circuit(self):
+        mgr = ChatTaskManager()
+        assert mgr._resolve_metric_paths(MagicMock(), []) == []
+        assert mgr._resolve_sql_paths(MagicMock(), None) == []

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -927,34 +927,28 @@ class TestResolveAtContext:
     """Tests for _resolve_at_context — @ reference resolution."""
 
     def test_resolve_empty_paths_returns_empty(self, real_agent_config):
-        """_resolve_at_context with no paths returns empty lists."""
+        """_resolve_at_context with no paths returns empty lists + no hints."""
         manager = ChatTaskManager()
-        tables, metrics, sqls = manager._resolve_at_context(real_agent_config, None, None, None)
+        tables, metrics, sqls, hints = manager._resolve_at_context(real_agent_config, None, None, None, None)
         assert tables == []
         assert metrics == []
         assert sqls == []
+        assert hints == []
 
     def test_resolve_with_empty_lists(self, real_agent_config):
         """_resolve_at_context with empty lists returns empty results."""
         manager = ChatTaskManager()
-        tables, metrics, sqls = manager._resolve_at_context(real_agent_config, [], [], [])
+        tables, metrics, sqls, hints = manager._resolve_at_context(real_agent_config, [], [], [], [])
         assert tables == []
         assert metrics == []
         assert sqls == []
+        assert hints == []
 
-    def test_resolve_nonexistent_paths(self, real_agent_config):
-        """_resolve_at_context with nonexistent paths returns empty (no crash)."""
+    def test_knowledge_paths_always_become_hints(self, real_agent_config):
+        """@Knowledge has no store loader, so every ref surfaces as a look-up hint."""
         manager = ChatTaskManager()
-        tables, metrics, sqls = manager._resolve_at_context(
-            real_agent_config,
-            ["nonexistent/table/path"],
-            ["nonexistent/metric/path"],
-            ["nonexistent/sql/path"],
-        )
-        # Should return empty lists since paths don't exist
-        assert isinstance(tables, list)
-        assert isinstance(metrics, list)
-        assert isinstance(sqls, list)
+        _, _, _, hints = manager._resolve_at_context(real_agent_config, None, None, None, ["Domain/Glossary/gmv"])
+        assert hints == [{"kind": "knowledge", "name": "gmv", "subject_path": ["Domain", "Glossary"]}]
 
     def test_table_completer_failure_still_yields_name_only_ref(self, real_agent_config):
         """A completer failure must not drop a picked @Table — it degrades to a
@@ -966,17 +960,21 @@ class TestResolveAtContext:
 
         assert [t.table_name for t in tables] == ["table"]
 
-    def test_metric_store_failure_degrades_to_empty(self, real_agent_config):
-        """@Metric resolution swallows a store failure and yields no refs."""
+    def test_metric_store_failure_degrades_to_hint(self, real_agent_config):
+        """A store failure yields no typed metric but a look-up hint (not a silent drop)."""
         manager = ChatTaskManager()
         with patch("datus.storage.metric.store.MetricRAG", side_effect=RuntimeError("store down")):
-            assert manager._resolve_metric_paths(real_agent_config, ["Finance/revenue"]) == []
+            metrics, hints = manager._resolve_metric_paths(real_agent_config, ["Finance/revenue"])
+        assert metrics == []
+        assert hints == [{"kind": "metric", "name": "revenue", "subject_path": ["Finance"]}]
 
-    def test_sql_store_failure_degrades_to_empty(self, real_agent_config):
-        """@Sql resolution swallows a store failure and yields no refs."""
+    def test_sql_store_failure_degrades_to_hint(self, real_agent_config):
+        """A store failure yields no typed reference SQL but a look-up hint."""
         manager = ChatTaskManager()
         with patch("datus.storage.reference_sql.store.ReferenceSqlRAG", side_effect=RuntimeError("store down")):
-            assert manager._resolve_sql_paths(real_agent_config, ["Finance/sql"]) == []
+            sqls, hints = manager._resolve_sql_paths(real_agent_config, ["Finance/sql"])
+        assert sqls == []
+        assert hints == [{"kind": "reference_sql", "name": "sql", "subject_path": ["Finance"]}]
 
 
 class TestCreateNode:
@@ -2041,16 +2039,19 @@ class TestResolveMetricSqlPaths:
         fake_rag = MagicMock()
         fake_rag.get_metrics_detail.return_value = [{"name": "aov", "description": "avg order value"}]
         with patch("datus.storage.metric.store.MetricRAG", return_value=fake_rag):
-            out = mgr._resolve_metric_paths(MagicMock(), ["Commerce/Orders/aov"])
+            metrics, hints = mgr._resolve_metric_paths(MagicMock(), ["Commerce/Orders/aov"])
         fake_rag.get_metrics_detail.assert_called_once_with(subject_path=["Commerce", "Orders"], name="aov")
-        assert len(out) == 1 and out[0].name == "aov"
+        assert len(metrics) == 1 and metrics[0].name == "aov"
+        assert hints == []
 
-    def test_metric_unresolved_returns_empty(self):
+    def test_metric_unresolved_becomes_hint(self):
         mgr = ChatTaskManager()
         fake_rag = MagicMock()
         fake_rag.get_metrics_detail.return_value = []
         with patch("datus.storage.metric.store.MetricRAG", return_value=fake_rag):
-            assert mgr._resolve_metric_paths(MagicMock(), ["A/b/missing"]) == []
+            metrics, hints = mgr._resolve_metric_paths(MagicMock(), ["A/b/missing"])
+        assert metrics == []
+        assert hints == [{"kind": "metric", "name": "missing", "subject_path": ["A", "b"]}]
 
     def test_sql_uses_path_scoped_detail_lookup(self):
         mgr = ChatTaskManager()
@@ -2061,20 +2062,21 @@ class TestResolveMetricSqlPaths:
             {"name": "q", "sql": "select 1", "summary": None, "comment": None, "tags": None}
         ]
         with patch("datus.storage.reference_sql.store.ReferenceSqlRAG", return_value=fake_store):
-            out = mgr._resolve_sql_paths(MagicMock(), ["main/q"])
+            sqls, hints = mgr._resolve_sql_paths(MagicMock(), ["main/q"])
         fake_store.get_reference_sql_detail.assert_called_once_with(subject_path=["main"], name="q")
-        assert len(out) == 1 and out[0].sql == "select 1"
-        assert out[0].comment == "" and out[0].tags == ""
+        assert len(sqls) == 1 and sqls[0].sql == "select 1"
+        assert sqls[0].comment == "" and sqls[0].tags == ""
+        assert hints == []
 
     def test_metric_none_description_coerced(self):
         mgr = ChatTaskManager()
         fake_rag = MagicMock()
         fake_rag.get_metrics_detail.return_value = [{"name": "aov", "description": None}]
         with patch("datus.storage.metric.store.MetricRAG", return_value=fake_rag):
-            out = mgr._resolve_metric_paths(MagicMock(), ["Commerce/aov"])
-        assert len(out) == 1 and out[0].name == "aov" and out[0].description == ""
+            metrics, _ = mgr._resolve_metric_paths(MagicMock(), ["Commerce/aov"])
+        assert len(metrics) == 1 and metrics[0].name == "aov" and metrics[0].description == ""
 
     def test_empty_paths_short_circuit(self):
         mgr = ChatTaskManager()
-        assert mgr._resolve_metric_paths(MagicMock(), []) == []
-        assert mgr._resolve_sql_paths(MagicMock(), None) == []
+        assert mgr._resolve_metric_paths(MagicMock(), []) == ([], [])
+        assert mgr._resolve_sql_paths(MagicMock(), None) == ([], [])

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2038,3 +2038,21 @@ class TestLookupSubject:
 
     def test_empty_store_returns_none(self):
         assert ChatTaskManager._lookup_subject({}, "main/raw_customers") is None
+
+    def test_shared_suffix_exact_query_hits_the_right_one(self):
+        # A/b/c and D/b/c share the trailing 'b/c'. A full, exact query must
+        # resolve to that exact entry (exact-key match, no ambiguity).
+        flat = {"A/b/c": {"name": "c", "sql": "-- A"}, "D/b/c": {"name": "c", "sql": "-- D"}}
+        assert ChatTaskManager._lookup_subject(flat, "A/b/c")["sql"] == "-- A"
+        assert ChatTaskManager._lookup_subject(flat, "D/b/c")["sql"] == "-- D"
+
+    def test_shared_suffix_bare_query_is_ambiguous(self):
+        # A bare 'b/c' (or 'c') suffix-matches both -> no guess.
+        flat = {"A/b/c": {"name": "c"}, "D/b/c": {"name": "c"}}
+        assert ChatTaskManager._lookup_subject(flat, "b/c") is None
+        assert ChatTaskManager._lookup_subject(flat, "c") is None
+
+    def test_suffix_match_resolves_extra_store_prefix(self):
+        # Picker sends 'main/raw_customers'; store prepended a datasource prefix.
+        flat = {"jeff_shop_live/main/raw_customers": {"name": "raw_customers", "sql": "select 1"}}
+        assert ChatTaskManager._lookup_subject(flat, "main/raw_customers")["sql"] == "select 1"

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2055,11 +2055,24 @@ class TestResolveMetricSqlPaths:
     def test_sql_uses_path_scoped_detail_lookup(self):
         mgr = ChatTaskManager()
         fake_store = MagicMock()
-        fake_store.get_reference_sql_detail.return_value = [{"name": "q", "sql": "select 1"}]
+        # Store returns optional string columns as None (no comment/tags) —
+        # must still build a valid ReferenceSql (regression: pydantic rejected None).
+        fake_store.get_reference_sql_detail.return_value = [
+            {"name": "q", "sql": "select 1", "summary": None, "comment": None, "tags": None}
+        ]
         with patch("datus.storage.reference_sql.store.ReferenceSqlRAG", return_value=fake_store):
             out = mgr._resolve_sql_paths(MagicMock(), ["main/q"])
         fake_store.get_reference_sql_detail.assert_called_once_with(subject_path=["main"], name="q")
         assert len(out) == 1 and out[0].sql == "select 1"
+        assert out[0].comment == "" and out[0].tags == ""
+
+    def test_metric_none_description_coerced(self):
+        mgr = ChatTaskManager()
+        fake_rag = MagicMock()
+        fake_rag.get_metrics_detail.return_value = [{"name": "aov", "description": None}]
+        with patch("datus.storage.metric.store.MetricRAG", return_value=fake_rag):
+            out = mgr._resolve_metric_paths(MagicMock(), ["Commerce/aov"])
+        assert len(out) == 1 and out[0].name == "aov" and out[0].description == ""
 
     def test_empty_paths_short_circuit(self):
         mgr = ChatTaskManager()

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -1928,3 +1928,56 @@ class TestStartChatDatasourceOverride:
         request = StreamChatInput(message="hi", session_id="ds-invalid", datasource="nonexistent")
         with pytest.raises(DatusException):
             await manager.start_chat(real_agent_config, request)
+
+
+class TestMatchTableEntry:
+    """_match_table_entry — resilient @Table resolution when the picker's
+    fullName (live introspection) diverges from the metadata-store key."""
+
+    FLAT = {
+        "jeff_shop_live.main.raw_stores": {
+            "table_name": "raw_stores",
+            "database_name": "jeff_shop_live",
+            "schema_name": "main",
+            "definition": "x",
+            "identifier": "i",
+        },
+        "jeff_shop_live.main.raw_orders": {
+            "table_name": "raw_orders",
+            "database_name": "jeff_shop_live",
+            "schema_name": "main",
+            "definition": "x",
+            "identifier": "i",
+        },
+    }
+
+    def test_catalog_prefix_mismatch_resolves(self):
+        entry = ChatTaskManager._match_table_entry(self.FLAT, "default_catalog.jeff_shop_live.raw_stores")
+        assert entry and entry["table_name"] == "raw_stores"
+
+    def test_bare_db_table_resolves(self):
+        entry = ChatTaskManager._match_table_entry(self.FLAT, "jeff_shop_live.raw_stores")
+        assert entry and entry["table_name"] == "raw_stores"
+
+    def test_unknown_table_returns_none(self):
+        assert ChatTaskManager._match_table_entry(self.FLAT, "default_catalog.jeff_shop_live.nope") is None
+
+    def test_ambiguous_without_db_returns_none(self):
+        amb = {
+            "db1.t": {"table_name": "t", "database_name": "db1"},
+            "db2.t": {"table_name": "t", "database_name": "db2"},
+        }
+        assert ChatTaskManager._match_table_entry(amb, "t") is None
+
+    def test_ambiguous_disambiguated_by_db(self):
+        amb = {
+            "db1.t": {"table_name": "t", "database_name": "db1"},
+            "db2.t": {"table_name": "t", "database_name": "db2"},
+        }
+        entry = ChatTaskManager._match_table_entry(amb, "db2.t")
+        assert entry and entry["database_name"] == "db2"
+
+    def test_sqlite_single_level_resolves(self):
+        flat = {"raw_stores": {"table_name": "raw_stores", "definition": "x"}}
+        entry = ChatTaskManager._match_table_entry(flat, "raw_stores")
+        assert entry and entry["table_name"] == "raw_stores"

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -1981,3 +1981,26 @@ class TestMatchTableEntry:
         flat = {"raw_stores": {"table_name": "raw_stores", "definition": "x"}}
         entry = ChatTaskManager._match_table_entry(flat, "raw_stores")
         assert entry and entry["table_name"] == "raw_stores"
+
+
+class TestSynthesizeTableEntry:
+    """_synthesize_table_entry — name-only fallback when the metadata store
+    can't resolve a picked @Table (KB not indexed for the datasource)."""
+
+    def test_three_part_path(self):
+        from datus.schemas.node_models import TableSchema
+
+        entry = ChatTaskManager._synthesize_table_entry("default_catalog.jeff_shop_live.raw_orders")
+        assert entry["table_name"] == "raw_orders"
+        assert entry["database_name"] == "jeff_shop_live"
+        # Must build a valid TableSchema and render to its own name in the prompt.
+        ts = TableSchema.from_dict(entry)
+        assert TableSchema.table_names_to_prompt([ts]) == "raw_orders"
+
+    def test_single_segment(self):
+        entry = ChatTaskManager._synthesize_table_entry("raw_orders")
+        assert entry["table_name"] == "raw_orders"
+        assert entry["database_name"] == ""
+
+    def test_empty_path(self):
+        assert ChatTaskManager._synthesize_table_entry("") is None

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2004,3 +2004,24 @@ class TestSynthesizeTableEntry:
 
     def test_empty_path(self):
         assert ChatTaskManager._synthesize_table_entry("") is None
+
+
+class TestLookupSubject:
+    """_lookup_subject — subject-tree ref resolution tolerating '.'/'/' separators."""
+
+    FLAT = {
+        "main/raw_customers": {"name": "raw_customers", "comment": "", "summary": "s", "tags": "", "sql": "select 1"}
+    }
+
+    def test_dot_separator_normalizes_to_slash(self):
+        assert ChatTaskManager._lookup_subject(self.FLAT, "main.raw_customers")["name"] == "raw_customers"
+
+    def test_exact_slash_key(self):
+        assert ChatTaskManager._lookup_subject(self.FLAT, "main/raw_customers")["name"] == "raw_customers"
+
+    def test_miss_returns_none(self):
+        assert ChatTaskManager._lookup_subject(self.FLAT, "nope.x") is None
+
+    def test_top_level_name_without_subject_path(self):
+        flat = {"raw_customers": {"name": "raw_customers"}}
+        assert ChatTaskManager._lookup_subject(flat, "raw_customers")["name"] == "raw_customers"

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -2040,6 +2040,74 @@ class TestCopySession:
         assert [it.get("content") for it in read_items] == ["Q1", "A1", "Q2", "A2"]
 
 
+class TestUserMessageContext:
+    """save_user_message_context + get_session_messages @-context round-trip."""
+
+    def _seed_turn(self, sm_custom, session_id, user_text="gen metrics from raw_customers"):
+        import asyncio
+
+        db_path = os.path.join(sm_custom.session_dir, f"{session_id}.db")
+        session = AdvancedSQLiteSession(session_id=session_id, db_path=db_path, create_tables=True)
+        asyncio.run(
+            session.add_items(
+                [
+                    {"role": "user", "content": user_text},
+                    {"role": "assistant", "content": "done"},
+                ]
+            )
+        )
+
+    def test_round_trip_attaches_at_context_to_user_bubble(self, sm_custom):
+        session_id = "chat_session_atctx01"
+        self._seed_turn(sm_custom, session_id)
+        sm_custom.save_user_message_context(
+            session_id,
+            {"table_paths": ["default_catalog.jeff_shop_live.raw_customers"], "metric_paths": ["m/gmv"]},
+        )
+        users = [m for m in sm_custom.get_session_messages(session_id) if m.get("role") == "user"]
+        assert len(users) == 1
+        assert users[0]["at_context"]["table_paths"] == ["default_catalog.jeff_shop_live.raw_customers"]
+        assert users[0]["at_context"]["metric_paths"] == ["m/gmv"]
+
+    def test_no_context_leaves_user_bubble_without_at_context(self, sm_custom):
+        session_id = "chat_session_atctx02"
+        self._seed_turn(sm_custom, session_id)
+        # Empty context is a no-op — nothing persisted.
+        sm_custom.save_user_message_context(session_id, {})
+        users = [m for m in sm_custom.get_session_messages(session_id) if m.get("role") == "user"]
+        assert len(users) == 1
+        assert "at_context" not in users[0]
+
+    def test_context_maps_to_correct_turn(self, sm_custom):
+        """A second turn's context must not bleed onto the first turn's bubble."""
+        import asyncio
+
+        session_id = "chat_session_atctx03"
+        db_path = os.path.join(sm_custom.session_dir, f"{session_id}.db")
+        session = AdvancedSQLiteSession(session_id=session_id, db_path=db_path, create_tables=True)
+        asyncio.run(
+            session.add_items([{"role": "user", "content": "turn one"}, {"role": "assistant", "content": "a1"}])
+        )
+        # No context for turn 1.
+        asyncio.run(
+            session.add_items([{"role": "user", "content": "turn two"}, {"role": "assistant", "content": "a2"}])
+        )
+        sm_custom.save_user_message_context(session_id, {"table_paths": ["c.d.t2"]})
+
+        users = [m for m in sm_custom.get_session_messages(session_id) if m.get("role") == "user"]
+        assert len(users) == 2
+        assert "at_context" not in users[0]
+        assert users[1]["at_context"]["table_paths"] == ["c.d.t2"]
+
+    def test_missing_side_table_is_graceful(self, sm_custom):
+        """Sessions predating the feature (no side table) read back cleanly."""
+        session_id = "chat_session_atctx04"
+        self._seed_turn(sm_custom, session_id)
+        users = [m for m in sm_custom.get_session_messages(session_id) if m.get("role") == "user"]
+        assert len(users) == 1
+        assert "at_context" not in users[0]
+
+
 # ---------------------------------------------------------------------------
 # Module-level helpers: extract_agent_from_session_id, session_matches_agent
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -2107,6 +2107,21 @@ class TestUserMessageContext:
         assert len(users) == 1
         assert "at_context" not in users[0]
 
+    def test_guard_skips_when_no_new_turn(self, sm_custom):
+        """previous_turn_number == current max => run added no turn => no write."""
+        session_id = "chat_session_atctx05"
+        self._seed_turn(sm_custom, session_id)
+        current = sm_custom.get_max_user_turn_number(session_id)
+        assert current >= 1
+        # Simulate a run that persisted no new user turn: guard must skip.
+        sm_custom.save_user_message_context(session_id, {"table_paths": ["c.d.t"]}, previous_turn_number=current)
+        users = [m for m in sm_custom.get_session_messages(session_id) if m.get("role") == "user"]
+        assert "at_context" not in users[0]
+        # A genuinely new turn (previous < max) writes.
+        sm_custom.save_user_message_context(session_id, {"table_paths": ["c.d.t"]}, previous_turn_number=current - 1)
+        users = [m for m in sm_custom.get_session_messages(session_id) if m.get("role") == "user"]
+        assert users[0]["at_context"]["table_paths"] == ["c.d.t"]
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers: extract_agent_from_session_id, session_matches_agent

--- a/tests/unit_tests/schemas/test_at_context.py
+++ b/tests/unit_tests/schemas/test_at_context.py
@@ -1,0 +1,115 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/schemas/at_context.py.
+
+Covers the shared @-context carrier:
+- AtContextInput declares the four reference fields with safe defaults.
+- apply_at_context sets / skips / preserves fields correctly.
+- The anti-leak contract: every subagent node input inherits AtContextInput,
+  so a new reference kind added to the mixin reaches all of them at once.
+"""
+
+import pytest
+
+from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
+from datus.schemas.at_context import AtContextInput, apply_at_context
+from datus.schemas.base import BaseInput
+from datus.schemas.chat_agentic_node_models import ChatNodeInput
+from datus.schemas.explore_agentic_node_models import ExploreNodeInput
+from datus.schemas.feedback_agentic_node_models import FeedbackNodeInput
+from datus.schemas.gen_dashboard_agentic_node_models import GenDashboardNodeInput
+from datus.schemas.gen_report_agentic_node_models import GenReportNodeInput
+from datus.schemas.gen_skill_agentic_node_models import SkillCreatorNodeInput
+from datus.schemas.gen_sql_agentic_node_models import GenSQLNodeInput
+from datus.schemas.gen_visual_dashboard_models import GenVisualDashboardNodeInput
+from datus.schemas.gen_visual_report_models import GenVisualReportNodeInput
+from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
+from datus.schemas.scheduler_agentic_node_models import SchedulerNodeInput
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.schemas.sql_summary_agentic_node_models import SqlSummaryNodeInput
+
+# Every input a subagent funnel (create_node_input / _build_node_input) may
+# construct. Each MUST inherit AtContextInput so @-context reaches its node.
+SUBAGENT_INPUTS = [
+    ChatNodeInput,
+    GenSQLNodeInput,
+    SemanticNodeInput,
+    ExploreNodeInput,
+    AskMetricsNodeInput,
+    GenReportNodeInput,
+    GenVisualReportNodeInput,
+    GenVisualDashboardNodeInput,
+    GenDashboardNodeInput,
+    SqlSummaryNodeInput,
+    SchedulerNodeInput,
+    SkillCreatorNodeInput,
+    FeedbackNodeInput,
+]
+
+AT_CONTEXT_FIELDS = ("schemas", "metrics", "reference_sql", "external_knowledge")
+
+
+def _table() -> TableSchema:
+    return TableSchema(
+        identifier="c.d.t",
+        catalog_name="c",
+        database_name="d",
+        schema_name="",
+        table_name="t",
+        definition="CREATE TABLE t(x int)",
+    )
+
+
+@pytest.mark.parametrize("input_cls", SUBAGENT_INPUTS)
+def test_subagent_input_inherits_at_context(input_cls):
+    """Anti-leak guard: no subagent input may drop the @-context contract."""
+    assert issubclass(input_cls, AtContextInput), f"{input_cls.__name__} must inherit AtContextInput"
+    for field in AT_CONTEXT_FIELDS:
+        assert field in input_cls.model_fields, f"{input_cls.__name__} missing @-context field '{field}'"
+
+
+def test_at_context_defaults_are_empty():
+    si = SemanticNodeInput(user_message="hi")
+    assert si.schemas is None
+    assert si.metrics is None
+    assert si.reference_sql is None
+    assert si.external_knowledge == ""
+
+
+def test_apply_at_context_sets_fields():
+    si = SemanticNodeInput(user_message="hi")
+    ts = _table()
+    m = Metric(name="gmv")
+    r = ReferenceSql(name="q", sql="select 1")
+    apply_at_context(si, schemas=[ts], metrics=[m], reference_sql=[r], external_knowledge="biz")
+    assert si.schemas == [ts]
+    assert si.metrics == [m]
+    assert si.reference_sql == [r]
+    assert si.external_knowledge == "biz"
+
+
+def test_apply_at_context_none_preserves_existing():
+    si = SemanticNodeInput(user_message="hi", external_knowledge="keep")
+    apply_at_context(si, schemas=None, metrics=None, reference_sql=None, external_knowledge=None)
+    assert si.schemas is None
+    assert si.external_knowledge == "keep"
+
+
+def test_apply_at_context_skips_unknown_fields():
+    """A plain BaseInput lacks the fields; helper must not raise (hasattr guard)."""
+
+    class Bare(BaseInput):
+        user_message: str
+
+    bare = Bare(user_message="x")
+    result = apply_at_context(bare, schemas=[_table()], external_knowledge="biz")
+    assert result is bare
+    assert not hasattr(bare, "schemas")
+
+
+def test_reference_sql_accepts_historical_alias():
+    """reference_sql keeps the legacy ``historical_sql`` alias on the mixin."""
+    node = ChatNodeInput.model_validate({"user_message": "hi", "historical_sql": [{"name": "q", "sql": "select 1"}]})
+    assert node.reference_sql and node.reference_sql[0].name == "q"


### PR DESCRIPTION
## Why

@Table / @Metric / @Sql references (`table_paths` / `metric_paths` / `sql_paths`) sent with a chat turn never reached the **semantic subagents** (`gen_metrics`, `gen_semantic_model`, `gen_table`, `gen_job`):

- `SemanticNodeInput` had no fields to carry them, so `node_factory.create_node_input` silently dropped the resolved context, and the `task()`-spawned subagent path (`sub_agent_task_tool._build_node_input`) forwarded none of it.
- Result: `/gen_metrics` with `table_paths` set still re-asked the user "which table?" — the reported bug.

The same gap affected `ask_metrics` / `gen_report` / `gen_visual_report` / `gen_visual_dashboard` / `gen_dashboard` / `scheduler` / `sql_summary` / `explore` inputs. On the consumption side, the `DeliverableAgenticNode` and `BaseVisualArtifactAgenticNode` `_build_enhanced_message` overrides bypassed the base at-context rendering entirely.

Separately, chat **history could not re-render** the references a user attached — they were only ever folded into the enhanced-prompt text and stripped on read.

## Solution

- **One carrier, no leaks.** New `AtContextInput` base (`datus/schemas/at_context.py`) declares `schemas` / `metrics` / `reference_sql` / `external_knowledge`; every subagent input inherits it. `ChatNodeInput` / `GenSQLNodeInput` drop their duplicated fields.
- **One choke point.** A single `apply_at_context` helper is called by both node-input funnels (`create_node_input` and `_build_node_input`); the task tool now inherits the parent turn's @-context (mirroring `_parent_db_context`).
- **One renderer.** `AgenticNode._render_at_context_parts` is the sole place that formats @-context into the prompt, shared by the base `_build_enhanced_message` and the deliverable/visual overrides — a new reference kind renders everywhere by editing one method.
- **History replay.** Each turn's raw reference paths are persisted in a session side table (`user_message_context`, keyed by `user_turn_number`, never fed back to the LLM) and echoed by `GET /api/v1/chat/history` on `SSEMessagePayload.at_context`.

Tradeoff: `knowledge_paths` are persisted/echoed for display, but not resolved into `external_knowledge` (no knowledge completer exists yet) — noted for follow-up.

## Test Cases

- `tests/unit_tests/schemas/test_at_context.py` — anti-leak guard (every subagent input inherits `AtContextInput` and carries all 4 fields), `apply_at_context` set/skip/preserve semantics, `historical_sql` alias round-trip.
- `tests/unit_tests/models/test_session_manager.py::TestUserMessageContext` — save/get round-trip, correct per-turn mapping (no cross-turn bleed), empty-context no-op, and missing-side-table graceful read.
- Full unit suite green (16490 passed; 2 pre-existing failures require local `bird_sqlite` benchmark data and are unrelated to this change).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added support for preserving and replaying referenced tables, metrics, SQL, and external knowledge across chat history.
  * Ensured referenced context is consistently available to agent and subagent workflows.
  * Added support for legacy historical SQL references.

* **Bug Fixes**
  * Improved context mapping to the correct user message and graceful handling when context is unavailable.

* **Tests**
  * Added coverage for context propagation, persistence, replay, defaults, aliases, and unsupported fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preserving and replaying `@`-referenced tables, metrics, SQL, and business knowledge in chat history.
  * Improved context resolution with subject-aware metric and SQL details.
  * Added graceful fallback hints when referenced information cannot be loaded.
  * Enhanced generated prompts with clearer, structured context sections and lookup guidance.

* **Bug Fixes**
  * Prevented referenced context from being lost between turns or incorrectly attached to other messages.
  * Improved handling of ambiguous, incomplete, and legacy reference paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->