### PR TITLE
[Feature] Read-only config mode: hide plugin setup skills and config-edit prompt guidance on the chat API

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2215,6 +2215,7 @@ class AgenticNode(Node):
             self.skill_manager = SkillManager(
                 config=skills_config,
                 permission_manager=self.permission_manager,
+                config_mutable=self._resolve_config_mutable(),
             )
             logger.debug(
                 f"Skill manager initialized for node '{self.get_node_name()}' "
@@ -2260,6 +2261,7 @@ class AgenticNode(Node):
 
                 self.skill_manager = SkillManager(
                     permission_manager=self.permission_manager,
+                    config_mutable=self._resolve_config_mutable(),
                 )
                 logger.info(
                     f"Created default SkillManager for node '{self.get_node_name()}' "
@@ -2313,7 +2315,10 @@ class AgenticNode(Node):
         if not self.skill_manager:
             from datus.tools.skill_tools.skill_manager import SkillManager
 
-            self.skill_manager = SkillManager(permission_manager=self.permission_manager)
+            self.skill_manager = SkillManager(
+                permission_manager=self.permission_manager,
+                config_mutable=self._resolve_config_mutable(),
+            )
 
         from xml.sax.saxutils import quoteattr as xml_quoteattr
 
@@ -3447,6 +3452,17 @@ class AgenticNode(Node):
         if self.agent_config is None:
             return False
         return bool(self.agent_config.filesystem_strict)
+
+    def _resolve_config_mutable(self) -> bool:
+        """Whether the agent may edit the agent config file (agent.yml).
+
+        Reads ``self.agent_config.config_mutable`` (default ``True``). The
+        chat API / gateway set it to ``False`` on their per-request config
+        clone so config-editing setup skills are hidden and refused.
+        """
+        if not self.agent_config:
+            return True
+        return bool(getattr(self.agent_config, "config_mutable", True))
 
     def _make_filesystem_tool(self, **kwargs):
         """Construct a ``FilesystemFuncTool`` with this node's identity baked in.

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -238,6 +238,7 @@ class ChatAgenticNode(AgenticNode):
             self.skill_manager = SkillManager(
                 config=skills_config,
                 permission_manager=self.permission_manager,
+                config_mutable=self._resolve_config_mutable(),
             )
             self.skill_func_tool = SkillFuncTool(
                 manager=self.skill_manager,

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -166,6 +166,7 @@ class SkillCreatorAgenticNode(AgenticNode):
 
             skill_manager = SkillManager(
                 permission_manager=self.permission_manager,
+                config_mutable=self._resolve_config_mutable(),
             )
             self.skill_func_tool_instance = SkillFuncTool(
                 manager=skill_manager,

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -318,6 +318,12 @@ class ChatTaskManager:
         # access, so force filesystem strict mode — every node constructed
         # below reads this flag via AgenticNode._resolve_filesystem_strict().
         agent_config.filesystem_strict = True
+        # Multi-tenant API surface: the AgentConfig may be supplied by an
+        # AuthProvider and the agent must never modify configuration. Hides
+        # ``requires_mutable_config`` setup skills and switches the plugin
+        # prompt preamble to read-only wording. Set on the per-request clone
+        # only — the shared config keeps its default.
+        agent_config.config_mutable = False
         # vscode owns its own local shell: the daemon must not offer a
         # server-side BashTool at all. web has no shell of its own, but plugin
         # CLIs run through bash ("datus <plugin> ..."), so web keeps a

--- a/datus/cli/plugin_commands.py
+++ b/datus/cli/plugin_commands.py
@@ -38,10 +38,14 @@ class PluginCommands:
         if not getattr(self.agent_config, "plugins_enabled", True):
             print_warning(self.console, "Plugins are disabled (`agent.plugins_enabled: false`).")
             return
+        # Gate on list_plugins() (manifest-based) rather than entry points:
+        # a disabled managed plugin's directory is off sys.path, so an
+        # entry-point probe would misreport "no plugins installed" and make
+        # the manager — the tool for re-enabling plugins — unreachable.
         try:
-            from datus.plugins.registry import iter_plugin_entry_points
+            from datus.cli.plugin_service import list_plugins
 
-            if not list(iter_plugin_entry_points()):
+            if not list_plugins(self.agent_config):
                 print_info(
                     self.console,
                     "No plugins installed. Install one with `datus plugin install <source>`.",

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -909,6 +909,15 @@ class AgentConfig:
         # CLI, or direct assignment from API/gateway bootstraps.
         filesystem_raw = kwargs.get("filesystem") or {}
         self._filesystem_strict = bool(filesystem_raw.get("strict", False))
+        # ``config_mutable`` gates whether the agent may be guided to edit the
+        # loaded agent config file (e.g. ``agent.plugins`` profiles). Default
+        # ``True`` (CLI). The chat API and gateway force it to ``False`` on
+        # their per-request config clone: in multi-tenant deployments the
+        # AgentConfig may be supplied by an AuthProvider and must never be
+        # modified by the agent — skills declaring ``requires_mutable_config``
+        # are hidden/refused and the plugin prompt preamble stops naming the
+        # config file.
+        self._config_mutable = _coerce_bool(kwargs.get("config_mutable"), True)
         # ``bash.enabled`` toggles whether agentic nodes instantiate the
         # general-purpose ``BashTool``. Default ``True`` preserves the
         # current behaviour where every node exposes ``bash``
@@ -1158,6 +1167,24 @@ class AgentConfig:
     @filesystem_strict.setter
     def filesystem_strict(self, value: bool) -> None:
         self._filesystem_strict = bool(value)
+
+    @property
+    def config_mutable(self) -> bool:
+        """Whether the agent may edit the loaded agent config file.
+
+        ``True`` (default, CLI): config-editing setup skills may guide the
+        user through writing ``agent.plugins`` profiles.
+
+        ``False`` (chat API / gateway): the config is read-only — skills
+        declaring ``requires_mutable_config: true`` are hidden from
+        ``<available_skills>`` and refused on load, and plugin system-prompt
+        sections must not suggest configuration edits.
+        """
+        return self._config_mutable
+
+    @config_mutable.setter
+    def config_mutable(self, value: bool) -> None:
+        self._config_mutable = bool(value)
 
     @property
     def bash_tool_enabled(self) -> bool:

--- a/datus/gateway/main.py
+++ b/datus/gateway/main.py
@@ -104,6 +104,10 @@ def _run_gateway(args: argparse.Namespace) -> None:
     # file access. Force filesystem strict mode so nodes reject EXTERNAL
     # paths instead of hanging on a prompt.
     agent_config.filesystem_strict = True
+    # IM users must never be guided to edit the server's config file:
+    # hide/refuse setup skills and use the read-only plugin prompt preamble.
+    # (ChatTaskManager.start_chat re-asserts this on its per-request clone.)
+    agent_config.config_mutable = False
 
     try:
         am = agent_config.active_model()

--- a/datus/plugins/base.py
+++ b/datus/plugins/base.py
@@ -88,12 +88,17 @@ Only ``manifest_version`` is required — every other key is optional::
     # the agent's system prompt. Render context: ``plugin_name`` (str),
     # ``profiles`` (dict[str, dict] — the project-activated profiles carrying
     # ONLY fields declared non-secret in ``config_schema``; without a schema,
-    # profile names map to empty dicts) and ``config_path`` (str | None).
+    # profile names map to empty dicts), ``config_path`` (str | None —
+    # ``None`` when the runtime config is read-only) and ``config_mutable``
+    # (bool — ``False`` in deployments where the agent must not edit the
+    # config file, e.g. the multi-tenant chat API).
     # Profile values are env-expanded at load, so secret stripping is
     # structural: undeclared or ``x-secret`` fields never reach the template.
     # An installed-but-unconfigured plugin renders with ``profiles == {}`` —
-    # use ``{% if profiles %}`` to emit setup guidance (pointing at the
-    # bundled setup skill) instead of disappearing from the prompt. datus
+    # use ``{% if profiles %}`` to emit setup guidance instead of disappearing
+    # from the prompt, and inside that unconfigured branch check
+    # ``config_mutable``: point at the bundled setup skill only when it is
+    # true, otherwise tell the user to contact the administrator. datus
     # prepends its own ``## Plugins`` preamble naming the loaded config file,
     # so the template must not hard-code config paths.
 
@@ -101,7 +106,9 @@ Only ``manifest_version`` is required — every other key is optional::
     # Path (relative to the package dir) of a bundled skill directory.
     # Plugins that need configuration should bundle a ``<name>-setup`` skill
     # describing the profile YAML shape, with secrets as ``${ENV_VAR}``
-    # placeholders, never literal values.
+    # placeholders, never literal values. A setup skill must declare
+    # ``requires_mutable_config: true`` in its SKILL.md frontmatter so datus
+    # hides and refuses it when the agent config is read-only (API mode).
 
     config_schema:
       type: object

--- a/datus/plugins/prompt.py
+++ b/datus/plugins/prompt.py
@@ -5,7 +5,9 @@
 """Render a plugin's system-prompt Jinja2 template.
 
 The template named by ``manifest.system_prompt`` is rendered with a context of
-``plugin_name``, ``profiles`` and ``config_path``. Secret handling is
+``plugin_name``, ``profiles``, ``config_path`` and ``config_mutable``
+(``config_path`` is ``None`` and ``config_mutable`` is ``False`` when the
+runtime config is read-only, e.g. the multi-tenant chat API). Secret handling is
 structural: :func:`strip_secret_fields` whitelists profile fields against the
 manifest's ``config_schema`` BEFORE the template sees them — profile values
 are env-expanded (real secrets) by the time prompts are built, so undeclared
@@ -81,11 +83,15 @@ def render_plugin_prompt(
     manifest: PluginManifest,
     profiles: Any,
     config_path: Optional[str] = None,
+    config_mutable: bool = True,
 ) -> Optional[str]:
     """Render ``manifest.system_prompt`` into a system-prompt section.
 
     ``profiles`` is the plugin's (already project-narrowed) profile mapping;
-    it is secret-stripped here before rendering. Returns the stripped rendered
+    it is secret-stripped here before rendering. ``config_mutable`` tells the
+    template whether the agent may guide config edits — unconfigured plugins
+    should point at their setup skill only when it is ``True`` and defer to
+    the administrator otherwise. Returns the stripped rendered
     text, or ``None`` when the manifest declares no template, the template
     escapes the package dir, or rendering fails for any reason. Never raises.
     """
@@ -124,6 +130,7 @@ def render_plugin_prompt(
             plugin_name=manifest.name,
             profiles=strip_secret_fields(profiles, manifest.config_schema),
             config_path=config_path,
+            config_mutable=config_mutable,
         )
     except Exception as exc:  # noqa: BLE001 - one bad template must not break prompt build
         logger.warning("Plugin %r system_prompt template failed to render: %s; skipping.", manifest.name, exc)

--- a/datus/plugins/registry.py
+++ b/datus/plugins/registry.py
@@ -341,13 +341,26 @@ def _agent_config_location() -> Optional[str]:
         return None
 
 
-def _plugin_config_preamble() -> str:
+def _plugin_config_preamble(config_mutable: bool = True) -> str:
     """datus-owned header prepended to the plugin prompt sections.
 
     Tells the agent where plugin profiles live so it can add or edit them
     (e.g. when a setup skill walks the user through configuration). Contains
     only the file path and the config shape — never profile values.
+
+    When ``config_mutable`` is ``False`` (multi-tenant chat API / gateway) the
+    header must not name the config file nor describe its shape — the agent is
+    told configuration is administrator-managed instead.
     """
+    if not config_mutable:
+        return (
+            "## Plugins\n"
+            "Plugin profiles are managed by the deployment administrator and the "
+            "agent configuration is read-only in this environment. Never suggest "
+            "editing configuration files and never walk the user through plugin "
+            "setup; if a plugin is not configured, tell the user to contact their "
+            "administrator. Configured `datus <plugin>` commands work normally."
+        )
     config_path = _agent_config_location()
     location = f"`{config_path}` " if config_path else "the agent config file (agent.yml) "
     return (
@@ -374,11 +387,17 @@ def plugin_system_prompt_sections(agent_config) -> List[str]:
 
     When at least one plugin contributes a section, a datus-owned ``## Plugins``
     preamble naming the loaded config file location is prepended so the agent
-    knows where profiles are added or edited.
+    knows where profiles are added or edited. When
+    ``agent_config.config_mutable`` is ``False`` (multi-tenant chat API /
+    gateway) the preamble switches to read-only wording, ``config_path`` is
+    withheld from templates (a server-local path must not leak to tenants) and
+    templates receive ``config_mutable=False`` so they can defer to the
+    administrator instead of pointing at their setup skill.
     """
     plugin_services = getattr(agent_config, "plugin_services", None) or {}
     active_names = _active_names_from_config(agent_config)
-    config_path = _agent_config_location()
+    config_mutable = bool(getattr(agent_config, "config_mutable", True))
+    config_path = _agent_config_location() if config_mutable else None
     sections: List[str] = []
     for name, manifest in _loaded_manifests():
         if manifest is None or not manifest.system_prompt:
@@ -386,11 +405,11 @@ def plugin_system_prompt_sections(agent_config) -> List[str]:
         if not _is_active(name, active_names):
             continue
         profiles = _active_profiles_subset(agent_config, name, plugin_services.get(name, {}))
-        section = render_plugin_prompt(manifest, profiles, config_path=config_path)
+        section = render_plugin_prompt(manifest, profiles, config_path=config_path, config_mutable=config_mutable)
         if section:
             sections.append(section)
     if sections:
-        sections.insert(0, _plugin_config_preamble())
+        sections.insert(0, _plugin_config_preamble(config_mutable))
     return sections
 
 

--- a/datus/tools/skill_tools/skill_config.py
+++ b/datus/tools/skill_tools/skill_config.py
@@ -277,6 +277,7 @@ class SkillMetadata(BaseModel):
           - gen_dashboard
         context: fork
         agent: Explore
+        requires_mutable_config: false
         ---
 
     Attributes:
@@ -291,6 +292,11 @@ class SkillMetadata(BaseModel):
         allowed_agents: Node names (from ``AgenticNode.get_node_name()``) allowed
             to see and load this skill. Empty list means no restriction — every
             agent can see it.
+        requires_mutable_config: If true, the skill guides the agent through
+            editing the agent config file (the plugin ``<name>-setup``
+            convention). Hidden from ``<available_skills>`` and refused by
+            ``load_skill`` when ``AgentConfig.config_mutable`` is False
+            (chat API / gateway deployments with read-only config).
         context: "fork" to run in isolated subagent
         agent: Subagent type when context=fork (Explore, Plan, general-purpose)
         content: Full SKILL.md content (lazy loaded)
@@ -309,6 +315,13 @@ class SkillMetadata(BaseModel):
     allowed_agents: List[str] = Field(
         default_factory=list,
         description="Agent node names allowed to see/load this skill; empty = unrestricted",
+    )
+    # Config mutability: skills whose purpose is editing local config files
+    # (the plugin ``<name>-setup`` convention) declare this so they can be
+    # hidden/refused when the runtime config is read-only (API mode).
+    requires_mutable_config: bool = Field(
+        default=False,
+        description="If true, hidden/refused when the agent config is read-only (API mode)",
     )
     # Subagent execution
     context: Optional[str] = Field(default=None, description="'fork' to run in isolated subagent")
@@ -407,6 +420,7 @@ class SkillMetadata(BaseModel):
             disable_model_invocation=frontmatter.get("disable_model_invocation", False),
             user_invocable=frontmatter.get("user_invocable", True),
             allowed_agents=frontmatter.get("allowed_agents", []),
+            requires_mutable_config=bool(frontmatter.get("requires_mutable_config", False)),
             context=frontmatter.get("context"),
             agent=frontmatter.get("agent"),
             kind=frontmatter.get("kind", "skill"),
@@ -478,6 +492,7 @@ class SkillMetadata(BaseModel):
             "disable_model_invocation": self.disable_model_invocation,
             "user_invocable": self.user_invocable,
             "allowed_agents": self.allowed_agents,
+            "requires_mutable_config": self.requires_mutable_config,
             "context": self.context,
             "agent": self.agent,
             "kind": self.kind,

--- a/datus/tools/skill_tools/skill_manager.py
+++ b/datus/tools/skill_tools/skill_manager.py
@@ -55,6 +55,7 @@ class SkillManager:
         config: Optional[SkillConfig] = None,
         permission_manager: Optional["PermissionManager"] = None,
         registry: Optional[SkillRegistry] = None,
+        config_mutable: bool = True,
     ):
         """Initialize the skill manager.
 
@@ -62,10 +63,15 @@ class SkillManager:
             config: Skills configuration
             permission_manager: Permission manager for access control
             registry: Optional pre-configured registry (for testing)
+            config_mutable: Whether the agent config file may be edited in
+                this deployment. When False (chat API / gateway), skills
+                declaring ``requires_mutable_config: true`` are hidden from
+                listings and refused on load.
         """
         self.config = config or SkillConfig()
         self.permission_manager = permission_manager
         self.registry = registry or SkillRegistry(config=self.config)
+        self.config_mutable = bool(config_mutable)
 
         # Scan directories on initialization
         self.registry.scan_directories()
@@ -124,6 +130,12 @@ class SkillManager:
         # by the hook). See ValidationHook design doc (Part §5.3).
         all_skills = [s for s in all_skills if not s.is_validator()]
 
+        # Hide config-editing setup skills when the runtime config is
+        # immutable (chat API / gateway): the agent must not be pointed at
+        # skills whose whole purpose is editing the agent config file.
+        if not self.config_mutable:
+            all_skills = [s for s in all_skills if not s.requires_mutable_config]
+
         logger.debug(f"Available skills for {node_name}: {[s.name for s in all_skills]}")
         return all_skills
 
@@ -176,6 +188,22 @@ class SkillManager:
             return (
                 False,
                 f"Skill '{skill_name}' is a validator — executed by ValidationHook, not loadable here",
+                None,
+            )
+
+        # Refuse config-editing setup skills when the runtime config is
+        # read-only. Placed before the scope/authoring bypasses so even a
+        # ``gen_skill`` authoring flow in API mode cannot load one.
+        if not self.config_mutable and skill.requires_mutable_config:
+            logger.warning(
+                "Skill '%s' requires a mutable agent config; refused in read-only config mode",
+                skill_name,
+            )
+            return (
+                False,
+                f"Skill '{skill_name}' walks through editing the agent configuration, "
+                "which is read-only in this deployment. Plugin profiles are managed by "
+                "the administrator — ask them to configure it.",
                 None,
             )
 

--- a/docs/plugin/development.md
+++ b/docs/plugin/development.md
@@ -489,8 +489,13 @@ Environments ({{ profiles | length }}):
 - {{ name }}: {{ cfg.get("greeting", "?") }}
 {% endfor %}
 {% else %}
-Installed but not configured — run the `hello-setup` skill to configure an
-environment.
+Installed but not configured.
+{% if config_mutable %}
+Run the `hello-setup` skill to configure an environment.
+{% else %}
+Configuration is managed by the deployment administrator — tell the user to
+contact them.
+{% endif %}
 {% endif %}
 ```
 
@@ -500,17 +505,20 @@ The render context:
 |---|---|
 | `plugin_name` | your entry-point name |
 | `profiles` | `dict[str, dict]` — the plugin's profile mapping, **narrowed to the profiles the project activated** (`plugins.<name>.active_profile` in `./.datus/config.yml`) and **secret-stripped** (see below) |
-| `config_path` | the loaded agent config file path, or `None` |
+| `config_path` | the loaded agent config file path, or `None` (always `None` when the config is read-only) |
+| `config_mutable` | `True` when the agent may edit the config file; `False` in managed deployments (multi-tenant chat API / gateway). Requires datus-agent ≥ the release introducing it — on older versions a template referencing it fails to render (strict mode) and the section is skipped |
 
 An installed-but-unconfigured plugin (or one whose pin matches nothing)
 renders with `profiles == {}` — use `{% if profiles %}` to emit a short
-"installed, not configured" note pointing at your bundled setup skill instead
-of disappearing from the prompt.
+"installed, not configured" note instead of disappearing from the prompt, and
+inside that branch check `config_mutable`: point at your bundled setup skill
+only when it is `True`, otherwise defer to the administrator.
 
 When at least one plugin contributes a section, Datus prepends its own
 `## Plugins` preamble naming the loaded config file and the
 `agent.plugins.<plugin>.<profile>` shape — your template never needs to
-hard-code config paths.
+hard-code config paths. In read-only mode the preamble switches to wording
+that forbids config-edit suggestions and defers to the administrator.
 
 !!! note "Secrets are stripped structurally"
     The rendered text enters the LLM context, and profile values are already
@@ -681,9 +689,14 @@ The setup `SKILL.md` should cover, in order:
    `datus <plugin>` reloads the config on every invocation, so the profile
    works immediately; the prompt's environment list refreshes next session.
 
-Add a guard note: if the current environment cannot edit the config file
-(API / VSCode / web deployment), the agent should tell the user to edit
-`agent.yml` on the server instead.
+Declare `requires_mutable_config: true` in the setup skill's frontmatter.
+Datus then hides the skill from `<available_skills>` and refuses `load_skill`
+in deployments where the agent config is read-only (multi-tenant chat API /
+gateway) — the agent defers to the administrator instead of walking the user
+through an edit it cannot make. Keep an in-body guard note as a fallback for
+older datus-agent versions that ignore the frontmatter field: if the current
+environment cannot edit the config file, the agent should tell the user to
+edit `agent.yml` on the server instead.
 
 A complete minimal `hello-setup/SKILL.md`:
 
@@ -691,6 +704,7 @@ A complete minimal `hello-setup/SKILL.md`:
 ---
 name: hello-setup
 description: Configure an environment profile for the `datus hello` plugin
+requires_mutable_config: true
 ---
 
 # Hello Setup
@@ -782,10 +796,14 @@ def test_prompt_template_renders_without_secrets():
     env = Environment(loader=FileSystemLoader(PKG), undefined=StrictUndefined)
     template = env.get_template("prompts/system.md.j2")
     # datus strips undeclared / x-secret fields before rendering; emulate that.
-    text = template.render(plugin_name="hello", profiles={"prod": {"greeting": "Hi"}}, config_path=None)
+    ctx = {"plugin_name": "hello", "config_path": None, "config_mutable": True}
+    text = template.render(profiles={"prod": {"greeting": "Hi"}}, **ctx)
     assert "## Hello" in text
-    text = template.render(plugin_name="hello", profiles={}, config_path=None)
+    text = template.render(profiles={}, **ctx)
     assert "hello-setup" in text
+    # read-only deployments must not be pointed at the setup skill
+    text = template.render(profiles={}, plugin_name="hello", config_path=None, config_mutable=False)
+    assert "hello-setup" not in text
 ```
 
 ## Distributing for offline install

--- a/docs/plugin/development.zh.md
+++ b/docs/plugin/development.zh.md
@@ -456,8 +456,13 @@ Environments ({{ profiles | length }}):
 - {{ name }}: {{ cfg.get("greeting", "?") }}
 {% endfor %}
 {% else %}
-Installed but not configured — run the `hello-setup` skill to configure an
-environment.
+Installed but not configured.
+{% if config_mutable %}
+Run the `hello-setup` skill to configure an environment.
+{% else %}
+Configuration is managed by the deployment administrator — tell the user to
+contact them.
+{% endif %}
 {% endif %}
 ```
 
@@ -467,15 +472,17 @@ environment.
 |---|---|
 | `plugin_name` | 你的 entry-point 名 |
 | `profiles` | `dict[str, dict]`——plugin 的 profile 映射,**已收窄到项目激活的 profile**(`./.datus/config.yml` 的 `plugins.<name>.active_profile`)且**已剥离 secret**(见下) |
-| `config_path` | 已加载的 agent 配置文件路径,或 `None` |
+| `config_path` | 已加载的 agent 配置文件路径,或 `None`(配置只读时恒为 `None`) |
+| `config_mutable` | agent 可编辑配置文件时为 `True`;托管部署(多租户 chat API / gateway)下为 `False`。需要引入该变量的 datus-agent 版本及以上——旧版本中引用它的模板会渲染失败(严格模式)并跳过该 section |
 
 已安装但未配置的 plugin(或 pin 无匹配)渲染时 `profiles == {}`——用
-`{% if profiles %}` 输出一段"已安装未配置"提示并指向捆绑的 setup skill,而不是
-从提示词中消失。
+`{% if profiles %}` 输出一段"已安装未配置"提示而不是从提示词中消失,并在该
+分支内检查 `config_mutable`:仅当它为 `True` 时指向捆绑的 setup skill,否则
+提示用户联系管理员。
 
 只要有任一 plugin 贡献了 section,Datus 会前置自己的 `## Plugins` 导语,写明已
 加载的配置文件和 `agent.plugins.<plugin>.<profile>` 结构——你的模板永远不需要
-硬编码配置路径。
+硬编码配置路径。只读模式下导语会换成禁止建议修改配置、请联系管理员的措辞。
 
 !!! note "secret 是结构性剥离的"
     渲染出的文本会进入 LLM 上下文,而 profile 的值在提示词构建时已完成
@@ -614,8 +621,12 @@ setup `SKILL.md` 应按顺序覆盖:
    `datus <plugin>` 每次调用都重新加载配置,profile 立即生效;提示词里的环境列
    表下个会话刷新。
 
-加一条保护性说明:若当前环境无法编辑配置文件(API / VSCode / web 部署),agent
-应告知用户去服务器上改 `agent.yml`。
+在 setup skill 的 frontmatter 里声明 `requires_mutable_config: true`。配置只读
+的部署(多租户 chat API / gateway)中,Datus 会把该 skill 从
+`<available_skills>` 中隐藏并拒绝 `load_skill`——agent 会引导用户联系管理员,
+而不是走一遍它做不到的配置编辑。同时在正文保留一条保护性说明,作为旧版
+datus-agent(会忽略该 frontmatter 字段)的兜底:若当前环境无法编辑配置文件,
+agent 应告知用户去服务器上改 `agent.yml`。
 
 一个完整的最小 `hello-setup/SKILL.md`:
 
@@ -623,6 +634,7 @@ setup `SKILL.md` 应按顺序覆盖:
 ---
 name: hello-setup
 description: Configure an environment profile for the `datus hello` plugin
+requires_mutable_config: true
 ---
 
 # Hello Setup
@@ -709,10 +721,14 @@ def test_prompt_template_renders_without_secrets():
     env = Environment(loader=FileSystemLoader(PKG), undefined=StrictUndefined)
     template = env.get_template("prompts/system.md.j2")
     # datus 渲染前会剥离未声明 / x-secret 字段;此处模拟同样的输入。
-    text = template.render(plugin_name="hello", profiles={"prod": {"greeting": "Hi"}}, config_path=None)
+    ctx = {"plugin_name": "hello", "config_path": None, "config_mutable": True}
+    text = template.render(profiles={"prod": {"greeting": "Hi"}}, **ctx)
     assert "## Hello" in text
-    text = template.render(plugin_name="hello", profiles={}, config_path=None)
+    text = template.render(profiles={}, **ctx)
     assert "hello-setup" in text
+    # 只读部署下绝不能把 agent 指向 setup skill
+    text = template.render(profiles={}, plugin_name="hello", config_path=None, config_mutable=False)
+    assert "hello-setup" not in text
 ```
 
 ## 分发离线安装包

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -242,7 +242,9 @@ Beyond running `datus <name> ...` yourself, plugins integrate with the agent:
   itself in the prompt and points the agent at its bundled `<name>-setup`
   skill. Ask the agent to set the plugin up, and it collects the required
   values and writes the profile for you (secrets are referenced as `${VAR}`,
-  never written literally).
+  never written literally). In managed deployments where the agent config is
+  read-only (the multi-tenant chat API / gateway), setup skills are hidden and
+  the agent directs users to their administrator instead.
 
 ## Agent bash permissions
 

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -209,7 +209,9 @@ datus plugin disable noisy-plugin            # 本项目停用
   掌握的信息。prompt 段落在会话启动时刷新;会话中途的配置修改要到下一个会话才可见。
 - **引导式配置** —— 已安装但未配置的插件通常会在 prompt 中声明自己,并指向自带的
   `<name>-setup` skill。让 agent 帮你配置,它会收集必填项并替你写入 profile
-  (密钥以 `${VAR}` 形式引用,绝不写明文)。
+  (密钥以 `${VAR}` 形式引用,绝不写明文)。在 agent 配置只读的托管部署
+  (多租户 chat API / gateway)中,setup skill 会被隐藏,agent 会引导用户联系
+  管理员。
 
 ## Agent bash 权限
 

--- a/docs/skills/introduction.md
+++ b/docs/skills/introduction.md
@@ -267,6 +267,7 @@ Available subagent types for isolated execution:
 |-------|---------|-------------|
 | `disable_model_invocation` | `false` | If true, only user can invoke via `/skill-name` |
 | `user_invocable` | `true` | If false, hidden from CLI menu (only model invokes) |
+| `requires_mutable_config` | `false` | If true, hidden and refused when the agent config is read-only (multi-tenant chat API / gateway) — for skills that guide config-file edits |
 
 ## SKILL.md Reference
 
@@ -282,6 +283,7 @@ Available subagent types for isolated execution:
 | `agent` | No | Subagent type: `Explore`, `Plan`, `general-purpose` |
 | `disable_model_invocation` | No | If true, only user can invoke |
 | `user_invocable` | No | If false, hidden from CLI menu |
+| `requires_mutable_config` | No | If true, hidden/refused when the agent config is read-only (API mode) |
 
 ### Security Features
 

--- a/docs/skills/introduction.zh.md
+++ b/docs/skills/introduction.zh.md
@@ -284,6 +284,7 @@ This skill runs in an isolated Explore subagent for thorough investigation.
 |------|--------|------|
 | `disable_model_invocation` | `false` | 如为 true，仅用户可通过 `/skill-name` 调用 |
 | `user_invocable` | `true` | 如为 false，从 CLI 菜单隐藏（仅模型调用） |
+| `requires_mutable_config` | `false` | 如为 true，在 agent 配置只读的部署（多租户 chat API / gateway）中隐藏并拒绝加载——用于引导修改配置文件的技能 |
 
 ## SKILL.md 参考
 
@@ -300,6 +301,7 @@ This skill runs in an isolated Explore subagent for thorough investigation.
 | `agent` | 否 | Subagent 类型：`Explore`、`Plan`、`general-purpose` |
 | `disable_model_invocation` | 否 | 如为 true，仅用户可调用 |
 | `user_invocable` | 否 | 如为 false，从 CLI 菜单隐藏 |
+| `requires_mutable_config` | 否 | 如为 true，配置只读（API 模式）时隐藏/拒绝加载 |
 
 ### 命令模式格式
 

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -791,6 +791,27 @@ class TestStartChat:
             "db_schema": "configured_schema",
         }
 
+    async def test_start_chat_forces_immutable_config(self, real_agent_config, monkeypatch):
+        """The per-request clone is marked read-only (filesystem + config)
+        while the shared config keeps its defaults."""
+        from datus.api.models.cli_models import StreamChatInput
+
+        captured = {}
+
+        async def fake_run_loop(self, task, agent_config, request, **kwargs):
+            captured["config"] = agent_config
+
+        monkeypatch.setattr(ChatTaskManager, "_run_loop", fake_run_loop)
+        manager = ChatTaskManager()
+        request = StreamChatInput(message="hello", session_id="immutable-config")
+        task = await manager.start_chat(real_agent_config, request)
+        await task.asyncio_task
+
+        assert captured["config"].config_mutable is False
+        assert captured["config"].filesystem_strict is True
+        # The shared config must not be mutated by the request.
+        assert real_agent_config.config_mutable is True
+
     async def test_start_chat_duplicate_session_raises(self, real_agent_config, mock_llm_create):
         """start_chat raises ValueError for duplicate session_id."""
         from datus.api.models.cli_models import StreamChatInput

--- a/tests/unit_tests/cli/test_plugin_commands.py
+++ b/tests/unit_tests/cli/test_plugin_commands.py
@@ -1,0 +1,129 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for :mod:`datus.cli.plugin_commands` (the ``/plugins`` gate).
+
+CI-level: a throwaway ``~/.datus`` home and a stubbed entry-point registry —
+no plugin code is imported and no real ``datus.plugins`` entry points leak in
+from the dev environment. The regression under test: the gate must consult the
+manifest-based ``list_plugins()`` listing, because a disabled managed plugin's
+directory is off ``sys.path`` and therefore invisible to entry-point probing.
+"""
+
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from datus.cli.plugin_commands import PluginCommands
+from datus.plugins import store
+from datus.utils.path_manager import DatusPathManager, reset_path_manager, set_current_path_manager
+
+
+@pytest.fixture
+def home(tmp_path):
+    token = set_current_path_manager(DatusPathManager(datus_home=tmp_path))
+    try:
+        yield tmp_path
+    finally:
+        reset_path_manager(token)
+
+
+def _agent_config(*, plugins_enabled=True):
+    config = MagicMock()
+    config.plugins_enabled = plugins_enabled
+    # Project config lists plugins but none is enabled — the state that keeps
+    # every managed plugin directory off sys.path.
+    config.active_plugin_names.return_value = set()
+    config.active_plugin_profiles.return_value = []
+    config.plugin_services = {}
+    config.plugin_paths = None
+    return config
+
+
+def _build_commands(agent_config, tui_app=None):
+    buf = io.StringIO()
+    cli = SimpleNamespace(
+        console=Console(file=buf, force_terminal=False, width=120, log_path=False),
+        agent_config=agent_config,
+        tui_app=tui_app,
+    )
+    return PluginCommands(cli), buf
+
+
+def _install_managed_plugin(name="demo"):
+    store.write_meta(
+        store.plugin_dir(name),
+        {
+            "name": name,
+            "distribution": f"datus-{name}-plugin",
+            "version": "0.1.0",
+            "entry_point": f"datus_{name}_plugin",
+            "install": {"type": "whl"},
+        },
+    )
+
+
+def test_master_switch_off_prints_warning_and_skips_manager(home):
+    commands, buf = _build_commands(_agent_config(plugins_enabled=False))
+    with patch("datus.cli.plugin_commands.PluginApp") as app_cls:
+        commands.cmd_plugins("")
+    assert "Plugins are disabled" in buf.getvalue()
+    app_cls.assert_not_called()
+
+
+def test_empty_store_prints_install_hint(home):
+    commands, buf = _build_commands(_agent_config())
+    with (
+        patch("datus.plugins.registry.iter_plugin_entry_points", return_value=[]),
+        patch("datus.cli.plugin_commands.PluginApp") as app_cls,
+    ):
+        commands.cmd_plugins("")
+    assert "No plugins installed" in buf.getvalue()
+    app_cls.assert_not_called()
+
+
+def test_disabled_managed_plugin_still_opens_manager(home):
+    """A managed plugin with project activation off must reach the manager.
+
+    Its directory is off sys.path, so entry-point probing sees nothing — the
+    gate must rely on the datus-plugin.json manifest listing instead, else
+    /plugins (the tool for re-enabling plugins) becomes unreachable.
+    """
+    _install_managed_plugin("demo")
+    agent_config = _agent_config()
+    commands, buf = _build_commands(agent_config)
+    with (
+        patch("datus.plugins.registry.iter_plugin_entry_points", return_value=[]),
+        patch("datus.cli.plugin_commands.PluginApp") as app_cls,
+    ):
+        commands.cmd_plugins("")
+    assert "No plugins installed" not in buf.getvalue()
+    app_cls.assert_called_once_with(agent_config, commands.console)
+    app_cls.return_value.run.assert_called_once_with()
+
+
+def test_discovery_failure_degrades_open(home):
+    commands, _buf = _build_commands(_agent_config())
+    with (
+        patch("datus.cli.plugin_service.list_plugins", side_effect=RuntimeError("boom")),
+        patch("datus.cli.plugin_commands.PluginApp") as app_cls,
+    ):
+        commands.cmd_plugins("")
+    app_cls.return_value.run.assert_called_once_with()
+
+
+def test_active_tui_embeds_manager_via_run_wizard(home):
+    _install_managed_plugin("demo")
+    tui_app = SimpleNamespace(_loop=object(), run_wizard=MagicMock(return_value=None))
+    commands, _buf = _build_commands(_agent_config(), tui_app=tui_app)
+    with (
+        patch("datus.plugins.registry.iter_plugin_entry_points", return_value=[]),
+        patch("datus.cli.plugin_commands.PluginApp") as app_cls,
+    ):
+        commands.cmd_plugins("")
+    tui_app.run_wizard.assert_called_once_with(app_cls.return_value.build_embedded_panel)
+    app_cls.return_value.run.assert_not_called()

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2849,6 +2849,43 @@ class TestPluginsEnabledSwitch:
         assert cfg.get_plugin_profile("hello") == {}
 
 
+class TestConfigMutable:
+    """``config_mutable`` — read-only config mode for API/gateway surfaces."""
+
+    def _make(self, tmp_path, **extra):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            skip_init_dirs=True,
+            **extra,
+        )
+
+    def test_defaults_to_mutable(self, tmp_path):
+        assert self._make(tmp_path).config_mutable is True
+
+    @pytest.mark.parametrize("value", [False, "false", "no", "off", "0"])
+    def test_immutable_values(self, tmp_path, value):
+        assert self._make(tmp_path, config_mutable=value).config_mutable is False
+
+    def test_setter_coerces_to_bool(self, tmp_path):
+        cfg = self._make(tmp_path)
+        cfg.config_mutable = 0
+        assert cfg.config_mutable is False
+        cfg.config_mutable = "yes"
+        assert cfg.config_mutable is True
+
+    def test_deepcopy_isolates_the_clone(self, tmp_path):
+        import copy
+
+        cfg = self._make(tmp_path)
+        clone = copy.deepcopy(cfg)
+        clone.config_mutable = False
+        assert clone.config_mutable is False
+        assert cfg.config_mutable is True
+
+
 class TestPluginPathsConfig:
     """``agent.plugin_paths`` — extra plugin-level directory mounts."""
 

--- a/tests/unit_tests/plugins/test_prompt.py
+++ b/tests/unit_tests/plugins/test_prompt.py
@@ -206,6 +206,25 @@ def test_render_config_path_in_context(tmp_path):
     assert render_plugin_prompt(manifest, {}, config_path="/srv/agent.yml") == "cfg=/srv/agent.yml"
 
 
+def test_render_config_mutable_in_context(tmp_path):
+    manifest = _manifest(tmp_path, "{% if config_mutable %}RW{% else %}RO{% endif %}")
+    assert render_plugin_prompt(manifest, {}, config_mutable=True) == "RW"
+    assert render_plugin_prompt(manifest, {}, config_mutable=False) == "RO"
+
+
+def test_render_config_mutable_defaults_true(tmp_path):
+    manifest = _manifest(tmp_path, "{% if config_mutable %}RW{% else %}RO{% endif %}")
+    assert render_plugin_prompt(manifest, {}) == "RW"
+
+
+def test_render_template_without_config_mutable_still_renders(tmp_path):
+    """Back-compat: templates that never reference the new variable render
+    unchanged under both values (StrictUndefined only fails on reference)."""
+    manifest = _manifest(tmp_path, "{% if profiles %}configured{% else %}unconfigured{% endif %}")
+    assert render_plugin_prompt(manifest, {}, config_mutable=True) == "unconfigured"
+    assert render_plugin_prompt(manifest, {}, config_mutable=False) == "unconfigured"
+
+
 def test_render_nested_template_dir(tmp_path):
     manifest = _manifest(tmp_path, "nested ok", rel="prompts/system.md.j2")
     assert render_plugin_prompt(manifest, {}) == "nested ok"

--- a/tests/unit_tests/plugins/test_registry.py
+++ b/tests/unit_tests/plugins/test_registry.py
@@ -20,10 +20,16 @@ TRANSFORMER_MODULE = "def passthrough(tool_name, args, context):\n    return arg
 
 
 class _FakeConfig:
-    """Stand-in for AgentConfig exposing only ``plugin_services``."""
+    """Stand-in for AgentConfig exposing only ``plugin_services``.
 
-    def __init__(self, plugin_services):
+    ``config_mutable`` is only set when supplied so the default case also
+    exercises the ``getattr``-fallback path in the registry.
+    """
+
+    def __init__(self, plugin_services, config_mutable=None):
         self.plugin_services = plugin_services
+        if config_mutable is not None:
+            self.config_mutable = config_mutable
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +276,34 @@ def test_preamble_degrades_without_config_path(plugin_env, monkeypatch):
     sections = registry.plugin_system_prompt_sections(_FakeConfig({}))
     assert sections[0].startswith("## Plugins")
     assert "agent.yml" in sections[0]  # generic wording instead of a path
+
+
+def test_preamble_immutable_omits_config_path_and_edit_guidance(plugin_env, monkeypatch):
+    """Read-only mode: the preamble must not leak the server config path nor
+    describe the profile shape — it defers to the administrator instead."""
+    _prompt_plugin(plugin_env)
+    monkeypatch.setattr(registry, "_agent_config_location", lambda: "/srv/conf/agent.yml")
+    sections = registry.plugin_system_prompt_sections(_FakeConfig({}, config_mutable=False))
+    assert sections[0].startswith("## Plugins")
+    assert "/srv/conf/agent.yml" not in sections[0]
+    assert "agent.plugins.<plugin>.<profile>" not in sections[0]
+    assert "administrator" in sections[0]
+    assert "read-only" in sections[0]
+
+
+def test_sections_pass_config_mutable_to_template(plugin_env):
+    _prompt_plugin(plugin_env, template="{% if config_mutable %}CAN-EDIT{% else %}NO-EDIT{% endif %}")
+    assert "NO-EDIT" in registry.plugin_system_prompt_sections(_FakeConfig({}, config_mutable=False))
+    assert "CAN-EDIT" in registry.plugin_system_prompt_sections(_FakeConfig({}, config_mutable=True))
+
+
+def test_immutable_withholds_config_path_from_template(plugin_env, monkeypatch):
+    _prompt_plugin(plugin_env, template="PATH={{ config_path }}")
+    monkeypatch.setattr(registry, "_agent_config_location", lambda: "/srv/conf/agent.yml")
+    sections = registry.plugin_system_prompt_sections(_FakeConfig({}, config_mutable=False))
+    assert "PATH=None" in sections
+    mutable_sections = registry.plugin_system_prompt_sections(_FakeConfig({}, config_mutable=True))
+    assert "PATH=/srv/conf/agent.yml" in mutable_sections
 
 
 def test_agent_config_location_prefers_loaded_manager(monkeypatch):

--- a/tests/unit_tests/tools/skill_tools/test_skill_config.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_config.py
@@ -457,6 +457,24 @@ class TestSkillMetadata:
         assert metadata.description == "Simple skill"
         assert metadata.tags == []
 
+    def test_requires_mutable_config_defaults_false(self):
+        """Omitted frontmatter key parses to False and still serializes."""
+        frontmatter = {"name": "plain", "description": "Plain skill"}
+        metadata = SkillMetadata.from_frontmatter(frontmatter, Path("/skills/plain"))
+        assert metadata.requires_mutable_config is False
+        assert metadata.to_dict()["requires_mutable_config"] is False
+
+    def test_requires_mutable_config_parsed_true(self):
+        """The plugin ``<name>-setup`` convention: frontmatter true survives parsing."""
+        frontmatter = {
+            "name": "hello-setup",
+            "description": "Configure a profile for the hello plugin",
+            "requires_mutable_config": True,
+        }
+        metadata = SkillMetadata.from_frontmatter(frontmatter, Path("/skills/hello-setup"))
+        assert metadata.requires_mutable_config is True
+        assert metadata.to_dict()["requires_mutable_config"] is True
+
     def test_skill_metadata_serialization(self):
         """Test SkillMetadata serialization."""
         metadata = SkillMetadata(

--- a/tests/unit_tests/tools/skill_tools/test_skill_func_tool.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_func_tool.py
@@ -189,6 +189,34 @@ class TestSkillFuncToolLoadSkill:
         assert result.success == 1
         assert "Scoped Table Skill" in result.result
 
+    def test_load_skill_blocked_in_immutable_config_mode(self, skill_config_with_extra):
+        """A ``requires_mutable_config`` skill is refused through the whole
+        ``SkillFuncTool -> SkillManager`` chain when the config is read-only."""
+        config, extra_dir = skill_config_with_extra
+        setup_dir = extra_dir / "fake-setup"
+        setup_dir.mkdir()
+        (setup_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: fake-setup\n"
+            "description: Configure a plugin profile\n"
+            "requires_mutable_config: true\n"
+            "---\n"
+            "# Fake Setup\nEdit agent.yml.\n",
+            encoding="utf-8",
+        )
+        immutable_manager = SkillManager(config=config, config_mutable=False)
+        tool = SkillFuncTool(manager=immutable_manager, node_name="chat")
+        result = tool.load_skill("fake-setup")
+
+        assert result.success == 0
+        assert "read-only" in result.error
+        assert "administrator" in result.error
+
+        mutable_manager = SkillManager(config=config)
+        ok_result = SkillFuncTool(manager=mutable_manager, node_name="chat").load_skill("fake-setup")
+        assert ok_result.success == 1
+        assert "Fake Setup" in ok_result.result
+
 
 class TestSkillFuncToolPermissionCallback:
     """Tests for permission callback integration."""

--- a/tests/unit_tests/tools/skill_tools/test_skill_manager_unit.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_manager_unit.py
@@ -108,6 +108,68 @@ class TestGetAvailableSkills:
         assert skills == []
 
 
+class TestConfigMutableFiltering:
+    """Read-only config mode hides and refuses ``requires_mutable_config`` skills."""
+
+    def _registry(self, *skills):
+        registry = MagicMock()
+        registry.get_skill_count.return_value = len(skills)
+        registry.list_skills.return_value = list(skills)
+        registry.get_skill.side_effect = lambda name: next((s for s in skills if s.name == name), None)
+        registry.load_skill_content.return_value = "# Setup steps"
+        return registry
+
+    def test_immutable_hides_requires_mutable_skill(self):
+        setup = _make_skill("hello-setup", requires_mutable_config=True)
+        plain = _make_skill("hello")
+        manager = SkillManager(registry=self._registry(setup, plain), config_mutable=False)
+        assert [s.name for s in manager.get_available_skills("chat")] == ["hello"]
+
+    def test_mutable_keeps_requires_mutable_skill(self):
+        setup = _make_skill("hello-setup", requires_mutable_config=True)
+        manager = SkillManager(registry=self._registry(setup))
+        assert [s.name for s in manager.get_available_skills("chat")] == ["hello-setup"]
+
+    def test_immutable_xml_omits_requires_mutable_skill(self):
+        setup = _make_skill("hello-setup", requires_mutable_config=True)
+        plain = _make_skill("hello")
+        manager = SkillManager(registry=self._registry(setup, plain), config_mutable=False)
+        xml = manager.generate_available_skills_xml("chat")
+        assert "hello-setup" not in xml
+        assert 'name="hello"' in xml
+
+    def test_load_refused_when_immutable(self):
+        setup = _make_skill("hello-setup", requires_mutable_config=True)
+        manager = SkillManager(registry=self._registry(setup), config_mutable=False)
+        ok, msg, content = manager.load_skill("hello-setup", "chat")
+        assert ok is False
+        assert content is None
+        assert "read-only" in msg
+        assert "administrator" in msg
+
+    def test_load_refused_even_with_authoring_bypasses(self):
+        """The guard sits before scope/permission bypasses — gen_skill in API mode is refused too."""
+        setup = _make_skill("hello-setup", requires_mutable_config=True, allowed_agents=["gen_skill"])
+        manager = SkillManager(registry=self._registry(setup), config_mutable=False)
+        ok, msg, _ = manager.load_skill("hello-setup", "gen_skill", check_permission=False, check_scope=False)
+        assert ok is False
+        assert "read-only" in msg
+
+    def test_load_succeeds_when_mutable(self):
+        setup = _make_skill("hello-setup", requires_mutable_config=True)
+        manager = SkillManager(registry=self._registry(setup))
+        ok, _, content = manager.load_skill("hello-setup", "chat")
+        assert ok is True
+        assert content == "# Setup steps"
+
+    def test_ordinary_skill_unaffected_when_immutable(self):
+        plain = _make_skill("hello")
+        manager = SkillManager(registry=self._registry(plain), config_mutable=False)
+        ok, _, content = manager.load_skill("hello", "chat")
+        assert ok is True
+        assert content == "# Setup steps"
+
+
 class TestLoadSkill:
     def test_load_success(self):
         registry = MagicMock()


### PR DESCRIPTION
## Why

Plugins bundle `<name>-setup` skills that walk the agent through editing `agent.yml` plugin profiles, and their system-prompt templates point at those skills when unconfigured. In multi-tenant API deployments the `AgentConfig` may be supplied by an `AuthProvider`: there is no local config file and the agent must never modify configuration. Today the only lever is `agent.plugins_enabled: false`, which kills the whole plugin system (CLI dispatch, usage skills, prompt sections) instead of just the setup guidance. Web/IM users were being guided through config edits that either cannot work or would touch the server's own config.

The branch also carries a related `/plugins` gate fix: once every managed plugin was deactivated, the entry-point probe in `cmd_plugins` misreported "no plugins installed", making the manager — the tool for re-enabling plugins — unreachable.

## Solution

Introduce a read-only config mode orthogonal to `plugins_enabled`:

- **`AgentConfig.config_mutable`** (default `True`): mirrors the `filesystem_strict` pattern (underscore-stored, excluded from the service-cache fingerprint). `ChatTaskManager.start_chat` forces it to `False` on the per-request deep-copied config — covering web/vscode chat and the IM gateway funnel — and `gateway/main.py` re-asserts it; the CLI keeps the default so local setup flows are untouched.
- **`SkillMetadata.requires_mutable_config`** frontmatter field: `SkillManager` takes a `config_mutable` ctor flag, hides marked skills from `<available_skills>`, and refuses `load_skill` with a friendly "config is read-only, contact the administrator" error placed *before* the scope/authoring bypasses, so even a `gen_skill` authoring flow in API mode is refused. All five node-side `SkillManager` construction sites resolve the flag via a new `AgenticNode._resolve_config_mutable()` helper.
- **Plugin prompt**: templates now receive `config_mutable` in their render context (StrictUndefined keeps old templates that never reference it fully compatible); in read-only mode `config_path` is withheld (`None`) so a server-local path never leaks to tenants, and the datus-owned `## Plugins` preamble switches to wording that forbids config-edit suggestions and defers to the administrator while keeping configured `datus <plugin>` commands available.
- Manifest contract docstring (`datus/plugins/base.py`) and bilingual docs (`docs/plugin/development*`, `docs/plugin/introduction*`, `docs/skills/introduction*`) updated; the companion Datus-Plugins PR marks all 11 setup skills and branches all 11 templates.
- **`/plugins` gate bugfix** (separate commit): gate on `list_plugins()` (datus-plugin.json manifests + `plugin_paths` mounts + entry-point fallback) instead of the entry-point probe, since a disabled managed plugin's directory is off `sys.path`.

## Test Cases

No integration/nightly tests added: the changed behavior is deterministic prompt construction and skill filtering with no external service involved, so it is fully covered at the unit tier (CI runs them):

- `tests/unit_tests/tools/skill_tools/test_skill_manager_unit.py` — new `TestConfigMutableFiltering` (hide/list/XML/load-refusal incl. authoring-bypass, ordinary skills unaffected)
- `tests/unit_tests/tools/skill_tools/test_skill_config.py` — frontmatter default/parse/serialize
- `tests/unit_tests/tools/skill_tools/test_skill_func_tool.py` — end-to-end refusal through `SkillFuncTool`
- `tests/unit_tests/plugins/test_prompt.py` / `test_registry.py` — render-context plumbing, read-only preamble wording, `config_path=None` withholding, old-template back-compat
- `tests/unit_tests/configuration/test_agent_config.py` — flag default/coercion/deepcopy isolation
- `tests/unit_tests/api/services/test_chat_task_manager.py` — `start_chat` marks the clone immutable while the shared config stays mutable
- `tests/unit_tests/cli/test_plugin_commands.py` — `/plugins` gate detects installed-but-disabled plugins

PR harness (`ci/run-pr-tests.py`): diff coverage 96%; test-quality audit P0=0/P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only configuration mode for chat and gateway deployments.
  * Setup skills requiring configuration changes are hidden and blocked when configuration is read-only.
  * Plugin prompts now adapt guidance based on configuration editability.
  * Added support for marking skills as requiring mutable configuration.

* **Bug Fixes**
  * Improved plugin detection so installed managed plugins are recognized reliably.

* **Documentation**
  * Updated plugin and skill guidance for read-only deployments and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->