### PR TITLE
[BugFix] Generate main metadata sync PR from merged release state

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -360,14 +360,15 @@ jobs:
           git fetch origin --prune main
 
           sync_branch="sync/release-${VERSION}-metadata-to-main"
+          merged_tree="$(git merge-tree --write-tree origin/main "${SOURCE_SHA}" | sed -n '1p')"
           existing_sync_sha="$(git ls-remote --heads origin "${sync_branch}" | awk '{print $1}')"
           if [[ -n "${existing_sync_sha}" ]]; then
             git fetch origin "refs/heads/${sync_branch}:refs/remotes/origin/${sync_branch}"
           fi
 
           git checkout -B "${sync_branch}" origin/main
-          git checkout "${SOURCE_SHA}" -- pyproject.toml requirements.txt requirements-test.txt uv.lock
-          if git diff --quiet; then
+          git checkout "${merged_tree}" -- pyproject.toml requirements.txt requirements-test.txt uv.lock
+          if git diff --cached --quiet -- pyproject.toml requirements.txt requirements-test.txt uv.lock; then
             echo "Main already has release ${VERSION} metadata"
             exit 0
           fi
@@ -391,7 +392,7 @@ jobs:
 
           ## Changes
 
-          - copy release source metadata from ${SOURCE_SHA}
+          - merge release source metadata from ${SOURCE_SHA} onto the latest main branch
           - update pyproject.toml, requirements.txt, requirements-test.txt, and uv.lock on main
 
           ## Validation

--- a/tests/unit_tests/ci/test_release_workflows.py
+++ b/tests/unit_tests/ci/test_release_workflows.py
@@ -30,3 +30,14 @@ def test_publish_release_skips_finalize_steps_for_prereleases():
         "&& steps.release_version.outputs.is_prerelease != 'true' }}"
     ) in workflow
     assert "Tag/docs/main metadata sync: skipped for prerelease" in workflow
+
+
+def test_publish_release_checks_staged_metadata_changes():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "publish-release.yml").read_text(encoding="utf-8")
+
+    assert 'merged_tree="$(git merge-tree --write-tree origin/main "${SOURCE_SHA}" | sed -n \'1p\')"' in workflow
+    assert 'git checkout "${merged_tree}" -- pyproject.toml requirements.txt requirements-test.txt uv.lock' in workflow
+    assert (
+        "if git diff --cached --quiet -- pyproject.toml requirements.txt requirements-test.txt uv.lock; then"
+        in workflow
+    )


### PR DESCRIPTION
## Why

The stable publish workflow completed successfully but skipped creating the requested main metadata sync PR. The workflow checked only unstaged changes after `git checkout <tree> -- <paths>` had already staged the metadata files, so it incorrectly reported that main was already synchronized.

Copying the release versions of all four files directly would also overwrite metadata added only on main after the release branch diverged.

## Solution

- build a three-way merged tree from the latest main branch and the published release source
- extract only `pyproject.toml`, `requirements.txt`, `requirements-test.txt`, and `uv.lock` from that merged tree
- check the staged diff before deciding that main already has the release metadata
- describe the generated PR as a merge onto latest main instead of a direct file copy
- add workflow regression coverage for the merge-tree and staged-diff behavior

## Validation

- `uv run pytest tests/unit_tests/ci/test_release_workflows.py -q`
- `uv run ruff check tests/unit_tests/ci/test_release_workflows.py`
- `git diff --check`
- verified the merge-tree output for `main` and `v0.3.8` matches the intended four-file metadata sync

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release metadata synchronization now merges release changes with the latest main branch, helping preserve concurrent updates.
  - Improved change detection ensures synchronization requests are created only when relevant metadata files actually differ.
  - Updated release descriptions now clearly indicate that metadata is merged rather than copied.

- **Tests**
  - Added automated coverage to verify merged metadata handling and change detection during release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->