### PR TITLE
[Tool] Sync main release metadata to 0.3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Project basic information configuration, required.
 [project]
 name = "datus-agent"
-version = "0.3.7"
+version = "0.3.8"
 description = "AI-powered SQL Agent for data engineering (Compiled Version)"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -76,7 +76,7 @@ dependencies = [
     "lxml>=5.0.0",
     "markdown-it-py>=3.0.0",
     "tabulate>=0.9.0",
-    "datus-semantic-core>=0.2.0",
+    "datus-semantic-core>=0.2.1",
     # BI platform adapters (core models & interfaces)
     "datus-bi-core>=0.1.2",
     # Workflow scheduler adapters (core framework)
@@ -201,7 +201,7 @@ dev = [
 ci = [
     "datus-storage-postgresql>=0.1.5",
     "datus-metricflow>=0.2.7",
-    "datus-semantic-metricflow>=0.2.8",
+    "datus-semantic-metricflow>=0.2.9",
 ]
 
 [tool.coverage.run]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -386,13 +386,13 @@ datus-metricflow==0.2.7 \
     --hash=sha256:79326bc901b1a4e2ce9a92347536c302eb0ea80891bffccd67077f3eb2490787 \
     --hash=sha256:a85727556c2f1fb667b9e2059de095f1422ecc0eac4f05c8ced25d29acf80a95
     # via datus-semantic-metricflow
-datus-semantic-core==0.2.0 \
-    --hash=sha256:2e29c6df77489c4a7444ef8afa9fb0d5a37fe1512dbaaa2d81b610c2f1b65cc7 \
-    --hash=sha256:4679d031629b73788e86882e56cef2e4d6f3bd00c970930d1aac2798152d995f
+datus-semantic-core==0.2.1 \
+    --hash=sha256:1ca8c1b0671f63a09175659ceac199f65664efb0d592a5495e7223c2c87de5e2 \
+    --hash=sha256:f1f8f43f2dab0944372f0028af3424c1dd18e5a37de23068e4e80d38d7583b5a
     # via datus-semantic-metricflow
-datus-semantic-metricflow==0.2.8 \
-    --hash=sha256:a4aa647916e9b9a96f2841ceef5d2e88a0c05bef638dbf853bc36317c37bfd8a \
-    --hash=sha256:f3467bc6e5f2a50993651f5dbb5c9e0df756e9156352dd19e29a6200e8747a0a
+datus-semantic-metricflow==0.2.9 \
+    --hash=sha256:543d4249f4c029a30c36c9c018565495b187d95b70a5ba2b4861815c8750468e \
+    --hash=sha256:c00778827c1771156cd4eda76c38551e08a585597b028e88598124fe7a478a76
 datus-storage-base==0.1.5 \
     --hash=sha256:3865635243dde9b46761bce8ecca21ed25efe4cf7bdd9ab64f52eb4576984a3c \
     --hash=sha256:ab70b8db8823590b2272b5c86178b833532e0b915014a9645ae8bc8aac7814a3

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,6 @@ markdown-it-py>=3.0.0
 tabulate>=0.9.0
 datus-storage-base==0.1.5
 datus-db-core>=0.1.4
-datus-semantic-core>=0.2.0
+datus-semantic-core>=0.2.1
 datus-bi-core>=0.1.2
 datus-scheduler-core>=0.1.1

--- a/uv.lock
+++ b/uv.lock
@@ -683,7 +683,7 @@ wheels = [
 
 [[package]]
 name = "datus-agent"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -776,7 +776,7 @@ requires-dist = [
     { name = "datus-bi-core", specifier = ">=0.1.2" },
     { name = "datus-db-core", specifier = ">=0.1.4" },
     { name = "datus-scheduler-core", specifier = ">=0.1.1" },
-    { name = "datus-semantic-core", specifier = ">=0.2.0" },
+    { name = "datus-semantic-core", specifier = ">=0.2.1" },
     { name = "datus-storage-base", specifier = ">=0.1.5,<0.2.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.5.2,<2.0.0" },
@@ -823,7 +823,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 ci = [
     { name = "datus-metricflow", specifier = ">=0.2.7" },
-    { name = "datus-semantic-metricflow", specifier = ">=0.2.8" },
+    { name = "datus-semantic-metricflow", specifier = ">=0.2.9" },
     { name = "datus-storage-postgresql", specifier = ">=0.1.5" },
 ]
 dev = [
@@ -940,28 +940,28 @@ wheels = [
 
 [[package]]
 name = "datus-semantic-core"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/d8/782ee846a122e497fea520748721c6d2386f257ec3f7bc8105c634039144/datus_semantic_core-0.2.0.tar.gz", hash = "sha256:2e29c6df77489c4a7444ef8afa9fb0d5a37fe1512dbaaa2d81b610c2f1b65cc7", size = 12569, upload-time = "2026-04-23T08:43:57.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/5c/e6e53f56532d2d1360c98f025b9ac54815b1a550baa10149d866872c24a9/datus_semantic_core-0.2.1.tar.gz", hash = "sha256:f1f8f43f2dab0944372f0028af3424c1dd18e5a37de23068e4e80d38d7583b5a", size = 13288, upload-time = "2026-07-13T06:27:00.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/85/81cd088fc4e1c86cfff3b7764e9d47a94fef48ee519c70252e680ac0966b/datus_semantic_core-0.2.0-py3-none-any.whl", hash = "sha256:4679d031629b73788e86882e56cef2e4d6f3bd00c970930d1aac2798152d995f", size = 10394, upload-time = "2026-04-23T08:43:56.269Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b2/9c29e92ea49485bcec9645e6ea8405011da3d101eb9e20a80ff8a177fb7b/datus_semantic_core-0.2.1-py3-none-any.whl", hash = "sha256:1ca8c1b0671f63a09175659ceac199f65664efb0d592a5495e7223c2c87de5e2", size = 10929, upload-time = "2026-07-13T06:27:00.144Z" },
 ]
 
 [[package]]
 name = "datus-semantic-metricflow"
-version = "0.2.8"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datus-metricflow", extra = ["snowflake"] },
     { name = "datus-semantic-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/93/be8346ec6241b8ebe0dfffb9713161056dbea43625635a89820ef1fabb32/datus_semantic_metricflow-0.2.8.tar.gz", hash = "sha256:f3467bc6e5f2a50993651f5dbb5c9e0df756e9156352dd19e29a6200e8747a0a", size = 16907, upload-time = "2026-06-03T16:52:32.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/84/9156fb341a31fd2755c7d47361508a1c1512544de4975e22fc82563a298b/datus_semantic_metricflow-0.2.9.tar.gz", hash = "sha256:c00778827c1771156cd4eda76c38551e08a585597b028e88598124fe7a478a76", size = 22249, upload-time = "2026-07-13T06:41:36.809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/4d/089899b523e4f4518ac866daceac321690b553922999fe61d9b72194c8e8/datus_semantic_metricflow-0.2.8-py3-none-any.whl", hash = "sha256:a4aa647916e9b9a96f2841ceef5d2e88a0c05bef638dbf853bc36317c37bfd8a", size = 18584, upload-time = "2026-06-03T16:52:31.754Z" },
+    { url = "https://files.pythonhosted.org/packages/27/81/c7cf2145a332a03b189b8a4a87eb1c994d1aec125b289c66a0a95daa1922/datus_semantic_metricflow-0.2.9-py3-none-any.whl", hash = "sha256:543d4249f4c029a30c36c9c018565495b187d95b70a5ba2b4861815c8750468e", size = 23758, upload-time = "2026-07-13T06:41:35.982Z" },
 ]
 
 [[package]]
@@ -3976,8 +3976,8 @@ name = "secretstorage"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/9f/11ef35cf1027c1339552ea7bfe6aaa74a8516d8b5caf6e7d338daf54fd80/secretstorage-3.4.0.tar.gz", hash = "sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c", size = 19748, upload-time = "2025-09-09T16:42:13.859Z" }
 wheels = [


### PR DESCRIPTION
## Why

The 0.3.8 publish run completed successfully, but the workflow incorrectly concluded that main already contained the release metadata and did not create the requested sync PR.

## Changes

- update the datus-agent source version from `0.3.7` to `0.3.8`
- update `datus-semantic-core` from `>=0.2.0` to `>=0.2.1`
- update `datus-semantic-metricflow` from `>=0.2.8` to `>=0.2.9`
- synchronize `requirements.txt`, `requirements-test.txt`, and `uv.lock`
- preserve dependencies and lock metadata added only on main after the release branch diverged

## Validation

- `uv lock --locked`
- `python3 ci/check_release_readiness.py --expected-version 0.3.8 --check-adapter-latest`
- `git diff --check`
- verified the four files exactly match the three-way merge result of current `main` and `v0.3.8`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release to version 0.3.8.
  * Updated supported semantic core and metricflow components to newer compatible versions.
  * Refreshed test dependency pins and integrity checks for the updated components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->