### PR TITLE
[BugFix] Make multiprocessing initialization safe across entrypoints

### DIFF
--- a/datus/api/main.py
+++ b/datus/api/main.py
@@ -27,6 +27,7 @@ import uvicorn
 from datus import __version__
 from datus.configuration.agent_config_loader import parse_config_path
 from datus.utils.loggings import configure_logging, get_logger
+from datus.utils.multiprocessing_utils import configure_multiprocessing_start_method
 
 logger = get_logger(__name__)
 
@@ -304,11 +305,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main():
     """Main entry point for starting the Datus Agent API server."""
-    if hasattr(multiprocessing, "set_start_method"):
-        try:
-            multiprocessing.set_start_method("spawn", force=True)
-        except RuntimeError:
-            pass
+    configure_multiprocessing_start_method()
 
     parser = _build_parser()
     args = parser.parse_args()

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -15,6 +15,7 @@ from datus.utils.async_utils import setup_windows_policy
 from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import configure_logging, get_logger
+from datus.utils.multiprocessing_utils import configure_multiprocessing_start_method
 
 logger = get_logger(__name__)
 
@@ -769,6 +770,8 @@ def main():
     """Entry point for console scripts"""
     import signal
     import sys
+
+    configure_multiprocessing_start_method()
 
     # Intercept 'upgrade' subcommand: self-upgrade datus-agent and the installed
     # datus-* adapter packages. Handled before the REPL is built so it works even

--- a/datus/entrypoints.py
+++ b/datus/entrypoints.py
@@ -1,0 +1,39 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Lightweight console-script entrypoints.
+
+Multiprocessing policy must be selected before importing application modules
+that initialize threaded runtimes such as LanceDB or embedding providers.
+"""
+
+from importlib import import_module
+from typing import Any
+
+from datus.utils.multiprocessing_utils import configure_multiprocessing_start_method
+
+
+def _run(module_name: str) -> Any:
+    configure_multiprocessing_start_method()
+    return import_module(module_name).main()
+
+
+def agent_main() -> Any:
+    return _run("datus.main")
+
+
+def cli_main() -> Any:
+    return _run("datus.cli.main")
+
+
+def api_main() -> Any:
+    return _run("datus.api.main")
+
+
+def mcp_main() -> Any:
+    return _run("datus.mcp_server")
+
+
+def gateway_main() -> Any:
+    return _run("datus.gateway.main")

--- a/datus/gateway/main.py
+++ b/datus/gateway/main.py
@@ -25,6 +25,7 @@ from typing import Optional, Tuple
 
 from datus import __version__
 from datus.utils.loggings import configure_logging, get_logger
+from datus.utils.multiprocessing_utils import configure_multiprocessing_start_method
 
 logger = get_logger(__name__)
 
@@ -268,11 +269,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     """Main entry point for starting the Datus Gateway."""
-    if hasattr(multiprocessing, "set_start_method"):
-        try:
-            multiprocessing.set_start_method("spawn", force=True)
-        except RuntimeError:
-            pass
+    configure_multiprocessing_start_method()
 
     parser = _build_parser()
     args = parser.parse_args()

--- a/datus/main.py
+++ b/datus/main.py
@@ -23,6 +23,7 @@ from datus.configuration.agent_config_loader import load_agent_config
 from datus.schemas.node_models import SqlTask
 from datus.utils.exceptions import setup_exception_handler
 from datus.utils.loggings import configure_logging, get_logger
+from datus.utils.multiprocessing_utils import configure_multiprocessing_start_method
 
 logger = get_logger(__name__)
 
@@ -496,6 +497,7 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 def main():
+    configure_multiprocessing_start_method()
     parser = create_parser()
     args = parser.parse_args()
 

--- a/datus/mcp_server.py
+++ b/datus/mcp_server.py
@@ -90,6 +90,7 @@ from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
 from datus.utils.loggings import configure_logging, get_logger
+from datus.utils.multiprocessing_utils import configure_multiprocessing_start_method
 
 # Re-export for external use
 __all__ = [
@@ -1155,6 +1156,7 @@ def run_dynamic_server(
 
 def main():
     """Main entry point for the MCP server CLI."""
+    configure_multiprocessing_start_method()
     parser = argparse.ArgumentParser(
         description="Datus MCP Server - Expose Datus tools via Model Context Protocol",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/datus/models/base.py
+++ b/datus/models/base.py
@@ -4,9 +4,7 @@
 
 import asyncio
 import hashlib
-import multiprocessing
 import os
-import platform
 import threading
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -21,22 +19,6 @@ from datus.utils.constants import LLMProvider
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
-
-
-def configure_multiprocessing_start_method() -> None:
-    """Set a safe multiprocessing start method for the current platform."""
-    try:
-        if platform.system() == "Windows":
-            multiprocessing.set_start_method("spawn", force=True)
-        else:
-            multiprocessing.set_start_method("fork", force=True)
-    except RuntimeError:
-        # set_start_method can only be called once
-        pass
-
-
-# Fix multiprocessing issues with PyTorch/sentence-transformers in Python 3.12
-configure_multiprocessing_start_method()
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 

--- a/datus/storage/embedding_models.py
+++ b/datus/storage/embedding_models.py
@@ -3,9 +3,7 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import copy
-import multiprocessing
 import os
-import platform
 from dataclasses import dataclass
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Dict, Optional
@@ -17,22 +15,6 @@ from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
     from datus.configuration.agent_config import ModelConfig
-
-
-def configure_multiprocessing_start_method() -> None:
-    """Set a safe multiprocessing start method for the current platform."""
-    try:
-        if platform.system() == "Windows":
-            multiprocessing.set_start_method("spawn", force=True)
-        else:
-            multiprocessing.set_start_method("fork", force=True)
-    except RuntimeError:
-        # set_start_method can only be called once
-        pass
-
-
-# Fix multiprocessing issues with PyTorch/sentence-transformers in Python 3.12
-configure_multiprocessing_start_method()
 
 # Set environment variables to prevent multiprocessing issues
 os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/datus/utils/multiprocessing_utils.py
+++ b/datus/utils/multiprocessing_utils.py
@@ -1,0 +1,28 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Process-level multiprocessing policy for Datus entrypoints."""
+
+import multiprocessing
+
+
+def configure_multiprocessing_start_method() -> str:
+    """Select ``spawn`` once without overriding an embedding host.
+
+    Datus entrypoints call this before starting application services. Library
+    modules must not call it during import because multiprocessing policy is a
+    process-wide choice owned by the executable (or by an embedding host).
+    """
+
+    current_method = multiprocessing.get_start_method(allow_none=True)
+    if current_method:
+        return current_method
+
+    try:
+        multiprocessing.set_start_method("spawn")
+    except RuntimeError:
+        # Another thread or library may have selected a method between the
+        # check and the setter. Respect that choice instead of forcing ours.
+        return multiprocessing.get_start_method(allow_none=True) or "spawn"
+    return "spawn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,12 +93,12 @@ Repository = "https://github.com/datus-ai/datus-agent"
 "Bug Tracker" = "https://github.com/datus-ai/datus-agent/issues"
 
 [project.scripts]
-datus-agent = "datus.main:main"
-datus-cli = "datus.cli.main:main"
-datus = "datus.cli.main:main"
-datus-api = "datus.api.main:main"
-datus-mcp = "datus.mcp_server:main"
-datus-gateway = "datus.gateway.main:main"
+datus-agent = "datus.entrypoints:agent_main"
+datus-cli = "datus.entrypoints:cli_main"
+datus = "datus.entrypoints:cli_main"
+datus-api = "datus.entrypoints:api_main"
+datus-mcp = "datus.entrypoints:mcp_main"
+datus-gateway = "datus.entrypoints:gateway_main"
 
 [build-system]
 requires = ["setuptools>=80.9.0", "wheel"]

--- a/tests/unit_tests/utils/test_windows_compatibility.py
+++ b/tests/unit_tests/utils/test_windows_compatibility.py
@@ -1,64 +1,57 @@
-from importlib import import_module
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from datus import entrypoints
 from datus.utils.constants import DBType
+from datus.utils.multiprocessing_utils import configure_multiprocessing_start_method
 from datus.utils.path_utils import get_files_from_glob_pattern
 
 
-# test datus.models.base
+def test_multiprocessing_start_method_defaults_to_spawn():
+    with patch("multiprocessing.get_start_method", return_value=None):
+        with patch("multiprocessing.set_start_method") as mock_set:
+            assert configure_multiprocessing_start_method() == "spawn"
+            mock_set.assert_called_once_with("spawn")
+
+
+def test_multiprocessing_start_method_preserves_host_choice():
+    with patch("multiprocessing.get_start_method", return_value="fork"):
+        with patch("multiprocessing.set_start_method") as mock_set:
+            assert configure_multiprocessing_start_method() == "fork"
+            mock_set.assert_not_called()
+
+
+def test_multiprocessing_start_method_handles_selection_race():
+    with patch("multiprocessing.get_start_method", side_effect=[None, "forkserver"]):
+        with patch("multiprocessing.set_start_method", side_effect=RuntimeError("already set")):
+            assert configure_multiprocessing_start_method() == "forkserver"
+
+
 @pytest.mark.parametrize(
-    "platform_name, expected_method",
+    ("entrypoint", "module_name"),
     [
-        ("Windows", "spawn"),  # Windows
-        ("Linux", "fork"),  # not Windows
-        ("Darwin", "fork"),  # macOS
+        (entrypoints.agent_main, "datus.main"),
+        (entrypoints.cli_main, "datus.cli.main"),
+        (entrypoints.api_main, "datus.api.main"),
+        (entrypoints.mcp_main, "datus.mcp_server"),
+        (entrypoints.gateway_main, "datus.gateway.main"),
     ],
 )
-def test_multiprocessing_start_method_base(platform_name, expected_method):
-    with patch("platform.system", return_value=platform_name):
-        with patch("multiprocessing.set_start_method") as mock_set:
-            base_module = import_module("datus.models.base")
-            mock_set.reset_mock()
-            base_module.configure_multiprocessing_start_method()
-            mock_set.assert_called_once_with(expected_method, force=True)
+def test_console_entrypoint_configures_before_import(entrypoint, module_name):
+    events = []
+    module = SimpleNamespace(main=lambda: events.append("run") or 17)
 
+    with (
+        patch.object(
+            entrypoints, "configure_multiprocessing_start_method", side_effect=lambda: events.append("configure")
+        ),
+        patch.object(entrypoints, "import_module", side_effect=lambda name: events.append(f"import:{name}") or module),
+    ):
+        assert entrypoint() == 17
 
-# test datus.storage.embedding_models
-@pytest.mark.parametrize(
-    "platform_name, expected_method",
-    [
-        ("Windows", "spawn"),
-        ("Linux", "fork"),
-        ("Darwin", "fork"),
-    ],
-)
-def test_multiprocessing_start_method_embedding(platform_name, expected_method):
-    with patch("platform.system", return_value=platform_name):
-        with patch("multiprocessing.set_start_method") as mock_set:
-            embedding_module = import_module("datus.storage.embedding_models")
-            mock_set.reset_mock()
-            embedding_module.configure_multiprocessing_start_method()
-            mock_set.assert_called_once_with(expected_method, force=True)
-
-
-def test_multiprocessing_start_method_base_ignores_runtime_error():
-    with patch("platform.system", return_value="Linux"):
-        with patch("multiprocessing.set_start_method", side_effect=RuntimeError("already set")) as mock_set:
-            base_module = import_module("datus.models.base")
-            mock_set.reset_mock()
-            base_module.configure_multiprocessing_start_method()
-            mock_set.assert_called_once_with("fork", force=True)
-
-
-def test_multiprocessing_start_method_embedding_ignores_runtime_error():
-    with patch("platform.system", return_value="Linux"):
-        with patch("multiprocessing.set_start_method", side_effect=RuntimeError("already set")) as mock_set:
-            embedding_module = import_module("datus.storage.embedding_models")
-            mock_set.reset_mock()
-            embedding_module.configure_multiprocessing_start_method()
-            mock_set.assert_called_once_with("fork", force=True)
+    assert events == ["configure", f"import:{module_name}", "run"]
 
 
 def test_detect_toxicology_db(tmp_path):


### PR DESCRIPTION
## Summary

- remove import-time multiprocessing policy changes from model and embedding library modules
- centralize the Datus process policy in a helper that selects `spawn` once without overriding a method already chosen by an embedding host
- route console scripts through lightweight wrappers so the policy is selected before application modules initialize threaded runtimes
- retain defensive calls in direct application entrypoints and add regression coverage for entrypoint ordering, host-policy preservation, and initialization races

## Why

The library modules forced `fork` during import on macOS and Linux, while API and Gateway entrypoints forced `spawn`. This mixed process-wide policy could fork after LanceDB or another threaded runtime was initialized, producing LanceDB's experimental fork warning and resetting its async runtime. Importing a library module should not override the executable or host process, and Datus-owned entrypoints should select a cross-platform-safe method before heavy imports occur.

## Impact

- official Datus CLI, Agent, API, MCP, and Gateway commands start with `spawn` on macOS, Linux, and Windows
- embedded/library use preserves an existing host-selected multiprocessing method
- import-time side effects no longer overwrite multiprocessing policy with `force=True`

## Validation

- `127 passed` across multiprocessing, CLI, Agent, and API unit tests
- Ruff check and format
- `uv lock --check`
- `uv run datus -v` reports Datus CLI 0.3.8
- real OSI validation against the configured Greenplum datasource with the LanceDB fork warning promoted to an exception

The complementary [MetricFlow PR #45](https://github.com/Datus-ai/metricflow/pull/45) avoids a process pool entirely for single-worker validation and uses an explicit `spawn` context for parallel validation.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup reliability for agent, CLI, API, MCP, and gateway commands across platforms.
  * Added consistent initialization for multiprocessing before commands and services launch.
  * Consolidated application command entrypoints for more predictable startup behavior.

* **Bug Fixes**
  * Reduced potential multiprocessing and threading conflicts involving model and embedding workloads.
  * Preserved existing multiprocessing settings when already configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->