### PR TITLE
[BugFix] Use official agent entrypoint for nightly data build

### DIFF
--- a/build_scripts/build_test_data.sh
+++ b/build_scripts/build_test_data.sh
@@ -48,15 +48,7 @@ validate_test_home() {
 }
 
 run_bootstrap_kb() {
-  uv run python - "$@" <<'PY'
-from agents import set_tracing_disabled
-
-set_tracing_disabled(True)
-
-from datus.main import main
-
-raise SystemExit(main())
-PY
+  uv run datus-agent "$@"
 }
 
 # Clean old data before creating a cacheable, deterministic fixture set.

--- a/tests/unit_tests/build_scripts/test_build_test_data.py
+++ b/tests/unit_tests/build_scripts/test_build_test_data.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_build_test_data_uses_official_agent_entrypoint():
+    build_script = (_REPO_ROOT / "build_scripts" / "build_test_data.sh").read_text(encoding="utf-8")
+
+    assert 'uv run datus-agent "$@"' in build_script


### PR DESCRIPTION
## Summary

- replace the stdin-backed Python bootstrap in `build_test_data.sh` with the official `datus-agent` console entrypoint
- add a regression test that keeps the nightly data build on that entrypoint

## Root cause

The nightly data build invoked `datus.main` from a Python heredoc. After multiprocessing startup switched to `spawn`, child processes tried to reload the parent module from `<stdin>` and failed with `FileNotFoundError` during semantic validation.

The `datus-agent` console entrypoint configures multiprocessing before importing `datus.main` and runs from a real file-backed entrypoint, so spawned workers can initialize correctly. It also preserves the existing observability-aware tracing setup instead of disabling SDK tracing unconditionally in the build script.

## Validation

- `uv run pytest tests/unit_tests/build_scripts/test_build_test_data.py tests/unit_tests/utils/test_windows_compatibility.py -q` (10 passed)
- `uv run ruff check tests/unit_tests/build_scripts/test_build_test_data.py`
- `uv run ruff format --check tests/unit_tests/build_scripts/test_build_test_data.py`
- `bash -n build_scripts/build_test_data.sh`
- reran the metrics bootstrap with the MetricFlow adapter installed; semantic validation completed without the `<stdin>` / `FileNotFoundError` failure

Failed nightly run: https://github.com/Datus-ai/Datus-agent/actions/runs/29703009160

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the test-data bootstrap process to use the standard agent entry point, improving consistency and reliability.

* **Tests**
  * Added coverage to verify that the bootstrap script uses the expected agent invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->