### PR TITLE
[BugFix] Wire mid-run insert queue into the API chat path

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -458,7 +458,11 @@ async def insert_message(
 ) -> Result[InsertMessageData]:
     task_manager = svc.task_manager
     task = task_manager.get_task(request.session_id)
-    if task is None or task.node is None:
+    # The queue is task-scoped and created up-front, so a still-initializing
+    # node (``task.node is None``) is fine — enqueue anyway; the node picks up
+    # the queue on startup. Only reject when there is no live run at all
+    # (missing, or already completed/errored/cancelled).
+    if task is None or task.status != "running":
         return Result[InsertMessageData](
             success=False,
             errorCode="SESSION_NOT_RUNNING",
@@ -473,7 +477,7 @@ async def insert_message(
             errorMessage="message must be non-empty after stripping whitespace",
         )
 
-    queue = getattr(task.node, "pending_input_queue", None)
+    queue = getattr(task, "pending_input_queue", None)
     if queue is None:
         return Result[InsertMessageData](
             success=False,

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -462,7 +462,7 @@ async def insert_message(
     # node (``task.node is None``) is fine — enqueue anyway; the node picks up
     # the queue on startup. Only reject when there is no live run at all
     # (missing, or already completed/errored/cancelled).
-    if task is None or task.status != "running":
+    if task is None or task.status != "running" or not getattr(task, "accepting_inserts", True):
         return Result[InsertMessageData](
             success=False,
             errorCode="SESSION_NOT_RUNNING",

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -29,8 +29,9 @@ from datus.api.models.cli_models import (
 )
 from datus.api.services.action_sse_converter import action_to_sse_event
 from datus.cli.autocomplete import AtReferenceCompleter
+from datus.cli.execution_state import PendingInputQueue
 from datus.configuration.agent_config import AgentConfig
-from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
 from datus.tools.proxy.proxy_tool import apply_proxy_tools
 from datus.utils.loggings import get_logger
@@ -268,6 +269,11 @@ class ChatTask:
         self.created_at = datetime.now()
         self.error: Optional[str] = None
         self.consumer_offset: int = 0
+        # Created up-front — before the node exists — so ``POST /chat/insert``
+        # can enqueue during node startup (node creation is an ``await
+        # to_thread`` that can take hundreds of ms). ``_run_loop`` points the
+        # node at this same instance, so the filter drains these on turn one.
+        self.pending_input_queue: PendingInputQueue = PendingInputQueue()
 
 
 COMPLETED_TASK_TTL = 300  # seconds to keep completed tasks for resume
@@ -542,6 +548,15 @@ class ChatTaskManager:
 
             node = await asyncio.to_thread(_init_node)
             task.node = node
+            # Enable mid-run insert (steering): point the node at the
+            # task-scoped queue that ``start_chat`` created before the node
+            # existed, so messages POSTed to ``/chat/insert`` during node
+            # startup are preserved. The model layer's
+            # ``call_model_input_filter`` — wired ONLY when the queue is
+            # non-None — injects queued messages at the next LLM turn boundary.
+            # Without this the API path silently drops mid-run messages (the
+            # CLI wires its own queue in chat_commands).
+            node.pending_input_queue = task.pending_input_queue
             trace_token = set_trace_context(
                 build_chat_trace_context(
                     session_id=session_id,
@@ -659,75 +674,109 @@ class ChatTaskManager:
             tool_result_seen = False
             seen_assistant_message_fingerprints: set[str] = set()
 
-            async for action in node.execute_stream_with_interactions(action_history):
-                action_count += 1
+            async def _run_pass() -> None:
+                nonlocal event_id, action_count, assistant_response_sent, tool_result_seen
+                async for action in node.execute_stream_with_interactions(action_history):
+                    action_count += 1
 
-                # Convert action to SSE
-                # Per-request stream_response overrides the server-level --stream flag
-                effective_stream = (
-                    request.stream_response if request.stream_response is not None else self._stream_thinking
-                )
+                    # Convert action to SSE
+                    # Per-request stream_response overrides the server-level --stream flag
+                    effective_stream = (
+                        request.stream_response if request.stream_response is not None else self._stream_thinking
+                    )
 
-                is_first_delta = True
-                if action.action_type == "thinking_delta":
-                    is_first_delta = action.action_id not in seen_delta_action_ids
-                    seen_delta_action_ids.add(action.action_id)
+                    is_first_delta = True
+                    if action.action_type == "thinking_delta":
+                        is_first_delta = action.action_id not in seen_delta_action_ids
+                        seen_delta_action_ids.add(action.action_id)
 
-                # finalize_progress actions reuse the same id across stages
-                # so the SSE wire emits CREATE then UPDATE_MESSAGE; we mark
-                # everything past the first emission as an update.
-                is_finalize_progress_update = False
-                if action.action_type == "finalize_progress":
-                    is_finalize_progress_update = action.action_id in seen_delta_action_ids
-                    seen_delta_action_ids.add(action.action_id)
+                    # finalize_progress actions reuse the same id across stages
+                    # so the SSE wire emits CREATE then UPDATE_MESSAGE; we mark
+                    # everything past the first emission as an update.
+                    is_finalize_progress_update = False
+                    if action.action_type == "finalize_progress":
+                        is_finalize_progress_update = action.action_id in seen_delta_action_ids
+                        seen_delta_action_ids.add(action.action_id)
 
-                is_update = is_finalize_progress_update or (
-                    effective_stream
-                    and action.action_type == "response"
-                    and isinstance(action.output, dict)
-                    and action.action_id in seen_delta_action_ids
-                )
+                    is_update = is_finalize_progress_update or (
+                        effective_stream
+                        and action.action_type == "response"
+                        and isinstance(action.output, dict)
+                        and action.action_id in seen_delta_action_ids
+                    )
 
-                sse = action_to_sse_event(
-                    action,
-                    event_id,
-                    action.action_id,
-                    stream_thinking=effective_stream,
-                    is_first_delta=is_first_delta,
-                    is_update=bool(is_update),
-                    include_final_response=_should_include_final_response(action, assistant_response_sent),
-                    proxied_tool_names=getattr(node, "proxied_tool_names", None),
-                )
-                if sse:
-                    # Per-LLM-call usage event: the converter has no access
-                    # to the service-level session ids, so we stamp them
-                    # here before fan-out. Skip the assistant-message dedup
-                    # path entirely since usage carries no rendered text.
-                    if sse.event == "usage" and isinstance(sse.data, SSEUsageData):
-                        sse.data.session_id = session_id
-                        # Only main-agent usage (depth==0) belongs to this
-                        # node's LLM session. Sub-agent usage (depth>0) keeps the
-                        # sub-agent session id stamped by the converter so the
-                        # consumer can attribute it to the right session instead
-                        # of mislabelling it as the parent's.
-                        if sse.data.depth == 0:
-                            sse.data.llm_session_id = node.session_id
+                    sse = action_to_sse_event(
+                        action,
+                        event_id,
+                        action.action_id,
+                        stream_thinking=effective_stream,
+                        is_first_delta=is_first_delta,
+                        is_update=bool(is_update),
+                        include_final_response=_should_include_final_response(action, assistant_response_sent),
+                        proxied_tool_names=getattr(node, "proxied_tool_names", None),
+                    )
+                    if sse:
+                        # Per-LLM-call usage event: the converter has no access
+                        # to the service-level session ids, so we stamp them
+                        # here before fan-out. Skip the assistant-message dedup
+                        # path entirely since usage carries no rendered text.
+                        if sse.event == "usage" and isinstance(sse.data, SSEUsageData):
+                            sse.data.session_id = session_id
+                            # Only main-agent usage (depth==0) belongs to this
+                            # node's LLM session. Sub-agent usage (depth>0) keeps the
+                            # sub-agent session id stamped by the converter so the
+                            # consumer can attribute it to the right session instead
+                            # of mislabelling it as the parent's.
+                            if sse.data.depth == 0:
+                                sse.data.llm_session_id = node.session_id
+                            await self._push_event(task, sse)
+                            event_id += 1
+                            continue
+                        if _should_skip_duplicate_assistant_message(
+                            action,
+                            sse,
+                            seen_assistant_message_fingerprints,
+                        ):
+                            continue
                         await self._push_event(task, sse)
                         event_id += 1
-                        continue
-                    if _should_skip_duplicate_assistant_message(
-                        action,
-                        sse,
-                        seen_assistant_message_fingerprints,
-                    ):
-                        continue
-                    await self._push_event(task, sse)
-                    event_id += 1
-                    _remember_assistant_message(sse, seen_assistant_message_fingerprints)
-                    if _is_visible_assistant_response(action, sse, tool_result_seen=tool_result_seen):
-                        assistant_response_sent = True
-                    if action.role == ActionRole.TOOL and action.status != ActionStatus.PROCESSING:
-                        tool_result_seen = True
+                        _remember_assistant_message(sse, seen_assistant_message_fingerprints)
+                        if _is_visible_assistant_response(action, sse, tool_result_seen=tool_result_seen):
+                            assistant_response_sent = True
+                        if action.role == ActionRole.TOOL and action.status != ActionStatus.PROCESSING:
+                            tool_result_seen = True
+
+            # Mid-run insert (steering) auto-continuation: a message queued
+            # AFTER the final LLM turn is never seen by the SDK's
+            # call_model_input_filter (no further turn boundary fires), so after
+            # each run drain any residue and continue with a fresh turn. Mirrors
+            # the CLI's execute_chat_command loop and prevents silently dropping
+            # late mid-run messages. Messages queued mid-turn are injected in-run
+            # by the filter and never reach here.
+            while True:
+                await _run_pass()
+                residual = self._drain_pending_for_continuation(node)
+                if not residual:
+                    break
+                # Echo each residual as a user_insert frame so the client
+                # dismisses its pending entry and renders the user bubble —
+                # the same wire shape the in-run filter path emits via the
+                # InteractionBroker.
+                for text in residual:
+                    event_id = await self._emit_user_insert_sse(task, text, event_id)
+                node.input = self._create_node_input(
+                    user_message="\n\n".join(residual),
+                    current_node=node,
+                    at_tables=[],
+                    at_metrics=[],
+                    at_sqls=[],
+                    at_hints=[],
+                    catalog=request.catalog,
+                    database=request.database,
+                    db_schema=request.db_schema,
+                    plan_mode=request.plan_mode or False,
+                    source_session_id=None,
+                )
 
             # 6.5 Persist this turn's @-context (table/metric/sql/knowledge refs)
             # so the history API can re-render them. Best-effort and off the
@@ -805,6 +854,46 @@ class ChatTaskManager:
             # Keep completed task for resume within TTL
             self._completed_tasks[session_id] = task
             self._purge_expired_completed()
+
+    @staticmethod
+    def _drain_pending_for_continuation(node) -> Optional[List[str]]:
+        """Drain mid-run messages left in the queue after a run finished.
+
+        Returns the FIFO list to continue with, or ``None`` when there is
+        nothing to continue or the run was interrupted (in which case the
+        queue is cleared, matching the CLI's cancel semantics).
+        """
+        queue = getattr(node, "pending_input_queue", None)
+        if queue is None or len(queue) == 0:
+            return None
+        ic = getattr(node, "interrupt_controller", None)
+        if ic is not None and getattr(ic, "is_interrupted", False):
+            queue.clear()
+            return None
+        return queue.drain()
+
+    async def _emit_user_insert_sse(self, task: "ChatTask", text: str, event_id: int) -> int:
+        """Emit a ``user_insert`` SSE frame for a residual mid-run message.
+
+        Mirrors the in-run filter path (which surfaces injections via
+        ``InteractionBroker.emit_user_insert``) so the client dismisses the
+        matching pending entry and renders the user bubble. Returns the next
+        ``event_id``.
+        """
+        action = ActionHistory(
+            action_id=str(uuid.uuid4()),
+            role=ActionRole.USER,
+            status=ActionStatus.SUCCESS,
+            action_type="user_insert",
+            messages=text,
+            input={"user_message": text, "source": "mid_run_insert"},
+            output={"user_message": text},
+        )
+        sse = action_to_sse_event(action, event_id, action.action_id)
+        if sse:
+            await self._push_event(task, sse)
+            return event_id + 1
+        return event_id
 
     @staticmethod
     def _session_manager(agent_config: AgentConfig, user_id: Optional[str]):

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -43,6 +43,10 @@ logger = get_logger(__name__)
 
 HEARTBEAT_INTERVAL = 10  # seconds
 
+# Max run-boundary auto-continuations per task, bounding a client that keeps
+# POSTing /chat/insert from running one task indefinitely.
+_MAX_INSERT_CONTINUATIONS = 20
+
 
 def is_thinking_only_content(content_items) -> bool:
     """Return True if all content items are thinking chunks (i.e. a delta message).
@@ -274,6 +278,12 @@ class ChatTask:
         # to_thread`` that can take hundreds of ms). ``_run_loop`` points the
         # node at this same instance, so the filter drains these on turn one.
         self.pending_input_queue: PendingInputQueue = PendingInputQueue()
+        # Whether ``/chat/insert`` may still enqueue. ``_run_loop`` flips this
+        # off once it stops draining (final drain empty), so inserts arriving
+        # during the run's tail (persist / usage / end events) get
+        # SESSION_NOT_RUNNING and the client falls back to a fresh turn, rather
+        # than enqueueing with nothing left to drain them.
+        self.accepting_inserts: bool = True
 
 
 COMPLETED_TASK_TTL = 300  # seconds to keep completed tasks for resume
@@ -669,13 +679,18 @@ class ChatTaskManager:
             # 6. Execute streaming
             action_history = ActionHistoryManager()
             action_count = 0
+            # action_id is globally unique, so delta de-dup can safely span passes.
             seen_delta_action_ids: set[str] = set()
-            assistant_response_sent = False
-            tool_result_seen = False
-            seen_assistant_message_fingerprints: set[str] = set()
 
             async def _run_pass() -> None:
-                nonlocal event_id, action_count, assistant_response_sent, tool_result_seen
+                nonlocal event_id, action_count
+                # Per-run render state — reset each pass. A continuation pass is a
+                # fresh turn, so its reply must not be dropped as a duplicate of an
+                # earlier pass ("re-run it" is a common steering ask) nor suppressed
+                # by a stale assistant_response_sent carried over between passes.
+                assistant_response_sent = False
+                tool_result_seen = False
+                seen_assistant_message_fingerprints: set[str] = set()
                 async for action in node.execute_stream_with_interactions(action_history):
                     action_count += 1
 
@@ -753,11 +768,35 @@ class ChatTaskManager:
             # the CLI's execute_chat_command loop and prevents silently dropping
             # late mid-run messages. Messages queued mid-turn are injected in-run
             # by the filter and never reach here.
+            continuations = 0
             while True:
                 await _run_pass()
                 residual = self._drain_pending_for_continuation(node)
                 if not residual:
+                    # Close the accept window, then drain once more. An insert
+                    # that landed during this run's tail must not be stranded;
+                    # after the window closes /chat/insert returns
+                    # SESSION_NOT_RUNNING and the client re-sends as a new turn.
+                    task.accepting_inserts = False
+                    residual = self._drain_pending_for_continuation(node)
+                    if not residual:
+                        break
+                    task.accepting_inserts = True
+
+                continuations += 1
+                if continuations > _MAX_INSERT_CONTINUATIONS:
+                    # Defensive bound: a client that inserts without pause could
+                    # otherwise keep one task running forever. Stop accepting and
+                    # log what we drop rather than silently truncating.
+                    task.accepting_inserts = False
+                    logger.warning(
+                        "Mid-run insert continuation cap (%d) hit for session %s; dropping %d residual message(s)",
+                        _MAX_INSERT_CONTINUATIONS,
+                        session_id,
+                        len(residual),
+                    )
                     break
+
                 # Echo each residual as a user_insert frame so the client
                 # dismisses its pending entry and renders the user bubble —
                 # the same wire shape the in-run filter path emits via the

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -405,8 +405,10 @@ class TestInsertMessageEndpoint:
 
     The endpoint is the API equivalent of typing in the TUI while the
     agent is streaming: it appends a free-text user message to the
-    pending-input queue carried by the running node, so the model sees
-    it before its next LLM turn.
+    task-scoped pending-input queue, so the model sees it before its next
+    LLM turn. The queue lives on the task (not the node) and is created
+    up-front, so a message that arrives while the node is still starting
+    up is still enqueued rather than lost.
     """
 
     @staticmethod
@@ -416,11 +418,12 @@ class TestInsertMessageEndpoint:
         return InsertMessageInput(session_id=session_id, message=message)
 
     @staticmethod
-    def _make_task_with_queue(queue=None):
+    def _make_task_with_queue(queue=None, status="running"):
         from datus.cli.execution_state import PendingInputQueue
 
         task = MagicMock()
-        task.node.pending_input_queue = queue if queue is not None else PendingInputQueue()
+        task.status = status
+        task.pending_input_queue = queue if queue is not None else PendingInputQueue()
         return task
 
     @pytest.mark.asyncio
@@ -435,7 +438,7 @@ class TestInsertMessageEndpoint:
         assert result.success is True
         assert result.data.session_id == "s1"
         assert result.data.queued_count == 1
-        assert task.node.pending_input_queue.snapshot() == ["hello"]
+        assert task.pending_input_queue.snapshot() == ["hello"]
 
     @pytest.mark.asyncio
     async def test_multiple_pushes_accumulate(self):
@@ -449,7 +452,7 @@ class TestInsertMessageEndpoint:
 
         assert result.success is True
         assert result.data.queued_count == 2
-        assert task.node.pending_input_queue.snapshot() == ["first", "second"]
+        assert task.pending_input_queue.snapshot() == ["first", "second"]
 
     @pytest.mark.asyncio
     async def test_missing_task_returns_session_not_running(self):
@@ -463,17 +466,35 @@ class TestInsertMessageEndpoint:
         assert result.errorCode == "SESSION_NOT_RUNNING"
 
     @pytest.mark.asyncio
-    async def test_task_without_node_returns_session_not_running(self):
+    async def test_completed_task_returns_session_not_running(self):
+        """A finished task must not accept inserts — its run loop is gone and
+        nothing would ever drain the queue."""
         from datus.api.routes.chat_routes import insert_message
 
-        task = MagicMock()
-        task.node = None
+        task = self._make_task_with_queue(status="completed")
         svc = _mock_svc(task=task)
 
         result = await insert_message(self._make_request("anything"), svc)
 
         assert result.success is False
         assert result.errorCode == "SESSION_NOT_RUNNING"
+
+    @pytest.mark.asyncio
+    async def test_node_still_starting_up_still_enqueues(self):
+        """Race: /insert arrives before ``_run_loop`` built the node
+        (``task.node is None``). The queue is task-scoped, so the message is
+        still enqueued and the node drains it on the first turn."""
+        from datus.api.routes.chat_routes import insert_message
+
+        task = self._make_task_with_queue()
+        task.node = None
+        svc = _mock_svc(task=task)
+
+        result = await insert_message(self._make_request("hello"), svc)
+
+        assert result.success is True
+        assert result.data.queued_count == 1
+        assert task.pending_input_queue.snapshot() == ["hello"]
 
     @pytest.mark.asyncio
     async def test_whitespace_only_message_returns_invalid_input(self):
@@ -487,17 +508,16 @@ class TestInsertMessageEndpoint:
         assert result.success is False
         assert result.errorCode == "INVALID_INPUT"
         # Queue untouched.
-        assert len(task.node.pending_input_queue) == 0
+        assert len(task.pending_input_queue) == 0
 
     @pytest.mark.asyncio
-    async def test_node_without_queue_returns_queue_unavailable(self):
-        """Node exists but caller never initialised pending_input_queue —
-        the route must surface that as a distinct error rather than
-        silently pushing nowhere."""
+    async def test_missing_queue_returns_queue_unavailable(self):
+        """Defensive: the queue is somehow absent — surface a distinct error
+        rather than silently pushing nowhere."""
         from datus.api.routes.chat_routes import insert_message
 
-        task = MagicMock()
-        task.node.pending_input_queue = None
+        task = self._make_task_with_queue()
+        task.pending_input_queue = None
         svc = _mock_svc(task=task)
 
         result = await insert_message(self._make_request("hello"), svc)
@@ -515,7 +535,7 @@ class TestInsertMessageEndpoint:
         await insert_message(self._make_request("  padded  "), svc)
 
         # Stripped form lands in the queue.
-        assert task.node.pending_input_queue.snapshot() == ["padded"]
+        assert task.pending_input_queue.snapshot() == ["padded"]
 
 
 # ===========================================================================

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -392,6 +392,97 @@ class TestChatTaskManagerBehavior:
         assert content.payload["content"] == "1 table: orders"
 
     @pytest.mark.asyncio
+    async def test_run_loop_shares_task_pending_queue_with_node(self, real_agent_config):
+        """The node must share the task-scoped pending queue so a /chat/insert
+        that arrived during node startup is drained on the first turn."""
+        from datus.api.models.cli_models import StreamChatInput
+
+        captured = {}
+
+        class FakeNode:
+            session_id = "s-share"
+
+            def __init__(self):
+                self.pending_input_queue = None
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                captured["queue_during_run"] = self.pending_input_queue
+                if False:  # make this an async generator without yielding
+                    yield
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-share", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="hi", session_id="s-share"))
+
+        assert task.node.pending_input_queue is task.pending_input_queue
+        assert captured["queue_during_run"] is task.pending_input_queue
+
+    @pytest.mark.asyncio
+    async def test_run_loop_auto_continues_residual_mid_run_message(self, real_agent_config):
+        """A message queued after the final turn (never seen by the SDK filter)
+        is drained after the run, echoed as a user_insert frame, and run in a
+        fresh pass — instead of being silently dropped."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-cont"
+
+            def __init__(self):
+                self.pending_input_queue = None
+                self.input = None
+                self.run_count = 0
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                self.run_count += 1
+                if self.run_count == 1:
+                    # Simulate a mid-run insert that landed after the final
+                    # turn — the SDK's call_model_input_filter never sees it.
+                    self.pending_input_queue.push("run the second SQL")
+                yield ActionHistory(
+                    action_id=f"r{self.run_count}",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="done",
+                    input={},
+                    output={"response": f"pass {self.run_count}"},
+                    status=ActionStatus.SUCCESS,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        # Avoid the real @-context/node-input machinery for the continuation turn.
+        manager._create_node_input = lambda **kwargs: SimpleNamespace(**kwargs)  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-cont", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="explore", session_id="s-cont"))
+
+        # Two passes: the original run + one auto-continuation for the residual.
+        assert task.node.run_count == 2
+        # The residual was echoed to the client as a user bubble.
+        user_events = [
+            e for e in task.events if e.event == "message" and getattr(e.data.payload, "role", None) == "user"
+        ]
+        assert len(user_events) == 1
+        assert "run the second SQL" in user_events[0].data.payload.content[0].payload["content"]
+        # Queue fully drained.
+        assert len(task.pending_input_queue) == 0
+
+    @pytest.mark.asyncio
     async def test_run_loop_web_source_proxies_filesystem_writes(self, real_agent_config):
         """source='web' proxies the client-owned write tools (write/edit/delete_file)."""
         from datus.api.models.cli_models import StreamChatInput

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -481,6 +481,59 @@ class TestChatTaskManagerBehavior:
         assert "run the second SQL" in user_events[0].data.payload.content[0].payload["content"]
         # Queue fully drained.
         assert len(task.pending_input_queue) == 0
+        # The accept window is closed once draining stops, so a tail-race insert
+        # gets SESSION_NOT_RUNNING instead of stranding.
+        assert task.accepting_inserts is False
+
+    @pytest.mark.asyncio
+    async def test_run_loop_continuation_reply_not_deduped_against_prior_pass(self, real_agent_config):
+        """A continuation pass producing the SAME visible text as the first pass
+        must still be emitted. Per-run de-dup state must not span passes — else
+        'run it again' shows the user bubble but drops the reply."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-dup"
+
+            def __init__(self):
+                self.pending_input_queue = None
+                self.input = None
+                self.run_count = 0
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                self.run_count += 1
+                if self.run_count == 1:
+                    self.pending_input_queue.push("do it again")
+                yield ActionHistory(
+                    action_id=f"r{self.run_count}",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="done",
+                    input={},
+                    output={"response": "identical reply"},
+                    status=ActionStatus.SUCCESS,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        manager._create_node_input = lambda **kwargs: SimpleNamespace(**kwargs)  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-dup", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="explore", session_id="s-dup"))
+
+        assert task.node.run_count == 2
+        assistant_events = [
+            e for e in task.events if e.event == "message" and getattr(e.data.payload, "role", None) == "assistant"
+        ]
+        # Both passes' replies reach the client despite identical text.
+        assert len(assistant_events) == 2
 
     @pytest.mark.asyncio
     async def test_run_loop_web_source_proxies_filesystem_writes(self, real_agent_config):

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -535,6 +535,149 @@ class TestChatTaskManagerBehavior:
         # Both passes' replies reach the client despite identical text.
         assert len(assistant_events) == 2
 
+    def test_drain_pending_for_continuation_variants(self):
+        """Covers all branches of the drain helper: no queue, empty, interrupted
+        (cleared), and a normal FIFO drain."""
+        from datus.cli.execution_state import PendingInputQueue
+
+        # No queue → None.
+        assert ChatTaskManager._drain_pending_for_continuation(SimpleNamespace(pending_input_queue=None)) is None
+
+        # Empty queue → None.
+        empty = SimpleNamespace(pending_input_queue=PendingInputQueue())
+        assert ChatTaskManager._drain_pending_for_continuation(empty) is None
+
+        # Interrupted → cleared and None (residual is discarded on cancel).
+        q = PendingInputQueue()
+        q.push("x")
+        interrupted = SimpleNamespace(
+            pending_input_queue=q,
+            interrupt_controller=SimpleNamespace(is_interrupted=True),
+        )
+        assert ChatTaskManager._drain_pending_for_continuation(interrupted) is None
+        assert len(q) == 0
+
+        # Normal → FIFO list.
+        q2 = PendingInputQueue()
+        q2.push("a")
+        q2.push("b")
+        live = SimpleNamespace(
+            pending_input_queue=q2,
+            interrupt_controller=SimpleNamespace(is_interrupted=False),
+        )
+        assert ChatTaskManager._drain_pending_for_continuation(live) == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_emit_user_insert_sse_noop_when_converter_returns_none(self):
+        """If the converter drops the frame, event_id is unchanged and nothing
+        is pushed."""
+        manager = ChatTaskManager()
+        task = ChatTask(session_id="s-none", asyncio_task=MagicMock())
+
+        with patch("datus.api.services.chat_task_manager.action_to_sse_event", return_value=None):
+            new_id = await manager._emit_user_insert_sse(task, "hi", 5)
+
+        assert new_id == 5
+        assert task.events == []
+
+    @pytest.mark.asyncio
+    async def test_run_loop_caps_continuations(self, real_agent_config):
+        """A client that keeps inserting can't run one task forever — the loop
+        stops after _MAX_INSERT_CONTINUATIONS and closes the accept window."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.api.services import chat_task_manager as ctm
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-cap"
+
+            def __init__(self):
+                self.pending_input_queue = None
+                self.input = None
+                self.run_count = 0
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                self.run_count += 1
+                # Never stops producing residue.
+                self.pending_input_queue.push(f"m{self.run_count}")
+                yield ActionHistory(
+                    action_id=f"r{self.run_count}",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="x",
+                    input={},
+                    output={"response": "y"},
+                    status=ActionStatus.SUCCESS,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        manager._create_node_input = lambda **kwargs: SimpleNamespace(**kwargs)  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-cap", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="go", session_id="s-cap"))
+
+        # Initial run + the cap in continuations, then it stops.
+        assert task.node.run_count == ctm._MAX_INSERT_CONTINUATIONS + 1
+        assert task.accepting_inserts is False
+
+    @pytest.mark.asyncio
+    async def test_run_loop_reopens_window_for_tail_race_insert(self, real_agent_config):
+        """A residual that only appears after the accept window closed must
+        re-open the window and continue — not be dropped."""
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        class FakeNode:
+            session_id = "s-reopen"
+
+            def __init__(self):
+                self.pending_input_queue = None
+                self.input = None
+                self.run_count = 0
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                self.run_count += 1
+                yield ActionHistory(
+                    action_id=f"r{self.run_count}",
+                    role=ActionRole.ASSISTANT,
+                    action_type="chat_response",
+                    messages="x",
+                    input={},
+                    output={"response": "y"},
+                    status=ActionStatus.SUCCESS,
+                )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        manager._create_node_input = lambda **kwargs: SimpleNamespace(**kwargs)  # type: ignore[method-assign]
+        # pass 1: first drain empty → close window → second drain finds a tail
+        # message → re-open and continue. pass 2: both drains empty → stop.
+        drains = iter([None, ["tail msg"], None, None])
+        manager._drain_pending_for_continuation = lambda node: next(drains)  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-reopen", asyncio_task=MagicMock())
+
+        await manager._run_loop(task, real_agent_config, StreamChatInput(message="go", session_id="s-reopen"))
+
+        # The re-opened window ran a second pass and echoed the tail message.
+        assert task.node.run_count == 2
+        user_events = [
+            e for e in task.events if e.event == "message" and getattr(e.data.payload, "role", None) == "user"
+        ]
+        assert len(user_events) == 1
+
     @pytest.mark.asyncio
     async def test_run_loop_web_source_proxies_filesystem_writes(self, real_agent_config):
         """source='web' proxies the client-owned write tools (write/edit/delete_file)."""


### PR DESCRIPTION
## Why

Mid-run messages POSTed to `/api/v1/chat/insert` during an API/SaaS chat were **silently dropped** — the agent never executed them and the client's pending entry was rolled back (looks like the message was "eaten").

Root cause: the node's `pending_input_queue` was only ever initialised by the CLI (`chat_commands.py`). On the API path it stayed `None`, which meant:
- `/chat/insert` returned `QUEUE_UNAVAILABLE` (never enqueued);
- the SDK's `call_model_input_filter` was never wired (`_build_run_config` only attaches it when the queue is non-`None`), so **turn-boundary injection never happened**;
- there was no run-boundary fallback for messages queued after the final LLM turn.

There was also a race: `/chat/insert` fired immediately after `/chat/stream` returned `SESSION_NOT_RUNNING`, because `task.node` is only set partway through `_run_loop` (after an `await to_thread(_init_node)`), while the insert route gated on `task.node`.

## Solution

- **Task-scoped queue.** `ChatTask` creates the `PendingInputQueue` up-front (before the node exists), so `/chat/insert` can enqueue during node startup. `_run_loop` points `node.pending_input_queue` at the same instance, so the filter drains it on the first turn. This wires turn-boundary injection (and its `emit_user_insert` SSE frame, which the client uses to dismiss the pending entry and render the user bubble) for the API path.
- **`/chat/insert` gates on `task.status == "running"`** instead of `task.node`, fixing the immediate-insert race (a still-initialising node no longer rejects; a completed task still does), and enqueues onto `task.pending_input_queue`.
- **Run-boundary auto-continuation** in `_run_loop`, mirroring the CLI's `execute_chat_command` loop: after each run, drain any residual queued messages (those that landed after the final turn, which the filter never sees), echo each as a `user_insert` SSE frame, and continue with a fresh turn. Interrupted runs clear the queue. This closes the last hole where late mid-run messages were dropped.

## Test Cases

Unit tests in `tests/unit_tests/api/`:
- `test_chat_task_manager.py`: `_run_loop` shares the task-scoped queue with the node; auto-continuation runs a residual mid-run message in a second pass and echoes it as a `user_insert` frame (queue fully drained).
- `test_chat_routes.py`: `/insert` enqueues onto the task queue; a still-starting node (`task.node is None`) still enqueues (race fix); a completed task returns `SESSION_NOT_RUNNING`; whitespace-only → `INVALID_INPUT`; missing queue → `QUEUE_UNAVAILABLE`; message stripped before push.

Deterministic, no external calls. Full `tests/unit_tests/api/` suite passes (1162).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added support for sending messages while a chat session is starting or an AI response is in progress.
  * Queued messages are preserved and automatically processed to continue the conversation.
  * Queued user messages are displayed in the live conversation stream.

* **Bug Fixes**
  * Prevented valid messages from being lost when submitted before chat initialization completes.
  * Improved handling of completed sessions and unavailable input queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “steering” for chat inserts that arrive while a session is still starting or while an AI response is finishing.
  * Messages are now queued on a task basis and carried forward automatically; residual queued inputs can be streamed back to the client during continuation passes.
* **Bug Fixes**
  * Improved enqueue eligibility during startup/race conditions and added a cap to auto-continuations to prevent sessions from running indefinitely.
  * Updated behavior when the insert queue is unavailable.
* **Tests**
  * Expanded unit coverage for task-scoped queuing and continuation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->