### PR TITLE
[Enhancement] Isolate Ossie semantic model generation

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -203,6 +203,8 @@ class GenMetricsAgenticNode(AgenticNode):
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
+            if authoring_format == "osi":
+                self.tools.append(trans_to_function_tool(self.generation_tools.resolve_osi_semantic_model_target))
             self.tools.append(trans_to_function_tool(self.generation_tools.end_metric_generation))
             if authoring_format != "osi":
                 self.tools.append(trans_to_function_tool(self.generation_tools.end_semantic_model_generation))
@@ -335,11 +337,33 @@ class GenMetricsAgenticNode(AgenticNode):
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
             resolve_authoring_format,
+            resolve_osi_semantic_model_target,
         )
 
         context["authoring_format"] = resolve_authoring_format(self.agent_config)
+        requested_name = str(getattr(user_input, "semantic_model_name", "") or "").strip()
+        business_domain = str(getattr(user_input, "business_domain", "") or "").strip()
+        fact_tables = list(getattr(user_input, "fact_tables", None) or [])
+        dimension_tables = list(getattr(user_input, "dimension_tables", None) or [])
+        context["requested_semantic_model_name"] = requested_name
+        context["requested_business_domain"] = business_domain
+        context["requested_fact_tables"] = fact_tables
+        context["requested_dimension_tables"] = dimension_tables
+        context["osi_target_resolved"] = False
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
+        if context["authoring_format"] == "osi" and (requested_name or business_domain or fact_tables):
+            target = resolve_osi_semantic_model_target(
+                self.agent_config,
+                semantic_model_name=requested_name,
+                business_domain=business_domain,
+                fact_tables=fact_tables,
+                dimension_tables=dimension_tables,
+            )
+            if not target.get("ambiguous"):
+                context["osi_target_resolved"] = True
+                context["default_osi_semantic_model_name"] = target["semantic_model_name"]
+                context["default_osi_semantic_model_file"] = target["semantic_model_file"]
 
         # Handle subject_tree context based on whether predefined or query from storage
         if self.subject_tree:
@@ -725,14 +749,20 @@ class GenMetricsAgenticNode(AgenticNode):
 
         if not getattr(self, "semantic_tools", None):
             raise RuntimeError("Metric generation produced a metric_file, but validate_semantic is unavailable.")
-        validation_result = self.semantic_tools.validate_semantic(checks=["authoring_quality"])
+        abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
+        model_names = self.generation_tools.extract_osi_model_names(abs_metric_file)
+        if len(model_names) != 1:
+            raise RuntimeError("The generated Ossie metric artifact must declare exactly one semantic model.")
+        validation_result = self.semantic_tools.validate_semantic(
+            semantic_model_name=model_names[0],
+            checks=["authoring_quality"],
+        )
         self.generation_evidence.record_validation_result(validation_result)
         if not self._tool_succeeded(validation_result):
             raise RuntimeError(
                 f"validate_semantic failed before publishing OSI metrics: {self._tool_error(validation_result)}"
             )
 
-        abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
         metric_names = self.generation_tools.extract_osi_metric_names(abs_metric_file)
         if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
             query_metrics = getattr(getattr(self, "semantic_tools", None), "query_metrics", None)

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -206,12 +206,24 @@ class GenSemanticModelAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup semantic func tools: {e}")
 
+    def _ensure_bash_tool_in_tools(self) -> None:
+        """Keep Ossie authoring on the explicit filesystem-tool surface."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        if is_osi_authoring(self.agent_config):
+            return
+        super()._ensure_bash_tool_in_tools()
+
     def _setup_filesystem_tools(self):
         """Setup filesystem tools."""
         try:
-            self.filesystem_func_tool = self._make_filesystem_tool()
+            from datus.agent.node.semantic_authoring import is_osi_authoring
 
-            self.tools.extend(self.filesystem_func_tool.available_tools())
+            self.filesystem_func_tool = self._make_filesystem_tool()
+            filesystem_tools = self.filesystem_func_tool.available_tools()
+            if is_osi_authoring(self.agent_config):
+                filesystem_tools = [tool for tool in filesystem_tools if tool.name != "delete_file"]
+            self.tools.extend(filesystem_tools)
             logger.debug("Added filesystem tools: read_file, write_file, edit_file, glob, grep")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
@@ -222,15 +234,18 @@ class GenSemanticModelAgenticNode(AgenticNode):
             from datus.agent.node.semantic_authoring import resolve_authoring_format
             from datus.tools.func_tool import trans_to_function_tool
 
+            authoring_format = resolve_authoring_format(self.agent_config)
             self.generation_tools = GenerationTools(
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
-                authoring_format=resolve_authoring_format(self.agent_config),
+                authoring_format=authoring_format,
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
+            if authoring_format == "osi":
+                self.tools.append(trans_to_function_tool(self.generation_tools.resolve_osi_semantic_model_target))
             self.tools.append(trans_to_function_tool(self.generation_tools.end_semantic_model_generation))
-            logger.debug("Added tools: check_semantic_object_exists, end_semantic_model_generation")
+            logger.debug("Added semantic-model generation tools for authoring_format=%s", authoring_format)
 
         except Exception as e:
             logger.error(f"Failed to setup generation tools: {e}")
@@ -310,11 +325,33 @@ class GenSemanticModelAgenticNode(AgenticNode):
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
             resolve_authoring_format,
+            resolve_osi_semantic_model_target,
         )
 
         context["authoring_format"] = resolve_authoring_format(self.agent_config)
+        requested_name = str(getattr(user_input, "semantic_model_name", "") or "").strip()
+        business_domain = str(getattr(user_input, "business_domain", "") or "").strip()
+        fact_tables = list(getattr(user_input, "fact_tables", None) or [])
+        dimension_tables = list(getattr(user_input, "dimension_tables", None) or [])
+        context["requested_semantic_model_name"] = requested_name
+        context["requested_business_domain"] = business_domain
+        context["requested_fact_tables"] = fact_tables
+        context["requested_dimension_tables"] = dimension_tables
+        context["osi_target_resolved"] = False
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
+        if context["authoring_format"] == "osi" and (requested_name or business_domain or fact_tables):
+            target = resolve_osi_semantic_model_target(
+                self.agent_config,
+                semantic_model_name=requested_name,
+                business_domain=business_domain,
+                fact_tables=fact_tables,
+                dimension_tables=dimension_tables,
+            )
+            if not target.get("ambiguous"):
+                context["osi_target_resolved"] = True
+                context["default_osi_semantic_model_name"] = target["semantic_model_name"]
+                context["default_osi_semantic_model_file"] = target["semantic_model_file"]
         context["osi_authoring_spec"] = ""
         if context["authoring_format"] == "osi":
             # The OSI core spec document ships with the adapter package so the
@@ -460,7 +497,20 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 raise RuntimeError(
                     "Semantic model generation produced semantic_model_files, but validate_semantic is unavailable."
                 )
-            validation_result = self.semantic_func_tool.validate_semantic(scope="semantic_model")
+            validation_kwargs = {"scope": "semantic_model"}
+            from datus.agent.node.semantic_authoring import is_osi_authoring
+
+            if is_osi_authoring(self.agent_config):
+                if len(semantic_model_files) != 1:
+                    raise RuntimeError("Ossie semantic model generation must publish exactly one target file.")
+                if not getattr(self, "generation_tools", None):
+                    raise RuntimeError("Cannot resolve the generated Ossie model name without generation tools.")
+                resolved = self.generation_tools._resolve_generation_path(semantic_model_files[0], "semantic")
+                model_names = self.generation_tools.extract_osi_model_names(resolved)
+                if len(model_names) != 1:
+                    raise RuntimeError("The generated Ossie file must declare exactly one semantic model.")
+                validation_kwargs["semantic_model_name"] = model_names[0]
+            validation_result = self.semantic_func_tool.validate_semantic(**validation_kwargs)
             self.generation_evidence.record_validation_result(validation_result)
             if not self._tool_succeeded(validation_result):
                 raise RuntimeError(

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -492,30 +492,42 @@ class GenSemanticModelAgenticNode(AgenticNode):
         if not semantic_model_files or self.generation_evidence.semantic_kb_sync_passed:
             return
 
-        if not self.generation_evidence.validation_passed:
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        osi_target = None
+        validation_passed = self.generation_evidence.validation_passed
+        if is_osi_authoring(self.agent_config):
+            if len(semantic_model_files) != 1:
+                raise RuntimeError("Ossie semantic model generation must publish exactly one target file.")
+            if not getattr(self, "generation_tools", None):
+                raise RuntimeError("Cannot resolve the generated Ossie model name without generation tools.")
+            resolved = self.generation_tools._resolve_generation_path(semantic_model_files[0], "semantic")
+            if not resolved:
+                raise RuntimeError("The generated Ossie file is outside the Knowledge Base sandbox.")
+            model_names = self.generation_tools.extract_osi_model_names(resolved)
+            if len(model_names) != 1:
+                raise RuntimeError("The generated Ossie file must declare exactly one semantic model.")
+            osi_target = (resolved, model_names[0])
+            validation_passed = self.generation_evidence.semantic_artifact_validation_passed(model_names[0], resolved)
+
+        if not validation_passed:
             if not getattr(self, "semantic_func_tool", None):
                 raise RuntimeError(
                     "Semantic model generation produced semantic_model_files, but validate_semantic is unavailable."
                 )
             validation_kwargs = {"scope": "semantic_model"}
-            from datus.agent.node.semantic_authoring import is_osi_authoring
-
-            if is_osi_authoring(self.agent_config):
-                if len(semantic_model_files) != 1:
-                    raise RuntimeError("Ossie semantic model generation must publish exactly one target file.")
-                if not getattr(self, "generation_tools", None):
-                    raise RuntimeError("Cannot resolve the generated Ossie model name without generation tools.")
-                resolved = self.generation_tools._resolve_generation_path(semantic_model_files[0], "semantic")
-                model_names = self.generation_tools.extract_osi_model_names(resolved)
-                if len(model_names) != 1:
-                    raise RuntimeError("The generated Ossie file must declare exactly one semantic model.")
-                validation_kwargs["semantic_model_name"] = model_names[0]
+            if osi_target is not None:
+                resolved, model_name = osi_target
+                validation_kwargs["semantic_model_name"] = model_name
             validation_result = self.semantic_func_tool.validate_semantic(**validation_kwargs)
             self.generation_evidence.record_validation_result(validation_result)
             if not self._tool_succeeded(validation_result):
                 raise RuntimeError(
                     f"validate_semantic failed before publishing semantic models: {self._tool_error(validation_result)}"
                 )
+            if osi_target is not None:
+                if not self.generation_evidence.record_semantic_artifact_validation(model_name, resolved):
+                    raise RuntimeError("Cannot bind semantic validation evidence to the generated Ossie artifact.")
 
         synced_files = []
         failed_files = []

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -25,7 +25,10 @@ from __future__ import annotations
 
 import re
 from dataclasses import fields, is_dataclass
-from typing import Any, Dict, Optional
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import yaml
 
 AUTHORING_FORMAT_METRICFLOW = "metricflow"
 AUTHORING_FORMAT_OSI = "osi"
@@ -184,6 +187,251 @@ def default_osi_semantic_model_file(agent_config: Any = None) -> str:
     if not datasource:
         datasource = "default"
     return f"subject/semantic_models/{datasource}/{default_osi_semantic_model_name(agent_config)}.yml"
+
+
+def _osi_semantic_model_dir(agent_config: Any = None) -> Optional[Path]:
+    """Return the active datasource's semantic-model directory when resolvable."""
+    if agent_config is None:
+        return None
+
+    datasource = str(getattr(agent_config, "current_datasource", "") or "default").strip() or "default"
+    path_manager = getattr(agent_config, "path_manager", None)
+    semantic_model_path = getattr(path_manager, "semantic_model_path", None)
+    if callable(semantic_model_path):
+        try:
+            return Path(semantic_model_path(datasource)).expanduser()
+        except Exception:
+            pass
+
+    project_root = getattr(agent_config, "project_root", None)
+    if not isinstance(project_root, (str, Path)):
+        project_root = getattr(path_manager, "project_root", None)
+    if project_root:
+        return Path(str(project_root)).expanduser() / "subject" / "semantic_models" / datasource
+    return None
+
+
+def _table_lookup_names(value: Any) -> set[str]:
+    """Return stable lookup keys for a logical or fully-qualified table name."""
+    text = str(value or "").strip().strip('`"[]')
+    if not text:
+        return set()
+    normalized = _normalize_model_name(text)
+    leaf = _normalize_model_name(re.split(r"[./]", text)[-1].strip('`"[]'))
+    return {candidate for candidate in (normalized, leaf) if candidate}
+
+
+def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any]]:
+    """Discover Ossie semantic models already authored for the active datasource.
+
+    The result is intentionally filesystem-backed rather than vector-store-backed:
+    target selection must preserve the durable model name and file even before or
+    after Knowledge Base synchronization.
+    """
+    model_dir = _osi_semantic_model_dir(agent_config)
+    if model_dir is None or not model_dir.is_dir():
+        return []
+
+    datasource = str(getattr(agent_config, "current_datasource", "") or "default").strip() or "default"
+    discovered: list[Dict[str, Any]] = []
+    paths = sorted([*model_dir.glob("*.yml"), *model_dir.glob("*.yaml")])
+    for path in paths:
+        try:
+            document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        models = document.get("semantic_model") if isinstance(document, dict) else None
+        if not isinstance(models, list):
+            continue
+        for model in models:
+            if not isinstance(model, dict):
+                continue
+            model_name = str(model.get("name") or "").strip()
+            if not model_name:
+                continue
+            dataset_names: list[str] = []
+            dataset_sources: list[str] = []
+            table_lookup_names: set[str] = set()
+            for dataset in model.get("datasets") or []:
+                if not isinstance(dataset, dict):
+                    continue
+                dataset_name = str(dataset.get("name") or "").strip()
+                dataset_source = str(dataset.get("source") or "").strip()
+                if dataset_name:
+                    dataset_names.append(dataset_name)
+                    table_lookup_names.update(_table_lookup_names(dataset_name))
+                if dataset_source:
+                    dataset_sources.append(dataset_source)
+                    table_lookup_names.update(_table_lookup_names(dataset_source))
+            discovered.append(
+                {
+                    "semantic_model_name": model_name,
+                    "semantic_model_file": f"subject/semantic_models/{datasource}/{path.name}",
+                    "absolute_path": str(path),
+                    "dataset_names": dataset_names,
+                    "dataset_sources": dataset_sources,
+                    "table_lookup_names": sorted(table_lookup_names),
+                }
+            )
+    return discovered
+
+
+def osi_semantic_models_cover_tables(agent_config: Any, tables: Iterable[str]) -> bool:
+    """Return whether existing Ossie files cover every requested source table."""
+    models = discover_osi_semantic_models(agent_config)
+    if not models:
+        return False
+    covered_names = {str(name) for model in models for name in model.get("table_lookup_names") or [] if str(name)}
+    requested = [str(table).strip() for table in tables if str(table).strip()]
+    return bool(requested) and all(_table_lookup_names(table).intersection(covered_names) for table in requested)
+
+
+def _new_osi_semantic_model_name(business_domain: str, fact_tables: Iterable[str]) -> tuple[str, str]:
+    normalized_domain = _normalize_model_name(business_domain)
+    if normalized_domain:
+        return normalized_domain, "business_domain"
+
+    for fact_table in fact_tables:
+        table_names = _table_lookup_names(fact_table)
+        if not table_names:
+            continue
+        leaf_name = min(table_names, key=lambda value: (value.count("_"), len(value), value))
+        if leaf_name.endswith(("_analytics", "_model", "_semantic_model")):
+            return leaf_name, "core_fact_table"
+        return f"{leaf_name}_analytics", "core_fact_table"
+    return "", "missing_core_fact_table"
+
+
+def _ambiguous_osi_target(
+    matched_by: str,
+    models: Iterable[Dict[str, Any]],
+    dimensions: list[str],
+    reason: str,
+) -> Dict[str, Any]:
+    return {
+        "ambiguous": True,
+        "matched_by": matched_by,
+        "reason": reason,
+        "candidates": [
+            {
+                "semantic_model_name": model["semantic_model_name"],
+                "semantic_model_file": model["semantic_model_file"],
+            }
+            for model in models
+        ],
+        "dimension_tables": dimensions,
+    }
+
+
+def resolve_osi_semantic_model_target(
+    agent_config: Any = None,
+    semantic_model_name: str = "",
+    business_domain: str = "",
+    fact_tables: Optional[Iterable[str]] = None,
+    dimension_tables: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Resolve a stable Ossie model name and file from authoring intent.
+
+    An explicit name always wins. Without one, an existing model containing the
+    core fact table is reused to keep its durable name. A new model is named by
+    business domain when available, then by the first/core fact table. The
+    dimension-table list is returned for observability but never participates
+    in naming, so adding dimensions cannot rename an existing model.
+    """
+    facts = [str(value).strip() for value in (fact_tables or []) if str(value).strip()]
+    dimensions = [str(value).strip() for value in (dimension_tables or []) if str(value).strip()]
+    existing_models = discover_osi_semantic_models(agent_config)
+    datasource = str(getattr(agent_config, "current_datasource", "") or "default").strip() or "default"
+
+    explicit_name = _normalize_model_name(semantic_model_name)
+    if explicit_name:
+        target_file = f"subject/semantic_models/{datasource}/{explicit_name}.yml"
+        matches = [
+            model
+            for model in existing_models
+            if _normalize_model_name(model.get("semantic_model_name")) == explicit_name
+        ]
+        if len(matches) == 1:
+            target = dict(matches[0])
+            target.update({"exists": True, "matched_by": "explicit_name", "dimension_tables": dimensions})
+            return target
+        if len(matches) > 1:
+            return _ambiguous_osi_target(
+                "explicit_name",
+                matches,
+                dimensions,
+                "The explicit semantic model name matches multiple existing files.",
+            )
+        occupied_file = [model for model in existing_models if model["semantic_model_file"] == target_file]
+        if occupied_file:
+            return _ambiguous_osi_target(
+                "explicit_name",
+                occupied_file,
+                dimensions,
+                "The target filename is already occupied by a differently named semantic model.",
+            )
+        return {
+            "semantic_model_name": explicit_name,
+            "semantic_model_file": target_file,
+            "exists": False,
+            "matched_by": "explicit_name",
+            "dimension_tables": dimensions,
+        }
+
+    fact_lookup_names = _table_lookup_names(facts[0]) if facts else set()
+    fact_matches = [
+        model for model in existing_models if fact_lookup_names.intersection(model.get("table_lookup_names") or [])
+    ]
+    if len(fact_matches) == 1:
+        target = dict(fact_matches[0])
+        target.update({"exists": True, "matched_by": "existing_fact_table", "dimension_tables": dimensions})
+        return target
+    if len(fact_matches) > 1:
+        return _ambiguous_osi_target(
+            "existing_fact_table",
+            fact_matches,
+            dimensions,
+            "The core fact table appears in multiple existing semantic models.",
+        )
+
+    new_name, matched_by = _new_osi_semantic_model_name(business_domain, facts)
+    if not new_name:
+        return _ambiguous_osi_target(
+            matched_by,
+            [],
+            dimensions,
+            "A business domain or core fact table is required to name a new semantic model safely.",
+        )
+    same_name = [
+        model for model in existing_models if _normalize_model_name(model.get("semantic_model_name")) == new_name
+    ]
+    if len(same_name) == 1:
+        target = dict(same_name[0])
+        target.update({"exists": True, "matched_by": matched_by, "dimension_tables": dimensions})
+        return target
+    if len(same_name) > 1:
+        return _ambiguous_osi_target(
+            matched_by,
+            same_name,
+            dimensions,
+            "The inferred semantic model name matches multiple existing files.",
+        )
+    target_file = f"subject/semantic_models/{datasource}/{new_name}.yml"
+    occupied_file = [model for model in existing_models if model["semantic_model_file"] == target_file]
+    if occupied_file:
+        return _ambiguous_osi_target(
+            matched_by,
+            occupied_file,
+            dimensions,
+            "The inferred target filename is already occupied by a differently named semantic model.",
+        )
+    return {
+        "semantic_model_name": new_name,
+        "semantic_model_file": target_file,
+        "exists": False,
+        "matched_by": matched_by,
+        "dimension_tables": dimensions,
+    }
 
 
 def required_authoring_skills(agent_config: Any, node_name: str) -> str:

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -213,12 +213,41 @@ def _osi_semantic_model_dir(agent_config: Any = None) -> Optional[Path]:
 
 def _table_lookup_names(value: Any) -> set[str]:
     """Return stable lookup keys for a logical or fully-qualified table name."""
-    text = str(value or "").strip().strip('`"[]')
-    if not text:
+    parts = [part.strip().strip('`"[]') for part in re.split(r"[./]", str(value or "").strip())]
+    parts = [part for part in parts if part]
+    if not parts:
         return set()
-    normalized = _normalize_model_name(text)
-    leaf = _normalize_model_name(re.split(r"[./]", text)[-1].strip('`"[]'))
+    normalized = _normalize_model_name(".".join(parts))
+    leaf = _normalize_model_name(parts[-1])
     return {candidate for candidate in (normalized, leaf) if candidate}
+
+
+def _table_reference(value: Any) -> tuple[str, str, bool]:
+    """Return ``(qualified, leaf, is_qualified)`` for safe table matching."""
+    parts = [part.strip().strip('`"[]') for part in re.split(r"[./]", str(value or "").strip())]
+    parts = [part for part in parts if part]
+    if not parts:
+        return "", "", False
+    normalized_parts = [_normalize_model_name(part) for part in parts]
+    leaf = normalized_parts[-1]
+    qualified = ".".join(normalized_parts)
+    return qualified, leaf, len(parts) > 1
+
+
+def _table_references_match(left: Any, right: Any) -> bool:
+    """Match qualified references exactly, falling back only for unqualified input."""
+    left_qualified, left_leaf, left_is_qualified = _table_reference(left)
+    right_qualified, right_leaf, right_is_qualified = _table_reference(right)
+    if not left_leaf or not right_leaf:
+        return False
+    if left_is_qualified and right_is_qualified:
+        return left_qualified == right_qualified
+    return left_leaf == right_leaf
+
+
+def _model_covers_table(model: Dict[str, Any], table: Any) -> bool:
+    references = model.get("table_references") or model.get("dataset_sources") or model.get("dataset_names") or []
+    return any(_table_references_match(table, reference) for reference in references)
 
 
 def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any]]:
@@ -251,6 +280,7 @@ def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any
                 continue
             dataset_names: list[str] = []
             dataset_sources: list[str] = []
+            table_references: list[str] = []
             table_lookup_names: set[str] = set()
             for dataset in model.get("datasets") or []:
                 if not isinstance(dataset, dict):
@@ -263,6 +293,9 @@ def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any
                 if dataset_source:
                     dataset_sources.append(dataset_source)
                     table_lookup_names.update(_table_lookup_names(dataset_source))
+                table_reference = dataset_source or dataset_name
+                if table_reference and table_reference not in table_references:
+                    table_references.append(table_reference)
             discovered.append(
                 {
                     "semantic_model_name": model_name,
@@ -270,6 +303,7 @@ def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any
                     "absolute_path": str(path),
                     "dataset_names": dataset_names,
                     "dataset_sources": dataset_sources,
+                    "table_references": table_references,
                     "table_lookup_names": sorted(table_lookup_names),
                 }
             )
@@ -277,13 +311,12 @@ def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any
 
 
 def osi_semantic_models_cover_tables(agent_config: Any, tables: Iterable[str]) -> bool:
-    """Return whether existing Ossie files cover every requested source table."""
+    """Return whether one existing Ossie model covers every requested table."""
     models = discover_osi_semantic_models(agent_config)
     if not models:
         return False
-    covered_names = {str(name) for model in models for name in model.get("table_lookup_names") or [] if str(name)}
     requested = [str(table).strip() for table in tables if str(table).strip()]
-    return bool(requested) and all(_table_lookup_names(table).intersection(covered_names) for table in requested)
+    return bool(requested) and any(all(_model_covers_table(model, table) for table in requested) for model in models)
 
 
 def _new_osi_semantic_model_name(business_domain: str, fact_tables: Iterable[str]) -> tuple[str, str]:
@@ -291,15 +324,31 @@ def _new_osi_semantic_model_name(business_domain: str, fact_tables: Iterable[str
     if normalized_domain:
         return normalized_domain, "business_domain"
 
-    for fact_table in fact_tables:
-        table_names = _table_lookup_names(fact_table)
+    facts = list(fact_tables)
+    if facts:
+        table_names = _table_lookup_names(facts[0])
         if not table_names:
-            continue
+            return "", "missing_core_fact_table"
         leaf_name = min(table_names, key=lambda value: (value.count("_"), len(value), value))
         if leaf_name.endswith(("_analytics", "_model", "_semantic_model")):
             return leaf_name, "core_fact_table"
         return f"{leaf_name}_analytics", "core_fact_table"
     return "", "missing_core_fact_table"
+
+
+def _undiscovered_target_occupant(agent_config: Any, target_file: str) -> Optional[Dict[str, Any]]:
+    """Return a fail-closed record when a target path exists but was not discoverable."""
+    model_dir = _osi_semantic_model_dir(agent_config)
+    if model_dir is None:
+        return None
+    target_path = model_dir / Path(target_file).name
+    if not target_path.exists():
+        return None
+    return {
+        "semantic_model_name": target_path.stem or "unknown",
+        "semantic_model_file": target_file,
+        "absolute_path": str(target_path),
+    }
 
 
 def _ambiguous_osi_target(
@@ -370,6 +419,14 @@ def resolve_osi_semantic_model_target(
                 dimensions,
                 "The target filename is already occupied by a differently named semantic model.",
             )
+        undiscovered_file = _undiscovered_target_occupant(agent_config, target_file)
+        if undiscovered_file:
+            return _ambiguous_osi_target(
+                "explicit_name",
+                [undiscovered_file],
+                dimensions,
+                "The target filename already exists but does not contain a safely discoverable semantic model.",
+            )
         return {
             "semantic_model_name": explicit_name,
             "semantic_model_file": target_file,
@@ -378,10 +435,7 @@ def resolve_osi_semantic_model_target(
             "dimension_tables": dimensions,
         }
 
-    fact_lookup_names = _table_lookup_names(facts[0]) if facts else set()
-    fact_matches = [
-        model for model in existing_models if fact_lookup_names.intersection(model.get("table_lookup_names") or [])
-    ]
+    fact_matches = [model for model in existing_models if facts and _model_covers_table(model, facts[0])]
     if len(fact_matches) == 1:
         target = dict(fact_matches[0])
         target.update({"exists": True, "matched_by": "existing_fact_table", "dimension_tables": dimensions})
@@ -424,6 +478,14 @@ def resolve_osi_semantic_model_target(
             occupied_file,
             dimensions,
             "The inferred target filename is already occupied by a differently named semantic model.",
+        )
+    undiscovered_file = _undiscovered_target_occupant(agent_config, target_file)
+    if undiscovered_file:
+        return _ambiguous_osi_target(
+            matched_by,
+            [undiscovered_file],
+            dimensions,
+            "The inferred target filename already exists but does not contain a safely discoverable semantic model.",
         )
     return {
         "semantic_model_name": new_name,

--- a/datus/api/models/table_models.py
+++ b/datus/api/models/table_models.py
@@ -67,6 +67,7 @@ class SemanticModelInput(BaseModel):
     catalog: Optional[str] = Field(None, description="Current catalog context")
     database: Optional[str] = Field(None, description="Current database context")
     db_schema: Optional[str] = Field(None, description="Current schema context")
+    semantic_model_name: Optional[str] = Field(None, description="Semantic model owning a shared physical table")
 
 
 class ValidateSemanticModelData(BaseModel):

--- a/datus/api/routes/table_routes.py
+++ b/datus/api/routes/table_routes.py
@@ -56,6 +56,7 @@ async def get_semantic_model(
     catalog: str | None = Query(None, description="Current catalog context"),
     database: str | None = Query(None, description="Current database context"),
     db_schema: str | None = Query(None, description="Current schema context"),
+    semantic_model_name: str | None = Query(None, description="Semantic model owning a shared physical table"),
 ) -> Result[GetSemanticModelData]:
     """Get SemanticModel YAML."""
     return await asyncio.to_thread(
@@ -64,6 +65,7 @@ async def get_semantic_model(
         catalog=catalog,
         database=database,
         db_schema=db_schema,
+        semantic_model_name=semantic_model_name,
     )
 
 

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -454,6 +454,7 @@ class DatasourceService:
         catalog: Optional[str] = None,
         database: Optional[str] = None,
         db_schema: Optional[str] = None,
+        semantic_model_name: Optional[str] = None,
     ):
         # Parse table name parts
         name_parts = parse_table_name_parts(full_name, self.current_db_connector.get_type())
@@ -464,12 +465,15 @@ class DatasourceService:
         table_name = name_parts["table_name"]
 
         # Get semantic model using SemanticMetricsRAG
-        semantic_model = self._ensure_semantic_rag().get_semantic_model(
+        lookup_kwargs = dict(
             catalog_name=catalog_name,
             database_name=database_name,
             schema_name=schema_name,
             table_name=table_name,
         )
+        if semantic_model_name:
+            lookup_kwargs["semantic_model_name"] = semantic_model_name
+        semantic_model = self._ensure_semantic_rag().get_semantic_model(**lookup_kwargs)
         return semantic_model
 
     def get_semantic_model(
@@ -479,6 +483,7 @@ class DatasourceService:
         catalog: Optional[str] = None,
         database: Optional[str] = None,
         db_schema: Optional[str] = None,
+        semantic_model_name: Optional[str] = None,
     ) -> Result[GetSemanticModelData]:
         """Get SemanticModel YAML.
 
@@ -500,6 +505,7 @@ class DatasourceService:
                 catalog=catalog,
                 database=database,
                 db_schema=db_schema,
+                semantic_model_name=semantic_model_name,
             )
             if not semantic_model:
                 return Result[GetSemanticModelData](
@@ -563,6 +569,7 @@ class DatasourceService:
             catalog=request.catalog,
             database=request.database,
             db_schema=request.db_schema,
+            semantic_model_name=request.semantic_model_name,
         )
         if not semantic_model:
             return Result[dict](
@@ -642,6 +649,7 @@ class DatasourceService:
                 catalog=request.catalog,
                 database=request.database,
                 db_schema=request.db_schema,
+                semantic_model_name=request.semantic_model_name,
             )
             if not semantic_model:
                 return Result[ValidateSemanticModelData](

--- a/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
@@ -45,17 +45,20 @@ Record the classification as defined in the `<required_skill>` specification{% i
 - Restrict filesystem reads/writes/reuse to `{{ kind_subdir }}/...`. Never read, edit, or pass paths from a sibling datasource directory such as `subject/semantic_models/other_datasource/...`.
 {% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource_dialect | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
 - OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
-- Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
-- Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`
+{% if osi_target_resolved %}- Resolved semantic model name: `{{ default_osi_semantic_model_name }}`
+- Resolved semantic model file: `{{ default_osi_semantic_model_file }}`
+{% else %}- Semantic model target is not resolved yet. Identify the metric's core fact table, then call `resolve_osi_semantic_model_target(..., require_existing=true)` and use its returned file.
+{% endif %}{% if requested_semantic_model_name %}- User-specified semantic model name: `{{ requested_semantic_model_name }}` (highest priority)
+{% endif %}
 {% endif %}
 
 ## Workflow
 
 1. **Discover existing assets**: Call `list_metrics()` and build an existing metric catalog. Do not recreate metrics that already exist — but note that "already exists" requires the same aggregation AND the same window/offset semantics; cumulative/window/period-over-period variants of a published base metric are NEW metrics.
 2. **Understand the request**: Confirm scope per the rules above. For provided historical SQL, call `analyze_metric_candidates_from_history` with the existing metric catalog before writing any files, and follow the candidate handling rules in the `<required_skill>` specification.
-3. **Ensure model prerequisites**: Check `check_semantic_object_exists(name, kind='table')` for involved tables{% if authoring_format == "osi" %}. The target OSI model must already exist. Load it to learn dataset names, fields, time fields, and relationships. If it is missing, stop and report that `gen_semantic_model` must run first; never create or modify datasets, fields, or relationships in this workflow{% else %}. If a semantic model is missing, load the `metricflow-semantic-authoring` skill from `<available_skills>` and follow it to create the model{% endif %}.
+3. **Ensure model prerequisites**: Check `check_semantic_object_exists(name, kind='table')` for involved tables{% if authoring_format == "osi" %}. Classify fact and dimension tables, then call `resolve_osi_semantic_model_target(semantic_model_name, business_domain, fact_tables, dimension_tables, require_existing=true)`. The target OSI model must already exist. Load the returned file to learn dataset names, fields, time fields, and relationships. If it is missing or ambiguous, stop and report that `gen_semantic_model` or an explicit model name is required; never create or modify datasets, fields, or relationships in this workflow{% else %}. If a semantic model is missing, load the `metricflow-semantic-authoring` skill from `<available_skills>` and follow it to create the model{% endif %}.
 4. **Author metrics**: Check `check_semantic_object_exists(name, kind='metric')` for each metric, then write the metric YAML per the `<required_skill>` specification{% if authoring_format == "osi" %} using `upsert_osi_metrics`; it creates new metrics and may replace an existing metric by name when an update is required{% endif %}.
-5. **Validate (MUST PASS)**: Call `validate_semantic`. If it fails, {% if authoring_format == "osi" %}fix the metric definitions with another `upsert_osi_metrics` call{% else %}fix with `edit_file`{% endif %} and retry until it passes. Do NOT proceed until validation passes.
+5. **Validate (MUST PASS)**: {% if authoring_format == "osi" %}Call `validate_semantic(semantic_model_name="{% if osi_target_resolved %}{{ default_osi_semantic_model_name }}{% else %}<semantic_model_name returned by resolve_osi_semantic_model_target>{% endif %}")` so only the resolved model runs full backend validation. If it fails, fix that model's metric definitions with another `upsert_osi_metrics` call{% else %}Call `validate_semantic`. If it fails, fix with `edit_file`{% endif %} and retry until it passes. Do NOT proceed until validation passes.
 6. **Dry-run**: Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric. If the source SQL groups by dimensions or a time grain, dry-run with matching `dimensions` / `time_granularity`; use `get_dimensions` for exact names. Collect each generated SQL into `metric_sqls_json`.
 7. **Publish**: After validation and dry-run pass, call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` ONCE{% if authoring_format == "osi" %}, passing `semantic_model_files=[]` because this workflow did not change semantic objects{% endif %}. Do not rely on the final JSON host fallback — it is only a last-resort guard. If no metrics were generated, do NOT call `end_metric_generation`.
 
@@ -66,7 +69,7 @@ Record the classification as defined in the `<required_skill>` specification{% i
 {% if authoring_format == "osi" %}```json
 {
   "semantic_model_files": [],
-  "metric_file": "{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}",
+  "metric_file": "subject/semantic_models/<datasource>/<resolved_model_name>.yml",
   "status": "generated",
   "output": "brief summary"
 }

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
@@ -14,8 +14,12 @@ The complete authoring specification for this run — YAML structure, field clas
   (resolves to `{{ semantic_model_dir }}` on disk)
 {% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource_dialect | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
 - OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
-- Target semantic model name: `{{ default_osi_semantic_model_name | default('<model_name>', true) }}`
-- Target semantic model file: `{{ default_osi_semantic_model_file | default('subject/semantic_models/<datasource>/<model_name>.yml', true) }}`
+{% if osi_target_resolved %}- Resolved semantic model name: `{{ default_osi_semantic_model_name }}`
+- Resolved semantic model file: `{{ default_osi_semantic_model_file }}`
+{% else %}- Semantic model target is not resolved yet. After classifying fact and dimension tables, call `resolve_osi_semantic_model_target` and use its returned name and file exactly.
+{% endif %}{% if requested_semantic_model_name %}- User-specified semantic model name: `{{ requested_semantic_model_name }}` (highest priority)
+{% endif %}{% if requested_business_domain %}- Provided business domain: `{{ requested_business_domain }}`
+{% endif %}
 {% if osi_authoring_spec %}
 ## OSI Core Authoring Specification (from the active semantic adapter)
 
@@ -42,20 +46,35 @@ The authoritative document shape you author against, including the Datus executi
 
 {% include "_semantic_sql_history_profiler_gate.j2" %}
 
-2. **Check for existing semantic objects**
+2. **Resolve the stable semantic model target**{% if authoring_format == "osi" %}
+   - Classify involved tables into fact tables and dimension tables. Put the core fact table first.
+   - Call `resolve_osi_semantic_model_target(semantic_model_name, business_domain, fact_tables, dimension_tables)` before any file mutation.
+   - Naming priority is: explicit `semantic_model_name`; reuse an existing model containing the core fact table; inferred business domain; core fact table fallback.
+   - Dimension tables never participate in the name. Adding a dimension to an existing model MUST reuse its current name and file.
+   - If the resolver reports ambiguity, do not guess; ask for or require an explicit semantic model name.
+   - Use the resolver's returned `semantic_model_name` inside the document and `semantic_model_file` for every file and publish operation.
+{% else %}
+   - Use the per-table file naming convention in the required MetricFlow authoring specification.
+{% endif %}
+
+3. **Check for existing semantic objects**
    - Use `check_semantic_object_exists(table_name, kind='table')` to verify whether a model already exists.
    - If it exists, decide whether to update it with `edit_file` or skip.
 
-3. **Author the semantic model YAML**
+4. **Author the semantic model YAML**
    - Follow the `<required_skill>` authoring specification for document structure, field classification, descriptions, and time-dimension rules.
-   - Save files with `write_file` under the path convention defined in the specification. If you forget the `{{ kind_subdir }}/` prefix the host silently normalizes it, but always include it so subsequent `read_file` / `edit_file` use the same path.
+{% if authoring_format == "osi" %}   - If the resolved file does not exist, create it with `write_file` at `<resolved semantic_model_file>`.
+   - If the resolved file already exists, read it first and use `edit_file` for targeted changes. Preserve its current semantic model name and all unrelated datasets, relationships, and metrics. Never replace an existing model with a partial document containing only the requested objects.
+{% else %}   - Save files with `write_file` under the path convention defined in the specification. If you forget the `{{ kind_subdir }}/` prefix the host silently normalizes it, but always include it so subsequent `read_file` / `edit_file` use the same path.
+{% endif %}
 
-4. **Validate (MANDATORY — DO NOT SKIP)**
-   - Call `validate_semantic(scope="semantic_model")`.
-   - If validation fails: analyze the error, fix the YAML with `edit_file` (actually execute the fix — do not just describe it), then call `validate_semantic` again. Repeat until it passes.
+5. **Validate (MANDATORY — DO NOT SKIP)**
+{% if authoring_format == "osi" %}   - Call `validate_semantic(scope="semantic_model", semantic_model_name="{% if osi_target_resolved %}{{ default_osi_semantic_model_name }}{% else %}<semantic_model_name returned by resolve_osi_semantic_model_target>{% endif %}")`. This validates only the resolved target model; never merge or rewrite another model to satisfy validation.
+{% else %}   - Call `validate_semantic(scope="semantic_model")`.
+{% endif %}   - If validation fails: analyze the error, fix the target YAML with `edit_file` (actually execute the fix — do not just describe it), then call the same targeted `validate_semantic` again. Repeat until it passes.
    - **ABSOLUTE RULE**: You MUST NOT return the final JSON response until `validate_semantic` returns success.
 
-5. **Publish (ONLY AFTER VALIDATION PASSES)**
+6. **Publish (ONLY AFTER VALIDATION PASSES)**
    - Prefer calling `end_semantic_model_generation(semantic_model_files=[...])` with all generated file paths so publish errors are caught while you can still fix files.
    - If you forget this tool, the host will use the final JSON `semantic_model_files` to validate and publish before reporting success.
    - Validation passing is the publish gate; no additional approval step is needed.

--- a/datus/resources/skills/osi-metrics-authoring/SKILL.md
+++ b/datus/resources/skills/osi-metrics-authoring/SKILL.md
@@ -23,7 +23,7 @@ CRITICAL MODEL RULE — **build the model once, then only upsert metrics**:
 - Never use general filesystem writes to create or modify datasets, fields, or relationships. If the target model is missing, stop and report that `gen_semantic_model` must run first.
 - A given logical dataset has one canonical definition shared by all metrics. Reuse that dataset by name in each metric's DATUS `dataset` hint.
 
-The OSI expression dialect and target semantic model file for the current run are shown in the system prompt Workspace section — use those exact values (`<osi_dialect>` below stands for that dialect).
+The OSI expression dialect is shown in the system prompt Workspace section. Resolve the existing target semantic model with `resolve_osi_semantic_model_target(..., require_existing=true)` after identifying the core fact table; use the returned file exactly (`<osi_dialect>` below stands for that dialect).
 
 ## What you produce
 
@@ -110,7 +110,7 @@ Before writing any YAML, classify the source SQL:
 
 ## Workflow notes
 
-- FIRST, load the existing model from the target semantic model file to learn dataset names, fields, time fields, and relationships. If the file is missing, stop and report the prerequisite. Call `list_metrics()` to see metrics that already exist.
+- FIRST, classify fact and dimension tables and resolve the existing model target. An explicit semantic model name wins; otherwise the resolver reuses the model containing the core fact table. Dimension tables do not affect the model name. Load the returned file to learn dataset names, fields, time fields, and relationships. If the file is missing or ambiguous, stop and report the prerequisite. Call `list_metrics()` to see metrics that already exist.
 - For provided SQL/history, call `analyze_metric_candidates_from_history` before writing files. Use `direct_metric_candidates` for base metrics and fixed `period_over_period` final metrics; use `derived_metric_candidates` only for second-stage OSI metrics that explicitly depend on published input metrics. If it returns `metric_generation_skips`, skip those SQLs instead of writing metric YAML.
 - Candidate-plan compliance: every candidate in `direct_metric_candidates` and `derived_metric_candidates` (including cumulative, rolling-window, and period_over_period candidates) MUST end this run either published via `end_metric_generation` or listed in your final `output` with a concrete blocker such as a validation failure. "Covered by an existing base metric" is never a valid blocker for a cumulative/window/period_over_period candidate.
 - Reference, reconcile, reuse: point each metric's DATUS `dataset` hint at an existing dataset. If a metric with the same meaning and correct definition already exists (`check_semantic_object_exists(name, kind='metric')`), reuse/skip it. If the user requests an update or the stored definition is incorrect, replace it by name with `upsert_osi_metrics`. "Same meaning" requires the same aggregation AND the same window/offset semantics: a base aggregate never covers its cumulative/rolling/period-over-period variants, so `running_x`/`moving_x`/`previous_x` candidates must still be published when only `x` exists. For a derived metric, make sure its input metrics already exist.

--- a/datus/resources/skills/osi-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/osi-semantic-authoring/SKILL.md
@@ -18,7 +18,7 @@ Describe tables as strict **OSI (Open Semantic Interchange) core schema** docume
 
 CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow `data_source:`, `measures:`, `identifiers:`, `agg_time_dimension`, `create_metric`, or any execution-engine YAML. The Datus OSI compiler lowers OSI core documents to the configured backend.
 
-The OSI expression dialect, target semantic model name, and target semantic model file for the current run are shown in the system prompt Workspace section — use those exact values (`<osi_dialect>` below stands for that dialect).
+The OSI expression dialect is shown in the system prompt Workspace section. Resolve the target model name and file with `resolve_osi_semantic_model_target` after identifying the fact and dimension tables; use the returned values exactly (`<osi_dialect>` below stands for that dialect).
 
 ## Field roles — the three-way decision
 
@@ -98,8 +98,12 @@ WRONG (do not do this): declaring `loan_balance` or `npl_rate` as fields **with*
 
 ## Workflow notes
 
-- Write OSI core YAML under the semantic model directory shown in the system prompt only, at the target semantic model file path.
+- Resolve the target before writing. Priority: an explicit user-provided semantic model name; an existing model containing the core fact table; an inferred business domain; the core fact table as fallback.
+- Put the core fact table first in `fact_tables`. Pass dimensions separately; dimension tables never participate in naming.
+- When the resolver returns an existing file, preserve its semantic model name permanently, even when adding dimensions. Read and update that file instead of creating a renamed model.
+- Create a new resolved target with `write_file`. For an existing target, read it first and use `edit_file` for targeted changes.
+- For an existing target, keep its current semantic model name and preserve all unrelated datasets, relationships, and metrics. Never replace the file with a partial document containing only the requested objects.
 - Inspect the table schema and comments (`describe_table` reports `pk`/`nullable` facts when the database declares them); map columns to roles per the table above.
 - When a critical modeling choice is ambiguous (which column set is the grain, which is the primary time dimension), ASK before generating.
-- Call `validate_semantic(scope="semantic_model")` after writing the OSI semantic model and fix errors until it passes; treat warnings about "aggregates column X which is also a dimension" as instructions to drop that field's `dimension:` block or the field itself.
+- Call `validate_semantic(scope="semantic_model")` after writing or editing the OSI semantic model and fix errors with `edit_file` until it passes; treat warnings about "aggregates column X which is also a dimension" as instructions to drop that field's `dimension:` block or the field itself.
 - After validation passes, call `end_semantic_model_generation(semantic_model_files=[...])`. In OSI mode this syncs OSI datasets to the Knowledge Base without using MetricFlow YAML.

--- a/datus/schemas/semantic_agentic_node_models.py
+++ b/datus/schemas/semantic_agentic_node_models.py
@@ -26,6 +26,22 @@ class SemanticNodeInput(AtContextInput):
     catalog: Optional[str] = Field(default=None, description="Database catalog for context")
     database: Optional[str] = Field(default=None, description="Database name for context")
     db_schema: Optional[str] = Field(default=None, description="Database schema for context")
+    semantic_model_name: Optional[str] = Field(
+        default=None,
+        description="Explicit stable semantic model name; takes priority over inferred naming in Ossie mode",
+    )
+    business_domain: Optional[str] = Field(
+        default=None,
+        description="Business domain used to name a new Ossie semantic model when no explicit name is supplied",
+    )
+    fact_tables: Optional[list[str]] = Field(
+        default=None,
+        description="Fact tables in priority order; the first/core fact table is the stable naming fallback",
+    )
+    dimension_tables: Optional[list[str]] = Field(
+        default=None,
+        description="Dimension tables used by the model; recorded for context but excluded from model naming",
+    )
     max_turns: Optional[int] = Field(default=None, description="Maximum conversation turns; None uses node config")
     workspace_root: Optional[str] = Field(default=None, description="Root directory path for filesystem MCP server")
     prompt_version: Optional[str] = Field(default=None, description="Version for prompt template")

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -257,10 +257,12 @@ async def _ensure_semantic_models_for_metrics(
         from datus.storage.semantic_model.store import SemanticModelRAG
 
         before_models = discover_osi_semantic_models(agent_config)
-        requested_tables = extract_tables_from_sql_list(sql_list, agent_config)
+        requested_table_groups = [extract_tables_from_sql_list([sql], agent_config) for sql in sql_list]
+        requested_tables = list(dict.fromkeys(table for table_group in requested_table_groups for table in table_group))
         has_semantic_rows = SemanticModelRAG(agent_config).get_size() > 0
-        existing_models_cover_request = not requested_tables or osi_semantic_models_cover_tables(
-            agent_config, requested_tables
+        existing_models_cover_request = not requested_tables or all(
+            not table_group or osi_semantic_models_cover_tables(agent_config, table_group)
+            for table_group in requested_table_groups
         )
         if has_semantic_rows and before_models and existing_models_cover_request:
             logger.info(

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -13,7 +13,8 @@ import pandas as pd
 from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_OSI,
-    default_osi_semantic_model_file,
+    discover_osi_semantic_models,
+    osi_semantic_models_cover_tables,
     resolve_authoring_format,
 )
 from datus.configuration.agent_config import AgentConfig
@@ -244,14 +245,6 @@ def _metrics_authoring_format(agent_config: AgentConfig) -> str:
     return resolve_authoring_format(agent_config)
 
 
-def _project_relative_path(agent_config: AgentConfig, path_value: str) -> Path:
-    path = Path(path_value)
-    if path.is_absolute():
-        return path
-    project_root = Path(str(getattr(agent_config, "project_root", "") or ".")).expanduser()
-    return project_root / path
-
-
 async def _ensure_semantic_models_for_metrics(
     agent_config: AgentConfig,
     success_story: str,
@@ -263,14 +256,20 @@ async def _ensure_semantic_models_for_metrics(
         from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
         from datus.storage.semantic_model.store import SemanticModelRAG
 
-        target_file = default_osi_semantic_model_file(agent_config)
-        target_path = _project_relative_path(agent_config, target_file)
+        before_models = discover_osi_semantic_models(agent_config)
+        requested_tables = extract_tables_from_sql_list(sql_list, agent_config)
         has_semantic_rows = SemanticModelRAG(agent_config).get_size() > 0
-        if has_semantic_rows and target_path.exists():
-            logger.info("Reusing existing OSI semantic model file for metric bootstrap: %s", target_file)
+        existing_models_cover_request = not requested_tables or osi_semantic_models_cover_tables(
+            agent_config, requested_tables
+        )
+        if has_semantic_rows and before_models and existing_models_cover_request:
+            logger.info(
+                "Reusing %d existing OSI semantic model file(s) for metric bootstrap",
+                len(before_models),
+            )
             return True, "", []
 
-        logger.info("Generating OSI semantic model for metric bootstrap: %s", target_file)
+        logger.info("Generating OSI semantic model(s) for metric bootstrap")
         success, error = await init_success_story_semantic_model_async(
             agent_config,
             success_story,
@@ -280,9 +279,14 @@ async def _ensure_semantic_models_for_metrics(
         )
         if not success:
             return False, error, []
-        if not target_path.exists():
-            return False, f"OSI semantic model generation did not create target file: {target_file}", []
-        return True, "", [target_file]
+        after_models = discover_osi_semantic_models(agent_config)
+        if not after_models:
+            return False, "OSI semantic model generation did not create a model file", []
+        before_files = {model["semantic_model_file"] for model in before_models}
+        created_files = sorted(
+            model["semantic_model_file"] for model in after_models if model["semantic_model_file"] not in before_files
+        )
+        return True, "", created_files
 
     all_tables = extract_tables_from_sql_list(sql_list, agent_config)
     if not all_tables:

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -400,17 +400,25 @@ class SemanticModelRAG:
                 obj.get("catalog_name", ""),
                 obj.get("database_name", ""),
                 obj.get("schema_name", ""),
+                obj.get("semantic_model_name", ""),
             )
             if not scope[0] or scope in seen_scopes:
                 continue
             seen_scopes.add(scope)
-            table_name, catalog_name, database_name, schema_name = scope
+            (
+                table_name,
+                catalog_name,
+                database_name,
+                schema_name,
+                semantic_model_name,
+            ) = scope
             conditions = [
                 in_("kind", ["table", "column"]),
                 eq("table_name", table_name),
                 eq("catalog_name", catalog_name),
                 eq("database_name", database_name),
                 eq("schema_name", schema_name),
+                eq("semantic_model_name", semantic_model_name),
                 not_(in_("id", keep_ids)),
             ]
             try:
@@ -489,14 +497,22 @@ class SemanticModelRAG:
         database_name: str = "",
         schema_name: str = "",
         table_name: str = "",
+        semantic_model_name: str = "",
         select_fields: Optional[List[str]] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Reconstruct semantic model object from granular storage."""
+        """Reconstruct one table from granular semantic-model storage.
+
+        ``semantic_model_name`` disambiguates a physical table shared by more
+        than one Ossie model. Existing callers may omit it when the table belongs
+        to only one model.
+        """
         if not table_name:
             logger.warning("get_semantic_model called without table_name")
             return None
 
         base_conds = self._sub_agent_conditions()
+        if semantic_model_name:
+            base_conds.append(eq("semantic_model_name", semantic_model_name))
 
         # Build filter conditions
         table_conds = [eq("kind", "table"), eq("table_name", table_name)] + base_conds
@@ -531,7 +547,7 @@ class SemanticModelRAG:
             return None
 
         semantic_model = table_objs[0]
-        model_name = semantic_model.get("name", table_name)
+        model_name = semantic_model.get("semantic_model_name") or semantic_model.get("name") or table_name
 
         # Find children
         children_conds = [
@@ -544,6 +560,8 @@ class SemanticModelRAG:
             children_conds.append(eq("database_name", semantic_model["database_name"]))
         if semantic_model.get("schema_name"):
             children_conds.append(eq("schema_name", semantic_model["schema_name"]))
+        if semantic_model.get("semantic_model_name"):
+            children_conds.append(eq("semantic_model_name", semantic_model["semantic_model_name"]))
 
         children = self.storage._search_all(where=And(children_conds)).to_pylist()
 

--- a/datus/storage/semantic_model/store.py
+++ b/datus/storage/semantic_model/store.py
@@ -546,6 +546,22 @@ class SemanticModelRAG:
         if not table_objs:
             return None
 
+        if not semantic_model_name:
+            candidate_models = sorted(
+                {
+                    str(obj.get("semantic_model_name") or obj.get("name") or "").strip() or "<legacy>"
+                    for obj in table_objs
+                }
+            )
+            if len(candidate_models) > 1:
+                raise DatusException(
+                    ErrorCode.STORAGE_INVALID_ARGUMENT,
+                    message=(
+                        f"Table `{table_name}` belongs to multiple semantic models: "
+                        f"{', '.join(candidate_models)}. Specify semantic_model_name explicitly."
+                    ),
+                )
+
         semantic_model = table_objs[0]
         model_name = semantic_model.get("semantic_model_name") or semantic_model.get("name") or table_name
 

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -6,8 +6,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set
 
 
@@ -58,6 +60,7 @@ class GenerationEvidence:
     metric_kb_sync_passed: bool = False
     generic_kb_sync_passed: bool = False
     storage_revision: int = 0
+    validated_semantic_artifacts: Dict[str, Dict[str, str]] = field(default_factory=dict)
 
     @property
     def kb_sync_passed(self) -> bool:
@@ -68,6 +71,52 @@ class GenerationEvidence:
         valid = isinstance(payload, dict) and payload.get("valid") is True
         if _result_success(result) and valid:
             self.validation_passed = True
+            semantic_model_name = str(payload.get("semantic_model_name") or "").strip()
+            semantic_model_file = str(payload.get("semantic_model_file") or "").strip()
+            semantic_model_file_sha256 = str(payload.get("semantic_model_file_sha256") or "").strip()
+            if semantic_model_name and semantic_model_file:
+                self.record_semantic_artifact_validation(
+                    semantic_model_name,
+                    semantic_model_file,
+                    expected_sha256=semantic_model_file_sha256,
+                )
+
+    @staticmethod
+    def _semantic_artifact_state(path: str | Path) -> Optional[Dict[str, str]]:
+        try:
+            resolved = Path(path).expanduser().resolve(strict=True)
+            if not resolved.is_file():
+                return None
+            return {
+                "path": str(resolved),
+                "sha256": hashlib.sha256(resolved.read_bytes()).hexdigest(),
+            }
+        except (OSError, RuntimeError):
+            return None
+
+    def record_semantic_artifact_validation(
+        self,
+        semantic_model_name: str,
+        path: str | Path,
+        *,
+        expected_sha256: str = "",
+    ) -> bool:
+        """Bind successful validation to one model and the exact file content."""
+        model_name = str(semantic_model_name or "").strip()
+        state = self._semantic_artifact_state(path)
+        if not model_name or state is None:
+            return False
+        if expected_sha256 and state["sha256"] != expected_sha256:
+            return False
+        self.validated_semantic_artifacts[model_name] = state
+        return True
+
+    def semantic_artifact_validation_passed(self, semantic_model_name: str, path: str | Path) -> bool:
+        """Return whether the current artifact bytes match recorded validation evidence."""
+        model_name = str(semantic_model_name or "").strip()
+        expected = self.validated_semantic_artifacts.get(model_name)
+        current = self._semantic_artifact_state(path)
+        return expected is not None and current is not None and expected == current
 
     def set_metric_queryability_contracts(
         self,

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -27,6 +27,7 @@ from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.metric_queryability import summarize_queryability_contracts
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.path_manager import get_path_manager
 
@@ -357,18 +358,45 @@ class GenerationTools:
             dict: Result containing completion message and semantic_model_files
         """
         try:
-            if self._is_osi_authoring() and len(semantic_model_files) != 1:
-                return FuncToolResult(
-                    success=0,
-                    error=("Ossie semantic model generation must publish exactly one target file per run."),
-                    result={"semantic_model_files": semantic_model_files},
+            osi_target: Optional[tuple[str, str]] = None
+            if self._is_osi_authoring():
+                if len(semantic_model_files) != 1:
+                    return FuncToolResult(
+                        success=0,
+                        error=("Ossie semantic model generation must publish exactly one target file per run."),
+                        result={"semantic_model_files": semantic_model_files},
+                    )
+                resolved = self._resolve_generation_path(semantic_model_files[0], "semantic")
+                if not resolved:
+                    return FuncToolResult(
+                        success=0,
+                        error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_files[0]!r}",
+                        result={"semantic_model_files": semantic_model_files},
+                    )
+                model_names = self.extract_osi_model_names(resolved)
+                if len(model_names) != 1:
+                    return FuncToolResult(
+                        success=0,
+                        error=(
+                            "Generated Ossie files must declare exactly one semantic model; "
+                            f"found {model_names or '<none>'}."
+                        ),
+                        result={"semantic_model_files": semantic_model_files},
+                    )
+                osi_target = (resolved, model_names[0])
+                validation_passed = self.generation_evidence.semantic_artifact_validation_passed(
+                    model_names[0], resolved
                 )
-            if not self.generation_evidence.validation_passed:
+            else:
+                validation_passed = self.generation_evidence.validation_passed
+
+            if not validation_passed:
                 return FuncToolResult(
                     success=0,
                     error=(
-                        "validate_semantic must pass before publishing semantic models. "
-                        "Call validate_semantic, fix any issues, and retry end_semantic_model_generation."
+                        "validate_semantic must pass for the exact semantic model artifact before publishing. "
+                        "Call validate_semantic with the target semantic_model_name after the final file edit, "
+                        "then retry end_semantic_model_generation."
                     ),
                     result={"semantic_model_files": semantic_model_files},
                 )
@@ -380,33 +408,16 @@ class GenerationTools:
             self._semantic_table_object_index = None
 
             if self._is_osi_authoring():
-                sync_results = []
-                for semantic_model_file in semantic_model_files:
-                    resolved = self._resolve_generation_path(semantic_model_file, "semantic")
-                    if not resolved:
-                        return FuncToolResult(
-                            success=0,
-                            error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}",
-                            result={"semantic_model_files": semantic_model_files},
-                        )
-                    model_names = self.extract_osi_model_names(resolved)
-                    if len(model_names) != 1:
-                        return FuncToolResult(
-                            success=0,
-                            error=(
-                                "Generated Ossie files must declare exactly one semantic model; "
-                                f"found {model_names or '<none>'}."
-                            ),
-                            result={"semantic_model_files": semantic_model_files},
-                        )
-                    sync_result = self.sync_osi_semantic_to_db(resolved)
-                    sync_results.append(sync_result)
-                    if not sync_result.get("success"):
-                        return FuncToolResult(
-                            success=0,
-                            error=f"OSI semantic model KB sync failed: {sync_result.get('error', 'unknown')}",
-                            result={"semantic_model_files": semantic_model_files, "sync": sync_results},
-                        )
+                assert osi_target is not None
+                resolved, _model_name = osi_target
+                sync_result = self.sync_osi_semantic_to_db(resolved)
+                sync_results = [sync_result]
+                if not sync_result.get("success"):
+                    return FuncToolResult(
+                        success=0,
+                        error=f"OSI semantic model KB sync failed: {sync_result.get('error', 'unknown')}",
+                        result={"semantic_model_files": semantic_model_files, "sync": sync_results},
+                    )
                 self.generation_evidence.mark_kb_sync("semantic")
                 return FuncToolResult(
                     result={
@@ -1140,8 +1151,11 @@ class GenerationTools:
             model_names = self.extract_osi_model_names(semantic_model_file)
         if len(model_names) != 1:
             candidates = ", ".join(model_names) or "<none>"
-            raise ValueError(
-                f"Exactly one semantic model must be identifiable from the target artifact. Found: {candidates}."
+            raise DatusException(
+                ErrorCode.TOOL_INVALID_INPUT,
+                message=(
+                    f"Exactly one semantic model must be identifiable from the target artifact. Found: {candidates}."
+                ),
             )
         return load_osi_model(
             self._osi_document_root(metric_file, semantic_model_file),

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -235,6 +235,70 @@ class GenerationTools:
             logger.error(f"Error checking semantic object existence: {e}")
             return FuncToolResult(success=0, error=f"Failed to check object: {str(e)}")
 
+    def resolve_osi_semantic_model_target(
+        self,
+        semantic_model_name: str = "",
+        business_domain: str = "",
+        fact_tables: Optional[List[str]] = None,
+        dimension_tables: Optional[List[str]] = None,
+        require_existing: bool = False,
+    ) -> FuncToolResult:
+        """Choose the stable Ossie semantic-model name and file for this task.
+
+        Call this after identifying fact and dimension tables, before any file
+        mutation. An explicit semantic_model_name wins. Otherwise an existing
+        model containing the core fact table is reused, then business_domain is
+        used, and finally the first/core fact table becomes the naming fallback.
+        Dimension tables never affect the name. Set require_existing for metric
+        authoring, which is not allowed to create a semantic model.
+
+        Args:
+            semantic_model_name: User-specified stable model name, when provided.
+            business_domain: Concise business-domain name inferred from the request.
+            fact_tables: Fact tables in priority order, with the core fact first.
+            dimension_tables: Related dimensions; excluded from naming.
+            require_existing: Fail when the resolved model file does not exist.
+        """
+        try:
+            from datus.agent.node.semantic_authoring import (
+                is_osi_authoring,
+                resolve_osi_semantic_model_target,
+            )
+
+            if not is_osi_authoring(self.agent_config):
+                return FuncToolResult(success=0, error="Ossie target resolution is only available in OSI mode.")
+            target = resolve_osi_semantic_model_target(
+                self.agent_config,
+                semantic_model_name=semantic_model_name,
+                business_domain=business_domain,
+                fact_tables=fact_tables,
+                dimension_tables=dimension_tables,
+            )
+            if target.get("ambiguous"):
+                candidates = ", ".join(candidate["semantic_model_name"] for candidate in target.get("candidates") or [])
+                candidate_suffix = f" Candidates: {candidates}" if candidates else ""
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        f"Unable to resolve a safe Ossie semantic model target: {target.get('reason', 'ambiguous target')}"
+                        f" Specify semantic_model_name explicitly when needed.{candidate_suffix}"
+                    ),
+                    result=target,
+                )
+            if require_existing and not target.get("exists"):
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        "No existing Ossie semantic model matches this request. "
+                        "Run gen_semantic_model first or specify an existing semantic_model_name."
+                    ),
+                    result=target,
+                )
+            return FuncToolResult(result=target)
+        except Exception as exc:
+            logger.error("Failed to resolve Ossie semantic-model target: %s", exc)
+            return FuncToolResult(success=0, error=f"Failed to resolve Ossie semantic-model target: {exc}")
+
     # Backward compatibility wrapper
     def check_semantic_model_exists(
         self,
@@ -293,6 +357,12 @@ class GenerationTools:
             dict: Result containing completion message and semantic_model_files
         """
         try:
+            if self._is_osi_authoring() and len(semantic_model_files) != 1:
+                return FuncToolResult(
+                    success=0,
+                    error=("Ossie semantic model generation must publish exactly one target file per run."),
+                    result={"semantic_model_files": semantic_model_files},
+                )
             if not self.generation_evidence.validation_passed:
                 return FuncToolResult(
                     success=0,
@@ -317,6 +387,16 @@ class GenerationTools:
                         return FuncToolResult(
                             success=0,
                             error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}",
+                            result={"semantic_model_files": semantic_model_files},
+                        )
+                    model_names = self.extract_osi_model_names(resolved)
+                    if len(model_names) != 1:
+                        return FuncToolResult(
+                            success=0,
+                            error=(
+                                "Generated Ossie files must declare exactly one semantic model; "
+                                f"found {model_names or '<none>'}."
+                            ),
                             result={"semantic_model_files": semantic_model_files},
                         )
                     sync_result = self.sync_osi_semantic_to_db(resolved)
@@ -989,6 +1069,19 @@ class GenerationTools:
                         names.append(item["name"])
         return names
 
+    def extract_osi_model_names(self, osi_path: str) -> List[str]:
+        """Return semantic-model names declared by one OSI artifact."""
+        names: List[str] = []
+        for doc in self._iter_yaml_docs(osi_path):
+            semantic_models = doc.get("semantic_model")
+            if isinstance(semantic_models, list):
+                for model in semantic_models:
+                    if isinstance(model, dict) and isinstance(model.get("name"), str):
+                        names.append(model["name"])
+            elif isinstance(semantic_models, dict) and isinstance(semantic_models.get("name"), str):
+                names.append(semantic_models["name"])
+        return self._dedupe_strings(names)
+
     def extract_osi_dataset_names(self, semantic_model_path: str) -> List[str]:
         """Return dataset names declared in OSI core semantic-model documents."""
         names: List[str] = []
@@ -1035,10 +1128,26 @@ class GenerationTools:
                 return str(candidate)
         return str(candidates[0]) if candidates else str(Path(metric_file or semantic_model_file or ".").parent)
 
-    def _load_osi_document(self, metric_file: Optional[str] = None, semantic_model_file: Optional[str] = None):
-        from datus_semantic_osi.profile import load_osi_path
+    def _load_osi_document(
+        self,
+        metric_file: Optional[str] = None,
+        semantic_model_file: Optional[str] = None,
+    ):
+        from datus_semantic_osi.profile import load_osi_model
 
-        return load_osi_path(self._osi_document_root(metric_file, semantic_model_file), normalize=True)
+        model_names = self.extract_osi_model_names(metric_file) if metric_file else []
+        if not model_names and semantic_model_file:
+            model_names = self.extract_osi_model_names(semantic_model_file)
+        if len(model_names) != 1:
+            candidates = ", ".join(model_names) or "<none>"
+            raise ValueError(
+                f"Exactly one semantic model must be identifiable from the target artifact. Found: {candidates}."
+            )
+        return load_osi_model(
+            self._osi_document_root(metric_file, semantic_model_file),
+            semantic_model_name=model_names[0],
+            normalize=True,
+        )
 
     @staticmethod
     def _jsonable(value: Any) -> Any:
@@ -1172,7 +1281,7 @@ class GenerationTools:
         semantic_model_name = str(getattr(doc, "name", "") or "")
         physical_table = table_fq_name or table_name
         return {
-            "id": f"osi:{physical_table}",
+            "id": f"osi:{semantic_model_name}:{physical_table}",
             "format": "osi",
             "physical_table_fq_name": physical_table,
             "table_name": table_name,
@@ -1473,6 +1582,7 @@ class GenerationTools:
                 }
 
             doc = self._load_osi_document(semantic_model_file=semantic_model_path)
+            semantic_model_name = str(getattr(doc, "name", "") or "")
             default_db_parts = self._current_db_parts(self.agent_config)
             semantic_objects: List[dict] = []
             table_profiles: List[dict] = []
@@ -1500,7 +1610,7 @@ class GenerationTools:
 
                 semantic_objects.append(
                     {
-                        "id": f"table:{table_fq_name}",
+                        "id": f"table:{semantic_model_name}:{table_fq_name}",
                         "kind": "table",
                         "name": table_name,
                         "fq_name": table_fq_name,
@@ -1509,7 +1619,7 @@ class GenerationTools:
                         "yaml_path": yaml_path,
                         "updated_at": datetime.now().replace(microsecond=0),
                         **db_parts,
-                        "semantic_model_name": dataset_name or table_name,
+                        "semantic_model_name": semantic_model_name,
                         "is_dimension": False,
                         "is_measure": False,
                         "is_entity_key": False,
@@ -1534,7 +1644,7 @@ class GenerationTools:
                         self._osi_column_object(
                             table_name=table_name,
                             table_fq_name=table_fq_name,
-                            semantic_model_name=dataset_name or table_name,
+                            semantic_model_name=semantic_model_name,
                             name=str(key),
                             description="Primary key",
                             expr=str(key),
@@ -1551,7 +1661,7 @@ class GenerationTools:
                         self._osi_column_object(
                             table_name=table_name,
                             table_fq_name=table_fq_name,
-                            semantic_model_name=dataset_name or table_name,
+                            semantic_model_name=semantic_model_name,
                             name=str(time_dimension.name),
                             description="Primary time dimension",
                             expr=str(time_dimension.name),
@@ -1571,7 +1681,7 @@ class GenerationTools:
                         self._osi_column_object(
                             table_name=table_name,
                             table_fq_name=table_fq_name,
-                            semantic_model_name=dataset_name or table_name,
+                            semantic_model_name=semantic_model_name,
                             name=str(dim_name),
                             description=getattr(dim, "description", "") or "",
                             expr=getattr(dim, "expr", None) or str(dim_name),
@@ -1641,7 +1751,7 @@ class GenerationTools:
         time_granularity: str = "",
     ) -> dict:
         return {
-            "id": f"column:{table_fq_name}.{name}",
+            "id": f"column:{semantic_model_name}:{table_fq_name}.{name}",
             "kind": "column",
             "name": name,
             "fq_name": f"{table_fq_name}.{name}",
@@ -1687,13 +1797,7 @@ class GenerationTools:
                 metric_file=metric_file,
                 semantic_model_file=semantic_model_files[0] if semantic_model_files else None,
             )
-            datasets = self._dataset_lookup(doc)
-            metrics_by_name = {getattr(item, "name", ""): item for item in getattr(doc, "metrics", [])}
-            default_dataset = (
-                str(getattr(getattr(doc, "datasets", [None])[0], "name", "") or "")
-                if getattr(doc, "datasets", None)
-                else ""
-            )
+            semantic_model_name = str(getattr(doc, "name", "") or "")
             db_parts = self._current_db_parts(self.agent_config)
             metric_objects: List[dict] = []
             synced_items: List[str] = []
@@ -1704,14 +1808,6 @@ class GenerationTools:
                     continue
                 if metric_name not in target_metric_names:
                     continue
-                dataset_names = self._metric_dataset_names(
-                    metric,
-                    metrics_by_name=metrics_by_name,
-                    default_dataset=default_dataset,
-                )
-                dataset_name = getattr(metric, "dataset", None) or (dataset_names[0] if len(dataset_names) == 1 else "")
-                dataset = datasets.get(dataset_name)
-                table_name = self._dataset_table_name(dataset) if dataset else dataset_name or "Unknown"
                 dimensions = self._metric_query_dimensions(doc, metric)
                 entities = self._metric_entities(doc, metric)
 
@@ -1720,7 +1816,7 @@ class GenerationTools:
                 metric_obj = {
                     "name": metric_name,
                     "subject_path": subject_path,
-                    "semantic_model_name": dataset_name or table_name,
+                    "semantic_model_name": semantic_model_name,
                     "id": build_metric_id(subject_path, metric_name),
                     "description": getattr(metric, "description", "") or "",
                     "metric_type": getattr(metric, "kind", None) or "aggregate",

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -10,10 +10,12 @@ All public semantic tools require a successfully initialized semantic adapter.
 """
 
 import csv
+import hashlib
 import inspect
 import io
 import json
 from collections import OrderedDict
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Set, Tuple
 
 from agents import Tool
@@ -419,6 +421,29 @@ class SemanticTools:
         if resolved_adapter:
             self.adapter_type = resolved_adapter
         return resolved_adapter
+
+    def _semantic_model_artifact_evidence(self, semantic_model_name: str) -> Dict[str, str]:
+        """Return exact Ossie artifact identity for target-bound validation evidence."""
+        if str(self.adapter_type or "").strip().lower() != "osi" or not semantic_model_name:
+            return {}
+        try:
+            from datus.agent.node.semantic_authoring import discover_osi_semantic_models
+
+            matches = [
+                model
+                for model in discover_osi_semantic_models(self.agent_config)
+                if str(model.get("semantic_model_name") or "") == semantic_model_name
+            ]
+            if len(matches) != 1:
+                return {}
+            path = Path(str(matches[0]["absolute_path"])).expanduser().resolve(strict=True)
+            return {
+                "semantic_model_name": semantic_model_name,
+                "semantic_model_file": str(path),
+                "semantic_model_file_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+        except (KeyError, OSError, RuntimeError):
+            return {}
 
     @staticmethod
     def _normalize_runtime_db_context(runtime_db_context: Optional[Mapping[str, Any]]) -> Dict[str, str]:
@@ -1200,15 +1225,19 @@ class SemanticTools:
                 logger.info("Validation succeeded, reloading adapter to pick up new metrics...")
                 self._reload_adapter()
 
+            result_payload = {
+                "valid": effective_valid,
+                "issues": effective_issues,
+                "scope": scope,
+                "checks": checks_list,
+                "ignored_issues": ignored_issues,
+            }
+            if effective_valid and semantic_model_name:
+                result_payload.update(self._semantic_model_artifact_evidence(semantic_model_name))
+
             tool_result = FuncToolResult(
                 success=1 if effective_valid else 0,
-                result={
-                    "valid": effective_valid,
-                    "issues": effective_issues,
-                    "scope": scope,
-                    "checks": checks_list,
-                    "ignored_issues": ignored_issues,
-                },
+                result=result_payload,
                 error=None if effective_valid else _format_validation_error(effective_issues),
             )
             if self.generation_evidence:

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -1065,6 +1065,7 @@ class SemanticTools:
     def validate_semantic(
         self,
         scope: Literal["all", "semantic_model"] = "all",
+        semantic_model_name: str = "",
         checks: Optional[List[str] | str] = None,
         baseline_artifact_json: str = "",
     ) -> FuncToolResult:
@@ -1080,6 +1081,8 @@ class SemanticTools:
                 including metrics. Use "semantic_model" when generating semantic
                 models before metric definitions exist; this still fails on real
                 semantic model errors but ignores the expected no-metrics issue.
+            semantic_model_name: Optional target model for scoped Ossie validation.
+                Required when a datasource contains multiple semantic models.
             checks: Optional adapter-specific validation checks. Adapters that do
                 not support named checks return an error when this is supplied.
             baseline_artifact_json: Optional JSON-encoded semantic artifact used
@@ -1089,6 +1092,7 @@ class SemanticTools:
             FuncToolResult with validation status and issues
         """
         scope = normalize_null(scope) or "all"
+        semantic_model_name = str(normalize_null(semantic_model_name) or "").strip()
         if scope not in ("all", "semantic_model"):
             return FuncToolResult(
                 success=0,
@@ -1131,6 +1135,16 @@ class SemanticTools:
                     validation_kwargs["scope"] = scope
                 elif scope != "all" and "validation_scope" in params:
                     validation_kwargs["validation_scope"] = scope
+                if semantic_model_name:
+                    if not _signature_accepts_parameter(params, "semantic_model_name"):
+                        return FuncToolResult(
+                            success=0,
+                            error=(
+                                "Targeted semantic-model validation is not supported by the current semantic adapter"
+                            ),
+                            result=None,
+                        )
+                    validation_kwargs["semantic_model_name"] = semantic_model_name
                 if checks_list is not None:
                     if not _signature_accepts_parameter(params, "checks"):
                         return FuncToolResult(

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -387,7 +387,7 @@ class SubAgentTaskTool:
     def _osi_metric_precondition(self) -> Optional[FuncToolResult]:
         """Require the OSI domain model before starting the metric subagent."""
         from datus.agent.node.semantic_authoring import (
-            default_osi_semantic_model_file,
+            discover_osi_semantic_models,
             is_osi_authoring,
         )
 
@@ -399,9 +399,11 @@ class SubAgentTaskTool:
         if project_root is None:
             return None
 
-        target = Path(project_root) / default_osi_semantic_model_file(self.agent_config)
-        if target.is_file():
+        if discover_osi_semantic_models(self.agent_config):
             return None
+
+        datasource = str(getattr(self.agent_config, "current_datasource", "") or "default")
+        target_dir = Path(project_root) / "subject" / "semantic_models" / datasource
 
         return FuncToolResult(
             success=0,
@@ -412,7 +414,7 @@ class SubAgentTaskTool:
             result={
                 "code": "semantic_model_required",
                 "required_subagent": "gen_semantic_model",
-                "semantic_model_file": str(target),
+                "semantic_model_directory": str(target_dir),
                 "retry_subagent": "gen_metrics",
             },
         )

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -100,6 +100,7 @@ class TestGenMetricsAgenticNodeInit:
         assert {"write_file", "edit_file", "delete_file", "end_semantic_model_generation", "bash"}.isdisjoint(
             tool_names
         )
+        assert "resolve_osi_semantic_model_target" in tool_names
         assert "end_metric_generation" in tool_names
 
     def test_metrics_max_turns(self, real_agent_config, mock_llm_create):
@@ -1162,6 +1163,7 @@ semantic_model:
         node.semantic_tools.validate_semantic = MagicMock(
             return_value=FuncToolResult(success=0, error="invalid OSI", result={"valid": False})
         )
+        node.generation_tools.extract_osi_model_names = MagicMock(return_value=["shop"])
 
         with pytest.raises(RuntimeError, match="validate_semantic failed"):
             node._finalize_metric_generation(None, "orders_metrics.yml", "generated")
@@ -1192,7 +1194,9 @@ semantic_model:
             "generated",
         )
 
-        node.semantic_tools.validate_semantic.assert_called_once_with(checks=["authoring_quality"])
+        node.semantic_tools.validate_semantic.assert_called_once_with(
+            semantic_model_name="shop", checks=["authoring_quality"]
+        )
 
     def test_osi_final_metric_publish_requires_query_metrics_tool(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -24,6 +24,7 @@ Design principle: NO mock except LLM.
 """
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -658,6 +659,41 @@ class TestExecutionModeGenSemanticModel:
 
 
 class TestExecuteStreamGenSemanticModelError:
+    def test_osi_finalizer_revalidates_when_evidence_targets_another_model(self, tmp_path):
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+        from datus.tools.func_tool.generation_evidence import GenerationEvidence
+
+        sales_file = tmp_path / "sales.yml"
+        finance_file = tmp_path / "finance.yml"
+        sales_file.write_text("semantic_model: sales\n", encoding="utf-8")
+        finance_file.write_text("semantic_model: finance\n", encoding="utf-8")
+
+        node = GenSemanticModelAgenticNode.__new__(GenSemanticModelAgenticNode)
+        node.agent_config = SimpleNamespace(resolve_semantic_adapter=lambda requested=None: "osi")
+        node.generation_evidence = GenerationEvidence(validation_passed=True)
+        node.generation_evidence.record_semantic_artifact_validation("sales", sales_file)
+        node.generation_tools = MagicMock()
+        node.generation_tools._resolve_generation_path.return_value = str(finance_file)
+        node.generation_tools.extract_osi_model_names.return_value = ["finance"]
+        node.semantic_func_tool = MagicMock()
+        node.semantic_func_tool.validate_semantic.return_value = FuncToolResult(result={"valid": True, "issues": []})
+        node._save_to_db = MagicMock(return_value=True)
+
+        node._finalize_semantic_model_generation(["finance.yml"])
+
+        node.semantic_func_tool.validate_semantic.assert_called_once_with(
+            scope="semantic_model",
+            semantic_model_name="finance",
+        )
+        node._save_to_db.assert_called_once_with(
+            "finance.yml",
+            catalog=None,
+            database=None,
+            db_schema=None,
+        )
+        assert node.generation_evidence.semantic_artifact_validation_passed("finance", finance_file)
+
     @pytest.mark.asyncio
     async def test_execute_stream_error_yields_error_action(self, real_agent_config, mock_llm_create):
         """When model raises a generic exception, execute_stream yields error action."""

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -107,6 +107,28 @@ class TestGenSemanticModelAgenticNodeInit:
         assert isinstance(node.semantic_discovery_tools, SemanticDiscoveryTools)
         assert "profile_semantic_model_evidence" in tool_names
 
+    def test_osi_semantic_model_restores_write_and_edit_without_delete(self, real_agent_config, mock_llm_create):
+        """Ossie authoring supports straightforward create/edit without destructive delete."""
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenSemanticModelAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate an Ossie semantic model")
+
+        node._get_system_prompt(template_context=node._prepare_template_context(node.input))
+        tool_names = {tool.name for tool in node.tools}
+
+        assert {
+            "read_file",
+            "write_file",
+            "edit_file",
+            "glob",
+            "grep",
+            "resolve_osi_semantic_model_target",
+        }.issubset(tool_names)
+        assert {"delete_file", "upsert_osi_metrics", "bash"}.isdisjoint(tool_names)
+        assert "end_semantic_model_generation" in tool_names
+
     def test_semantic_sql_history_profiler_tool_opt_out(self, real_agent_config, mock_llm_create):
         """An explicit empty skills entry removes the profiler tool."""
         from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
@@ -509,6 +531,24 @@ class TestPrepareTemplateContext:
         context = node._prepare_template_context(user_input)
 
         assert "test_tool" in context["native_tools"]
+
+    def test_osi_template_context_resolves_explicit_model_name_first(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = _make_node(real_agent_config, mock_llm_create)
+        user_input = SemanticNodeInput(
+            user_message="Generate a semantic model",
+            semantic_model_name="Executive Sales",
+            business_domain="commerce",
+            fact_tables=["main.orders"],
+            dimension_tables=["main.customers"],
+        )
+
+        context = node._prepare_template_context(user_input)
+
+        assert context["osi_target_resolved"] is True
+        assert context["default_osi_semantic_model_name"] == "executive_sales"
+        assert context["default_osi_semantic_model_file"].endswith("/executive_sales.yml")
+        assert context["requested_dimension_tables"] == ["main.customers"]
 
 
 class TestGetSystemPrompt:

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -232,7 +232,7 @@ def test_osi_target_identity_uses_only_the_core_fact_table(tmp_path):
     assert target["exists"] is False
 
 
-def test_osi_model_coverage_is_checked_across_all_discovered_files(tmp_path):
+def test_osi_model_coverage_requires_one_model_to_cover_the_table_group(tmp_path):
     config = _osi_config(tmp_path)
     _write_osi_model(
         tmp_path,
@@ -247,7 +247,9 @@ def test_osi_model_coverage_is_checked_across_all_discovered_files(tmp_path):
         [{"name": "payments", "source": "finance.fact_payments"}],
     )
 
-    assert osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "finance.fact_payments"])
+    assert osi_semantic_models_cover_tables(config, ["analytics.fact_orders"])
+    assert osi_semantic_models_cover_tables(config, ["finance.fact_payments"])
+    assert not osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "finance.fact_payments"])
     assert not osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "support.fact_tickets"])
 
 
@@ -266,6 +268,65 @@ def test_osi_target_creates_a_different_file_for_an_unrelated_fact(tmp_path):
     assert target["semantic_model_file"].endswith("/fact_payments_analytics.yml")
     assert target["exists"] is False
     assert len(discover_osi_semantic_models(config)) == 1
+
+
+def test_osi_target_does_not_reuse_same_leaf_table_from_another_schema(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "sales_orders.yml",
+        "sales_orders",
+        [{"name": "orders", "source": "sales.fact_orders"}],
+    )
+
+    target = resolve_osi_semantic_model_target(config, fact_tables=["finance.fact_orders"])
+
+    assert target["semantic_model_name"] == "fact_orders_analytics"
+    assert target["semantic_model_file"].endswith("/fact_orders_analytics.yml")
+    assert target["exists"] is False
+
+
+def test_osi_target_preserves_qualified_table_component_boundaries(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "sales_orders.yml",
+        "sales_orders",
+        [{"name": "orders", "source": "sales_fact.orders"}],
+    )
+
+    target = resolve_osi_semantic_model_target(config, fact_tables=["sales.fact_orders"])
+
+    assert target["semantic_model_name"] == "fact_orders_analytics"
+    assert target["exists"] is False
+
+
+def test_osi_target_allows_leaf_fallback_for_unqualified_fact_reference(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "sales_orders.yml",
+        "sales_orders",
+        [{"name": "orders", "source": "sales.fact_orders"}],
+    )
+
+    target = resolve_osi_semantic_model_target(config, fact_tables=["fact_orders"])
+
+    assert target["semantic_model_name"] == "sales_orders"
+    assert target["matched_by"] == "existing_fact_table"
+
+
+def test_osi_target_refuses_to_overwrite_an_unparseable_target_file(tmp_path):
+    config = _osi_config(tmp_path)
+    target_path = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text("semantic_model: [\n", encoding="utf-8")
+
+    target = resolve_osi_semantic_model_target(config, semantic_model_name="sales")
+
+    assert target["ambiguous"] is True
+    assert "already exists" in target["reason"]
+    assert target["candidates"][0]["semantic_model_file"].endswith("/sales.yml")
 
 
 def test_osi_target_refuses_an_unsafe_generic_fallback(tmp_path):

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_METRICFLOW,
@@ -11,8 +12,11 @@ from datus.agent.node.semantic_authoring import (
     default_optional_skills,
     default_osi_semantic_model_file,
     default_osi_semantic_model_name,
+    discover_osi_semantic_models,
+    osi_semantic_models_cover_tables,
     required_authoring_skills,
     resolve_authoring_format,
+    resolve_osi_semantic_model_target,
     resolve_semantic_adapter_type,
 )
 from datus.utils.exceptions import DatusException, ErrorCode
@@ -27,6 +31,31 @@ class _DbScope:
 
 def _agent_config(adapter):
     return SimpleNamespace(resolve_semantic_adapter=lambda requested=None: requested or adapter)
+
+
+def _osi_config(tmp_path):
+    model_dir = tmp_path / "subject" / "semantic_models" / "warehouse"
+    return SimpleNamespace(
+        current_datasource="warehouse",
+        project_root=str(tmp_path),
+        path_manager=SimpleNamespace(semantic_model_path=lambda datasource: model_dir),
+    )
+
+
+def _write_osi_model(tmp_path, filename, model_name, datasets):
+    target = tmp_path / "subject" / "semantic_models" / "warehouse" / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        yaml.safe_dump(
+            {
+                "version": "0.2.0.dev0",
+                "semantic_model": [{"name": model_name, "datasets": datasets}],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return target
 
 
 def test_legacy_node_config_fields_are_ignored():
@@ -107,6 +136,166 @@ def test_default_osi_semantic_model_name_uses_agent_scope_fallbacks():
 
     assert default_osi_semantic_model_name(config) == "project_alpha"
     assert default_osi_semantic_model_file(config) == "subject/semantic_models/default/project_alpha.yml"
+
+
+def test_osi_target_explicit_name_wins_over_domain_and_existing_fact(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "legacy_sales.yml",
+        "legacy_sales",
+        [{"name": "orders", "source": "analytics.fact_orders"}],
+    )
+
+    target = resolve_osi_semantic_model_target(
+        config,
+        semantic_model_name="Executive Sales",
+        business_domain="commerce",
+        fact_tables=["analytics.fact_orders"],
+    )
+
+    assert target["semantic_model_name"] == "executive_sales"
+    assert target["semantic_model_file"] == "subject/semantic_models/warehouse/executive_sales.yml"
+    assert target["matched_by"] == "explicit_name"
+    assert target["exists"] is False
+
+
+def test_osi_target_uses_business_domain_for_a_new_model(tmp_path):
+    target = resolve_osi_semantic_model_target(
+        _osi_config(tmp_path),
+        business_domain="Order Fulfillment",
+        fact_tables=["analytics.fact_orders"],
+        dimension_tables=["analytics.dim_customer"],
+    )
+
+    assert target["semantic_model_name"] == "order_fulfillment"
+    assert target["matched_by"] == "business_domain"
+
+
+def test_osi_target_fact_fallback_does_not_change_when_dimensions_change(tmp_path):
+    config = _osi_config(tmp_path)
+    first = resolve_osi_semantic_model_target(
+        config,
+        fact_tables=["analytics.fact_order_items"],
+        dimension_tables=["analytics.dim_customer"],
+    )
+    second = resolve_osi_semantic_model_target(
+        config,
+        fact_tables=["analytics.fact_order_items"],
+        dimension_tables=["analytics.dim_customer", "analytics.dim_product"],
+    )
+
+    assert first["semantic_model_name"] == "fact_order_items_analytics"
+    assert second["semantic_model_name"] == first["semantic_model_name"]
+    assert second["semantic_model_file"] == first["semantic_model_file"]
+
+
+def test_osi_target_reuses_existing_model_name_when_dimensions_are_added(tmp_path):
+    config = _osi_config(tmp_path)
+    existing = _write_osi_model(
+        tmp_path,
+        "durable_revenue.yml",
+        "revenue_v1",
+        [{"name": "orders", "source": "analytics.fact_orders"}],
+    )
+
+    target = resolve_osi_semantic_model_target(
+        config,
+        business_domain="new_domain_label",
+        fact_tables=["analytics.fact_orders"],
+        dimension_tables=["analytics.dim_customer"],
+    )
+
+    assert target["semantic_model_name"] == "revenue_v1"
+    assert target["semantic_model_file"].endswith("/durable_revenue.yml")
+    assert target["absolute_path"] == str(existing)
+    assert target["matched_by"] == "existing_fact_table"
+
+
+def test_osi_target_identity_uses_only_the_core_fact_table(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "shared_inventory.yml",
+        "shared_inventory",
+        [{"name": "inventory", "source": "analytics.fact_inventory"}],
+    )
+
+    target = resolve_osi_semantic_model_target(
+        config,
+        business_domain="support",
+        fact_tables=["support.fact_tickets", "analytics.fact_inventory"],
+    )
+
+    assert target["semantic_model_name"] == "support"
+    assert target["matched_by"] == "business_domain"
+    assert target["exists"] is False
+
+
+def test_osi_model_coverage_is_checked_across_all_discovered_files(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "orders.yml",
+        "orders",
+        [{"name": "orders", "source": "analytics.fact_orders"}],
+    )
+    _write_osi_model(
+        tmp_path,
+        "payments.yml",
+        "payments",
+        [{"name": "payments", "source": "finance.fact_payments"}],
+    )
+
+    assert osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "finance.fact_payments"])
+    assert not osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "support.fact_tickets"])
+
+
+def test_osi_target_creates_a_different_file_for_an_unrelated_fact(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "orders_analytics.yml",
+        "orders_analytics",
+        [{"name": "orders", "source": "analytics.fact_orders"}],
+    )
+
+    target = resolve_osi_semantic_model_target(config, fact_tables=["finance.fact_payments"])
+
+    assert target["semantic_model_name"] == "fact_payments_analytics"
+    assert target["semantic_model_file"].endswith("/fact_payments_analytics.yml")
+    assert target["exists"] is False
+    assert len(discover_osi_semantic_models(config)) == 1
+
+
+def test_osi_target_refuses_an_unsafe_generic_fallback(tmp_path):
+    target = resolve_osi_semantic_model_target(
+        _osi_config(tmp_path),
+        dimension_tables=["analytics.dim_customer"],
+    )
+
+    assert target["ambiguous"] is True
+    assert target["matched_by"] == "missing_core_fact_table"
+    assert "business domain or core fact table" in target["reason"]
+
+
+def test_osi_target_refuses_to_reuse_an_occupied_filename_with_a_different_model_name(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "sales.yml",
+        "legacy_sales_model",
+        [{"name": "orders", "source": "analytics.fact_orders"}],
+    )
+
+    target = resolve_osi_semantic_model_target(
+        config,
+        semantic_model_name="sales",
+        fact_tables=["analytics.fact_payments"],
+    )
+
+    assert target["ambiguous"] is True
+    assert "already occupied" in target["reason"]
 
 
 def test_defaults_to_metricflow_when_unknown():

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -275,6 +275,16 @@ class TestGetSemanticModel:
             "table_name": "schools",
         }
 
+    def test_get_semantic_model_passes_explicit_model_name(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        semantic_rag = MagicMock()
+        semantic_rag.get_semantic_model.return_value = None
+        svc._ensure_semantic_rag = lambda: semantic_rag
+
+        svc._get_semantic_model("schools", semantic_model_name="education")
+
+        assert semantic_rag.get_semantic_model.call_args.kwargs["semantic_model_name"] == "education"
+
     @pytest.mark.asyncio
     async def test_validate_semantic_model_nonexistent(self, real_agent_config):
         """validate_semantic_model for nonexistent table returns error."""

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -20,6 +20,9 @@ COMMON_VARS = {
     "kind_subdir": "subject/semantic_models/duckdb",
     "default_osi_semantic_model_name": "sales_domain",
     "default_osi_semantic_model_file": "subject/semantic_models/duckdb/sales_domain.yml",
+    "osi_target_resolved": True,
+    "requested_semantic_model_name": "",
+    "requested_business_domain": "",
 }
 
 
@@ -59,7 +62,10 @@ def test_semantic_model_template_osi_mode():
     text = _render("gen_semantic_model_system", "osi")
     assert "OSI (Open Semantic Interchange) core schema" in text
     assert "never write backend YAML" in text
-    assert "Target semantic model file: `subject/semantic_models/duckdb/sales_domain.yml`" in text
+    assert "Resolved semantic model file: `subject/semantic_models/duckdb/sales_domain.yml`" in text
+    assert "create it with `write_file`" in text
+    assert "use `edit_file` for targeted changes" in text
+    assert "Dimension tables never participate in the name" in text
     assert '"semantic_model_files"' in text  # same publish contract as metricflow
 
 

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -675,6 +675,71 @@ class TestEnsureSemanticModelsForMetrics:
         assert captured["action_callback"] is action_callback
 
     @pytest.mark.asyncio
+    async def test_osi_reuses_separate_models_for_independent_queries(self, tmp_path):
+        from unittest.mock import patch
+
+        model_dir = tmp_path / "subject" / "semantic_models" / "warehouse"
+        model_dir.mkdir(parents=True)
+        (model_dir / "orders.yml").write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: orders\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: analytics.fact_orders\n",
+            encoding="utf-8",
+        )
+        (model_dir / "payments.yml").write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: payments\n"
+            "    datasets:\n"
+            "      - name: payments\n"
+            "        source: finance.fact_payments\n",
+            encoding="utf-8",
+        )
+        config = SimpleNamespace(
+            project_root=str(tmp_path),
+            current_datasource="warehouse",
+            resolve_semantic_adapter=lambda requested=None: "osi",
+        )
+        semantic_rag = MagicMock()
+        semantic_rag.get_size.return_value = 2
+        sql_list = [
+            "SELECT COUNT(*) FROM analytics.fact_orders",
+            "SELECT SUM(amount) FROM finance.fact_payments",
+        ]
+
+        def extract_tables(sqls, _config):
+            sql = sqls[0]
+            if "fact_orders" in sql:
+                return ["analytics.fact_orders"]
+            return ["finance.fact_payments"]
+
+        with (
+            patch("datus.storage.semantic_model.store.SemanticModelRAG", return_value=semantic_rag),
+            patch(
+                "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async"
+            ) as init_mock,
+            patch(
+                "datus.storage.metric.metric_init.extract_tables_from_sql_list",
+                side_effect=extract_tables,
+            ) as extract_mock,
+        ):
+            ok, error, created = await _ensure_semantic_models_for_metrics(
+                config,
+                "success_story.csv",
+                [{"sql": sql, "question": sql} for sql in sql_list],
+                sql_list,
+            )
+
+        assert ok is True
+        assert error == ""
+        assert created == []
+        assert extract_mock.call_count == 2
+        init_mock.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_metricflow_keeps_per_table_semantic_model_auto_create(self):
         from unittest.mock import patch
 

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -623,7 +623,7 @@ class TestEnsureSemanticModelsForMetrics:
     async def test_osi_generates_domain_semantic_model_once(self, tmp_path):
         from unittest.mock import patch
 
-        target_file = "subject/semantic_models/warehouse/warehouse.yml"
+        target_file = "subject/semantic_models/warehouse/orders_analytics.yml"
         target_path = tmp_path / target_file
         config = SimpleNamespace(
             project_root=str(tmp_path),
@@ -637,7 +637,10 @@ class TestEnsureSemanticModelsForMetrics:
 
         async def fake_init(agent_config, success_story, emit=None, build_mode="overwrite", action_callback=None):
             target_path.parent.mkdir(parents=True)
-            target_path.write_text("version: 0.2.0.dev0\nsemantic_model:\n  - name: warehouse\n", encoding="utf-8")
+            target_path.write_text(
+                "version: 0.2.0.dev0\nsemantic_model:\n  - name: orders_analytics\n",
+                encoding="utf-8",
+            )
             captured["build_mode"] = build_mode
             captured["action_callback"] = action_callback
             return True, ""
@@ -648,7 +651,10 @@ class TestEnsureSemanticModelsForMetrics:
                 "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
                 side_effect=fake_init,
             ) as init_mock,
-            patch("datus.storage.metric.metric_init.extract_tables_from_sql_list") as extract_mock,
+            patch(
+                "datus.storage.metric.metric_init.extract_tables_from_sql_list",
+                return_value=["orders"],
+            ) as extract_mock,
             patch("datus.storage.metric.metric_init.ensure_semantic_models_exist") as ensure_mock,
         ):
             ok, error, created = await _ensure_semantic_models_for_metrics(
@@ -663,7 +669,7 @@ class TestEnsureSemanticModelsForMetrics:
         assert error == ""
         assert created == [target_file]
         init_mock.assert_called_once()
-        extract_mock.assert_not_called()
+        extract_mock.assert_called_once()
         ensure_mock.assert_not_called()
         assert captured["build_mode"] == "incremental"
         assert captured["action_callback"] is action_callback

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -1131,6 +1131,33 @@ class TestSemanticModelRAGDeleteShadowedTableRows:
         db1_model = sem_rag.get_semantic_model(database_name="db1", schema_name="public", table_name="orders")
         assert db1_model["description"] == "db1 orders"
 
+    def test_does_not_touch_same_table_in_other_semantic_model(self, sem_rag):
+        sales = _fq_table_object("db1", description="sales customer")
+        sales["semantic_model_name"] = "sales"
+        sales["id"] = f"table:sales:{sales['fq_name']}"
+        retention = _fq_table_object("db1", description="retention customer")
+        retention["semantic_model_name"] = "retention"
+        retention["id"] = f"table:retention:{retention['fq_name']}"
+        sem_rag.store_batch([sales, retention])
+
+        sem_rag.delete_shadowed_table_rows([sales])
+
+        assert sem_rag.get_size() == 2
+        sales_model = sem_rag.get_semantic_model(
+            database_name="db1",
+            schema_name="public",
+            table_name="orders",
+            semantic_model_name="sales",
+        )
+        retention_model = sem_rag.get_semantic_model(
+            database_name="db1",
+            schema_name="public",
+            table_name="orders",
+            semantic_model_name="retention",
+        )
+        assert sales_model["description"] == "sales customer"
+        assert retention_model["description"] == "retention customer"
+
     def test_empty_hierarchy_scope_is_not_a_wildcard(self, sem_rag):
         """A fresh row whose hierarchy did not resolve must not delete same-named tables in other databases."""
         db1 = _fq_table_object("db1", description="db1 orders")

--- a/tests/unit_tests/storage/semantic_model/test_store.py
+++ b/tests/unit_tests/storage/semantic_model/test_store.py
@@ -1158,6 +1158,30 @@ class TestSemanticModelRAGDeleteShadowedTableRows:
         assert sales_model["description"] == "sales customer"
         assert retention_model["description"] == "retention customer"
 
+    def test_shared_table_requires_semantic_model_name_for_lookup(self, sem_rag):
+        sales = _fq_table_object("db1", description="sales customer")
+        sales["semantic_model_name"] = "sales"
+        sales["id"] = f"table:sales:{sales['fq_name']}"
+        retention = _fq_table_object("db1", description="retention customer")
+        retention["semantic_model_name"] = "retention"
+        retention["id"] = f"table:retention:{retention['fq_name']}"
+        sem_rag.store_batch([sales, retention])
+
+        with pytest.raises(DatusException, match="multiple semantic models"):
+            sem_rag.get_semantic_model(
+                database_name="db1",
+                schema_name="public",
+                table_name="orders",
+            )
+
+        selected = sem_rag.get_semantic_model(
+            database_name="db1",
+            schema_name="public",
+            table_name="orders",
+            semantic_model_name="retention",
+        )
+        assert selected["description"] == "retention customer"
+
     def test_empty_hierarchy_scope_is_not_a_wildcard(self, sem_rag):
         """A fresh row whose hierarchy did not resolve must not delete same-named tables in other databases."""
         db1 = _fq_table_object("db1", description="db1 orders")

--- a/tests/unit_tests/tools/func_tool/test_generation_evidence.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_evidence.py
@@ -164,6 +164,28 @@ class TestGenerationEvidence:
         ev.record_validation_result({"success": 0, "result": {"valid": True}})
         assert ev.validation_passed is False
 
+    def test_semantic_validation_is_bound_to_model_and_file_content(self, tmp_path):
+        artifact = tmp_path / "sales.yml"
+        artifact.write_text("semantic_model: sales\n", encoding="utf-8")
+        ev = GenerationEvidence()
+        ev.record_validation_result(
+            {
+                "success": 1,
+                "result": {
+                    "valid": True,
+                    "semantic_model_name": "sales",
+                    "semantic_model_file": str(artifact),
+                },
+            }
+        )
+
+        assert ev.semantic_artifact_validation_passed("sales", artifact)
+        assert not ev.semantic_artifact_validation_passed("finance", artifact)
+
+        artifact.write_text("semantic_model: changed\n", encoding="utf-8")
+
+        assert not ev.semantic_artifact_validation_passed("sales", artifact)
+
     def test_record_metric_dry_run_success(self):
         ev = GenerationEvidence()
         result = {"success": 1, "result": {"metadata": {}}}

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -939,7 +939,7 @@ class TestOsiSync:
             subject_path=None,
             kind=None,
         )
-        doc = SimpleNamespace(datasets=[dataset], metrics=[metric, old_metric])
+        doc = SimpleNamespace(name="shop", datasets=[dataset], metrics=[metric, old_metric])
 
         with patch.object(generation_tools, "_load_osi_document", return_value=doc):
             result = generation_tools._sync_osi_metric_to_db(
@@ -955,7 +955,7 @@ class TestOsiSync:
         assert len(metric_objects) == 1
         metric_obj = metric_objects[0]
         assert metric_obj["name"] == "order_count"
-        assert metric_obj["semantic_model_name"] == "orders"
+        assert metric_obj["semantic_model_name"] == "shop"
         assert metric_obj["measure_expr"] == "COUNT(DISTINCT order_id)"
         assert metric_obj["dimensions"] == ["order_date", "customer_segment"]
         assert metric_obj["entities"] == ["order_id"]
@@ -1132,6 +1132,7 @@ class TestOsiSync:
             measures=[],
         )
         doc = SimpleNamespace(
+            name="shop",
             datasets=[orders, customers, regions],
             relationships=relationships,
             metrics=[base_metric, derived_metric],
@@ -1149,7 +1150,7 @@ class TestOsiSync:
             "customer_id__region_id__region_name",
         ]
         assert by_name["order_count"]["entities"] == ["order_id"]
-        assert by_name["order_count_prev"]["semantic_model_name"] == "orders"
+        assert by_name["order_count_prev"]["semantic_model_name"] == "shop"
         assert by_name["order_count_prev"]["dimensions"] == by_name["order_count"]["dimensions"]
         assert by_name["order_count_prev"]["entities"] == ["order_id"]
 
@@ -1266,7 +1267,12 @@ class TestOsiSync:
                 "to_columns": ["customer_id", "store_id"],
             }
         )
-        doc = SimpleNamespace(datasets=[dataset, other_dataset], relationships=[relationship], metrics=[])
+        doc = SimpleNamespace(
+            name="shop",
+            datasets=[dataset, other_dataset],
+            relationships=[relationship],
+            metrics=[],
+        )
 
         with patch.object(generation_tools, "_load_osi_document", return_value=doc):
             result = generation_tools.sync_osi_semantic_to_db(str(semantic_file))
@@ -1293,6 +1299,51 @@ class TestOsiSync:
         assert '"to_columns": ["customer_id", "store_id"]' in profiles[0]["relationships_json"]
         assert result["table_semantic_profiles"] == 1
 
+    def test_load_osi_document_selects_only_artifact_model(self, generation_tools, tmp_path):
+        (tmp_path / "sales.yml").write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: sales\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: orders\n"
+            "        primary_key: [order_id]\n"
+        )
+        (tmp_path / "finance.yml").write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: finance\n"
+            "    datasets:\n"
+            "      - name: budgets\n"
+            "        source: budgets\n"
+            "        primary_key: [budget_id]\n"
+        )
+        metric_file = tmp_path / "finance_metrics.yml"
+        metric_file.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: finance\n"
+            "    datasets:\n"
+            "      - name: budgets\n"
+            "        source: budgets\n"
+            "        primary_key: [budget_id]\n"
+            "    metrics:\n"
+            "      - name: budget_total\n"
+            "        expression:\n"
+            "          dialects:\n"
+            "            - dialect: ANSI_SQL\n"
+            "              expression: SUM(amount)\n"
+            "        custom_extensions:\n"
+            "          - vendor_name: DATUS\n"
+            '            data: \'{"dataset":"budgets"}\'\n'
+        )
+
+        doc = generation_tools._load_osi_document(metric_file=str(metric_file))
+
+        assert doc.name == "finance"
+        assert [dataset.name for dataset in doc.datasets] == ["budgets"]
+        assert [metric.name for metric in doc.metrics] == ["budget_total"]
+
     def test_sync_osi_semantic_to_db_distinguishes_same_named_tables_across_databases(self, generation_tools, tmp_path):
         """Issue #1084 (OSI path): qualified source tables in different databases keep distinct ids."""
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
@@ -1312,6 +1363,7 @@ class TestOsiSync:
             "        source: db2.sales.orders\n"
         )
         doc = SimpleNamespace(
+            name="shop",
             datasets=[
                 SimpleNamespace(
                     name="orders_db1",
@@ -1340,14 +1392,20 @@ class TestOsiSync:
         assert result["success"] is True
         objects = generation_tools.semantic_rag.upsert_batch.call_args.args[0]
         table_ids = [obj["id"] for obj in objects if obj["kind"] == "table"]
-        assert table_ids == ["table:db1.public.orders", "table:db2.sales.orders"]
+        assert table_ids == [
+            "table:shop:db1.public.orders",
+            "table:shop:db2.sales.orders",
+        ]
         column_ids = [obj["id"] for obj in objects if obj["kind"] == "column"]
-        assert column_ids == ["column:db1.public.orders.order_id", "column:db2.sales.orders.order_id"]
+        assert column_ids == [
+            "column:shop:db1.public.orders.order_id",
+            "column:shop:db2.sales.orders.order_id",
+        ]
         tables_by_id = {obj["id"]: obj for obj in objects if obj["kind"] == "table"}
-        assert tables_by_id["table:db1.public.orders"]["database_name"] == "db1"
-        assert tables_by_id["table:db1.public.orders"]["schema_name"] == "public"
-        assert tables_by_id["table:db2.sales.orders"]["database_name"] == "db2"
-        assert tables_by_id["table:db2.sales.orders"]["schema_name"] == "sales"
+        assert tables_by_id["table:shop:db1.public.orders"]["database_name"] == "db1"
+        assert tables_by_id["table:shop:db1.public.orders"]["schema_name"] == "public"
+        assert tables_by_id["table:shop:db2.sales.orders"]["database_name"] == "db2"
+        assert tables_by_id["table:shop:db2.sales.orders"]["schema_name"] == "sales"
 
     def test_sync_osi_semantic_to_db_fails_when_table_profile_sync_fails(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -4,7 +4,8 @@
 
 import json
 import os
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -216,6 +217,57 @@ class TestEndSemanticModelGeneration:
             result = generation_tools.end_semantic_model_generation(["/path/model.yaml"])
         assert result.success == 0
         assert "log failure" in result.error
+
+    def test_osi_requires_validation_for_the_exact_target_artifact(self, generation_tools, tmp_path):
+        generation_tools.authoring_format = "osi"
+        sales_file = tmp_path / "semantic_models" / "warehouse" / "sales.yml"
+        finance_file = tmp_path / "semantic_models" / "warehouse" / "finance.yml"
+        sales_file.parent.mkdir(parents=True)
+        sales_file.write_text(
+            "version: 0.2.0.dev0\nsemantic_model:\n  - name: sales\n    datasets: []\n",
+            encoding="utf-8",
+        )
+        finance_file.write_text(
+            "version: 0.2.0.dev0\nsemantic_model:\n  - name: finance\n    datasets: []\n",
+            encoding="utf-8",
+        )
+        generation_tools.generation_evidence.validation_passed = True
+        generation_tools.generation_evidence.record_semantic_artifact_validation("sales", sales_file)
+        mock_pm = Mock(subject_dir=str(tmp_path))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "sync_osi_semantic_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_semantic_model_generation([str(finance_file)])
+
+        assert result.success == 0
+        assert "exact semantic model artifact" in result.error
+        sync_mock.assert_not_called()
+
+    def test_osi_publishes_the_exact_validated_artifact(self, generation_tools, tmp_path):
+        generation_tools.authoring_format = "osi"
+        model_file = tmp_path / "semantic_models" / "warehouse" / "finance.yml"
+        model_file.parent.mkdir(parents=True)
+        model_file.write_text(
+            "version: 0.2.0.dev0\nsemantic_model:\n  - name: finance\n    datasets: []\n",
+            encoding="utf-8",
+        )
+        generation_tools.generation_evidence.record_semantic_artifact_validation("finance", model_file)
+        mock_pm = Mock(subject_dir=str(tmp_path))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(
+                generation_tools,
+                "sync_osi_semantic_to_db",
+                return_value={"success": True},
+            ) as sync_mock,
+        ):
+            result = generation_tools.end_semantic_model_generation([str(model_file)])
+
+        assert result.success == 1
+        sync_mock.assert_called_once_with(str(model_file))
 
 
 class TestEndMetricGeneration:
@@ -1338,11 +1390,42 @@ class TestOsiSync:
             '            data: \'{"dataset":"budgets"}\'\n'
         )
 
-        doc = generation_tools._load_osi_document(metric_file=str(metric_file))
+        calls = {}
+        finance_doc = SimpleNamespace(
+            name="finance",
+            datasets=[SimpleNamespace(name="budgets")],
+            metrics=[SimpleNamespace(name="budget_total")],
+        )
+        profile_module = ModuleType("datus_semantic_osi.profile")
+
+        def load_osi_model(path, semantic_model_name, normalize):
+            calls.update(
+                path=path,
+                semantic_model_name=semantic_model_name,
+                normalize=normalize,
+            )
+            return finance_doc
+
+        profile_module.load_osi_model = load_osi_model
+        package_module = ModuleType("datus_semantic_osi")
+        package_module.__path__ = []
+        with patch.dict(
+            sys.modules,
+            {
+                "datus_semantic_osi": package_module,
+                "datus_semantic_osi.profile": profile_module,
+            },
+        ):
+            doc = generation_tools._load_osi_document(metric_file=str(metric_file))
 
         assert doc.name == "finance"
         assert [dataset.name for dataset in doc.datasets] == ["budgets"]
         assert [metric.name for metric in doc.metrics] == ["budget_total"]
+        assert calls == {
+            "path": str(tmp_path),
+            "semantic_model_name": "finance",
+            "normalize": True,
+        }
 
     def test_sync_osi_semantic_to_db_distinguishes_same_named_tables_across_databases(self, generation_tools, tmp_path):
         """Issue #1084 (OSI path): qualified source tables in different databases keep distinct ids."""

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -2159,8 +2159,15 @@ class TestValidateSemantic:
         calls = {}
 
         class _Adapter:
-            async def validate_semantic(self, scope="all", checks=None, baseline_artifact=None):
+            async def validate_semantic(
+                self,
+                scope="all",
+                semantic_model_name=None,
+                checks=None,
+                baseline_artifact=None,
+            ):
                 calls["scope"] = scope
+                calls["semantic_model_name"] = semantic_model_name
                 calls["checks"] = checks
                 calls["baseline_artifact"] = baseline_artifact
                 result = Mock()
@@ -2173,6 +2180,7 @@ class TestValidateSemantic:
 
         with patch.object(tool, "_reload_adapter", return_value=True):
             result = tool.validate_semantic(
+                semantic_model_name="shop",
                 checks="authoring_quality,mutation_guard",
                 baseline_artifact_json=json.dumps(baseline),
             )
@@ -2181,6 +2189,7 @@ class TestValidateSemantic:
         assert result.result["checks"] == ["authoring_quality", "mutation_guard"]
         assert calls == {
             "scope": "all",
+            "semantic_model_name": "shop",
             "checks": ["authoring_quality", "mutation_guard"],
             "baseline_artifact": baseline,
         }
@@ -2203,6 +2212,7 @@ class TestValidateSemantic:
         with patch.object(tool, "_reload_adapter", return_value=True):
             result = tool.validate_semantic(
                 scope="semantic_model",
+                semantic_model_name="commerce",
                 checks=["authoring_quality"],
                 baseline_artifact_json=json.dumps(baseline),
             )
@@ -2210,9 +2220,27 @@ class TestValidateSemantic:
         assert result.success == 1
         assert calls == {
             "scope": "semantic_model",
+            "semantic_model_name": "commerce",
             "checks": ["authoring_quality"],
             "baseline_artifact": baseline,
         }
+
+    def test_rejects_target_when_adapter_does_not_support_it(self, semantic_tools_with_adapter):
+        tool, _ = semantic_tools_with_adapter
+
+        class _Adapter:
+            async def validate_semantic(self, scope="all"):
+                result = Mock()
+                result.valid = True
+                result.issues = []
+                return result
+
+        tool._adapter = _Adapter()
+
+        result = tool.validate_semantic(semantic_model_name="shop")
+
+        assert result.success == 0
+        assert "Targeted semantic-model validation is not supported" in result.error
 
     def test_rejects_checks_when_adapter_does_not_support_them(self, semantic_tools_with_adapter):
         tool, _ = semantic_tools_with_adapter

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -2225,6 +2225,61 @@ class TestValidateSemantic:
             "baseline_artifact": baseline,
         }
 
+    def test_records_target_artifact_validation_evidence(self, semantic_tools_with_adapter, tmp_path):
+        tool, _ = semantic_tools_with_adapter
+        artifact = tmp_path / "commerce.yml"
+        artifact.write_text("semantic_model: commerce\n", encoding="utf-8")
+        evidence = GenerationEvidence()
+        tool.generation_evidence = evidence
+
+        class _Adapter:
+            async def validate_semantic(self, scope="all", semantic_model_name=None):
+                result = Mock()
+                result.valid = True
+                result.issues = []
+                return result
+
+        tool._adapter = _Adapter()
+        with (
+            patch.object(tool, "_reload_adapter", return_value=True),
+            patch.object(
+                tool,
+                "_semantic_model_artifact_evidence",
+                return_value={
+                    "semantic_model_name": "commerce",
+                    "semantic_model_file": str(artifact),
+                },
+            ),
+        ):
+            result = tool.validate_semantic(
+                scope="semantic_model",
+                semantic_model_name="commerce",
+            )
+
+        assert result.success == 1
+        assert evidence.semantic_artifact_validation_passed("commerce", artifact)
+
+    def test_resolves_target_artifact_validation_evidence(self, semantic_tools_with_adapter, tmp_path):
+        tool, _ = semantic_tools_with_adapter
+        artifact = tmp_path / "commerce.yml"
+        artifact.write_text("semantic_model: commerce\n", encoding="utf-8")
+        tool.adapter_type = "osi"
+
+        with patch(
+            "datus.agent.node.semantic_authoring.discover_osi_semantic_models",
+            return_value=[
+                {
+                    "semantic_model_name": "commerce",
+                    "absolute_path": str(artifact),
+                }
+            ],
+        ):
+            result = tool._semantic_model_artifact_evidence("commerce")
+
+        assert result["semantic_model_name"] == "commerce"
+        assert result["semantic_model_file"] == str(artifact.resolve())
+        assert len(result["semantic_model_file_sha256"]) == 64
+
     def test_rejects_target_when_adapter_does_not_support_it(self, semantic_tools_with_adapter):
         tool, _ = semantic_tools_with_adapter
 

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -785,20 +785,36 @@ class TestTaskExecution:
     @pytest.mark.asyncio
     async def test_osi_gen_metrics_requires_existing_semantic_model(self, task_tool, tmp_path):
         task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
+        task_tool.agent_config.current_datasource = "test_db"
         task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
 
-        with patch(
-            "datus.agent.node.semantic_authoring.default_osi_semantic_model_file",
-            return_value="subject/semantic_models/test_db/sales.yml",
-        ):
-            with patch.object(task_tool, "_execute_node") as execute_node:
-                result = await task_tool.task(type="gen_metrics", prompt="Generate revenue")
+        with patch.object(task_tool, "_execute_node") as execute_node:
+            result = await task_tool.task(type="gen_metrics", prompt="Generate revenue")
 
         assert result.success == 0
         assert result.result["code"] == "semantic_model_required"
         assert result.result["required_subagent"] == "gen_semantic_model"
         assert result.result["retry_subagent"] == "gen_metrics"
         execute_node.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_osi_gen_metrics_accepts_any_discovered_model_in_the_datasource(self, task_tool, tmp_path):
+        task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
+        task_tool.agent_config.current_datasource = "test_db"
+        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
+        target = tmp_path / "subject" / "semantic_models" / "test_db" / "orders_analytics.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "version: 0.2.0.dev0\nsemantic_model:\n  - name: orders_analytics\n    datasets: []\n",
+            encoding="utf-8",
+        )
+        expected = FuncToolResult(result={"response": "generated"})
+
+        with patch.object(task_tool, "_execute_node", return_value=expected) as execute_node:
+            result = await task_tool.task(type="gen_metrics", prompt="Generate order count")
+
+        assert result is expected
+        execute_node.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_semantic_authoring_tasks_are_serialized_across_tool_instances(


### PR DESCRIPTION
## Summary

- Resolve one stable Ossie semantic-model target per generation run using explicit name, inferred business domain, then core fact table fallback.
- Reuse an existing model when its fact tables match, while keeping dimension tables out of naming so later dimension additions do not rename the model.
- Scope artifact validation, publishing, knowledge-base identifiers, lookup, cleanup, and metric generation by `semantic_model_name`.
- Keep `write_file` and `edit_file` available for semantic-model authoring while enforcing that finalization validates exactly one target model.

## Why

Semantic models were stored under a datasource/domain path, and the generated domain could collapse to a generic database-level name. A second unrelated model in the same database could therefore select the first file or overwrite its contents. Storage and adapter calls also lacked enough model identity to disambiguate shared physical tables.

## Impact

Unrelated semantic models in the same database now produce independent files. Explicit user names remain authoritative; new models use a business-domain name when available and otherwise fall back to the core fact table. Existing model names remain stable as dimensions are added.

## Validation

- `746 passed` across the affected Agent suites with the companion Adapter branch loaded
- Ruff hooks and `git diff --check`
- Same-database E2E using benchmark cases 74 and 87 generated `activity_budget.yml` and `market_sales.yml` in sequence
- The first file's SHA-256 remained `47f98a336c7d05ab36c50888bea7111935cafcad0bad08e53a39ad4087ab80f7` after the second generation
- Both models were independently loaded, validated, compiled, and retained in the semantic-model knowledge base

## Related

- Adapter support: https://github.com/Datus-ai/datus-semantic-adapter/pull/53

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added OSI semantic model discovery and automatic target resolution using model names, business domains, and fact tables.
  * Added support for targeted semantic validation and clearer handling of ambiguous model matches.
  * Improved OSI metric and semantic model generation workflows with safer, non-destructive tooling.

* **Bug Fixes**
  * Prevented cleanup and synchronization operations from affecting unrelated semantic models.
  * Improved OSI artifact identity, file selection, and validation consistency.
  * Enhanced metric bootstrapping to reuse existing models and detect newly generated models reliably.

* **Documentation**
  * Updated OSI authoring guidance and generation workflows to reflect target resolution and validation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OSI semantic model discovery with automatic target resolution using semantic model name, business domain, and core fact tables.
  * Added targeted semantic validation tied to the resolved OSI model, with evidence tracking.
  * Extended semantic model APIs/endpoints to accept an optional semantic model name selector.
* **Bug Fixes**
  * Prevented semantic cleanup/sync from impacting other semantic-model variants.
  * Strengthened OSI publish-time validation to require exactly one declared model and reject mismatches/ambiguous targets.
* **Documentation**
  * Updated OSI authoring, metric, and prompt guidance to use resolved OSI targets and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->