### PR TITLE
[BugFix] Bootstrap Ossie models before metric generation

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -11,11 +11,12 @@ hooks, and metricflow MCP server integration.
 """
 
 import json
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
 from datus.configuration.agent_config import AgentConfig
+from datus.schemas.action_history import ActionHistory, ActionHistoryManager
 from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SemanticNodeResult
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
@@ -119,6 +120,16 @@ class GenMetricsAgenticNode(AgenticNode):
         """
         return self.NODE_NAME
 
+    async def execute_stream(
+        self, action_history_manager: Optional[ActionHistoryManager] = None
+    ) -> AsyncGenerator[ActionHistory, None]:
+        """Serialize metric writes with semantic-model authoring for this datasource."""
+        from datus.agent.node.semantic_authoring import semantic_authoring_guard
+
+        async with semantic_authoring_guard(self.agent_config):
+            async for action in super().execute_stream(action_history_manager):
+                yield action
+
     def setup_tools(self):
         """Setup tools for metrics generation."""
         if not self.agent_config:
@@ -132,10 +143,124 @@ class GenMetricsAgenticNode(AgenticNode):
         self._setup_generation_tools()
         self._setup_filesystem_tools()
         self._setup_semantic_tools()
+        self._setup_semantic_model_bootstrap()
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
 
         logger.info(f"Setup {len(self.tools)} tools for {self.NODE_NAME}: {[tool.name for tool in self.tools]}")
+
+    def _setup_semantic_model_bootstrap(self) -> None:
+        """Create a host-only semantic-model runner for directly selected OSI metrics."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        self.sub_agent_task_tool = None
+        if self._is_subagent or not is_osi_authoring(self.agent_config):
+            return
+
+        from datus.tools.func_tool.sub_agent_task_tool import SubAgentTaskTool
+
+        self.sub_agent_task_tool = SubAgentTaskTool(
+            agent_config=self.agent_config,
+            allowed_subagents=["gen_semantic_model"],
+            parent_node_name=self.get_node_name(),
+        )
+        self.sub_agent_task_tool.set_action_bus(self.action_bus)
+        self.sub_agent_task_tool.set_interaction_broker(self.interaction_broker)
+        self.sub_agent_task_tool.set_parent_node(self)
+
+    async def _before_stream(self, ctx: StreamRunContext) -> None:
+        """Resolve or bootstrap the prerequisite OSI semantic model before metrics."""
+        await super()._before_stream(ctx)
+
+        from datus.agent.node.semantic_authoring import (
+            is_osi_authoring,
+            resolve_existing_osi_semantic_model,
+        )
+
+        if not is_osi_authoring(self.agent_config):
+            return
+
+        resolution = resolve_existing_osi_semantic_model(
+            self.agent_config,
+            user_input=ctx.user_input,
+            request_text=ctx.user_input.user_message,
+        )
+        if resolution["status"] == "found":
+            self._set_osi_semantic_model_target(ctx.user_input, resolution["selected"])
+            return
+        if resolution["status"] == "ambiguous":
+            self._raise_osi_semantic_model_selection_error(resolution)
+        if self._is_subagent:
+            raise DatusException(
+                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
+                message_args={
+                    "error_message": (
+                        "no OSI semantic model contains the requested datasets; "
+                        "run gen_semantic_model first, then retry gen_metrics"
+                    )
+                },
+            )
+        if self.sub_agent_task_tool is None:
+            raise DatusException(
+                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
+                message_args={"error_message": "gen_semantic_model runner is unavailable"},
+            )
+
+        result = await self.sub_agent_task_tool.task(
+            type="gen_semantic_model",
+            prompt=(
+                "Create the OSI semantic model prerequisite for the metric request below. "
+                "Author semantic objects only; do not generate metrics.\n\n"
+                f"Original metric request:\n{ctx.user_input.user_message}"
+            ),
+            description="Create required OSI semantic model",
+        )
+        if not result.success:
+            raise DatusException(
+                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
+                message_args={"error_message": result.error or "gen_semantic_model failed"},
+            )
+
+        post_resolution = resolve_existing_osi_semantic_model(
+            self.agent_config,
+            user_input=ctx.user_input,
+            request_text=ctx.user_input.user_message,
+        )
+        selected = post_resolution.get("selected") if post_resolution["status"] == "found" else None
+
+        if selected is None:
+            if post_resolution["status"] == "ambiguous":
+                self._raise_osi_semantic_model_selection_error(post_resolution)
+            raise DatusException(
+                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
+                message_args={
+                    "error_message": "gen_semantic_model completed without creating a resolvable OSI semantic model"
+                },
+            )
+
+        self._set_osi_semantic_model_target(ctx.user_input, selected)
+        logger.info("Bootstrapped prerequisite OSI semantic model: %s", selected["semantic_model_file"])
+
+    @staticmethod
+    def _set_osi_semantic_model_target(user_input: SemanticNodeInput, model: Dict[str, Any]) -> None:
+        """Attach the selected model name so the upstream resolver supplies its real file."""
+        user_input.semantic_model_name = model["semantic_model_name"]
+
+    @staticmethod
+    def _raise_osi_semantic_model_selection_error(resolution: Dict[str, Any]) -> None:
+        candidates = ", ".join(
+            f"{model['semantic_model_name']} ({model['semantic_model_file']})"
+            for model in resolution.get("candidates") or []
+        )
+        raise DatusException(
+            ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
+            message_args={
+                "error_message": (
+                    f"semantic model selection is ambiguous: {candidates}. "
+                    "Specify semantic_model_name or reference a dataset from the intended model."
+                )
+            },
+        )
 
     def _ensure_bash_tool_in_tools(self) -> None:
         """Keep OSI metric authoring on its metrics-only filesystem surface."""
@@ -337,33 +462,18 @@ class GenMetricsAgenticNode(AgenticNode):
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
             resolve_authoring_format,
-            resolve_osi_semantic_model_target,
         )
 
         context["authoring_format"] = resolve_authoring_format(self.agent_config)
-        requested_name = str(getattr(user_input, "semantic_model_name", "") or "").strip()
-        business_domain = str(getattr(user_input, "business_domain", "") or "").strip()
-        fact_tables = list(getattr(user_input, "fact_tables", None) or [])
-        dimension_tables = list(getattr(user_input, "dimension_tables", None) or [])
-        context["requested_semantic_model_name"] = requested_name
-        context["requested_business_domain"] = business_domain
-        context["requested_fact_tables"] = fact_tables
-        context["requested_dimension_tables"] = dimension_tables
+        # Request-scoped target details belong in the enhanced user message;
+        # this context is frozen in the per-session system-prompt snapshot.
+        context["requested_semantic_model_name"] = ""
+        context["requested_business_domain"] = ""
+        context["requested_fact_tables"] = []
+        context["requested_dimension_tables"] = []
         context["osi_target_resolved"] = False
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
-        if context["authoring_format"] == "osi" and (requested_name or business_domain or fact_tables):
-            target = resolve_osi_semantic_model_target(
-                self.agent_config,
-                semantic_model_name=requested_name,
-                business_domain=business_domain,
-                fact_tables=fact_tables,
-                dimension_tables=dimension_tables,
-            )
-            if not target.get("ambiguous"):
-                context["osi_target_resolved"] = True
-                context["default_osi_semantic_model_name"] = target["semantic_model_name"]
-                context["default_osi_semantic_model_file"] = target["semantic_model_file"]
 
         # Handle subject_tree context based on whether predefined or query from storage
         if self.subject_tree:
@@ -377,6 +487,26 @@ class GenMetricsAgenticNode(AgenticNode):
 
         logger.debug(f"Prepared template context: {context}")
         return context
+
+    def _build_enhanced_message(
+        self,
+        user_input: SemanticNodeInput,
+        extra_enhanced_parts: Optional[List[str]] = None,
+    ) -> str:
+        """Add the resolved Ossie target to this turn instead of the cached system prompt."""
+        from datus.agent.node.semantic_authoring import osi_semantic_model_turn_context
+
+        parts = list(extra_enhanced_parts or [])
+        target_context = osi_semantic_model_turn_context(self.agent_config, user_input)
+        if target_context:
+            parts.append(target_context)
+        return super()._build_enhanced_message(user_input, parts)
+
+    def _system_prompt_snapshot_meta(self, prompt_version: Optional[str]) -> Dict[str, str]:
+        """Invalidate snapshots created before semantic targets became request-scoped."""
+        meta = super()._system_prompt_snapshot_meta(prompt_version)
+        meta["semantic_target_scope"] = "per_turn_v1"
+        return meta
 
     def _get_system_prompt(
         self,

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -10,12 +10,13 @@ semantic model generation with support for filesystem tools, generation tools,
 database tools, hooks, and metricflow MCP server integration.
 """
 
-from typing import Any, Literal, Optional
+from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
 from datus.cli.generation_hooks import GenerationHooks
 from datus.configuration.agent_config import AgentConfig
+from datus.schemas.action_history import ActionHistory, ActionHistoryManager
 from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SemanticNodeResult
 from datus.tools.func_tool import DBFuncTool
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
@@ -113,6 +114,16 @@ class GenSemanticModelAgenticNode(AgenticNode):
             The configured node name
         """
         return self.NODE_NAME
+
+    async def execute_stream(
+        self, action_history_manager: Optional[ActionHistoryManager] = None
+    ) -> AsyncGenerator[ActionHistory, None]:
+        """Serialize semantic-model writes with metric authoring for this datasource."""
+        from datus.agent.node.semantic_authoring import semantic_authoring_guard
+
+        async with semantic_authoring_guard(self.agent_config):
+            async for action in super().execute_stream(action_history_manager):
+                yield action
 
     def setup_tools(self):
         """Setup tools for semantic model generation."""
@@ -325,33 +336,18 @@ class GenSemanticModelAgenticNode(AgenticNode):
             default_osi_semantic_model_file,
             default_osi_semantic_model_name,
             resolve_authoring_format,
-            resolve_osi_semantic_model_target,
         )
 
         context["authoring_format"] = resolve_authoring_format(self.agent_config)
-        requested_name = str(getattr(user_input, "semantic_model_name", "") or "").strip()
-        business_domain = str(getattr(user_input, "business_domain", "") or "").strip()
-        fact_tables = list(getattr(user_input, "fact_tables", None) or [])
-        dimension_tables = list(getattr(user_input, "dimension_tables", None) or [])
-        context["requested_semantic_model_name"] = requested_name
-        context["requested_business_domain"] = business_domain
-        context["requested_fact_tables"] = fact_tables
-        context["requested_dimension_tables"] = dimension_tables
+        # Request-scoped target details belong in the enhanced user message;
+        # this context is frozen in the per-session system-prompt snapshot.
+        context["requested_semantic_model_name"] = ""
+        context["requested_business_domain"] = ""
+        context["requested_fact_tables"] = []
+        context["requested_dimension_tables"] = []
         context["osi_target_resolved"] = False
         context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
         context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
-        if context["authoring_format"] == "osi" and (requested_name or business_domain or fact_tables):
-            target = resolve_osi_semantic_model_target(
-                self.agent_config,
-                semantic_model_name=requested_name,
-                business_domain=business_domain,
-                fact_tables=fact_tables,
-                dimension_tables=dimension_tables,
-            )
-            if not target.get("ambiguous"):
-                context["osi_target_resolved"] = True
-                context["default_osi_semantic_model_name"] = target["semantic_model_name"]
-                context["default_osi_semantic_model_file"] = target["semantic_model_file"]
         context["osi_authoring_spec"] = ""
         if context["authoring_format"] == "osi":
             # The OSI core spec document ships with the adapter package so the
@@ -367,6 +363,26 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
         logger.debug(f"Prepared template context: {context}")
         return context
+
+    def _build_enhanced_message(
+        self,
+        user_input: SemanticNodeInput,
+        extra_enhanced_parts: Optional[List[str]] = None,
+    ) -> str:
+        """Add Ossie naming intent to this turn instead of the cached system prompt."""
+        from datus.agent.node.semantic_authoring import osi_semantic_model_turn_context
+
+        parts = list(extra_enhanced_parts or [])
+        target_context = osi_semantic_model_turn_context(self.agent_config, user_input)
+        if target_context:
+            parts.append(target_context)
+        return super()._build_enhanced_message(user_input, parts)
+
+    def _system_prompt_snapshot_meta(self, prompt_version: Optional[str]) -> Dict[str, str]:
+        """Invalidate snapshots created before semantic targets became request-scoped."""
+        meta = super()._system_prompt_snapshot_meta(prompt_version)
+        meta["semantic_target_scope"] = "per_turn_v1"
+        return meta
 
     def _get_system_prompt(
         self,

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -23,7 +23,11 @@ into the prompt at render time (see ``required_authoring_skills``).
 
 from __future__ import annotations
 
+import asyncio
 import re
+import weakref
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
@@ -32,6 +36,12 @@ import yaml
 
 AUTHORING_FORMAT_METRICFLOW = "metricflow"
 AUTHORING_FORMAT_OSI = "osi"
+
+_SEMANTIC_AUTHORING_LOCKS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+_HELD_SEMANTIC_AUTHORING_KEYS: ContextVar[frozenset[str]] = ContextVar(
+    "held_semantic_authoring_keys",
+    default=frozenset(),
+)
 
 # Authoring specification skills injected into the system prompt on every run,
 # keyed by node name then authoring format. These carry the full YAML format
@@ -211,6 +221,11 @@ def _osi_semantic_model_dir(agent_config: Any = None) -> Optional[Path]:
     return None
 
 
+def osi_semantic_model_directory(agent_config: Any = None) -> Optional[Path]:
+    """Return the active datasource's semantic-model directory."""
+    return _osi_semantic_model_dir(agent_config)
+
+
 def _table_lookup_names(value: Any) -> set[str]:
     """Return stable lookup keys for a logical or fully-qualified table name."""
     parts = [part.strip().strip('`"[]') for part in re.split(r"[./]", str(value or "").strip())]
@@ -317,6 +332,197 @@ def osi_semantic_models_cover_tables(agent_config: Any, tables: Iterable[str]) -
         return False
     requested = [str(table).strip() for table in tables if str(table).strip()]
     return bool(requested) and any(all(_model_covers_table(model, table) for table in requested) for model in models)
+
+
+def _dedupe_table_references(values: Iterable[Any]) -> list[str]:
+    references: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        key = text.lower()
+        if text and key not in seen:
+            seen.add(key)
+            references.append(text)
+    return references
+
+
+def _metric_request_table_references(
+    user_input: Any,
+    request_text: str,
+    models: Iterable[Dict[str, Any]],
+) -> list[str]:
+    """Extract deterministic table hints carried by a metric request."""
+    references: list[Any] = []
+    references.extend(getattr(user_input, "fact_tables", None) or [])
+    references.extend(getattr(user_input, "dimension_tables", None) or [])
+
+    for schema in getattr(user_input, "schemas", None) or []:
+        parts = [
+            getattr(schema, "catalog_name", ""),
+            getattr(schema, "database_name", ""),
+            getattr(schema, "schema_name", ""),
+            getattr(schema, "table_name", ""),
+        ]
+        qualified = ".".join(str(part) for part in parts if part)
+        references.append(qualified or getattr(schema, "identifier", ""))
+
+    try:
+        from datus.utils.sql_utils import extract_table_names
+
+        for reference_sql in getattr(user_input, "reference_sql", None) or []:
+            references.extend(extract_table_names(getattr(reference_sql, "sql", ""), ignore_empty=True))
+        if re.search(r"\b(?:select|with)\b", str(request_text or ""), flags=re.IGNORECASE):
+            references.extend(extract_table_names(request_text, ignore_empty=True))
+    except Exception:
+        pass
+
+    if not any(str(value or "").strip() for value in references):
+        from_match = re.search(r"\bfrom\s+[`\"[]?([A-Za-z_][\w.]*)", str(request_text or ""), re.IGNORECASE)
+        if from_match:
+            references.append(from_match.group(1))
+
+    if not any(str(value or "").strip() for value in references):
+        text = str(request_text or "").lower()
+        for model in models:
+            for value in [*(model.get("dataset_names") or []), *(model.get("dataset_sources") or [])]:
+                leaf = re.split(r"[./]", str(value or ""))[-1].strip().strip('`"[]').lower()
+                if leaf and re.search(rf"(?<![\w]){re.escape(leaf)}(?![\w])", text):
+                    references.append(value)
+
+    return _dedupe_table_references(references)
+
+
+def _requested_semantic_model_name(user_input: Any, request_text: str) -> str:
+    declared = str(getattr(user_input, "semantic_model_name", "") or "").strip()
+    if declared:
+        return declared
+    for pattern in (
+        r"\bsemantic_model_name\s*[:=]\s*[`\"']?([A-Za-z0-9_.-]+)",
+        r"\bsemantic\s+model\s+(?:named|name\s*[:=])\s*[`\"']?([A-Za-z0-9_.-]+)",
+        r"semantic\s*model\s*(?:名称为|名为)\s*[`\"']?([\w.-]+)",
+    ):
+        match = re.search(pattern, str(request_text or ""), flags=re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+    return ""
+
+
+def _existing_model_resolution(
+    status: str,
+    *,
+    selected: Optional[Dict[str, Any]] = None,
+    candidates: Optional[Iterable[Dict[str, Any]]] = None,
+    reason: str,
+    requested_name: str = "",
+    referenced_tables: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "status": status,
+        "candidates": list(candidates or []),
+        "reason": reason,
+    }
+    if selected is not None:
+        result["selected"] = selected
+    if requested_name:
+        result["requested_name"] = requested_name
+    if referenced_tables:
+        result["referenced_tables"] = list(referenced_tables)
+    return result
+
+
+def resolve_existing_osi_semantic_model(
+    agent_config: Any,
+    *,
+    user_input: Any = None,
+    request_text: str = "",
+    referenced_tables: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Select an existing Ossie model for metric authoring without guessing.
+
+    Source YAML is authoritative. Selection prefers an explicit model name,
+    then a unique model covering every referenced dataset. A single model is a
+    safe datasource default; otherwise ambiguity is returned to the caller.
+    """
+    models = discover_osi_semantic_models(agent_config)
+    requested_name = _requested_semantic_model_name(user_input, request_text)
+    if requested_name:
+        target = resolve_osi_semantic_model_target(
+            agent_config,
+            semantic_model_name=requested_name,
+        )
+        if target.get("ambiguous"):
+            return _existing_model_resolution(
+                "ambiguous",
+                candidates=target.get("candidates"),
+                requested_name=requested_name,
+                reason=target.get("reason") or "the explicit model name is ambiguous",
+            )
+        if target.get("exists"):
+            return _existing_model_resolution(
+                "found",
+                selected=target,
+                candidates=[target],
+                requested_name=requested_name,
+                reason="explicit semantic model name",
+            )
+        return _existing_model_resolution(
+            "missing",
+            requested_name=requested_name,
+            reason="the explicitly requested semantic model does not exist",
+        )
+
+    tables = _dedupe_table_references(
+        [
+            *_metric_request_table_references(user_input, request_text, models),
+            *(referenced_tables or []),
+        ]
+    )
+    if tables:
+        matches = [model for model in models if all(_model_covers_table(model, table) for table in tables)]
+        if len(matches) == 1:
+            return _existing_model_resolution(
+                "found",
+                selected=matches[0],
+                candidates=matches,
+                referenced_tables=tables,
+                reason="referenced datasets uniquely identify the semantic model",
+            )
+        if len(matches) > 1:
+            return _existing_model_resolution(
+                "ambiguous",
+                candidates=matches,
+                referenced_tables=tables,
+                reason="referenced datasets occur in multiple semantic models",
+            )
+        partial_matches = [model for model in models if any(_model_covers_table(model, table) for table in tables)]
+        if len(partial_matches) > 1:
+            return _existing_model_resolution(
+                "ambiguous",
+                candidates=partial_matches,
+                referenced_tables=tables,
+                reason="referenced datasets are split across multiple semantic models",
+            )
+        return _existing_model_resolution(
+            "missing",
+            candidates=partial_matches,
+            referenced_tables=tables,
+            reason="no semantic model contains all referenced datasets",
+        )
+
+    if len(models) == 1:
+        return _existing_model_resolution(
+            "found",
+            selected=models[0],
+            candidates=models,
+            reason="only one semantic model exists for the datasource",
+        )
+    if len(models) > 1:
+        return _existing_model_resolution(
+            "ambiguous",
+            candidates=models,
+            reason="multiple semantic models exist and the request does not identify a dataset",
+        )
+    return _existing_model_resolution("missing", reason="no semantic model exists for the datasource")
 
 
 def _new_osi_semantic_model_name(business_domain: str, fact_tables: Iterable[str]) -> tuple[str, str]:
@@ -494,6 +700,102 @@ def resolve_osi_semantic_model_target(
         "matched_by": matched_by,
         "dimension_tables": dimensions,
     }
+
+
+def osi_semantic_model_turn_context(agent_config: Any, user_input: Any) -> str:
+    """Render request-scoped Ossie target details for the user message.
+
+    Semantic-model intent can change between turns in one persisted session, so
+    these values must never be frozen into the session system-prompt snapshot.
+    """
+    if resolve_authoring_format(agent_config) != AUTHORING_FORMAT_OSI:
+        return ""
+
+    requested_name = str(getattr(user_input, "semantic_model_name", "") or "").strip()
+    business_domain = str(getattr(user_input, "business_domain", "") or "").strip()
+    fact_tables = [
+        str(value).strip() for value in (getattr(user_input, "fact_tables", None) or []) if str(value).strip()
+    ]
+    dimension_tables = [
+        str(value).strip() for value in (getattr(user_input, "dimension_tables", None) or []) if str(value).strip()
+    ]
+    if not (requested_name or business_domain or fact_tables or dimension_tables):
+        return ""
+
+    target = resolve_osi_semantic_model_target(
+        agent_config,
+        semantic_model_name=requested_name,
+        business_domain=business_domain,
+        fact_tables=fact_tables,
+        dimension_tables=dimension_tables,
+    )
+    lines = [
+        "## Ossie Semantic Model Target for This Turn",
+        "This block is request-scoped and supersedes any semantic-model target mentioned in earlier turns.",
+    ]
+    if requested_name:
+        lines.append(f"- Selected semantic model name: `{requested_name}`")
+    if business_domain:
+        lines.append(f"- Business domain: `{business_domain}`")
+    if fact_tables:
+        lines.append(f"- Fact tables: `{', '.join(fact_tables)}`")
+    if dimension_tables:
+        lines.append(f"- Dimension tables: `{', '.join(dimension_tables)}`")
+
+    if target.get("ambiguous"):
+        lines.append(f"- Resolution status: ambiguous ({target.get('reason') or 'target is not unique'})")
+        candidates = target.get("candidates") or []
+        if candidates:
+            rendered = ", ".join(
+                f"{candidate['semantic_model_name']} ({candidate['semantic_model_file']})" for candidate in candidates
+            )
+            lines.append(f"- Candidates: {rendered}")
+        lines.append("Do not guess; call `resolve_osi_semantic_model_target` and require clarification if needed.")
+    else:
+        lines.extend(
+            [
+                f"- Resolved semantic model name: `{target['semantic_model_name']}`",
+                f"- Resolved semantic model file: `{target['semantic_model_file']}`",
+                "Use this exact name and file for this turn.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def semantic_authoring_lock_key(agent_config: Any = None) -> str:
+    """Return the lock key shared by semantic authoring for one datasource."""
+    path_manager = getattr(agent_config, "path_manager", None)
+    project_root = getattr(path_manager, "project_root", "")
+    datasource = str(getattr(agent_config, "current_datasource", "") or "default")
+    try:
+        project_key = str(Path(project_root).expanduser().resolve(strict=False))
+    except TypeError:
+        project_key = str(project_root)
+    return f"{project_key}:{datasource}"
+
+
+def _semantic_authoring_lock(agent_config: Any = None) -> asyncio.Lock:
+    """Return the event-loop-local lock for one project datasource."""
+    loop = asyncio.get_running_loop()
+    loop_locks = _SEMANTIC_AUTHORING_LOCKS.setdefault(loop, {})
+    return loop_locks.setdefault(semantic_authoring_lock_key(agent_config), asyncio.Lock())
+
+
+@asynccontextmanager
+async def semantic_authoring_guard(agent_config: Any = None):
+    """Serialize semantic writes while allowing nested host delegation."""
+    key = semantic_authoring_lock_key(agent_config)
+    held_keys = _HELD_SEMANTIC_AUTHORING_KEYS.get()
+    if key in held_keys:
+        yield
+        return
+
+    async with _semantic_authoring_lock(agent_config):
+        token = _HELD_SEMANTIC_AUTHORING_KEYS.set(held_keys | {key})
+        try:
+            yield
+        finally:
+            _HELD_SEMANTIC_AUTHORING_KEYS.reset(token)
 
 
 def required_authoring_skills(agent_config: Any, node_name: str) -> str:

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -254,17 +254,15 @@ async def _ensure_semantic_models_for_metrics(
 ) -> tuple[bool, str, list[str]]:
     if _metrics_authoring_format(agent_config) == AUTHORING_FORMAT_OSI:
         from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
-        from datus.storage.semantic_model.store import SemanticModelRAG
 
         before_models = discover_osi_semantic_models(agent_config)
         requested_table_groups = [extract_tables_from_sql_list([sql], agent_config) for sql in sql_list]
         requested_tables = list(dict.fromkeys(table for table_group in requested_table_groups for table in table_group))
-        has_semantic_rows = SemanticModelRAG(agent_config).get_size() > 0
         existing_models_cover_request = not requested_tables or all(
             not table_group or osi_semantic_models_cover_tables(agent_config, table_group)
             for table_group in requested_table_groups
         )
-        if has_semantic_rows and before_models and existing_models_cover_request:
+        if before_models and existing_models_cover_request:
             logger.info(
                 "Reusing %d existing OSI semantic model file(s) for metric bootstrap",
                 len(before_models),

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -13,13 +13,10 @@ tools, template rendering, and action history.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import uuid
-import weakref
 from contextlib import nullcontext
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from agents import FunctionTool, Tool
@@ -49,8 +46,6 @@ if TYPE_CHECKING:
     from datus.schemas.base import BaseInput
 
 logger = get_logger(__name__)
-
-_SEMANTIC_AUTHORING_LOCKS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
 # Mapping from subagent type string to NodeType constants
 NODE_CLASS_MAP = {
@@ -346,10 +341,11 @@ class SubAgentTaskTool:
             normalized_type = type.strip().strip("\"'") if isinstance(type, str) else type
             semantic_types = {"gen_semantic_model", "gen_metrics"}
             if normalized_type in semantic_types and normalized_type in self._get_available_types():
-                lock = self._semantic_authoring_lock()
-                async with lock:
+                from datus.agent.node.semantic_authoring import semantic_authoring_guard
+
+                async with semantic_authoring_guard(self.agent_config):
                     if normalized_type == "gen_metrics":
-                        precondition = self._osi_metric_precondition()
+                        precondition = self._osi_metric_precondition(prompt)
                         if precondition is not None:
                             return precondition
                     return await self._execute_node(
@@ -367,43 +363,45 @@ class SubAgentTaskTool:
             logger.error(f"Task tool execution error (type={type}): {e}")
             return FuncToolResult(success=0, error=f"Task execution failed: {str(e)}")
 
-    def _semantic_authoring_lock_key(self) -> str:
-        """Serialize semantic authoring tasks for one project datasource."""
-        path_manager = getattr(self.agent_config, "path_manager", None)
-        project_root = getattr(path_manager, "project_root", "")
-        datasource = str(getattr(self.agent_config, "current_datasource", "") or "default")
-        try:
-            project_key = str(Path(project_root).expanduser().resolve(strict=False))
-        except TypeError:
-            project_key = str(project_root)
-        return f"{project_key}:{datasource}"
-
-    def _semantic_authoring_lock(self) -> asyncio.Lock:
-        """Return the event-loop shared lock for one project datasource."""
-        loop = asyncio.get_running_loop()
-        loop_locks = _SEMANTIC_AUTHORING_LOCKS.setdefault(loop, {})
-        return loop_locks.setdefault(self._semantic_authoring_lock_key(), asyncio.Lock())
-
-    def _osi_metric_precondition(self) -> Optional[FuncToolResult]:
+    def _osi_metric_precondition(self, prompt: str = "") -> Optional[FuncToolResult]:
         """Require the OSI domain model before starting the metric subagent."""
         from datus.agent.node.semantic_authoring import (
-            discover_osi_semantic_models,
             is_osi_authoring,
+            osi_semantic_model_directory,
+            resolve_existing_osi_semantic_model,
         )
 
         if not is_osi_authoring(self.agent_config):
             return None
 
-        path_manager = getattr(self.agent_config, "path_manager", None)
-        project_root = getattr(path_manager, "project_root", None)
-        if project_root is None:
+        resolution = resolve_existing_osi_semantic_model(
+            self.agent_config,
+            user_input=getattr(self._parent_node, "input", None),
+            request_text=prompt,
+        )
+        if resolution["status"] == "found":
             return None
+        if resolution["status"] == "ambiguous":
+            return FuncToolResult(
+                success=0,
+                error=(
+                    "Multiple OSI semantic models match this metric request. "
+                    "Specify semantic_model_name or reference a dataset from the intended model."
+                ),
+                result={
+                    "code": "semantic_model_selection_required",
+                    "candidates": [
+                        {
+                            "semantic_model_name": model["semantic_model_name"],
+                            "semantic_model_file": model["semantic_model_file"],
+                        }
+                        for model in resolution.get("candidates") or []
+                    ],
+                    "retry_subagent": "gen_metrics",
+                },
+            )
 
-        if discover_osi_semantic_models(self.agent_config):
-            return None
-
-        datasource = str(getattr(self.agent_config, "current_datasource", "") or "default")
-        target_dir = Path(project_root) / "subject" / "semantic_models" / datasource
+        target_dir = osi_semantic_model_directory(self.agent_config)
 
         return FuncToolResult(
             success=0,
@@ -414,7 +412,7 @@ class SubAgentTaskTool:
             result={
                 "code": "semantic_model_required",
                 "required_subagent": "gen_semantic_model",
-                "semantic_model_directory": str(target_dir),
+                "semantic_model_directory": str(target_dir) if target_dir is not None else "",
                 "retry_subagent": "gen_metrics",
             },
         )

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -178,6 +178,10 @@ class ErrorCode(Enum):
     SEMANTIC_ADAPTER_ERROR = ("600002", "Semantic adapter operation failed: {error_message}")
     SEMANTIC_ADAPTER_CONFIG_ERROR = ("600003", "Semantic adapter configuration error: {error_message}")
     SEMANTIC_ADAPTER_SYNC_FAILED = ("600004", "Failed to sync from semantic adapter: {error_message}")
+    SEMANTIC_MODEL_BOOTSTRAP_FAILED = (
+        "600005",
+        "Failed to create prerequisite OSI semantic model: {error_message}",
+    )
 
     def __init__(self, code: str, desc: str):
         self.code = code

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -24,12 +24,13 @@ Design principle: NO mock except LLM.
 """
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.generation_tools import GenerationTools
@@ -100,8 +101,24 @@ class TestGenMetricsAgenticNodeInit:
         assert {"write_file", "edit_file", "delete_file", "end_semantic_model_generation", "bash"}.isdisjoint(
             tool_names
         )
+        assert "task" not in tool_names
+        assert node.sub_agent_task_tool is not None
+        assert node.sub_agent_task_tool._allowed_subagents == ["gen_semantic_model"]
         assert "resolve_osi_semantic_model_target" in tool_names
         assert "end_metric_generation" in tool_names
+
+    def test_osi_metrics_subagent_does_not_bootstrap_recursively(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+            is_subagent=True,
+        )
+
+        assert node.sub_agent_task_tool is None
+        assert "task" not in {tool.name for tool in node.tools}
 
     def test_metrics_max_turns(self, real_agent_config, mock_llm_create):
         """Test max_turns is read from agentic_nodes config."""
@@ -191,6 +208,197 @@ class TestGenMetricsAgenticNodeExecution:
         # Last action should be SUCCESS
         last_action = actions[-1]
         assert last_action.status == ActionStatus.SUCCESS
+
+    @pytest.mark.asyncio
+    async def test_direct_osi_metrics_bootstraps_missing_model_before_llm(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate enrollment metrics from schools")
+        target = (
+            real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+            / "school-domain.yaml"
+        )
+
+        async def bootstrap(**kwargs):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                "version: 0.2.0.dev0\n"
+                "semantic_model:\n"
+                "  - name: school_operations\n"
+                "    datasets:\n"
+                "      - name: schools\n"
+                "        source: education.schools\n",
+                encoding="utf-8",
+            )
+            return FuncToolResult(result={"semantic_models": [str(target)]})
+
+        node.sub_agent_task_tool.task = AsyncMock(side_effect=bootstrap)
+        ctx = StreamRunContext(user_input=node.input, action_history_manager=ActionHistoryManager())
+
+        await node._before_stream(ctx)
+
+        node.sub_agent_task_tool.task.assert_awaited_once()
+        assert node.input.semantic_model_name == "school_operations"
+        context = node._prepare_template_context(node.input)
+        assert context["osi_target_resolved"] is False
+        enhanced = node._build_enhanced_message(node.input)
+        assert "school_operations" in enhanced
+        assert "school-domain.yaml" in enhanced
+        assert mock_llm_create.call_history == []
+
+    @pytest.mark.asyncio
+    async def test_direct_osi_metrics_reuses_arbitrarily_named_model_by_dataset(
+        self, real_agent_config, mock_llm_create
+    ):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        target = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource) / "ops.yml"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: sales\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: commerce.orders\n",
+            encoding="utf-8",
+        )
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate revenue metrics from orders")
+        node.sub_agent_task_tool.task = AsyncMock()
+        ctx = StreamRunContext(user_input=node.input, action_history_manager=ActionHistoryManager())
+
+        await node._before_stream(ctx)
+
+        node.sub_agent_task_tool.task.assert_not_awaited()
+        assert node.input.semantic_model_name == "sales"
+        context = node._prepare_template_context(node.input)
+        assert context["osi_target_resolved"] is False
+        enhanced = node._build_enhanced_message(node.input)
+        assert "sales" in enhanced
+        assert "ops.yml" in enhanced
+
+    @pytest.mark.asyncio
+    async def test_osi_target_is_request_scoped_when_session_switches_models(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        (model_dir / "alpha-target.yml").write_text(
+            "semantic_model:\n"
+            "  - name: alpha_orders_domain\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: commerce.orders\n",
+            encoding="utf-8",
+        )
+        (model_dir / "beta-target.yml").write_text(
+            "semantic_model:\n"
+            "  - name: beta_payments_domain\n"
+            "    datasets:\n"
+            "      - name: payments\n"
+            "        source: finance.payments\n",
+            encoding="utf-8",
+        )
+
+        session_id = "metrics_target_switch_session"
+        first = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+            session_id=session_id,
+        )
+        first.input = SemanticNodeInput(user_message="Generate metrics from orders")
+        first_ctx = StreamRunContext(user_input=first.input, action_history_manager=ActionHistoryManager())
+        await first._before_stream(first_ctx)
+        first_system = first._get_session_system_prompt(
+            template_context=first._build_template_context(first_ctx),
+        )
+        first_message = first._build_enhanced_message(first.input)
+
+        second = GenMetricsAgenticNode(
+            agent_config=real_agent_config,
+            execution_mode="workflow",
+            session_id=session_id,
+        )
+        second.input = SemanticNodeInput(user_message="Generate metrics from payments")
+        second_ctx = StreamRunContext(user_input=second.input, action_history_manager=ActionHistoryManager())
+        await second._before_stream(second_ctx)
+        second_system = second._get_session_system_prompt(
+            template_context=second._build_template_context(second_ctx),
+        )
+        second_message = second._build_enhanced_message(second.input)
+
+        assert first_system == second_system
+        assert "alpha_orders_domain" not in first_system
+        assert "beta_payments_domain" not in second_system
+        assert "alpha_orders_domain" in first_message
+        assert "alpha-target.yml" in first_message
+        assert "beta_payments_domain" in second_message
+        assert "beta-target.yml" in second_message
+        assert "alpha_orders_domain" not in second_message
+
+    @pytest.mark.asyncio
+    async def test_direct_osi_metrics_rejects_bootstrap_result_without_full_dataset_coverage(
+        self, real_agent_config, mock_llm_create
+    ):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(
+            user_message="Generate enrollment metrics",
+            fact_tables=["education.schools", "education.students"],
+        )
+        target = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource) / "school.yml"
+
+        async def incomplete_bootstrap(**kwargs):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                "semantic_model:\n"
+                "  - name: school_operations\n"
+                "    datasets:\n"
+                "      - name: schools\n"
+                "        source: education.schools\n",
+                encoding="utf-8",
+            )
+            return FuncToolResult(result={"semantic_models": [str(target)]})
+
+        node.sub_agent_task_tool.task = AsyncMock(side_effect=incomplete_bootstrap)
+
+        actions = [action async for action in node.execute_stream(ActionHistoryManager())]
+
+        node.sub_agent_task_tool.task.assert_awaited_once()
+        assert actions[-1].action_type == "error"
+        assert actions[-1].status == ActionStatus.FAILED
+        assert "without creating a resolvable OSI semantic model" in str(actions[-1].output)
+        assert mock_llm_create.call_history == []
+
+    @pytest.mark.asyncio
+    async def test_direct_osi_metrics_bootstrap_failure_stops_before_metrics_llm(
+        self, real_agent_config, mock_llm_create
+    ):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate revenue metrics")
+        node.sub_agent_task_tool.task = AsyncMock(
+            return_value=FuncToolResult(success=0, error="semantic validation failed")
+        )
+
+        actions = [action async for action in node.execute_stream(ActionHistoryManager())]
+
+        assert actions[-1].action_type == "error"
+        assert actions[-1].status == ActionStatus.FAILED
+        assert "semantic validation failed" in str(actions[-1].output)
+        assert mock_llm_create.call_history == []
 
     @pytest.mark.asyncio
     async def test_metrics_with_filesystem_tool(self, real_agent_config, mock_llm_create):

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -533,7 +533,7 @@ class TestPrepareTemplateContext:
 
         assert "test_tool" in context["native_tools"]
 
-    def test_osi_template_context_resolves_explicit_model_name_first(self, real_agent_config, mock_llm_create):
+    def test_osi_target_is_in_request_context_not_system_template(self, real_agent_config, mock_llm_create):
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = _make_node(real_agent_config, mock_llm_create)
         user_input = SemanticNodeInput(
@@ -546,10 +546,14 @@ class TestPrepareTemplateContext:
 
         context = node._prepare_template_context(user_input)
 
-        assert context["osi_target_resolved"] is True
-        assert context["default_osi_semantic_model_name"] == "executive_sales"
-        assert context["default_osi_semantic_model_file"].endswith("/executive_sales.yml")
-        assert context["requested_dimension_tables"] == ["main.customers"]
+        assert context["osi_target_resolved"] is False
+        assert context["requested_semantic_model_name"] == ""
+        assert context["requested_dimension_tables"] == []
+        enhanced = node._build_enhanced_message(user_input)
+        assert "executive_sales" in enhanced
+        assert "executive_sales.yml" in enhanced
+        assert "main.orders" in enhanced
+        assert "main.customers" in enhanced
 
 
 class TestGetSystemPrompt:

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -16,6 +16,7 @@ from datus.agent.node.semantic_authoring import (
     osi_semantic_models_cover_tables,
     required_authoring_skills,
     resolve_authoring_format,
+    resolve_existing_osi_semantic_model,
     resolve_osi_semantic_model_target,
     resolve_semantic_adapter_type,
 )
@@ -251,6 +252,69 @@ def test_osi_model_coverage_requires_one_model_to_cover_the_table_group(tmp_path
     assert osi_semantic_models_cover_tables(config, ["finance.fact_payments"])
     assert not osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "finance.fact_payments"])
     assert not osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "support.fact_tickets"])
+
+
+def test_existing_osi_metric_target_uses_dataset_mentioned_in_request(tmp_path):
+    config = _osi_config(tmp_path)
+    school_file = _write_osi_model(
+        tmp_path,
+        "school-domain.yaml",
+        "school_operations",
+        [{"name": "schools", "source": "education.schools"}],
+    )
+    _write_osi_model(
+        tmp_path,
+        "sales.yml",
+        "sales",
+        [{"name": "orders", "source": "commerce.orders"}],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(
+        config,
+        request_text="Generate enrollment metrics from schools",
+    )
+
+    assert resolution["status"] == "found"
+    assert resolution["selected"]["semantic_model_name"] == "school_operations"
+    assert resolution["selected"]["absolute_path"] == str(school_file)
+
+
+def test_existing_osi_metric_target_is_ambiguous_without_dataset_hint(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(tmp_path, "schools.yml", "schools", [{"name": "schools", "source": "edu.schools"}])
+    _write_osi_model(tmp_path, "sales.yml", "sales", [{"name": "orders", "source": "sales.orders"}])
+
+    resolution = resolve_existing_osi_semantic_model(config, request_text="Generate metrics")
+
+    assert resolution["status"] == "ambiguous"
+    assert {model["semantic_model_name"] for model in resolution["candidates"]} == {"schools", "sales"}
+
+
+def test_existing_osi_metric_target_does_not_reuse_unrelated_single_model(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(tmp_path, "sales.yml", "sales", [{"name": "orders", "source": "sales.orders"}])
+
+    resolution = resolve_existing_osi_semantic_model(
+        config,
+        request_text="Generate total amount from payments",
+    )
+
+    assert resolution["status"] == "missing"
+    assert resolution["referenced_tables"] == ["payments"]
+
+
+def test_existing_osi_metric_target_rejects_tables_split_across_models(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(tmp_path, "schools.yml", "schools", [{"name": "schools", "source": "edu.schools"}])
+    _write_osi_model(tmp_path, "sales.yml", "sales", [{"name": "orders", "source": "sales.orders"}])
+
+    resolution = resolve_existing_osi_semantic_model(
+        config,
+        referenced_tables=["edu.schools", "sales.orders"],
+    )
+
+    assert resolution["status"] == "ambiguous"
+    assert resolution["reason"] == "referenced datasets are split across multiple semantic models"
 
 
 def test_osi_target_creates_a_different_file_for_an_unrelated_fact(tmp_path):

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -630,8 +630,6 @@ class TestEnsureSemanticModelsForMetrics:
             current_datasource="warehouse",
             resolve_semantic_adapter=lambda requested=None: "osi",
         )
-        semantic_rag = MagicMock()
-        semantic_rag.get_size.return_value = 0
         action_callback = MagicMock()
         captured = {}
 
@@ -646,7 +644,6 @@ class TestEnsureSemanticModelsForMetrics:
             return True, ""
 
         with (
-            patch("datus.storage.semantic_model.store.SemanticModelRAG", return_value=semantic_rag),
             patch(
                 "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
                 side_effect=fake_init,
@@ -703,8 +700,6 @@ class TestEnsureSemanticModelsForMetrics:
             current_datasource="warehouse",
             resolve_semantic_adapter=lambda requested=None: "osi",
         )
-        semantic_rag = MagicMock()
-        semantic_rag.get_size.return_value = 2
         sql_list = [
             "SELECT COUNT(*) FROM analytics.fact_orders",
             "SELECT SUM(amount) FROM finance.fact_payments",
@@ -717,7 +712,6 @@ class TestEnsureSemanticModelsForMetrics:
             return ["finance.fact_payments"]
 
         with (
-            patch("datus.storage.semantic_model.store.SemanticModelRAG", return_value=semantic_rag),
             patch(
                 "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async"
             ) as init_mock,

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -794,27 +794,62 @@ class TestTaskExecution:
         assert result.success == 0
         assert result.result["code"] == "semantic_model_required"
         assert result.result["required_subagent"] == "gen_semantic_model"
+        assert result.result["semantic_model_directory"].endswith("subject/semantic_models/test_db")
         assert result.result["retry_subagent"] == "gen_metrics"
         execute_node.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_osi_gen_metrics_accepts_any_discovered_model_in_the_datasource(self, task_tool, tmp_path):
+    async def test_osi_gen_metrics_selects_discovered_model_by_dataset(self, task_tool, tmp_path):
         task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
         task_tool.agent_config.current_datasource = "test_db"
         task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
-        target = tmp_path / "subject" / "semantic_models" / "test_db" / "orders_analytics.yml"
-        target.parent.mkdir(parents=True)
-        target.write_text(
-            "version: 0.2.0.dev0\nsemantic_model:\n  - name: orders_analytics\n    datasets: []\n",
-            encoding="utf-8",
-        )
+        model_dir = tmp_path / "subject" / "semantic_models" / "test_db"
+        model_dir.mkdir(parents=True)
+        for name, dataset in (("orders_analytics", "orders"), ("support", "tickets")):
+            (model_dir / f"{name}.yml").write_text(
+                "version: 0.2.0.dev0\n"
+                "semantic_model:\n"
+                f"  - name: {name}\n"
+                "    datasets:\n"
+                f"      - name: {dataset}\n"
+                f"        source: main.{dataset}\n",
+                encoding="utf-8",
+            )
         expected = FuncToolResult(result={"response": "generated"})
 
         with patch.object(task_tool, "_execute_node", return_value=expected) as execute_node:
-            result = await task_tool.task(type="gen_metrics", prompt="Generate order count")
+            result = await task_tool.task(type="gen_metrics", prompt="Generate order count from orders")
 
         assert result is expected
         execute_node.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_osi_gen_metrics_reports_ambiguous_model_candidates(self, task_tool, tmp_path):
+        task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
+        task_tool.agent_config.current_datasource = "test_db"
+        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
+        model_dir = tmp_path / "subject" / "semantic_models" / "test_db"
+        model_dir.mkdir(parents=True)
+        for name, dataset in (("orders", "orders"), ("support", "tickets")):
+            (model_dir / f"{name}.yml").write_text(
+                "semantic_model:\n"
+                f"  - name: {name}\n"
+                "    datasets:\n"
+                f"      - name: {dataset}\n"
+                f"        source: main.{dataset}\n",
+                encoding="utf-8",
+            )
+
+        with patch.object(task_tool, "_execute_node") as execute_node:
+            result = await task_tool.task(type="gen_metrics", prompt="Generate metrics")
+
+        assert result.success == 0
+        assert result.result["code"] == "semantic_model_selection_required"
+        assert {candidate["semantic_model_name"] for candidate in result.result["candidates"]} == {
+            "orders",
+            "support",
+        }
+        execute_node.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_semantic_authoring_tasks_are_serialized_across_tool_instances(
@@ -834,9 +869,9 @@ class TestTaskExecution:
             return FuncToolResult(result={"subagent_type": subagent_type})
 
         monkeypatch.setattr(task_tool, "_execute_node", fake_execute)
-        monkeypatch.setattr(task_tool, "_osi_metric_precondition", lambda: None)
+        monkeypatch.setattr(task_tool, "_osi_metric_precondition", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(metrics_tool, "_execute_node", fake_execute)
-        monkeypatch.setattr(metrics_tool, "_osi_metric_precondition", lambda: None)
+        monkeypatch.setattr(metrics_tool, "_osi_metric_precondition", lambda *_args, **_kwargs: None)
 
         semantic_result, metrics_result = await asyncio.gather(
             task_tool.task(type="gen_semantic_model", prompt="Generate the sales model"),
@@ -846,6 +881,26 @@ class TestTaskExecution:
         assert semantic_result.success == 1
         assert metrics_result.success == 1
         assert max_active == 1
+
+    @pytest.mark.asyncio
+    async def test_semantic_authoring_guard_is_reentrant_for_nested_subagent(self, task_tool, monkeypatch, tmp_path):
+        from datus.agent.node.semantic_authoring import semantic_authoring_guard
+
+        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
+
+        async def fake_execute(subagent_type, prompt, **kwargs):
+            return FuncToolResult(result={"subagent_type": subagent_type})
+
+        monkeypatch.setattr(task_tool, "_execute_node", fake_execute)
+
+        async with semantic_authoring_guard(task_tool.agent_config):
+            result = await asyncio.wait_for(
+                task_tool.task(type="gen_semantic_model", prompt="Generate the sales model"),
+                timeout=0.5,
+            )
+
+        assert result.success == 1
+        assert result.result["subagent_type"] == "gen_semantic_model"
 
     @pytest.mark.asyncio
     async def test_execute_gen_sql_success(self, task_tool):


### PR DESCRIPTION
## Summary

- resolve an existing Ossie semantic model from source YAML before metric authoring
- when gen_metrics is selected directly and no model exists, let the host invoke gen_semantic_model first, then resume metric generation without exposing arbitrary subagent tools to the LLM
- keep semantic-model targets request-scoped so resumed sessions can switch models without reusing a stale cached system-prompt target
- serialize semantic authoring and require the post-bootstrap model to be resolvable before continuing
- use filesystem artifacts rather than stale semantic-store rows when deciding whether bootstrap is required

## Root cause

gen_metrics assumed an Ossie semantic model already existed. Directly selecting it therefore stopped instead of bootstrapping the prerequisite model. In addition, target details were rendered into the persisted system-prompt snapshot, so a later turn in the same session could keep using the previous model.

## Validation

- 441 focused unit tests passed
- Ruff checks passed
- local StarRocks E2E with datus-semantic-osi 0.1.3 passed: empty project to semantic-model generation to metric generation and KB sync
- same-session multi-model switch passed and wrote the second metric only to the selected model

Linear: DAT-23

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically finds and reuses applicable OSI semantic models for metric requests.
  * Creates prerequisite semantic models when none are available.
  * Adds clear handling for ambiguous, missing, or failed semantic-model selection.
  * Preserves semantic-model context separately for each request.

* **Bug Fixes**
  * Prevents unrelated or incomplete semantic models from being reused.
  * Improves reliability when multiple authoring tasks run concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->