### PR TITLE
[BugFix] Trace native Claude model calls

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -33,6 +33,13 @@ from datus.configuration.agent_config import ModelConfig
 from datus.models.litellm_adapter import is_official_anthropic_endpoint
 from datus.models.mcp_utils import multiple_mcp_servers
 from datus.models.openai_compatible import OpenAICompatibleModel
+from datus.observability.native_agents import (
+    capture_native_trace_content,
+    finish_native_span,
+    start_native_generation_span,
+    start_native_tool_span,
+    trace_native_agent_stream,
+)
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
 from datus.schemas.tool_summary import detect_tool_failure
@@ -41,7 +48,6 @@ from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_sql_type
 from datus.utils.ssl_utils import is_ssl_cert_verification_error
-from datus.utils.traceable_utils import optional_traceable
 
 logger = get_logger(__name__)
 
@@ -58,6 +64,75 @@ class _ToolResult:
     """Lightweight stand-in for MCP CallToolResult (`.content[0].text`)."""
 
     content: List[_ToolResultPart] = field(default_factory=list)
+
+
+def _anthropic_trace_input(request_kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Normalize an Anthropic request into the chat-message shape used by Agents tracing."""
+    trace_messages: List[Dict[str, Any]] = []
+    system = request_kwargs.get("system")
+    if system is not None and system is not anthropic.NOT_GIVEN:
+        trace_messages.append({"role": "system", "content": copy.deepcopy(system)})
+    messages = request_kwargs.get("messages") or []
+    if isinstance(messages, list):
+        trace_messages.extend(copy.deepcopy(message) for message in messages if isinstance(message, dict))
+    return trace_messages
+
+
+def _anthropic_trace_output(response: Any) -> List[Dict[str, Any]]:
+    """Normalize Anthropic content blocks for ``GenerationSpanData.output``."""
+    text_parts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+    for block in getattr(response, "content", None) or []:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            text = getattr(block, "text", "") or ""
+            if text:
+                text_parts.append(text)
+        elif block_type in ("tool_use", "server_tool_use"):
+            tool_input = getattr(block, "input", None) or {}
+            tool_calls.append(
+                {
+                    "id": str(getattr(block, "id", None) or ""),
+                    "type": "function",
+                    "function": {
+                        "name": str(getattr(block, "name", None) or block_type),
+                        "arguments": json.dumps(tool_input, ensure_ascii=False, default=str),
+                    },
+                }
+            )
+    output: Dict[str, Any] = {"role": "assistant", "content": "\n".join(text_parts)}
+    if tool_calls:
+        output["tool_calls"] = tool_calls
+    return [output]
+
+
+def _anthropic_trace_usage(response: Any) -> Dict[str, int]:
+    """Return per-call token usage, including Anthropic prompt-cache tokens."""
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return {}
+    fresh_input = int(getattr(usage, "input_tokens", 0) or 0)
+    cache_read = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+    cache_write = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
+    output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    input_tokens = fresh_input + cache_read + cache_write
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "cache_read_input_tokens": cache_read,
+        "cache_creation_input_tokens": cache_write,
+    }
+
+
+def _anthropic_trace_model_config(request_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep only non-content invocation parameters on the generation span."""
+    config: Dict[str, Any] = {"provider": "anthropic", "system": "anthropic"}
+    for key in ("max_tokens", "temperature", "top_p", "top_k"):
+        value = request_kwargs.get(key)
+        if value is not None and value is not anthropic.NOT_GIVEN:
+            config[key] = value
+    return config
 
 
 def wrap_prompt_cache(messages):
@@ -435,14 +510,12 @@ class ClaudeModel(OpenAICompatibleModel):
 
         return system_message if system_message else anthropic.NOT_GIVEN
 
-    @optional_traceable(name="anthropic_messages_create", run_type="llm")
     def _anthropic_messages_create(self, **kwargs):
         """Call the correct Anthropic Messages endpoint for the current auth mode."""
         if self._is_oauth_token:
             return self.anthropic_client.beta.messages.create(**kwargs)
         return self.anthropic_client.messages.create(**kwargs)
 
-    @optional_traceable(name="anthropic_messages_stream", run_type="llm")
     def _anthropic_messages_stream(self, **kwargs):
         """Return an async context manager that streams Anthropic Messages events.
 
@@ -451,11 +524,9 @@ class ClaudeModel(OpenAICompatibleModel):
         ``messages.stream`` for standard API-key auth. Caller enters via
         ``async with self._anthropic_messages_stream(...) as stream:``.
 
-        Note: ``optional_traceable`` here records the call returning the
-        context manager. For ``messages.stream`` langsmith's ``wrap_anthropic``
-        additionally instruments per-event iteration; ``beta.messages.stream``
-        is not wrapped upstream, so this decorator is the only tracing the
-        OAuth path gets.
+        The surrounding native-agent loop owns the generation span so tracing
+        covers the full stream iteration instead of only this context-manager
+        factory call.
         """
         if self.async_anthropic_client is None:
             raise DatusException(
@@ -587,6 +658,7 @@ class ClaudeModel(OpenAICompatibleModel):
             logger.error(f"Error generating with Anthropic: {str(e)}")
             raise
 
+    @trace_native_agent_stream
     async def _generate_with_mcp_stream(
         self,
         prompt: Union[str, List[Dict[str, str]]],
@@ -616,6 +688,9 @@ class ClaudeModel(OpenAICompatibleModel):
         self._setup_custom_json_encoder()
 
         logger.debug(f"Using native Anthropic API with prompt caching, model: {self.model_name}")
+        active_generation_span = None
+        active_tool_span = None
+        trace_failure: BaseException | None = None
         try:
             all_tools = []
 
@@ -756,6 +831,12 @@ class ClaudeModel(OpenAICompatibleModel):
                         tools=tools,
                         max_tokens=kwargs.get("max_tokens") or self.max_tokens() or 20480,
                         temperature=kwargs.get("temperature", anthropic.NOT_GIVEN),
+                    )
+                    generation_input = capture_native_trace_content("prompts", _anthropic_trace_input(request_kwargs))
+                    active_generation_span = start_native_generation_span(
+                        input_messages=generation_input,
+                        model=self.model_name,
+                        model_config=_anthropic_trace_model_config(request_kwargs),
                     )
 
                     # Track server-side web tool calls emitted in real time during
@@ -935,6 +1016,11 @@ class ClaudeModel(OpenAICompatibleModel):
                         )
                         await self._invoke_hook(hooks, "on_llm_end", run_ctx, hook_agent, response)
 
+                    active_generation_span.span_data.usage = _anthropic_trace_usage(response)
+                    generation_output = capture_native_trace_content("responses", _anthropic_trace_output(response))
+                    finish_native_span(active_generation_span, output=generation_output)
+                    active_generation_span = None
+
                     message = response.content
 
                     # Surface server-side tool calls (Anthropic web_search /
@@ -1072,6 +1158,11 @@ class ClaudeModel(OpenAICompatibleModel):
                                 or mcp_tool_objs.get(block.name)
                                 or SimpleNamespace(name=block.name)
                             )
+                            active_tool_span = start_native_tool_span(
+                                name=block.name,
+                                tool_call_id=block.id,
+                                input_value=block.input,
+                            )
                             await self._invoke_hook(hooks, "on_tool_start", tool_ctx, hook_agent, tool_obj)
 
                             tool_executed = False
@@ -1178,6 +1269,16 @@ class ClaudeModel(OpenAICompatibleModel):
                                 tool_obj,
                                 hook_result if tool_executed else {"success": 0, "error": result_summary},
                             )
+                            traced_tool_output = capture_native_trace_content("tool_results", tool_output)
+                            traced_tool_error = None
+                            if tool_failed:
+                                traced_tool_error = result_text or f"Tool {block.name} execution failed"
+                            finish_native_span(
+                                active_tool_span,
+                                output=traced_tool_output,
+                                error=traced_tool_error,
+                            )
+                            active_tool_span = None
 
                     # Build assistant message content from all blocks
                     content = []
@@ -1346,15 +1447,23 @@ class ClaudeModel(OpenAICompatibleModel):
                 yield final_action
 
         except anthropic.AuthenticationError as e:
+            trace_failure = e
             await self._persist_failed_turn(locals(), e)
             self._diagnose_oauth_401(e)
             raise
         except Exception as e:
+            trace_failure = e
             await self._persist_failed_turn(locals(), e)
             if is_ssl_cert_verification_error(e):
                 raise DatusException(ErrorCode.MODEL_SSL_CERT_ERROR) from e
             logger.error(f"Error in _generate_with_mcp_stream: {str(e)}")
             raise
+        except BaseException as e:
+            trace_failure = e
+            raise
+        finally:
+            finish_native_span(active_tool_span, error=trace_failure)
+            finish_native_span(active_generation_span, error=trace_failure)
 
     async def _persist_failed_turn(self, frame_locals: Dict[str, Any], error: Exception) -> None:
         """Best-effort save of an interrupted turn so the next turn isn't amnesiac.

--- a/datus/observability/native_agents.py
+++ b/datus/observability/native_agents.py
@@ -1,0 +1,235 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tracing helpers for agent loops that do not run through ``agents.Runner``."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+import json
+import sys
+from collections.abc import Mapping
+from typing import Any, AsyncGenerator, Callable
+
+from agents import agent_span, function_span, generation_span, trace
+
+from datus.observability.manager import get_observability_manager
+from datus.utils.loggings import get_logger
+from datus.utils.trace_context import build_agents_run_config_kwargs, build_trace_span_attributes
+
+logger = get_logger(__name__)
+
+
+def native_agents_tracing_enabled() -> bool:
+    """Return whether Datus has an active external tracing adapter."""
+    return bool(get_observability_manager().adapters)
+
+
+def trace_native_agent_stream(func: Callable[..., AsyncGenerator[Any, None]]):
+    """Give a custom async agent loop the same root trace shape as ``Runner``.
+
+    The OpenAI Agents SDK context managers intentionally avoid resetting their
+    context on ``GeneratorExit``. That is unsafe for a long-lived async generator,
+    so this wrapper starts and finishes the trace/span explicitly and always
+    restores both context variables when the consumer closes the stream.
+    """
+
+    signature = inspect.signature(func)
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        observability = get_observability_manager()
+        if not observability.adapters:
+            stream = func(*args, **kwargs)
+            try:
+                async for item in stream:
+                    yield item
+            finally:
+                await _close_async_stream(stream)
+            return
+
+        bound = signature.bind_partial(*args, **kwargs)
+        extra_kwargs = bound.arguments.get("kwargs") or {}
+        agent_name = str(extra_kwargs.get("agent_name") or kwargs.get("agent_name") or "Tools_Agent")
+        func_tools = bound.arguments.get("func_tools") or kwargs.get("func_tools") or []
+        tool_names = [str(tool.name) for tool in func_tools if getattr(tool, "name", None)] or None
+        output_type = _output_type_name(bound.arguments.get("output_type") or kwargs.get("output_type"))
+
+        run_config = build_agents_run_config_kwargs(agent_name=agent_name)
+        workflow_name = str(run_config.get("workflow_name") or f"agent/{agent_name}")
+        attributes = build_trace_span_attributes(operation=agent_name, run_type="llm")
+        trace_name = str(attributes.get("datus.trace.name") or workflow_name)
+        request_queue: asyncio.Queue[None] = asyncio.Queue(maxsize=1)
+        output_queue: asyncio.Queue[tuple[str, Any, Any]] = asyncio.Queue(maxsize=1)
+
+        async def produce() -> None:
+            stream = func(*args, **kwargs)
+            trace_obj = trace(
+                workflow_name=workflow_name,
+                group_id=run_config.get("group_id"),
+                metadata=run_config.get("trace_metadata"),
+            )
+            agent_obj = None
+            try:
+                with observability.trace_baggage(trace_name, attributes):
+                    trace_obj.start(mark_as_current=True)
+                    agent_obj = agent_span(name=agent_name, tools=tool_names, output_type=output_type)
+                    agent_obj.start(mark_as_current=True)
+
+                    while True:
+                        await request_queue.get()
+                        try:
+                            item = await anext(stream)
+                        except StopAsyncIteration:
+                            await output_queue.put(("done", None, None))
+                            break
+                        await output_queue.put(("item", item, None))
+            except asyncio.CancelledError:
+                raise
+            except BaseException as exc:
+                if agent_obj is not None and not isinstance(exc, GeneratorExit):
+                    agent_obj.set_error(_span_error(exc, observability))
+                await output_queue.put(("error", exc, sys.exc_info()[2]))
+            finally:
+                await _close_async_stream(stream)
+                if agent_obj is not None:
+                    try:
+                        agent_obj.finish(reset_current=True)
+                    except Exception as exc:  # pragma: no cover - processor failures are best-effort
+                        logger.debug("Failed to finish native agent span: %s", exc)
+                try:
+                    trace_obj.finish(reset_current=True)
+                except Exception as exc:  # pragma: no cover - processor failures are best-effort
+                    logger.debug("Failed to finish native agent trace: %s", exc)
+
+        producer = asyncio.create_task(produce(), name=f"datus-native-trace-{agent_name}")
+        try:
+            while True:
+                await request_queue.put(None)
+                event, payload, traceback = await output_queue.get()
+                if event == "item":
+                    yield payload
+                    continue
+                if event == "error":
+                    raise payload.with_traceback(traceback)
+                break
+        finally:
+            if not producer.done():
+                producer.cancel()
+            try:
+                await producer
+            except asyncio.CancelledError:
+                pass
+
+    return wrapper
+
+
+def start_native_generation_span(
+    *,
+    input_messages: list[dict[str, Any]] | None,
+    model: str,
+    model_config: dict[str, Any],
+):
+    """Start one model-call span under the current native agent trace."""
+    span = generation_span(
+        input=input_messages,
+        model=model,
+        model_config=model_config,
+        disabled=not native_agents_tracing_enabled(),
+    )
+    span.start(mark_as_current=True)
+    return span
+
+
+def start_native_tool_span(*, name: str, tool_call_id: str | None, input_value: Any):
+    """Start one tool-call span under the current native agent trace."""
+    captured_input = capture_native_trace_content("tool_args", input_value)
+    input_json = _json_string(captured_input) if captured_input is not None else None
+    span = function_span(name=name, input=input_json, disabled=not native_agents_tracing_enabled())
+    if tool_call_id:
+        span.span_data.mcp_data = {"tool_call_id": str(tool_call_id)}
+    span.start(mark_as_current=True)
+    return span
+
+
+def finish_native_span(span: Any, *, output: Any = None, error: BaseException | str | None = None) -> None:
+    """Finish a generation/tool span without allowing telemetry to break a run."""
+    if span is None:
+        return
+    observability = get_observability_manager()
+    try:
+        if output is not None:
+            span.span_data.output = output
+        if error is not None and not isinstance(error, GeneratorExit):
+            span.set_error(_span_error(error, observability))
+        span.finish(reset_current=True)
+    except Exception as exc:  # pragma: no cover - processor failures are best-effort
+        logger.debug("Failed to finish native agent child span: %s", exc)
+
+
+def capture_native_trace_content(field_name: str, value: Any) -> Any:
+    """Apply the shared Datus capture and redaction policy to native span data."""
+    observability = get_observability_manager()
+    if not observability.content_enabled(field_name):
+        return None
+    return _redact_embedded_json(observability.redact(value), observability)
+
+
+def _output_type_name(output_type: Any) -> str | None:
+    if output_type is None:
+        return None
+    if isinstance(output_type, type):
+        return output_type.__name__
+    if isinstance(output_type, dict):
+        return "dict"
+    return str(output_type)
+
+
+def _span_error(error: BaseException | str, observability: Any) -> dict[str, Any]:
+    if isinstance(error, BaseException):
+        message = str(error) or type(error).__name__
+        error_type = type(error).__name__
+    else:
+        message = str(error)
+        error_type = "ToolError"
+    return {
+        "message": str(observability.redact(message)),
+        "data": {"exception.type": error_type},
+    }
+
+
+def _json_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _redact_embedded_json(value: Any, observability: Any) -> Any:
+    """Redact sensitive fields inside JSON strings produced by tool protocols."""
+    if isinstance(value, Mapping):
+        return {str(key): _redact_embedded_json(item, observability) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_embedded_json(item, observability) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_embedded_json(item, observability) for item in value)
+    if not isinstance(value, str) or not value.lstrip().startswith(("{", "[")):
+        return value
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return value
+    redacted = _redact_embedded_json(observability.redact(parsed), observability)
+    return json.dumps(redacted, ensure_ascii=False, default=str)
+
+
+async def _close_async_stream(stream: Any) -> None:
+    close = getattr(stream, "aclose", None)
+    if not callable(close):
+        return
+    try:
+        await close()
+    except Exception as exc:  # pragma: no cover - cleanup is best-effort
+        logger.debug("Failed to close native agent stream: %s", exc)

--- a/datus/observability/openai_agents.py
+++ b/datus/observability/openai_agents.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, cast
 
 
@@ -83,6 +84,7 @@ class DatusOpenInferenceTracingProcessor(_OpenInferenceTracingProcessorBase):  #
 
     def on_span_end(self, span: Any) -> None:
         if span.span_id not in self._merged_root_agent_span_ids:
+            self._set_datus_span_attributes(span)
             super().on_span_end(span)
             return
 
@@ -98,6 +100,43 @@ class DatusOpenInferenceTracingProcessor(_OpenInferenceTracingProcessorBase):  #
             key = f"{data.name}:{span.trace_id}"
             if parent_node := self._reverse_handoffs_dict.pop(key, None):
                 root_span.set_attribute(_oi_processor.GRAPH_NODE_PARENT_ID, parent_node)
+
+    def _set_datus_span_attributes(self, span: Any) -> None:
+        """Add provider-neutral fields missing from the upstream Agents mapper."""
+        otel_span = self._otel_spans.get(span.span_id)
+        if otel_span is None:
+            return
+        data = span.span_data
+        if isinstance(data, _oi_processor.GenerationSpanData):
+            model_config = data.model_config if isinstance(data.model_config, Mapping) else {}
+            provider = model_config.get("provider")
+            system = model_config.get("system")
+            if isinstance(provider, str) and provider:
+                otel_span.set_attribute(_oi_processor.LLM_PROVIDER, provider)
+            if isinstance(system, str) and system:
+                otel_span.set_attribute(_oi_processor.LLM_SYSTEM, system)
+
+            usage = data.usage if isinstance(data.usage, Mapping) else {}
+            _set_numeric_attribute(
+                otel_span,
+                _oi_processor.LLM_TOKEN_COUNT_TOTAL,
+                usage.get("total_tokens"),
+            )
+            _set_numeric_attribute(
+                otel_span,
+                "llm.token_count.prompt_details.cache_read",
+                usage.get("cache_read_input_tokens"),
+            )
+            _set_numeric_attribute(
+                otel_span,
+                "llm.token_count.prompt_details.cache_write",
+                usage.get("cache_creation_input_tokens"),
+            )
+        elif isinstance(data, _oi_processor.FunctionSpanData):
+            mcp_data = data.mcp_data if isinstance(data.mcp_data, Mapping) else {}
+            tool_call_id = mcp_data.get("tool_call_id")
+            if tool_call_id:
+                otel_span.set_attribute("tool.id", str(tool_call_id))
 
     def shutdown(self) -> None:
         self._merged_root_agent_span_ids.clear()
@@ -115,3 +154,9 @@ class DatusOpenInferenceTracingProcessor(_OpenInferenceTracingProcessorBase):  #
             return False
         self._merged_root_trace_ids.add(span.trace_id)
         return True
+
+
+def _set_numeric_attribute(span: Any, key: str, value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return
+    span.set_attribute(key, value)

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -13,7 +13,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from datus.models.claude_model import ClaudeModel, convert_tools_for_anthropic, wrap_prompt_cache
+from datus.models.claude_model import (
+    ClaudeModel,
+    _anthropic_trace_input,
+    _anthropic_trace_model_config,
+    _anthropic_trace_output,
+    _anthropic_trace_usage,
+    convert_tools_for_anthropic,
+    wrap_prompt_cache,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -103,6 +111,55 @@ class TestWrapPromptCache:
         result = wrap_prompt_cache(messages)
         # String content should remain unchanged (not list, so no cache_control added)
         assert result[-1]["content"] == "plain string"
+
+
+class TestAnthropicTraceNormalization:
+    def test_normalizes_input_output_and_usage_without_mutating_request(self):
+        request = {
+            "system": [{"type": "text", "text": "system"}],
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+            "max_tokens": 2048,
+            "temperature": 0.2,
+        }
+        response = _make_response(
+            [
+                _make_text_block("working"),
+                _make_tool_use_block("sync_semantic", "toolu_1", {"model": "orders"}),
+            ],
+            input_tokens=5,
+            output_tokens=7,
+        )
+        response.usage.cache_read_input_tokens = 100
+        response.usage.cache_creation_input_tokens = 20
+
+        traced_input = _anthropic_trace_input(request)
+        traced_output = _anthropic_trace_output(response)
+
+        assert traced_input[0] == {"role": "system", "content": [{"type": "text", "text": "system"}]}
+        assert traced_input[1]["role"] == "user"
+        traced_input[1]["content"][0]["text"] = "changed"
+        assert request["messages"][0]["content"][0]["text"] == "hello"
+        assert traced_output[0]["content"] == "working"
+        assert traced_output[0]["tool_calls"] == [
+            {
+                "id": "toolu_1",
+                "type": "function",
+                "function": {"name": "sync_semantic", "arguments": '{"model": "orders"}'},
+            }
+        ]
+        assert _anthropic_trace_usage(response) == {
+            "input_tokens": 125,
+            "output_tokens": 7,
+            "total_tokens": 132,
+            "cache_read_input_tokens": 100,
+            "cache_creation_input_tokens": 20,
+        }
+        assert _anthropic_trace_model_config(request) == {
+            "provider": "anthropic",
+            "system": "anthropic",
+            "max_tokens": 2048,
+            "temperature": 0.2,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/observability/test_native_agents.py
+++ b/tests/unit_tests/observability/test_native_agents.py
@@ -1,0 +1,220 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from agents.tracing.provider import DefaultTraceProvider
+from agents.tracing.setup import get_trace_provider, set_trace_provider
+from openinference.instrumentation import OITracer, TraceConfig
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from datus.observability.adapters.langfuse import _LangfuseBaggageSpanProcessor
+from datus.observability.adapters.otlp import _BaggageAttributeSpanProcessor
+from datus.observability.config import TracingConfig
+from datus.observability.manager import ObservabilityManager
+from datus.observability.native_agents import (
+    capture_native_trace_content,
+    finish_native_span,
+    start_native_generation_span,
+    start_native_tool_span,
+    trace_native_agent_stream,
+)
+from datus.observability.openai_agents import DatusOpenInferenceTracingProcessor
+from datus.utils.trace_context import TraceContext, trace_context
+
+
+@pytest.mark.asyncio
+async def test_native_agent_stream_exports_agent_generation_tool_tree(monkeypatch):
+    exporter = InMemorySpanExporter()
+    otel_provider = TracerProvider()
+    otel_provider.add_span_processor(_BaggageAttributeSpanProcessor())
+    otel_provider.add_span_processor(_LangfuseBaggageSpanProcessor())
+    otel_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    oi_tracer = OITracer(otel_provider.get_tracer(__name__), config=TraceConfig())
+    processor = DatusOpenInferenceTracingProcessor(oi_tracer)
+
+    agents_provider = DefaultTraceProvider()
+    agents_provider.set_processors([processor])
+    previous_agents_provider = get_trace_provider()
+    set_trace_provider(agents_provider)
+
+    observability = ObservabilityManager()
+    observability._adapters = [object()]
+    observability._tracing_config = TracingConfig(enabled=True)
+    monkeypatch.setattr(
+        "datus.observability.native_agents.get_observability_manager",
+        lambda: observability,
+    )
+
+    @trace_native_agent_stream
+    async def native_loop(self, prompt, func_tools=None, output_type=dict, **kwargs):
+        generation = start_native_generation_span(
+            input_messages=capture_native_trace_content(
+                "prompts",
+                [{"role": "user", "content": prompt, "api_key": "must-not-leak"}],
+            ),
+            model="custom/sonnet",
+            model_config={"provider": "anthropic", "system": "anthropic", "max_tokens": 1024},
+        )
+        generation.span_data.usage = {
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "total_tokens": 150,
+            "cache_read_input_tokens": 100,
+            "cache_creation_input_tokens": 10,
+        }
+        finish_native_span(
+            generation,
+            output=capture_native_trace_content(
+                "responses",
+                [{"role": "assistant", "content": "calling sync_semantic"}],
+            ),
+        )
+
+        tool = start_native_tool_span(
+            name="sync_semantic",
+            tool_call_id="toolu_123",
+            input_value={"semantic_model": "orders", "token": "must-not-leak"},
+        )
+        finish_native_span(
+            tool,
+            output=capture_native_trace_content("tool_results", {"success": True}),
+        )
+        failed_tool = start_native_tool_span(
+            name="end_semantic_model_generation",
+            tool_call_id="toolu_456",
+            input_value={"semantic_model": "orders"},
+        )
+        finish_native_span(
+            failed_tool,
+            output=capture_native_trace_content("tool_results", {"success": False, "error": "sync failed"}),
+            error="sync failed",
+        )
+        yield "done"
+
+    ctx = TraceContext(
+        name="agent/gen_metrics",
+        session_id="gen_metrics_session_test",
+        user_id="user-1",
+    )
+    try:
+        with trace_context(ctx):
+            items = [
+                item
+                async for item in native_loop(
+                    object(),
+                    "build metrics",
+                    func_tools=[SimpleNamespace(name="sync_semantic")],
+                    agent_name="gen_metrics",
+                )
+            ]
+        assert items == ["done"]
+        assert agents_provider.get_current_trace() is None
+        assert agents_provider.get_current_span() is None
+    finally:
+        set_trace_provider(previous_agents_provider)
+        agents_provider.shutdown()
+
+    spans = exporter.get_finished_spans()
+    otel_provider.shutdown()
+    span_by_name = {span.name: span for span in spans}
+
+    assert sorted(span_by_name) == [
+        "agent/gen_metrics",
+        "end_semantic_model_generation",
+        "generation",
+        "sync_semantic",
+    ]
+    root = span_by_name["agent/gen_metrics"]
+    generation = span_by_name["generation"]
+    tool = span_by_name["sync_semantic"]
+
+    assert root.attributes["openinference.span.kind"] == "AGENT"
+    assert root.attributes["langfuse.session.id"] == "gen_metrics_session_test"
+    assert generation.parent.span_id == root.context.span_id
+    assert generation.attributes["openinference.span.kind"] == "LLM"
+    assert generation.attributes["llm.model_name"] == "custom/sonnet"
+    assert generation.attributes["llm.provider"] == "anthropic"
+    assert generation.attributes["llm.system"] == "anthropic"
+    assert generation.attributes["llm.token_count.prompt"] == 120
+    assert generation.attributes["llm.token_count.completion"] == 30
+    assert generation.attributes["llm.token_count.total"] == 150
+    assert generation.attributes["llm.token_count.prompt_details.cache_read"] == 100
+    assert generation.attributes["llm.token_count.prompt_details.cache_write"] == 10
+    assert "[REDACTED]" in generation.attributes["input.value"]
+    assert "must-not-leak" not in generation.attributes["input.value"]
+
+    assert tool.parent.span_id == root.context.span_id
+    assert tool.attributes["openinference.span.kind"] == "TOOL"
+    assert tool.attributes["tool.id"] == "toolu_123"
+    assert "[REDACTED]" in tool.attributes["input.value"]
+    assert "must-not-leak" not in tool.attributes["input.value"]
+    assert tool.attributes["output.value"] == '{"success": true}'
+    failed_tool = span_by_name["end_semantic_model_generation"]
+    assert failed_tool.parent.span_id == root.context.span_id
+    assert failed_tool.status.status_code.name == "ERROR"
+    assert failed_tool.attributes["output.value"] == '{"success": false, "error": "sync failed"}'
+
+
+def test_native_trace_content_honors_per_field_capture(monkeypatch):
+    observability = ObservabilityManager()
+    observability._adapters = [object()]
+    observability._tracing_config = TracingConfig.from_dict(
+        {
+            "enabled": True,
+            "capture_content": True,
+            "capture": {"prompts": False, "tool_args": False},
+        }
+    )
+    monkeypatch.setattr(
+        "datus.observability.native_agents.get_observability_manager",
+        lambda: observability,
+    )
+
+    assert capture_native_trace_content("prompts", "hidden") is None
+    assert capture_native_trace_content("tool_args", {"query": "hidden"}) is None
+    assert capture_native_trace_content("responses", "visible") == "visible"
+    assert capture_native_trace_content(
+        "responses",
+        {"tool_calls": [{"function": {"arguments": '{"token": "hidden", "model": "orders"}'}}]},
+    ) == {"tool_calls": [{"function": {"arguments": '{"token": "[REDACTED]", "model": "orders"}'}}]}
+
+
+@pytest.mark.asyncio
+async def test_native_agent_stream_resets_context_when_consumer_closes(monkeypatch):
+    observability = ObservabilityManager()
+    observability._adapters = [object()]
+    observability._tracing_config = TracingConfig(enabled=True)
+    monkeypatch.setattr(
+        "datus.observability.native_agents.get_observability_manager",
+        lambda: observability,
+    )
+
+    agents_provider = DefaultTraceProvider()
+    previous_agents_provider = get_trace_provider()
+    set_trace_provider(agents_provider)
+
+    @trace_native_agent_stream
+    async def native_loop(self, **kwargs):
+        yield "first"
+        yield "second"
+
+    stream = native_loop(object(), agent_name="chat")
+    try:
+        assert await anext(stream) == "first"
+        # The traced loop runs in a dedicated producer task, so SDK/OTel context
+        # tokens never leak into the consumer and can be closed from another task.
+        assert agents_provider.get_current_trace() is None
+        assert agents_provider.get_current_span() is None
+        await asyncio.create_task(stream.aclose())
+        assert agents_provider.get_current_trace() is None
+        assert agents_provider.get_current_span() is None
+    finally:
+        await stream.aclose()
+        set_trace_provider(previous_agents_provider)
+        agents_provider.shutdown()


### PR DESCRIPTION
## Summary

- add OpenAI Agents-compatible tracing around the native Anthropic/Claude tool loop
- export Claude model calls as generation spans with request/response content, model metadata, token usage, and prompt-cache usage
- export function and MCP calls as tool spans with inputs, outputs, tool call IDs, and error status
- preserve Datus capture/redaction controls and isolate tracing context for async stream cleanup
- enrich OpenInference spans with provider-neutral Claude usage and tool attributes

## Root cause

Claude subscription traffic uses the native Anthropic streaming loop instead of `agents.Runner`. The existing decorators only observed the method that returned the stream context manager, so Langfuse did not receive the same agent/generation/tool hierarchy or model and tool I/O that other model paths export.

## Impact

Claude runs now produce the same trace shape as other providers:

```text
AGENT
├── GENERATION
└── TOOL
```

This makes failures in tools such as `sync_semantic`, `validate_semantic`, and `end_semantic_model_generation` visible with their inputs and outputs. Existing content capture and redaction settings continue to apply.

## Validation

- `uv run pytest tests/unit_tests/models/test_claude_model.py tests/unit_tests/observability -q` — 170 passed
- `uv run ruff format --check ...` — passed
- `uv run ruff check ...` — passed
- live SaaS dev export verified with `bootstrap-kb`: trace `be84e176f80b3ac86d189c1445217dfa` contained the root bootstrap span, the semantic generation agent, 14 Claude generation spans, and 17 tool spans with linked I/O; the run was deliberately interrupted after trace verification to limit model usage

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced tracing for Claude model responses, tool calls, token usage, and errors.
  * Added native agent tracing for streamed interactions, including generation and tool-call spans.
  * Added redaction controls for sensitive tracing content.
  * Improved exported observability metadata, including provider, model, token, cache, and tool details.

* **Bug Fixes**
  * Improved cleanup and context handling when streamed interactions end early or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->