### PR TITLE
[Feature] Fine-grained execute_sql permissions by SQL statement class

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -82,7 +82,8 @@ agent:
   #
   # Profiles:
   #   normal    — Read-only allowed; all writes prompt; named destructive deny
-  #   auto      — Normal + workspace writes auto; DB writes + destructives prompt (not deny)
+  #   auto      — Normal + workspace writes auto + SQL non-destructive writes
+  #               auto; destructive SQL (UPDATE/DELETE/DROP/...) prompts (not deny)
   #   dangerous — Nearly everything auto (writes outside workspace still prompt)
   #
   # User rules in ``rules:`` are evaluated after the profile base, so they
@@ -126,6 +127,27 @@ agent:
   #   # plugin ``ask`` rule can be relaxed per project via the prompt's
   #   # "allow (project)" choice (or a matching ``bash_allow`` entry in
   #   # ``.datus/config.yml``): an exact-match grant auto-runs that pattern.
+  #   #
+  #   # Per-class SQL statement rules for ``execute_sql`` (optional; profile
+  #   # defaults apply when omitted). The statement is classified into a kind
+  #   # and gated by its class:
+  #   #   read        — SELECT / SHOW / DESCRIBE / EXPLAIN
+  #   #   write       — INSERT, CREATE, benign DDL (COMMENT/GRANT/ANALYZE/...),
+  #   #                 USE/SET/CALL. NOTE: CALL/EXEC can run arbitrary stored
+  #   #                 procedures — set ``write: ask`` if that matters to you.
+  #   #   destructive — UPDATE, DELETE, MERGE, DROP, TRUNCATE, ALTER, REPLACE
+  #   #   unknown     — unparseable SQL (fail-safe)
+  #   # Profile defaults: normal = read allow, rest ask; auto = read+write
+  #   # allow, destructive/unknown ask; dangerous = everything allow.
+  #   # The confirmation prompt offers once / session / project scopes;
+  #   # "project" appends the statement kind (e.g. ``drop``) to
+  #   # ``.datus/config.yml``'s ``sql_allow`` list, which auto-allows that
+  #   # exact kind in this project from then on.
+  #   # sql_statements:
+  #   #   read: allow
+  #   #   write: ask
+  #   #   destructive: ask
+  #   #   unknown: ask
 
 
   nodes:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2258,6 +2258,7 @@ class AgenticNode(Node):
                 active_profile=active_profile,
                 plugin_bash_rules=getattr(self.agent_config, "plugin_bash_rules", None),
                 project_bash_allows=getattr(self.agent_config, "project_bash_allow", None),
+                project_sql_allows=getattr(self.agent_config, "project_sql_allow", None),
             )
             # Forward existing callback to permission manager
             if self._permission_callback:

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -231,6 +231,7 @@ class ChatAgenticNode(AgenticNode):
                 active_profile=getattr(self.agent_config, "active_profile_name", None) or "normal",
                 plugin_bash_rules=getattr(self.agent_config, "plugin_bash_rules", None),
                 project_bash_allows=getattr(self.agent_config, "project_bash_allow", None),
+                project_sql_allows=getattr(self.agent_config, "project_sql_allow", None),
             )
             self.permission_manager.set_permission_callback(self._handle_permission_ask)
 

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -986,6 +986,13 @@ class AgentConfig:
             if isinstance(raw_project_bash_allow, list)
             else []
         )
+        # Raw project-scope SQL grants (``.datus/config.yml`` sql_allow),
+        # forwarded by ``_apply_project_override``. Exact-match statement
+        # kinds the execute_sql permission gate auto-allows for this project.
+        raw_project_sql_allow = kwargs.get("project_sql_allow")
+        self.project_sql_allow: List[str] = (
+            [k for k in raw_project_sql_allow if isinstance(k, str)] if isinstance(raw_project_sql_allow, list) else []
+        )
 
         for name, raw_config in self.agentic_nodes.items():
             if not _SAFE_NAME_RE.match(name):

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -349,6 +349,12 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         # ask-rule hit (e.g. a plugin-declared ask persisted via the
         # "allow (project)" prompt choice).
         agent_raw["project_bash_allow"] = list(override.bash_allow)
+    if override.sql_allow:
+        # Unlike bash_allow, SQL grants are NOT merged into ``permissions.*``:
+        # the execute_sql gate resolves statement classes dynamically, so a
+        # static rule cannot express a per-kind grant. The raw kind list feeds
+        # PermissionManager's exact-match grant set only.
+        agent_raw["project_sql_allow"] = list(override.sql_allow)
     # ``dashboard`` / ``scheduler`` overrides reach AgentConfig through
     # dedicated kwargs so the project-level pin is consulted between the
     # explicit call-site argument and the global default flag at lookup

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -49,6 +49,13 @@ pin a handful of values without copying the full config:
   ``agent.permissions.bash_commands.allow`` at load time. Written by the
   "allow (project)" choice in the bash permission prompt via
   :func:`append_project_bash_allow`.
+- ``sql_allow``: list of SQL statement kinds (``insert``, ``drop``, ... —
+  see ``parse_sql_statement_kind`` in ``datus/utils/sql_utils.py``) that the
+  ``execute_sql`` permission gate auto-allows for this project. Unlike
+  ``bash_allow`` these are NOT merged into ``permissions`` rules; they feed
+  ``PermissionManager``'s exact-match grant set only. Written by the
+  "allow (project)" choice in the SQL permission prompt via
+  :func:`append_project_sql_allow`.
 
 Any other keys in the file are ignored with a warning so users do not
 mistakenly expect the overlay to accept arbitrary YAML.
@@ -80,6 +87,7 @@ ALLOWED_KEYS = frozenset(
         "language",
         "reasoning_effort",
         "bash_allow",
+        "sql_allow",
     }
 )
 REASONING_EFFORT_CHOICES = frozenset({"off", "minimal", "low", "medium", "high"})
@@ -140,6 +148,7 @@ class ProjectOverride:
     language: Optional[str] = None
     reasoning_effort: Optional[str] = None
     bash_allow: Optional[list] = None
+    sql_allow: Optional[list] = None
 
     def is_empty(self) -> bool:
         return (
@@ -153,6 +162,7 @@ class ProjectOverride:
             and self.language is None
             and self.reasoning_effort is None
             and self.bash_allow is None
+            and self.sql_allow is None
         )
 
 
@@ -230,6 +240,7 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         language=raw.get("language"),
         reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
         bash_allow=_parse_bash_allow(raw.get("bash_allow")),
+        sql_allow=_parse_sql_allow(raw.get("sql_allow")),
     )
 
 
@@ -251,6 +262,30 @@ def _parse_bash_allow(raw: Any) -> Optional[list]:
         else:
             logger.warning(f"Ignoring non-string bash_allow entry: {entry!r}")
     return patterns or None
+
+
+def _parse_sql_allow(raw: Any) -> Optional[list]:
+    """Normalize the ``sql_allow:`` field into a list of statement kinds.
+
+    Kinds are lower-cased for exact matching against
+    ``parse_sql_statement_kind`` output. Non-list values and non-string
+    entries are dropped with a warning; unrecognized kind strings are kept
+    (they are inert — nothing ever produces them — so they can never widen
+    the grant set, and dropping them would silently discard a future kind
+    after a downgrade).
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        logger.warning(f"sql_allow must be a list of strings, got {type(raw).__name__}. Ignoring.")
+        return None
+    kinds = []
+    for entry in raw:
+        if isinstance(entry, str) and entry.strip():
+            kinds.append(entry.strip().lower())
+        else:
+            logger.warning(f"Ignoring non-string sql_allow entry: {entry!r}")
+    return kinds or None
 
 
 def _parse_optional_string(raw: Any, *, key: str) -> Optional[str]:
@@ -437,6 +472,7 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
             "language": override.language,
             "reasoning_effort": override.reasoning_effort,
             "bash_allow": override.bash_allow,
+            "sql_allow": override.sql_allow,
         }.items()
         if v is not None
     }
@@ -445,18 +481,66 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
     return path
 
 
-def append_project_bash_allow(pattern: str, cwd: Optional[str] = None) -> Path:
-    """Append a bash allow pattern to ``./.datus/config.yml``'s ``bash_allow`` list.
+def _append_project_list_entry(key: str, value: str, key_comment: str, cwd: Optional[str] = None) -> Path:
+    """Append ``value`` to the ``<key>:`` list in ``./.datus/config.yml``.
 
-    Used by the "allow (project)" choice in the bash permission prompt.
     Edits at the TEXT level (not load->dump) so user comments and formatting
     in the rest of the file are preserved:
 
-    - file missing        -> create it with a commented ``bash_allow`` block
-    - no ``bash_allow:``  -> append the block at the end of the file
-    - key present         -> insert ``  - "<pattern>"`` right after the key line
-    - pattern already in the parsed list -> no-op
+    - file missing     -> create it with a commented ``<key>`` block
+    - no ``<key>:``    -> append the block at the end of the file
+    - key present      -> insert ``  - "<value>"`` right after the key line
+    - value already in the parsed list -> no-op
 
+    Raises ``OSError`` on write failures; callers degrade to a session-level
+    grant.
+    """
+    path = project_config_path(cwd)
+    # json.dumps yields a valid double-quoted YAML scalar with proper
+    # escaping, so a value containing ``"`` or a trailing backslash cannot
+    # corrupt the file (a parse failure would drop ALL project overrides).
+    entry_line = f"  - {json.dumps(value)}"
+
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = (
+            "# Project-level Datus overrides. See conf/agent.yml.example for the full schema.\n"
+            f"# {key_comment}\n"
+            f"{key}:\n{entry_line}\n"
+        )
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    text = path.read_text(encoding="utf-8")
+
+    # No-op when the value is already present (compare parsed values, not
+    # raw text, so quoting style differences don't cause duplicates).
+    try:
+        existing = yaml.safe_load(text) or {}
+        if isinstance(existing, dict) and value in (existing.get(key) or []):
+            return path
+    except yaml.YAMLError:
+        logger.warning(f"{path} is not valid YAML; appending {key} anyway.")
+
+    lines = text.splitlines()
+    key_idx = next(
+        (i for i, line in enumerate(lines) if line.startswith(f"{key}:") and not line.lstrip().startswith("#")),
+        None,
+    )
+    if key_idx is None:
+        suffix = "" if (not text or text.endswith("\n")) else "\n"
+        path.write_text(f"{text}{suffix}{key}:\n{entry_line}\n", encoding="utf-8")
+    else:
+        lines.insert(key_idx + 1, entry_line)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def append_project_bash_allow(pattern: str, cwd: Optional[str] = None) -> Path:
+    """Append a bash allow pattern to ``./.datus/config.yml``'s ``bash_allow`` list.
+
+    Used by the "allow (project)" choice in the bash permission prompt; see
+    :func:`_append_project_list_entry` for the text-level edit semantics.
     Raises ``OSError`` on write failures; callers (``PermissionManager.
     add_project_bash_allow``) degrade to a session-level grant.
     """
@@ -470,42 +554,35 @@ def append_project_bash_allow(pattern: str, cwd: Optional[str] = None) -> Path:
                 "your_value": pattern,
             },
         )
-    path = project_config_path(cwd)
-    # json.dumps yields a valid double-quoted YAML scalar with proper
-    # escaping, so a pattern containing ``"`` or a trailing backslash cannot
-    # corrupt the file (a parse failure would drop ALL project overrides).
-    entry_line = f"  - {json.dumps(pattern)}"
-
-    if not path.exists():
-        path.parent.mkdir(parents=True, exist_ok=True)
-        content = (
-            "# Project-level Datus overrides. See conf/agent.yml.example for the full schema.\n"
-            "# bash_allow patterns are appended to agent.permissions.bash_commands.allow.\n"
-            f"bash_allow:\n{entry_line}\n"
-        )
-        path.write_text(content, encoding="utf-8")
-        return path
-
-    text = path.read_text(encoding="utf-8")
-
-    # No-op when the pattern is already present (compare parsed values, not
-    # raw text, so quoting style differences don't cause duplicates).
-    try:
-        existing = yaml.safe_load(text) or {}
-        if isinstance(existing, dict) and pattern in (existing.get("bash_allow") or []):
-            return path
-    except yaml.YAMLError:
-        logger.warning(f"{path} is not valid YAML; appending bash_allow anyway.")
-
-    lines = text.splitlines()
-    key_idx = next(
-        (i for i, line in enumerate(lines) if line.startswith("bash_allow:") and not line.lstrip().startswith("#")),
-        None,
+    return _append_project_list_entry(
+        "bash_allow",
+        pattern,
+        "bash_allow patterns are appended to agent.permissions.bash_commands.allow.",
+        cwd,
     )
-    if key_idx is None:
-        suffix = "" if (not text or text.endswith("\n")) else "\n"
-        path.write_text(f"{text}{suffix}bash_allow:\n{entry_line}\n", encoding="utf-8")
-    else:
-        lines.insert(key_idx + 1, entry_line)
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    return path
+
+
+def append_project_sql_allow(kind: str, cwd: Optional[str] = None) -> Path:
+    """Append a SQL statement kind to ``./.datus/config.yml``'s ``sql_allow`` list.
+
+    Used by the "allow (project)" choice in the SQL permission prompt; see
+    :func:`_append_project_list_entry` for the text-level edit semantics.
+    Raises ``OSError`` on write failures; callers (``PermissionManager.
+    add_project_sql_allow``) degrade to a session-level grant.
+    """
+    kind = kind.strip().lower()
+    if not kind:
+        raise DatusException(
+            code=ErrorCode.COMMON_FIELD_INVALID,
+            message_args={
+                "field_name": "sql allow kind",
+                "except_values": "non-empty string",
+                "your_value": kind,
+            },
+        )
+    return _append_project_list_entry(
+        "sql_allow",
+        kind,
+        "sql_allow statement kinds are auto-allowed by the execute_sql permission gate.",
+        cwd,
+    )

--- a/datus/tools/permission/__init__.py
+++ b/datus/tools/permission/__init__.py
@@ -24,6 +24,8 @@ from datus.tools.permission.permission_config import (
     PermissionConfig,
     PermissionLevel,
     PermissionRule,
+    SqlStatementRules,
+    classify_sql_kind,
 )
 from datus.tools.permission.permission_hooks import (
     CompositeHooks,
@@ -43,6 +45,8 @@ __all__ = [
     "BashCommandRules",
     "BashRuleDecision",
     "evaluate_bash_command",
+    "SqlStatementRules",
+    "classify_sql_kind",
     "BashCommandClassifier",
     "BashClassifierContext",
     "ClassifierVerdict",

--- a/datus/tools/permission/permission_config.py
+++ b/datus/tools/permission/permission_config.py
@@ -82,6 +82,121 @@ class PermissionRule(BaseModel):
         return True
 
 
+# Fine-grained statement kinds (``parse_sql_statement_kind``) mapped to the
+# permission classes ``SqlStatementRules`` gates on. Destructive = statements
+# that irreversibly mutate or remove existing data/schema; REPLACE deletes
+# matched rows before re-inserting, and MERGE carries UPDATE/DELETE semantics
+# in its WHEN MATCHED branches, so both count as destructive.
+_SQL_KIND_TO_CLASS: Dict[str, str] = {
+    "select": "read",
+    "metadata": "read",
+    "explain": "read",
+    "insert": "write",
+    "create": "write",
+    "ddl": "write",
+    "context_set": "write",
+    "update": "destructive",
+    "delete": "destructive",
+    "merge": "destructive",
+    "drop": "destructive",
+    "truncate": "destructive",
+    "alter": "destructive",
+    "replace": "destructive",
+    "unknown": "unknown",
+}
+
+
+def classify_sql_kind(kind: str) -> str:
+    """Map a fine-grained statement kind to its permission class.
+
+    Unmapped kinds fall to ``unknown`` (fail-safe: an unrecognized statement
+    must never inherit a permissive class).
+    """
+    return _SQL_KIND_TO_CLASS.get(kind, "unknown")
+
+
+class SqlStatementRules(BaseModel):
+    """Per-class permission levels for ``db_tools.execute_sql``.
+
+    ``execute_sql`` is the unified SQL entry point, so a single static rule
+    cannot express "reads auto-allow, writes ask, destructive statements
+    always confirm". This model carries one :class:`PermissionLevel` per
+    statement class; the classes are resolved from the concrete statement by
+    ``parse_sql_statement_kind`` + :func:`classify_sql_kind`.
+
+    Configured per profile (``profiles.py``) and user-overridable under
+    ``permissions.sql_statements`` in agent.yml:
+
+        permissions:
+          sql_statements:
+            read: allow        # SELECT / SHOW / DESCRIBE / EXPLAIN
+            write: ask         # INSERT, CREATE, COMMENT/GRANT/..., USE/SET
+            destructive: ask   # UPDATE, DELETE, MERGE, DROP, TRUNCATE, ALTER, REPLACE
+            unknown: ask       # unparseable SQL (fail-safe)
+    """
+
+    read: PermissionLevel = Field(
+        default=PermissionLevel.ALLOW, description="SELECT / SHOW / DESCRIBE / EXPLAIN statements"
+    )
+    write: PermissionLevel = Field(
+        default=PermissionLevel.ASK, description="INSERT, CREATE, benign DDL, and session statements"
+    )
+    destructive: PermissionLevel = Field(
+        default=PermissionLevel.ASK,
+        description="Irreversible statements: UPDATE, DELETE, MERGE, DROP, TRUNCATE, ALTER, REPLACE",
+    )
+    unknown: PermissionLevel = Field(default=PermissionLevel.ASK, description="Unparseable statements (fail-safe)")
+
+    class Config:
+        use_enum_values = True
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> Optional["SqlStatementRules"]:
+        """Build from the ``permissions.sql_statements`` YAML block.
+
+        Returns ``None`` when the block is absent so callers can distinguish
+        "not configured" from "configured with defaults". Only keys present in
+        the YAML are passed to the constructor so ``model_fields_set`` records
+        which levels were explicit — ``merge_with`` relies on that to layer
+        user overrides without clobbering profile defaults.
+        """
+        if data is None:
+            return None
+        if not isinstance(data, dict):
+            raise ValueError(f"permissions.sql_statements must be a mapping, got {type(data).__name__}")
+        kwargs: Dict[str, Any] = {}
+        for field_name in ("read", "write", "destructive", "unknown"):
+            if field_name in data:
+                kwargs[field_name] = PermissionLevel(data[field_name])
+        return cls(**kwargs)
+
+    def merge_with(self, override: Optional["SqlStatementRules"]) -> "SqlStatementRules":
+        """Layer another ruleset on top; explicit override fields win.
+
+        Mirrors ``BashCommandRules.merge_with`` scalar semantics: a level from
+        ``override`` replaces this one only when it was explicitly set
+        (tracked via ``model_fields_set``).
+        """
+        if override is None:
+            return self
+        merged = self.model_copy()
+        for field_name in ("read", "write", "destructive", "unknown"):
+            if field_name in override.model_fields_set:
+                setattr(merged, field_name, getattr(override, field_name))
+        return merged
+
+    def level_for_class(self, sql_class: str) -> PermissionLevel:
+        """Permission level for a statement class; unmapped classes fail safe.
+
+        ``use_enum_values`` stores fields as plain strings at runtime, so the
+        value is coerced back to :class:`PermissionLevel` before returning.
+        """
+        value = getattr(self, sql_class, None)
+        if value is None:
+            value = self.unknown
+        return PermissionLevel(value)
+
+
 class PermissionConfig(BaseModel):
     """Unified permission configuration for all tools, MCP, and skills.
 
@@ -109,6 +224,9 @@ class PermissionConfig(BaseModel):
         bash_commands: Optional command-level bash rules (see ``bash_rules.py``);
             consumed by ``PermissionHooks._handle_bash_permission``. When None,
             the coarse ``bash_tools.bash`` rule governs as before.
+        sql_statements: Optional per-class statement rules for ``execute_sql``;
+            consumed by ``PermissionHooks._handle_sql_permission``. When None,
+            the legacy read-only/ASK gating governs as before.
     """
 
     rules: List[PermissionRule] = Field(default_factory=list, description="Permission rules evaluated in order")
@@ -117,6 +235,9 @@ class PermissionConfig(BaseModel):
     )
     bash_commands: Optional["BashCommandRules"] = Field(
         default=None, description="Command-level allow/deny/ask rules for the bash tool"
+    )
+    sql_statements: Optional[SqlStatementRules] = Field(
+        default=None, description="Per-class permission levels for execute_sql statements"
     )
 
     class Config:
@@ -150,6 +271,7 @@ class PermissionConfig(BaseModel):
             default_permission=PermissionLevel(default),
             rules=rules,
             bash_commands=BashCommandRules.from_dict(data.get("bash_commands")),
+            sql_statements=SqlStatementRules.from_dict(data.get("sql_statements")),
         )
 
     def merge_with(self, override: Optional["PermissionConfig"]) -> "PermissionConfig":
@@ -176,12 +298,20 @@ class PermissionConfig(BaseModel):
         else:
             merged_bash = override.bash_commands
 
+        # SQL statement rules layer: per-class levels override only when
+        # explicitly set (see SqlStatementRules.merge_with).
+        if self.sql_statements is not None:
+            merged_sql = self.sql_statements.merge_with(override.sql_statements)
+        else:
+            merged_sql = override.sql_statements
+
         # Always use override's default_permission when override is provided
         # This allows overriding just the default without adding rules
         return PermissionConfig(
             default_permission=override.default_permission,
             rules=merged_rules,
             bash_commands=merged_bash,
+            sql_statements=merged_sql,
         )
 
 

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -35,7 +35,7 @@ from datus.tools.permission.bash_rules import (
     BashRuleDecision,
     evaluate_bash_command,
 )
-from datus.tools.permission.permission_config import PermissionLevel
+from datus.tools.permission.permission_config import PermissionLevel, classify_sql_kind
 from datus.tools.registry.tool_registry import ToolRegistry
 from datus.utils.constants import SQLType
 from datus.utils.json_utils import to_pretty_str
@@ -373,12 +373,15 @@ class PermissionHooks(AgentHooks):
             if handled:
                 return
 
-        # db_tools.execute_sql: statement-type gating overrides rules.
-        #   read-only (SELECT/SHOW/DESCRIBE/EXPLAIN) → bypass; writes (INSERT/
-        #   UPDATE/DELETE), DDL, and unknown/MERGE → ASK (session cache bucketed
-        #   per SQL type), dangerous bypass, non-interactive raise. A ``.sql``
-        #   file is resolved first; an unreadable file or unparseable text falls
-        #   through to UNKNOWN → ASK (fail safe).
+        # db_tools.execute_sql: statement-class gating overrides rules.
+        #   The statement is classified into a fine-grained kind (insert/
+        #   create/drop/...) whose class (read/write/destructive/unknown) is
+        #   resolved against the profile's ``sql_statements`` ruleset: read
+        #   auto-allows everywhere, write auto-allows under auto, destructive
+        #   and unknown ASK (session cache bucketed per kind, project grants
+        #   via ``.datus/config.yml`` sql_allow), dangerous bypass,
+        #   non-interactive raise. A ``.sql`` file is resolved first; an
+        #   unreadable file or unparseable text falls to unknown → ASK.
         if category == "db_tools" and tool_name == "execute_sql":
             handled = await self._handle_sql_permission(context, tool_name, pattern_name)
             if handled:
@@ -719,71 +722,82 @@ class PermissionHooks(AgentHooks):
             logger.error(f"Error in external filesystem confirmation for {tool_name}: {e}")
             return False
 
-    # Read-only SQL statement types that auto-allow under ``execute_sql``.
-    # Everything else (INSERT/UPDATE/DELETE/DDL/MERGE/UNKNOWN) defers to the
-    # normal category-level permission check.
-    _SQL_READONLY_TYPES = frozenset({SQLType.SELECT, SQLType.METADATA_SHOW, SQLType.EXPLAIN})
+    # Read-only statement kinds that auto-allow under ``execute_sql``
+    # regardless of profile (legacy path — the class-rule path resolves the
+    # same set through ``classify_sql_kind``'s ``read`` class).
+    _SQL_READONLY_KINDS = frozenset({SQLType.SELECT.value, SQLType.METADATA_SHOW.value, SQLType.EXPLAIN.value})
+
+    # Fine-grained kinds folded back into their legacy ``SQLType`` value for
+    # the no-ruleset path, so session buckets stay byte-compatible with
+    # configs that predate ``sql_statements`` (e.g. ``execute_sql.ddl``, not
+    # ``execute_sql.drop``).
+    _SQL_LEGACY_KIND_MAP = {
+        "create": SQLType.DDL.value,
+        "alter": SQLType.DDL.value,
+        "drop": SQLType.DDL.value,
+        "truncate": SQLType.DDL.value,
+        "replace": SQLType.INSERT.value,
+    }
 
     async def _handle_sql_permission(self, context: Any, tool_name: str, pattern_name: str) -> bool:
-        """Statement-type gating for ``db_tools.execute_sql`` calls.
+        """Statement-class gating for ``db_tools.execute_sql`` calls.
 
         ``execute_sql`` is the unified SQL entry point, so a single static rule
-        cannot express "reads auto-allow, writes ask". This gate inspects the
-        statement type instead:
+        cannot express "reads auto-allow, writes ask, destructive statements
+        always confirm". This gate classifies the statement into a fine-grained
+        kind (``parse_sql_statement_kind``: ``insert`` / ``create`` / ``drop``
+        / ...) and gates on the kind's class (:func:`classify_sql_kind`:
+        read / write / destructive / unknown) via the effective config's
+        ``sql_statements`` ruleset:
 
-        * Read-only (SELECT/SHOW/DESCRIBE/EXPLAIN) → auto-allow, unless an
-          explicit DENY rule blocks ``db_tools.execute_sql`` (then defer so the
-          DENY is surfaced).
-        * Writes (INSERT/UPDATE/DELETE), DDL, and unknown/MERGE → category-level
-          rule check for DENY/ALLOW, then ASK with a session cache **bucketed by
-          the concrete SQL type** (``execute_sql.insert`` / ``.update`` /
-          ``.delete`` / ``.ddl`` / ``.merge`` / ``.unknown``). Per-type bucketing
-          matters because ``execute_sql`` is one tool name: an "Always allow"
-          keyed on the bare tool name would let one approved INSERT silently
-          green-light every later DELETE / DROP / MERGE, so each statement type
-          carries its own session approval. ALLOW under dangerous (rule check
-          returns ALLOW), raise when non-interactive.
+        * Coarse category rules stay authoritative: an explicit DENY defers so
+          the main flow raises the standardized message; an explicit ALLOW
+          (dangerous profile default, or a user ``db_tools/execute_sql: allow``
+          rule) bypasses everything.
+        * No ``sql_statements`` ruleset (legacy configs, bare
+          ``PermissionConfig``) → original behavior: read-only statements
+          auto-allow, everything else prompts with a per-SQLType session
+          bucket.
+        * Ruleset present → the class level decides. ALLOW passes (this is how
+          ``auto`` runs INSERT/CREATE without prompting), DENY raises in-hook,
+          ASK consults the project grant set (``.datus/config.yml``
+          ``sql_allow``), then the per-kind session cache, then prompts with
+          allow once / session / project / deny. Session and project grants
+          are keyed by the concrete kind (``execute_sql.drop`` vs
+          ``.truncate``) so one approval never cascades across kinds.
 
-        A ``.sql`` file reference is resolved (same workspace-relative read as the
-        tool) so the gate classifies the real statement — a read-only ``.sql``
-        file auto-allows instead of prompting. An unreadable file or unparseable
-        text falls through to UNKNOWN → ASK (fail safe).
+        A ``.sql`` file reference is resolved (same workspace-relative read as
+        the tool) so the gate classifies the real statement — a read-only
+        ``.sql`` file auto-allows instead of prompting. An unreadable file or
+        unparseable text falls to kind ``unknown`` → ASK (fail safe). Only the
+        first statement is classified; the tool layer's multi-statement
+        rejection (``_validate_read_sql`` and the write/DDL validators) is the
+        backstop for trailing statements.
 
-        Returns ``True`` when the call has been fully handled (read auto-allowed,
-        explicit/dangerous ALLOW, or bucketed ASK approved), ``False`` to let the
-        normal category-level permission check run (surfaces DENY / the
-        standardized non-interactive raise).
+        Returns ``True`` when the call has been fully handled, ``False`` to
+        let the normal category-level permission check run (surfaces DENY /
+        the standardized non-interactive raise).
         """
-        from datus.utils.sql_utils import looks_like_sql_file_ref, parse_sql_type, read_workspace_sql_file
+        from datus.utils.sql_utils import looks_like_sql_file_ref, parse_sql_statement_kind, read_workspace_sql_file
 
         args = self._parse_tool_args(context)
         if not isinstance(args, dict):
             return False
         sql = args.get("sql", "")
         # Resolve a ``.sql`` file reference to its real (single) statement so the
-        # type detection below sees the SQL, not the path. On any read failure,
-        # leave ``sql`` as-is → UNKNOWN → ASK (fail safe).
+        # kind detection below sees the SQL, not the path. On any read failure,
+        # leave ``sql`` as-is → unknown → ASK (fail safe).
         if isinstance(sql, str) and looks_like_sql_file_ref(sql):
             try:
                 sql = read_workspace_sql_file(sql.strip(), self.project_root or ".")
             except Exception as e:
                 logger.debug("execute_sql gate: could not resolve .sql file (%s); treating as UNKNOWN", e)
         # No dialect available at the hook layer; the keyword fallback in
-        # ``parse_sql_type`` is enough to separate reads from writes/DDL.
-        sql_type = parse_sql_type(sql, "") if isinstance(sql, str) else SQLType.UNKNOWN
+        # ``parse_sql_statement_kind`` is enough to separate the classes.
+        kind = parse_sql_statement_kind(sql, "") if isinstance(sql, str) else SQLType.UNKNOWN.value
+        sql_class = classify_sql_kind(kind)
 
-        if sql_type in self._SQL_READONLY_TYPES:
-            # Respect an explicit DENY; otherwise reads auto-allow regardless of
-            # profile (there is no static ALLOW rule for execute_sql to rely on).
-            if (
-                self.permission_manager.check_permission("db_tools", pattern_name, self.node_name)
-                == PermissionLevel.DENY
-            ):
-                return False
-            logger.debug("execute_sql read-only (%s): auto-allow", sql_type.value)
-            return True
-
-        # Non-read (write / DDL / unknown). Honour explicit rules first.
+        # Honour explicit coarse rules first — they are the escape hatches.
         permission = self.permission_manager.check_permission("db_tools", pattern_name, self.node_name)
         if permission == PermissionLevel.DENY:
             # Surface the standardized DENY raise via the main flow.
@@ -792,21 +806,109 @@ class PermissionHooks(AgentHooks):
             # Explicit ALLOW rule or a permissive profile (e.g. dangerous).
             return True
 
-        # ASK. Non-interactive flows must not prompt — defer so the main flow
+        rules = getattr(self.permission_manager.get_effective_config(self.node_name), "sql_statements", None)
+        if rules is None:
+            # Legacy path (no per-class ruleset): reads auto-allow, everything
+            # else prompts with the coarse SQLType bucket.
+            return await self._handle_sql_permission_legacy(context, kind)
+
+        level = rules.level_for_class(sql_class)
+        if level == PermissionLevel.ALLOW:
+            logger.debug("execute_sql %s (class %s): auto-allow by sql_statements", kind, sql_class)
+            return True
+        if level == PermissionLevel.DENY:
+            profile = getattr(self.permission_manager, "active_profile", None) or "unknown"
+            logger.warning("execute_sql %s (class %s) denied by sql_statements rules", kind, sql_class)
+            raise PermissionDeniedException(
+                (
+                    f"PERMISSION_DENIED: SQL statement kind '{kind}' (class '{sql_class}') is "
+                    f"blocked by the '{profile}' permission profile's sql_statements rules. "
+                    f"STOP retrying — rewording the SQL will not change the outcome. Return "
+                    f"the failure to your caller. The user can adjust "
+                    f"`permissions.sql_statements` in agent.yml."
+                ),
+                tool_category="db_tools",
+                tool_name="execute_sql",
+            )
+
+        # ASK. A project-scope grant (``.datus/config.yml`` sql_allow or an
+        # "allow (project)" prompt choice earlier this session) covering this
+        # exact kind bypasses the confirmation.
+        if self.permission_manager.has_project_sql_grant(kind):
+            logger.debug("execute_sql %s bypassed by project grant", kind)
+            return True
+
+        # Non-interactive flows must not prompt — defer so the main flow
         # raises the standardized non-interactive PermissionDeniedException.
         if self.non_interactive:
             return False
 
-        # Bucket the session approval by the concrete SQL type so an "always
-        # allow" only ever covers that one type (e.g. approving an INSERT never
-        # green-lights a later DELETE / DROP / MERGE).
-        sql_class = sql_type.value
+        # Bucket the session approval by the concrete kind so an "always
+        # allow" only ever covers that one kind (e.g. approving a DROP never
+        # green-lights a later TRUNCATE). Broad keys still honor a deliberate
+        # wide approval (a prior un-bucketed ``db_tools.execute_sql`` or a
+        # category wildcard).
+        cache_keys = (f"db_tools.execute_sql.{kind}", "db_tools.execute_sql", "db_tools.*")
+
+        def _session_approved() -> bool:
+            return any(self.permission_manager._session_approvals.get(key) for key in cache_keys)
+
+        if _session_approved():
+            logger.debug("execute_sql %s already approved for session", kind)
+            return True
+
+        async with _get_permission_prompt_lock(self.broker):
+            if _session_approved():
+                return True
+            # The project choice is offered for every concrete kind — the user
+            # opted into project-scope grants for destructive statements too —
+            # but never for ``unknown``: persisting a grant that auto-allows
+            # every future unparseable statement would be a blank cheque.
+            offer_project = kind != SQLType.UNKNOWN.value
+            choice = await self._request_sql_confirmation(sql, kind, sql_class, offer_project=offer_project)
+            if choice == "y":
+                logger.info("User approved execute_sql (%s, once)", kind)
+                return True
+            if choice == "a":
+                self.permission_manager.approve_for_session("db_tools", f"execute_sql.{kind}")
+                logger.info("User approved execute_sql kind %r for session", kind)
+                return True
+            if choice == "p" and offer_project:
+                persisted = self.permission_manager.add_project_sql_allow(kind, self.project_root)
+                # Session cache too, so later same-kind calls this session skip
+                # the prompt without re-consulting the grant set.
+                self.permission_manager.approve_for_session("db_tools", f"execute_sql.{kind}")
+                logger.info(
+                    "User granted project-level sql allow %r%s",
+                    kind,
+                    "" if persisted else " (disk write failed; session-only)",
+                )
+                return True
+            logger.info("User rejected execute_sql (%s)", kind)
+            raise PermissionDeniedException(
+                "User rejected execution of 'execute_sql'",
+                tool_category="db_tools",
+                tool_name="execute_sql",
+            )
+
+    async def _handle_sql_permission_legacy(self, context: Any, kind: str) -> bool:
+        """Pre-``sql_statements`` gating, kept for configs without a ruleset.
+
+        Reads auto-allow; everything else prompts via the generic
+        ``_request_user_confirmation`` (allow once / session / deny — no
+        project choice) with the session approval bucketed by the coarse
+        ``SQLType`` value, exactly as before the per-class ruleset existed.
+        The caller has already resolved coarse DENY/ALLOW rules.
+        """
+        if kind in self._SQL_READONLY_KINDS:
+            logger.debug("execute_sql read-only (%s): auto-allow", kind)
+            return True
+
+        if self.non_interactive:
+            return False
+
+        sql_class = self._SQL_LEGACY_KIND_MAP.get(kind, kind)
         bucket_pattern = f"execute_sql.{sql_class}"
-        # Honour the per-type bucket plus any deliberately broad session approval
-        # (a prior un-bucketed ``db_tools.execute_sql`` or a category wildcard).
-        # Only the prompt-driven "always allow" below is bucketed per type, so a
-        # single approval never cascades across statement types — but an explicit
-        # broad approval still covers every type.
         cache_keys = (f"db_tools.{bucket_pattern}", "db_tools.execute_sql", "db_tools.*")
 
         def _session_approved() -> bool:
@@ -833,6 +935,53 @@ class PermissionHooks(AgentHooks):
                 )
             logger.info("User approved execute_sql (%s)", sql_class)
             return True
+
+    async def _request_sql_confirmation(
+        self,
+        sql: str,
+        kind: str,
+        sql_class: str,
+        *,
+        offer_project: bool,
+    ) -> str:
+        """Prompt for a SQL statement; returns the raw choice key ('' on cancel).
+
+        Mirrors ``_request_bash_confirmation``: callers need the concrete
+        choice to distinguish session from project grants.
+        """
+        profile = getattr(self.permission_manager, "active_profile", None) or "unknown"
+        sql_text = sql if isinstance(sql, str) else str(sql)
+        content = (
+            f"### SQL Statement Permission\n\n"
+            f"```sql\n{sql_text}\n```\n\n"
+            f"**Statement:** `{kind}` (class: {sql_class})\n"
+            f"**Reason:** '{sql_class}' statements require confirmation under the '{profile}' profile\n"
+        )
+        choices = {
+            "y": "Allow (once)",
+            "a": f"Allow '{kind}' (session)",
+        }
+        if offer_project:
+            choices["p"] = f"Allow '{kind}' (project)"
+        choices["n"] = "Deny"
+
+        try:
+            answers = await self.broker.request(
+                [
+                    InteractionEvent(
+                        title="SQL Permission",
+                        content=content,
+                        choices=choices,
+                        default_choice="n",
+                    )
+                ]
+            )
+            return answers[0][0] if answers and answers[0] else ""
+        except InteractionCancelled:
+            return ""
+        except Exception as e:
+            logger.error(f"Error in SQL permission confirmation: {e}")
+            return ""
 
     async def _handle_bash_permission(self, context: Any, tool_name: str, pattern_name: str) -> bool:
         """Command-level gating for ``bash_tools.bash`` calls.

--- a/datus/tools/permission/permission_manager.py
+++ b/datus/tools/permission/permission_manager.py
@@ -55,6 +55,7 @@ class PermissionManager:
         active_profile: str = "normal",
         plugin_bash_rules: Optional[Dict[str, "BashCommandRules"]] = None,
         project_bash_allows: Optional[List[str]] = None,
+        project_sql_allows: Optional[List[str]] = None,
     ):
         """Initialize the permission manager.
 
@@ -78,6 +79,11 @@ class PermissionManager:
                 grant set that lets the hook bypass an *ask-rule* hit whose
                 matched pattern the project explicitly allowed — plain allow
                 entries cannot beat ask rules at evaluation time.
+            project_sql_allows: SQL statement kinds granted at project scope
+                (``./.datus/config.yml`` ``sql_allow``). Exact-match grant set
+                consulted by ``PermissionHooks._handle_sql_permission`` to
+                auto-allow a statement kind before prompting; never merged
+                into rules.
         """
         # Copy the incoming config — ``get_profile`` returns shared module-level
         # objects, and ``add_persistent_rule`` mutates ``global_config.rules``
@@ -113,6 +119,15 @@ class PermissionManager:
         # unaffected by profile switches — the on-disk grant is user intent.
         self._project_bash_grants: set = set(project_bash_allows or [])
 
+        # Exact-match project SQL statement-kind grants (``.datus/config.yml``
+        # sql_allow, plus "allow (project)" prompt choices this session).
+        # Like bash grants, unaffected by profile switches; unlike bash
+        # grants, never installed into ``global_config`` — the SQL gate
+        # consults this set directly.
+        self._project_sql_grants: set = {
+            k.strip().lower() for k in (project_sql_allows or []) if isinstance(k, str) and k.strip()
+        }
+
         logger.debug(
             f"PermissionManager initialized: profile={self.active_profile}, "
             f"{len(self.global_config.rules)} global rules"
@@ -137,6 +152,7 @@ class PermissionManager:
             # Deep copy so runtime mutations (add_project_bash_allow) never
             # bleed into the shared profile singletons in profiles.py.
             bash_commands=config.bash_commands.model_copy(deep=True) if config.bash_commands else None,
+            sql_statements=config.sql_statements.model_copy(deep=True) if config.sql_statements else None,
         )
 
     def set_permission_callback(self, callback: Callable[[str, str, Dict[str, Any]], Awaitable[bool]]) -> None:
@@ -411,6 +427,41 @@ class PermissionManager:
         silences a narrower ask rule.
         """
         return bool(pattern) and pattern in self._project_bash_grants
+
+    def add_project_sql_allow(self, kind: str, project_root: Optional[str] = None) -> bool:
+        """Grant a SQL statement kind at project scope ("allow (project)").
+
+        Two effects (no ``global_config`` install — the SQL gate consults the
+        grant set directly, so nothing needs to survive a config rebuild):
+        1. Add the kind to the in-memory ``_project_sql_grants`` set.
+        2. Persist it to ``./.datus/config.yml`` (``sql_allow`` key) so future
+           sessions pick it up through ``_apply_project_override``.
+
+        Returns True when the kind was persisted to disk; False when the
+        write failed (read-only checkout, etc.) — the in-memory grant still
+        applies, so callers may degrade to a session-level approval message.
+        """
+        kind = kind.strip().lower()
+        self._project_sql_grants.add(kind)
+
+        try:
+            from datus.configuration.project_config import append_project_sql_allow
+
+            append_project_sql_allow(kind, project_root or ".")
+            logger.info(f"Project-level sql allow persisted: {kind!r}")
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to persist project sql allow {kind!r}: {e}; grant applies to this session only")
+            return False
+
+    def has_project_sql_grant(self, kind: Optional[str]) -> bool:
+        """True when statement ``kind`` was granted at project scope.
+
+        Exact match, like :meth:`has_project_bash_grant`: the grant string is
+        the concrete kind produced by ``parse_sql_statement_kind`` (e.g.
+        ``"drop"``), so a grant can never widen to a different kind.
+        """
+        return bool(kind) and kind.strip().lower() in self._project_sql_grants
 
     def is_plugin_ask_pattern(self, pattern: Optional[str]) -> bool:
         """True when ``pattern`` is an ask rule declared by a plugin for the

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -12,9 +12,11 @@ layered on top via ``PermissionConfig.merge_with`` (last-match-wins).
 The three profiles embody three security postures:
 
 * ``normal``:    read-only tools, semantic tools, and skill loading allowed,
-  all other writes ASK, named destructive tools DENY. Default for new installs.
+  all other writes ASK, named destructive tools DENY. SQL reads auto-allow,
+  every other statement class ASK. Default for new installs.
 * ``auto``:      Normal + workspace writes auto-execute, BI/scheduler
-  non-trigger writes auto, DB writes still ASK.
+  non-trigger writes auto, SQL non-destructive writes auto — destructive
+  statements (UPDATE/DELETE/MERGE/DROP/TRUNCATE/ALTER/REPLACE) still ASK.
 * ``dangerous``: everything ALLOW, including EXTERNAL filesystem paths in
   interactive mode. Workflow (non-interactive) flows still fail closed on
   EXTERNAL paths regardless of profile.
@@ -50,6 +52,7 @@ from datus.tools.permission.permission_config import (
     PermissionConfig,
     PermissionLevel,
     PermissionRule,
+    SqlStatementRules,
 )
 
 PROFILE_NAMES: tuple[str, ...] = ("normal", "auto", "dangerous")
@@ -65,10 +68,11 @@ _NORMAL_RULES = [
     # context search / date utilities
     _rule("context_search_tools", "*", PermissionLevel.ALLOW),
     _rule("date_parsing_tools", "*", PermissionLevel.ALLOW),
-    # db read. ``execute_sql`` is the unified SQL entry point; its read-vs-write
-    # gating is handled dynamically per statement type in
-    # ``PermissionHooks._handle_sql_permission`` (read-only bypass, writes/DDL
-    # ASK), so it intentionally has no static rule here.
+    # db read. ``execute_sql`` is the unified SQL entry point; its gating is
+    # handled dynamically per statement class in
+    # ``PermissionHooks._handle_sql_permission`` driven by each profile's
+    # ``sql_statements`` ruleset (read auto-allow, write/destructive per
+    # profile), so it intentionally has no static rule here.
     _rule("db_tools", "verify_sql", PermissionLevel.ALLOW),
     _rule("db_tools", "list_*", PermissionLevel.ALLOW),
     _rule("db_tools", "search_*", PermissionLevel.ALLOW),
@@ -271,6 +275,9 @@ NORMAL = PermissionConfig(
     default_permission=PermissionLevel.ASK,
     rules=_NORMAL_RULES,
     bash_commands=BashCommandRules(allow=_NORMAL_BASH_ALLOW),
+    # execute_sql statement classes: reads auto-allow, everything else ASK
+    # (the SqlStatementRules defaults are exactly normal's posture).
+    sql_statements=SqlStatementRules(),
 )
 
 # --- Auto --------------------------------------------------------------------
@@ -302,9 +309,10 @@ _AUTO_EXTRA_RULES = [
     _rule("scheduler_tools", "pause_job", PermissionLevel.ALLOW),
     _rule("scheduler_tools", "resume_job", PermissionLevel.ALLOW),
     _rule("scheduler_tools", "trigger_*", PermissionLevel.ASK),
-    # db writes: always ASK. ``execute_sql`` writes/DDL are gated dynamically by
-    # ``PermissionHooks._handle_sql_permission`` (read-only bypass), so only the
-    # standalone cross-DB transfer tool needs an explicit ASK rule here.
+    # db statements: gated dynamically by ``PermissionHooks._handle_sql_permission``
+    # via auto's ``sql_statements`` ruleset below (reads + non-destructive writes
+    # auto-allow, destructive statements ASK), so only the standalone cross-DB
+    # transfer tool needs an explicit ASK rule here.
     _rule("db_tools", "transfer_query_result", PermissionLevel.ASK),
     # Named destructives — downgrade NORMAL's DENY to ASK in Auto. The user
     # can confirm at the prompt; DENY would force a profile switch to
@@ -317,13 +325,19 @@ AUTO = PermissionConfig(
     default_permission=PermissionLevel.ASK,
     rules=_NORMAL_RULES + _AUTO_EXTRA_RULES,
     bash_commands=BashCommandRules(allow=_AUTO_BASH_ALLOW),
+    # execute_sql statement classes: reads AND non-destructive writes (INSERT/
+    # CREATE/benign DDL/USE) auto-allow; destructive statements (UPDATE/DELETE/
+    # MERGE/DROP/TRUNCATE/ALTER/REPLACE) and unparseable SQL still ASK.
+    sql_statements=SqlStatementRules(write=PermissionLevel.ALLOW),
 )
 
 # --- Dangerous ---------------------------------------------------------------
 # default=ALLOW, no rules. PathZone at hook layer still gates EXTERNAL fs.
 # bash_commands stays None: the fine-grained bash gate steps aside and the
 # profile default of ALLOW lets every command through, preserving the
-# historical allow-everything behavior of this profile.
+# historical allow-everything behavior of this profile. sql_statements stays
+# None for the same reason: the SQL gate falls back to the coarse rule check,
+# which resolves to the profile default of ALLOW for every statement class.
 DANGEROUS = PermissionConfig(
     default_permission=PermissionLevel.ALLOW,
     rules=[],
@@ -421,11 +435,14 @@ def build_effective_config(
     base = get_profile(profile_name)
     if plugin_bash_rules is not None and not plugin_bash_rules.is_empty() and base.bash_commands is not None:
         # Rebuild instead of mutating: ``get_profile`` returns shared
-        # module-level singletons.
+        # module-level singletons. Every profile field must be carried over —
+        # omitting one here silently drops it whenever a plugin declares bash
+        # rules.
         base = PermissionConfig(
             default_permission=base.default_permission,
             rules=list(base.rules),
             bash_commands=base.bash_commands.merge_with(plugin_bash_rules),
+            sql_statements=base.sql_statements,
         )
     if not user_raw:
         return base

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -677,6 +677,59 @@ def parse_sql_type(sql: str, dialect: str) -> SQLType:
     return inferred if inferred else SQLType.UNKNOWN
 
 
+# ``SQLType.DDL`` refinements for the permission layer: statements that
+# destroy data or schema get their own kind so they can be gated separately
+# from benign DDL (COMMENT/GRANT/ANALYZE/...). RENAME maps to ``alter`` — it
+# is the same ALTER-family schema mutation under a different keyword.
+_DDL_KIND_KEYWORDS: Dict[str, str] = {
+    "CREATE": "create",
+    "ALTER": "alter",
+    "DROP": "drop",
+    "TRUNCATE": "truncate",
+    "RENAME": "alter",
+}
+
+
+def parse_sql_statement_kind(sql: str, dialect: str = "") -> str:
+    """Fine-grained statement kind for the permission layer.
+
+    Same as ``parse_sql_type(...).value`` except two refinements the
+    ``execute_sql`` permission gate needs:
+
+    * ``SQLType.DDL`` is split by leading keyword into ``create`` / ``alter``
+      / ``drop`` / ``truncate`` (RENAME counts as ``alter``); everything else
+      (COMMENT/GRANT/REVOKE/ANALYZE/VACUUM/...) stays ``ddl``.
+    * ``REPLACE`` statements (folded into ``SQLType.INSERT`` by
+      ``parse_sql_type``) become ``replace`` — REPLACE INTO deletes matched
+      rows before re-inserting, so it must not inherit INSERT's class.
+
+    Only the first statement is classified (same contract as
+    ``parse_sql_type``); the tool layer's multi-statement rejection is the
+    backstop for trailing statements.
+
+    Returns one of: ``select``, ``metadata``, ``explain``, ``insert``,
+    ``replace``, ``create``, ``ddl``, ``context_set``, ``update``,
+    ``delete``, ``merge``, ``drop``, ``truncate``, ``alter``, ``unknown``.
+    """
+    sql_type = parse_sql_type(sql, dialect)
+    if sql_type not in (SQLType.DDL, SQLType.INSERT, SQLType.CONTENT_SET):
+        return sql_type.value
+
+    first_statement = _first_statement(sql.strip())
+    match = re.match(r"\s*([A-Za-z_]+)", first_statement)
+    keyword = match.group(1).upper() if match else ""
+
+    if sql_type == SQLType.INSERT:
+        return "replace" if keyword == "REPLACE" else SQLType.INSERT.value
+    if sql_type == SQLType.CONTENT_SET:
+        # sqlglot parses dialect-specific statements it cannot model as a
+        # generic Command, which ``parse_sql_type`` folds into CONTENT_SET
+        # (e.g. MySQL ``RENAME TABLE``). A destructive leading keyword must
+        # not ride that fold into the write class.
+        return _DDL_KIND_KEYWORDS.get(keyword, SQLType.CONTENT_SET.value)
+    return _DDL_KIND_KEYWORDS.get(keyword, "ddl")
+
+
 _CONTEXT_CMD_RE = re.compile(r"^\s*(use|set)\b", flags=re.IGNORECASE)
 
 

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -677,6 +677,40 @@ class TestApplyProjectOverrideBashAllow:
         assert "project_bash_allow" not in agent_raw
 
 
+class TestApplyProjectOverrideSqlAllow:
+    """sql_allow rides as a raw grant list only — never merged into permissions."""
+
+    def test_sql_allow_forwarded_as_raw_grant_list(self):
+        agent_raw = {"target": "openai", "models": {"openai": {}}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(sql_allow=["insert", "drop"]),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["project_sql_allow"] == ["insert", "drop"]
+
+    def test_sql_allow_does_not_touch_permissions(self):
+        """Unlike bash_allow, SQL grants act only through the exact-match
+        grant set — the permissions section must stay untouched."""
+        agent_raw = {"permissions": {"profile": "normal"}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(sql_allow=["drop"]),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["permissions"] == {"profile": "normal"}
+        assert agent_raw["project_sql_allow"] == ["drop"]
+
+    def test_no_sql_allow_leaves_grant_list_unset(self):
+        agent_raw = {"target": "openai", "models": {"openai": {}}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(project_name="p"),
+        ):
+            _apply_project_override(agent_raw)
+        assert "project_sql_allow" not in agent_raw
+
+
 class TestPermissionModeCliOverride:
     """--permission-mode kwarg reshapes permissions.profile at load time."""
 

--- a/tests/unit_tests/configuration/test_agent_config_permissions.py
+++ b/tests/unit_tests/configuration/test_agent_config_permissions.py
@@ -170,6 +170,34 @@ def test_malformed_user_rules_falls_back_to_base(caplog):
     )
 
 
+def test_user_sql_statements_layered_on_profile_base():
+    cfg = _make_config({"profile": "normal", "sql_statements": {"write": "allow"}})
+    rules = cfg.permissions_config.sql_statements
+    assert rules.level_for_class("write") == PermissionLevel.ALLOW
+    # Unset classes keep the normal profile posture.
+    assert rules.level_for_class("destructive") == PermissionLevel.ASK
+
+
+def test_profile_sql_statements_present_without_user_override():
+    cfg = _make_config({"profile": "auto"})
+    rules = cfg.permissions_config.sql_statements
+    assert rules.level_for_class("write") == PermissionLevel.ALLOW
+    assert rules.level_for_class("destructive") == PermissionLevel.ASK
+
+
+def test_malformed_sql_statements_falls_back_to_base(caplog):
+    """An invalid sql_statements level must not crash startup — fall back to
+    the profile base (fail closed) with a warning."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="datus.configuration.agent_config"):
+        cfg = _make_config({"profile": "auto", "sql_statements": {"destructive": "yolo"}})
+    # Fell back to base normal (the loader's fail-closed target).
+    assert cfg.permissions_config.default_permission == PermissionLevel.ASK
+    assert cfg.permissions_config.sql_statements.level_for_class("write") == PermissionLevel.ASK
+    assert any("permissions" in rec.message for rec in caplog.records)
+
+
 def test_non_mapping_permissions_falls_back_to_normal(caplog):
     """A list/scalar in ``permissions`` must not crash the loader.
 

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -220,6 +220,7 @@ class TestAllowedKeys:
                 "language",
                 "reasoning_effort",
                 "bash_allow",
+                "sql_allow",
             }
         )
 
@@ -328,6 +329,97 @@ class TestServiceDefaultFields:
         loaded = yaml.safe_load(written.read_text())
         assert "dashboard" in loaded
         assert "scheduler" not in loaded
+
+
+class TestSqlAllow:
+    """Project-level sql_allow parsing and text-level appending."""
+
+    def _write(self, tmp_path, content: str):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def test_parse_sql_allow_list_normalizes_case(self, tmp_path):
+        self._write(tmp_path, yaml.safe_dump({"sql_allow": ["INSERT", "drop"]}))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow == ["insert", "drop"]
+
+    def test_non_list_sql_allow_dropped(self, tmp_path):
+        self._write(tmp_path, yaml.safe_dump({"sql_allow": "insert"}))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow is None
+
+    def test_non_string_entries_dropped(self, tmp_path):
+        self._write(tmp_path, yaml.safe_dump({"sql_allow": ["insert", 42, ""]}))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow == ["insert"]
+
+    def test_sql_allow_round_trips_through_save(self, tmp_path):
+        save_project_override(ProjectOverride(sql_allow=["delete"]), cwd=str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow == ["delete"]
+
+    def test_is_empty_false_when_sql_allow_set(self):
+        assert not ProjectOverride(sql_allow=["drop"]).is_empty()
+
+    def test_append_creates_file(self, tmp_path):
+        from datus.configuration.project_config import append_project_sql_allow
+
+        append_project_sql_allow("insert", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow == ["insert"]
+
+    def test_append_normalizes_kind(self, tmp_path):
+        from datus.configuration.project_config import append_project_sql_allow
+
+        append_project_sql_allow("  DROP ", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow == ["drop"]
+
+    def test_append_to_file_without_key_preserves_content(self, tmp_path):
+        from datus.configuration.project_config import append_project_sql_allow
+
+        self._write(tmp_path, "# my project config\nproject_name: proj_a\n")
+        append_project_sql_allow("delete", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow == ["delete"]
+        assert result.project_name == "proj_a"
+        assert "# my project config" in (tmp_path / PROJECT_CONFIG_REL).read_text()
+
+    def test_append_to_existing_key_preserves_entries(self, tmp_path):
+        from datus.configuration.project_config import append_project_sql_allow
+
+        self._write(tmp_path, '# header comment\nsql_allow:\n  - "insert"\nproject_name: proj_a\n')
+        append_project_sql_allow("drop", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert sorted(result.sql_allow) == ["drop", "insert"]
+        assert "# header comment" in (tmp_path / PROJECT_CONFIG_REL).read_text()
+
+    def test_append_is_idempotent(self, tmp_path):
+        from datus.configuration.project_config import append_project_sql_allow
+
+        append_project_sql_allow("drop", str(tmp_path))
+        append_project_sql_allow("drop", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.sql_allow == ["drop"]
+
+    def test_append_empty_kind_raises(self, tmp_path):
+        from datus.configuration.project_config import append_project_sql_allow
+        from datus.utils.exceptions import DatusException
+
+        with pytest.raises(DatusException):
+            append_project_sql_allow("   ", str(tmp_path))
+
+    def test_append_coexists_with_bash_allow(self, tmp_path):
+        """sql_allow and bash_allow edits must not clobber each other."""
+        from datus.configuration.project_config import append_project_bash_allow, append_project_sql_allow
+
+        append_project_bash_allow("make:*", str(tmp_path))
+        append_project_sql_allow("drop", str(tmp_path))
+        result = load_project_override(str(tmp_path))
+        assert result.bash_allow == ["make:*"]
+        assert result.sql_allow == ["drop"]
 
 
 class TestBashAllow:

--- a/tests/unit_tests/tools/permission/test_permission_config.py
+++ b/tests/unit_tests/tools/permission/test_permission_config.py
@@ -254,3 +254,162 @@ class TestPermissionConfig:
         assert len(merged.rules) == 2
         assert merged.rules[0].tool == "db_tools"  # Base rule
         assert merged.rules[1].tool == "skills"  # Override rule (evaluated later)
+
+
+class TestClassifySqlKind:
+    """Kind → class mapping used by the execute_sql permission gate."""
+
+    @pytest.mark.parametrize(
+        "kind,expected",
+        [
+            ("select", "read"),
+            ("metadata", "read"),
+            ("explain", "read"),
+            ("insert", "write"),
+            ("create", "write"),
+            ("ddl", "write"),
+            ("context_set", "write"),
+            ("update", "destructive"),
+            ("delete", "destructive"),
+            ("merge", "destructive"),
+            ("drop", "destructive"),
+            ("truncate", "destructive"),
+            ("alter", "destructive"),
+            ("replace", "destructive"),
+            ("unknown", "unknown"),
+        ],
+    )
+    def test_known_kinds(self, kind, expected):
+        from datus.tools.permission.permission_config import classify_sql_kind
+
+        assert classify_sql_kind(kind) == expected
+
+    def test_unmapped_kind_fails_safe_to_unknown(self):
+        from datus.tools.permission.permission_config import classify_sql_kind
+
+        assert classify_sql_kind("frobnicate") == "unknown"
+        assert classify_sql_kind("") == "unknown"
+
+
+class TestSqlStatementRules:
+    """Per-class SQL statement rules model."""
+
+    def test_defaults_match_normal_posture(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        rules = SqlStatementRules()
+        assert rules.level_for_class("read") == PermissionLevel.ALLOW
+        assert rules.level_for_class("write") == PermissionLevel.ASK
+        assert rules.level_for_class("destructive") == PermissionLevel.ASK
+        assert rules.level_for_class("unknown") == PermissionLevel.ASK
+
+    def test_level_for_class_returns_permission_level(self):
+        """use_enum_values stores strings; level_for_class must coerce back."""
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        level = SqlStatementRules().level_for_class("read")
+        assert isinstance(level, PermissionLevel)
+
+    def test_level_for_unmapped_class_falls_to_unknown(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        rules = SqlStatementRules(unknown=PermissionLevel.DENY)
+        assert rules.level_for_class("nonsense") == PermissionLevel.DENY
+
+    def test_from_dict_none_returns_none(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        assert SqlStatementRules.from_dict(None) is None
+
+    def test_from_dict_tracks_explicit_fields_only(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        rules = SqlStatementRules.from_dict({"write": "allow"})
+        assert rules.model_fields_set == {"write"}
+        assert rules.level_for_class("write") == PermissionLevel.ALLOW
+        assert rules.level_for_class("destructive") == PermissionLevel.ASK
+
+    def test_from_dict_empty_dict_has_no_explicit_fields(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        rules = SqlStatementRules.from_dict({})
+        assert isinstance(rules, SqlStatementRules)
+        assert rules.model_fields_set == set()
+
+    def test_from_dict_rejects_non_mapping(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        with pytest.raises(ValueError, match="mapping"):
+            SqlStatementRules.from_dict(["read"])
+
+    def test_from_dict_rejects_invalid_level(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        with pytest.raises(ValueError):
+            SqlStatementRules.from_dict({"destructive": "yolo"})
+
+    def test_merge_with_override_if_set(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        base = SqlStatementRules(write=PermissionLevel.ALLOW)
+        override = SqlStatementRules.from_dict({"destructive": "deny"})
+        merged = base.merge_with(override)
+        # Explicit override field wins; unset override fields keep base values.
+        assert merged.level_for_class("destructive") == PermissionLevel.DENY
+        assert merged.level_for_class("write") == PermissionLevel.ALLOW
+        assert merged.level_for_class("read") == PermissionLevel.ALLOW
+
+    def test_merge_with_none_returns_self(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        base = SqlStatementRules(write=PermissionLevel.ALLOW)
+        assert base.merge_with(None) is base
+
+    def test_merge_does_not_mutate_base(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        base = SqlStatementRules()
+        base.merge_with(SqlStatementRules.from_dict({"write": "deny"}))
+        assert base.level_for_class("write") == PermissionLevel.ASK
+
+
+class TestPermissionConfigSqlStatements:
+    """sql_statements carried through PermissionConfig from_dict / merge_with."""
+
+    def test_from_dict_parses_sql_statements(self):
+        config = PermissionConfig.from_dict(
+            {"default": "ask", "sql_statements": {"write": "allow", "destructive": "ask"}}
+        )
+        assert config.sql_statements.level_for_class("write") == PermissionLevel.ALLOW
+        assert config.sql_statements.level_for_class("destructive") == PermissionLevel.ASK
+
+    def test_from_dict_without_sql_statements_is_none(self):
+        config = PermissionConfig.from_dict({"default": "ask"})
+        assert config.sql_statements is None
+
+    def test_merge_with_layers_sql_statements(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        base = PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            sql_statements=SqlStatementRules(write=PermissionLevel.ALLOW),
+        )
+        override = PermissionConfig.from_dict({"default": "ask", "sql_statements": {"destructive": "deny"}})
+        merged = base.merge_with(override)
+        assert merged.sql_statements.level_for_class("write") == PermissionLevel.ALLOW
+        assert merged.sql_statements.level_for_class("destructive") == PermissionLevel.DENY
+
+    def test_merge_with_no_base_takes_override(self):
+        override = PermissionConfig.from_dict({"default": "ask", "sql_statements": {"write": "allow"}})
+        merged = PermissionConfig(default_permission=PermissionLevel.ASK).merge_with(override)
+        assert merged.sql_statements.level_for_class("write") == PermissionLevel.ALLOW
+
+    def test_merge_with_override_lacking_sql_statements_keeps_base(self):
+        from datus.tools.permission.permission_config import SqlStatementRules
+
+        base = PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            sql_statements=SqlStatementRules(write=PermissionLevel.ALLOW),
+        )
+        merged = base.merge_with(PermissionConfig(default_permission=PermissionLevel.ASK))
+        assert merged.sql_statements.level_for_class("write") == PermissionLevel.ALLOW

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -11,7 +11,12 @@ import pytest
 
 from datus.cli.execution_state import InteractionBroker
 from datus.tools.permission import permission_hooks as permission_hooks_module
-from datus.tools.permission.permission_config import PermissionConfig, PermissionLevel, PermissionRule
+from datus.tools.permission.permission_config import (
+    PermissionConfig,
+    PermissionLevel,
+    PermissionRule,
+    SqlStatementRules,
+)
 from datus.tools.permission.permission_hooks import (
     CompositeHooks,
     FilesystemPolicy,
@@ -1772,6 +1777,301 @@ class TestExecuteSqlPermission:
         # A DDL (different type again) → prompts once more.
         await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
         assert mock_broker.request.await_count == 3
+
+
+class TestExecuteSqlClassRules:
+    """Statement-class gating for ``execute_sql`` when ``sql_statements`` rules are present."""
+
+    def _make_hooks(
+        self,
+        mock_broker,
+        config,
+        non_interactive=False,
+        project_root=None,
+        project_sql_allows=None,
+    ):
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "execute_sql"
+        registry.register_tools("db_tools", [tool_mock])
+        manager = PermissionManager(global_config=config, project_sql_allows=project_sql_allows)
+        return PermissionHooks(
+            broker=mock_broker,
+            permission_manager=manager,
+            node_name="chat",
+            tool_registry=registry,
+            non_interactive=non_interactive,
+            project_root=project_root,
+        )
+
+    @staticmethod
+    def _normal_config(**rule_overrides):
+        return PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            rules=[],
+            sql_statements=SqlStatementRules(**rule_overrides),
+        )
+
+    @staticmethod
+    def _auto_config():
+        return PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            rules=[],
+            sql_statements=SqlStatementRules(write=PermissionLevel.ALLOW),
+        )
+
+    @staticmethod
+    def _ctx(sql):
+        import json
+
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps({"sql": sql})
+        return ctx
+
+    @staticmethod
+    def _tool():
+        t = MagicMock()
+        t.name = "execute_sql"
+        return t
+
+    @pytest.mark.asyncio
+    async def test_normal_read_auto_allows(self, mock_broker):
+        hooks = self._make_hooks(mock_broker, self._normal_config())
+
+        await hooks.on_tool_start(self._ctx("SELECT * FROM users"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "INSERT INTO t VALUES (1)",
+            "CREATE TABLE t (id INT)",
+            "UPDATE t SET a = 1",
+            "DROP TABLE t",
+        ],
+    )
+    async def test_normal_write_and_destructive_prompt(self, mock_broker, sql):
+        hooks = self._make_hooks(mock_broker, self._normal_config())
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx(sql), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "INSERT INTO t VALUES (1)",
+            "CREATE TABLE t (id INT)",
+            "COMMENT ON TABLE t IS 'x'",
+            "USE analytics",
+        ],
+    )
+    async def test_auto_non_destructive_writes_auto_allow(self, mock_broker, sql):
+        """Under auto's ruleset (write=ALLOW), non-destructive writes never prompt."""
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+
+        await hooks.on_tool_start(self._ctx(sql), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "UPDATE t SET a = 1",
+            "DELETE FROM t",
+            "DROP TABLE t",
+            "TRUNCATE TABLE t",
+            "ALTER TABLE t ADD COLUMN b INT",
+            "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = 1",
+        ],
+    )
+    async def test_auto_destructive_still_prompts(self, mock_broker, sql):
+        """Destructive statements prompt under auto despite write=ALLOW."""
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx(sql), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_auto_unknown_prompts(self, mock_broker):
+        """Unparseable SQL stays ASK under auto (fail safe), despite write=ALLOW."""
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("FROBNICATE THE WIDGETS"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_class_deny_raises_without_prompt(self, mock_broker):
+        hooks = self._make_hooks(mock_broker, self._normal_config(destructive=PermissionLevel.DENY))
+
+        with pytest.raises(PermissionDeniedException, match="sql_statements"):
+            await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_session_bucket_is_per_kind_not_per_class(self, mock_broker):
+        """Approving DROP for the session must not cover TRUNCATE (same class)."""
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+        # Same kind: served from the session cache.
+        await hooks.on_tool_start(self._ctx("DROP TABLE u"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+        # Different kind in the same (destructive) class: prompts again.
+        await hooks.on_tool_start(self._ctx("TRUNCATE TABLE t"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_project_grant_bypasses_prompt(self, mock_broker):
+        hooks = self._make_hooks(mock_broker, self._auto_config(), project_sql_allows=["drop"])
+
+        await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_project_grant_is_exact_kind(self, mock_broker):
+        """A ``drop`` grant must not cover TRUNCATE (or any other kind)."""
+        hooks = self._make_hooks(mock_broker, self._auto_config(), project_sql_allows=["drop"])
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("TRUNCATE TABLE t"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_project_choice_persists_and_covers_session(self, mock_broker, tmp_path):
+        hooks = self._make_hooks(mock_broker, self._auto_config(), project_root=str(tmp_path))
+        mock_broker.request = AsyncMock(return_value=[["p"]])
+
+        await hooks.on_tool_start(self._ctx("DELETE FROM t"), MagicMock(), self._tool())
+
+        config_file = tmp_path / ".datus" / "config.yml"
+        assert config_file.exists()
+        import yaml
+
+        assert yaml.safe_load(config_file.read_text())["sql_allow"] == ["delete"]
+
+        # Later same-kind calls this session skip the prompt.
+        await hooks.on_tool_start(self._ctx("DELETE FROM u"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_project_choice_not_offered_for_unknown(self, mock_broker):
+        """The prompt for unparseable SQL must not include the project choice."""
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("FROBNICATE THE WIDGETS"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "p" not in event.choices
+        assert set(event.choices) == {"y", "a", "n"}
+
+    @pytest.mark.asyncio
+    async def test_project_choice_offered_for_destructive(self, mock_broker):
+        """Destructive kinds DO offer the project choice (user decision)."""
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert event.choices["p"] == "Allow 'drop' (project)"
+
+    @pytest.mark.asyncio
+    async def test_rejection_raises(self, mock_broker):
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+        mock_broker.request = AsyncMock(return_value=[["n"]])
+
+        with pytest.raises(PermissionDeniedException, match="User rejected"):
+            await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_destructive_raises_without_prompt(self, mock_broker):
+        hooks = self._make_hooks(mock_broker, self._auto_config(), non_interactive=True)
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(self._ctx("DELETE FROM t"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_auto_write_allowed(self, mock_broker):
+        """Workflow flows under auto rules run non-destructive writes silently."""
+        hooks = self._make_hooks(mock_broker, self._auto_config(), non_interactive=True)
+
+        await hooks.on_tool_start(self._ctx("INSERT INTO t VALUES (1)"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sql_file_with_drop_prompts_as_destructive(self, mock_broker, tmp_path):
+        """A .sql file is resolved so a DROP inside prompts even under auto."""
+        sql_dir = tmp_path / "sql"
+        sql_dir.mkdir()
+        (sql_dir / "cleanup.sql").write_text("DROP TABLE staging")
+        hooks = self._make_hooks(mock_broker, self._auto_config(), project_root=str(tmp_path))
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("sql/cleanup.sql"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
+        event = mock_broker.request.await_args.args[0][0]
+        assert "drop" in event.content
+
+    @pytest.mark.asyncio
+    async def test_explicit_allow_rule_bypasses_class_rules(self, mock_broker):
+        """A user ``db_tools/execute_sql: allow`` rule remains the escape hatch."""
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            rules=[PermissionRule(tool="db_tools", pattern="execute_sql", permission=PermissionLevel.ALLOW)],
+            sql_statements=SqlStatementRules(destructive=PermissionLevel.DENY),
+        )
+        hooks = self._make_hooks(mock_broker, config)
+
+        await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_deny_rule_beats_class_allow(self, mock_broker):
+        """A coarse DENY rule blocks even reads regardless of class rules."""
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            rules=[PermissionRule(tool="db_tools", pattern="execute_sql", permission=PermissionLevel.DENY)],
+            sql_statements=SqlStatementRules(),
+        )
+        hooks = self._make_hooks(mock_broker, config)
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(self._ctx("SELECT 1"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_replace_prompts_as_destructive_under_auto(self, mock_broker):
+        """REPLACE INTO deletes matched rows first — it must not ride write=ALLOW."""
+        hooks = self._make_hooks(mock_broker, self._auto_config())
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("REPLACE INTO t VALUES (1)"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 1
 
 
 class TestFormatToolArgsMarkdown:

--- a/tests/unit_tests/tools/permission/test_permission_manager.py
+++ b/tests/unit_tests/tools/permission/test_permission_manager.py
@@ -704,3 +704,71 @@ class TestProjectBashGrants:
         mgr.switch_profile("auto")
         assert mgr.is_plugin_ask_pattern("datus hello config del:*")
         assert not mgr.is_plugin_ask_pattern("datus hello config set:*")
+
+
+class TestProjectSqlGrants:
+    """Exact-match project SQL statement-kind grants for execute_sql."""
+
+    def test_constructor_seeds_and_normalizes_grants(self):
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(
+            global_config=get_profile("normal"),
+            project_sql_allows=["INSERT", "  drop  "],
+        )
+        assert mgr.has_project_sql_grant("insert")
+        assert mgr.has_project_sql_grant("drop")
+        assert mgr.has_project_sql_grant("DROP")  # lookup normalizes too
+        assert not mgr.has_project_sql_grant("truncate")
+        assert not mgr.has_project_sql_grant(None)
+        assert not mgr.has_project_sql_grant("")
+
+    def test_add_project_sql_allow_registers_grant_and_persists(self):
+        from unittest.mock import patch
+
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(global_config=get_profile("normal"))
+        with patch("datus.configuration.project_config.append_project_sql_allow") as mock_append:
+            persisted = mgr.add_project_sql_allow("Delete", project_root="/tmp/proj")
+        assert persisted is True
+        mock_append.assert_called_once_with("delete", "/tmp/proj")
+        assert mgr.has_project_sql_grant("delete")
+
+    def test_add_project_sql_allow_degrades_on_write_failure(self):
+        from unittest.mock import patch
+
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(global_config=get_profile("normal"))
+        with patch(
+            "datus.configuration.project_config.append_project_sql_allow",
+            side_effect=OSError("read-only"),
+        ):
+            persisted = mgr.add_project_sql_allow("drop")
+        assert persisted is False
+        # In-memory grant still applies for the rest of the session.
+        assert mgr.has_project_sql_grant("drop")
+
+    def test_grants_survive_profile_switches(self):
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(
+            global_config=get_profile("normal"),
+            project_sql_allows=["drop"],
+        )
+        mgr.switch_profile("auto")
+        assert mgr.has_project_sql_grant("drop")
+        mgr.switch_profile("dangerous")
+        mgr.switch_profile("normal")
+        assert mgr.has_project_sql_grant("drop")
+
+    def test_switch_profile_rebuilds_sql_statements_from_target_profile(self):
+        from datus.tools.permission.profiles import get_profile
+
+        mgr = PermissionManager(global_config=get_profile("normal"), active_profile="normal")
+        assert mgr.global_config.sql_statements.level_for_class("write") == PermissionLevel.ASK
+        mgr.switch_profile("auto")
+        assert mgr.global_config.sql_statements.level_for_class("write") == PermissionLevel.ALLOW
+        mgr.switch_profile("dangerous")
+        assert mgr.global_config.sql_statements is None

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -462,3 +462,63 @@ class TestPluginBashRulesMerge:
 
         effective = build_effective_config("normal", None, plugin_bash_rules=BashCommandRules())
         assert effective is NORMAL
+
+
+class TestProfileSqlStatements:
+    """Per-class execute_sql rules attached to each profile."""
+
+    def test_normal_levels(self):
+        rules = NORMAL.sql_statements
+        assert rules.level_for_class("read") == PermissionLevel.ALLOW
+        assert rules.level_for_class("write") == PermissionLevel.ASK
+        assert rules.level_for_class("destructive") == PermissionLevel.ASK
+        assert rules.level_for_class("unknown") == PermissionLevel.ASK
+
+    def test_auto_levels(self):
+        rules = AUTO.sql_statements
+        assert rules.level_for_class("read") == PermissionLevel.ALLOW
+        assert rules.level_for_class("write") == PermissionLevel.ALLOW
+        # Destructive statements still confirm under auto — that is the point.
+        assert rules.level_for_class("destructive") == PermissionLevel.ASK
+        assert rules.level_for_class("unknown") == PermissionLevel.ASK
+
+    def test_dangerous_has_no_sql_ruleset(self):
+        """Dangerous leaves sql_statements unset so the gate falls back to the
+        coarse rule check, which resolves to default ALLOW for every class."""
+        assert DANGEROUS.sql_statements is None
+
+    def test_user_sql_statements_merge_into_profile(self):
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config("normal", {"sql_statements": {"write": "allow"}})
+        assert effective.sql_statements.level_for_class("write") == PermissionLevel.ALLOW
+        # Unset user fields keep the profile posture.
+        assert effective.sql_statements.level_for_class("destructive") == PermissionLevel.ASK
+
+    def test_user_can_deny_destructive_under_auto(self):
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config("auto", {"sql_statements": {"destructive": "deny"}})
+        assert effective.sql_statements.level_for_class("destructive") == PermissionLevel.DENY
+        assert effective.sql_statements.level_for_class("write") == PermissionLevel.ALLOW
+
+    def test_plugin_bash_rules_rebuild_preserves_sql_statements(self):
+        """Regression: the plugin-bash-rules rebuild in build_effective_config
+        constructs a fresh PermissionConfig and must carry sql_statements."""
+        from datus.tools.permission.bash_rules import BashCommandRules
+        from datus.tools.permission.profiles import build_effective_config
+
+        effective = build_effective_config(
+            "auto", None, plugin_bash_rules=BashCommandRules(allow=["datus hello greet:*"])
+        )
+        assert effective.sql_statements.level_for_class("write") == PermissionLevel.ALLOW
+        assert effective.sql_statements.level_for_class("destructive") == PermissionLevel.ASK
+
+    def test_profile_singleton_sql_rules_not_mutated_by_manager(self):
+        """PermissionManager deep-copies sql_statements; mutations must not
+        leak into the shared profile singleton."""
+        from datus.tools.permission.permission_manager import PermissionManager
+
+        manager = PermissionManager(global_config=get_profile("auto"))
+        manager.global_config.sql_statements.write = PermissionLevel.DENY
+        assert AUTO.sql_statements.level_for_class("write") == PermissionLevel.ALLOW

--- a/tests/unit_tests/utils/test_sql_utils.py
+++ b/tests/unit_tests/utils/test_sql_utils.py
@@ -20,6 +20,7 @@ from datus.utils.sql_utils import (
     parse_dialect,
     parse_metadata_from_ddl,
     parse_read_dialect,
+    parse_sql_statement_kind,
     parse_sql_type,
     parse_table_name_parts,
     parse_table_names_parts,
@@ -1619,3 +1620,77 @@ class TestReadWorkspaceSqlFile:
     def test_missing_file_raises_file_not_found(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             read_workspace_sql_file("sql/missing.sql", str(tmp_path))
+
+
+class TestParseSqlStatementKind:
+    """Fine-grained statement kinds for the execute_sql permission gate."""
+
+    @pytest.mark.parametrize(
+        "sql,expected",
+        [
+            # Kinds identical to parse_sql_type values.
+            ("SELECT * FROM t", "select"),
+            ("WITH cte AS (SELECT 1) SELECT * FROM cte", "select"),
+            ("VALUES (1), (2)", "select"),
+            ("SHOW TABLES", "metadata"),
+            ("DESCRIBE t", "metadata"),
+            ("EXPLAIN SELECT 1", "explain"),
+            ("INSERT INTO t VALUES (1)", "insert"),
+            ("UPDATE t SET a = 1", "update"),
+            ("DELETE FROM t WHERE id = 1", "delete"),
+            ("MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = 1", "merge"),
+            ("USE analytics", "context_set"),
+            ("SET search_path = public", "context_set"),
+            # DDL refined by leading keyword.
+            ("CREATE TABLE t (id INT)", "create"),
+            ("CREATE OR REPLACE VIEW v AS SELECT 1", "create"),
+            ("CREATE TABLE t AS SELECT * FROM s", "create"),
+            ("ALTER TABLE t ADD COLUMN b INT", "alter"),
+            ("DROP TABLE t", "drop"),
+            ("DROP VIEW IF EXISTS v", "drop"),
+            ("TRUNCATE TABLE t", "truncate"),
+            # Benign DDL stays in the coarse ddl bucket.
+            ("COMMENT ON TABLE t IS 'x'", "ddl"),
+            ("GRANT SELECT ON t TO alice", "ddl"),
+            ("ANALYZE t", "ddl"),
+            # sqlglot models VACUUM as a generic Command → CONTENT_SET; a
+            # benign maintenance command in the write class is acceptable.
+            ("VACUUM", "context_set"),
+        ],
+    )
+    def test_kind_classification(self, sql, expected):
+        assert parse_sql_statement_kind(sql, "duckdb") == expected
+
+    def test_rename_counts_as_alter(self):
+        assert parse_sql_statement_kind("RENAME TABLE t TO u", "mysql") == "alter"
+
+    def test_replace_into_is_its_own_kind(self):
+        """REPLACE deletes matched rows before inserting — must not be 'insert'."""
+        assert parse_sql_statement_kind("REPLACE INTO t VALUES (1)", "mysql") == "replace"
+
+    def test_cte_fronted_insert_is_insert(self):
+        """A WITH-fronted INSERT classifies by the real statement, not 'WITH'."""
+        assert parse_sql_statement_kind("WITH src AS (SELECT 1 AS a) INSERT INTO t SELECT * FROM src", "") == "insert"
+
+    def test_multi_statement_classifies_first_only(self):
+        """First-statement semantics: the tool layer's multi-statement
+        rejection is the backstop for trailing statements."""
+        assert parse_sql_statement_kind("SELECT 1; DROP TABLE t", "") == "select"
+
+    def test_leading_comment_ignored(self):
+        assert parse_sql_statement_kind("-- cleanup\nDROP TABLE t", "") == "drop"
+
+    def test_empty_and_garbage_fall_to_unknown(self):
+        assert parse_sql_statement_kind("", "") == "unknown"
+        assert parse_sql_statement_kind("   ", "") == "unknown"
+        assert parse_sql_statement_kind("FROBNICATE THE WIDGETS", "") == "unknown"
+
+    def test_no_dialect_works_for_common_statements(self):
+        """The permission hook has no dialect; the fallback must still split."""
+        assert parse_sql_statement_kind("DROP TABLE t", "") == "drop"
+        assert parse_sql_statement_kind("TRUNCATE TABLE t", "") == "truncate"
+        assert parse_sql_statement_kind("SELECT 1", "") == "select"
+
+    def test_case_insensitive_keywords(self):
+        assert parse_sql_statement_kind("drop table t", "") == "drop"
+        assert parse_sql_statement_kind("Truncate Table t", "") == "truncate"


### PR DESCRIPTION
## Why

`execute_sql` is the unified SQL entry point, but its permission gate only distinguished "read-only vs everything else": reads auto-allowed and every other statement prompted, in every profile. This had three gaps:

- The `auto` profile could not express "writes run without confirmation, but irreversible statements still confirm" — every INSERT/CREATE prompted, which defeats auto's productive posture.
- `SQLType.DDL` folds DROP/TRUNCATE/ALTER together with CREATE/COMMENT/GRANT, so destructive DDL could not be gated more strictly than benign DDL.
- The SQL confirmation prompt had no project-level "always allow" and no global config knob, unlike the bash tool (`bash_allow` in `.datus/config.yml`, `permissions.bash_commands` in agent.yml).

## Solution

Classify each statement into a fine-grained kind and gate on the kind's class (read / write / destructive / unknown), mirroring the bash tool's layered logic:

| class | statements | normal | auto | dangerous |
|---|---|---|---|---|
| read | SELECT / SHOW / DESCRIBE / EXPLAIN | allow | allow | allow |
| write | INSERT, CREATE, benign DDL (COMMENT/GRANT/…), USE/SET | ask | **allow** | allow |
| destructive | UPDATE, DELETE, MERGE, DROP, TRUNCATE, ALTER, REPLACE | ask | ask | allow |
| unknown | unparseable SQL (fail-safe) | ask | ask | allow |

Key decisions:

- **`SQLType` untouched.** A new `parse_sql_statement_kind()` in `sql_utils.py` refines `SQLType.DDL` into `create`/`alter`/`drop`/`truncate`/`ddl` by leading keyword and splits `REPLACE` (deletes matched rows) from `INSERT`. Statements sqlglot folds into a generic `Command` (e.g. MySQL `RENAME TABLE`) are refined the same way so destructive keywords can never ride the `CONTENT_SET` fold into the write class. Extending the enum would have changed serialized values and broken external assertions for no benefit.
- **`SqlStatementRules`** (per-class `allow`/`ask`/`deny`) lives on `PermissionConfig` next to `bash_commands`, with per-profile defaults in `profiles.py` and user overrides via `permissions.sql_statements` in agent.yml (override-if-set merge, same semantics as bash rules). `dangerous` leaves it unset and keeps its default-ALLOW flow.
- **Session approvals bucket by fine-grained kind** (`execute_sql.drop` vs `.truncate`): approving one DROP never green-lights a later TRUNCATE — previously both shared the `ddl` bucket.
- **Project-scope grants**: the SQL prompt gains an `Allow '<kind>' (project)` choice persisting the kind to `.datus/config.yml`'s new `sql_allow:` list (text-level edit preserving comments, shared helper with `bash_allow`). Loaded at startup into an exact-match grant set on `PermissionManager` that survives profile switches. Not offered for `unknown` — a grant auto-allowing every future unparseable statement would be a blank cheque.
- **Coarse rules stay authoritative**: an explicit `db_tools/execute_sql` DENY/ALLOW rule still wins (escape hatch), and configs without `sql_statements` run the legacy path byte-for-byte (all 13 pre-existing `TestExecuteSqlPermission` tests pass unchanged).
- Also fixes a latent bug: the plugin-bash-rules rebuild in `build_effective_config` constructed a fresh `PermissionConfig` and silently dropped any field not listed — `sql_statements` would have vanished whenever a plugin declared bash rules (regression test added).

Tradeoff called out in `agent.yml.example`: `CALL`/`EXEC` land in the write class but can run arbitrary stored procedures; users can tighten with `sql_statements: {write: ask}`.

## Test Cases

~70 new unit tests (all CI-tier, fully mocked, no external deps):

- `tests/unit_tests/utils/test_sql_utils.py` — `TestParseSqlStatementKind`: full kind table, `CREATE OR REPLACE`→create, `RENAME`→alter (Command-fold refinement), `REPLACE INTO`→replace, WITH-fronted INSERT, multi-statement first-only semantics, garbage→unknown.
- `tests/unit_tests/tools/permission/test_permission_hooks.py` — new `TestExecuteSqlClassRules`: per-profile prompt matrix, class DENY raises without prompting, per-kind session buckets (DROP approval doesn't cover TRUNCATE), project grant bypass + exact-kind scoping, `p` choice persists to `.datus/config.yml` and covers the session, `p` not offered for unknown, non-interactive behavior, `.sql` file resolution, coarse-rule escape hatches. All 13 legacy tests pass unchanged.
- `test_permission_config.py` / `test_profiles.py` / `test_permission_manager.py` — rules model (from_dict/merge/coercion), profile levels, plugin-rebuild regression, project grant lifecycle (seeding, normalization, disk-failure degradation, profile-switch survival, singleton deep-copy).
- `tests/unit_tests/configuration/` — `sql_allow` parse/append/round-trip (comment preservation, dedupe, coexistence with `bash_allow`), loader forwarding (grant list only, `permissions.*` untouched), agent.yml `sql_statements` parsing with fail-closed fallback.

No integration/nightly tests added: the feature is confirmation-prompt UX + config plumbing, fully exercised at the unit tier with a mocked broker; there is no external service to integrate against. `ci/audit_tests.py` reports P0=0, P1=0 on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added fine-grained SQL permission controls for reads, writes, destructive statements, and unknown commands.
  * SQL permissions now support profile-specific behavior, including automatic approval for non-destructive writes and confirmation for destructive actions.
  * Added project-level SQL approvals that can persist in project configuration.
  * Confirmation prompts now support one-time, session, and project approvals where appropriate.

* **Documentation**
  * Updated example configuration guidance for SQL permission rules and approval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fine-grained SQL permission controls for statement classes (read, write, destructive, unknown) that govern `execute_sql` behavior.
  * SQL permissions are now profile-aware, with non-destructive writes auto-approved in the permissive profile and destructive statements still requiring confirmation.
  * Added project-level SQL approvals (`sql_allow`) that can persist and bypass prompts for exact matching statement kinds.

* **Documentation**
  * Updated the example configuration to clarify permission-profile behavior and added guidance for statement-kind classification and confirmation defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->