### PR TITLE
[Tool] Opt in to fork-PR checkout after actions/checkout security change

### DIFF
--- a/.github/workflows/python-format-check.yml
+++ b/.github/workflows/python-format-check.yml
@@ -10,6 +10,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          # recent actions/checkout v4 releases refuse fork-PR checkouts under
+          # pull_request_target by default. This job only runs ruff over the
+          # PR files with a read-only token and no secrets, so opting in is
+          # the intended (pre-existing) behavior.
+          allow-unsafe-pr-checkout: true
 
       - name: Debug - Show current commit
         run: |

--- a/.github/workflows/run-ut-and-coverage.yml
+++ b/.github/workflows/run-ut-and-coverage.yml
@@ -12,6 +12,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           fetch-depth: 0
+          # recent actions/checkout v4 releases refuse fork-PR checkouts under
+          # pull_request_target by default. Running the PR's test suite in
+          # this context is this workflow's long-standing design; opt in
+          # explicitly to restore it.
+          allow-unsafe-pr-checkout: true
 
       - name: Fetch base branch
         run: |

--- a/.github/workflows/test-audit.yml
+++ b/.github/workflows/test-audit.yml
@@ -56,6 +56,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr
           fetch-depth: 0
+          # recent actions/checkout v4 releases refuse fork-PR checkouts under
+          # pull_request_target by default. Safe here by construction: the
+          # pr/ tree is data for the base-repo auditor and is never executed.
+          allow-unsafe-pr-checkout: true
 
       - name: Fetch base ref inside pr/ (needed for git diff)
         if: ${{ github.event_name == 'pull_request_target' }}


### PR DESCRIPTION
## Why

Every fork PR now fails CI at the **Checkout code** step, before any check runs — see https://github.com/Datus-ai/Datus-agent/actions/runs/29795906438 (blocking #1173):

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. … To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

Root cause is a GitHub platform change, not any PR's code: the floating `actions/checkout@v4` tag moved from SHA `34e11487` (last passing fork-PR run, 2026-07-20 14:11 UTC) to SHA `11d5960a` (first failing run, 2026-07-21 02:28 UTC). The new patch release refuses fork-PR checkouts under `pull_request_target` by default. Same-repo branch PRs and `merge_group` runs are unaffected, which is why only fork PRs broke.

## Solution

Add `allow-unsafe-pr-checkout: true` to the three checkout steps that fetch fork-PR code under `pull_request_target`, restoring each workflow's long-standing pre-existing behavior:

- `python-format-check.yml` — runs ruff over the PR files; read-only token, no secrets used.
- `run-ut-and-coverage.yml` — running the PR's test suite in base context is this workflow's existing design (concurrency-guarded, coverage comment needs the write-scoped token).
- `test-audit.yml` — the `pr/` checkout is untrusted **data only**, analyzed statically by the base repo's auditor and never executed (the file's own SECURITY header documents this); safe by construction.

The alternative — migrating these workflows to plain `pull_request` triggers — would lose the ability to post PR comments from fork PRs (read-only token) and is a larger redesign; this change simply makes the previously implicit accepted risk explicit, as the new checkout release requires. Each opt-in carries a comment explaining why it is acceptable at that site.

Note for the merger: this PR itself comes from a fork, so its own Code Quality run still fails on the *current* main's workflows (`pull_request_target` uses the base branch's workflow definitions — a PR cannot fix its own run). It needs an admin merge, or apply the same three-line-per-file patch directly on main. Once merged, re-running the failed checks on open fork PRs (e.g. #1173) will unblock them.

## Test Cases

None — workflow-only change with no runtime code paths to test. Verification is observational: after merge, re-run Code Quality on any open fork PR and confirm the Checkout step passes and downstream ruff/coverage/audit steps execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to support checkout of pull requests from forked repositories.
  * Preserved existing formatting checks, test execution, coverage reporting, and audit processes.
  * Added safeguards and clarification around how pull-request code is handled during auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->