### PR TITLE
[Others] Revert complete Ossie semantic document synchronization

### DIFF
--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -19,14 +19,7 @@ from datus.agent.workflow import Workflow
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionRole, ActionStatus
 from datus.schemas.chat_agentic_node_models import ChatNodeInput, ChatNodeResult
-from datus.tools.func_tool import (
-    ContextSearchTools,
-    DBFuncTool,
-    FilesystemFuncTool,
-    GenerationTools,
-    PlatformDocSearchTool,
-    trans_to_function_tool,
-)
+from datus.tools.func_tool import ContextSearchTools, DBFuncTool, FilesystemFuncTool, PlatformDocSearchTool
 from datus.tools.func_tool.date_parsing_tools import DateParsingTools
 from datus.tools.func_tool.reference_template_tools import ReferenceTemplateTools
 from datus.tools.permission.permission_manager import PermissionManager
@@ -102,7 +95,6 @@ class ChatAgenticNode(AgenticNode):
         self.degraded_capabilities: Dict[str, str] = {}
         self.date_parsing_tools: Optional[DateParsingTools] = None
         self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
-        self.semantic_sync_tools: Optional[GenerationTools] = None
         self._platform_doc_tool: Optional[PlatformDocSearchTool] = None
         self.reference_template_tools: Optional[ReferenceTemplateTools] = None
 
@@ -151,7 +143,6 @@ class ChatAgenticNode(AgenticNode):
         self._setup_reference_template_tools()
         self._setup_date_parsing_tools()
         self._setup_filesystem_tools()
-        self._setup_semantic_sync_tools()
         self._setup_memory_tools()
         # self.bash_tool was created in AgenticNode.__init__; just surface its
         # tool in this node's eager tools list (rebuild_tools also re-appends).
@@ -215,23 +206,6 @@ class ChatAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
 
-    def _setup_semantic_sync_tools(self):
-        """Expose only the complete Ossie sync tool on the main chat agent."""
-        try:
-            from datus.agent.node.semantic_authoring import is_osi_authoring
-
-            if self._is_subagent or not is_osi_authoring(self.agent_config):
-                self.semantic_sync_tools = None
-                return
-            self.semantic_sync_tools = GenerationTools(
-                self.agent_config,
-                authoring_format="osi",
-                runtime_db_context_provider=self._semantic_runtime_db_context,
-            )
-        except Exception as exc:
-            self.semantic_sync_tools = None
-            logger.warning("Failed to setup semantic sync tool, continuing without it: %s", exc)
-
     def _setup_platform_doc_tools(self):
         """Setup platform documentation search tools."""
         try:
@@ -290,8 +264,6 @@ class ChatAgenticNode(AgenticNode):
             self.tools.extend(self.date_parsing_tools.available_tools())
         if self.filesystem_func_tool:
             self.tools.extend(self.filesystem_func_tool.available_tools())
-        if self.semantic_sync_tools:
-            self.tools.append(trans_to_function_tool(self.semantic_sync_tools.sync_semantic))
         if self.memory_func_tool:
             self.tools.extend(self.memory_func_tool.available_tools())
         if self.bash_tool:
@@ -488,23 +460,11 @@ class ChatAgenticNode(AgenticNode):
         pm = get_prompt_manager(agent_config=self.agent_config)
         try:
             base_prompt = pm.render_template(template_name=template_name, version=prompt_version, **context)
-            if "sync_semantic" in exposed:
-                base_prompt += (
-                    "\n\nAfter directly modifying an existing Ossie semantic YAML file, call `sync_semantic` "
-                    "after the final write. The YAML is the sole source of truth, so removed datasets, profiles, "
-                    "and metrics are removed from the Knowledge Base. Do not report the change as effective until "
-                    "the sync succeeds."
-                )
             return self._finalize_system_prompt(base_prompt)
 
         except FileNotFoundError:
             logger.warning(f"Failed to render system prompt '{system_prompt_name}', using the default template instead")
             base_prompt = pm.render_template(template_name="chat_system", version=None, **context)
-            if "sync_semantic" in exposed:
-                base_prompt += (
-                    "\n\nAfter directly modifying an existing Ossie semantic YAML file, call `sync_semantic` "
-                    "after the final write and do not report success until synchronization succeeds."
-                )
             return self._finalize_system_prompt(base_prompt)
         except Exception as e:
             logger.error(f"Template loading error for '{template_name}': {e}")

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -325,7 +325,6 @@ class GenMetricsAgenticNode(AgenticNode):
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
                 authoring_format=authoring_format,
-                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -250,7 +250,6 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
                 authoring_format=authoring_format,
-                runtime_db_context_provider=self._semantic_runtime_db_context,
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
@@ -655,7 +654,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 if not self.generation_tools:
                     logger.error("Generation tools unavailable for OSI semantic sync")
                     return False
-                result = self.generation_tools.reconcile_osi_document_to_db(full_path)
+                result = self.generation_tools.sync_osi_semantic_to_db(full_path)
                 if result.get("success"):
                     self.generation_evidence.mark_kb_sync("semantic")
                     logger.info(f"Successfully saved OSI semantic model to database: {result.get('message')}")

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -599,7 +599,7 @@ class DatasourceService:
                 sync_result = GenerationTools(
                     agent_config=self.agent_config,
                     authoring_format="osi",
-                ).reconcile_osi_document_to_db(semantic_file_path)
+                ).sync_osi_semantic_to_db(semantic_file_path)
             else:
                 sync_result = GenerationHooks._sync_semantic_to_db(
                     semantic_file_path,

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -1090,11 +1090,7 @@ def init_semantic_yaml_metrics(
     agent_config: AgentConfig,
 ) -> tuple[bool, str]:
     """
-    Initialize metrics from semantic YAML.
-
-    MetricFlow keeps the legacy metrics-only projection. An Ossie YAML is a
-    unified artifact, so its datasets, profiles, and metrics are reconciled
-    together and removed objects are cleared from storage.
+    Initialize ONLY metrics from semantic YAML file, skip semantic model objects.
 
     Args:
         yaml_file_path: Path to semantic YAML file
@@ -1109,7 +1105,7 @@ def init_semantic_yaml_metrics(
 
         result = GenerationTools(
             agent_config=agent_config, authoring_format=AUTHORING_FORMAT_OSI
-        ).reconcile_osi_document_to_db(yaml_file_path)
+        )._sync_osi_metric_to_db(yaml_file_path)
         if result.get("success"):
             return True, result.get("message", "")
         return False, result.get("error", "Unknown error")

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -691,9 +691,9 @@ def refresh_semantic_yaml_profile_descriptions(
             try:
                 from datus.tools.func_tool.generation_tools import GenerationTools
 
-                result = GenerationTools(
-                    agent_config=agent_config, authoring_format="osi"
-                ).reconcile_osi_document_to_db(resolved_yaml_path)
+                result = GenerationTools(agent_config=agent_config, authoring_format="osi").sync_osi_semantic_to_db(
+                    resolved_yaml_path
+                )
             except Exception as exc:
                 sync_error = f"Failed to sync OSI semantic YAML file '{resolved_yaml_path}' to vector store: {exc}"
                 logger.exception(sync_error)

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -3,14 +3,13 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 # -*- coding: utf-8 -*-
-import hashlib
 import json
 import os
 import tempfile
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 from agents import Tool
@@ -91,11 +90,9 @@ class GenerationTools:
         agent_config: AgentConfig,
         generation_evidence: Optional[GenerationEvidence] = None,
         authoring_format: Optional[str] = None,
-        runtime_db_context_provider: Optional[Callable[[], Mapping[str, Any]]] = None,
     ):
         self.agent_config = agent_config
         self.generation_evidence = generation_evidence or GenerationEvidence()
-        self._runtime_db_context_provider = runtime_db_context_provider
         if authoring_format:
             self.authoring_format = str(authoring_format).strip().lower()
         else:
@@ -105,32 +102,16 @@ class GenerationTools:
         self.metric_rag = MetricRAG(agent_config)
         self.semantic_rag = SemanticModelRAG(agent_config)
         self.table_semantic_profile_rag = None
-        self._table_semantic_profile_init_error = ""
         if isinstance(getattr(agent_config, "project_name", ""), str):
             try:
                 self.table_semantic_profile_rag = TableSemanticProfileRAG(agent_config)
             except Exception as exc:
-                self._table_semantic_profile_init_error = str(exc)
-                if self._is_osi_authoring():
-                    logger.warning("Failed to initialize table semantic profile storage: %s", exc)
-                else:
-                    logger.debug("Failed to initialize table semantic profile storage: %s", exc)
+                logger.debug(f"Failed to initialize table semantic profile storage: {exc}")
         self._semantic_object_exists_cache: Dict[tuple[str, str, str], FuncToolResult] = {}
         self._semantic_table_object_index: Optional[Dict[str, Dict[str, object]]] = None
 
     def _is_osi_authoring(self) -> bool:
         return self.authoring_format == "osi"
-
-    @classmethod
-    def all_tools_name(cls) -> List[str]:
-        """Return every tool name that may be mounted from this group."""
-        return [
-            "check_semantic_object_exists",
-            "generate_sql_summary_id",
-            "end_semantic_model_generation",
-            "end_metric_generation",
-            "sync_semantic",
-        ]
 
     def available_tools(self) -> List[Tool]:
         """
@@ -148,92 +129,6 @@ class GenerationTools:
                 self.end_metric_generation,
             )
         ]
-
-    def sync_semantic(self, semantic_model_file: str) -> FuncToolResult:
-        """Validate and synchronize one complete Ossie semantic YAML document.
-
-        Call this after directly editing an existing Ossie semantic YAML file.
-        The YAML document is the sole source of truth: datasets, table profiles,
-        and metrics removed from it are also removed from the Knowledge Base.
-
-        Args:
-            semantic_model_file: YAML path inside the current datasource's
-                semantic-model workspace.
-        """
-        if not self._is_osi_authoring():
-            return FuncToolResult(success=0, error="sync_semantic is only available for Ossie authoring")
-
-        resolved = self._resolve_generation_path(semantic_model_file, "semantic")
-        if not resolved:
-            return FuncToolResult(
-                success=0,
-                error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}",
-            )
-        try:
-            before_hash = hashlib.sha256(Path(resolved).read_bytes()).hexdigest()
-        except OSError as exc:
-            return FuncToolResult(success=0, error=f"Failed to read semantic model file: {exc}")
-
-        model_names = self.extract_osi_model_names(resolved)
-        if len(model_names) != 1:
-            return FuncToolResult(
-                success=0,
-                error=(f"The Ossie artifact must declare exactly one semantic model; found {model_names or '<none>'}."),
-            )
-
-        try:
-            from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
-            from datus.tools.func_tool.semantic_tools import SemanticTools
-
-            semantic_tools = SemanticTools(
-                self.agent_config,
-                sub_agent_name="chat",
-                adapter_type=resolve_semantic_adapter_type(self.agent_config),
-                runtime_db_context_provider=self._runtime_db_context_provider,
-            )
-            metric_names = self.extract_osi_metric_names(resolved)
-            validation = semantic_tools.validate_semantic(
-                scope="all" if metric_names else "semantic_model",
-                semantic_model_name=model_names[0],
-            )
-            if not validation.success:
-                return FuncToolResult(
-                    success=0,
-                    error=f"Semantic validation failed: {validation.error or 'unknown error'}",
-                    result={"validation": validation.result},
-                )
-
-            metric_sql_result = self._compile_osi_metric_sqls(metric_names)
-            if not metric_sql_result.success:
-                return FuncToolResult(
-                    success=0,
-                    error=metric_sql_result.error,
-                    result={"validation": validation.result, "dry_run": metric_sql_result.result},
-                )
-
-            after_hash = hashlib.sha256(Path(resolved).read_bytes()).hexdigest()
-            if after_hash != before_hash:
-                return FuncToolResult(
-                    success=0,
-                    error="Semantic YAML changed during validation; retry sync_semantic",
-                )
-
-            sync_result = self.reconcile_osi_document_to_db(
-                resolved,
-                metric_sqls=metric_sql_result.result["metric_sqls"],
-            )
-            if not sync_result.get("success"):
-                return FuncToolResult(
-                    success=0,
-                    error=f"Knowledge Base sync failed: {sync_result.get('error', 'unknown error')}",
-                    result={"sync": sync_result},
-                )
-            sync_result["source_sha256"] = before_hash
-            sync_result["validation"] = validation.result
-            return FuncToolResult(result=sync_result)
-        except Exception as exc:
-            logger.error("sync_semantic failed: %s", exc, exc_info=True)
-            return FuncToolResult(success=0, error=f"Failed to sync semantic YAML: {exc}")
 
     def check_semantic_object_exists(
         self,
@@ -515,7 +410,7 @@ class GenerationTools:
             if self._is_osi_authoring():
                 assert osi_target is not None
                 resolved, _model_name = osi_target
-                sync_result = self.reconcile_osi_document_to_db(resolved)
+                sync_result = self.sync_osi_semantic_to_db(resolved)
                 sync_results = [sync_result]
                 if not sync_result.get("success"):
                     return FuncToolResult(
@@ -576,8 +471,8 @@ class GenerationTools:
 
         try:
             if self._is_osi_authoring():
-                # One Ossie file owns the complete datasets/profiles/metrics
-                # projection, so split semantic-model file arguments are ignored.
+                # OSI gen_metrics owns only the metrics collection. Semantic
+                # objects are authored and synced by gen_semantic_model.
                 semantic_model_files = []
             elif semantic_model_files is None and semantic_model_file:
                 semantic_model_files = [semantic_model_file]
@@ -684,7 +579,9 @@ class GenerationTools:
                 )
 
             if self._is_osi_authoring():
-                sync_result = self.reconcile_osi_document_to_db(abs_metric, metric_sqls=metric_sqls)
+                sync_result = self._sync_osi_metric_to_db(
+                    abs_metric, abs_semantic_files, metric_sqls, replace_metric_artifact=False
+                )
                 if not sync_result.get("success"):
                     return FuncToolResult(
                         success=0,
@@ -1436,31 +1333,15 @@ class GenerationTools:
             )
         return len(profiles)
 
-    def _runtime_db_context(self) -> dict[str, Any]:
-        if callable(self._runtime_db_context_provider):
-            try:
-                context = self._runtime_db_context_provider()
-                return dict(context) if isinstance(context, Mapping) else {}
-            except Exception as exc:
-                logger.debug("Failed to resolve runtime DB context for OSI synchronization: %s", exc)
-                return {}
-        runtime_db_context_getter = getattr(self.agent_config, "runtime_db_context", None)
-        context = runtime_db_context_getter() if callable(runtime_db_context_getter) else {}
-        return dict(context) if isinstance(context, Mapping) else {}
-
     @staticmethod
-    def _current_db_parts(
-        agent_config: AgentConfig,
-        runtime_db_context: Optional[Mapping[str, Any]] = None,
-    ) -> dict[str, str]:
+    def _current_db_parts(agent_config: AgentConfig) -> dict[str, str]:
         try:
             current_db_config = agent_config.current_db_config()
         except Exception:
             current_db_config = object()
-        if runtime_db_context is None:
-            runtime_db_context_getter = getattr(agent_config, "runtime_db_context", None)
-            runtime_db_context = runtime_db_context_getter() if callable(runtime_db_context_getter) else {}
-        runtime_db_context = runtime_db_context if isinstance(runtime_db_context, Mapping) else {}
+        runtime_db_context_getter = getattr(agent_config, "runtime_db_context", None)
+        runtime_db_context = runtime_db_context_getter() if callable(runtime_db_context_getter) else {}
+        runtime_db_context = runtime_db_context if isinstance(runtime_db_context, dict) else {}
         return {
             "catalog_name": runtime_db_context.get("catalog")
             or runtime_db_context.get("catalog_name")
@@ -1704,124 +1585,168 @@ class GenerationTools:
             entities.extend(cls._dataset_primary_keys(datasets.get(dataset_name)))
         return cls._dedupe_strings(entities)
 
-    def _build_osi_semantic_projection(
-        self,
-        doc: Any,
-        yaml_path: str,
-        target_dataset_names: set[str],
-    ) -> tuple[List[dict], List[dict], List[str]]:
-        """Project one complete OSI artifact into semantic and table-profile rows."""
-        semantic_model_name = str(getattr(doc, "name", "") or "")
-        default_db_parts = self._current_db_parts(self.agent_config, self._runtime_db_context())
-        semantic_objects: List[dict] = []
-        table_profiles: List[dict] = []
-        synced_items: List[str] = []
-
-        for dataset in getattr(doc, "datasets", []):
-            dataset_name = getattr(dataset, "name", "")
-            if dataset_name not in target_dataset_names:
-                continue
-            table_name = self._dataset_table_name(dataset)
-            db_parts = self._dataset_db_parts(dataset, default_db_parts)
-            fq_parts = [db_parts["catalog_name"], db_parts["database_name"], db_parts["schema_name"], table_name]
-            table_fq_name = ".".join(part for part in fq_parts if part)
-            table_profiles.append(
-                self._osi_table_semantic_profile(
-                    doc=doc,
-                    dataset=dataset,
-                    table_name=table_name,
-                    table_fq_name=table_fq_name,
-                    db_parts=db_parts,
-                    yaml_path=yaml_path,
-                )
-            )
-
-            semantic_objects.append(
-                {
-                    "id": f"table:{semantic_model_name}:{table_fq_name}",
-                    "kind": "table",
-                    "name": table_name,
-                    "fq_name": table_fq_name,
-                    "table_name": table_name,
-                    "description": getattr(dataset, "description", "") or "",
-                    "yaml_path": yaml_path,
-                    "updated_at": datetime.now().replace(microsecond=0),
-                    **db_parts,
-                    "semantic_model_name": semantic_model_name,
-                    "is_dimension": False,
-                    "is_measure": False,
-                    "is_entity_key": False,
-                    "is_deprecated": False,
-                    "expr": "",
-                    "column_type": "",
-                    "agg": "",
-                    "create_metric": False,
-                    "agg_time_dimension": "",
-                    "is_partition": False,
-                    "time_granularity": "",
-                    "entity": "",
+    def sync_osi_semantic_to_db(self, semantic_model_path: str) -> dict:
+        """Sync OSI datasets into the semantic object store."""
+        try:
+            target_dataset_names = set(self.extract_osi_dataset_names(semantic_model_path))
+            if not target_dataset_names:
+                return {
+                    "success": False,
+                    "error": f"No OSI datasets found in semantic model file to sync: {semantic_model_path}",
                 }
-            )
-            synced_items.append(f"table:{table_fq_name}")
 
-            primary_keys = getattr(dataset, "primary_key", None) or []
-            if isinstance(primary_keys, str):
-                primary_keys = [primary_keys]
-            for key in primary_keys:
-                semantic_objects.append(
-                    self._osi_column_object(
-                        table_name=table_name,
-                        table_fq_name=table_fq_name,
-                        semantic_model_name=semantic_model_name,
-                        name=str(key),
-                        description="Primary key",
-                        expr=str(key),
-                        column_type="PRIMARY",
-                        yaml_path=yaml_path,
-                        db_parts=db_parts,
-                        is_entity_key=True,
-                    )
-                )
+            doc = self._load_osi_document(semantic_model_file=semantic_model_path)
+            semantic_model_name = str(getattr(doc, "name", "") or "")
+            default_db_parts = self._current_db_parts(self.agent_config)
+            semantic_objects: List[dict] = []
+            table_profiles: List[dict] = []
+            synced_items: List[str] = []
 
-            time_dimension = getattr(dataset, "time_dimension", None)
-            if time_dimension and getattr(time_dimension, "name", None):
-                semantic_objects.append(
-                    self._osi_column_object(
-                        table_name=table_name,
-                        table_fq_name=table_fq_name,
-                        semantic_model_name=semantic_model_name,
-                        name=str(time_dimension.name),
-                        description="Primary time dimension",
-                        expr=str(time_dimension.name),
-                        column_type="TIME",
-                        yaml_path=yaml_path,
-                        db_parts=db_parts,
-                        is_dimension=True,
-                        time_granularity=getattr(time_dimension, "granularity", "") or "",
-                    )
-                )
-
-            for dim in getattr(dataset, "dimensions", []):
-                dim_name = getattr(dim, "name", "")
-                if not dim_name:
+            for dataset in getattr(doc, "datasets", []):
+                dataset_name = getattr(dataset, "name", "")
+                if dataset_name not in target_dataset_names:
                     continue
-                semantic_objects.append(
-                    self._osi_column_object(
+                table_name = self._dataset_table_name(dataset)
+                db_parts = self._dataset_db_parts(dataset, default_db_parts)
+                fq_parts = [db_parts["catalog_name"], db_parts["database_name"], db_parts["schema_name"], table_name]
+                table_fq_name = ".".join(part for part in fq_parts if part)
+                yaml_path = semantic_model_path
+                table_profiles.append(
+                    self._osi_table_semantic_profile(
+                        doc=doc,
+                        dataset=dataset,
                         table_name=table_name,
                         table_fq_name=table_fq_name,
-                        semantic_model_name=semantic_model_name,
-                        name=str(dim_name),
-                        description=getattr(dim, "description", "") or "",
-                        expr=getattr(dim, "expr", None) or str(dim_name),
-                        column_type=str(getattr(dim, "type", "") or ""),
-                        yaml_path=yaml_path,
                         db_parts=db_parts,
-                        is_dimension=True,
-                        time_granularity=getattr(dim, "granularity", "") or "",
+                        yaml_path=yaml_path,
                     )
                 )
 
-        return semantic_objects, table_profiles, synced_items
+                semantic_objects.append(
+                    {
+                        "id": f"table:{semantic_model_name}:{table_fq_name}",
+                        "kind": "table",
+                        "name": table_name,
+                        "fq_name": table_fq_name,
+                        "table_name": table_name,
+                        "description": getattr(dataset, "description", "") or "",
+                        "yaml_path": yaml_path,
+                        "updated_at": datetime.now().replace(microsecond=0),
+                        **db_parts,
+                        "semantic_model_name": semantic_model_name,
+                        "is_dimension": False,
+                        "is_measure": False,
+                        "is_entity_key": False,
+                        "is_deprecated": False,
+                        "expr": "",
+                        "column_type": "",
+                        "agg": "",
+                        "create_metric": False,
+                        "agg_time_dimension": "",
+                        "is_partition": False,
+                        "time_granularity": "",
+                        "entity": "",
+                    }
+                )
+                synced_items.append(f"table:{table_fq_name}")
+
+                primary_keys = getattr(dataset, "primary_key", None) or []
+                if isinstance(primary_keys, str):
+                    primary_keys = [primary_keys]
+                for key in primary_keys:
+                    semantic_objects.append(
+                        self._osi_column_object(
+                            table_name=table_name,
+                            table_fq_name=table_fq_name,
+                            semantic_model_name=semantic_model_name,
+                            name=str(key),
+                            description="Primary key",
+                            expr=str(key),
+                            column_type="PRIMARY",
+                            yaml_path=yaml_path,
+                            db_parts=db_parts,
+                            is_entity_key=True,
+                        )
+                    )
+
+                time_dimension = getattr(dataset, "time_dimension", None)
+                if time_dimension and getattr(time_dimension, "name", None):
+                    semantic_objects.append(
+                        self._osi_column_object(
+                            table_name=table_name,
+                            table_fq_name=table_fq_name,
+                            semantic_model_name=semantic_model_name,
+                            name=str(time_dimension.name),
+                            description="Primary time dimension",
+                            expr=str(time_dimension.name),
+                            column_type="TIME",
+                            yaml_path=yaml_path,
+                            db_parts=db_parts,
+                            is_dimension=True,
+                            time_granularity=getattr(time_dimension, "granularity", "") or "",
+                        )
+                    )
+
+                for dim in getattr(dataset, "dimensions", []):
+                    dim_name = getattr(dim, "name", "")
+                    if not dim_name:
+                        continue
+                    semantic_objects.append(
+                        self._osi_column_object(
+                            table_name=table_name,
+                            table_fq_name=table_fq_name,
+                            semantic_model_name=semantic_model_name,
+                            name=str(dim_name),
+                            description=getattr(dim, "description", "") or "",
+                            expr=getattr(dim, "expr", None) or str(dim_name),
+                            column_type=str(getattr(dim, "type", "") or ""),
+                            yaml_path=yaml_path,
+                            db_parts=db_parts,
+                            is_dimension=True,
+                            time_granularity=getattr(dim, "granularity", "") or "",
+                        )
+                    )
+
+            if not semantic_objects:
+                return {
+                    "success": False,
+                    "error": (
+                        "OSI datasets declared in semantic model file were not found after loading datasource "
+                        f"context: {', '.join(sorted(target_dataset_names))}"
+                    ),
+                }
+            replacement_plans = [(self.semantic_rag, semantic_model_path, semantic_objects)]
+            if table_profiles and self.table_semantic_profile_rag is not None:
+                replacement_plans.append((self.table_semantic_profile_rag, semantic_model_path, table_profiles))
+            snapshots = snapshot_artifact_replacements(replacement_plans)
+            try:
+                self.semantic_rag.upsert_batch(semantic_objects)
+                self.semantic_rag.create_indices()
+                profile_count = 0
+                if table_profiles and self.table_semantic_profile_rag is not None:
+                    self.table_semantic_profile_rag.upsert_batch(table_profiles)
+                    self.table_semantic_profile_rag.create_indices()
+                    profile_count = len(table_profiles)
+                delete_stale_artifact_rows(replacement_plans)
+            except Exception as sync_exc:
+                restore_failures = restore_artifact_replacements(snapshots)
+                if restore_failures:
+                    raise RuntimeError(
+                        "OSI semantic replacement failed and rollback was incomplete for: "
+                        f"{', '.join(restore_failures)}"
+                    ) from sync_exc
+                raise
+            # Post-commit, best-effort cleanup of shadowed stale rows; never raises.
+            self.semantic_rag.delete_shadowed_table_rows(semantic_objects)
+            return {
+                "success": True,
+                "message": f"Synced {len(semantic_objects)} OSI semantic object(s): {', '.join(synced_items[:5])}",
+                "semantic_objects": len(semantic_objects),
+                "table_semantic_profiles": profile_count,
+            }
+        except Exception as e:
+            logger.error(f"Error syncing OSI semantic objects to DB: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
 
     @staticmethod
     def _osi_column_object(
@@ -1864,29 +1789,45 @@ class GenerationTools:
             "entity": name if is_entity_key else "",
         }
 
-    def _build_osi_metric_projection(
+    def _sync_osi_metric_to_db(
         self,
-        doc: Any,
-        yaml_path: str,
-        target_metric_names: set[str],
+        metric_file: str,
+        semantic_model_file: Optional[str | List[str]] = None,
         metric_sqls: Optional[Dict[str, str]] = None,
-    ) -> tuple[List[dict], List[str]]:
-        """Project every metric declared by one OSI artifact into MetricRAG rows."""
-        semantic_model_name = str(getattr(doc, "name", "") or "")
-        db_parts = self._current_db_parts(self.agent_config, self._runtime_db_context())
-        metric_objects: List[dict] = []
-        synced_items: List[str] = []
+        replace_metric_artifact: bool = True,
+    ) -> dict:
+        """Sync OSI metrics into MetricRAG using the OSI document as source of truth."""
+        try:
+            semantic_model_files = (
+                list(semantic_model_file)
+                if isinstance(semantic_model_file, list)
+                else ([semantic_model_file] if semantic_model_file else [])
+            )
+            target_metric_names = set(self.extract_osi_metric_names(metric_file))
+            if not target_metric_names:
+                return {"success": False, "error": f"No OSI metrics found in metric file to sync: {metric_file}"}
 
-        for metric in getattr(doc, "metrics", []):
-            metric_name = getattr(metric, "name", "")
-            if not metric_name or metric_name not in target_metric_names:
-                continue
-            dimensions = self._metric_query_dimensions(doc, metric)
-            entities = self._metric_entities(doc, metric)
-            subject_path = self._metric_subject_path(metric)
-            measure_expr = self._metric_expression(metric)
-            metric_objects.append(
-                {
+            doc = self._load_osi_document(
+                metric_file=metric_file,
+                semantic_model_file=semantic_model_files[0] if semantic_model_files else None,
+            )
+            semantic_model_name = str(getattr(doc, "name", "") or "")
+            db_parts = self._current_db_parts(self.agent_config)
+            metric_objects: List[dict] = []
+            synced_items: List[str] = []
+
+            for metric in getattr(doc, "metrics", []):
+                metric_name = getattr(metric, "name", "")
+                if not metric_name:
+                    continue
+                if metric_name not in target_metric_names:
+                    continue
+                dimensions = self._metric_query_dimensions(doc, metric)
+                entities = self._metric_entities(doc, metric)
+
+                subject_path = self._metric_subject_path(metric)
+                measure_expr = self._metric_expression(metric)
+                metric_obj = {
                     "name": metric_name,
                     "subject_path": subject_path,
                     "semantic_model_name": semantic_model_name,
@@ -1901,223 +1842,77 @@ class GenerationTools:
                     "updated_at": datetime.now().replace(microsecond=0),
                     **db_parts,
                     "sql": metric_sqls.get(metric_name, "") if metric_sqls else "",
-                    "yaml_path": yaml_path,
+                    "yaml_path": metric_file,
                 }
-            )
-            synced_items.append(f"metric:{metric_name}")
+                metric_objects.append(metric_obj)
+                synced_items.append(f"metric:{metric_name}")
 
-        return metric_objects, synced_items
-
-    def _compile_osi_metric_sqls(
-        self,
-        metric_names: Iterable[str],
-        metric_sqls: Optional[Dict[str, str]] = None,
-    ) -> FuncToolResult:
-        """Ensure every metric has SQL from an independent adapter dry-run."""
-        names = self._dedupe_strings(metric_names)
-        compiled = {
-            name: sql.strip()
-            for name, sql in (metric_sqls or {}).items()
-            if name in names and isinstance(sql, str) and sql.strip()
-        }
-        missing = [name for name in names if name not in compiled]
-        if not missing:
-            return FuncToolResult(result={"metric_sqls": compiled})
-
-        try:
-            from datus.agent.node.semantic_authoring import resolve_semantic_adapter_type
-            from datus.tools.func_tool.semantic_tools import SemanticTools
-
-            evidence = GenerationEvidence()
-            semantic_tools = SemanticTools(
-                self.agent_config,
-                sub_agent_name="chat",
-                adapter_type=resolve_semantic_adapter_type(self.agent_config),
-                generation_evidence=evidence,
-                runtime_db_context_provider=self._runtime_db_context_provider,
-            )
-            for metric_name in missing:
-                dry_run = semantic_tools.query_metrics(metrics=[metric_name], dry_run=True)
-                if not dry_run.success:
-                    return FuncToolResult(
-                        success=0,
-                        error=f"Metric dry-run failed for '{metric_name}': {dry_run.error or 'unknown error'}",
-                        result={"metric": metric_name, "dry_run": dry_run.result},
-                    )
-
-                evidence_sql = evidence.metric_sqls.get(metric_name, "")
-                sql = evidence_sql.strip() if isinstance(evidence_sql, str) else ""
-                payload = dry_run.result if isinstance(dry_run.result, dict) else {}
-                metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
-                returned_metric_sqls = metadata.get("metric_sqls")
-                if not sql and isinstance(returned_metric_sqls, dict):
-                    candidate = returned_metric_sqls.get(metric_name) or returned_metric_sqls.get(
-                        "__query_metrics_dry_run__"
-                    )
-                    sql = candidate.strip() if isinstance(candidate, str) else ""
-                if not sql:
-                    for key in ("sql", "compiled_sql", "generated_sql", "dry_run_sql", "query"):
-                        candidate = metadata.get(key)
-                        if isinstance(candidate, str) and candidate.strip():
-                            sql = candidate.strip()
-                            break
-                if not sql:
-                    return FuncToolResult(
-                        success=0,
-                        error=f"Metric dry-run for '{metric_name}' did not return compiled SQL",
-                        result={"metric": metric_name, "dry_run": dry_run.result},
-                    )
-                compiled[metric_name] = sql
-        except Exception as exc:
-            logger.error("Failed to compile Ossie metric SQL: %s", exc, exc_info=True)
-            return FuncToolResult(success=0, error=f"Failed to compile Ossie metric SQL: {exc}")
-
-        return FuncToolResult(result={"metric_sqls": compiled})
-
-    def reconcile_osi_document_to_db(
-        self,
-        osi_file_path: str,
-        metric_sqls: Optional[Dict[str, str]] = None,
-    ) -> dict:
-        """Replace every KB projection owned by one complete OSI document.
-
-        The YAML artifact is the sole source of truth. Datasets, table profiles,
-        and metrics all participate in the same snapshot/write/stale-delete cycle;
-        an empty metrics collection therefore removes every metric row previously
-        projected from this artifact.
-        """
-        try:
-            if self.table_semantic_profile_rag is None:
-                detail = self._table_semantic_profile_init_error or "storage was not initialized"
-                return {
-                    "success": False,
-                    "error": f"Table semantic profile storage is unavailable: {detail}",
-                }
-            try:
-                canonical_path = Path(osi_file_path).expanduser().resolve(strict=True)
-            except (OSError, RuntimeError) as exc:
-                return {"success": False, "error": f"Failed to resolve OSI document path: {exc}"}
-            if not canonical_path.is_file():
-                return {"success": False, "error": f"OSI document path is not a file: {canonical_path}"}
-            osi_file_path = str(canonical_path)
-            target_dataset_names = set(self.extract_osi_dataset_names(osi_file_path))
-            if not target_dataset_names:
-                return {
-                    "success": False,
-                    "error": f"No OSI datasets found in document to sync: {osi_file_path}",
-                }
-            target_metric_names = set(self.extract_osi_metric_names(osi_file_path))
-            metric_sql_result = self._compile_osi_metric_sqls(sorted(target_metric_names), metric_sqls)
-            if not metric_sql_result.success:
-                return {
-                    "success": False,
-                    "error": metric_sql_result.error,
-                    "dry_run": metric_sql_result.result,
-                }
-            compiled_metric_sqls = metric_sql_result.result["metric_sqls"]
-            doc = self._load_osi_document(metric_file=osi_file_path, semantic_model_file=osi_file_path)
-            semantic_model_name = str(getattr(doc, "name", "") or "")
-
-            semantic_objects, table_profiles, semantic_items = self._build_osi_semantic_projection(
-                doc,
-                osi_file_path,
-                target_dataset_names,
-            )
-            if not semantic_objects:
+            if not metric_objects:
                 return {
                     "success": False,
                     "error": (
-                        "OSI datasets declared in the document were not found after loading datasource context: "
-                        f"{', '.join(sorted(target_dataset_names))}"
+                        "OSI metrics declared in metric file were not found after loading datasource context: "
+                        f"{', '.join(sorted(target_metric_names))}"
                     ),
                 }
-            metric_objects, metric_items = self._build_osi_metric_projection(
-                doc,
-                osi_file_path,
-                target_metric_names,
-                compiled_metric_sqls,
-            )
-            projected_metric_names = {obj["name"] for obj in metric_objects}
-            if projected_metric_names != target_metric_names:
-                missing = ", ".join(sorted(target_metric_names - projected_metric_names))
-                return {
-                    "success": False,
-                    "error": f"OSI metrics were not found after loading datasource context: {missing}",
-                }
 
-            replacement_plans = [(self.semantic_rag, osi_file_path, semantic_objects)]
-            if self.table_semantic_profile_rag is not None:
-                replacement_plans.append((self.table_semantic_profile_rag, osi_file_path, table_profiles))
-            # Always include MetricRAG, including when metric_objects is empty.
-            replacement_plans.append((self.metric_rag, osi_file_path, metric_objects))
+            synced_semantic_files: List[str] = []
+            for current_semantic_file in semantic_model_files:
+                sem_result = self.sync_osi_semantic_to_db(current_semantic_file)
+                if not sem_result.get("success"):
+                    return sem_result
+                synced_semantic_files.append(current_semantic_file)
 
-            snapshots = snapshot_artifact_replacements(replacement_plans)
+            metric_plan = (self.metric_rag, metric_file, metric_objects)
+            replacement_plans = [metric_plan] if replace_metric_artifact else []
+            snapshots = snapshot_artifact_replacements([metric_plan])
             try:
-                self.semantic_rag.upsert_batch(semantic_objects)
-                self.semantic_rag.create_indices()
-                if self.table_semantic_profile_rag is not None and table_profiles:
-                    self.table_semantic_profile_rag.upsert_batch(table_profiles)
-                    self.table_semantic_profile_rag.create_indices()
-                if metric_objects:
-                    self.metric_rag.upsert_batch(metric_objects)
-                    self.metric_rag.create_indices()
+                self.metric_rag.upsert_batch(metric_objects)
+                self.metric_rag.create_indices()
                 delete_stale_artifact_rows(replacement_plans)
             except Exception as sync_exc:
                 restore_failures = restore_artifact_replacements(snapshots)
                 if restore_failures:
                     raise RuntimeError(
-                        "OSI document replacement failed and rollback was incomplete for: "
-                        f"{', '.join(restore_failures)}"
+                        f"OSI metric replacement failed and rollback was incomplete for: {', '.join(restore_failures)}"
                     ) from sync_exc
                 raise
-
-            # Post-commit, best-effort cleanup of shadowed stale rows; never raises.
-            self.semantic_rag.delete_shadowed_table_rows(semantic_objects)
-            self._semantic_object_exists_cache.clear()
-            self._semantic_table_object_index = None
-            synced_items = [*semantic_items, *metric_items]
             return {
                 "success": True,
-                "message": (
-                    f"Synced complete OSI document with {len(semantic_objects)} semantic object(s), "
-                    f"{len(table_profiles)} table profile(s), and {len(metric_objects)} metric(s): "
-                    f"{', '.join(synced_items[:5])}"
-                ),
-                "semantic_model_name": semantic_model_name,
-                "semantic_objects": len(semantic_objects),
-                "table_semantic_profiles": len(table_profiles) if self.table_semantic_profile_rag is not None else 0,
+                "message": f"Synced {len(metric_objects)} OSI metric(s): {', '.join(synced_items[:5])}",
                 "metric_artifact_ids": [obj["id"] for obj in metric_objects],
                 "metric_names": [obj["name"] for obj in metric_objects],
-                "semantic_synced": True,
-                "semantic_model_files_synced": [osi_file_path],
-                "synced": len(semantic_objects) + len(metric_objects),
+                "semantic_synced": bool(synced_semantic_files),
+                "semantic_model_files_synced": synced_semantic_files,
             }
         except Exception as e:
-            logger.error(f"Error syncing complete OSI document to DB: {e}", exc_info=True)
+            logger.error(f"Error syncing OSI metrics to DB: {e}", exc_info=True)
             return {"success": False, "error": str(e)}
 
-    def sync_osi_to_db(
-        self,
-        osi_file_path: str,
-        metric_sqls: Optional[Dict[str, str]] = None,
-    ) -> dict:
-        """Backward-compatible public name for complete OSI reconciliation."""
-        return self.reconcile_osi_document_to_db(osi_file_path, metric_sqls=metric_sqls)
+    def sync_osi_to_db(self, osi_file_path: str) -> dict:
+        """Sync a complete OSI document (datasets + metrics) into the Knowledge Base.
 
-    def sync_osi_semantic_to_db(self, semantic_model_path: str) -> dict:
-        """Deprecated alias; OSI semantic artifacts are always reconciled in full."""
-        return self.reconcile_osi_document_to_db(semantic_model_path)
+        Public composition entry for callers that materialize a self-contained OSI
+        file and need it vectorized (e.g. the SaaS Semantic Hub pull) without
+        reaching into the per-kind sync internals.
 
-    def _sync_osi_metric_to_db(
-        self,
-        metric_file: str,
-        semantic_model_file: Optional[str | List[str]] = None,
-        metric_sqls: Optional[Dict[str, str]] = None,
-        replace_metric_artifact: bool = True,
-    ) -> dict:
-        """Deprecated alias; OSI semantic artifacts are always reconciled in full."""
-        del semantic_model_file, replace_metric_artifact
-        return self.reconcile_osi_document_to_db(metric_file, metric_sqls=metric_sqls)
+        A metrics-bearing document is synced in one pass: ``_sync_osi_metric_to_db``
+        already vectorizes the referenced datasets before the metrics when a
+        ``semantic_model_file`` is given, so no separate dataset sync is needed. A
+        dataset-only document syncs just its datasets. The result always carries a
+        ``synced`` count for uniform accounting across both shapes.
+        """
+        try:
+            if self.extract_osi_metric_names(osi_file_path):
+                result = self._sync_osi_metric_to_db(metric_file=osi_file_path, semantic_model_file=osi_file_path)
+                synced = len(result.get("metric_artifact_ids") or [])
+            else:
+                result = self.sync_osi_semantic_to_db(osi_file_path)
+                synced = int(result.get("semantic_objects") or 0)
+            return {**result, "synced": synced}
+        except Exception as e:
+            logger.error(f"Error syncing OSI document to DB: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
 
     def _sync_metric_to_db(
         self,

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -90,7 +90,6 @@ _NORMAL_RULES = [
     _rule("semantic_tools", "query_metrics", PermissionLevel.ALLOW),
     # semantic generation helpers
     _rule("semantic_tools", "check_semantic_object_exists", PermissionLevel.ALLOW),
-    _rule("semantic_tools", "sync_semantic", PermissionLevel.ALLOW),
     _rule("semantic_tools", "end_*_generation", PermissionLevel.ALLOW),
     _rule("semantic_tools", "generate_*_id", PermissionLevel.ALLOW),
     _rule("semantic_tools", "*", PermissionLevel.ALLOW),

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -179,42 +179,6 @@ class TestChatAgenticNodeToolSetup:
 
         assert isinstance(node.filesystem_func_tool, FilesystemFuncTool)
 
-    def test_main_osi_chat_exposes_only_sync_semantic_from_generation_tools(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.chat_agentic_node import ChatAgenticNode
-        from datus.tools.func_tool.generation_tools import GenerationTools
-
-        with patch("datus.agent.node.semantic_authoring.is_osi_authoring", return_value=True):
-            node = ChatAgenticNode(
-                node_id="test_osi_sync",
-                description="Test Ossie sync tool",
-                node_type=NodeType.TYPE_CHAT,
-                agent_config=real_agent_config,
-            )
-
-        tool_names = {tool.name for tool in node.tools}
-        generation_tool_names = set(GenerationTools.all_tools_name())
-        assert tool_names & generation_tool_names == {"sync_semantic"}
-        assert node.tool_registry.get("sync_semantic") == "semantic_tools"
-        assert "sole source of truth" in node._get_system_prompt()
-        assert node.semantic_sync_tools._runtime_db_context_provider == node._semantic_runtime_db_context
-
-    def test_osi_subagent_does_not_expose_sync_semantic(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.chat_agentic_node import ChatAgenticNode
-        from datus.tools.func_tool.generation_tools import GenerationTools
-
-        with patch("datus.agent.node.semantic_authoring.is_osi_authoring", return_value=True):
-            node = ChatAgenticNode(
-                node_id="test_osi_subagent_sync",
-                description="Test Ossie subagent tool isolation",
-                node_type=NodeType.TYPE_CHAT,
-                agent_config=real_agent_config,
-                is_subagent=True,
-            )
-
-        tool_names = {tool.name for tool in node.tools}
-        assert tool_names.isdisjoint(GenerationTools.all_tools_name())
-        assert node.semantic_sync_tools is None
-
     def test_filesystem_strict_from_agent_config(self, real_agent_config, mock_llm_create):
         """agent_config.filesystem_strict = True propagates into the tool
         and the permission-hook policy. This is how API / gateway bootstraps

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -932,13 +932,11 @@ class TestSaveToDb:
         semantic_dir.mkdir(parents=True, exist_ok=True)
         semantic_file = semantic_dir / "orders.yml"
         semantic_file.write_text("version: 0.2.0.dev0\nsemantic_model: []\n", encoding="utf-8")
-        node.generation_tools.reconcile_osi_document_to_db = MagicMock(
-            return_value={"success": True, "message": "synced"}
-        )
+        node.generation_tools.sync_osi_semantic_to_db = MagicMock(return_value={"success": True, "message": "synced"})
 
         assert node._save_to_db(f"subject/semantic_models/{datasource}/orders.yml") is True
 
-        node.generation_tools.reconcile_osi_document_to_db.assert_called_once_with(str(semantic_file))
+        node.generation_tools.sync_osi_semantic_to_db.assert_called_once_with(str(semantic_file))
         assert node.generation_evidence.semantic_kb_sync_passed is True
 
     def test_osi_save_to_db_fails_without_generation_tools(self, real_agent_config, mock_llm_create):
@@ -960,13 +958,13 @@ class TestSaveToDb:
         semantic_dir.mkdir(parents=True, exist_ok=True)
         semantic_file = semantic_dir / "orders.yml"
         semantic_file.write_text("version: 0.2.0.dev0\nsemantic_model: []\n", encoding="utf-8")
-        node.generation_tools.reconcile_osi_document_to_db = MagicMock(
+        node.generation_tools.sync_osi_semantic_to_db = MagicMock(
             return_value={"success": False, "error": "sync failed"}
         )
 
         assert node._save_to_db(f"subject/semantic_models/{datasource}/orders.yml") is False
 
-        node.generation_tools.reconcile_osi_document_to_db.assert_called_once_with(str(semantic_file))
+        node.generation_tools.sync_osi_semantic_to_db.assert_called_once_with(str(semantic_file))
         assert node.generation_evidence.semantic_kb_sync_passed is False
 
 

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -183,13 +183,13 @@ class TestSemanticLayerServiceBranches:
         request = SemanticModelInput(table="orders", yaml="kind: semantic_model\n")
 
         with patch("datus.tools.func_tool.generation_tools.GenerationTools") as tools_cls:
-            tools_cls.return_value.reconcile_osi_document_to_db.return_value = {"success": True}
+            tools_cls.return_value.sync_osi_semantic_to_db.return_value = {"success": True}
             result = await svc.save_semantic_model(request)
 
         assert result.success is True
         assert yaml_file.read_text(encoding="utf-8") == request.yaml
         tools_cls.assert_called_once_with(agent_config=svc.agent_config, authoring_format="osi")
-        tools_cls.return_value.reconcile_osi_document_to_db.assert_called_once_with(str(yaml_file))
+        tools_cls.return_value.sync_osi_semantic_to_db.assert_called_once_with(str(yaml_file))
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_uses_metricflow_sync(self, tmp_path):

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -130,7 +130,7 @@ class TestInitSemanticYamlMetrics:
         yaml_file.write_text("metrics:\n  - name: revenue\n")
         mock_config = MagicMock()
         mock_tools = MagicMock()
-        mock_tools.reconcile_osi_document_to_db.return_value = {"success": True, "message": "synced"}
+        mock_tools._sync_osi_metric_to_db.return_value = {"success": True, "message": "synced"}
 
         with (
             patch(
@@ -144,7 +144,7 @@ class TestInitSemanticYamlMetrics:
         assert success is True
         assert error == "synced"
         mock_cls.assert_called_once_with(agent_config=mock_config, authoring_format="osi")
-        mock_tools.reconcile_osi_document_to_db.assert_called_once_with(str(yaml_file))
+        mock_tools._sync_osi_metric_to_db.assert_called_once_with(str(yaml_file))
 
     def test_osi_existing_file_returns_sync_error(self, tmp_path):
         """OSI sync failures are surfaced as init failures."""
@@ -152,7 +152,7 @@ class TestInitSemanticYamlMetrics:
         yaml_file.write_text("metrics:\n  - name: revenue\n")
         mock_config = MagicMock()
         mock_tools = MagicMock()
-        mock_tools.reconcile_osi_document_to_db.return_value = {"success": False, "error": "invalid osi metrics"}
+        mock_tools._sync_osi_metric_to_db.return_value = {"success": False, "error": "invalid osi metrics"}
 
         with (
             patch(

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -306,7 +306,7 @@ semantic_model:
         mock_config.path_manager = None
 
         with patch("datus.tools.func_tool.generation_tools.GenerationTools") as mock_tools_cls:
-            mock_tools_cls.return_value.reconcile_osi_document_to_db.return_value = {"success": True}
+            mock_tools_cls.return_value.sync_osi_semantic_to_db.return_value = {"success": True}
             success, error, changed = refresh_semantic_yaml_profile_descriptions(
                 str(yaml_file),
                 evidence,
@@ -319,7 +319,7 @@ semantic_model:
         assert error == ""
         assert changed == 2
         mock_tools_cls.assert_called_once_with(agent_config=mock_config, authoring_format="osi")
-        mock_tools_cls.return_value.reconcile_osi_document_to_db.assert_called_once_with(str(yaml_file))
+        mock_tools_cls.return_value.sync_osi_semantic_to_db.assert_called_once_with(str(yaml_file))
 
     def test_osi_refresh_returns_sync_exception(self, tmp_path):
         yaml_file = tmp_path / "orders.yml"
@@ -357,7 +357,7 @@ semantic_model:
         mock_config.path_manager = None
 
         with patch("datus.tools.func_tool.generation_tools.GenerationTools") as mock_tools_cls:
-            mock_tools_cls.return_value.reconcile_osi_document_to_db.side_effect = RuntimeError("storage offline")
+            mock_tools_cls.return_value.sync_osi_semantic_to_db.side_effect = RuntimeError("storage offline")
             success, error, changed = refresh_semantic_yaml_profile_descriptions(
                 str(yaml_file),
                 evidence,

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -5,9 +5,8 @@
 import json
 import os
 import sys
-from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -24,22 +23,17 @@ def generation_tools(mock_agent_config):
     with (
         patch("datus.tools.func_tool.generation_tools.MetricRAG") as mock_metric_rag_cls,
         patch("datus.tools.func_tool.generation_tools.SemanticModelRAG") as mock_semantic_rag_cls,
-        patch("datus.tools.func_tool.generation_tools.TableSemanticProfileRAG") as mock_profile_rag_cls,
     ):
         mock_metric_rag = Mock()
         mock_semantic_rag = Mock()
-        mock_profile_rag = Mock()
         mock_metric_rag_cls.return_value = mock_metric_rag
         mock_semantic_rag_cls.return_value = mock_semantic_rag
-        mock_profile_rag_cls.return_value = mock_profile_rag
-        mock_agent_config.project_name = "test-project"
 
         from datus.tools.func_tool.generation_tools import GenerationTools
 
         tool = GenerationTools(agent_config=mock_agent_config)
         tool.metric_rag = mock_metric_rag
         tool.semantic_rag = mock_semantic_rag
-        tool.table_semantic_profile_rag = mock_profile_rag
         return tool
 
 
@@ -49,185 +43,6 @@ class TestAvailableTools:
             mock_trans.side_effect = lambda f: Mock(name=f.__name__)
             tools = generation_tools.available_tools()
         assert len(tools) == 4
-
-    def test_all_tool_names_include_chat_only_sync_tool(self, generation_tools):
-        assert "sync_semantic" in generation_tools.all_tools_name()
-
-    def test_osi_profile_storage_init_failure_is_reported_by_reconcile(self):
-        from datus.tools.func_tool.generation_tools import GenerationTools
-
-        agent_config = Mock(project_name="test-project")
-        with (
-            patch("datus.tools.func_tool.generation_tools.MetricRAG"),
-            patch("datus.tools.func_tool.generation_tools.SemanticModelRAG"),
-            patch(
-                "datus.tools.func_tool.generation_tools.TableSemanticProfileRAG",
-                side_effect=RuntimeError("profile backend unavailable"),
-            ),
-        ):
-            tools = GenerationTools(agent_config, authoring_format="osi")
-
-        result = tools.reconcile_osi_document_to_db("shop.yml")
-
-        assert result["success"] is False
-        assert "profile backend unavailable" in result["error"]
-
-
-class TestSyncSemantic:
-    def test_validates_and_reconciles_dataset_only_document(self, generation_tools, tmp_path):
-        generation_tools.authoring_format = "osi"
-        model_file = tmp_path / "semantic_models" / "shop" / "shop.yml"
-        model_file.parent.mkdir(parents=True)
-        model_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n",
-            encoding="utf-8",
-        )
-        mock_pm = Mock(subject_dir=str(tmp_path))
-        semantic_tools = Mock()
-        semantic_tools.validate_semantic.return_value = FuncToolResult(result={"valid": True})
-
-        with (
-            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
-            patch("datus.tools.func_tool.semantic_tools.SemanticTools", return_value=semantic_tools),
-            patch.object(generation_tools, "reconcile_osi_document_to_db", return_value={"success": True}) as sync,
-        ):
-            result = generation_tools.sync_semantic(str(model_file))
-
-        assert result.success == 1
-        semantic_tools.validate_semantic.assert_called_once_with(
-            scope="semantic_model",
-            semantic_model_name="shop",
-        )
-        semantic_tools.query_metrics.assert_not_called()
-        sync.assert_called_once_with(str(model_file), metric_sqls={})
-        assert result.result["source_sha256"]
-
-    def test_validates_and_dry_runs_metrics_before_reconcile(self, generation_tools, tmp_path):
-        generation_tools.authoring_format = "osi"
-        model_file = tmp_path / "semantic_models" / "shop" / "shop.yml"
-        model_file.parent.mkdir(parents=True)
-        model_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n"
-            "    metrics:\n"
-            "      - name: order_count\n"
-            "      - name: gross_revenue\n",
-            encoding="utf-8",
-        )
-        mock_pm = Mock(subject_dir=str(tmp_path))
-        semantic_tools = Mock()
-        semantic_tools.validate_semantic.return_value = FuncToolResult(result={"valid": True})
-        semantic_tools.query_metrics.side_effect = [
-            FuncToolResult(result={"metadata": {"sql": "SELECT COUNT(*) FROM orders"}}),
-            FuncToolResult(result={"metadata": {"sql": "SELECT SUM(amount) FROM orders"}}),
-        ]
-
-        with (
-            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
-            patch("datus.tools.func_tool.semantic_tools.SemanticTools", return_value=semantic_tools),
-            patch.object(generation_tools, "reconcile_osi_document_to_db", return_value={"success": True}) as sync,
-        ):
-            result = generation_tools.sync_semantic(str(model_file))
-
-        assert result.success == 1
-        semantic_tools.validate_semantic.assert_called_once_with(scope="all", semantic_model_name="shop")
-        assert semantic_tools.query_metrics.call_args_list == [
-            call(metrics=["order_count"], dry_run=True),
-            call(metrics=["gross_revenue"], dry_run=True),
-        ]
-        sync.assert_called_once_with(
-            str(model_file),
-            metric_sqls={
-                "order_count": "SELECT COUNT(*) FROM orders",
-                "gross_revenue": "SELECT SUM(amount) FROM orders",
-            },
-        )
-
-    def test_validation_failure_does_not_sync(self, generation_tools, tmp_path):
-        generation_tools.authoring_format = "osi"
-        model_file = tmp_path / "semantic_models" / "shop" / "shop.yml"
-        model_file.parent.mkdir(parents=True)
-        model_file.write_text(
-            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    datasets: []\n",
-            encoding="utf-8",
-        )
-        mock_pm = Mock(subject_dir=str(tmp_path))
-        semantic_tools = Mock()
-        semantic_tools.validate_semantic.return_value = FuncToolResult(success=0, error="invalid model")
-
-        with (
-            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
-            patch("datus.tools.func_tool.semantic_tools.SemanticTools", return_value=semantic_tools),
-            patch.object(generation_tools, "reconcile_osi_document_to_db") as sync,
-        ):
-            result = generation_tools.sync_semantic(str(model_file))
-
-        assert result.success == 0
-        assert "invalid model" in result.error
-        sync.assert_not_called()
-
-    def test_metric_dry_run_without_compiled_sql_does_not_sync(self, generation_tools, tmp_path):
-        generation_tools.authoring_format = "osi"
-        model_file = tmp_path / "semantic_models" / "shop" / "shop.yml"
-        model_file.parent.mkdir(parents=True)
-        model_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n"
-            "    metrics:\n"
-            "      - name: order_count\n",
-            encoding="utf-8",
-        )
-        mock_pm = Mock(subject_dir=str(tmp_path))
-        semantic_tools = Mock()
-        semantic_tools.validate_semantic.return_value = FuncToolResult(result={"valid": True})
-        semantic_tools.query_metrics.return_value = FuncToolResult(result={"metadata": {"sql": "   "}})
-
-        with (
-            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
-            patch("datus.tools.func_tool.semantic_tools.SemanticTools", return_value=semantic_tools),
-            patch.object(generation_tools, "reconcile_osi_document_to_db") as sync,
-        ):
-            result = generation_tools.sync_semantic(str(model_file))
-
-        assert result.success == 0
-        assert "did not return compiled SQL" in result.error
-        sync.assert_not_called()
-
-    def test_metric_sql_compilation_keeps_supplied_sql_and_compiles_only_missing(self, generation_tools):
-        generation_tools.authoring_format = "osi"
-        runtime_context_provider = Mock(return_value={"database": "task_db", "schema": "task_schema"})
-        generation_tools._runtime_db_context_provider = runtime_context_provider
-        semantic_tools = Mock()
-        semantic_tools.query_metrics.return_value = FuncToolResult(
-            result={"metadata": {"metric_sqls": {"__query_metrics_dry_run__": "SELECT SUM(amount) FROM orders"}}}
-        )
-
-        with patch("datus.tools.func_tool.semantic_tools.SemanticTools", return_value=semantic_tools) as tools_cls:
-            result = generation_tools._compile_osi_metric_sqls(
-                ["order_count", "gross_revenue"],
-                {"order_count": "  SELECT COUNT(*) FROM orders\n"},
-            )
-
-        assert result.success == 1
-        assert result.result["metric_sqls"] == {
-            "order_count": "SELECT COUNT(*) FROM orders",
-            "gross_revenue": "SELECT SUM(amount) FROM orders",
-        }
-        semantic_tools.query_metrics.assert_called_once_with(metrics=["gross_revenue"], dry_run=True)
-        assert tools_cls.call_args.kwargs["runtime_db_context_provider"] is runtime_context_provider
 
 
 class TestCheckSemanticObjectExists:
@@ -422,7 +237,7 @@ class TestEndSemanticModelGeneration:
 
         with (
             patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
-            patch.object(generation_tools, "reconcile_osi_document_to_db") as sync_mock,
+            patch.object(generation_tools, "sync_osi_semantic_to_db") as sync_mock,
         ):
             result = generation_tools.end_semantic_model_generation([str(finance_file)])
 
@@ -445,7 +260,7 @@ class TestEndSemanticModelGeneration:
             patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
             patch.object(
                 generation_tools,
-                "reconcile_osi_document_to_db",
+                "sync_osi_semantic_to_db",
                 return_value={"success": True},
             ) as sync_mock,
         ):
@@ -544,7 +359,7 @@ class TestEndMetricGeneration:
             patch.object(type(generation_tools), "_validate_metric_file_has_blocks") as preflight_mock,
             patch.object(
                 generation_tools,
-                "reconcile_osi_document_to_db",
+                "_sync_osi_metric_to_db",
                 return_value={"success": True, "message": "synced"},
             ) as sync_mock,
         ):
@@ -552,7 +367,7 @@ class TestEndMetricGeneration:
 
         assert result.success == 1
         preflight_mock.assert_not_called()
-        sync_mock.assert_called_once_with(str(metric_file), metric_sqls={})
+        sync_mock.assert_called_once_with(str(metric_file), [], {}, replace_metric_artifact=False)
 
     def test_osi_ignores_semantic_model_files_to_avoid_duplicate_sync(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
@@ -574,7 +389,7 @@ class TestEndMetricGeneration:
             patch.object(type(generation_tools), "_validate_metric_file_has_blocks") as preflight_mock,
             patch.object(
                 generation_tools,
-                "reconcile_osi_document_to_db",
+                "_sync_osi_metric_to_db",
                 return_value={"success": True, "message": "synced"},
             ) as sync_mock,
         ):
@@ -585,7 +400,12 @@ class TestEndMetricGeneration:
 
         assert result.success == 1
         preflight_mock.assert_not_called()
-        sync_mock.assert_called_once_with(str(metric_file), metric_sqls={})
+        sync_mock.assert_called_once_with(
+            str(metric_file),
+            [],
+            {},
+            replace_metric_artifact=False,
+        )
         assert result.result["semantic_model_files"] == []
         assert generation_tools.generation_evidence.semantic_kb_sync_passed is False
 
@@ -956,23 +776,6 @@ class TestSyncMetricToDb:
             "schema_name": "public",
         }
 
-    def test_current_db_parts_accepts_node_runtime_context_override(self):
-        from datus.tools.func_tool.generation_tools import GenerationTools
-
-        agent_config = SimpleNamespace(
-            current_db_config=lambda: SimpleNamespace(catalog="default_catalog", database="default_db", schema=""),
-            runtime_db_context=lambda: {"database": "stale_db"},
-        )
-
-        assert GenerationTools._current_db_parts(
-            agent_config,
-            {"catalog": "task_catalog", "database": "task_db", "schema": "task_schema"},
-        ) == {
-            "catalog_name": "task_catalog",
-            "database_name": "task_db",
-            "schema_name": "task_schema",
-        }
-
     def test_metric_file_not_found(self, generation_tools):
         result = generation_tools._sync_metric_to_db("/nonexistent/metric.yaml")
         assert result["success"] is False
@@ -1212,7 +1015,7 @@ class TestOsiSync:
         assert metric_obj["yaml_path"] == str(metric_file)
         assert result["metric_names"] == ["order_count"]
 
-    def test_legacy_incremental_flag_still_reconciles_complete_artifact(self, generation_tools, tmp_path):
+    def test_sync_osi_metric_to_db_can_upsert_without_replacing_artifact(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
             catalog="default_catalog", database="shop", schema=""
         )
@@ -1221,9 +1024,6 @@ class TestOsiSync:
             "version: 0.2.0.dev0\n"
             "semantic_model:\n"
             "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n"
             "    metrics:\n"
             "      - name: order_count\n"
             "        expression:\n"
@@ -1246,27 +1046,18 @@ class TestOsiSync:
             subject_path=None,
             kind=None,
         )
-        doc = SimpleNamespace(name="shop", datasets=[dataset], relationships=[], metrics=[metric])
+        doc = SimpleNamespace(datasets=[dataset], metrics=[metric])
 
-        with (
-            patch.object(generation_tools, "_load_osi_document", return_value=doc),
-            patch.object(
-                generation_tools,
-                "_compile_osi_metric_sqls",
-                return_value=FuncToolResult(result={"metric_sqls": {"order_count": "SELECT 1"}}),
-            ) as compile_sqls,
-        ):
+        with patch.object(generation_tools, "_load_osi_document", return_value=doc):
             result = generation_tools._sync_osi_metric_to_db(str(metric_file), replace_metric_artifact=False)
 
         assert result["success"] is True
-        compile_sqls.assert_called_once_with(["order_count"], None)
         generation_tools.metric_rag.delete_artifact_rows.assert_not_called()
-        generation_tools.metric_rag.delete_artifact_rows_except.assert_called_once()
+        generation_tools.metric_rag.delete_artifact_rows_except.assert_not_called()
         generation_tools.metric_rag.list_artifact_rows.assert_called_once_with(str(metric_file))
         generation_tools.metric_rag.upsert_batch.assert_called_once()
-        assert generation_tools.metric_rag.upsert_batch.call_args.args[0][0]["sql"] == "SELECT 1"
 
-    def test_complete_osi_publish_restores_all_projections_on_later_failure(self, generation_tools, tmp_path):
+    def test_sync_osi_metric_partial_publish_restores_on_later_failure(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
             catalog="default_catalog", database="shop", schema=""
         )
@@ -1275,9 +1066,6 @@ class TestOsiSync:
             "version: 0.2.0.dev0\n"
             "semantic_model:\n"
             "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n"
             "    metrics:\n"
             "      - name: order_count\n"
             "        expression:\n"
@@ -1300,24 +1088,16 @@ class TestOsiSync:
             subject_path=None,
             kind=None,
         )
-        doc = SimpleNamespace(name="shop", datasets=[dataset], relationships=[], metrics=[metric])
-        generation_tools.semantic_rag.list_artifact_rows.return_value = [{"id": "old-table"}]
+        doc = SimpleNamespace(datasets=[dataset], metrics=[metric])
         generation_tools.metric_rag.list_artifact_rows.return_value = [{"id": "old-metric"}]
         generation_tools.metric_rag.create_indices.side_effect = RuntimeError("index failed")
 
         with patch.object(generation_tools, "_load_osi_document", return_value=doc):
-            result = generation_tools._sync_osi_metric_to_db(
-                str(metric_file),
-                metric_sqls={"order_count": "SELECT 1"},
-                replace_metric_artifact=False,
-            )
+            result = generation_tools._sync_osi_metric_to_db(str(metric_file), replace_metric_artifact=False)
 
         assert result["success"] is False
         assert "index failed" in result["error"]
         generation_tools.metric_rag.delete_artifact_rows_except.assert_not_called()
-        generation_tools.semantic_rag.restore_artifact_rows.assert_called_once_with(
-            str(metric_file), [{"id": "old-table"}]
-        )
         generation_tools.metric_rag.restore_artifact_rows.assert_called_once_with(
             str(metric_file), [{"id": "old-metric"}]
         )
@@ -1411,13 +1191,7 @@ class TestOsiSync:
         )
 
         with patch.object(generation_tools, "_load_osi_document", return_value=doc):
-            result = generation_tools._sync_osi_metric_to_db(
-                str(metric_file),
-                metric_sqls={
-                    "order_count": "SELECT 1",
-                    "order_count_prev": "SELECT 2",
-                },
-            )
+            result = generation_tools._sync_osi_metric_to_db(str(metric_file))
 
         assert result["success"] is True
         metric_objects = generation_tools.metric_rag.upsert_batch.call_args.args[0]
@@ -1432,20 +1206,13 @@ class TestOsiSync:
         assert by_name["order_count_prev"]["dimensions"] == by_name["order_count"]["dimensions"]
         assert by_name["order_count_prev"]["entities"] == ["order_id"]
 
-    def test_legacy_metric_sync_reconciles_the_unified_osi_artifact(self, generation_tools, tmp_path):
+    def test_sync_osi_metric_to_db_syncs_every_semantic_file(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
             catalog="default_catalog", database="shop", schema=""
         )
         metric_file = tmp_path / "orders_metrics.yml"
         metric_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n"
-            "    metrics:\n"
-            "      - name: order_count\n"
+            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: order_count\n"
         )
         orders_file = tmp_path / "orders.yml"
         customers_file = tmp_path / "customers.yml"
@@ -1468,7 +1235,7 @@ class TestOsiSync:
             inputs=[],
             measures=[],
         )
-        doc = SimpleNamespace(name="shop", datasets=[dataset], relationships=[], metrics=[metric])
+        doc = SimpleNamespace(datasets=[dataset], relationships=[], metrics=[metric])
 
         with (
             patch.object(generation_tools, "_load_osi_document", return_value=doc),
@@ -1477,18 +1244,14 @@ class TestOsiSync:
             result = generation_tools._sync_osi_metric_to_db(
                 str(metric_file),
                 [str(orders_file), str(customers_file)],
-                metric_sqls={"order_count": "SELECT 1"},
             )
 
         assert result["success"] is True
         assert result["semantic_synced"] is True
-        assert result["semantic_model_files_synced"] == [str(metric_file)]
-        sync_mock.assert_not_called()
+        assert result["semantic_model_files_synced"] == [str(orders_file), str(customers_file)]
+        assert [call.args[0] for call in sync_mock.call_args_list] == [str(orders_file), str(customers_file)]
 
-    def test_complete_sync_clears_metrics_when_document_has_none(self, generation_tools, tmp_path):
-        generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
-            catalog="default_catalog", database="shop", schema=""
-        )
+    def test_sync_osi_metric_to_db_rejects_metric_file_without_metrics(self, generation_tools, tmp_path):
         metric_file = tmp_path / "empty_metrics.yml"
         metric_file.write_text(
             "version: 0.2.0.dev0\n"
@@ -1499,51 +1262,10 @@ class TestOsiSync:
             "        source: orders\n"
         )
 
-        dataset = SimpleNamespace(
-            name="orders",
-            description="",
-            source=SimpleNamespace(table="orders"),
-            primary_key=[],
-            time_dimension=None,
-            dimensions=[],
-        )
-        doc = SimpleNamespace(name="empty", datasets=[dataset], relationships=[], metrics=[])
-        generation_tools._semantic_object_exists_cache[("table", "orders", "")] = FuncToolResult()
-        generation_tools._semantic_table_object_index = {"orders": {"kind": "table"}}
-        nested_dir = tmp_path / "nested"
-        nested_dir.mkdir()
-        noncanonical_path = nested_dir / ".." / metric_file.name
-        canonical_path = str(metric_file.resolve())
-
-        with patch.object(generation_tools, "_load_osi_document", return_value=doc):
-            result = generation_tools.reconcile_osi_document_to_db(str(noncanonical_path))
-
-        assert result["success"] is True
-        assert result["semantic_model_files_synced"] == [canonical_path]
-        generation_tools.metric_rag.upsert_batch.assert_not_called()
-        generation_tools.metric_rag.delete_artifact_rows_except.assert_called_once_with(canonical_path, [])
-        assert generation_tools._semantic_object_exists_cache == {}
-        assert generation_tools._semantic_table_object_index is None
-
-    def test_complete_sync_fails_closed_when_profile_storage_is_unavailable(self, generation_tools, tmp_path):
-        semantic_file = tmp_path / "shop.yml"
-        semantic_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n",
-            encoding="utf-8",
-        )
-        generation_tools.table_semantic_profile_rag = None
-        generation_tools._table_semantic_profile_init_error = "profile backend unavailable"
-
-        result = generation_tools.reconcile_osi_document_to_db(str(semantic_file))
+        result = generation_tools._sync_osi_metric_to_db(str(metric_file))
 
         assert result["success"] is False
-        assert "profile backend unavailable" in result["error"]
-        generation_tools.semantic_rag.upsert_batch.assert_not_called()
+        assert "No OSI metrics found in metric file" in result["error"]
         generation_tools.metric_rag.upsert_batch.assert_not_called()
 
     def test_sync_osi_semantic_to_db_upserts_only_current_dataset_columns(self, generation_tools, tmp_path):
@@ -1803,31 +1525,44 @@ class TestOsiSync:
         generation_tools.semantic_rag.restore_artifact_rows.assert_called_once()
         generation_tools.table_semantic_profile_rag.restore_artifact_rows.assert_called_once()
 
-    def test_sync_osi_to_db_always_uses_complete_reconcile(self, generation_tools, tmp_path):
+    def test_sync_osi_to_db_routes_metric_file_through_metric_sync(self, generation_tools, tmp_path):
+        # A metrics-bearing OSI doc: one pass through _sync_osi_metric_to_db (which
+        # also syncs the referenced datasets); no separate semantic sync call.
         osi_file = tmp_path / "shop.yml"
         osi_file.write_text("version: 0.2.0.dev0\n")
-        with patch.object(
-            generation_tools,
-            "reconcile_osi_document_to_db",
-            return_value={"success": True, "synced": 5},
-        ) as reconcile:
+        with (
+            patch.object(generation_tools, "extract_osi_metric_names", return_value=["order_count"]),
+            patch.object(
+                generation_tools,
+                "_sync_osi_metric_to_db",
+                return_value={"success": True, "metric_artifact_ids": ["metric:a", "metric:b"]},
+            ) as metric_sync,
+            patch.object(generation_tools, "sync_osi_semantic_to_db") as semantic_sync,
+        ):
             result = generation_tools.sync_osi_to_db(str(osi_file))
 
-        reconcile.assert_called_once_with(str(osi_file), metric_sqls=None)
+        metric_sync.assert_called_once_with(metric_file=str(osi_file), semantic_model_file=str(osi_file))
+        semantic_sync.assert_not_called()
         assert result["success"] is True
-        assert result["synced"] == 5
+        assert result["synced"] == 2
 
-    def test_sync_osi_to_db_does_not_branch_on_metric_presence(self, generation_tools, tmp_path):
+    def test_sync_osi_to_db_routes_dataset_only_file_through_semantic_sync(self, generation_tools, tmp_path):
+        # A dataset-only OSI doc (no metrics): syncs just the datasets.
         osi_file = tmp_path / "model.yml"
         osi_file.write_text("version: 0.2.0.dev0\n")
-        with patch.object(
-            generation_tools,
-            "reconcile_osi_document_to_db",
-            return_value={"success": True, "synced": 3},
-        ) as reconcile:
+        with (
+            patch.object(generation_tools, "extract_osi_metric_names", return_value=[]),
+            patch.object(
+                generation_tools,
+                "sync_osi_semantic_to_db",
+                return_value={"success": True, "semantic_objects": 3},
+            ) as semantic_sync,
+            patch.object(generation_tools, "_sync_osi_metric_to_db") as metric_sync,
+        ):
             result = generation_tools.sync_osi_to_db(str(osi_file))
 
-        reconcile.assert_called_once_with(str(osi_file), metric_sqls=None)
+        semantic_sync.assert_called_once_with(str(osi_file))
+        metric_sync.assert_not_called()
         assert result["success"] is True
         assert result["synced"] == 3
 
@@ -1836,116 +1571,9 @@ class TestOsiSync:
         # error dict rather than propagating out of the public entry.
         osi_file = tmp_path / "shop.yml"
         osi_file.write_text("version: 0.2.0.dev0\n")
-        with patch.object(generation_tools, "extract_osi_dataset_names", side_effect=RuntimeError("bad yaml")):
+        with patch.object(generation_tools, "extract_osi_metric_names", side_effect=RuntimeError("bad yaml")):
             result = generation_tools.sync_osi_to_db(str(osi_file))
         assert result == {"success": False, "error": "bad yaml"}
-
-
-class TestOsiReconcileRealStorage:
-    def test_sync_semantic_compiles_metric_sql_into_real_storage(self, real_agent_config):
-        pytest.importorskip("datus_semantic_osi")
-        pytest.importorskip("metricflow")
-        from datus.tools.func_tool.generation_tools import GenerationTools
-
-        real_agent_config.semantic_layer_configs = {"osi": {"type": "osi", "execution_backend": "metricflow"}}
-
-        model_dir = Path(real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource))
-        model_dir.mkdir(parents=True, exist_ok=True)
-        model_file = model_dir / "shop.yml"
-        model_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: satscores\n"
-            "        source: satscores\n"
-            "        primary_key: [cds]\n"
-            "        fields:\n"
-            "          - name: metric_date\n"
-            "            expression:\n"
-            "              dialects:\n"
-            "                - dialect: ANSI_SQL\n"
-            "                  expression: DATE('2020-01-01')\n"
-            "            dimension: {is_time: true}\n"
-            "            custom_extensions:\n"
-            "              - vendor_name: DATUS\n"
-            '                data: \'{"type":"time","time_granularity":"day"}\'\n'
-            "    metrics:\n"
-            "      - name: school_count\n"
-            "        expression:\n"
-            "          dialects:\n"
-            "            - dialect: ANSI_SQL\n"
-            "              expression: COUNT(DISTINCT cds)\n"
-            "        custom_extensions:\n"
-            "          - vendor_name: DATUS\n"
-            '            data: \'{"dataset":"satscores","time_dimension":"metric_date"}\'\n',
-            encoding="utf-8",
-        )
-        tools = GenerationTools(real_agent_config, authoring_format="osi")
-
-        result = tools.sync_semantic(str(model_file))
-
-        assert result.success == 1
-        metric_rows = tools.metric_rag.list_artifact_rows(str(model_file))
-        assert [row["name"] for row in metric_rows] == ["school_count"]
-        assert "COUNT" in metric_rows[0]["sql"].upper()
-
-    def test_removing_metrics_from_yaml_clears_real_metric_storage(self, real_agent_config):
-        osi_profile = pytest.importorskip("datus_semantic_osi.profile")
-        if not hasattr(osi_profile, "load_osi_model"):
-            pytest.skip("installed datus-semantic-osi does not support named model loading")
-
-        from datus.tools.func_tool.generation_tools import GenerationTools
-
-        model_dir = Path(real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource))
-        model_dir.mkdir(parents=True, exist_ok=True)
-        model_file = model_dir / "shop.yml"
-        model_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n"
-            "        primary_key: [order_id]\n"
-            "    metrics:\n"
-            "      - name: order_count\n"
-            "        expression:\n"
-            "          dialects:\n"
-            "            - dialect: ANSI_SQL\n"
-            "              expression: COUNT(DISTINCT order_id)\n"
-            "        custom_extensions:\n"
-            "          - vendor_name: DATUS\n"
-            '            data: \'{"dataset":"orders"}\'\n',
-            encoding="utf-8",
-        )
-        tools = GenerationTools(real_agent_config, authoring_format="osi")
-
-        first = tools.reconcile_osi_document_to_db(
-            str(model_file),
-            metric_sqls={"order_count": "SELECT COUNT(*) FROM orders"},
-        )
-
-        assert first["success"] is True
-        assert [row["name"] for row in tools.metric_rag.list_artifact_rows(str(model_file))] == ["order_count"]
-
-        model_file.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: shop\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: orders\n"
-            "        primary_key: [order_id]\n",
-            encoding="utf-8",
-        )
-
-        second = tools.reconcile_osi_document_to_db(str(model_file))
-
-        assert second["success"] is True
-        assert second["metric_names"] == []
-        assert tools.metric_rag.list_artifact_rows(str(model_file)) == []
-        assert tools.semantic_rag.list_artifact_rows(str(model_file))
 
 
 class TestGenerateSqlSummaryId:

--- a/tests/unit_tests/tools/permission/test_profiles.py
+++ b/tests/unit_tests/tools/permission/test_profiles.py
@@ -108,7 +108,6 @@ class TestNormalProfile:
         config = NORMAL
         assert _resolve(config, "semantic_tools", "check_semantic_object_exists") == PermissionLevel.ALLOW
         assert _resolve(config, "semantic_tools", "generate_sql_summary_id") == PermissionLevel.ALLOW
-        assert _resolve(config, "semantic_tools", "sync_semantic") == PermissionLevel.ALLOW
         assert _resolve(config, "semantic_tools", "end_semantic_model_generation") == PermissionLevel.ALLOW
         assert _resolve(config, "semantic_tools", "end_metric_generation") == PermissionLevel.ALLOW
 


### PR DESCRIPTION
## Summary

- revert #1176
- remove the complete Ossie semantic document synchronization changes introduced by that PR
- restore the repository tree to the state immediately before the merge

## Why

PR #1176 needs to be rolled back.

## Impact

This removes the synchronization behavior and related tests added by #1176. Existing behavior from before that merge is restored.

## Validation

- verified the reverted tree is identical to `b0498529a2e3764c8cde5c00dc2b642b0fe040b7`, the parent of the #1176 merge commit
- `git diff --check upstream/main...HEAD`

Reverts #1176.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved OSI publishing by synchronizing semantic models and metrics through dedicated workflows.
  - Added validation for metric YAML files, including required definitions and duplicate-name detection.
  - Improved recovery and cleanup during publishing when synchronization errors occur.

- **Changes**
  - Removed the semantic synchronization tool from Ossie authoring workflows.
  - Updated metric and semantic model publishing behavior for more targeted synchronization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->