### PR TITLE
[Others] Revert query_metrics and OSI-engine contract refactor

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -427,6 +427,10 @@ class AskMetricsAgenticNode(AgenticNode):
         where: Optional[str] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[str]] = None,
+        join_policy: Optional[
+            Literal["auto", "match_only", "fact_preserving", "dimension_preserving", "unmatched_only"]
+        ] = None,
+        zero_fill: bool = False,
         dry_run: bool = False,
     ) -> FuncToolResult:
         """
@@ -445,10 +449,11 @@ class AskMetricsAgenticNode(AgenticNode):
         metrics, AskMetrics expands the request to include related executable
         metrics when they are already present in the catalog.
 
-        Join behavior is declared on the semantic model and applied by the
-        adapter; there are no query-time join controls. For OSI-family
-        semantic layers, time_end is an exclusive upper bound (half-open
-        range).
+        For joined dimensions, use semantic join policies instead of SQL join
+        types: match_only for normal matched dimension grouping,
+        fact_preserving for unmatched fact analysis, dimension_preserving with
+        zero_fill for all dimension values including those with no facts, and
+        unmatched_only for only unmapped fact rows.
         """
         if not self.semantic_tools:
             return FuncToolResult(success=0, error="semantic tools unavailable")
@@ -493,6 +498,10 @@ class AskMetricsAgenticNode(AgenticNode):
             "order_by": normalized_order_by,
             "dry_run": dry_run,
         }
+        if join_policy:
+            query_kwargs["join_policy"] = join_policy
+        if zero_fill:
+            query_kwargs["zero_fill"] = zero_fill
         result = self.semantic_tools.query_metrics(**query_kwargs)
         if self._is_deterministic_validation_failure(result):
             self._failed_query_signatures.add(signature)
@@ -882,8 +891,6 @@ class AskMetricsAgenticNode(AgenticNode):
         return get_default_current_date(input_ref_date)
 
     def _get_system_prompt(self, prompt_version: Optional[str] = None) -> str:
-        from datus.agent.node.semantic_authoring import is_osi_authoring
-
         context: Dict[str, Any] = {
             "agent_config": self.agent_config,
             "rules": self.node_config.get("rules", []),
@@ -893,7 +900,6 @@ class AskMetricsAgenticNode(AgenticNode):
             "subject_tree_prompt": self.subject_tree_prompt,
             "subject_tree_prompt_limit": self.subject_tree_prompt_limit,
             "require_final_result_selection": self.require_final_result_selection,
-            "osi_semantics": is_osi_authoring(self.agent_config),
         }
 
         if self.agent_config:

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -37,11 +37,6 @@ import yaml
 AUTHORING_FORMAT_METRICFLOW = "metricflow"
 AUTHORING_FORMAT_OSI = "osi"
 
-# Semantic adapters that consume OSI authoring documents. ``osi`` lowers to
-# MetricFlow via the Datus OSI compiler; ``osi_engine`` executes natively on
-# osi-engine. Both author the same OSI format.
-OSI_FAMILY_ADAPTERS = frozenset({"osi", "osi_engine"})
-
 _SEMANTIC_AUTHORING_LOCKS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 _HELD_SEMANTIC_AUTHORING_KEYS: ContextVar[frozenset[str]] = ContextVar(
     "held_semantic_authoring_keys",
@@ -95,7 +90,7 @@ def resolve_authoring_format(
 
     adapter = _resolve_semantic_adapter(agent_config)
 
-    if adapter and str(adapter).strip().lower() in OSI_FAMILY_ADAPTERS:
+    if adapter and str(adapter).strip().lower() == AUTHORING_FORMAT_OSI:
         return AUTHORING_FORMAT_OSI
     return AUTHORING_FORMAT_METRICFLOW
 

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -31,24 +31,16 @@ Use the narrow metric workflow below:
 - Use the `Current date` from the runtime context as the reference date for relative or year-omitted time expressions.
 - For date periods without an explicit year, use the year from `Current date` unless the user explicitly states another year or a relative year.
 - Prefer closed calendar periods for standalone period mentions. Use open-ended ranges only when the user explicitly asks for cumulative or since-style results.
-{% if osi_semantics %}
-- `query_metrics.time_end` is an exclusive upper bound (half-open range `[time_start, time_end)`). For a closed calendar period, pass the first date after the period: month 2024-05 is `time_start=2024-05-01, time_end=2024-06-01`; May through June is `time_end=2024-07-01`.
-{% else %}
 - `query_metrics.time_end` is inclusive. For a closed calendar period, pass the inclusive final date of that period.
-{% endif %}
 - Choose grouping and filtering dimensions by semantic meaning. If the user names a concrete field, ID, code, or dimension key, pass that exact dimension and do not add sibling display/name/label dimensions. Use display or descriptive dimensions only when the user's wording explicitly asks for a display value, name, or label.
 - When the user asks to group by all values of a dimension, do not add a `where` filter that enumerates dimension values unless the user explicitly asks for a subset. The grouped metric query already returns all dimension values.
-- Join behavior is declared on the semantic model and applied by the semantic adapter; `query_metrics` has no join controls. Some question shapes therefore have no executable form unless a dedicated metric exists: "all values including those with no data" (zero-filled totals), "unmatched/unrecognized rows" audits, and "only those matching X" forced joins. For these, answer with the closest metric's standard semantics and state the difference explicitly, or state plainly that the question is not supported — never bend `where` filters to fake these semantics.
-{% if osi_semantics %}
-- Pass dimension names exactly as returned by `get_dimensions` (`dataset.field` form). In `order_by`, use output column names: the bare field name, or `<field>__<grain>` when a time grain applies — never the `dataset.field` form.
-- When `query_metrics` fails with a structured error, explain it in business terms instead of retrying blindly:
-  - `fan_out_risk`: the requested grouping or filter would double-count the metric (for example grouping a fact metric by an attribute of records that repeat per fact row); tell the user that dimension is not usable with this metric.
-  - `ambiguous_join_path`: more than one join path reaches the dimension; report the candidate paths and ask which business meaning is intended.
-  - Unknown metric/dimension errors: correct the request from the `candidates` list.
-  - Follow a `suggested_retry` only when it preserves the question's result shape; never add a time grouping just to satisfy a total-value question.
-{% endif %}
+- For joined dimensions, use semantic join controls, not SQL join types:
+  - Ordinary grouping by a joined dimension should use the default `join_policy="auto"`/`match_only`, which excludes facts that cannot match the requested dimension.
+  - If the user asks for all dimension values, including values with no facts, use `join_policy="dimension_preserving"` and `zero_fill=true`.
+  - If the user asks to keep unmatched facts, use `join_policy="fact_preserving"`.
+  - If the user asks only for unmapped or unrecognized fact rows, use `join_policy="unmatched_only"`.
 - Query complete metric results by default. Do not pass `limit` just to preview data, reduce output size, or be conservative; the system compresses visible tool output and caches the full result. Use `limit` only when the user explicitly asks for Top N, first N, maximum N rows, a preview, or another row-count restriction. When using `limit` for Top N/Bottom N, also pass `order_by`.
-- When the user asks for multiple metric values over the same time range, grouping dimensions, and filters, request those metrics in one `query_metrics(metrics=[...])` call. Do not split them into separate queries unless the metrics require incompatible dimensions, filters, or paths.
+- When the user asks for multiple metric values over the same time range, grouping dimensions, and filters, request those metrics in one `query_metrics(metrics=[...])` call. Do not split them into separate queries unless the metrics require incompatible dimensions, filters, paths, or join policies.
 - Prefer the most specific metric whose name or description directly matches the requested business concept. Do not rebuild a specific metric by querying a generic base metric plus filters when a matching specific metric is available.
 - For ratio, rate, conditional count, and compound-condition metrics, use the dedicated metric directly when available. Do not approximate it with numerator/base metrics or ad hoc `where` filters unless no dedicated metric exists.
 - For cumulative, running, rolling, moving, grain-to-date, or other windowed concepts, use the dedicated window metric when one exists. Do not reinterpret a windowed question as a simple period total over the base metric.

--- a/datus/resources/skills/osi-metrics-authoring/SKILL.md
+++ b/datus/resources/skills/osi-metrics-authoring/SKILL.md
@@ -94,19 +94,10 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
            - vendor_name: DATUS
              data: '{"dataset":"orders","time_dimension":"order_date","period_over_period":{"time_grain":"month","offset_window":"1 year","calculation":"percent_change"},"subject_path":["sales","revenue","growth"],"format":"0.00%","unit":"%"}'
      ```
-7. **Joins**: to group or slice by another table, use the existing semantic-model relationships. If the link is absent, report that the semantic model must be updated by `gen_semantic_model`; do not add relationships here. Join behavior (`inner`/`left`) is declared on the relationship, never on the metric.
-8. **Null fill for empty groups (`fill_nulls_with`)**: when the SQL history shows a metric's final value wrapped in `COALESCE(..., 0)` for groups with no data, declare it as a DATUS hint instead of burying the COALESCE in the expression:
-
-   ```yaml
-   custom_extensions:
-     - vendor_name: DATUS
-       data: '{"v": 1, "fill_nulls_with": 0}'
-   ```
-
-   Plain COUNT metrics read 0 for empty groups automatically — do not declare it for them. The fill applies to the metric's final output only; never emulate it on a component inside a ratio/expression (a count denominator must stay NULL-safe, not become a literal 0). Do not declare a fill for AVG-style metrics — an empty group's average is unknown, not 0.
-9. **Not metrics**: detail/list queries (`SELECT DISTINCT ...`) and window/ranking (`ROW_NUMBER()`, `RANK() OVER`, TopN per group) are NOT metrics. SKIP them. Do NOT create a dataset/view here and never force them into a metric. If the discovery tool returns `metric_generation_skips` or rank-like `derived_datasource_recommendations`, treat that SQL as skipped.
-10. Use clear English `snake_case` metric names; metric names must be globally unique. Every metric MUST include `description` and `ai_context`. Put the business definition in `description`; put LLM-facing usage guidance in `ai_context.instructions`, including grain, metric-specific conditions, time field, and join caveats.
-11. **Subject classification (required).** Every metric MUST carry a `subject_path` in its DATUS extension, encoded as an ordered `[domain, layer1, layer2]` list (e.g. `["sales","revenue","growth"]`). Choose the classification exactly as instructed by the **Subject Classification** section of the system prompt — same required categories, same reuse-or-create rule, same `{domain}/{layer1}/{layer2}` hierarchy the MetricFlow path uses; the only difference is the carrier (a DATUS `subject_path` list here, a `locked_metadata.tags` entry there).
+7. **Joins**: to group or slice by another table, use the existing semantic-model relationships. If the link is absent, report that the semantic model must be updated by `gen_semantic_model`; do not add relationships here.
+8. **Not metrics**: detail/list queries (`SELECT DISTINCT ...`) and window/ranking (`ROW_NUMBER()`, `RANK() OVER`, TopN per group) are NOT metrics. SKIP them. Do NOT create a dataset/view here and never force them into a metric. If the discovery tool returns `metric_generation_skips` or rank-like `derived_datasource_recommendations`, treat that SQL as skipped.
+9. Use clear English `snake_case` metric names; metric names must be globally unique. Every metric MUST include `description` and `ai_context`. Put the business definition in `description`; put LLM-facing usage guidance in `ai_context.instructions`, including grain, metric-specific conditions, time field, and join caveats.
+10. **Subject classification (required).** Every metric MUST carry a `subject_path` in its DATUS extension, encoded as an ordered `[domain, layer1, layer2]` list (e.g. `["sales","revenue","growth"]`). Choose the classification exactly as instructed by the **Subject Classification** section of the system prompt — same required categories, same reuse-or-create rule, same `{domain}/{layer1}/{layer2}` hierarchy the MetricFlow path uses; the only difference is the carrier (a DATUS `subject_path` list here, a `locked_metadata.tags` entry there).
 
 ## Hard skip gate
 

--- a/datus/resources/skills/osi-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/osi-semantic-authoring/SKILL.md
@@ -56,21 +56,8 @@ One valid OSI core document for the current business domain / semantic model sco
 9. **Time dimension**: exactly one primary time field per dataset. When several date columns exist and the primary one is ambiguous, ASK before generating. **Verify `time_granularity` with data**: run one query such as `SELECT COUNT(DISTINCT <time_col>), MIN(<time_col>), MAX(<time_col>) FROM <table>` and derive the snapshot interval (e.g. month-end dates spanning months → `month`; consecutive dates → `day`). When the data is indeterminate (a single distinct date), fall back to the table/column comments (e.g. a "monthly statistics" table comment → `month`), else default to `day`.
 10. **Validation conflicts are fixed structurally.** If `validate_semantic` reports an element lowering to multiple types, follow the structural fix in the message: move the column into `primary_key`/a relationship everywhere, or give it a `dimension:` block everywhere, or drop the `dimension:` block in datasets that only aggregate it. Never bounce a column between roles across validation attempts, and never falsify keys to silence the validator (e.g. do not delete a snapshot date from a declared composite key — the compiler resolves that case automatically).
 11. **Relationships** live inside the semantic model object, never inside a dataset. Use OSI core fields `from`, `to`, `from_columns`, `to_columns`. Do NOT use non-core fields such as `from_dataset`, `from_identifier`, `join_on`, `from_column`, or `to_column`.
-12. **Relationship join semantics (DATUS extension).** Every relationship MUST declare its join type explicitly:
-
-    ```yaml
-    custom_extensions:
-      - vendor_name: DATUS
-        data: '{"v": 1, "join_type": "inner"}'
-    ```
-
-    - `join_type` is `"inner"` (drop fact rows with no match — the standard semantics for plain grouping and filtering questions) or `"left"` (keep unmatched fact rows in a NULL dimension bucket — reconciliation/audit semantics). Mine the value from the provided SQL history: write whatever join the dominant queries use; a plain `JOIN` means `"inner"`. Never omit the declaration.
-    - `to_columns` MUST be the target dataset's declared `primary_key` or one of its `unique_keys`. Treat a `RelationshipTargetNotUnique` validation warning as an error: fix it structurally (transcribe the real key per rule 7, or drop the relationship) — never ship a model with this warning, the join can multiply results.
-    - Snapshot tables (composite key containing the time column, e.g. `[entity_id, snapshot_date]`): do NOT create a relationship that joins only the entity columns — every fact row would match one row per snapshot and metric values would multiply.
-    - The same table in two roles (e.g. owner department and executing department both referencing one department table), and self-referencing hierarchies: create two datasets with distinct names over the same `source`, and bind each relationship to its own columns.
-    - Many-to-many links: model the bridge table as its own dataset with two many-to-one relationships; do not relate the two end tables directly.
-13. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
-14. Preserve literal values and column names exactly; do not invent columns. Keep column comments in their original language — do not translate.
+12. Do NOT add metrics in the semantic-model step. Metrics are added by the metrics workflow under `semantic_model[0].metrics`.
+13. Preserve literal values and column names exactly; do not invent columns. Keep column comments in their original language — do not translate.
 
 ## Worked example — monthly snapshot table
 

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -142,6 +142,22 @@ def _normalize_optional_path(value) -> Optional[List[str]]:
     return names or None
 
 
+def _normalize_optional_bool(value) -> bool:
+    """Normalize optional tool boolean arguments that may arrive as strings."""
+    value = normalize_null(value)
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"1", "true", "yes", "y", "on"}:
+            return True
+        if text in {"0", "false", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
 def _signature_accepts_parameter(parameters, name: str) -> bool:
     """Return true when a callable explicitly accepts ``name`` or arbitrary kwargs."""
     return name in parameters or any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
@@ -902,29 +918,33 @@ class SemanticTools:
         where: Optional[str] = None,
         limit: Optional[int] = None,
         order_by: Optional[List[str]] = None,
+        join_policy: Optional[
+            Literal["auto", "match_only", "fact_preserving", "dimension_preserving", "unmatched_only"]
+        ] = None,
+        zero_fill: bool = False,
         dry_run: bool = False,
     ) -> FuncToolResult:
         """
         Query metrics data (requires adapter).
-
-        Join behavior is not a query-time concern: it is declared on the
-        semantic model (relationship ``join_type``) and applied by the
-        semantic adapter deterministically.
 
         Args:
             metrics: List of metric names to query
             dimensions: Optional list of dimensions to group by (from get_dimensions)
             path: Optional subject tree path (from list_subject_tree)
             time_start: Optional start time (ISO format like '2024-01-01' or relative like '-7d')
-            time_end: Optional end time (ISO format like '2024-01-31' or relative like 'now').
-                      For OSI-family semantic layers this is an exclusive upper bound
-                      (half-open range ``[time_start, time_end)``).
+            time_end: Optional end time (ISO format like '2024-01-31' or relative like 'now')
             time_granularity: Optional time granularity for aggregation ('day', 'week', 'month', 'quarter', 'year')
             where: Optional SQL WHERE clause (without WHERE keyword)
             limit: Optional maximum number of rows
             order_by: Optional list of columns to sort by. Use column name for ascending,
                       prefix with '-' for descending. Examples: ['metric_time__day'] for ascending,
                       ['-message_count'] for descending. Do NOT use 'asc'/'desc' keywords.
+            join_policy: Optional relationship handling policy for joined dimensions:
+                      'auto'/'match_only' keeps only facts that match requested joined dimensions;
+                      'fact_preserving' keeps unmatched facts;
+                      'dimension_preserving' keeps all dimension values;
+                      'unmatched_only' returns only unmatched facts.
+            zero_fill: Fill missing metric values with 0 when join_policy='dimension_preserving'.
             dry_run: If True, only validate and return query plan
 
         Returns:
@@ -954,10 +974,12 @@ class SemanticTools:
         time_end = normalize_null(time_end)
         time_granularity = normalize_null(time_granularity)
         where = normalize_null(where)
+        join_policy = normalize_null(join_policy)
+        zero_fill = _normalize_optional_bool(zero_fill)
         logger.info(
             f"query_metrics called: metrics={metrics}, dimensions={dimensions}, path={path}, "
             f"time=[{time_start},{time_end}], granularity={time_granularity}, where={where}, "
-            f"limit={limit}, dry_run={dry_run}"
+            f"limit={limit}, join_policy={join_policy}, zero_fill={zero_fill}, dry_run={dry_run}"
         )
 
         try:
@@ -978,6 +1000,30 @@ class SemanticTools:
                 "order_by": order_by or None,
                 "dry_run": dry_run,
             }
+            adapter_params = inspect.signature(adapter.query_metrics).parameters
+            requested_join_controls = bool(join_policy) or bool(zero_fill)
+            supports_join_policy = _signature_accepts_parameter(adapter_params, "join_policy")
+            supports_zero_fill = _signature_accepts_parameter(adapter_params, "zero_fill")
+            if supports_join_policy and join_policy:
+                adapter_query_kwargs["join_policy"] = join_policy
+            elif join_policy:
+                return FuncToolResult(
+                    success=0,
+                    error="query_metrics join_policy is not supported by the current semantic adapter.",
+                )
+            if supports_zero_fill and zero_fill:
+                adapter_query_kwargs["zero_fill"] = zero_fill
+            elif zero_fill:
+                return FuncToolResult(
+                    success=0,
+                    error="query_metrics zero_fill is not supported by the current semantic adapter.",
+                )
+            if requested_join_controls and not (supports_join_policy or supports_zero_fill):
+                return FuncToolResult(
+                    success=0,
+                    error="query_metrics join controls are not supported by the current semantic adapter.",
+                )
+
             result = _run_async(adapter.query_metrics(**adapter_query_kwargs))
 
             # Drop non-JSON-serializable metadata entries (MetricFlow puts a

--- a/docs/configuration/semantic_layer.md
+++ b/docs/configuration/semantic_layer.md
@@ -23,11 +23,6 @@ agent:
       osi:
         # execution_backend defaults to metricflow and normally does not need
         # to be configured.
-
-      osi_engine:
-        # Native Rust engine path (datus-semantic-osi-engine). Datus fills
-        # db_config from the active datasource and the semantic model path
-        # from subject/semantic_models/<datasource>/ automatically.
 ```
 
 ## Selection Rules
@@ -65,8 +60,6 @@ Comparison is case-insensitive and trims surrounding whitespace.
 - OSI mode authors strict OSI core YAML and stores Datus execution hints in `custom_extensions`.
 - The current OSI execution backend is MetricFlow by default. You normally do not need to set `execution_backend`.
 - Configure `services.semantic_layer.osi` and mark it `default: true` to select this path globally when other adapters are also configured. An empty `osi: {}` entry is selected automatically only when it is the sole semantic adapter, or when the current project pins `semantic: osi`.
-- `osi_engine` (package `datus-semantic-osi-engine`) executes the same OSI authoring documents natively on the Rust osi-engine — no MetricFlow dependency. Both `osi` and `osi_engine` author the OSI format; generation and ask flows treat them identically.
-- For OSI-family adapters, `query_metrics.time_end` is an exclusive upper bound (half-open time range `[time_start, time_end)`).
 
 ## Configuring through the CLI (`/services`)
 

--- a/docs/configuration/semantic_layer.zh.md
+++ b/docs/configuration/semantic_layer.zh.md
@@ -17,10 +17,6 @@ agent:
 
       osi:
         # execution_backend 默认是 metricflow，通常不需要配置。
-
-      osi_engine:
-        # 原生 Rust 引擎路径(datus-semantic-osi-engine)。Datus 会自动从当前
-        # datasource 填充 db_config,语义模型路径取 subject/semantic_models/<datasource>/。
 ```
 
 ## 选择规则
@@ -50,8 +46,6 @@ agent:
 - OSI 模式编写 strict OSI core YAML，并把 Datus 执行提示放在 `custom_extensions` 中。
 - 当前 OSI 执行后端默认是 MetricFlow，通常不需要设置 `execution_backend`。
 - 配置 `services.semantic_layer.osi` 并标记 `default: true`，可在同时配置其他 adapter 时全局选择 OSI。空的 `osi: {}` 只有在它是唯一 semantic adapter，或当前项目 pin 到 `semantic: osi` 时才会被选中。
-- `osi_engine`（包 `datus-semantic-osi-engine`）在 Rust osi-engine 上原生执行同一份 OSI authoring 文档，不依赖 MetricFlow。`osi` 与 `osi_engine` 使用相同的 OSI authoring 格式；生成与问数流程对两者一视同仁。
-- 对 OSI 家族 adapter，`query_metrics.time_end` 是开上界（前闭后开时间区间 `[time_start, time_end)`）。
 
 ## 通过 CLI 配置（`/services`）
 

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -125,37 +125,6 @@ class TestAskMetricsAgenticNode:
         assert "do not add sibling display/name/label dimensions" in prompt
         assert node.subject_tree_prompt_limit == 100
 
-    def test_system_prompt_time_bound_follows_semantic_adapter_family(
-        self, real_agent_config, mock_llm_create, monkeypatch
-    ):
-        node, _, _ = _make_node(real_agent_config, tree={"Sales": {"Orders": {"metrics": ["order_count"]}}})
-
-        monkeypatch.setattr(
-            real_agent_config,
-            "resolve_semantic_adapter",
-            lambda requested=None: "osi_engine",
-            raising=False,
-        )
-        osi_prompt = node._get_system_prompt()
-        assert "exclusive upper bound" in osi_prompt
-        assert "time_end=2024-06-01" in osi_prompt
-        assert "`query_metrics.time_end` is inclusive" not in osi_prompt
-        assert "Pass dimension names exactly as returned by `get_dimensions`" in osi_prompt
-        assert "fan_out_risk" in osi_prompt
-        assert "Join behavior is declared on the semantic model" in osi_prompt
-
-        monkeypatch.setattr(
-            real_agent_config,
-            "resolve_semantic_adapter",
-            lambda requested=None: "metricflow",
-            raising=False,
-        )
-        mf_prompt = node._get_system_prompt()
-        assert "`query_metrics.time_end` is inclusive" in mf_prompt
-        assert "exclusive upper bound" not in mf_prompt
-        assert "fan_out_risk" not in mf_prompt
-        assert "Join behavior is declared on the semantic model" in mf_prompt
-
     def test_reference_date_is_injected_into_runtime_context(self, real_agent_config, mock_llm_create):
         from datus.schemas.ask_metrics_agentic_node_models import AskMetricsNodeInput
 
@@ -738,6 +707,31 @@ class TestAskMetricsAgenticNode:
 
         semantic_tools.query_metrics.assert_called_once()
         assert semantic_tools.query_metrics.call_args.kwargs["where"] == "region = 'east'"
+
+    def test_query_metrics_passes_join_controls(
+        self,
+        real_agent_config,
+        mock_llm_create,
+    ):
+        node, semantic_tools, _ = _make_node(
+            real_agent_config,
+            tree={"Sales": {"Orders": {"metrics": ["order_count"]}}},
+        )
+        semantic_tools.list_metrics.return_value = FuncToolResult(
+            result={"items": [{"name": "order_count", "metadata": {}}], "has_more": False}
+        )
+        semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
+
+        node.query_metrics(
+            metrics=["order_count"],
+            dimensions=["dimension_key__display_name"],
+            join_policy="dimension_preserving",
+            zero_fill=True,
+        )
+
+        semantic_tools.query_metrics.assert_called_once()
+        assert semantic_tools.query_metrics.call_args.kwargs["join_policy"] == "dimension_preserving"
+        assert semantic_tools.query_metrics.call_args.kwargs["zero_fill"] is True
 
     def test_query_metrics_aliases_joined_dimension_display_columns(
         self,

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -72,15 +72,6 @@ def test_derives_from_active_semantic_adapter():
     assert resolve_authoring_format(_agent_config("metricflow"), None) == AUTHORING_FORMAT_METRICFLOW
 
 
-def test_osi_engine_adapter_authors_osi_format():
-    """The native osi-engine adapter consumes the same OSI authoring documents."""
-    assert resolve_authoring_format(_agent_config("osi_engine"), None) == AUTHORING_FORMAT_OSI
-    assert resolve_authoring_format(_agent_config("OSI_ENGINE"), None) == AUTHORING_FORMAT_OSI
-    assert resolve_semantic_adapter_type(_agent_config("osi_engine")) == "osi_engine"
-    assert required_authoring_skills(_agent_config("osi_engine"), "gen_semantic_model") == "osi-semantic-authoring"
-    assert required_authoring_skills(_agent_config("osi_engine"), "gen_metrics") == "osi-metrics-authoring"
-
-
 def test_legacy_node_semantic_adapter_is_ignored():
     assert (
         resolve_authoring_format(_agent_config("metricflow"), {"semantic_adapter": "osi"})

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -1226,6 +1226,130 @@ class TestQueryMetricsCompression:
             assert result.result["data"]["original_rows"] == 1
             assert result.result["data"]["original_columns"] == ["x"]
 
+    def test_query_metrics_passes_join_controls_to_supporting_adapter(self, semantic_tools):
+        """Test that semantic join controls are forwarded when the adapter supports them."""
+        query_result = QueryResult(columns=["x"], data=[{"x": 1}], metadata={})
+
+        class AdapterWithJoinControls:
+            def __init__(self):
+                self.query_kwargs = None
+
+            def get_dimensions(self, metric_name, path=None):
+                return [{"name": "customer_id__customer_name"}]
+
+            def query_metrics(
+                self,
+                metrics,
+                dimensions=None,
+                path=None,
+                time_start=None,
+                time_end=None,
+                time_granularity=None,
+                where=None,
+                limit=None,
+                order_by=None,
+                join_policy=None,
+                zero_fill=False,
+                dry_run=False,
+            ):
+                self.query_kwargs = {
+                    "metrics": metrics,
+                    "dimensions": dimensions,
+                    "path": path,
+                    "time_start": time_start,
+                    "time_end": time_end,
+                    "time_granularity": time_granularity,
+                    "where": where,
+                    "limit": limit,
+                    "order_by": order_by,
+                    "join_policy": join_policy,
+                    "zero_fill": zero_fill,
+                    "dry_run": dry_run,
+                }
+                return query_result
+
+        adapter = AdapterWithJoinControls()
+        semantic_tools._adapter = adapter
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "customer_id__customer_name"}],
+                query_result,
+            ],
+        ):
+            result = semantic_tools.query_metrics(
+                metrics=["order_count"],
+                dimensions=["customer_id__customer_name"],
+                join_policy="dimension_preserving",
+                zero_fill=True,
+            )
+
+        assert result.success == 1
+        assert adapter.query_kwargs["join_policy"] == "dimension_preserving"
+        assert adapter.query_kwargs["zero_fill"] is True
+
+    def test_query_metrics_passes_join_controls_to_kwargs_adapter(self, semantic_tools):
+        query_result = QueryResult(columns=["x"], data=[{"x": 1}], metadata={})
+
+        class AdapterWithKwargs:
+            def __init__(self):
+                self.query_kwargs = None
+
+            def get_dimensions(self, metric_name, path=None):
+                return [{"name": "customer_id__customer_name"}]
+
+            def query_metrics(self, metrics, dimensions=None, path=None, **kwargs):
+                self.query_kwargs = kwargs
+                return query_result
+
+        adapter = AdapterWithKwargs()
+        semantic_tools._adapter = adapter
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=[
+                [{"name": "customer_id__customer_name"}],
+                query_result,
+            ],
+        ):
+            result = semantic_tools.query_metrics(
+                metrics=["order_count"],
+                dimensions=["customer_id__customer_name"],
+                join_policy="dimension_preserving",
+                zero_fill=True,
+            )
+
+        assert result.success == 1
+        assert adapter.query_kwargs["join_policy"] == "dimension_preserving"
+        assert adapter.query_kwargs["zero_fill"] is True
+
+    def test_query_metrics_normalizes_false_zero_fill_before_adapter_gating(self, semantic_tools):
+        query_result = QueryResult(columns=["x"], data=[{"x": 1}], metadata={})
+
+        class AdapterWithoutJoinControls:
+            def get_dimensions(self, metric_name, path=None):
+                return []
+
+            def query_metrics(
+                self,
+                metrics,
+                dimensions=None,
+                path=None,
+                time_start=None,
+                time_end=None,
+                time_granularity=None,
+                where=None,
+                limit=None,
+                order_by=None,
+                dry_run=False,
+            ):
+                return query_result
+
+        semantic_tools._adapter = AdapterWithoutJoinControls()
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=query_result):
+            result = semantic_tools.query_metrics(metrics=["order_count"], zero_fill="false")
+
+        assert result.success == 1
+
 
 # ---------------------------------------------------------------------------
 # Extended fixtures (no adapter_type)


### PR DESCRIPTION
## Summary

- revert #1171
- restore the previous `query_metrics` join-control behavior
- restore the pre-#1171 OSI adapter routing, prompts, authoring guidance, configuration docs, and tests

## Why

PR #1171 needs to be rolled back.

## Impact

This removes the agent-side osi-engine contract alignment introduced by #1171 and restores the behavior that existed before that merge.

## Validation

- verified the revert patch ID exactly matches the original #1171 patch in reverse
- `uv run pytest tests/unit_tests/agent/node/test_semantic_authoring.py tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py tests/unit_tests/tools/func_tool/test_semantic_tools.py -q` (`210 passed`)
- `git diff --check upstream/main...HEAD`

Reverts #1171.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query controls for join behavior, including dimension-preserving, fact-preserving, and unmatched-only results.
  * Added optional zero-filling for empty metric groups.
  * Unsupported query controls now return a clear structured error.

* **Documentation**
  * Updated semantic-layer configuration and authoring guidance for OSI usage.
  * Clarified inclusive time-period handling and join-control behavior.
  * Removed outdated null-fill and relationship-join instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->