### PR TITLE
[Feature] Bash tool OS-level sandbox with strict multi-tenant tier

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -149,6 +149,24 @@ agent:
   #   #   destructive: ask
   #   #   unknown: ask
 
+  # ---------------------------------------------------------------------------
+  # General-purpose bash tool.
+  #   enabled          — master switch; false removes the ``bash`` tool entirely
+  #   allowed_patterns — execution-layer hard whitelist (default ["*"])
+  #   sandbox          — OS-level sandbox wrapped around every command
+  #                      (macOS sandbox-exec / Linux bubblewrap). When enabled,
+  #                      file writes are restricted to the workspace, the
+  #                      session data dir and tmp; file reads to system dirs +
+  #                      the same allowlist. Fail-closed: if no mechanism is
+  #                      available (Windows, Linux without bwrap) commands are
+  #                      rejected. Toggle at runtime with /sandbox on|off.
+  # ---------------------------------------------------------------------------
+  # bash:
+  #   enabled: true
+  #   sandbox:
+  #     enabled: false
+  #     allow_read: []        # extra readable dirs (e.g. ~/.gitconfig)
+  #     allow_write: []       # extra writable dirs
 
   nodes:
     schema_linking:

--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -160,13 +160,23 @@ agent:
   #                      the same allowlist. Fail-closed: if no mechanism is
   #                      available (Windows, Linux without bwrap) commands are
   #                      rejected. Toggle at runtime with /sandbox on|off.
+  #   sandbox.mode     — "normal" (default) keeps ~/.datus readable and the
+  #                      session data dir writable. "strict" is the
+  #                      multi-tenant tier: workspace + tmp + explicit
+  #                      allowlists ONLY (~/.datus fully blocked) and the
+  #                      child env is reduced to a small allowlist so
+  #                      process-wide secrets never reach commands.
+  #   sandbox.deny_network — cut network access inside the sandbox
+  #                      (bwrap --unshare-net / Seatbelt deny network*).
   # ---------------------------------------------------------------------------
   # bash:
   #   enabled: true
   #   sandbox:
   #     enabled: false
+  #     mode: normal          # normal | strict
   #     allow_read: []        # extra readable dirs (e.g. ~/.gitconfig)
   #     allow_write: []       # extra writable dirs
+  #     deny_network: false   # true blocks all network inside the sandbox
 
   nodes:
     schema_linking:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2580,6 +2580,16 @@ class AgenticNode(Node):
         try:
             from datus.tools.func_tool.bash_tool import BashTool
 
+            # Datus home stays readable inside the sandbox: skills, templates
+            # and plugins live there and are read/executed via bash.
+            sandbox_read_dirs = []
+            try:
+                from datus.utils.path_manager import get_path_manager
+
+                sandbox_read_dirs.append(str(get_path_manager(agent_config=self.agent_config).datus_home))
+            except Exception as exc:
+                logger.debug("Failed to resolve datus home for sandbox read dirs: %s", exc)
+
             self.bash_tool = BashTool(
                 workspace_root=self._resolve_workspace_root(),
                 allowed_patterns=allowed_patterns,
@@ -2589,6 +2599,10 @@ class AgenticNode(Node):
                 # at execute time. Returns None until a session id exists → the
                 # tool falls back to in-memory truncation.
                 output_dir_provider=self._bash_output_dir,
+                # Shared mutable settings: /sandbox on|off flips ``enabled`` on
+                # the AgentConfig object and this tool sees it next call.
+                sandbox_settings=getattr(self.agent_config, "bash_sandbox", None),
+                sandbox_read_dirs=sandbox_read_dirs,
             )
             logger.debug(f"Setup bash tool with workspace: {self.bash_tool.workspace_root}")
         except Exception as e:

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -288,9 +288,9 @@ class ChatTask:
 
 COMPLETED_TASK_TTL = 300  # seconds to keep completed tasks for resume
 
-# Bash whitelist for web clients: plugin CLIs ("datus <plugin> ...") and the
-# datus binaries themselves are the only commands the server-side bash accepts.
-WEB_BASH_ALLOWED_PATTERNS = ["datus*"]
+# Web clients run a FULL server-side bash (all commands allowed), confined by
+# the strict OS sandbox rather than a command whitelist — see ``start_chat``.
+WEB_BASH_ALLOWED_PATTERNS = ["*"]
 
 
 class ChatTaskManager:
@@ -341,21 +341,28 @@ class ChatTaskManager:
         # only — the shared config keeps its default.
         agent_config.config_mutable = False
         # vscode owns its own local shell: the daemon must not offer a
-        # server-side BashTool at all. web has no shell of its own, but plugin
-        # CLIs run through bash ("datus <plugin> ..."), so web keeps a
-        # server-side bash restricted to datus-prefixed commands only —
-        # everything else is rejected at the tool layer regardless of the
-        # permission profile. An agent.yml ``bash.enabled: false`` still wins:
-        # patterns never re-enable a disabled tool. ``project_root`` is
-        # intentionally left untouched — web keeps its configured root, and
-        # the read-only ``AgentConfig.project_root`` property already falls
-        # back to the launch CWD when no root was supplied, so an empty
-        # project_root naturally resolves to the current directory.
+        # server-side BashTool at all. web has no shell of its own; it runs a
+        # FULL server-side bash (all commands allowed) confined by the strict
+        # OS sandbox instead of a command whitelist. Strict gives
+        # kernel-enforced file isolation (workspace + tmp + explicit allowlist
+        # only, ``~/.datus`` blocked) plus a minimized child environment that
+        # hides process-wide secrets — a far stronger boundary than the old
+        # ``datus*``-prefix soft whitelist. Fail-closed: if no OS sandbox
+        # mechanism is available (e.g. a Linux host without bubblewrap) the
+        # tool rejects every command rather than run it unconfined. An
+        # agent.yml ``bash.enabled: false`` still wins: this never re-enables a
+        # disabled tool. ``project_root`` is intentionally left untouched — web
+        # keeps its configured root, and the read-only
+        # ``AgentConfig.project_root`` property already falls back to the launch
+        # CWD when no root was supplied, so an empty project_root naturally
+        # resolves to the current directory.
         effective_source = request.source or self._default_source
         if effective_source == "vscode":
             agent_config.bash_tool_enabled = False
         elif effective_source == "web":
             agent_config.bash_allowed_patterns = WEB_BASH_ALLOWED_PATTERNS
+            agent_config.bash_sandbox.enabled = True
+            agent_config.bash_sandbox.mode = "strict"
         # Stash the resolved source on the cloned config so downstream nodes
         # can adapt prompt-side hints to the front-end (e.g. vscode renders
         # the literal "." for the SQL files root because the IDE owns its own

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -69,6 +69,7 @@ from datus.cli.input_modes import MODE_CHROME, InputMode, next_input_mode
 from datus.cli.language_commands import LanguageCommands
 from datus.cli.metadata_commands import MetadataCommands
 from datus.cli.model_commands import ModelCommands
+from datus.cli.sandbox_commands import SandboxCommands
 from datus.cli.service_commands import ServiceCommands
 from datus.cli.slash_registry import GROUP_ORDER, GROUP_TITLES, iter_visible, lookup
 from datus.cli.status_bar import StatusBarProvider
@@ -285,6 +286,7 @@ class DatusCLI:
         self.plugin_commands = PluginCommands(self)
         self.language_commands = LanguageCommands(self)
         self.effort_commands = EffortCommands(self)
+        self.sandbox_commands = SandboxCommands(self)
         self.init_commands = InitCommands(self)
         self.build_kb_commands = BuildKbCommands(self)
         self.session_summarize_commands = SessionSummarizeCommands(self)
@@ -366,6 +368,7 @@ class DatusCLI:
             "services": self.service_commands.cmd_services,
             "permission": self._cmd_permission,
             "profile": self._cmd_profile,
+            "sandbox": self.sandbox_commands.cmd_sandbox,
         }
 
     @property

--- a/datus/cli/sandbox_commands.py
+++ b/datus/cli/sandbox_commands.py
@@ -7,18 +7,21 @@
 Entry points
 ------------
 
-  - ``/sandbox`` / ``/sandbox status`` — show enabled state, the detected
+  - ``/sandbox`` / ``/sandbox status`` — show state, mode, the detected
     mechanism (sandbox-exec / bwrap) and the extra allowlists.
   - ``/sandbox on|off``            — flip for this session only (immediate:
     every BashTool shares the same ``SandboxSettings`` object).
-  - ``/sandbox on|off --project``  — also persist to ``./.datus/config.yml``.
-  - ``/sandbox on|off --global``   — also persist to ``agent.yml``.
+  - ``/sandbox strict|normal``     — enable AND pin the mode. ``strict`` is
+    the multi-tenant tier: workspace + tmp + explicit allowlists only
+    (``~/.datus`` fully blocked) and a minimal child environment.
+  - ``... --project``              — also persist to ``./.datus/config.yml``.
+  - ``... --global``               — also persist to ``agent.yml``.
   - ``/sandbox --clear``           — remove the project-level override.
 
 When enabled, bash commands can only write inside the workspace, the session
-data dir and tmp, and only read system dirs plus the same allowlist
-(``agent.bash.sandbox.allow_read`` / ``allow_write`` extend it). Fail-closed:
-if no OS mechanism is available, bash commands are rejected while enabled.
+data dir (normal mode) and tmp, and only read system dirs plus the same
+allowlist (``agent.bash.sandbox.allow_read`` / ``allow_write`` extend it).
+Fail-closed: if no OS mechanism is available, commands are rejected.
 """
 
 from __future__ import annotations
@@ -35,7 +38,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_USAGE = "/sandbox [status|on|off] [--project|--global] | /sandbox --clear"
+_USAGE = "/sandbox [status|on|off|strict|normal] [--project|--global] | /sandbox --clear"
 
 
 class SandboxCommands:
@@ -60,15 +63,21 @@ class SandboxCommands:
         if value in ("", "status"):
             self._status()
             return
-        if value not in ("on", "off"):
+        if value not in ("on", "off", "strict", "normal"):
             print_error(self.console, f"Invalid argument '{value}'. Usage: {_USAGE}")
             return
 
-        enabled = value == "on"
         # Immediate session effect: BashTool holds the same SandboxSettings
-        # object and re-reads ``enabled`` on every call.
-        self.agent_config.bash_sandbox.enabled = enabled
-        if enabled and not bash_sandbox.is_available():
+        # object and re-reads it on every call. ``on``/``off`` toggle the
+        # switch (mode untouched); ``strict``/``normal`` enable and pin mode.
+        settings = self.agent_config.bash_sandbox
+        if value == "off":
+            settings.enabled = False
+        else:
+            settings.enabled = True
+            if value in (bash_sandbox.MODE_STRICT, bash_sandbox.MODE_NORMAL):
+                settings.mode = value
+        if settings.enabled and not bash_sandbox.is_available():
             print_warning(
                 self.console,
                 f"No OS sandbox mechanism is available ({bash_sandbox.unavailable_reason()}). "
@@ -76,35 +85,41 @@ class SandboxCommands:
             )
 
         if flag_project:
-            self._save_project(enabled)
+            self._save_project(value)
         elif flag_global:
-            self._save_global(enabled)
+            self._save_global()
         else:
             print_success(self.console, f"Bash sandbox {value} (this session only)")
 
-    def _save_project(self, enabled: bool) -> None:
+    def _save_project(self, value: str) -> None:
         override = load_project_override() or ProjectOverride()
-        override.sandbox = enabled
+        # ``on``/``off`` persist as booleans (mode follows global config);
+        # mode names persist as strings (enable + pin, see project_config).
+        override.sandbox = {"on": True, "off": False}.get(value, value)
         path = save_project_override(override)
-        print_success(self.console, f"Bash sandbox {'on' if enabled else 'off'} (saved to {path})")
+        print_success(self.console, f"Bash sandbox {value} (saved to {path})")
 
-    def _save_global(self, enabled: bool) -> None:
+    def _save_global(self) -> None:
         """Persist the whole ``bash.sandbox`` section to agent.yml.
 
-        Serialized from the live settings so ``allow_read``/``allow_write``
-        survive the shallow ``update_item`` merge (the ``sandbox`` sub-dict is
-        replaced as a unit; sibling ``bash.*`` keys are preserved).
+        Serialized from the live settings so ``mode``, ``deny_network`` and
+        ``allow_read``/``allow_write`` survive the shallow ``update_item``
+        merge (the ``sandbox`` sub-dict is replaced as a unit; sibling
+        ``bash.*`` keys are preserved).
         """
         settings = self.agent_config.bash_sandbox
-        sandbox_yaml = {"enabled": enabled}
+        sandbox_yaml = {"enabled": settings.enabled, "mode": settings.mode}
         if settings.allow_read:
             sandbox_yaml["allow_read"] = list(settings.allow_read)
         if settings.allow_write:
             sandbox_yaml["allow_write"] = list(settings.allow_write)
+        if settings.deny_network:
+            sandbox_yaml["deny_network"] = True
         self.cli.configuration_manager.update_item("bash", {"sandbox": sandbox_yaml})
-        print_success(self.console, f"Bash sandbox {'on' if enabled else 'off'} (saved to agent.yml)")
+        state = f"{'on' if settings.enabled else 'off'} ({settings.mode})"
+        print_success(self.console, f"Bash sandbox {state} (saved to agent.yml)")
         override = load_project_override()
-        if override is not None and override.sandbox is not None and override.sandbox != enabled:
+        if override is not None and override.sandbox is not None:
             print_info(
                 self.console,
                 f"Note: project-level override 'sandbox: {str(override.sandbox).lower()}' "
@@ -121,8 +136,10 @@ class SandboxCommands:
     def _status(self) -> None:
         settings = self.agent_config.bash_sandbox
         mechanism = bash_sandbox.detect_mechanism()
-        print_info(self.console, f"Bash sandbox: {'on' if settings.enabled else 'off'}")
+        print_info(self.console, f"Bash sandbox: {'on' if settings.enabled else 'off'} (mode: {settings.mode})")
         print_info(self.console, f"Mechanism: {mechanism or 'unavailable'}")
+        if settings.deny_network:
+            print_info(self.console, "Network: denied inside the sandbox")
         if settings.enabled and mechanism is None:
             print_warning(
                 self.console,
@@ -131,7 +148,21 @@ class SandboxCommands:
         override = load_project_override()
         if override is not None and override.sandbox is not None:
             print_info(self.console, f"Source: project (.datus/config.yml: sandbox: {str(override.sandbox).lower()})")
-        if settings.enabled:
+        if not settings.enabled:
+            return
+        if settings.is_strict:
+            print_info(
+                self.console,
+                "Writable: workspace, tmp"
+                + (f", extra: {', '.join(settings.allow_write)}" if settings.allow_write else ""),
+            )
+            print_info(
+                self.console,
+                "Readable: system dirs, python env + all writable (datus home BLOCKED)"
+                + (f", extra: {', '.join(settings.allow_read)}" if settings.allow_read else ""),
+            )
+            print_info(self.console, "Environment: minimal allowlist (process secrets hidden)")
+        else:
             print_info(
                 self.console,
                 "Writable: workspace, session data dir, tmp"

--- a/datus/cli/sandbox_commands.py
+++ b/datus/cli/sandbox_commands.py
@@ -1,0 +1,144 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""``/sandbox`` slash command — toggle the OS-level bash sandbox.
+
+Entry points
+------------
+
+  - ``/sandbox`` / ``/sandbox status`` — show enabled state, the detected
+    mechanism (sandbox-exec / bwrap) and the extra allowlists.
+  - ``/sandbox on|off``            — flip for this session only (immediate:
+    every BashTool shares the same ``SandboxSettings`` object).
+  - ``/sandbox on|off --project``  — also persist to ``./.datus/config.yml``.
+  - ``/sandbox on|off --global``   — also persist to ``agent.yml``.
+  - ``/sandbox --clear``           — remove the project-level override.
+
+When enabled, bash commands can only write inside the workspace, the session
+data dir and tmp, and only read system dirs plus the same allowlist
+(``agent.bash.sandbox.allow_read`` / ``allow_write`` extend it). Fail-closed:
+if no OS mechanism is available, bash commands are rejected while enabled.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from datus.cli.cli_styles import print_error, print_info, print_success, print_warning
+from datus.configuration.project_config import ProjectOverride, load_project_override, save_project_override
+from datus.tools.func_tool import bash_sandbox
+from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from datus.cli.repl import DatusCLI
+
+logger = get_logger(__name__)
+
+_USAGE = "/sandbox [status|on|off] [--project|--global] | /sandbox --clear"
+
+
+class SandboxCommands:
+    """Handlers for the ``/sandbox`` slash command."""
+
+    def __init__(self, cli: "DatusCLI"):
+        self.cli = cli
+        self.console = cli.console
+        self.agent_config = cli.agent_config
+
+    def cmd_sandbox(self, args: str) -> None:
+        tokens = args.strip().split()
+        flag_global = "--global" in tokens
+        flag_project = "--project" in tokens
+        flag_clear = "--clear" in tokens
+        value_tokens = [t for t in tokens if not t.startswith("--")]
+        value = value_tokens[0].strip().lower() if value_tokens else ""
+
+        if flag_clear:
+            self._clear_project()
+            return
+        if value in ("", "status"):
+            self._status()
+            return
+        if value not in ("on", "off"):
+            print_error(self.console, f"Invalid argument '{value}'. Usage: {_USAGE}")
+            return
+
+        enabled = value == "on"
+        # Immediate session effect: BashTool holds the same SandboxSettings
+        # object and re-reads ``enabled`` on every call.
+        self.agent_config.bash_sandbox.enabled = enabled
+        if enabled and not bash_sandbox.is_available():
+            print_warning(
+                self.console,
+                f"No OS sandbox mechanism is available ({bash_sandbox.unavailable_reason()}). "
+                "Bash commands will be REJECTED until it is installed or the sandbox is turned off.",
+            )
+
+        if flag_project:
+            self._save_project(enabled)
+        elif flag_global:
+            self._save_global(enabled)
+        else:
+            print_success(self.console, f"Bash sandbox {value} (this session only)")
+
+    def _save_project(self, enabled: bool) -> None:
+        override = load_project_override() or ProjectOverride()
+        override.sandbox = enabled
+        path = save_project_override(override)
+        print_success(self.console, f"Bash sandbox {'on' if enabled else 'off'} (saved to {path})")
+
+    def _save_global(self, enabled: bool) -> None:
+        """Persist the whole ``bash.sandbox`` section to agent.yml.
+
+        Serialized from the live settings so ``allow_read``/``allow_write``
+        survive the shallow ``update_item`` merge (the ``sandbox`` sub-dict is
+        replaced as a unit; sibling ``bash.*`` keys are preserved).
+        """
+        settings = self.agent_config.bash_sandbox
+        sandbox_yaml = {"enabled": enabled}
+        if settings.allow_read:
+            sandbox_yaml["allow_read"] = list(settings.allow_read)
+        if settings.allow_write:
+            sandbox_yaml["allow_write"] = list(settings.allow_write)
+        self.cli.configuration_manager.update_item("bash", {"sandbox": sandbox_yaml})
+        print_success(self.console, f"Bash sandbox {'on' if enabled else 'off'} (saved to agent.yml)")
+        override = load_project_override()
+        if override is not None and override.sandbox is not None and override.sandbox != enabled:
+            print_info(
+                self.console,
+                f"Note: project-level override 'sandbox: {str(override.sandbox).lower()}' "
+                "still takes precedence in this project on reload.",
+            )
+
+    def _clear_project(self) -> None:
+        override = load_project_override()
+        if override and override.sandbox is not None:
+            override.sandbox = None
+            save_project_override(override)
+        print_success(self.console, "Project sandbox override cleared. agent.yml (or the default: off) applies.")
+
+    def _status(self) -> None:
+        settings = self.agent_config.bash_sandbox
+        mechanism = bash_sandbox.detect_mechanism()
+        print_info(self.console, f"Bash sandbox: {'on' if settings.enabled else 'off'}")
+        print_info(self.console, f"Mechanism: {mechanism or 'unavailable'}")
+        if settings.enabled and mechanism is None:
+            print_warning(
+                self.console,
+                f"Fail-closed: bash commands are rejected ({bash_sandbox.unavailable_reason()}).",
+            )
+        override = load_project_override()
+        if override is not None and override.sandbox is not None:
+            print_info(self.console, f"Source: project (.datus/config.yml: sandbox: {str(override.sandbox).lower()})")
+        if settings.enabled:
+            print_info(
+                self.console,
+                "Writable: workspace, session data dir, tmp"
+                + (f", extra: {', '.join(settings.allow_write)}" if settings.allow_write else ""),
+            )
+            print_info(
+                self.console,
+                "Readable: system dirs, datus home, python env + all writable"
+                + (f", extra: {', '.join(settings.allow_read)}" if settings.allow_read else ""),
+            )

--- a/datus/cli/slash_registry.py
+++ b/datus/cli/slash_registry.py
@@ -101,7 +101,7 @@ SLASH_COMMANDS: tuple[SlashSpec, ...] = (
     ),
     SlashSpec(
         "sandbox",
-        "Toggle the OS-level bash sandbox (status / on / off)",
+        "Toggle the OS-level bash sandbox (status / on / off / strict / normal)",
         "system",
     ),
     SlashSpec(

--- a/datus/cli/slash_registry.py
+++ b/datus/cli/slash_registry.py
@@ -100,6 +100,11 @@ SLASH_COMMANDS: tuple[SlashSpec, ...] = (
         "system",
     ),
     SlashSpec(
+        "sandbox",
+        "Toggle the OS-level bash sandbox (status / on / off)",
+        "system",
+    ),
+    SlashSpec(
         "profile",
         "Deprecated: use /permission",
         "system",

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -935,6 +935,15 @@ class AgentConfig:
         # the permission profile. API front-ends override this at runtime
         # (e.g. web gets ``["datus*"]``).
         self._bash_allowed_patterns = _coerce_pattern_list(bash_raw.get("allowed_patterns"))
+        # ``bash.sandbox`` configures the OS-level sandbox (macOS sandbox-exec
+        # / Linux bubblewrap) wrapped around every BashTool command. The parsed
+        # ``SandboxSettings`` object is SHARED with every BashTool instance so
+        # ``/sandbox on|off`` mutating ``enabled`` takes effect immediately.
+        # Lazy import: datus.tools.func_tool pulls in the CLI package, which
+        # imports this module (same cycle-breaking pattern as sql_policy).
+        from datus.tools.func_tool.bash_sandbox import SandboxSettings
+
+        self._bash_sandbox = SandboxSettings.from_dict(bash_raw.get("sandbox"))
         # ``compact`` controls the AgenticNode session summarization /
         # archiving subsystem. Defaults preserve the legacy 90% major-compact
         # threshold while enabling the new rule-based minor compact + on-disk
@@ -1229,6 +1238,17 @@ class AgentConfig:
     @bash_allowed_patterns.setter
     def bash_allowed_patterns(self, value: List[str]) -> None:
         self._bash_allowed_patterns = _coerce_pattern_list(value)
+
+    @property
+    def bash_sandbox(self):
+        """OS-level sandbox settings for the general-purpose ``BashTool``.
+
+        Parsed from ``agent.bash.sandbox``. Returns the mutable
+        ``SandboxSettings`` instance shared with every ``BashTool`` —
+        ``/sandbox on|off`` flips ``enabled`` in place and the tools pick it
+        up on their next call. Default: disabled.
+        """
+        return self._bash_sandbox
 
     @property
     def current_datasource(self):

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -320,6 +320,18 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         agent_raw["language"] = override.language
     if override.reasoning_effort is not None:
         agent_raw["target_reasoning_effort"] = override.reasoning_effort
+    if override.sandbox is not None:
+        # Project-level bash sandbox switch: only ``enabled`` is overridden;
+        # ``allow_read``/``allow_write`` from the global agent.yml survive.
+        bash_raw = agent_raw.get("bash")
+        if not isinstance(bash_raw, dict):
+            bash_raw = {}
+        agent_raw["bash"] = bash_raw
+        sandbox_raw = bash_raw.get("sandbox")
+        if not isinstance(sandbox_raw, dict):
+            sandbox_raw = {}
+        bash_raw["sandbox"] = sandbox_raw
+        sandbox_raw["enabled"] = override.sandbox
     if override.bash_allow:
         # Append project-level bash allow patterns into the permissions raw
         # dict so they ride the normal parse/merge pipeline

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -321,7 +321,8 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
     if override.reasoning_effort is not None:
         agent_raw["target_reasoning_effort"] = override.reasoning_effort
     if override.sandbox is not None:
-        # Project-level bash sandbox switch: only ``enabled`` is overridden;
+        # Project-level bash sandbox switch. A bool only toggles ``enabled``;
+        # the mode strings ``"strict"``/``"normal"`` enable AND pin the mode.
         # ``allow_read``/``allow_write`` from the global agent.yml survive.
         bash_raw = agent_raw.get("bash")
         if not isinstance(bash_raw, dict):
@@ -331,7 +332,11 @@ def _apply_project_override(agent_raw: Dict[str, Any]) -> None:
         if not isinstance(sandbox_raw, dict):
             sandbox_raw = {}
         bash_raw["sandbox"] = sandbox_raw
-        sandbox_raw["enabled"] = override.sandbox
+        if isinstance(override.sandbox, str):
+            sandbox_raw["enabled"] = True
+            sandbox_raw["mode"] = override.sandbox
+        else:
+            sandbox_raw["enabled"] = override.sandbox
     if override.bash_allow:
         # Append project-level bash allow patterns into the permissions raw
         # dict so they ride the normal parse/merge pipeline

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -150,9 +150,12 @@ class ProjectOverride:
     reasoning_effort: Optional[str] = None
     bash_allow: Optional[list] = None
     sql_allow: Optional[list] = None
-    # ``sandbox`` overrides ``agent.bash.sandbox.enabled`` for this project.
-    # ``False`` is a meaningful value (force-off), distinct from ``None``.
-    sandbox: Optional[bool] = None
+    # ``sandbox`` overrides the bash sandbox for this project. Accepted values:
+    # ``True``/``False`` toggle ``agent.bash.sandbox.enabled`` (mode follows
+    # the global config); the strings ``"strict"``/``"normal"`` enable the
+    # sandbox AND pin the mode. ``False`` is a meaningful value (force-off),
+    # distinct from ``None``.
+    sandbox: Optional[Union[bool, str]] = None
 
     def is_empty(self) -> bool:
         return (
@@ -246,7 +249,7 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
         bash_allow=_parse_bash_allow(raw.get("bash_allow")),
         sql_allow=_parse_sql_allow(raw.get("sql_allow")),
-        sandbox=_parse_optional_bool(raw.get("sandbox"), key="sandbox"),
+        sandbox=_parse_sandbox(raw.get("sandbox")),
     )
 
 
@@ -294,12 +297,13 @@ def _parse_sql_allow(raw: Any) -> Optional[list]:
     return kinds or None
 
 
-def _parse_optional_bool(raw: Any, *, key: str) -> Optional[bool]:
-    """Coerce a YAML scalar into ``Optional[bool]`` for ProjectOverride fields.
+def _parse_sandbox(raw: Any) -> Optional[Union[bool, str]]:
+    """Normalize the ``sandbox:`` field: bool toggle or mode string.
 
-    Only real booleans (and their common string spellings) are accepted;
-    anything else is dropped with a warning so a typo like ``sandbox: yess``
-    cannot silently flip a security switch.
+    Booleans (and their common string spellings) toggle ``enabled``;
+    ``"strict"``/``"normal"`` enable the sandbox and pin the mode. Anything
+    else is dropped with a warning so a typo like ``sandbox: strick`` cannot
+    silently change a security posture.
     """
     if raw is None:
         return None
@@ -311,7 +315,9 @@ def _parse_optional_bool(raw: Any, *, key: str) -> Optional[bool]:
             return True
         if lowered in ("false", "0", "no", "off"):
             return False
-    logger.warning(f"{key} must be a boolean, got {raw!r}. Ignoring.")
+        if lowered in ("strict", "normal"):
+            return lowered
+    logger.warning(f"sandbox must be true/false/strict/normal, got {raw!r}. Ignoring.")
     return None
 
 

--- a/datus/configuration/project_config.py
+++ b/datus/configuration/project_config.py
@@ -88,6 +88,7 @@ ALLOWED_KEYS = frozenset(
         "reasoning_effort",
         "bash_allow",
         "sql_allow",
+        "sandbox",
     }
 )
 REASONING_EFFORT_CHOICES = frozenset({"off", "minimal", "low", "medium", "high"})
@@ -149,6 +150,9 @@ class ProjectOverride:
     reasoning_effort: Optional[str] = None
     bash_allow: Optional[list] = None
     sql_allow: Optional[list] = None
+    # ``sandbox`` overrides ``agent.bash.sandbox.enabled`` for this project.
+    # ``False`` is a meaningful value (force-off), distinct from ``None``.
+    sandbox: Optional[bool] = None
 
     def is_empty(self) -> bool:
         return (
@@ -163,6 +167,7 @@ class ProjectOverride:
             and self.reasoning_effort is None
             and self.bash_allow is None
             and self.sql_allow is None
+            and self.sandbox is None
         )
 
 
@@ -241,6 +246,7 @@ def load_project_override(cwd: Optional[str] = None) -> Optional[ProjectOverride
         reasoning_effort=_parse_reasoning_effort(raw.get("reasoning_effort")),
         bash_allow=_parse_bash_allow(raw.get("bash_allow")),
         sql_allow=_parse_sql_allow(raw.get("sql_allow")),
+        sandbox=_parse_optional_bool(raw.get("sandbox"), key="sandbox"),
     )
 
 
@@ -286,6 +292,27 @@ def _parse_sql_allow(raw: Any) -> Optional[list]:
         else:
             logger.warning(f"Ignoring non-string sql_allow entry: {entry!r}")
     return kinds or None
+
+
+def _parse_optional_bool(raw: Any, *, key: str) -> Optional[bool]:
+    """Coerce a YAML scalar into ``Optional[bool]`` for ProjectOverride fields.
+
+    Only real booleans (and their common string spellings) are accepted;
+    anything else is dropped with a warning so a typo like ``sandbox: yess``
+    cannot silently flip a security switch.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        lowered = raw.strip().lower()
+        if lowered in ("true", "1", "yes", "on"):
+            return True
+        if lowered in ("false", "0", "no", "off"):
+            return False
+    logger.warning(f"{key} must be a boolean, got {raw!r}. Ignoring.")
+    return None
 
 
 def _parse_optional_string(raw: Any, *, key: str) -> Optional[str]:
@@ -473,6 +500,9 @@ def save_project_override(override: ProjectOverride, cwd: Optional[str] = None) 
             "reasoning_effort": override.reasoning_effort,
             "bash_allow": override.bash_allow,
             "sql_allow": override.sql_allow,
+            # ``sandbox: false`` must round-trip (force-off is meaningful),
+            # which the ``is not None`` filter below preserves.
+            "sandbox": override.sandbox,
         }.items()
         if v is not None
     }

--- a/datus/tools/func_tool/bash_sandbox.py
+++ b/datus/tools/func_tool/bash_sandbox.py
@@ -1,0 +1,416 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+OS-level sandbox for the general-purpose ``BashTool``.
+
+When enabled, every ``bash`` tool command is wrapped in a kernel-enforced
+sandbox that restricts filesystem access to an allowlist of directories:
+
+- **macOS**: ``sandbox-exec`` with a generated Seatbelt profile. Writes are
+  denied outside the writable roots; reads (``file-read-data``) are denied
+  outside the readable + writable roots. Metadata reads (stat/readlink) stay
+  allowed so PATH lookup, ``cd`` and dyld keep working.
+- **Linux**: ``bubblewrap`` (``bwrap``) mount namespace. Only allowlisted
+  directories are bind-mounted (system dirs read-only, workspace/tmp
+  writable); everything else simply does not exist inside the sandbox.
+
+This module is intentionally stdlib-only so ``datus.configuration`` can import
+:class:`SandboxSettings` without any dependency cycle. The permission layer
+(``PermissionHooks`` / ``bash_rules``) is unaffected — the sandbox is a second,
+kernel-level line of defense at the execution layer.
+
+Network access is NOT restricted (out of scope for the lightweight sandbox).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+MECHANISM_SEATBELT = "seatbelt"
+MECHANISM_BWRAP = "bwrap"
+
+# Seconds allowed for the one-shot availability probe.
+_PROBE_TIMEOUT = 10
+_PROBE_PROFILE = "(version 1)(allow default)"
+
+# macOS system roots that stay readable inside the sandbox: shells, coreutils,
+# interpreters, dyld caches, frameworks, timezone/locale data. All values are
+# canonical (``/etc`` and ``/tmp`` are symlinks into ``/private``; Seatbelt
+# matches on the resolved path).
+_MACOS_SYSTEM_READ_ROOTS = (
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/opt",
+    "/System",
+    "/Library",
+    "/private/etc",
+    "/private/var/db",
+    "/private/var/select",
+    "/dev",
+)
+
+# Paths whose DATA must stay readable as exact literals. Reading a
+# directory's entries counts as ``file-read-data`` on the directory itself,
+# and dyld reads ``/`` during cryptex/firmlink resolution at every process
+# start — denying it aborts (SIGABRT) before main() runs.
+_MACOS_READ_LITERALS = ("/",)
+
+# Device nodes that remain writable on macOS (bwrap covers these via
+# ``--dev /dev``). ``/dev/stdout`` / ``/dev/stderr`` are symlinks into
+# ``/dev/fd`` which is exempted as a subpath.
+_MACOS_WRITE_DEVICE_LITERALS = (
+    "/dev/null",
+    "/dev/zero",
+    "/dev/tty",
+    "/dev/random",
+    "/dev/urandom",
+)
+_MACOS_WRITE_DEVICE_SUBPATHS = ("/dev/fd",)
+
+# Linux system roots bind-mounted read-only. On merged-usr distros ``/bin``,
+# ``/sbin`` and ``/lib*`` are symlinks into ``/usr`` and are recreated as
+# symlinks inside the sandbox instead of bind mounts. ``/run`` is needed for
+# systemd-resolved's resolv.conf target.
+_LINUX_SYSTEM_READ_DIRS = (
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib32",
+    "/lib64",
+    "/etc",
+    "/opt",
+    "/run",
+)
+
+# Provided as fresh tmpfs mounts inside the bwrap sandbox rather than binding
+# the host directories: commands get a private scratch space and can't read
+# other processes' host tmp files. Writable roots equal to these paths are
+# skipped (the tmpfs already provides them); writable roots UNDER them (e.g. a
+# pytest tmp_path workspace) are bind-mounted after the tmpfs and shadow it.
+_BWRAP_TMPFS_DIRS = ("/tmp", "/var/tmp")
+
+
+class SandboxUnavailableError(RuntimeError):
+    """Raised when wrapping is requested but no OS sandbox mechanism works."""
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "1", "yes", "on"):
+            return True
+        if lowered in ("false", "0", "no", "off"):
+            return False
+    return default
+
+
+def _coerce_str_list(value: Any) -> List[str]:
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, (list, tuple)):
+        return [item for item in value if isinstance(item, str) and item.strip()]
+    return []
+
+
+@dataclass
+class SandboxSettings:
+    """Parsed ``agent.bash.sandbox`` configuration section.
+
+    Mutable at runtime by design: ``/sandbox on|off`` flips ``enabled`` in
+    place and every ``BashTool`` holding this object picks the change up on
+    its next call (the tool and ``AgentConfig`` share the same instance).
+    """
+
+    enabled: bool = False
+    allow_read: List[str] = field(default_factory=list)
+    allow_write: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "SandboxSettings":
+        if not isinstance(raw, dict):
+            return cls()
+        return cls(
+            enabled=_coerce_bool(raw.get("enabled"), False),
+            allow_read=_coerce_str_list(raw.get("allow_read")),
+            allow_write=_coerce_str_list(raw.get("allow_write")),
+        )
+
+
+@dataclass(frozen=True)
+class SandboxPolicy:
+    """Resolved allowlist for one command execution.
+
+    All paths are canonical (``os.path.realpath``), deduplicated and verified
+    to exist. Platform system baselines (:data:`_MACOS_SYSTEM_READ_ROOTS` /
+    :data:`_LINUX_SYSTEM_READ_DIRS`) are added by the mechanism-specific
+    builders, not stored here, so the policy itself is platform-neutral.
+    """
+
+    cwd: str
+    writable_roots: Tuple[str, ...]
+    # Extra read-only roots beyond the platform baseline (datus home, the
+    # python interpreter prefixes, user allow_read). Never overlaps
+    # ``writable_roots`` — write implies read in both mechanisms.
+    readable_roots: Tuple[str, ...]
+
+
+def _normalize_roots(candidates: Sequence[Any]) -> List[str]:
+    """Expand ``~``, resolve symlinks, drop missing paths and duplicates."""
+    out: List[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        resolved = os.path.realpath(os.path.expanduser(str(candidate)))
+        if os.path.exists(resolved) and resolved not in out:
+            out.append(resolved)
+    return out
+
+
+def build_policy(
+    settings: SandboxSettings,
+    workspace_root: Path,
+    dynamic_write_dirs: Sequence[Any] = (),
+    extra_read_dirs: Sequence[str] = (),
+) -> SandboxPolicy:
+    """Merge defaults, configuration and per-call dirs into a resolved policy.
+
+    Writable: workspace root, per-call dynamic dirs (session output dir), the
+    process tmp dir plus ``/tmp`` / ``/var/tmp`` (realpath'd — ``/private/*``
+    on macOS), and ``settings.allow_write``.
+
+    Readable: the python interpreter prefixes (the ``python`` shim in
+    ``BashTool._shell_prefix`` points at ``sys.executable``, whose venv often
+    lives outside the workspace), caller-injected ``extra_read_dirs`` (datus
+    home, so skills/templates stay usable) and ``settings.allow_read``.
+    """
+    writable = _normalize_roots(
+        [
+            workspace_root,
+            *dynamic_write_dirs,
+            tempfile.gettempdir(),
+            "/tmp",
+            "/var/tmp",
+            *settings.allow_write,
+        ]
+    )
+    readable = [
+        root
+        for root in _normalize_roots([sys.prefix, sys.base_prefix, *extra_read_dirs, *settings.allow_read])
+        if root not in writable
+    ]
+    return SandboxPolicy(
+        cwd=os.path.realpath(str(workspace_root)),
+        writable_roots=tuple(writable),
+        readable_roots=tuple(readable),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mechanism detection (cached per process)
+# ---------------------------------------------------------------------------
+
+_UNSET = object()
+_mechanism_cache: Any = _UNSET
+
+
+def _find_sandbox_exec() -> Optional[str]:
+    if os.path.exists("/usr/bin/sandbox-exec"):
+        return "/usr/bin/sandbox-exec"
+    return shutil.which("sandbox-exec")
+
+
+def _find_bwrap() -> Optional[str]:
+    return shutil.which("bwrap")
+
+
+def _probe(argv: List[str]) -> bool:
+    """Run a trivial command under the candidate wrapper.
+
+    ``which`` alone is not enough: bwrap can be installed yet unusable (no
+    user namespaces inside containers, non-setuid builds), which would turn
+    every command into a confusing runtime failure instead of one clear
+    fail-closed error.
+    """
+    try:
+        result = subprocess.run(argv, capture_output=True, timeout=_PROBE_TIMEOUT)
+        return result.returncode == 0
+    except Exception as e:
+        logger.debug("Sandbox probe failed for %s: %s", argv[0], e)
+        return False
+
+
+def _detect_mechanism_uncached() -> Optional[str]:
+    if sys.platform == "darwin":
+        exe = _find_sandbox_exec()
+        if exe and _probe([exe, "-p", _PROBE_PROFILE, "/usr/bin/true"]):
+            return MECHANISM_SEATBELT
+        return None
+    if sys.platform.startswith("linux"):
+        exe = _find_bwrap()
+        true_bin = shutil.which("true") or "/bin/true"
+        if exe and _probe([exe, "--ro-bind", "/", "/", true_bin]):
+            return MECHANISM_BWRAP
+        return None
+    return None
+
+
+def detect_mechanism() -> Optional[str]:
+    """Return ``"seatbelt"`` / ``"bwrap"`` / ``None``, probing once per process."""
+    global _mechanism_cache
+    if _mechanism_cache is _UNSET:
+        _mechanism_cache = _detect_mechanism_uncached()
+        logger.info("Bash sandbox mechanism: %s", _mechanism_cache or "unavailable")
+    return _mechanism_cache
+
+
+def _reset_detection_cache() -> None:
+    global _mechanism_cache
+    _mechanism_cache = _UNSET
+
+
+def is_available() -> bool:
+    return detect_mechanism() is not None
+
+
+def unavailable_reason() -> str:
+    if sys.platform == "darwin":
+        return "macOS sandbox-exec is missing or failed its probe"
+    if sys.platform.startswith("linux"):
+        return "bubblewrap (bwrap) is not installed or cannot run on this system (e.g. no user namespaces)"
+    return f"no OS sandbox mechanism exists for platform {sys.platform!r} (Windows is unsupported)"
+
+
+# ---------------------------------------------------------------------------
+# macOS Seatbelt
+# ---------------------------------------------------------------------------
+
+
+def _sb_quote(path: str) -> str:
+    escaped = path.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _sb_filters(subpaths: Sequence[str], literals: Sequence[str] = ()) -> str:
+    lines = [f"    (subpath {_sb_quote(p)})" for p in subpaths]
+    lines.extend(f"    (literal {_sb_quote(p)})" for p in literals)
+    return "\n".join(lines)
+
+
+def build_seatbelt_profile(policy: SandboxPolicy) -> str:
+    """Generate the Seatbelt profile text for ``sandbox-exec -p``.
+
+    Structure: ``(allow default)`` plus two targeted denies. A ``(deny
+    default)`` profile needs dozens of mach/sysctl/iokit allowances that drift
+    across OS releases; scoping the denies to filesystem access keeps the
+    sandbox lightweight and predictable.
+
+    Only ``file-read-data`` is denied for reads — denying ``file-read*`` would
+    also block metadata (stat/readlink), breaking PATH lookup, ``cd`` and
+    dyld everywhere. Outside the allowlist, file names are visible but their
+    contents are not.
+    """
+    write_subpaths = policy.writable_roots
+    read_subpaths = tuple(
+        dict.fromkeys(
+            (
+                *_MACOS_SYSTEM_READ_ROOTS,
+                *policy.readable_roots,
+                *policy.writable_roots,
+                *_MACOS_WRITE_DEVICE_SUBPATHS,
+            )
+        )
+    )
+    return (
+        "(version 1)\n"
+        "(allow default)\n"
+        "(deny file-write*\n"
+        "  (require-not (require-any\n"
+        f"{_sb_filters((*write_subpaths, *_MACOS_WRITE_DEVICE_SUBPATHS), _MACOS_WRITE_DEVICE_LITERALS)}\n"
+        "  )))\n"
+        "(deny file-read-data\n"
+        "  (require-not (require-any\n"
+        f"{_sb_filters(read_subpaths, _MACOS_READ_LITERALS)}\n"
+        "  )))\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Linux bubblewrap
+# ---------------------------------------------------------------------------
+
+
+def _mount_args_for_system_dir(path: str) -> List[str]:
+    """``--symlink`` for merged-usr symlinks, ``--ro-bind`` for real dirs.
+
+    Missing paths yield no args: bwrap errors out on a nonexistent bind
+    source, and filtering in Python keeps behavior deterministic without
+    depending on ``--ro-bind-try`` (bwrap >= 0.3).
+    """
+    if os.path.islink(path):
+        return ["--symlink", os.readlink(path), path]
+    if os.path.isdir(path):
+        return ["--ro-bind", path, path]
+    return []
+
+
+def build_bwrap_prefix(policy: SandboxPolicy) -> List[str]:
+    """Build the ``bwrap ...`` argv prefix implementing the policy.
+
+    Mount order matters — later mounts shadow earlier ones — so read-only
+    binds come first and writable binds last (e.g. the session output dir
+    stays writable underneath the read-only datus home). Network is left
+    shared and the host pid namespace is kept so ``killpg`` from
+    ``BashTool._kill_process_tree`` still reaches every child.
+    """
+    bwrap = _find_bwrap()
+    if not bwrap:
+        raise SandboxUnavailableError(unavailable_reason())
+    args = [bwrap, "--die-with-parent"]
+    for system_dir in _LINUX_SYSTEM_READ_DIRS:
+        args.extend(_mount_args_for_system_dir(system_dir))
+    args.extend(["--proc", "/proc", "--dev", "/dev"])
+    for tmp_dir in _BWRAP_TMPFS_DIRS:
+        args.extend(["--tmpfs", tmp_dir])
+    for readable in policy.readable_roots:
+        args.extend(["--ro-bind", readable, readable])
+    for writable in policy.writable_roots:
+        if writable in _BWRAP_TMPFS_DIRS:
+            continue
+        args.extend(["--bind", writable, writable])
+    args.extend(["--chdir", policy.cwd])
+    return args
+
+
+def wrap_argv(argv: List[str], policy: SandboxPolicy) -> List[str]:
+    """Wrap a spawn argv in the platform sandbox.
+
+    Raises :class:`SandboxUnavailableError` when no mechanism is usable —
+    callers are expected to have checked :func:`is_available` already; this
+    is the fail-closed backstop.
+    """
+    mechanism = detect_mechanism()
+    if mechanism == MECHANISM_SEATBELT:
+        exe = _find_sandbox_exec()
+        if not exe:
+            raise SandboxUnavailableError(unavailable_reason())
+        return [exe, "-p", build_seatbelt_profile(policy), *argv]
+    if mechanism == MECHANISM_BWRAP:
+        return [*build_bwrap_prefix(policy), *argv]
+    raise SandboxUnavailableError(unavailable_reason())

--- a/datus/tools/func_tool/bash_sandbox.py
+++ b/datus/tools/func_tool/bash_sandbox.py
@@ -21,7 +21,10 @@ This module is intentionally stdlib-only so ``datus.configuration`` can import
 (``PermissionHooks`` / ``bash_rules``) is unaffected — the sandbox is a second,
 kernel-level line of defense at the execution layer.
 
-Network access is NOT restricted (out of scope for the lightweight sandbox).
+Two modes: ``normal`` (CLI default — datus home readable, session data dir
+writable) and ``strict`` (multi-tenant tier — project workspace + tmp +
+explicit allowlists only, minimal child environment). Network stays shared
+unless ``deny_network`` is set.
 """
 
 import os
@@ -39,6 +42,38 @@ logger = get_logger(__name__)
 
 MECHANISM_SEATBELT = "seatbelt"
 MECHANISM_BWRAP = "bwrap"
+
+# Sandbox modes. ``normal`` keeps the CLI-friendly defaults (datus home
+# readable for skills/templates, session data dir writable for command-side
+# output). ``strict`` is the multi-tenant hardening tier: file access shrinks
+# to the workspace + tmp + explicit allowlists ONLY — the caller-injected
+# datus-home read root and session-dir write root are ignored — and the child
+# environment is reduced to a small allowlist so process-wide secrets
+# (LLM API keys, DB passwords) never reach sandboxed commands.
+MODE_NORMAL = "normal"
+MODE_STRICT = "strict"
+SANDBOX_MODES = (MODE_NORMAL, MODE_STRICT)
+
+# Environment variables forwarded to the child in strict mode (plus every
+# ``LC_*`` locale variable and the caller's explicit ``extra_env``). The
+# ``python`` shim uses an absolute interpreter path, so nothing here is
+# needed for it to work.
+STRICT_ENV_ALLOWLIST = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "LANG",
+        "TZ",
+        "TERM",
+        "TMPDIR",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "PWD",
+        "COLUMNS",
+        "LINES",
+    }
+)
 
 # Seconds allowed for the one-shot availability probe.
 _PROBE_TIMEOUT = 10
@@ -129,6 +164,24 @@ def _coerce_str_list(value: Any) -> List[str]:
     return []
 
 
+def _coerce_mode(value: Any) -> str:
+    if isinstance(value, str) and value.strip().lower() in SANDBOX_MODES:
+        return value.strip().lower()
+    if value is not None:
+        logger.warning("Invalid sandbox mode %r; expected one of %s. Using %r.", value, SANDBOX_MODES, MODE_NORMAL)
+    return MODE_NORMAL
+
+
+def strict_env(base_env: Dict[str, str]) -> Dict[str, str]:
+    """Reduce an environment mapping to the strict-mode allowlist.
+
+    Keeps :data:`STRICT_ENV_ALLOWLIST` plus ``LC_*`` locale variables so
+    shells and coreutils behave normally while process-wide secrets stay out
+    of the sandbox. Callers layer their explicit ``extra_env`` on top.
+    """
+    return {k: v for k, v in base_env.items() if k in STRICT_ENV_ALLOWLIST or k.startswith("LC_")}
+
+
 @dataclass
 class SandboxSettings:
     """Parsed ``agent.bash.sandbox`` configuration section.
@@ -139,8 +192,17 @@ class SandboxSettings:
     """
 
     enabled: bool = False
+    mode: str = MODE_NORMAL
     allow_read: List[str] = field(default_factory=list)
     allow_write: List[str] = field(default_factory=list)
+    # ``deny_network`` cuts network access inside the sandbox (bwrap
+    # ``--unshare-net`` / Seatbelt ``deny network*``). Orthogonal to ``mode``;
+    # off by default because it also blocks legitimate outbound calls.
+    deny_network: bool = False
+
+    @property
+    def is_strict(self) -> bool:
+        return self.mode == MODE_STRICT
 
     @classmethod
     def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "SandboxSettings":
@@ -148,8 +210,10 @@ class SandboxSettings:
             return cls()
         return cls(
             enabled=_coerce_bool(raw.get("enabled"), False),
+            mode=_coerce_mode(raw.get("mode")),
             allow_read=_coerce_str_list(raw.get("allow_read")),
             allow_write=_coerce_str_list(raw.get("allow_write")),
+            deny_network=_coerce_bool(raw.get("deny_network"), False),
         )
 
 
@@ -169,6 +233,9 @@ class SandboxPolicy:
     # python interpreter prefixes, user allow_read). Never overlaps
     # ``writable_roots`` — write implies read in both mechanisms.
     readable_roots: Tuple[str, ...]
+    # Cut network access: bwrap ``--unshare-net`` / Seatbelt ``deny network*``
+    # (the latter also covers unix-domain sockets).
+    deny_network: bool = False
 
 
 def _normalize_roots(candidates: Sequence[Any]) -> List[str]:
@@ -199,7 +266,20 @@ def build_policy(
     ``BashTool._shell_prefix`` points at ``sys.executable``, whose venv often
     lives outside the workspace), caller-injected ``extra_read_dirs`` (datus
     home, so skills/templates stay usable) and ``settings.allow_read``.
+
+    Strict mode ignores the caller-injected ``dynamic_write_dirs`` and
+    ``extra_read_dirs`` entirely — in a multi-tenant deployment those point
+    into the shared ``~/.datus`` tree, which strict tenants must not touch.
+    Filtering here (rather than at each call site) makes the guarantee hold
+    no matter who constructs the tool. Oversized-output archiving keeps
+    working: the redirect file is opened by the parent process and inherited
+    as an fd, and both mechanisms check permissions at open time only.
+    Explicit ``allow_read``/``allow_write`` still apply — they are the
+    operator's deliberate exceptions.
     """
+    if settings.is_strict:
+        dynamic_write_dirs = ()
+        extra_read_dirs = ()
     writable = _normalize_roots(
         [
             workspace_root,
@@ -219,6 +299,7 @@ def build_policy(
         cwd=os.path.realpath(str(workspace_root)),
         writable_roots=tuple(writable),
         readable_roots=tuple(readable),
+        deny_network=settings.deny_network,
     )
 
 
@@ -337,7 +418,7 @@ def build_seatbelt_profile(policy: SandboxPolicy) -> str:
             )
         )
     )
-    return (
+    profile = (
         "(version 1)\n"
         "(allow default)\n"
         "(deny file-write*\n"
@@ -349,6 +430,9 @@ def build_seatbelt_profile(policy: SandboxPolicy) -> str:
         f"{_sb_filters(read_subpaths, _MACOS_READ_LITERALS)}\n"
         "  )))\n"
     )
+    if policy.deny_network:
+        profile += "(deny network*)\n"
+    return profile
 
 
 # ---------------------------------------------------------------------------
@@ -383,6 +467,8 @@ def build_bwrap_prefix(policy: SandboxPolicy) -> List[str]:
     if not bwrap:
         raise SandboxUnavailableError(unavailable_reason())
     args = [bwrap, "--die-with-parent"]
+    if policy.deny_network:
+        args.append("--unshare-net")
     for system_dir in _LINUX_SYSTEM_READ_DIRS:
         args.extend(_mount_args_for_system_dir(system_dir))
     args.extend(["--proc", "/proc", "--dev", "/dev"])

--- a/datus/tools/func_tool/bash_sandbox.py
+++ b/datus/tools/func_tool/bash_sandbox.py
@@ -16,7 +16,8 @@ sandbox that restricts filesystem access to an allowlist of directories:
   directories are bind-mounted (system dirs read-only, workspace/tmp
   writable); everything else simply does not exist inside the sandbox.
 
-This module is intentionally stdlib-only so ``datus.configuration`` can import
+This module depends only on the stdlib plus leaf ``datus.utils`` helpers
+(``loggings``, ``exceptions``), so ``datus.configuration`` can import
 :class:`SandboxSettings` without any dependency cycle. The permission layer
 (``PermissionHooks`` / ``bash_rules``) is unaffected — the sandbox is a second,
 kernel-level line of defense at the execution layer.
@@ -36,6 +37,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -138,8 +140,11 @@ _LINUX_SYSTEM_READ_DIRS = (
 _BWRAP_TMPFS_DIRS = ("/tmp", "/var/tmp")
 
 
-class SandboxUnavailableError(RuntimeError):
+class SandboxUnavailableError(DatusException):
     """Raised when wrapping is requested but no OS sandbox mechanism works."""
+
+    def __init__(self, message: str):
+        super().__init__(ErrorCode.BASH_SANDBOX_UNAVAILABLE, message=message)
 
 
 def _coerce_bool(value: Any, default: bool) -> bool:

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -195,7 +195,7 @@ class BashTool:
                 error=f"Command not allowed. Allowed patterns: {', '.join(self.allowed_patterns) or '(none)'}",
             )
 
-        sandbox_active = self.sandbox_settings is not None and self.sandbox_settings.enabled
+        sandbox_active = self._sandbox_active()
         if sandbox_active and not bash_sandbox.is_available():
             # Fail closed: with the sandbox switched on, running unprotected
             # would silently drop the guarantee the user asked for.
@@ -573,13 +573,26 @@ class BashTool:
 
         return False
 
+    def _sandbox_active(self) -> bool:
+        return self.sandbox_settings is not None and self.sandbox_settings.enabled
+
     def _get_safe_env(self) -> dict:
         """Build the environment for command execution.
 
         Starts from ``os.environ`` and overlays ``self.extra_env`` so callers
         can inject context-specific variables (Skill name/dir, request ID, ...).
+
+        With the sandbox in strict mode the base environment is reduced to
+        :data:`bash_sandbox.STRICT_ENV_ALLOWLIST` — the OS sandbox cannot
+        stop a command from reading its own inherited environment, so
+        process-wide secrets (LLM API keys, DB passwords) must never enter
+        it in a multi-tenant deployment. ``extra_env`` still applies: it is
+        the caller's deliberate, per-tool injection.
         """
-        env = os.environ.copy()
+        if self._sandbox_active() and self.sandbox_settings.is_strict:
+            env = bash_sandbox.strict_env(os.environ)
+        else:
+            env = os.environ.copy()
         if self.extra_env:
             env.update(self.extra_env)
         return env

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from agents import Tool
 
+from datus.tools.func_tool import bash_sandbox
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.tools.permission.bash_rules import contains_shell_metachars, split_pipeline
 from datus.utils.loggings import get_logger
@@ -94,6 +95,8 @@ class BashTool:
         extra_env: Optional[Dict[str, str]] = None,
         identity: Optional[str] = None,
         output_dir_provider: Optional[Callable[[], Optional[Path]]] = None,
+        sandbox_settings: Optional[bash_sandbox.SandboxSettings] = None,
+        sandbox_read_dirs: Optional[List[str]] = None,
     ):
         """Initialize the bash tool.
 
@@ -114,6 +117,13 @@ class BashTool:
                 returns ``None``), output is captured in memory and truncated
                 at :data:`MAX_OUTPUT_SIZE` — the general-purpose fallback used
                 by MCP / standalone callers and tests.
+            sandbox_settings: Optional OS-sandbox settings SHARED with
+                ``AgentConfig`` — ``enabled`` is re-read on every call so
+                ``/sandbox on|off`` takes effect immediately. ``None`` means
+                the sandbox machinery is never engaged (legacy behavior).
+            sandbox_read_dirs: Extra read-only roots for the sandbox policy
+                beyond the built-in defaults (e.g. the datus home so skills
+                and templates stay readable).
         """
         self.workspace_root = Path(workspace_root).resolve()
         self.allowed_patterns = list(allowed_patterns) if allowed_patterns else []
@@ -121,6 +131,8 @@ class BashTool:
         self.extra_env = dict(extra_env) if extra_env else {}
         self.identity = identity
         self._output_dir_provider = output_dir_provider
+        self.sandbox_settings = sandbox_settings
+        self.sandbox_read_dirs = list(sandbox_read_dirs) if sandbox_read_dirs else []
         # Monotonic per-instance counter zero-padded into archive filenames so a
         # directory listing sorts in command-invocation order. Paired with a
         # per-instance random token so a recreated/resumed BashTool (which
@@ -183,6 +195,20 @@ class BashTool:
                 error=f"Command not allowed. Allowed patterns: {', '.join(self.allowed_patterns) or '(none)'}",
             )
 
+        sandbox_active = self.sandbox_settings is not None and self.sandbox_settings.enabled
+        if sandbox_active and not bash_sandbox.is_available():
+            # Fail closed: with the sandbox switched on, running unprotected
+            # would silently drop the guarantee the user asked for.
+            logger.warning("Sandbox enabled but unavailable (identity=%s); command rejected", self.identity)
+            return FuncToolResult(
+                success=0,
+                error=(
+                    "Sandbox is enabled but no OS sandbox mechanism is available: "
+                    f"{bash_sandbox.unavailable_reason()}. The command was NOT executed. "
+                    "Install the missing mechanism or disable the sandbox (/sandbox off)."
+                ),
+            )
+
         effective_timeout = self._resolve_timeout(timeout)
 
         try:
@@ -192,6 +218,17 @@ class BashTool:
 
         logger.info("Executing command (identity=%s, timeout=%ss): %s", self.identity, effective_timeout, command)
         output_dir = self._resolve_output_dir()
+        if sandbox_active:
+            policy = bash_sandbox.build_policy(
+                self.sandbox_settings,
+                workspace_root=self.workspace_root,
+                dynamic_write_dirs=[output_dir] if output_dir else [],
+                extra_read_dirs=self.sandbox_read_dirs,
+            )
+            try:
+                argv = bash_sandbox.wrap_argv(argv, policy)
+            except bash_sandbox.SandboxUnavailableError as e:
+                return FuncToolResult(success=0, error=f"Sandbox wrapping failed; command NOT executed: {e}")
         try:
             if output_dir is not None:
                 # Preferred path: stream the child's output straight to disk so

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -89,6 +89,7 @@ class ErrorCode(Enum):
     # Tool errors
     TOOL_EXECUTION_FAILED = ("400001", "Tool execution failed")
     TOOL_INVALID_INPUT = ("400002", "Invalid tool input")
+    BASH_SANDBOX_UNAVAILABLE = ("400003", "OS sandbox unavailable")
 
     # Validation errors (ValidationHook for table-producing subagents)
     VALIDATION_BLOCKING_FAILURE = (

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -57,4 +57,5 @@ All slash commands available in Datus-CLI, grouped by category.
 | `/bootstrap-bi` | | Extract BI dashboard assets for sub-agent context | |
 | `/services` | | List configured service platforms and their read-only methods | |
 | `/permission` | | Switch the active CLI / agent permission profile | |
+| `/sandbox` | | Toggle the OS-level bash sandbox (`status`/`on`/`off`, optional `--project`/`--global` persistence). When on, bash commands can only write inside the workspace, session data dir and tmp, and only read system dirs plus the allowlist (macOS `sandbox-exec` / Linux `bwrap`; fail-closed elsewhere) | |
 | `/profile` | | Deprecated alias for `/permission` | |

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -57,5 +57,5 @@ All slash commands available in Datus-CLI, grouped by category.
 | `/bootstrap-bi` | | Extract BI dashboard assets for sub-agent context | |
 | `/services` | | List configured service platforms and their read-only methods | |
 | `/permission` | | Switch the active CLI / agent permission profile | |
-| `/sandbox` | | Toggle the OS-level bash sandbox (`status`/`on`/`off`, optional `--project`/`--global` persistence). When on, bash commands can only write inside the workspace, session data dir and tmp, and only read system dirs plus the allowlist (macOS `sandbox-exec` / Linux `bwrap`; fail-closed elsewhere) | |
+| `/sandbox` | | Toggle the OS-level bash sandbox (`status`/`on`/`off`/`strict`/`normal`, optional `--project`/`--global` persistence). When on, bash commands can only write inside the workspace, session data dir and tmp, and only read system dirs plus the allowlist (macOS `sandbox-exec` / Linux `bwrap`; fail-closed elsewhere). `strict` is the multi-tenant tier: workspace + tmp + explicit allowlists only, `~/.datus` fully blocked, and a minimal child environment that hides process-wide secrets; `deny_network: true` in `agent.bash.sandbox` additionally cuts network access | |
 | `/profile` | | Deprecated alias for `/permission` | |

--- a/docs/cli/reference.zh.md
+++ b/docs/cli/reference.zh.md
@@ -57,5 +57,5 @@ Datus-CLI 中所有可用的斜杠命令，按类别分组。
 | `/bootstrap-bi` | | 为子 agent 上下文提取 BI 仪表盘资产 | |
 | `/services` | | 列出已配置的服务平台及其只读方法 | |
 | `/permission` | | 切换当前 CLI / agent 权限配置文件 | |
-| `/sandbox` | | 开关 OS 级 bash 沙箱（`status`/`on`/`off`，可用 `--project`/`--global` 持久化）。开启后 bash 命令只能写入工作区、会话数据目录和 tmp，只能读取系统目录与白名单目录（macOS `sandbox-exec` / Linux `bwrap`；其他平台 fail-closed 拒绝执行） | |
+| `/sandbox` | | 开关 OS 级 bash 沙箱（`status`/`on`/`off`/`strict`/`normal`，可用 `--project`/`--global` 持久化）。开启后 bash 命令只能写入工作区、会话数据目录和 tmp，只能读取系统目录与白名单目录（macOS `sandbox-exec` / Linux `bwrap`；其他平台 fail-closed 拒绝执行）。`strict` 为多租户加固档：仅工作区 + tmp + 显式白名单，`~/.datus` 完全不可读写，子进程环境变量收敛为最小白名单以隐藏进程级密钥；`agent.bash.sandbox` 中 `deny_network: true` 可额外禁网 | |
 | `/profile` | | 已废弃的 `/permission` 兼容别名 | |

--- a/docs/cli/reference.zh.md
+++ b/docs/cli/reference.zh.md
@@ -57,4 +57,5 @@ Datus-CLI 中所有可用的斜杠命令，按类别分组。
 | `/bootstrap-bi` | | 为子 agent 上下文提取 BI 仪表盘资产 | |
 | `/services` | | 列出已配置的服务平台及其只读方法 | |
 | `/permission` | | 切换当前 CLI / agent 权限配置文件 | |
+| `/sandbox` | | 开关 OS 级 bash 沙箱（`status`/`on`/`off`，可用 `--project`/`--global` 持久化）。开启后 bash 命令只能写入工作区、会话数据目录和 tmp，只能读取系统目录与白名单目录（macOS `sandbox-exec` / Linux `bwrap`；其他平台 fail-closed 拒绝执行） | |
 | `/profile` | | 已废弃的 `/permission` 兼容别名 | |

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -45,6 +45,22 @@ def test_tables_command(mock_args, capsys):
         assert "Tables in Database" in captured.out
 
 
+@pytest.mark.acceptance
+def test_sandbox_command_status_and_session_toggle(mock_args, capsys):
+    """/sandbox dispatches through the slash handler map: status shows the
+    current state and on/off flip the shared SandboxSettings for the session."""
+    with patch("datus.cli.repl.PromptSession.prompt") as mock_prompt:
+        mock_prompt.side_effect = ["/sandbox", "/sandbox on", "/sandbox status", "/sandbox off", EOFError]
+        cli = DatusCLI(args=mock_args)
+        cli.run()
+        captured = capsys.readouterr()
+        assert "Bash sandbox: off" in captured.out
+        assert "Bash sandbox on (this session only)" in captured.out
+        assert "Bash sandbox: on" in captured.out
+        assert "Bash sandbox off (this session only)" in captured.out
+        assert cli.agent_config.bash_sandbox.enabled is False
+
+
 @pytest.mark.nightly
 @pytest.mark.product_e2e
 def test_chat_command(mock_args, capsys, gen_sql_input: List[Dict[str, Any]]):

--- a/tests/integration/tools/test_bash_sandbox_execution.py
+++ b/tests/integration/tools/test_bash_sandbox_execution.py
@@ -162,3 +162,82 @@ class TestBashToolFullChain:
         result = self._tool(workspace).bash('f=$(mktemp) && echo scratch > "$f" && cat "$f" && rm -f "$f"')
         assert result.success == 1, result.error
         assert "scratch" in result.result
+
+
+@pytest.fixture
+def loopback_server():
+    """Local TCP listener so network tests never leave the machine."""
+    import socketserver
+    import threading
+
+    class Handler(socketserver.BaseRequestHandler):
+        def handle(self):
+            self.request.sendall(b"pong")
+
+    server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server.server_address[1]
+    server.shutdown()
+    server.server_close()
+
+
+@requires_sandbox
+class TestStrictTier:
+    """Kernel-level checks for the multi-tenant strict mode."""
+
+    def _tool(self, workspace, mode, read_dirs=None):
+        return BashTool(
+            workspace_root=str(workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=SandboxSettings(enabled=True, mode=mode),
+            sandbox_read_dirs=read_dirs,
+        )
+
+    def test_injected_read_dirs_honored_in_normal_mode(self, workspace, outside_home_dir):
+        secret = outside_home_dir / "shared.txt"
+        secret.write_text("normal-readable")
+        tool = self._tool(workspace, "normal", read_dirs=[str(outside_home_dir)])
+        result = tool.bash(f"cat {secret}")
+        assert result.success == 1, result.error
+        assert "normal-readable" in result.result
+
+    def test_injected_read_dirs_blocked_in_strict_mode(self, workspace, outside_home_dir):
+        # Same injection (the datus-home slot) must be ignored by strict —
+        # this is the multi-tenant "~/.datus is off limits" guarantee.
+        secret = outside_home_dir / "shared.txt"
+        secret.write_text("strict-blocked")
+        tool = self._tool(workspace, "strict", read_dirs=[str(outside_home_dir)])
+        result = tool.bash(f"cat {secret}")
+        assert result.success == 0
+        assert "strict-blocked" not in (result.result or "")
+
+    def test_strict_hides_env_secret_under_real_sandbox(self, workspace, monkeypatch):
+        monkeypatch.setenv("DATUS_SBX_SECRET", "sk-real-leak")
+        result = self._tool(workspace, "strict").bash('echo "[${DATUS_SBX_SECRET:-absent}]"')
+        assert result.success == 1, result.error
+        assert "[absent]" in result.result
+
+
+@requires_sandbox
+class TestDenyNetwork:
+    def _policy(self, workspace, deny):
+        return SandboxPolicy(
+            cwd=str(workspace),
+            writable_roots=(str(workspace),),
+            readable_roots=(str(Path(sys.prefix).resolve()), str(Path(sys.base_prefix).resolve())),
+            deny_network=deny,
+        )
+
+    def test_loopback_allowed_by_default(self, workspace, loopback_server):
+        # bash's /dev/tcp builtin needs no external binaries.
+        cmd = f"exec 3<>/dev/tcp/127.0.0.1/{loopback_server} && echo connected"
+        result = run_sandboxed(cmd, self._policy(workspace, deny=False), str(workspace))
+        assert result.returncode == 0, result.stderr
+        assert "connected" in result.stdout
+
+    def test_loopback_blocked_with_deny_network(self, workspace, loopback_server):
+        cmd = f"exec 3<>/dev/tcp/127.0.0.1/{loopback_server} && echo connected"
+        result = run_sandboxed(cmd, self._policy(workspace, deny=True), str(workspace))
+        assert result.returncode != 0
+        assert "connected" not in result.stdout

--- a/tests/integration/tools/test_bash_sandbox_execution.py
+++ b/tests/integration/tools/test_bash_sandbox_execution.py
@@ -1,0 +1,164 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Real OS-sandbox execution tests for the bash sandbox.
+
+These spawn the actual mechanism (macOS ``sandbox-exec`` / Linux ``bwrap``)
+and verify the kernel-enforced guarantees: writes and reads outside the
+allowlist fail, allowlisted and system paths keep working, and ``cd`` cannot
+escape. Skipped wherever no mechanism is available (e.g. CI runners without
+bubblewrap) — the pure argv/profile generation logic is covered by
+``tests/unit_tests/tools/func_tool/test_bash_sandbox.py`` on every platform.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from datus.tools.func_tool import bash_sandbox
+from datus.tools.func_tool.bash_sandbox import SandboxPolicy, SandboxSettings, wrap_argv
+from datus.tools.func_tool.bash_tool import BashTool
+
+requires_sandbox = pytest.mark.skipif(
+    bash_sandbox.detect_mechanism() is None,
+    reason="no OS sandbox mechanism available (needs macOS sandbox-exec or Linux bwrap)",
+)
+
+BASH = shutil.which("bash")
+
+
+def run_sandboxed(command: str, policy: SandboxPolicy, cwd: str):
+    argv = wrap_argv([BASH, "-c", command], policy)
+    return subprocess.run(argv, cwd=cwd, capture_output=True, text=True, timeout=30)
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    return ws.resolve()
+
+
+@pytest.fixture
+def outside_home_dir():
+    """A directory outside every default-writable root (workspace, tmp).
+
+    pytest's ``tmp_path`` lives under the process tmp dir, which the default
+    policy makes writable — escape targets must live elsewhere, so this one
+    goes under the real home directory.
+    """
+    path = Path(tempfile.mkdtemp(prefix=".datus_sbx_test_", dir=str(Path.home())))
+    yield path.resolve()
+    # Safe: removes only the uniquely-named dir mkdtemp created two lines up;
+    # it must live under $HOME because the sandbox escape target has to sit
+    # outside the default-writable tmp tree.
+    shutil.rmtree(path, ignore_errors=True)  # audit-noqa: rmtree_outside_tmp
+
+
+def minimal_policy(workspace, readable=()):
+    """Workspace-only write policy; system read baselines come from the builders."""
+    return SandboxPolicy(
+        cwd=str(workspace),
+        writable_roots=(str(workspace),),
+        readable_roots=(str(Path(sys.prefix).resolve()), str(Path(sys.base_prefix).resolve()), *readable),
+    )
+
+
+@requires_sandbox
+class TestSandboxedExecution:
+    def test_write_inside_workspace_succeeds(self, workspace):
+        result = run_sandboxed("echo data > inside.txt", minimal_policy(workspace), str(workspace))
+        assert result.returncode == 0, result.stderr
+        assert (workspace / "inside.txt").read_text().strip() == "data"
+
+    def test_write_outside_workspace_fails(self, workspace, outside_home_dir):
+        target = outside_home_dir / "escape.txt"
+        result = run_sandboxed(f"echo pwned > {target}", minimal_policy(workspace), str(workspace))
+        assert result.returncode != 0
+        assert not target.exists()
+
+    def test_cd_escape_write_fails(self, workspace, outside_home_dir):
+        target = outside_home_dir / "cd_escape.txt"
+        result = run_sandboxed(
+            f"cd {outside_home_dir} 2>/dev/null; touch {target}",
+            minimal_policy(workspace),
+            str(workspace),
+        )
+        assert result.returncode != 0
+        assert not target.exists()
+
+    def test_read_outside_allowlist_fails(self, workspace, outside_home_dir):
+        secret = outside_home_dir / "secret.txt"
+        secret.write_text("top-secret")
+        result = run_sandboxed(f"cat {secret}", minimal_policy(workspace), str(workspace))
+        # macOS Seatbelt: EPERM on open; Linux bwrap: path not bound -> ENOENT.
+        assert result.returncode != 0
+        assert "top-secret" not in result.stdout
+
+    def test_read_inside_allowlist_succeeds(self, workspace, outside_home_dir):
+        shared = outside_home_dir / "shared.txt"
+        shared.write_text("readable")
+        policy = minimal_policy(workspace, readable=(str(outside_home_dir),))
+        result = run_sandboxed(f"cat {shared}", policy, str(workspace))
+        assert result.returncode == 0, result.stderr
+        assert "readable" in result.stdout
+
+    def test_system_read_succeeds(self, workspace):
+        result = run_sandboxed(
+            "cat /etc/hosts > /dev/null && ls /usr/bin | head -1", minimal_policy(workspace), str(workspace)
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip()
+
+    def test_write_to_system_dirs_fails(self, workspace):
+        result = run_sandboxed(
+            "touch /usr/local/datus_sbx_probe 2>/dev/null", minimal_policy(workspace), str(workspace)
+        )
+        assert result.returncode != 0
+        assert not Path("/usr/local/datus_sbx_probe").exists()
+
+    def test_pipeline_works_inside_sandbox(self, workspace):
+        (workspace / "log.txt").write_text("a\nerror: boom\nb\n")
+        result = run_sandboxed("cat log.txt | grep error | wc -l", minimal_policy(workspace), str(workspace))
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "1"
+
+
+@requires_sandbox
+class TestBashToolFullChain:
+    """End-to-end through BashTool.bash() with the default build_policy."""
+
+    def _tool(self, workspace):
+        return BashTool(
+            workspace_root=str(workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=SandboxSettings(enabled=True),
+        )
+
+    def test_python_shim_runs_in_sandbox(self, workspace):
+        result = self._tool(workspace).bash('python -c "print(11 + 31)"')
+        assert result.success == 1, result.error
+        assert "42" in result.result
+
+    def test_workspace_write_succeeds(self, workspace):
+        result = self._tool(workspace).bash("echo ok > out.txt && cat out.txt")
+        assert result.success == 1, result.error
+        assert "ok" in result.result
+
+    def test_home_escape_fails(self, workspace, outside_home_dir):
+        target = outside_home_dir / "full_chain_escape.txt"
+        result = self._tool(workspace).bash(f"echo pwned > {target}")
+        assert not target.exists()
+        # bash surfaces the denial as a non-zero exit -> FuncToolResult error.
+        assert result.success == 0
+
+    def test_tmp_stays_writable(self, workspace):
+        # The default policy keeps tmp writable (scratch space contract).
+        result = self._tool(workspace).bash('f=$(mktemp) && echo scratch > "$f" && cat "$f" && rm -f "$f"')
+        assert result.success == 1, result.error
+        assert "scratch" in result.result

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2048,12 +2048,11 @@ class TestStartChatModelOverride:
 class TestStartChatRemoteSourceHardening:
     """Per-source bash policy for remote front-ends.
     ``filesystem_strict`` is always on for the API surface. vscode owns its
-    own local shell, so ``bash_tool_enabled`` is forced off; web keeps a
-    server-side bash restricted to datus-prefixed commands
-    (``bash_allowed_patterns = ["datus*"]``) so plugin CLIs
-    ("datus <plugin> ...") stay usable. ``project_root`` is intentionally
-    untouched — web keeps its configured root and the read-only property
-    falls back to CWD when empty.
+    own local shell, so ``bash_tool_enabled`` is forced off; web runs a full
+    server-side bash (``bash_allowed_patterns = ["*"]``) confined by the
+    strict OS sandbox (``bash_sandbox.enabled`` + ``mode == "strict"``).
+    ``project_root`` is intentionally untouched — web keeps its configured
+    root and the read-only property falls back to CWD when empty.
     """
 
     @pytest.mark.asyncio
@@ -2082,7 +2081,7 @@ class TestStartChatRemoteSourceHardening:
         assert real_agent_config.bash_tool_enabled is True
 
     @pytest.mark.asyncio
-    async def test_web_source_restricts_bash_to_datus_commands(self, real_agent_config, monkeypatch):
+    async def test_web_source_allows_all_bash_under_strict_sandbox(self, real_agent_config, monkeypatch):
         from datus.api.models.cli_models import StreamChatInput
 
         real_agent_config.bash_tool_enabled = True
@@ -2099,17 +2098,21 @@ class TestStartChatRemoteSourceHardening:
 
         cfg = captured["agent_config"]
         assert cfg.filesystem_strict is True
-        # web keeps bash for plugin CLIs, but only datus-prefixed commands.
+        # web runs a full bash confined by the strict OS sandbox, not a whitelist.
         assert cfg.bash_tool_enabled is True
-        assert cfg.bash_allowed_patterns == ["datus*"]
+        assert cfg.bash_allowed_patterns == ["*"]
+        assert cfg.bash_sandbox.enabled is True
+        assert cfg.bash_sandbox.is_strict is True
         assert cfg._client_source == "web"
         # Source config remains untouched because start_chat deep-copies.
         assert real_agent_config.bash_allowed_patterns == ["*"]
+        assert real_agent_config.bash_sandbox.enabled is False
 
     @pytest.mark.asyncio
     async def test_web_source_respects_yaml_bash_disable(self, real_agent_config, monkeypatch):
         """An agent.yml ``bash.enabled: false`` still wins under web —
-        restricting patterns must never re-enable a disabled tool."""
+        allowing all commands or enabling the sandbox must never re-enable a
+        disabled tool."""
         from datus.api.models.cli_models import StreamChatInput
 
         real_agent_config.bash_tool_enabled = False
@@ -2126,12 +2129,12 @@ class TestStartChatRemoteSourceHardening:
 
         cfg = captured["agent_config"]
         assert cfg.bash_tool_enabled is False
-        assert cfg.bash_allowed_patterns == ["datus*"]
+        assert cfg.bash_allowed_patterns == ["*"]
 
     @pytest.mark.asyncio
-    async def test_default_source_web_restricts_bash_without_request_source(self, real_agent_config, monkeypatch):
-        """A daemon launched with --source web applies the datus-only bash
-        whitelist to every request that does not override source."""
+    async def test_default_source_web_applies_strict_sandbox_without_request_source(self, real_agent_config, monkeypatch):
+        """A daemon launched with --source web applies the full-bash +
+        strict-sandbox policy to every request that does not override source."""
         from datus.api.models.cli_models import StreamChatInput
 
         real_agent_config.bash_tool_enabled = True
@@ -2148,7 +2151,8 @@ class TestStartChatRemoteSourceHardening:
 
         cfg = captured["agent_config"]
         assert cfg.bash_tool_enabled is True
-        assert cfg.bash_allowed_patterns == ["datus*"]
+        assert cfg.bash_allowed_patterns == ["*"]
+        assert cfg.bash_sandbox.is_strict is True
 
     @pytest.mark.asyncio
     async def test_default_source_vscode_applies_hardening_without_request_source(self, real_agent_config, monkeypatch):

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2132,7 +2132,9 @@ class TestStartChatRemoteSourceHardening:
         assert cfg.bash_allowed_patterns == ["*"]
 
     @pytest.mark.asyncio
-    async def test_default_source_web_applies_strict_sandbox_without_request_source(self, real_agent_config, monkeypatch):
+    async def test_default_source_web_applies_strict_sandbox_without_request_source(
+        self, real_agent_config, monkeypatch
+    ):
         """A daemon launched with --source web applies the full-bash +
         strict-sandbox policy to every request that does not override source."""
         from datus.api.models.cli_models import StreamChatInput

--- a/tests/unit_tests/cli/test_core_entrypoint_acceptance.py
+++ b/tests/unit_tests/cli/test_core_entrypoint_acceptance.py
@@ -93,6 +93,7 @@ def _build_core_cli() -> DatusCLI:
     cli.plugin_commands = PluginCommands(cli)
     cli.language_commands = MagicMock()
     cli.effort_commands = MagicMock()
+    cli.sandbox_commands = MagicMock()
     cli.init_commands = InitCommands(cli)
     cli.build_kb_commands = BuildKbCommands(cli)
     cli.datasource_commands = DatasourceCommands(cli)

--- a/tests/unit_tests/cli/test_sandbox_commands.py
+++ b/tests/unit_tests/cli/test_sandbox_commands.py
@@ -119,6 +119,47 @@ class TestProjectPersistence:
         mock_save.assert_not_called()
 
 
+class TestModeSwitch:
+    def test_strict_enables_and_pins_mode(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_AVAILABLE, return_value=True), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("strict")
+        settings = cli.agent_config.bash_sandbox
+        assert settings.enabled is True
+        assert settings.mode == "strict"
+        assert "session only" in cli.console.file.getvalue()
+
+    def test_normal_resets_mode(self):
+        cli = _stub_cli(SandboxSettings(enabled=True, mode="strict"))
+        cmds = SandboxCommands(cli)
+        with patch(_PATCH_AVAILABLE, return_value=True), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("normal")
+        assert cli.agent_config.bash_sandbox.mode == "normal"
+        assert cli.agent_config.bash_sandbox.enabled is True
+
+    def test_on_off_keep_existing_mode(self):
+        cli = _stub_cli(SandboxSettings(enabled=False, mode="strict"))
+        cmds = SandboxCommands(cli)
+        with patch(_PATCH_AVAILABLE, return_value=True), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("on")
+        assert cli.agent_config.bash_sandbox.mode == "strict"
+        assert cli.agent_config.bash_sandbox.enabled is True
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("off")
+        assert cli.agent_config.bash_sandbox.mode == "strict"
+        assert cli.agent_config.bash_sandbox.enabled is False
+
+    def test_strict_project_persists_mode_string(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_AVAILABLE, return_value=True),
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+        ):
+            cmds.cmd_sandbox("strict --project")
+        assert mock_save.call_args[0][0].sandbox == "strict"
+
+
 class TestGlobalPersistence:
     def test_on_global_writes_full_sandbox_section(self):
         settings = SandboxSettings(allow_read=["/data"], allow_write=["/scratch"])
@@ -128,15 +169,33 @@ class TestGlobalPersistence:
             cmds.cmd_sandbox("on --global")
         cli.configuration_manager.update_item.assert_called_once_with(
             "bash",
-            {"sandbox": {"enabled": True, "allow_read": ["/data"], "allow_write": ["/scratch"]}},
+            {"sandbox": {"enabled": True, "mode": "normal", "allow_read": ["/data"], "allow_write": ["/scratch"]}},
         )
         assert "agent.yml" in cli.console.file.getvalue()
+
+    def test_strict_global_persists_mode(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_AVAILABLE, return_value=True), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("strict --global")
+        cli.configuration_manager.update_item.assert_called_once_with(
+            "bash", {"sandbox": {"enabled": True, "mode": "strict"}}
+        )
+
+    def test_deny_network_survives_global_save(self):
+        cli = _stub_cli(SandboxSettings(deny_network=True))
+        cmds = SandboxCommands(cli)
+        with patch(_PATCH_AVAILABLE, return_value=True), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("on --global")
+        saved = cli.configuration_manager.update_item.call_args[0][1]["sandbox"]
+        assert saved["deny_network"] is True
 
     def test_off_global_omits_empty_lists(self, commands):
         cmds, cli = commands
         with patch(_PATCH_LOAD, return_value=None):
             cmds.cmd_sandbox("off --global")
-        cli.configuration_manager.update_item.assert_called_once_with("bash", {"sandbox": {"enabled": False}})
+        cli.configuration_manager.update_item.assert_called_once_with(
+            "bash", {"sandbox": {"enabled": False, "mode": "normal"}}
+        )
 
     def test_global_notes_conflicting_project_override(self, commands):
         cmds, cli = commands
@@ -178,3 +237,14 @@ class TestStatus:
         assert "project" in out
         assert "/data" in out
         assert "/scratch" in out
+
+    def test_status_strict_shows_blocked_datus_home_and_env(self):
+        cli = _stub_cli(SandboxSettings(enabled=True, mode="strict", deny_network=True))
+        cmds = SandboxCommands(cli)
+        with patch(_PATCH_MECH, return_value="bwrap"), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("status")
+        out = cli.console.file.getvalue()
+        assert "mode: strict" in out
+        assert "BLOCKED" in out
+        assert "minimal allowlist" in out
+        assert "Network: denied" in out

--- a/tests/unit_tests/cli/test_sandbox_commands.py
+++ b/tests/unit_tests/cli/test_sandbox_commands.py
@@ -1,0 +1,180 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for ``datus.cli.sandbox_commands.SandboxCommands``.
+
+CI-level: patches project-override IO and the sandbox mechanism probe so the
+dispatcher logic can be exercised without touching the filesystem or spawning
+sandbox binaries.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from datus.cli.sandbox_commands import SandboxCommands
+from datus.configuration.project_config import ProjectOverride
+from datus.tools.func_tool.bash_sandbox import SandboxSettings
+
+pytestmark = pytest.mark.ci
+
+_PATCH_LOAD = "datus.cli.sandbox_commands.load_project_override"
+_PATCH_SAVE = "datus.cli.sandbox_commands.save_project_override"
+_PATCH_MECH = "datus.cli.sandbox_commands.bash_sandbox.detect_mechanism"
+_PATCH_AVAILABLE = "datus.cli.sandbox_commands.bash_sandbox.is_available"
+
+
+def _stub_cli(settings: SandboxSettings | None = None):
+    cli = MagicMock()
+    cli.console = Console(file=io.StringIO(), no_color=True)
+    cli.agent_config = MagicMock()
+    cli.agent_config.bash_sandbox = settings if settings is not None else SandboxSettings()
+    cli.configuration_manager = MagicMock()
+    return cli
+
+
+@pytest.fixture
+def commands():
+    cli = _stub_cli()
+    return SandboxCommands(cli), cli
+
+
+class TestSessionToggle:
+    def test_on_flips_shared_settings(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_AVAILABLE, return_value=True), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("on")
+        assert cli.agent_config.bash_sandbox.enabled is True
+        assert "session only" in cli.console.file.getvalue()
+        cli.configuration_manager.update_item.assert_not_called()
+
+    def test_off_flips_shared_settings(self, commands):
+        cmds, cli = commands
+        cli.agent_config.bash_sandbox.enabled = True
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("off")
+        assert cli.agent_config.bash_sandbox.enabled is False
+
+    def test_on_warns_when_mechanism_unavailable(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_AVAILABLE, return_value=False), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("on")
+        # Still enabled (fail-closed happens at execution time) but loudly warned.
+        assert cli.agent_config.bash_sandbox.enabled is True
+        assert "REJECTED" in cli.console.file.getvalue()
+
+    def test_invalid_value_errors_without_side_effects(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_sandbox("maybe")
+        assert cli.agent_config.bash_sandbox.enabled is False
+        mock_save.assert_not_called()
+        assert "Usage" in cli.console.file.getvalue()
+
+
+class TestProjectPersistence:
+    def test_on_project_saves_override(self, commands):
+        cmds, cli = commands
+        with (
+            patch(_PATCH_AVAILABLE, return_value=True),
+            patch(_PATCH_LOAD, return_value=None),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+        ):
+            cmds.cmd_sandbox("on --project")
+        saved = mock_save.call_args[0][0]
+        assert saved.sandbox is True
+        assert cli.agent_config.bash_sandbox.enabled is True
+
+    def test_off_project_preserves_other_override_fields(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(target="deepseek", reasoning_effort="high")
+        with (
+            patch(_PATCH_LOAD, return_value=existing),
+            patch(_PATCH_SAVE, return_value="/tmp/.datus/config.yml") as mock_save,
+        ):
+            cmds.cmd_sandbox("off --project")
+        saved = mock_save.call_args[0][0]
+        assert saved.sandbox is False
+        assert saved.target == "deepseek"
+        assert saved.reasoning_effort == "high"
+
+    def test_clear_removes_project_override(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(sandbox=True, target="deepseek")
+        with patch(_PATCH_LOAD, return_value=existing), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_sandbox("--clear")
+        saved = mock_save.call_args[0][0]
+        assert saved.sandbox is None
+        assert saved.target == "deepseek"
+
+    def test_clear_without_override_is_noop_save(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None), patch(_PATCH_SAVE) as mock_save:
+            cmds.cmd_sandbox("--clear")
+        mock_save.assert_not_called()
+
+
+class TestGlobalPersistence:
+    def test_on_global_writes_full_sandbox_section(self):
+        settings = SandboxSettings(allow_read=["/data"], allow_write=["/scratch"])
+        cli = _stub_cli(settings)
+        cmds = SandboxCommands(cli)
+        with patch(_PATCH_AVAILABLE, return_value=True), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("on --global")
+        cli.configuration_manager.update_item.assert_called_once_with(
+            "bash",
+            {"sandbox": {"enabled": True, "allow_read": ["/data"], "allow_write": ["/scratch"]}},
+        )
+        assert "agent.yml" in cli.console.file.getvalue()
+
+    def test_off_global_omits_empty_lists(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("off --global")
+        cli.configuration_manager.update_item.assert_called_once_with("bash", {"sandbox": {"enabled": False}})
+
+    def test_global_notes_conflicting_project_override(self, commands):
+        cmds, cli = commands
+        existing = ProjectOverride(sandbox=True)
+        with patch(_PATCH_LOAD, return_value=existing):
+            cmds.cmd_sandbox("off --global")
+        assert "project-level override" in cli.console.file.getvalue()
+
+
+class TestStatus:
+    def test_status_shows_state_and_mechanism(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_MECH, return_value="seatbelt"), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("status")
+        out = cli.console.file.getvalue()
+        assert "off" in out
+        assert "seatbelt" in out
+
+    def test_empty_args_means_status(self, commands):
+        cmds, cli = commands
+        with patch(_PATCH_MECH, return_value=None), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("")
+        assert "Bash sandbox: off" in cli.console.file.getvalue()
+
+    def test_status_warns_fail_closed_when_enabled_but_unavailable(self):
+        cli = _stub_cli(SandboxSettings(enabled=True))
+        cmds = SandboxCommands(cli)
+        with patch(_PATCH_MECH, return_value=None), patch(_PATCH_LOAD, return_value=None):
+            cmds.cmd_sandbox("status")
+        out = cli.console.file.getvalue()
+        assert "Fail-closed" in out
+
+    def test_status_shows_project_source_and_allowlists(self):
+        cli = _stub_cli(SandboxSettings(enabled=True, allow_read=["/data"], allow_write=["/scratch"]))
+        cmds = SandboxCommands(cli)
+        with patch(_PATCH_MECH, return_value="bwrap"), patch(_PATCH_LOAD, return_value=ProjectOverride(sandbox=True)):
+            cmds.cmd_sandbox("status")
+        out = cli.console.file.getvalue()
+        assert "project" in out
+        assert "/data" in out
+        assert "/scratch" in out

--- a/tests/unit_tests/cli/test_sandbox_commands.py
+++ b/tests/unit_tests/cli/test_sandbox_commands.py
@@ -21,8 +21,6 @@ from datus.cli.sandbox_commands import SandboxCommands
 from datus.configuration.project_config import ProjectOverride
 from datus.tools.func_tool.bash_sandbox import SandboxSettings
 
-pytestmark = pytest.mark.ci
-
 _PATCH_LOAD = "datus.cli.sandbox_commands.load_project_override"
 _PATCH_SAVE = "datus.cli.sandbox_commands.save_project_override"
 _PATCH_MECH = "datus.cli.sandbox_commands.bash_sandbox.detect_mechanism"

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1912,6 +1912,48 @@ class TestAgentConfigBashAllowedPatterns:
         assert cfg.bash_allowed_patterns == ["*"]
 
 
+class TestAgentConfigBashSandbox:
+    """``bash.sandbox`` parses into a shared, mutable ``SandboxSettings``
+    driving the OS-level sandbox around ``BashTool``. Default is disabled so
+    existing deployments see zero behavior change.
+    """
+
+    _make = TestAgentConfigBashToolEnabled._make
+
+    def test_default_disabled_with_empty_lists(self, tmp_path):
+        cfg = self._make(tmp_path)
+        assert cfg.bash_sandbox.enabled is False
+        assert cfg.bash_sandbox.allow_read == []
+        assert cfg.bash_sandbox.allow_write == []
+
+    def test_from_yaml_full_section(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            bash={"sandbox": {"enabled": True, "allow_read": ["/data"], "allow_write": ["/scratch"]}},
+        )
+        assert cfg.bash_sandbox.enabled is True
+        assert cfg.bash_sandbox.allow_read == ["/data"]
+        assert cfg.bash_sandbox.allow_write == ["/scratch"]
+
+    @pytest.mark.parametrize("yaml_value", ["true", "1", "yes", "on", True])
+    def test_string_true_enables(self, tmp_path, yaml_value):
+        cfg = self._make(tmp_path, bash={"sandbox": {"enabled": yaml_value}})
+        assert cfg.bash_sandbox.enabled is True
+
+    def test_non_mapping_sandbox_section_defaults_disabled(self, tmp_path):
+        cfg = self._make(tmp_path, bash={"sandbox": "true"})
+        assert cfg.bash_sandbox.enabled is False
+
+    def test_settings_object_is_shared_and_mutable(self, tmp_path):
+        # /sandbox on|off mutates the object in place; BashTool holds the
+        # same reference, so identity across reads is the contract here.
+        cfg = self._make(tmp_path)
+        settings = cfg.bash_sandbox
+        settings.enabled = True
+        assert cfg.bash_sandbox is settings
+        assert cfg.bash_sandbox.enabled is True
+
+
 class TestAgentConfigTavilyApiKey:
     """``document.tavily_api_key`` resolution prefers the YAML value, falls
     back to ``TAVILY_API_KEY`` env only when the key is absent, and never

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1934,6 +1934,16 @@ class TestAgentConfigBashSandbox:
         assert cfg.bash_sandbox.enabled is True
         assert cfg.bash_sandbox.allow_read == ["/data"]
         assert cfg.bash_sandbox.allow_write == ["/scratch"]
+        assert cfg.bash_sandbox.mode == "normal"
+        assert cfg.bash_sandbox.deny_network is False
+
+    def test_from_yaml_strict_tier(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            bash={"sandbox": {"enabled": True, "mode": "strict", "deny_network": True}},
+        )
+        assert cfg.bash_sandbox.is_strict is True
+        assert cfg.bash_sandbox.deny_network is True
 
     @pytest.mark.parametrize("yaml_value", ["true", "1", "yes", "on", True])
     def test_string_true_enables(self, tmp_path, yaml_value):

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -279,6 +279,54 @@ class TestApplyProjectOverride:
             _apply_project_override(agent_raw)
         assert agent_raw["project_name"] == "my_proj"
 
+    @pytest.mark.parametrize("value", [True, False])
+    def test_sandbox_override_sets_bash_sandbox_enabled(self, value):
+        agent_raw = self._base_raw()
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(sandbox=value),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["bash"]["sandbox"]["enabled"] is value
+
+    def test_sandbox_override_preserves_existing_bash_section(self):
+        # Only ``enabled`` is overridden; allow_read/allow_write and sibling
+        # bash keys from the global agent.yml must survive.
+        agent_raw = self._base_raw()
+        agent_raw["bash"] = {
+            "enabled": True,
+            "allowed_patterns": ["datus*"],
+            "sandbox": {"enabled": False, "allow_read": ["/data"]},
+        }
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(sandbox=True),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["bash"]["sandbox"]["enabled"] is True
+        assert agent_raw["bash"]["sandbox"]["allow_read"] == ["/data"]
+        assert agent_raw["bash"]["allowed_patterns"] == ["datus*"]
+        assert agent_raw["bash"]["enabled"] is True
+
+    def test_sandbox_override_tolerates_malformed_bash_section(self):
+        agent_raw = self._base_raw()
+        agent_raw["bash"] = "not-a-mapping"
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(sandbox=True),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["bash"]["sandbox"]["enabled"] is True
+
+    def test_no_sandbox_override_leaves_bash_untouched(self):
+        agent_raw = self._base_raw()
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(project_name="p"),
+        ):
+            _apply_project_override(agent_raw)
+        assert "bash" not in agent_raw
+
     def test_valid_default_datasource_flips_default_flags(self):
         """default_datasource overlay is applied by flipping datasources[*].default
         so AgentConfig.services.default_datasource resolves to the override target

--- a/tests/unit_tests/configuration/test_agent_config_loader.py
+++ b/tests/unit_tests/configuration/test_agent_config_loader.py
@@ -308,6 +308,28 @@ class TestApplyProjectOverride:
         assert agent_raw["bash"]["allowed_patterns"] == ["datus*"]
         assert agent_raw["bash"]["enabled"] is True
 
+    @pytest.mark.parametrize("mode", ["strict", "normal"])
+    def test_sandbox_mode_string_enables_and_pins_mode(self, mode):
+        agent_raw = self._base_raw()
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(sandbox=mode),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["bash"]["sandbox"]["enabled"] is True
+        assert agent_raw["bash"]["sandbox"]["mode"] == mode
+
+    def test_sandbox_bool_does_not_touch_mode(self):
+        agent_raw = self._base_raw()
+        agent_raw["bash"] = {"sandbox": {"enabled": False, "mode": "strict"}}
+        with patch(
+            "datus.configuration.agent_config_loader.load_project_override",
+            return_value=ProjectOverride(sandbox=True),
+        ):
+            _apply_project_override(agent_raw)
+        assert agent_raw["bash"]["sandbox"]["enabled"] is True
+        assert agent_raw["bash"]["sandbox"]["mode"] == "strict"
+
     def test_sandbox_override_tolerates_malformed_bash_section(self):
         agent_raw = self._base_raw()
         agent_raw["bash"] = "not-a-mapping"

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -113,6 +113,27 @@ class TestLoadProjectOverride:
             result = load_project_override(str(tmp_path))
         assert result.reasoning_effort is None
 
+    @pytest.mark.parametrize(
+        "raw_value,expected",
+        [(True, True), (False, False), ("true", True), ("off", False), ("1", True), ("no", False)],
+    )
+    def test_parse_sandbox_field(self, tmp_path, raw_value, expected):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"sandbox": raw_value}))
+        result = load_project_override(str(tmp_path))
+        assert result.sandbox is expected
+
+    @pytest.mark.parametrize("bad_value", ["yess", 3, ["true"], {"enabled": True}])
+    def test_invalid_sandbox_dropped_with_warning(self, tmp_path, caplog, bad_value):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"sandbox": bad_value}))
+        with caplog.at_level(logging.WARNING):
+            result = load_project_override(str(tmp_path))
+        assert result.sandbox is None
+        assert "sandbox" in " ".join(r.message for r in caplog.records)
+
     def test_unknown_keys_warn_and_drop(self, tmp_path, caplog):
         path = tmp_path / PROJECT_CONFIG_REL
         path.parent.mkdir(parents=True)
@@ -205,6 +226,19 @@ class TestSaveProjectOverride:
         loaded = load_project_override(str(tmp_path))
         assert loaded.target == "new"
 
+    @pytest.mark.parametrize("value", [True, False])
+    def test_sandbox_round_trips_including_false(self, tmp_path, value):
+        # ``sandbox: false`` (force-off) must survive save/load — a naive
+        # truthiness filter would drop it and lose the override.
+        save_project_override(ProjectOverride(sandbox=value), cwd=str(tmp_path))
+        loaded = load_project_override(str(tmp_path))
+        assert loaded.sandbox is value
+
+    def test_sandbox_none_omitted_from_yaml(self, tmp_path):
+        written = save_project_override(ProjectOverride(target="x"), cwd=str(tmp_path))
+        loaded = yaml.safe_load(written.read_text())
+        assert "sandbox" not in loaded
+
 
 class TestAllowedKeys:
     def test_whitelist_contains_expected_keys(self):
@@ -221,6 +255,7 @@ class TestAllowedKeys:
                 "reasoning_effort",
                 "bash_allow",
                 "sql_allow",
+                "sandbox",
             }
         )
 
@@ -241,11 +276,16 @@ class TestProjectOverrideDataclass:
             ("project_name", "z"),
             ("language", "zh"),
             ("reasoning_effort", "high"),
+            ("sandbox", True),
         ],
     )
     def test_is_not_empty_when_any_set(self, field, value):
         override = ProjectOverride(**{field: value})
         assert not override.is_empty()
+
+    def test_is_not_empty_when_sandbox_false(self):
+        # ``sandbox: false`` is a meaningful force-off override, not "unset".
+        assert not ProjectOverride(sandbox=False).is_empty()
 
 
 class TestServiceDefaultFields:

--- a/tests/unit_tests/configuration/test_project_config.py
+++ b/tests/unit_tests/configuration/test_project_config.py
@@ -124,7 +124,15 @@ class TestLoadProjectOverride:
         result = load_project_override(str(tmp_path))
         assert result.sandbox is expected
 
-    @pytest.mark.parametrize("bad_value", ["yess", 3, ["true"], {"enabled": True}])
+    @pytest.mark.parametrize("mode", ["strict", "normal", "STRICT", " Normal "])
+    def test_parse_sandbox_mode_strings(self, tmp_path, mode):
+        path = tmp_path / PROJECT_CONFIG_REL
+        path.parent.mkdir(parents=True)
+        path.write_text(yaml.safe_dump({"sandbox": mode}))
+        result = load_project_override(str(tmp_path))
+        assert result.sandbox == mode.strip().lower()
+
+    @pytest.mark.parametrize("bad_value", ["yess", "strick", 3, ["true"], {"enabled": True}])
     def test_invalid_sandbox_dropped_with_warning(self, tmp_path, caplog, bad_value):
         path = tmp_path / PROJECT_CONFIG_REL
         path.parent.mkdir(parents=True)
@@ -233,6 +241,12 @@ class TestSaveProjectOverride:
         save_project_override(ProjectOverride(sandbox=value), cwd=str(tmp_path))
         loaded = load_project_override(str(tmp_path))
         assert loaded.sandbox is value
+
+    @pytest.mark.parametrize("value", ["strict", "normal"])
+    def test_sandbox_mode_string_round_trips(self, tmp_path, value):
+        save_project_override(ProjectOverride(sandbox=value), cwd=str(tmp_path))
+        loaded = load_project_override(str(tmp_path))
+        assert loaded.sandbox == value
 
     def test_sandbox_none_omitted_from_yaml(self, tmp_path):
         written = save_project_override(ProjectOverride(target="x"), cwd=str(tmp_path))

--- a/tests/unit_tests/tools/func_tool/test_bash_sandbox.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_sandbox.py
@@ -86,6 +86,52 @@ class TestSandboxSettingsFromDict:
         assert settings.allow_read == []
         assert settings.allow_write == []
 
+    def test_mode_defaults_to_normal(self):
+        settings = SandboxSettings.from_dict({"enabled": True})
+        assert settings.mode == bash_sandbox.MODE_NORMAL
+        assert settings.is_strict is False
+
+    def test_mode_strict_parsed_case_insensitive(self):
+        assert SandboxSettings.from_dict({"mode": "strict"}).is_strict is True
+        assert SandboxSettings.from_dict({"mode": " STRICT "}).is_strict is True
+        assert SandboxSettings.from_dict({"mode": "normal"}).is_strict is False
+
+    def test_invalid_mode_falls_back_to_normal(self):
+        for bad in ("paranoid", 3, ["strict"], {}):
+            assert SandboxSettings.from_dict({"mode": bad}).mode == bash_sandbox.MODE_NORMAL
+
+    def test_deny_network_parsed(self):
+        assert SandboxSettings.from_dict({"deny_network": True}).deny_network is True
+        assert SandboxSettings.from_dict({"deny_network": "true"}).deny_network is True
+        assert SandboxSettings.from_dict({}).deny_network is False
+
+
+class TestStrictEnv:
+    def test_keeps_allowlist_and_locale_only(self):
+        base = {
+            "PATH": "/usr/bin",
+            "HOME": "/home/u",
+            "LANG": "en_US.UTF-8",
+            "LC_ALL": "C",
+            "LC_CTYPE": "UTF-8",
+            "OPENAI_API_KEY": "sk-secret",
+            "DATABASE_PASSWORD": "hunter2",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            "TMPDIR": "/tmp/x",
+        }
+        result = bash_sandbox.strict_env(base)
+        assert result == {
+            "PATH": "/usr/bin",
+            "HOME": "/home/u",
+            "LANG": "en_US.UTF-8",
+            "LC_ALL": "C",
+            "LC_CTYPE": "UTF-8",
+            "TMPDIR": "/tmp/x",
+        }
+
+    def test_empty_base_yields_empty(self):
+        assert bash_sandbox.strict_env({}) == {}
+
 
 class TestBuildPolicy:
     def test_workspace_and_tmp_in_writable(self, workspace):
@@ -158,6 +204,57 @@ class TestBuildPolicy:
         assert os.path.realpath(sys.prefix) in combined
         assert os.path.realpath(sys.base_prefix) in combined
 
+    def test_deny_network_propagates_to_policy(self, workspace):
+        assert build_policy(SandboxSettings(), workspace).deny_network is False
+        assert build_policy(SandboxSettings(deny_network=True), workspace).deny_network is True
+
+
+class TestBuildPolicyStrict:
+    """Strict mode drops caller-injected dirs but keeps operator allowlists."""
+
+    def test_extra_read_dirs_ignored(self, tmp_path, workspace):
+        datus_home = tmp_path / "datus_home"
+        datus_home.mkdir()
+        policy = build_policy(
+            SandboxSettings(mode=bash_sandbox.MODE_STRICT),
+            workspace,
+            extra_read_dirs=[str(datus_home)],
+        )
+        assert str(datus_home.resolve()) not in policy.readable_roots
+
+    def test_dynamic_write_dirs_ignored(self, tmp_path, workspace):
+        session_dir = tmp_path / "session_out"
+        session_dir.mkdir()
+        policy = build_policy(
+            SandboxSettings(mode=bash_sandbox.MODE_STRICT),
+            workspace,
+            dynamic_write_dirs=[session_dir],
+        )
+        assert str(session_dir.resolve()) not in policy.writable_roots
+
+    def test_explicit_allowlists_still_apply(self, tmp_path, workspace):
+        shared_read = tmp_path / "shared_read"
+        shared_read.mkdir()
+        shared_write = tmp_path / "shared_write"
+        shared_write.mkdir()
+        policy = build_policy(
+            SandboxSettings(
+                mode=bash_sandbox.MODE_STRICT,
+                allow_read=[str(shared_read)],
+                allow_write=[str(shared_write)],
+            ),
+            workspace,
+        )
+        assert str(shared_read.resolve()) in policy.readable_roots
+        assert str(shared_write.resolve()) in policy.writable_roots
+
+    def test_workspace_tmp_and_python_env_survive(self, workspace):
+        policy = build_policy(SandboxSettings(mode=bash_sandbox.MODE_STRICT), workspace)
+        assert str(workspace.resolve()) in policy.writable_roots
+        assert os.path.realpath("/tmp") in policy.writable_roots
+        combined = set(policy.readable_roots) | set(policy.writable_roots)
+        assert os.path.realpath(sys.prefix) in combined
+
 
 class TestSeatbeltProfile:
     def test_profile_structure(self, workspace):
@@ -206,6 +303,18 @@ class TestSeatbeltProfile:
 
     def test_backslash_escaped(self):
         assert bash_sandbox._sb_quote("a\\b") == '"a\\\\b"'
+
+    def test_deny_network_appends_network_deny(self, workspace):
+        policy = SandboxPolicy(
+            cwd=str(workspace),
+            writable_roots=(str(workspace),),
+            readable_roots=(),
+            deny_network=True,
+        )
+        assert build_seatbelt_profile(policy).rstrip().endswith("(deny network*)")
+
+    def test_no_network_deny_by_default(self, workspace):
+        assert "(deny network*)" not in build_seatbelt_profile(make_policy(workspace))
 
 
 class TestBwrapPrefix:
@@ -262,6 +371,19 @@ class TestBwrapPrefix:
         monkeypatch.setattr(bash_sandbox, "_find_bwrap", lambda: None)
         with pytest.raises(SandboxUnavailableError):
             build_bwrap_prefix(make_policy(workspace))
+
+    def test_deny_network_adds_unshare_net(self, workspace):
+        policy = SandboxPolicy(
+            cwd=str(workspace),
+            writable_roots=(str(workspace),),
+            readable_roots=(),
+            deny_network=True,
+        )
+        args = build_bwrap_prefix(policy)
+        assert "--unshare-net" in args
+
+    def test_no_unshare_net_by_default(self, workspace):
+        assert "--unshare-net" not in build_bwrap_prefix(make_policy(workspace))
 
 
 class TestMountArgsForSystemDir:

--- a/tests/unit_tests/tools/func_tool/test_bash_sandbox.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_sandbox.py
@@ -1,0 +1,374 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Unit tests for the OS-level bash sandbox helpers.
+
+Covers ``SandboxSettings`` parsing, policy resolution (realpath, dedup,
+filtering), Seatbelt profile generation, bwrap argv generation, mechanism
+detection/caching and argv wrapping. All tests are deterministic and never
+spawn a real sandbox.
+"""
+
+import os
+import sys
+
+import pytest
+
+from datus.tools.func_tool import bash_sandbox
+from datus.tools.func_tool.bash_sandbox import (
+    MECHANISM_BWRAP,
+    MECHANISM_SEATBELT,
+    SandboxPolicy,
+    SandboxSettings,
+    SandboxUnavailableError,
+    build_bwrap_prefix,
+    build_policy,
+    build_seatbelt_profile,
+    wrap_argv,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_mechanism_cache():
+    bash_sandbox._reset_detection_cache()
+    yield
+    bash_sandbox._reset_detection_cache()
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    return ws
+
+
+def make_policy(workspace, readable=(), writable_extra=()):
+    return SandboxPolicy(
+        cwd=str(workspace),
+        writable_roots=(str(workspace), *writable_extra),
+        readable_roots=tuple(readable),
+    )
+
+
+class TestSandboxSettingsFromDict:
+    def test_none_and_non_dict_yield_defaults(self):
+        for raw in (None, "yes", 42, ["enabled"]):
+            settings = SandboxSettings.from_dict(raw)
+            assert settings.enabled is False
+            assert settings.allow_read == []
+            assert settings.allow_write == []
+
+    def test_enabled_coercion_variants(self):
+        assert SandboxSettings.from_dict({"enabled": True}).enabled is True
+        assert SandboxSettings.from_dict({"enabled": "true"}).enabled is True
+        assert SandboxSettings.from_dict({"enabled": "ON"}).enabled is True
+        assert SandboxSettings.from_dict({"enabled": 1}).enabled is True
+        assert SandboxSettings.from_dict({"enabled": "false"}).enabled is False
+        assert SandboxSettings.from_dict({"enabled": 0}).enabled is False
+        # Unparseable values fall back to the default (False).
+        assert SandboxSettings.from_dict({"enabled": "maybe"}).enabled is False
+        assert SandboxSettings.from_dict({"enabled": None}).enabled is False
+
+    def test_path_lists_filter_invalid_entries(self):
+        settings = SandboxSettings.from_dict(
+            {
+                "allow_read": ["/a", "", 42, None, "/b"],
+                "allow_write": "/single",
+            }
+        )
+        assert settings.allow_read == ["/a", "/b"]
+        assert settings.allow_write == ["/single"]
+
+    def test_non_list_path_values_yield_empty(self):
+        settings = SandboxSettings.from_dict({"allow_read": {"dir": "/a"}, "allow_write": 3})
+        assert settings.allow_read == []
+        assert settings.allow_write == []
+
+
+class TestBuildPolicy:
+    def test_workspace_and_tmp_in_writable(self, workspace):
+        policy = build_policy(SandboxSettings(), workspace)
+        assert str(workspace.resolve()) in policy.writable_roots
+        assert os.path.realpath("/tmp") in policy.writable_roots
+        assert policy.cwd == os.path.realpath(str(workspace))
+
+    def test_symlinks_resolved_to_realpath(self, tmp_path, workspace):
+        real_dir = tmp_path / "real_target"
+        real_dir.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real_dir)
+        policy = build_policy(SandboxSettings(allow_write=[str(link)]), workspace)
+        assert str(real_dir.resolve()) in policy.writable_roots
+        assert str(link) not in policy.writable_roots
+
+    def test_missing_dirs_filtered_out(self, tmp_path, workspace):
+        missing = tmp_path / "does_not_exist"
+        policy = build_policy(
+            SandboxSettings(allow_read=[str(missing)], allow_write=[str(missing)]),
+            workspace,
+            dynamic_write_dirs=[missing],
+        )
+        assert str(missing) not in policy.writable_roots
+        assert str(missing) not in policy.readable_roots
+
+    def test_dynamic_write_dirs_and_extra_read_dirs_merged(self, tmp_path, workspace):
+        output_dir = tmp_path / "session_out"
+        output_dir.mkdir()
+        datus_home = tmp_path / "datus_home"
+        datus_home.mkdir()
+        policy = build_policy(
+            SandboxSettings(),
+            workspace,
+            dynamic_write_dirs=[output_dir],
+            extra_read_dirs=[str(datus_home)],
+        )
+        assert str(output_dir.resolve()) in policy.writable_roots
+        assert str(datus_home.resolve()) in policy.readable_roots
+
+    def test_readable_excludes_writable_duplicates(self, tmp_path, workspace):
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        policy = build_policy(
+            SandboxSettings(allow_read=[str(shared)], allow_write=[str(shared)]),
+            workspace,
+        )
+        assert str(shared.resolve()) in policy.writable_roots
+        assert str(shared.resolve()) not in policy.readable_roots
+
+    def test_duplicates_deduped_preserving_order(self, workspace):
+        policy = build_policy(
+            SandboxSettings(allow_write=[str(workspace), str(workspace)]),
+            workspace,
+        )
+        assert policy.writable_roots.count(str(workspace.resolve())) == 1
+        assert policy.writable_roots[0] == str(workspace.resolve())
+
+    def test_tilde_expansion(self, tmp_path, workspace, monkeypatch):
+        home = tmp_path / "home"
+        (home / "extra").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        policy = build_policy(SandboxSettings(allow_read=["~/extra"]), workspace)
+        assert str((home / "extra").resolve()) in policy.readable_roots
+
+    def test_python_prefixes_readable(self, workspace):
+        policy = build_policy(SandboxSettings(), workspace)
+        combined = set(policy.readable_roots) | set(policy.writable_roots)
+        assert os.path.realpath(sys.prefix) in combined
+        assert os.path.realpath(sys.base_prefix) in combined
+
+
+class TestSeatbeltProfile:
+    def test_profile_structure(self, workspace):
+        profile = build_seatbelt_profile(make_policy(workspace))
+        assert profile.startswith("(version 1)\n(allow default)\n")
+        assert "(deny file-write*" in profile
+        assert "(deny file-read-data" in profile
+        # Regression guard: denying file-read* would also deny metadata and
+        # break stat/PATH lookup/dyld everywhere.
+        assert "(deny file-read*" not in profile
+
+    def test_writable_roots_exempted_from_both_denies(self, workspace):
+        profile = build_seatbelt_profile(make_policy(workspace))
+        assert profile.count(f'(subpath "{workspace}")') == 2
+
+    def test_readable_roots_only_in_read_deny(self, tmp_path, workspace):
+        readable = tmp_path / "readonly_root"
+        readable.mkdir()
+        profile = build_seatbelt_profile(make_policy(workspace, readable=[str(readable)]))
+        assert profile.count(f'(subpath "{readable}")') == 1
+        write_block = profile.split("(deny file-read-data")[0]
+        assert str(readable) not in write_block
+
+    def test_system_roots_and_devices_present(self, workspace):
+        profile = build_seatbelt_profile(make_policy(workspace))
+        for root in ("/usr", "/bin", "/System", "/Library", "/private/etc"):
+            assert f'(subpath "{root}")' in profile
+        assert '(literal "/dev/null")' in profile
+        assert '(literal "/dev/urandom")' in profile
+        assert '(subpath "/dev/fd")' in profile
+
+    def test_root_dir_data_stays_readable(self, workspace):
+        # Regression guard: dyld reads the ``/`` directory itself during
+        # cryptex resolution at process start; without this literal every
+        # sandboxed process dies with SIGABRT before main().
+        profile = build_seatbelt_profile(make_policy(workspace))
+        read_block = profile.split("(deny file-read-data")[1]
+        assert '(literal "/")' in read_block
+
+    def test_path_quoting_escapes_special_chars(self, tmp_path):
+        weird = tmp_path / 'dir with "quotes"'
+        weird.mkdir()
+        policy = make_policy(weird)
+        profile = build_seatbelt_profile(policy)
+        assert '\\"quotes\\"' in profile
+
+    def test_backslash_escaped(self):
+        assert bash_sandbox._sb_quote("a\\b") == '"a\\\\b"'
+
+
+class TestBwrapPrefix:
+    @pytest.fixture(autouse=True)
+    def fake_bwrap(self, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "_find_bwrap", lambda: "/usr/bin/bwrap")
+        # Deterministic system-dir layout regardless of the host OS.
+        monkeypatch.setattr(
+            bash_sandbox,
+            "_mount_args_for_system_dir",
+            lambda p: ["--ro-bind", p, p] if p in ("/usr", "/etc") else [],
+        )
+
+    def test_basic_structure(self, workspace):
+        args = build_bwrap_prefix(make_policy(workspace))
+        assert args[0] == "/usr/bin/bwrap"
+        assert "--die-with-parent" in args
+        assert "--unshare-net" not in args
+        assert ["--proc", "/proc"] == args[args.index("--proc") : args.index("--proc") + 2]
+        assert ["--dev", "/dev"] == args[args.index("--dev") : args.index("--dev") + 2]
+        assert args[-2:] == ["--chdir", str(workspace)]
+
+    def test_tmpfs_for_tmp_dirs(self, workspace):
+        args = build_bwrap_prefix(make_policy(workspace))
+        tmpfs_targets = [args[i + 1] for i, a in enumerate(args) if a == "--tmpfs"]
+        assert tmpfs_targets == ["/tmp", "/var/tmp"]
+
+    def test_writable_tmp_roots_skipped(self, workspace):
+        args = build_bwrap_prefix(make_policy(workspace, writable_extra=("/tmp", "/var/tmp")))
+        bind_targets = [args[i + 1] for i, a in enumerate(args) if a == "--bind"]
+        assert bind_targets == [str(workspace)]
+
+    def test_readonly_binds_before_writable_binds(self, tmp_path, workspace):
+        readable = tmp_path / "ro_root"
+        readable.mkdir()
+        args = build_bwrap_prefix(make_policy(workspace, readable=[str(readable)]))
+        joined = " ".join(args)
+        ro_pair = f"--ro-bind {readable} {readable}"
+        rw_pair = f"--bind {workspace} {workspace}"
+        assert ro_pair in joined
+        assert rw_pair in joined
+        assert joined.index(ro_pair) < joined.index(rw_pair)
+
+    def test_workspace_under_tmp_still_bound(self, workspace):
+        nested = "/tmp/pytest-of-user/ws"
+        policy = SandboxPolicy(cwd=nested, writable_roots=(nested,), readable_roots=())
+        args = build_bwrap_prefix(policy)
+        tmpfs_pos = args.index("--tmpfs")
+        bind_pos = args.index("--bind")
+        assert tmpfs_pos < bind_pos
+        assert args[bind_pos + 1 : bind_pos + 3] == [nested, nested]
+
+    def test_missing_bwrap_raises(self, workspace, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "_find_bwrap", lambda: None)
+        with pytest.raises(SandboxUnavailableError):
+            build_bwrap_prefix(make_policy(workspace))
+
+
+class TestMountArgsForSystemDir:
+    def test_symlink_becomes_symlink_arg(self, tmp_path):
+        target = tmp_path / "usr_bin"
+        target.mkdir()
+        link = tmp_path / "bin"
+        link.symlink_to("usr_bin")
+        assert bash_sandbox._mount_args_for_system_dir(str(link)) == ["--symlink", "usr_bin", str(link)]
+
+    def test_real_dir_becomes_ro_bind(self, tmp_path):
+        real = tmp_path / "usr"
+        real.mkdir()
+        assert bash_sandbox._mount_args_for_system_dir(str(real)) == ["--ro-bind", str(real), str(real)]
+
+    def test_missing_path_yields_nothing(self, tmp_path):
+        assert bash_sandbox._mount_args_for_system_dir(str(tmp_path / "nope")) == []
+
+
+class TestDetectMechanism:
+    def test_darwin_with_working_sandbox_exec(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(bash_sandbox, "_find_sandbox_exec", lambda: "/usr/bin/sandbox-exec")
+        monkeypatch.setattr(bash_sandbox, "_probe", lambda argv: True)
+        assert bash_sandbox.detect_mechanism() == MECHANISM_SEATBELT
+        assert bash_sandbox.is_available() is True
+
+    def test_darwin_probe_failure(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(bash_sandbox, "_find_sandbox_exec", lambda: "/usr/bin/sandbox-exec")
+        monkeypatch.setattr(bash_sandbox, "_probe", lambda argv: False)
+        assert bash_sandbox.detect_mechanism() is None
+
+    def test_darwin_missing_sandbox_exec(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setattr(bash_sandbox, "_find_sandbox_exec", lambda: None)
+        monkeypatch.setattr(bash_sandbox, "_probe", lambda argv: True)
+        assert bash_sandbox.detect_mechanism() is None
+
+    def test_linux_with_working_bwrap(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(bash_sandbox, "_find_bwrap", lambda: "/usr/bin/bwrap")
+        monkeypatch.setattr(bash_sandbox, "_probe", lambda argv: True)
+        assert bash_sandbox.detect_mechanism() == MECHANISM_BWRAP
+
+    def test_linux_bwrap_probe_failure(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(bash_sandbox, "_find_bwrap", lambda: "/usr/bin/bwrap")
+        monkeypatch.setattr(bash_sandbox, "_probe", lambda argv: False)
+        assert bash_sandbox.detect_mechanism() is None
+
+    def test_windows_unsupported(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert bash_sandbox.detect_mechanism() is None
+        assert bash_sandbox.is_available() is False
+
+    def test_result_cached_across_calls(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        calls = []
+
+        def probe(argv):
+            calls.append(argv)
+            return True
+
+        monkeypatch.setattr(bash_sandbox, "_find_bwrap", lambda: "/usr/bin/bwrap")
+        monkeypatch.setattr(bash_sandbox, "_probe", probe)
+        assert bash_sandbox.detect_mechanism() == MECHANISM_BWRAP
+        assert bash_sandbox.detect_mechanism() == MECHANISM_BWRAP
+        assert len(calls) == 1
+
+    def test_unavailable_reason_mentions_platform_tool(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert "sandbox-exec" in bash_sandbox.unavailable_reason()
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert "bwrap" in bash_sandbox.unavailable_reason()
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert "win32" in bash_sandbox.unavailable_reason()
+
+
+class TestWrapArgv:
+    def test_seatbelt_wrapping(self, workspace, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "detect_mechanism", lambda: MECHANISM_SEATBELT)
+        monkeypatch.setattr(bash_sandbox, "_find_sandbox_exec", lambda: "/usr/bin/sandbox-exec")
+        argv = ["/bin/bash", "-c", "echo hi"]
+        wrapped = wrap_argv(argv, make_policy(workspace))
+        assert wrapped[0] == "/usr/bin/sandbox-exec"
+        assert wrapped[1] == "-p"
+        assert "(deny file-write*" in wrapped[2]
+        assert wrapped[3:] == argv
+
+    def test_bwrap_wrapping(self, workspace, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "detect_mechanism", lambda: MECHANISM_BWRAP)
+        monkeypatch.setattr(bash_sandbox, "_find_bwrap", lambda: "/usr/bin/bwrap")
+        monkeypatch.setattr(bash_sandbox, "_mount_args_for_system_dir", lambda p: [])
+        argv = ["/bin/bash", "-c", "echo hi"]
+        wrapped = wrap_argv(argv, make_policy(workspace))
+        assert wrapped[0] == "/usr/bin/bwrap"
+        assert wrapped[-3:] == argv
+
+    def test_unavailable_raises(self, workspace, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "detect_mechanism", lambda: None)
+        with pytest.raises(SandboxUnavailableError):
+            wrap_argv(["/bin/bash", "-c", "true"], make_policy(workspace))
+
+
+class TestPolicyImmutability:
+    def test_policy_is_frozen(self, workspace):
+        policy = make_policy(workspace)
+        with pytest.raises(AttributeError):
+            policy.cwd = "/elsewhere"

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -11,9 +11,11 @@ whether the tool is exposed.
 """
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
+from datus.tools.func_tool import bash_sandbox
 from datus.tools.func_tool.bash_tool import BashTool
 
 
@@ -637,3 +639,114 @@ class TestRestrictedWhitelistHardening:
     def test_unrestricted_description_has_no_restriction_note(self, unrestricted_tool):
         tool = unrestricted_tool.available_tools()[0]
         assert "Restricted mode" not in tool.description
+
+
+class TestBashToolSandbox:
+    """Wiring between BashTool and the OS sandbox (no real sandbox spawned)."""
+
+    @pytest.fixture
+    def enabled_settings(self):
+        return bash_sandbox.SandboxSettings(enabled=True)
+
+    def test_fail_closed_when_mechanism_unavailable(self, temp_workspace, enabled_settings, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "is_available", lambda: False)
+        popen_spy = MagicMock()
+        monkeypatch.setattr("datus.tools.func_tool.bash_tool.subprocess.Popen", popen_spy)
+        tool = BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=enabled_settings,
+        )
+        result = tool.bash("echo hi")
+        assert result.success == 0
+        assert "NOT executed" in result.error
+        popen_spy.assert_not_called()
+
+    def test_wraps_argv_when_enabled(self, temp_workspace, enabled_settings, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "is_available", lambda: True)
+        captured = {}
+
+        def fake_wrap(argv, policy):
+            captured["argv"] = argv
+            captured["policy"] = policy
+            return argv
+
+        monkeypatch.setattr(bash_sandbox, "wrap_argv", fake_wrap)
+        tool = BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=enabled_settings,
+            sandbox_read_dirs=[str(temp_workspace / "scripts")],
+        )
+        result = tool.bash("echo sandboxed")
+        assert result.success == 1
+        assert "sandboxed" in result.result
+        assert captured["argv"][0].endswith("bash")
+        assert str(temp_workspace.resolve()) in captured["policy"].writable_roots
+        assert str((temp_workspace / "scripts").resolve()) in captured["policy"].readable_roots
+
+    def test_no_settings_never_touches_sandbox(self, temp_workspace, monkeypatch):
+        wrap_spy = MagicMock(side_effect=AssertionError("wrap_argv must not be called"))
+        availability_spy = MagicMock(side_effect=AssertionError("is_available must not be called"))
+        monkeypatch.setattr(bash_sandbox, "wrap_argv", wrap_spy)
+        monkeypatch.setattr(bash_sandbox, "is_available", availability_spy)
+        tool = BashTool(workspace_root=str(temp_workspace), allowed_patterns=["*"])
+        result = tool.bash("echo plain")
+        assert result.success == 1
+        assert "plain" in result.result
+
+    def test_disabled_settings_skip_wrapping(self, temp_workspace, monkeypatch):
+        wrap_spy = MagicMock(side_effect=AssertionError("wrap_argv must not be called"))
+        monkeypatch.setattr(bash_sandbox, "wrap_argv", wrap_spy)
+        tool = BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=bash_sandbox.SandboxSettings(enabled=False),
+        )
+        result = tool.bash("echo off")
+        assert result.success == 1
+        assert "off" in result.result
+
+    def test_runtime_toggle_takes_effect_next_call(self, temp_workspace, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "is_available", lambda: True)
+        calls = []
+
+        def fake_wrap(argv, policy):
+            calls.append(argv)
+            return argv
+
+        monkeypatch.setattr(bash_sandbox, "wrap_argv", fake_wrap)
+        shared = bash_sandbox.SandboxSettings(enabled=False)
+        tool = BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=shared,
+        )
+        assert tool.bash("echo one").success == 1
+        assert calls == []
+        shared.enabled = True  # what /sandbox on does to the shared object
+        assert tool.bash("echo two").success == 1
+        assert len(calls) == 1
+        shared.enabled = False
+        assert tool.bash("echo three").success == 1
+        assert len(calls) == 1
+
+    def test_wrap_failure_returns_error_without_execution(self, temp_workspace, enabled_settings, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "is_available", lambda: True)
+
+        def raise_unavailable(argv, policy):
+            raise bash_sandbox.SandboxUnavailableError("gone mid-flight")
+
+        monkeypatch.setattr(bash_sandbox, "wrap_argv", raise_unavailable)
+        popen_spy = MagicMock()
+        monkeypatch.setattr("datus.tools.func_tool.bash_tool.subprocess.Popen", popen_spy)
+        tool = BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=enabled_settings,
+        )
+        result = tool.bash("echo hi")
+        assert result.success == 0
+        assert "NOT executed" in result.error
+        assert "gone mid-flight" in result.error
+        popen_spy.assert_not_called()

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -750,3 +750,62 @@ class TestBashToolSandbox:
         assert "NOT executed" in result.error
         assert "gone mid-flight" in result.error
         popen_spy.assert_not_called()
+
+
+class TestBashToolStrictEnv:
+    """Strict mode minimizes the child environment (no real sandbox spawned:
+    wrap_argv is stubbed to identity so only the env contract is exercised)."""
+
+    @pytest.fixture(autouse=True)
+    def sandbox_pass_through(self, monkeypatch):
+        monkeypatch.setattr(bash_sandbox, "is_available", lambda: True)
+        monkeypatch.setattr(bash_sandbox, "wrap_argv", lambda argv, policy: argv)
+
+    def _tool(self, workspace, mode, extra_env=None):
+        return BashTool(
+            workspace_root=str(workspace),
+            allowed_patterns=["*"],
+            extra_env=extra_env,
+            sandbox_settings=bash_sandbox.SandboxSettings(enabled=True, mode=mode),
+        )
+
+    def test_strict_hides_process_secrets(self, temp_workspace, monkeypatch):
+        monkeypatch.setenv("DATUS_TEST_SECRET", "sk-leak-me")
+        tool = self._tool(temp_workspace, bash_sandbox.MODE_STRICT)
+        result = tool.bash('echo "[${DATUS_TEST_SECRET:-absent}]"')
+        assert result.success == 1
+        assert "[absent]" in result.result
+        assert "sk-leak-me" not in result.result
+
+    def test_normal_mode_keeps_process_env(self, temp_workspace, monkeypatch):
+        monkeypatch.setenv("DATUS_TEST_SECRET", "sk-visible")
+        tool = self._tool(temp_workspace, bash_sandbox.MODE_NORMAL)
+        result = tool.bash('echo "[${DATUS_TEST_SECRET:-absent}]"')
+        assert result.success == 1
+        assert "[sk-visible]" in result.result
+
+    def test_strict_keeps_baseline_vars(self, temp_workspace):
+        tool = self._tool(temp_workspace, bash_sandbox.MODE_STRICT)
+        result = tool.bash('echo "path=${PATH:+set} home=${HOME:+set}"')
+        assert result.success == 1
+        assert "path=set" in result.result
+        assert "home=set" in result.result
+
+    def test_strict_still_applies_extra_env(self, temp_workspace):
+        tool = self._tool(temp_workspace, bash_sandbox.MODE_STRICT, extra_env={"SKILL_NAME": "demo"})
+        result = tool.bash('echo "skill=${SKILL_NAME:-absent}"')
+        assert result.success == 1
+        assert "skill=demo" in result.result
+
+    def test_sandbox_off_ignores_strict_mode_for_env(self, temp_workspace, monkeypatch):
+        # mode=strict with enabled=False must not change behavior — the env
+        # contract is tied to the sandbox being active.
+        monkeypatch.setenv("DATUS_TEST_SECRET", "sk-still-here")
+        tool = BashTool(
+            workspace_root=str(temp_workspace),
+            allowed_patterns=["*"],
+            sandbox_settings=bash_sandbox.SandboxSettings(enabled=False, mode=bash_sandbox.MODE_STRICT),
+        )
+        result = tool.bash('echo "[${DATUS_TEST_SECRET:-absent}]"')
+        assert result.success == 1
+        assert "[sk-still-here]" in result.result


### PR DESCRIPTION
## Why

The general-purpose bash tool only had a fixed cwd and a command-pattern
whitelist. A command could still use absolute paths or `cd` to read/write
anywhere on the host, inherited the full process environment (LLM API keys,
DB passwords), and had unrestricted network. That is acceptable for a trusted
local CLI but unsafe for hardened or **multi-tenant `datus-api`** deployments,
where each tenant's `AgentConfig` carries its own `project_root` and must be
confined to it — nothing outside the project path, including `~/.datus`,
should be readable or writable.

## Solution

Two commits, opt-in and **off by default** (zero behavior change for existing
deployments; the permission layer `PermissionHooks`/`bash_rules` is untouched —
the sandbox is a second, kernel-level line of defense at the execution layer).

**1. Lightweight OS-level sandbox.** Wrap every bash command in a
kernel-enforced sandbox — macOS `sandbox-exec` (generated Seatbelt profile) /
Linux `bubblewrap`. Writes are limited to the workspace + session data dir +
tmp; reads to system dirs + the same allowlist. Fail-closed when no mechanism
is available (Windows, Linux without `bwrap`). New stdlib-only module
`datus/tools/func_tool/bash_sandbox.py`. Toggle via `agent.bash.sandbox`, the
project-level `.datus/config.yml` `sandbox:` key, or the new `/sandbox` slash
command (`on`/`off`, `--project`/`--global` persistence).

**2. Strict multi-tenant tier.** `mode: strict` drops the caller-injected
datus-home read root and session-dir write root, so file access shrinks to the
tenant workspace + tmp + explicit `allow_read`/`allow_write` only (`~/.datus`
fully blocked). Strict also minimizes the child environment to a small
allowlist (`PATH`/`HOME`/`LANG`/`LC_*`/… + explicit `extra_env`), keeping
process-wide secrets out of sandboxed commands — something the OS file sandbox
cannot do on its own. An orthogonal `deny_network` cuts network via bwrap
`--unshare-net` / Seatbelt `(deny network*)`. Configurable via
`agent.bash.sandbox.{mode,deny_network}`, project `sandbox: strict|normal`, and
`/sandbox strict|normal`.

Key decisions:
- `SandboxSettings` is a shared mutable object, so `/sandbox` toggles take
  effect on the next command without rebuilding the tool.
- Seatbelt uses `(allow default)` + targeted denies, denying only
  `file-read-data` (not `file-read*`) so metadata / PATH lookup / dyld keep
  working; `(literal "/")` is exempted because dyld reads `/` at process start
  (otherwise every sandboxed process aborts).
- Multi-tenant callers pair strict mode with `filesystem_strict` (filesystem
  tools bypass the bash sandbox) for a full boundary; documented in
  `conf/agent.yml.example`.

## Test Cases

- **Integration (deterministic, no real LLM):**
  `tests/integration/tools/test_bash_sandbox_execution.py` spawns the real
  mechanism (skipif when unavailable) and verifies kernel-enforced guarantees:
  out-of-allowlist writes/reads fail, `cd /` escape fails, system reads
  succeed, the python shim runs, pipelines work, **strict mode ignores the
  injected read dir**, **strict hides an env secret under the real sandbox**,
  and **`deny_network` blocks a real loopback TCP connect** while it succeeds
  by default. `/sandbox` dispatch added to
  `tests/integration/cli/test_cli_commands.py`. Verified locally on macOS under
  real `sandbox-exec` (17 passing).
- **Unit:** `tests/unit_tests/tools/func_tool/test_bash_sandbox.py`
  (policy/Seatbelt-profile/bwrap-argv generation, strict filtering, env
  minimization, deny_network, mechanism detection) and additions to
  `test_bash_tool.py` (fail-closed, wrap wiring, strict env). Config parsing in
  `test_agent_config.py` / `test_project_config.py` / `test_agent_config_loader.py`.
  CLI in `test_sandbox_commands.py` (+ slash-registry completeness).
- PR harness: diff coverage 97%, `audit_tests` P0=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added an OS-level sandbox for Bash commands, with configurable read/write access, network restrictions, and normal or strict modes.
  * Added the `/sandbox` command to view status, toggle sandboxing, change modes, and save project or global settings.
  * Added project-level sandbox configuration support.

* **Documentation**
  * Documented sandbox commands, configuration options, platform support, and fail-closed behavior.

* **Bug Fixes**
  * Bash commands are rejected safely when sandboxing is enabled but unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OS-level bash sandbox with **normal/strict** modes, filesystem read/write allowlists, and optional **network blocking**.
  * Added a **`/sandbox`** REPL/CLI command for status, session on/off, mode selection, and persistence to **project** (`./.datus/config.yml`) or **global** config.
  * Added **project-level sandbox overrides** and documented new sandbox configuration keys in the example config.
* **Documentation**
  * Updated CLI reference (including platform behavior and fail-closed expectations).
* **Bug Fixes**
  * Improved safety when sandboxing is enabled but unavailable (commands are rejected).
  * Hardened web-submitted bash by allowing all commands only when running under **strict** OS sandboxing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->