### PR TITLE
[BugFix] Exclude internal execute_sql dispatch methods from the db_tools catalog

### DIFF
--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -858,16 +858,34 @@ class DBFuncTool:
                 out_of_scope.append(name)
         return out_of_scope
 
+    # Public methods that belong to the tool-plumbing framework rather than the
+    # agent-facing tool surface. ``to_function_tool`` converts a bound method into
+    # a Tool; ``available_tools`` assembles the runtime list. Neither is a tool
+    # itself. Mirrors ``FilesystemFuncTool._BASE_TOOL_FRAMEWORK_METHODS``.
+    _FRAMEWORK_METHODS: frozenset = frozenset({"available_tools", "to_function_tool"})
+
+    # Internal statement-dispatch targets of the unified ``execute_sql`` entry
+    # point. ``execute_sql`` detects the statement type and routes to these by
+    # hand (SELECT -> read_query, DML -> execute_write, DDL/other -> execute_ddl),
+    # so they are never @mcp_tool()-decorated and never mounted as tools. They
+    # stay public because callers across modules (semantic_discovery_tools,
+    # reference_template_tools) and the connectors share the vocabulary, but they
+    # must not leak into the agent tool surface (VALID_TOOL_METHODS / the saas
+    # editor catalog) or the permission registry.
+    _INTERNAL_SQL_METHODS: frozenset = frozenset({"read_query", "execute_write", "execute_ddl", "get_table_ddl"})
+
     @staticmethod
     def all_tools_name() -> List[str]:
+        # Agent-facing tool surface: every public tool method, including the ones
+        # gen_job mounts directly (``transfer_query_result``, migration wrappers)
+        # that never carry an @mcp_tool() decorator. Framework plumbing and the
+        # internal execute_sql dispatch helpers are filtered out. Feeds both
+        # VALID_TOOL_METHODS and the permission registry
+        # (AgenticNode._populate_tool_registry).
         from datus.utils.class_utils import get_public_instance_methods
 
-        result = []
-        for name in get_public_instance_methods(DBFuncTool).keys():
-            if name == "available_tools":
-                continue
-            result.append(name)
-        return result
+        excluded = DBFuncTool._FRAMEWORK_METHODS | DBFuncTool._INTERNAL_SQL_METHODS
+        return [name for name in get_public_instance_methods(DBFuncTool).keys() if name not in excluded]
 
     @staticmethod
     def _dialect_name(value: Any) -> str:

--- a/tests/integration/tools/test_func_tools_db.py
+++ b/tests/integration/tools/test_func_tools_db.py
@@ -418,3 +418,79 @@ class TestSearchTable:
             assert "search_table" in tool_names, "search_table should be available when schema RAG exists"
         else:
             assert "search_table" not in tool_names, "search_table should not be available without schema RAG"
+
+
+@pytest.mark.acceptance
+class TestAllToolsNameContract:
+    """all_tools_name() is the agent-facing tool surface, minus non-tool methods.
+
+    It feeds two consumers: VALID_TOOL_METHODS (datus/api/services/agent_service.py,
+    the saas editor catalog returned by GET /agent/use_tools) and the permission
+    registry (AgenticNode._populate_tool_registry). Two kinds of public methods
+    must never leak into it: framework plumbing (``to_function_tool``) and the
+    internal statement-dispatch helpers of the unified ``execute_sql`` entry point
+    (``read_query`` / ``execute_write`` / ``execute_ddl`` / ``get_table_ddl``),
+    which are never decorated and never mounted as tools.
+    """
+
+    def test_all_tools_name_includes_decorated_tools(self):
+        """Every @mcp_tool()-decorated method is part of the surface."""
+        from datus.utils.mcp_decorators import get_mcp_tools
+
+        names = DBFuncTool.all_tools_name()
+
+        assert len(names) == len(set(names)), "no duplicate tool names"
+        decorated = {name for name, _, _ in get_mcp_tools(DBFuncTool)}
+        assert decorated == {
+            "search_table",
+            "list_databases",
+            "list_schemas",
+            "list_tables",
+            "describe_table",
+            "execute_sql",
+        }
+        assert decorated.issubset(set(names))
+
+    def test_all_tools_name_includes_directly_mounted_tools(self):
+        """Tools gen_job mounts directly (no decorator) stay in the surface so the
+        permission registry can classify them under db_tools — dropping them would
+        silently disable the ASK gate on ``transfer_query_result``."""
+        names = set(DBFuncTool.all_tools_name())
+
+        for tool in ("transfer_query_result", "get_migration_capabilities", "suggest_table_layout", "validate_ddl"):
+            assert tool in names, f"{tool} is mounted directly by gen_job and must stay classified"
+
+    def test_all_tools_name_excludes_non_tool_methods(self):
+        """Framework plumbing and internal execute_sql dispatch helpers are not
+        tools and must not appear in the surface (they leak into the saas editor
+        catalog otherwise)."""
+        names = set(DBFuncTool.all_tools_name())
+
+        for method in (
+            "to_function_tool",
+            "available_tools",
+            "read_query",
+            "execute_write",
+            "execute_ddl",
+            "get_table_ddl",
+        ):
+            assert hasattr(DBFuncTool, method), f"{method} should still exist as a method"
+            assert method not in names, f"{method} is not an agent tool and must be excluded"
+
+    def test_all_tools_name_is_exactly_the_real_tool_surface(self):
+        """The full db_tools surface is exactly the decorated tools plus the
+        gen_job-mounted tools — no more, no less. Pins the saas editor catalog."""
+        assert set(DBFuncTool.all_tools_name()) == {
+            # @mcp_tool()-decorated
+            "search_table",
+            "list_databases",
+            "list_schemas",
+            "list_tables",
+            "describe_table",
+            "execute_sql",
+            # mounted directly by gen_job
+            "transfer_query_result",
+            "get_migration_capabilities",
+            "suggest_table_layout",
+            "validate_ddl",
+        }

--- a/tests/unit_tests/agent/node/test_tool_category_maps.py
+++ b/tests/unit_tests/agent/node/test_tool_category_maps.py
@@ -201,7 +201,11 @@ class TestPopulateToolRegistry:
 
     def test_real_classes_register_via_class_level_introspection(self):
         """End-to-end over real classes: ``all_tools_name()`` is class-level
-        on the core tools, so bare instances classify their full surface."""
+        on the core tools, so bare instances classify their full surface —
+        both @mcp_tool()-decorated tools (``execute_sql``) and the tools gen_job
+        mounts directly (``transfer_query_result``). The internal execute_sql
+        dispatch helpers (read_query / execute_write / execute_ddl) are not tools
+        and are intentionally excluded from the surface."""
         from datus.tools.func_tool.database import DBFuncTool
         from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 
@@ -211,9 +215,13 @@ class TestPopulateToolRegistry:
 
         node._populate_tool_registry()
         registry = node.tool_registry.to_dict()
-        assert registry["read_query"] == "db_tools"
-        assert registry["execute_ddl"] == "db_tools"
-        assert registry["execute_write"] == "db_tools"
+        assert registry["execute_sql"] == "db_tools"
+        assert registry["describe_table"] == "db_tools"
+        assert registry["transfer_query_result"] == "db_tools"
+        # Internal execute_sql dispatch helpers are never mounted as tools, so
+        # they must not appear in the permission registry.
+        assert "read_query" not in registry
+        assert "execute_write" not in registry
         assert registry["read_file"] == "filesystem_tools"
         assert registry["write_file"] == "filesystem_tools"
         assert registry["delete_file"] == "filesystem_tools"

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -178,7 +178,7 @@ class TestValidateToolsForAgentType:
 
     def test_ask_metrics_allows_valid_tools_outside_default_surface(self):
         tools = [
-            "db_tools.read_query",
+            "db_tools.execute_sql",
             "date_parsing_tools.parse_temporal_expressions",
             "semantic_tools.validate_semantic",
             "semantic_tools.*",
@@ -426,7 +426,7 @@ class TestGetUseTools:
         assert result.success is True
         assert result.data["default_tools"] == SUBAGENT_TOOL_REFERENCE["ask_metrics"]["default_tools"]
         assert set(result.data["tool_types"].keys()) == set(_USER_FACING_TOOL_CATEGORIES)
-        assert "read_query" in result.data["tool_types"]["db_tools"]["tools"]
+        assert "execute_sql" in result.data["tool_types"]["db_tools"]["tools"]
         assert "parse_temporal_expressions" in result.data["tool_types"]["date_parsing_tools"]["tools"]
         assert result.data["tool_types"] == SUBAGENT_TOOL_REFERENCE["ask_metrics"]["tool_types"]
 


### PR DESCRIPTION


The GET /agent/use_tools API returned read_query / execute_write / execute_ddl / get_table_ddl in tool_types["db_tools"]["tools"], so the saas editor surfaced them as selectable tools. They are internal statement-dispatch targets of the unified execute_sql entry point — never @mcp_tool()-decorated and never mounted as tools — so they must not appear in the tool catalog or the permission registry. The framework helper to_function_tool leaked the same way.

Filter both via _FRAMEWORK_METHODS and _INTERNAL_SQL_METHODS on DBFuncTool so all_tools_name() returns exactly the real tool surface (6 decorated tools plus the 4 tools gen_job mounts directly). db_tools catalog shrinks 14 -> 10.

<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database tool discovery so public tools are listed accurately.
  * Excluded internal framework and SQL dispatch helpers from available tool listings and permission registries.
  * Updated metrics-related tool selection to use `execute_sql` instead of `read_query`.

* **Tests**
  * Added coverage to verify complete, unique, and correctly filtered database tool surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->