### PR TITLE
[BugFix] Guard artifact query execution from runaway SQL that OOMs the DB

### DIFF
--- a/datus/api/services/dashboard_service.py
+++ b/datus/api/services/dashboard_service.py
@@ -509,7 +509,16 @@ class DashboardService:
             )
 
         try:
-            exec_result = await asyncio.to_thread(connector.execute_query, rendered_sql, result_format="list")
+            # Enforced-read path (SQL policy + multi-statement rejection). View-time
+            # re-execution runs with live user params on every dashboard open, so an
+            # unbounded rendered statement here is the highest-blast-radius surface.
+            exec_result = await asyncio.to_thread(
+                db_tool.execute_read_enforced,
+                rendered_sql,
+                connector,
+                datasource=meta.datasource or "",
+                result_format="list",
+            )
         except Exception as exc:
             logger.exception("Query execution crashed for %s/%s: %s", dashboard_slug, query_slug, exc)
             return Result(

--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -887,8 +887,19 @@ class DashboardArtifactTools:
 
         ds_label = datasource or getattr(self._db_func_tool, "_default_datasource", "") or "default"
 
+        # Pre-flight EXPLAIN row-count guard on the trial-rendered SQL: reject a
+        # runaway template (e.g. a cross-join cartesian product) from its
+        # optimizer estimate before it executes. Fail-open when unmeasurable.
+        oversize = self._db_func_tool.guard_estimated_rows(rendered_sql, connector)
+        if oversize is not None:
+            return oversize
+
         try:
-            execute_result = connector.execute_query(rendered_sql, result_format="list")
+            # Enforced-read path: apply SQL policy + multi-statement rejection
+            # to the trial render so a runaway template can't OOM the engine.
+            execute_result = self._db_func_tool.execute_read_enforced(
+                rendered_sql, connector, datasource=datasource, result_format="list"
+            )
         except Exception as exc:
             logger.exception("save_query_template trial execute crashed", extra={"name": name})
             return FuncToolResult(success=0, error=f"Trial query execution failed: {exc}")

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -18,6 +18,7 @@ from datus_db_core import BaseSqlConnector, connector_registry
 
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.agent_models import SubAgentConfig
+from datus.schemas.node_models import ExecuteSQLResult
 from datus.storage.kb_retrieval import metadata_fts_enabled
 from datus.storage.schema_metadata import create_metadata_rag
 from datus.storage.schema_metadata.store import SchemaWithValueRAG
@@ -872,7 +873,16 @@ class DBFuncTool:
     # reference_template_tools) and the connectors share the vocabulary, but they
     # must not leak into the agent tool surface (VALID_TOOL_METHODS / the saas
     # editor catalog) or the permission registry.
-    _INTERNAL_SQL_METHODS: frozenset = frozenset({"read_query", "execute_write", "execute_ddl", "get_table_ddl"})
+    _INTERNAL_SQL_METHODS: frozenset = frozenset(
+        {
+            "read_query",
+            "execute_read_enforced",
+            "guard_estimated_rows",
+            "execute_write",
+            "execute_ddl",
+            "get_table_ddl",
+        }
+    )
 
     @staticmethod
     def all_tools_name() -> List[str]:
@@ -1503,23 +1513,100 @@ class DBFuncTool:
                 return validation_error
 
             logger.info("read_query", sql_type=sql_type.value, datasource=datasource or "default")
-            effective_datasource = self._resolve_effective_datasource(datasource)
-            sql = self._enforce_sql_policy(
+            result_format = "arrow" if connector.dialect == "snowflake" else "list"
+            result = self.execute_read_enforced(
                 sql,
-                datasource=effective_datasource,
-                dialect=connector.dialect,
+                connector,
+                datasource=datasource,
+                result_format=result_format,
             )
-            validation_error, _ = self._validate_read_sql(sql, connector)
-            if validation_error:
-                return validation_error
-            result = connector.execute_query(sql, result_format="arrow" if connector.dialect == "snowflake" else "list")
             if result.success:
-                data = result.sql_return
-                return FuncToolResult(result=self.compressor.compress(data))
-            else:
-                return FuncToolResult(success=0, error=result.error)
+                return FuncToolResult(result=self.compressor.compress(result.sql_return))
+            return FuncToolResult(success=0, error=result.error)
         except Exception as e:
             return FuncToolResult(success=0, error=str(e))
+
+    def execute_read_enforced(
+        self,
+        sql: str,
+        connector: BaseSqlConnector,
+        *,
+        datasource: Optional[str] = "",
+        result_format: str = "list",
+    ) -> ExecuteSQLResult:
+        """Run a read-only query through the shared read guardrails.
+
+        Single enforcement path for every read that hits the DB directly: the
+        LLM ``read_query`` path plus the report/dashboard artifact save paths
+        and dashboard view-time re-execution. Rejects multi-statement input and
+        applies the configured SQL policy (row caps / rewrites / denials) before
+        the statement reaches the engine, then returns the connector's raw
+        ``ExecuteSQLResult`` so callers keep control over row post-processing.
+        Without this, artifact query execution bypassed ``_enforce_sql_policy``
+        and could hand the engine an unbounded statement (e.g. a cross-join
+        cartesian product that OOM-killed the DB backend).
+        """
+        validation_error, _ = self._validate_read_sql(sql, connector)
+        if validation_error:
+            return ExecuteSQLResult(success=False, error=validation_error.error, sql_query=sql)
+        effective_datasource = self._resolve_effective_datasource(datasource)
+        try:
+            enforced_sql = self._enforce_sql_policy(sql, datasource=effective_datasource, dialect=connector.dialect)
+        except DatusException as exc:
+            return ExecuteSQLResult(success=False, error=str(exc), sql_query=sql)
+        if enforced_sql != sql:
+            # A policy rewrite (e.g. an injected LIMIT) must still be a single
+            # read-only statement — re-validate so it can't smuggle in DML/DDL.
+            validation_error, _ = self._validate_read_sql(enforced_sql, connector)
+            if validation_error:
+                return ExecuteSQLResult(success=False, error=validation_error.error, sql_query=enforced_sql)
+        return connector.execute_query(enforced_sql, result_format=result_format)
+
+    def guard_estimated_rows(
+        self,
+        sql: str,
+        connector: BaseSqlConnector,
+    ) -> Optional[FuncToolResult]:
+        """Reject a query whose EXPLAIN row estimate exceeds ``MAX_ESTIMATED_ROWS``.
+
+        Runs ``EXPLAIN <sql>`` (planning only — the statement never executes),
+        parses the optimizer's cardinality estimate, and returns a failure
+        ``FuncToolResult`` (with an actionable rewrite message for the LLM) when
+        it blows past the ceiling. Returns ``None`` to let the query proceed.
+
+        Fail-open: EXPLAIN being unsupported / erroring / unparseable all yield
+        ``None`` — the guard only ever blocks on a *confident* oversize estimate,
+        never on its own inability to measure.
+        """
+        from datus.tools.sql_guard import MAX_ESTIMATED_ROWS, build_oversize_message, estimate_rows_from_explain
+
+        # Reject multi-statement / non-read input before it reaches the engine
+        # inside ``EXPLAIN <sql>``. Callers only prefix-check with
+        # ``_looks_like_select``, which passes ``SELECT 1; DROP TABLE t`` — and a
+        # driver that splits statements would run the DROP as part of the EXPLAIN.
+        validation_error, _ = self._validate_read_sql(sql, connector)
+        if validation_error:
+            return validation_error
+
+        try:
+            explain_result = connector.execute_query(f"EXPLAIN {sql}", result_format="list")
+        except Exception as exc:
+            logger.debug("sql_guard EXPLAIN failed; allowing query", error=str(exc), dialect=connector.dialect)
+            return None
+        if not getattr(explain_result, "success", False):
+            return None
+
+        estimated = estimate_rows_from_explain(connector.dialect, explain_result.sql_return or [])
+        if estimated is None or estimated <= MAX_ESTIMATED_ROWS:
+            return None
+
+        logger.warning(
+            "sql_guard rejected oversized query",
+            estimated_rows=estimated,
+            threshold=MAX_ESTIMATED_ROWS,
+            dialect=connector.dialect,
+        )
+        return FuncToolResult(success=0, error=build_oversize_message(estimated, MAX_ESTIMATED_ROWS))
 
     def _resolve_effective_datasource(self, datasource: Optional[str]) -> str:
         effective_datasource = datasource or self._default_datasource

--- a/datus/tools/func_tool/report_artifact_tools.py
+++ b/datus/tools/func_tool/report_artifact_tools.py
@@ -673,8 +673,21 @@ class ReportArtifactTools:
 
         ds_label = datasource or getattr(self._db_func_tool, "_default_datasource", "") or "default"
 
+        # Pre-flight EXPLAIN row-count guard: reject a runaway query (e.g. a
+        # cross-join cartesian product) from its optimizer estimate before it
+        # executes and OOMs the DB backend. Fail-open when unmeasurable.
+        oversize = self._db_func_tool.guard_estimated_rows(sql, connector)
+        if oversize is not None:
+            return oversize
+
         try:
-            execute_result = connector.execute_query(sql, result_format="list")
+            # Route through the shared enforced-read path so SQL policy
+            # (row caps / rewrites / denials) and multi-statement rejection
+            # apply here too — a bare connector.execute_query would let an
+            # unbounded statement reach the engine and OOM the DB backend.
+            execute_result = self._db_func_tool.execute_read_enforced(
+                sql, connector, datasource=datasource, result_format="list"
+            )
         except Exception as exc:
             logger.exception("save_query execute_query crashed", extra={"name": name})
             return FuncToolResult(success=0, error=f"Query execution failed: {exc}")

--- a/datus/tools/sql_guard.py
+++ b/datus/tools/sql_guard.py
@@ -1,0 +1,153 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""EXPLAIN-based row-count guard for LLM-authored artifact queries.
+
+Estimates a query's cost from the engine's own ``EXPLAIN`` plan (planning only
+— the statement is never executed) and lets callers reject statements whose
+optimizer estimate blows past a fixed ceiling *before* the raw SQL reaches
+``execute_query``.
+
+Motivation: an LLM-authored ``CROSS JOIN`` cartesian product (~9e9 rows)
+OOM-killed a StarRocks BE. The result rows were never returned — the *join*
+itself exhausted memory — so a post-execution byte cap, a ``LIMIT`` wrapper, or
+a ``SELECT COUNT(*)`` pre-check are all useless or actively dangerous (the
+COUNT still forces the join to materialize). Only ``EXPLAIN`` inspects the plan
+without building it.
+
+The estimate is the **heaviest operator's** cardinality (a scan or join node),
+not the final result size — that's deliberate: OOM happens while the heaviest
+operator materializes, regardless of any downstream GROUP BY/LIMIT. So the
+ceiling is calibrated against per-operator row counts, not result rows.
+
+``MAX_ESTIMATED_ROWS`` sits in the wide gap between the two regimes this guard
+separates, for the report/dashboard flows it protects:
+
+* Legitimate report/dashboard queries feed charts. Results are aggregated
+  (hundreds to a few thousand rows), and ``save_query`` already caps the stored
+  result at 5 MB (~tens of thousands of rows). Their heaviest operator is a base
+  table scan — on the mid-size analytical data these flows target, that lands in
+  the hundreds-of-thousands-to-low-millions range.
+* Pathological queries (an unbounded CROSS JOIN, a missing JOIN key, a
+  ``WHERE ... OR 1=1``) multiply into the billions.
+
+50M leaves a 50×+ margin over a legitimate multi-million-row scan while still
+catching the ~9e9 incident by ~180×.
+
+Fail-open by design: if ``EXPLAIN`` is unsupported, errors, or its output can't
+be parsed, the estimate is ``None`` and the query proceeds. A guard that blocked
+on parse failure would reject far more legitimate queries than the rare runaway
+it protects against, so parsing is best-effort per dialect and any gap degrades
+to "allow".
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, List, Optional
+
+# Ceiling on the optimizer's per-operator row estimate. See the module docstring
+# for the calibration rationale (report/dashboard scans vs. cartesian blowups).
+MAX_ESTIMATED_ROWS = 50_000_000
+
+
+# StarRocks / Doris: each plan node prints ``cardinality: N`` (some versions use
+# ``cardinality=N``). The largest node cardinality bounds the query's cost — an
+# exploding join node carries the ~9e9 estimate we want to catch.
+_STARROCKS_CARDINALITY_RE = re.compile(r"cardinality\s*[:=]\s*([0-9]+)", re.IGNORECASE)
+
+# DuckDB: physical plan annotates operators with ``EC: N`` (estimated cardinality).
+_DUCKDB_EC_RE = re.compile(r"\bEC:\s*([0-9]+)", re.IGNORECASE)
+
+# PostgreSQL / Redshift: ``(cost=.. rows=N width=..)`` on every plan node. Take
+# the max across nodes, not the root's — a GROUP BY/LIMIT shrinks the root's
+# ``rows`` while an inner join stays huge, and the join is where OOM happens.
+_POSTGRES_ROWS_RE = re.compile(r"\brows=([0-9]+)")
+
+
+def _flatten_text(explain_rows: List[Any]) -> str:
+    """Join an EXPLAIN result set (list of dicts / tuples / scalars) into text."""
+    parts: List[str] = []
+    for row in explain_rows:
+        if isinstance(row, dict):
+            parts.extend(str(v) for v in row.values())
+        elif isinstance(row, (list, tuple)):
+            parts.extend(str(v) for v in row)
+        else:
+            parts.append(str(row))
+    return "\n".join(parts)
+
+
+def _max_match(pattern: re.Pattern[str], text: str) -> Optional[int]:
+    values = [int(m) for m in pattern.findall(text)]
+    return max(values) if values else None
+
+
+def _mysql_rows_product(explain_rows: List[Any]) -> Optional[int]:
+    """Multiply the per-row ``rows`` estimates of a tabular MySQL EXPLAIN.
+
+    MySQL's classic EXPLAIN reports rows scanned *per table*; the result-set
+    magnitude is roughly their product (each join multiplies), so a two-table
+    CROSS JOIN of ~1e5 × ~1e5 surfaces as ~1e10 here — a single ``rows`` column
+    would hide it.
+    """
+    product: Optional[int] = None
+    for row in explain_rows:
+        if not isinstance(row, dict):
+            continue
+        raw = next((v for k, v in row.items() if isinstance(k, str) and k.lower() == "rows"), None)
+        if raw is None:
+            continue
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            continue
+        product = n if product is None else product * n
+    return product
+
+
+def estimate_rows_from_explain(dialect: str, explain_rows: List[Any]) -> Optional[int]:
+    """Parse an EXPLAIN result set into a conservative row-count estimate.
+
+    Returns ``None`` when the dialect is unsupported or the plan yields no
+    parseable cardinality — callers treat ``None`` as "allow".
+    """
+    if not explain_rows:
+        return None
+    normalized = (dialect or "").lower()
+    if normalized in ("starrocks", "doris"):
+        return _max_match(_STARROCKS_CARDINALITY_RE, _flatten_text(explain_rows))
+    if normalized == "duckdb":
+        return _max_match(_DUCKDB_EC_RE, _flatten_text(explain_rows))
+    if normalized in ("postgres", "postgresql", "redshift"):
+        return _max_match(_POSTGRES_ROWS_RE, _flatten_text(explain_rows))
+    if normalized == "mysql":
+        return _mysql_rows_product(explain_rows)
+    return None
+
+
+def build_oversize_message(estimated: int, threshold: int) -> str:
+    """Actionable rejection text handed back to the authoring LLM.
+
+    Leads with the concrete estimate + ceiling, then rewrites that bound the
+    plan's heaviest operator, so the model can fix the SQL and retry rather than
+    guess at why the save failed.
+    """
+    return (
+        f"Query rejected before execution: the engine's EXPLAIN plan estimates "
+        f"~{estimated:,} rows for its heaviest operator, above the {threshold:,}-row "
+        f"safety ceiling. A query this large can exhaust database memory and take the "
+        f"backend down (a prior unbounded CROSS JOIN estimated ~9,000,000,000 rows and "
+        f"OOM-killed the DB). Rewrite the SQL to bound it before saving:\n"
+        f"  1. Verify every JOIN has a real ON/USING key. An unqualified CROSS JOIN, "
+        f"or a predicate like `WHERE ... OR 1=1`, disables filtering and multiplies "
+        f"row counts.\n"
+        f"  2. Aggregate (GROUP BY) or filter (WHERE) down to the rows the report "
+        f"actually charts — a visualization needs summarized data, not raw fact rows.\n"
+        f"  3. Reach for LIMIT only if it bounds the expensive operator itself (push "
+        f"it onto the subquery feeding the join). A LIMIT wrapped around the outer "
+        f"query won't clear this check — the heaviest operator materializes before "
+        f"the LIMIT applies.\n"
+        f"Then call the save tool again."
+    )

--- a/tests/unit_tests/api/services/test_dashboard_service.py
+++ b/tests/unit_tests/api/services/test_dashboard_service.py
@@ -104,6 +104,9 @@ def _patch_executor(monkeypatch, *, captured: dict) -> None:
             captured["datasource"] = datasource
             return _FakeConnector()
 
+        def execute_read_enforced(self, sql, connector, *, datasource="", result_format="list"):
+            return connector.execute_query(sql, result_format=result_format)
+
     import datus.tools.func_tool as func_tool_mod
 
     monkeypatch.setattr(func_tool_mod, "DBFuncTool", _FakeDBFuncTool)
@@ -506,6 +509,9 @@ def _patch_failing_executor(monkeypatch, *, exc: Exception | None = None, exec_r
 
         def _get_connector(self, datasource):
             return _Connector()
+
+        def execute_read_enforced(self, sql, connector, *, datasource="", result_format="list"):
+            return connector.execute_query(sql, result_format=result_format)
 
     import datus.tools.func_tool as func_tool_mod
 

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from datus.tools.func_tool.database import DBFuncTool
-from datus.utils.exceptions import DatusException
+from datus.utils.exceptions import DatusException, ErrorCode
 
 
 class TestDBFuncToolCompressorModelName:
@@ -1831,3 +1831,183 @@ class TestDBFuncToolExecuteSql:
         assert "read_query" not in tool_names
         assert "execute_ddl" not in tool_names
         assert "execute_write" not in tool_names
+
+
+class TestDBFuncToolExecuteReadEnforced:
+    """execute_read_enforced: the single policy-enforced raw-read path shared by
+    read_query and the report/dashboard artifact query executors. It must reject
+    multi-statement / non-read SQL and apply the SQL policy before the statement
+    reaches the engine — the guard the artifact save paths previously bypassed."""
+
+    def _make_tool(self, connector, agent_config=None):
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            return DBFuncTool(connector, agent_config=agent_config)
+
+    def _connector(self):
+        connector = Mock()
+        connector.dialect = "sqlite"
+        connector.get_databases.return_value = []
+        exec_result = Mock()
+        exec_result.success = True
+        exec_result.sql_return = [{"n": 1}]
+        connector.execute_query.return_value = exec_result
+        return connector
+
+    def test_readonly_select_executes_and_returns_raw_result(self):
+        connector = self._connector()
+        tool = self._make_tool(connector)
+
+        result = tool.execute_read_enforced("SELECT 1 AS n", connector)
+
+        assert result.success is True
+        connector.execute_query.assert_called_once()
+        args, kwargs = connector.execute_query.call_args
+        assert args[0] == "SELECT 1 AS n"
+        assert kwargs["result_format"] == "list"
+
+    def test_multi_statement_rejected_without_touching_connector(self):
+        connector = self._connector()
+        tool = self._make_tool(connector)
+
+        result = tool.execute_read_enforced("SELECT 1; DROP TABLE t", connector)
+
+        assert result.success is False
+        assert "Multi-statement" in result.error
+        connector.execute_query.assert_not_called()
+
+    def test_non_read_statement_rejected(self):
+        connector = self._connector()
+        tool = self._make_tool(connector)
+
+        result = tool.execute_read_enforced("INSERT INTO t VALUES (1)", connector)
+
+        assert result.success is False
+        connector.execute_query.assert_not_called()
+
+    def test_policy_rewrite_is_executed_verbatim(self):
+        connector = self._connector()
+        tool = self._make_tool(connector)
+
+        # A policy that injects a row cap; the rewrite is still a single
+        # read-only statement, so it must reach the connector verbatim.
+        with patch.object(tool, "_enforce_sql_policy", return_value="SELECT 1 AS n LIMIT 100"):
+            result = tool.execute_read_enforced("SELECT 1 AS n", connector)
+
+        assert result.success is True
+        assert connector.execute_query.call_args[0][0] == "SELECT 1 AS n LIMIT 100"
+
+    def test_policy_denial_surfaces_as_failure_without_executing(self):
+        connector = self._connector()
+        tool = self._make_tool(connector)
+
+        with patch.object(
+            tool,
+            "_enforce_sql_policy",
+            side_effect=DatusException(ErrorCode.TOOL_INVALID_INPUT, message="denied by policy"),
+        ):
+            result = tool.execute_read_enforced("SELECT 1 AS n", connector)
+
+        assert result.success is False
+        assert "denied by policy" in result.error
+        connector.execute_query.assert_not_called()
+
+    def test_policy_rewrite_to_non_read_is_rejected(self):
+        connector = self._connector()
+        tool = self._make_tool(connector)
+
+        # A buggy/hostile policy rewrite that turns a read into a mutation must
+        # be caught by the post-rewrite re-validation, not forwarded to the DB.
+        with patch.object(tool, "_enforce_sql_policy", return_value="DROP TABLE t"):
+            result = tool.execute_read_enforced("SELECT 1 AS n", connector)
+
+        assert result.success is False
+        connector.execute_query.assert_not_called()
+
+
+class TestDBFuncToolGuardEstimatedRows:
+    """guard_estimated_rows: EXPLAIN-based pre-flight row-count guard. Blocks a
+    query whose optimizer estimate exceeds the ceiling before it executes;
+    fail-open on anything it can't measure."""
+
+    def _make_tool(self, connector):
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            return DBFuncTool(connector)
+
+    def _connector_with_explain(self, explain_rows, dialect="starrocks", success=True):
+        connector = Mock()
+        connector.dialect = dialect
+        connector.get_databases.return_value = []
+        explain_result = Mock()
+        explain_result.success = success
+        explain_result.sql_return = explain_rows
+        connector.execute_query.return_value = explain_result
+        return connector
+
+    def test_oversize_estimate_is_rejected_with_actionable_message(self):
+        connector = self._connector_with_explain([{"plan": "CROSS JOIN cardinality: 9006993124"}])
+        tool = self._make_tool(connector)
+
+        result = tool.guard_estimated_rows("SELECT * FROM a, b", connector)
+
+        assert result.success == 0
+        assert "9,006,993,124" in result.error
+        # EXPLAIN must be planning-only — never the bare statement.
+        assert connector.execute_query.call_args[0][0].startswith("EXPLAIN ")
+
+    def test_multi_statement_rejected_before_explain_runs(self):
+        # A driver that splits statements would run the DROP as part of
+        # ``EXPLAIN SELECT 1; DROP TABLE t`` — reject before EXPLAIN is issued.
+        connector = self._connector_with_explain([{"plan": "cardinality: 10"}])
+        tool = self._make_tool(connector)
+
+        result = tool.guard_estimated_rows("SELECT 1; DROP TABLE t", connector)
+
+        assert result.success == 0
+        connector.execute_query.assert_not_called()
+
+    def test_estimate_under_ceiling_allows_query(self):
+        connector = self._connector_with_explain([{"plan": "cardinality: 42"}])
+        tool = self._make_tool(connector)
+
+        assert tool.guard_estimated_rows("SELECT 1", connector) is None
+
+    def test_boundary_around_the_ceiling(self):
+        from datus.tools.sql_guard import MAX_ESTIMATED_ROWS
+
+        # At the ceiling → allowed; one row over → rejected.
+        at_ceiling = self._connector_with_explain([{"plan": f"cardinality: {MAX_ESTIMATED_ROWS}"}])
+        assert self._make_tool(at_ceiling).guard_estimated_rows("SELECT 1", at_ceiling) is None
+
+        over = self._connector_with_explain([{"plan": f"cardinality: {MAX_ESTIMATED_ROWS + 1}"}])
+        assert self._make_tool(over).guard_estimated_rows("SELECT 1", over).success == 0
+
+    def test_explain_raising_fails_open(self):
+        connector = Mock()
+        connector.dialect = "starrocks"
+        connector.get_databases.return_value = []
+        connector.execute_query.side_effect = RuntimeError("EXPLAIN unsupported")
+        tool = self._make_tool(connector)
+
+        assert tool.guard_estimated_rows("SELECT 1", connector) is None
+
+    def test_explain_unsuccessful_fails_open(self):
+        connector = self._connector_with_explain([], success=False)
+        tool = self._make_tool(connector)
+
+        assert tool.guard_estimated_rows("SELECT 1", connector) is None
+
+    def test_unparseable_dialect_fails_open(self):
+        connector = self._connector_with_explain([{"detail": "SCAN t"}], dialect="sqlite")
+        tool = self._make_tool(connector)
+
+        assert tool.guard_estimated_rows("SELECT 1", connector) is None

--- a/tests/unit_tests/tools/test_sql_guard.py
+++ b/tests/unit_tests/tools/test_sql_guard.py
@@ -1,0 +1,79 @@
+"""Tests for the EXPLAIN-based row-count guard (datus/tools/sql_guard.py)."""
+
+from datus.tools.sql_guard import (
+    MAX_ESTIMATED_ROWS,
+    build_oversize_message,
+    estimate_rows_from_explain,
+)
+
+
+def test_ceiling_is_a_sane_positive_constant():
+    # Guards the calibration: above legitimate multi-million-row scans, well
+    # below the ~9e9 cartesian-blowup regime it must catch.
+    assert 1_000_000 < MAX_ESTIMATED_ROWS < 1_000_000_000
+
+
+class TestEstimateRowsFromExplain:
+    def test_starrocks_takes_max_cardinality(self):
+        # The exploding join node's cardinality bounds the result magnitude.
+        rows = [
+            {"Explain String": "  |  0:OlapScanNode  cardinality: 96478"},
+            {"Explain String": "  |  4:CROSS JOIN  cardinality: 9006993124"},
+            {"Explain String": "  |  1:OlapScanNode  cardinality: 93358"},
+        ]
+        assert estimate_rows_from_explain("starrocks", rows) == 9_006_993_124
+
+    def test_starrocks_cardinality_equals_form(self):
+        rows = [{"plan": "node cardinality=12345"}]
+        assert estimate_rows_from_explain("starrocks", rows) == 12345
+
+    def test_duckdb_estimated_cardinality(self):
+        rows = [{"explain_value": "HASH_JOIN\nEC: 8000000000"}, {"explain_value": "SEQ_SCAN\nEC: 100"}]
+        assert estimate_rows_from_explain("duckdb", rows) == 8_000_000_000
+
+    def test_postgres_takes_max_rows_across_nodes(self):
+        rows = [
+            {"QUERY PLAN": "Nested Loop  (cost=0.00..1.00 rows=9000000000 width=8)"},
+            {"QUERY PLAN": "  ->  Seq Scan on a  (cost=0.00..1.00 rows=96478 width=4)"},
+        ]
+        assert estimate_rows_from_explain("postgres", rows) == 9_000_000_000
+
+    def test_postgres_aggregated_join_does_not_bypass_via_small_root(self):
+        # GROUP BY/LIMIT shrinks the ROOT node's rows, but the inner join is the
+        # real blowup — taking the max (not the root) keeps it enforceable.
+        rows = [
+            {"QUERY PLAN": "Limit  (cost=0.00..1.00 rows=100 width=8)"},
+            {"QUERY PLAN": "  ->  GroupAggregate  (cost=0.00..1.00 rows=500 width=8)"},
+            {"QUERY PLAN": "        ->  Nested Loop  (cost=0.00..1.00 rows=9000000000 width=8)"},
+        ]
+        assert estimate_rows_from_explain("postgres", rows) == 9_000_000_000
+
+    def test_mysql_multiplies_per_table_rows(self):
+        rows = [{"id": 1, "table": "a", "rows": 96478}, {"id": 1, "table": "b", "rows": 93358}]
+        assert estimate_rows_from_explain("mysql", rows) == 96478 * 93358
+
+    def test_mysql_rows_key_case_insensitive(self):
+        rows = [{"ROWS": 1000}, {"ROWS": 2000}]
+        assert estimate_rows_from_explain("mysql", rows) == 2_000_000
+
+    def test_mysql_no_rows_column_returns_none(self):
+        assert estimate_rows_from_explain("mysql", [{"id": 1, "table": "a"}]) is None
+
+    def test_unknown_dialect_returns_none(self):
+        assert estimate_rows_from_explain("sqlite", [{"detail": "SCAN t"}]) is None
+        assert estimate_rows_from_explain("snowflake", [{"plan": "cardinality: 5"}]) is None
+
+    def test_empty_explain_returns_none(self):
+        assert estimate_rows_from_explain("starrocks", []) is None
+
+    def test_no_parseable_number_returns_none(self):
+        assert estimate_rows_from_explain("starrocks", [{"plan": "no numbers here"}]) is None
+
+
+class TestBuildOversizeMessage:
+    def test_message_carries_estimate_threshold_and_guidance(self):
+        msg = build_oversize_message(9_006_993_124, 100_000_000)
+        assert "9,006,993,124" in msg  # thousands-separated estimate
+        assert "100,000,000" in msg  # thousands-separated ceiling
+        assert "JOIN" in msg  # actionable rewrite guidance
+        assert "LIMIT" in msg


### PR DESCRIPTION
## Why

The report/dashboard `save_query` paths executed LLM-authored SQL directly via `connector.execute_query`, bypassing both `_enforce_sql_policy` and any row-count check. An LLM-authored `CROSS JOIN` cartesian product (~9,006,993,124 rows, from a `WHERE ... OR 1=1` that disabled filtering) OOM-killed a StarRocks BE on a dev deployment. The join exhausted host memory (7.75 GB) before any result returned, so the post-execution 5 MB byte cap in `save_query` never fired — the backend was killed by the Linux OOM killer during plan execution, not on result return.

## Solution

Two guards, both applied **before** the statement reaches the engine:

1. **`DBFuncTool.execute_read_enforced`** — a single policy-enforced raw-read path now shared by `read_query` (LLM tool) and the report/dashboard query executors: `save_query`, `save_query_template` trial render, and `DashboardService.run_query` view-time re-execution. It rejects multi-statement input and applies the configured SQL policy, then returns the connector's raw `ExecuteSQLResult`. The artifact save paths previously had no enforcement seam at all — this closes the bypass so any configured SQL policy (row caps / rewrites / denials) covers them too.

2. **`DBFuncTool.guard_estimated_rows` + `datus/tools/sql_guard.py`** — an EXPLAIN-based pre-flight. It runs `EXPLAIN <sql>` (planning only — never executed), parses the optimizer's cardinality estimate per dialect (StarRocks/Doris `cardinality:`, DuckDB `EC:`, Postgres/Redshift root `rows=`, MySQL per-table `rows` product), and rejects a query estimated above `MAX_ESTIMATED_ROWS` (50M) with an actionable rewrite message for the authoring LLM. Wired into `save_query` and `save_query_template`.

Key decisions:
- **EXPLAIN, not `SELECT COUNT(*)`** — a COUNT wrapper still forces the join to materialize and would re-trigger the same OOM. Only EXPLAIN inspects the plan without building it.
- **Estimate = heaviest operator's cardinality**, not final result size — OOM happens while the heaviest operator materializes, regardless of any downstream GROUP BY/LIMIT, so the exploding join node is exactly what gets caught.
- **Fail-open** — unsupported / erroring / unparseable EXPLAIN allows the query. A guard that blocked on parse failure would reject far more legitimate queries than the rare runaway it protects against.
- **50M ceiling** — sits in the wide gap between legitimate report/dashboard scans (hundreds-of-thousands to low-millions on the mid-size analytical data these flows target) and cartesian blowups (billions): 50×+ margin over legitimate scans, still catching the ~9e9 incident by ~180×. A hardcoded module constant (no new YAML config).

Scope: the EXPLAIN guard is wired into the save paths only (where the LLM authors the SQL and can be told to rewrite). `DashboardService.run_query` gets the enforced-read path but not the EXPLAIN guard, to avoid a per-view EXPLAIN round-trip and because its consumer isn't the LLM.

## Test Cases

Unit tests (CI tier, deterministic, no external deps):
- `tests/unit_tests/tools/test_sql_guard.py` (new) — per-dialect EXPLAIN parsing (StarRocks max-cardinality, DuckDB `EC:`, Postgres root `rows=`, MySQL product, unknown/empty → None), ceiling calibration, and the rejection-message contract.
- `tests/unit_tests/tools/func_tool/test_database.py` — `TestDBFuncToolExecuteReadEnforced` (multi-statement / non-read rejection, policy-rewrite re-validation, policy denial) and `TestDBFuncToolGuardEstimatedRows` (oversize rejection with the incident's 9e9 estimate, under-ceiling allow, boundary at the ceiling, EXPLAIN-raises / unsuccessful / unparseable-dialect all fail-open).
- `tests/unit_tests/api/services/test_dashboard_service.py` — updated the two `DBFuncTool` test doubles to the enforced-read path.

No nightly/integration tests added — the guard is pure planning-layer logic with no real-LLM or cross-service dependency; the connector EXPLAIN call is mocked.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only SQL queries now receive consistent safety and policy validation before execution.
  * Queries involving multiple statements or non-read operations are blocked.
  * SQL policy rewrites are revalidated before execution.
  * Oversized queries are identified before execution using database row estimates, with guidance to reduce joins or limit results.
  * Added safeguards across dashboards, reports, and saved query templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened read-only SQL execution with centralized enforcement and an additional safety re-check after any policy rewrite.
  * Blocked multi-statement and non-read SQL to prevent unintended execution.
  * Added an EXPLAIN-based pre-flight row-count guard to reject likely runaway queries (dashboards, reports, and saved templates), including guidance to bound joins and limit output.
* **Tests**
  * Expanded unit coverage for enforced-read routing, row-count guarding, and dialect-specific EXPLAIN parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->