### PR TITLE
[BugFix] Pin DuckDB to 1.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "textual[syntax]==5.1.1",
     "anthropic==0.51.0",
     "duckdb-engine>=0.17.0",
-    "duckdb>=1.5.2,<2.0.0",
+    "duckdb==1.5.2",
     # MCP (Model Context Protocol) support
     "mcp>=1.11.0",
     "anyio>=4.9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ textual[syntax]==5.1.1
 prompt-toolkit>=3.0.51
 anthropic==0.51.0
 duckdb-engine>=0.17.0
-duckdb==1.3.0
+duckdb==1.5.2
 json-repair>=0.47.6
 fastapi>=0.104.0,<1.0
 uvicorn>=0.24.0

--- a/uv.lock
+++ b/uv.lock
@@ -779,7 +779,7 @@ requires-dist = [
     { name = "datus-semantic-core", specifier = ">=0.2.1" },
     { name = "datus-storage-base", specifier = ">=0.1.5,<0.2.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
-    { name = "duckdb", specifier = ">=1.5.2,<2.0.0" },
+    { name = "duckdb", specifier = "==1.5.2" },
     { name = "duckdb-engine", specifier = ">=0.17.0" },
     { name = "fastapi", specifier = ">=0.104.0,<1.0" },
     { name = "fastembed", specifier = "==0.4.2" },


### PR DESCRIPTION
## Summary

- pin DuckDB to `1.5.2` in the package metadata
- align the legacy runtime requirements file with the same version
- update the lockfile dependency constraint

## Root cause

The previous `duckdb>=1.5.2,<2.0.0` constraint allowed backend image builds to resolve DuckDB 1.5.4. With an Iceberg REST catalog, DuckDB 1.5.4 attempts to create a local `data` directory while executing CTAS statements. Backend deployments run from a non-writable working directory, so the query fails with `IO Error: Failed to create directory "data": Permission denied`.

Pinning 1.5.2 keeps backend and package installations on the version that does not perform this local directory creation in the tested flow.

## Impact

- backend image builds no longer drift to DuckDB 1.5.4
- Iceberg CTAS execution works from a non-writable working directory
- package, legacy requirements, and lockfile constraints agree on one version

## Validation

- `uv lock --locked`
- built wheel metadata contains `Requires-Dist: duckdb==1.5.2`
- `uv pip install --dry-run .` resolves `duckdb==1.5.2`
- DuckDB 1.5.4 reproduced the directory permission failure from a read-only working directory; 1.5.2 completed the same six-table Iceberg SQL flow without creating a local `data` directory
- `airflow-etl-pipeline-core` benchmark passed with score `1.000`; staging and mart row-count assertions both returned `146`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DuckDB to version 1.5.2.
  * Standardized the DuckDB dependency to use the exact same version across project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->