### PR TITLE
[Feature] Author subject-tree metrics through the semantic adapter

### DIFF
--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -135,14 +135,16 @@ class ExplorerService:
         )
 
     @staticmethod
-    def _metric_exists_in_source(adapter, metric_name: str, parent_path: List[str]) -> bool:
-        """Whether the metric still reads from the source file (used after a
-        delete error to tell a real write failure from an already-absent metric)."""
-        try:
-            adapter.read_metric_source(metric_name, subject_path=parent_path)
-            return True
-        except Exception:  # noqa: BLE001 - any read failure means "not present"
-            return False
+    def _is_metric_absent_error(exc: Exception) -> bool:
+        """Whether a delete failure means the metric simply isn't in the source
+        file (benign file/KB drift) rather than a real I/O / lock / parse failure.
+
+        Both adapters raise a not-found error whose message contains
+        ``was not found`` (``FileNotFoundError`` for MetricFlow, the OSI error
+        class for OSI). Anything else is a real failure and must not be treated
+        as "already gone", or we would drop the KB row while the file still
+        holds the metric (the file is the source of truth)."""
+        return isinstance(exc, FileNotFoundError) or "was not found" in str(exc)
 
     def _author_metric(
         self,
@@ -203,9 +205,7 @@ class ExplorerService:
         try:
             # Empty parent_path (root-level metric) means "no categorization" —
             # pass None so the adapter does not inject an empty subject tag.
-            mutation = adapter.write_metric_source(
-                name, metric_yaml, subject_path=(parent_path or None), create=create
-            )
+            mutation = adapter.write_metric_source(name, metric_yaml, subject_path=(parent_path or None), create=create)
         except Exception as e:  # noqa: BLE001 - surface adapter write/validation errors
             logger.error(f"Failed to write metric source: {e}")
             return Result[dict](
@@ -1284,18 +1284,19 @@ class ExplorerService:
                     try:
                         await asyncio.to_thread(adapter.delete_metric_source, metric_name, subject_path=parent_path)
                     except Exception as e:  # noqa: BLE001
-                        # A real write failure must fail the request; only an
-                        # already-absent metric (file/KB drift) is benign,
-                        # otherwise the file keeps the metric while the KB row is
-                        # dropped and it "revives" on the next re-index.
-                        if await asyncio.to_thread(self._metric_exists_in_source, adapter, metric_name, parent_path):
+                        # Only a genuine "not found" is a benign fallback to KB
+                        # cleanup (file/KB drift). Real failures (I/O, lock, parse)
+                        # must fail the request, or the file keeps the metric while
+                        # the KB row is dropped and it "revives" on the next
+                        # re-index — breaking the YAML-source-of-truth invariant.
+                        if not self._is_metric_absent_error(e):
                             logger.error(f"Failed to delete metric from source file: {e}")
                             return Result[dict](
                                 success=False,
                                 errorCode=ErrorCode.TOOL_EXECUTION_ERROR,
                                 errorMessage=f"Failed to remove metric from source file: {e}",
                             )
-                        logger.warning(f"Metric already absent from source file, continuing: {e}")
+                        logger.warning(f"Metric already absent from source file, continuing to KB cleanup: {e}")
 
                 result = self.metric_rag.delete_metric(parent_path, metric_name)
                 if not result.get("success", False):

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -78,6 +78,117 @@ class ExplorerService:
                 message_args={"error_message": "No datasource is selected; select a datasource first"},
             )
 
+    def _is_osi_authoring(self) -> bool:
+        """Whether the active semantic adapter authors OSI (vs MetricFlow)."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        return bool(is_osi_authoring(self.agent_config))
+
+    def _semantic_adapter(self):
+        """Resolve the configured semantic adapter, or None if unavailable.
+
+        The adapter reads/writes the YAML source of truth (the authoring
+        surface is a backend-only API, not an agent/LLM tool).
+        """
+        from datus.tools.func_tool.semantic_tools import SemanticTools
+
+        try:
+            return SemanticTools(self.agent_config).adapter
+        except Exception as e:  # noqa: BLE001 - adapter is optional; fall back to KB
+            logger.warning(f"Semantic adapter unavailable: {e}")
+            return None
+
+    @staticmethod
+    def _metric_name_from_yaml(yaml_text: str) -> Optional[str]:
+        """Extract the metric name from OSI (top-level) or MetricFlow ({metric:}) YAML."""
+        import yaml
+
+        try:
+            doc = yaml.safe_load(yaml_text)
+        except yaml.YAMLError:
+            return None
+        if not isinstance(doc, dict):
+            return None
+        if isinstance(doc.get("metric"), dict):
+            return doc["metric"].get("name")
+        return doc.get("name")
+
+    def _sync_osi_file_to_kb(self, file_path: str) -> dict:
+        """Re-index an OSI source file (datasets + metrics) into the Knowledge Base."""
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        return GenerationTools(self.agent_config).sync_osi_to_db(file_path)
+
+    def _author_osi_metric(
+        self,
+        parent_path: List[str],
+        metric_yaml: str,
+        *,
+        create: bool,
+        metric_name: Optional[str] = None,
+    ) -> "Result[dict]":
+        """Validate + write an OSI metric to its source file, then re-index the KB.
+
+        The OSI adapter owns file placement and structure; this method handles
+        the app-level orchestration (name resolution, validation gate, KB
+        re-sync, and rollback when the KB sync fails).
+        """
+        from datus.api.models.config_models import ErrorCode
+
+        adapter = self._semantic_adapter()
+        if adapter is None:
+            return Result[dict](
+                success=False,
+                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorMessage="Semantic adapter is not available; cannot author this metric.",
+            )
+
+        name = metric_name or self._metric_name_from_yaml(metric_yaml)
+        if not name:
+            return Result[dict](
+                success=False,
+                errorCode=ErrorCode.INVALID_PARAMETERS,
+                errorMessage="No metric name found in YAML content.",
+            )
+
+        # Validation gate: reject before touching the file.
+        validation = adapter.validate_metric_source(metric_yaml, metric_name=name)
+        if not validation.valid:
+            messages = "; ".join(issue.message for issue in validation.issues if issue.severity == "error")
+            return Result[dict](
+                success=False,
+                errorCode=ErrorCode.INVALID_PARAMETERS,
+                errorMessage=f"YAML validation failed: {messages}",
+            )
+
+        try:
+            mutation = adapter.write_metric_source(name, metric_yaml, subject_path=parent_path, create=create)
+        except Exception as e:  # noqa: BLE001 - surface adapter write errors to the caller
+            logger.error(f"Failed to write OSI metric source: {e}")
+            return Result[dict](
+                success=False,
+                errorCode=ErrorCode.INVALID_PARAMETERS,
+                errorMessage=str(e),
+            )
+
+        # Re-index the changed file into the KB. On failure roll back a newly
+        # created metric so the file and KB do not drift.
+        sync_result = self._sync_osi_file_to_kb(mutation.file_path)
+        if not sync_result.get("success", False):
+            if create:
+                try:
+                    adapter.delete_metric_source(name, subject_path=parent_path)
+                except Exception as rollback_error:  # noqa: BLE001
+                    logger.error(f"Rollback of created OSI metric failed: {rollback_error}")
+            return Result[dict](
+                success=False,
+                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorMessage=sync_result.get("error", "Failed to sync metric to Knowledge Base"),
+            )
+
+        logger.info(f"Successfully {'created' if create else 'edited'} OSI metric: {name}")
+        return Result[dict](success=True, data={})
+
     def _semantic_runtime_db_context(self, request=None) -> dict:
         """Build runtime DB context for semantic adapter API calls."""
         context = {}
@@ -593,7 +704,25 @@ class ExplorerService:
             parent_path = subject_path[:-1] if len(subject_path) > 1 else []
             metric_name = subject_path[-1]
 
-            # Get metric from LanceDB
+            # Source of truth is the YAML file: read it back through the semantic
+            # adapter so the returned YAML is in the metric's native format (OSI
+            # or MetricFlow), not a lossy reconstruction from the KB projection.
+            adapter = self._semantic_adapter()
+            if adapter is not None:
+                from datus_semantic_core.authoring import AuthoringNotSupportedError
+
+                try:
+                    source = adapter.read_metric_source(metric_name, subject_path=parent_path)
+                    return Result[MetricInfo](
+                        success=True,
+                        data=MetricInfo(name=metric_name, yaml=source.text),
+                    )
+                except AuthoringNotSupportedError:
+                    pass  # adapter has no file source; fall back to KB reconstruction
+                except Exception as e:  # noqa: BLE001 - fall back on any read failure
+                    logger.warning(f"Adapter read_metric_source failed, using KB fallback: {e}")
+
+            # Fallback: reconstruct MetricFlow-shaped YAML from the KB projection.
             metrics_detail = self.metric_rag.get_metrics_detail(parent_path, metric_name)
 
             if not metrics_detail:
@@ -603,11 +732,8 @@ class ExplorerService:
                     errorMessage=f"Metric not found: {metric_name}",
                 )
 
-            # Convert DB object to YAML format
             metric_data = metrics_detail[0]
             yaml_dict = self._metric_db_to_yaml(metric_data)
-
-            # Convert to YAML string
             metric_yaml = yaml.dump(
                 yaml_dict,
                 default_flow_style=False,
@@ -617,10 +743,7 @@ class ExplorerService:
 
             return Result[MetricInfo](
                 success=True,
-                data=MetricInfo(
-                    name=metric_name,
-                    yaml=metric_yaml,
-                ),
+                data=MetricInfo(name=metric_name, yaml=metric_yaml),
             )
 
         except Exception as e:
@@ -968,6 +1091,12 @@ class ExplorerService:
             # subject_path is the parent directory
             parent_path = request.subject_path if request.subject_path else []
 
+            # OSI metrics live in the semantic_model file, not standalone metric
+            # files: author them through the adapter (source of truth), then
+            # re-index the changed file into the KB.
+            if self._is_osi_authoring():
+                return self._author_osi_metric(parent_path, request.yaml, create=True)
+
             # Step 1: Parse YAML to extract metric name (only one document allowed)
             try:
                 doc = yaml.safe_load(request.yaml)
@@ -1119,6 +1248,11 @@ class ExplorerService:
             # Extract parent path and metric name
             parent_path = request.subject_path[:-1] if len(request.subject_path) > 1 else []
             metric_name = request.subject_path[-1]
+
+            # OSI: update the metric in place inside its semantic_model file via
+            # the adapter, preserving datasets and sibling metrics.
+            if self._is_osi_authoring():
+                return self._author_osi_metric(parent_path, request.yaml, create=False, metric_name=metric_name)
 
             # Step 1: Check if metric exists
             existing_metrics = self.metric_rag.get_metrics_detail(parent_path, metric_name)
@@ -1382,6 +1516,17 @@ class ExplorerService:
 
                 parent_path = request.subject_path[:-1] if len(request.subject_path) > 1 else []
                 metric_name = request.subject_path[-1]
+
+                # OSI: remove the metric from its semantic_model file first (the
+                # KB row's file logic only understands MetricFlow docs). The KB
+                # delete below then drops the vector row (file edit is a no-op).
+                if self._is_osi_authoring():
+                    adapter = self._semantic_adapter()
+                    if adapter is not None:
+                        try:
+                            adapter.delete_metric_source(metric_name, subject_path=parent_path)
+                        except Exception as e:  # noqa: BLE001 - continue to KB cleanup
+                            logger.warning(f"Adapter delete_metric_source failed: {e}")
 
                 result = self.metric_rag.delete_metric(parent_path, metric_name)
                 if not result.get("success", False):

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -113,14 +113,29 @@ class ExplorerService:
             return doc["metric"].get("name")
         return doc.get("name")
 
-    def _sync_osi_file_to_kb(self, file_path: str) -> dict:
-        """Re-index an OSI source file (datasets + metrics) into the Knowledge Base."""
-        from datus.tools.func_tool.generation_tools import GenerationTools
+    def _sync_file_to_kb(self, is_osi: bool, file_path: str) -> dict:
+        """Re-index a semantic source file into the Knowledge Base.
 
-        return GenerationTools(self.agent_config).sync_osi_to_db(file_path)
+        The authoring adapter only writes the YAML file; the KB is a derived
+        index that must be re-synced through the format's own entry point —
+        the OSI vectorizer or the MetricFlow GenerationHooks sync.
+        """
+        if is_osi:
+            from datus.tools.func_tool.generation_tools import GenerationTools
+
+            return GenerationTools(self.agent_config).sync_osi_to_db(file_path)
+
+        from datus.cli.generation_hooks import GenerationHooks
+
+        return GenerationHooks._sync_semantic_to_db(
+            file_path,
+            self.agent_config,
+            include_semantic_objects=False,
+            include_metrics=True,
+        )
 
     @staticmethod
-    def _osi_metric_exists(adapter, metric_name: str, parent_path: List[str]) -> bool:
+    def _metric_exists_in_source(adapter, metric_name: str, parent_path: List[str]) -> bool:
         """Whether the metric still reads from the source file (used after a
         delete error to tell a real write failure from an already-absent metric)."""
         try:
@@ -129,7 +144,7 @@ class ExplorerService:
         except Exception:  # noqa: BLE001 - any read failure means "not present"
             return False
 
-    def _author_osi_metric(
+    def _author_metric(
         self,
         parent_path: List[str],
         metric_yaml: str,
@@ -137,13 +152,18 @@ class ExplorerService:
         create: bool,
         metric_name: Optional[str] = None,
     ) -> "Result[dict]":
-        """Validate + write an OSI metric to its source file, then re-index the KB.
+        """Validate + write a metric to its source file, then re-index the KB.
 
-        The OSI adapter owns file placement and structure; this method handles
-        the app-level orchestration: name resolution, validation gate, KB
-        re-sync, and rollback so the file (source of truth) and the KB never
-        drift. On KB-sync failure a create is deleted and an edit is restored to
-        its previous content.
+        Format-agnostic orchestration shared by create/edit for OSI and
+        MetricFlow: the adapter owns file placement/structure (source of truth),
+        this method handles name resolution, the validation gate, the
+        format-aware KB re-sync, and rollback so the file and the KB never drift
+        (a failed create is deleted, a failed edit is restored).
+
+        Validation depth is format-specific: OSI is fully validated inside the
+        adapter write (jsonschema + profile parse, before persisting), while
+        MetricFlow is validated with the real MetricFlow model validator on the
+        written file, rolling back if it fails.
 
         Runs synchronously (file I/O + KB embedding); callers off the event loop
         should invoke it via ``asyncio.to_thread``.
@@ -166,59 +186,78 @@ class ExplorerService:
                 errorMessage="No metric name found in YAML content.",
             )
 
-        # Validation gate: reject before touching the file.
-        validation = adapter.validate_metric_source(metric_yaml, metric_name=name)
-        if not validation.valid:
-            messages = "; ".join(issue.message for issue in validation.issues if issue.severity == "error")
-            return Result[dict](
-                success=False,
-                errorCode=ErrorCode.INVALID_PARAMETERS,
-                errorMessage=f"YAML validation failed: {messages}",
-            )
+        is_osi = self._is_osi_authoring()
 
-        # Capture the current content so an edit can be rolled back if the KB
-        # re-sync fails (a create rolls back by deleting).
+        # Snapshot current content so an edit can be rolled back on later failure
+        # (a create rolls back by deleting).
         previous_source = None
         if not create:
             try:
                 previous_source = adapter.read_metric_source(name, subject_path=parent_path)
             except Exception as e:  # noqa: BLE001 - restore is best-effort
-                logger.warning(f"Could not snapshot OSI metric before edit; rollback disabled: {e}")
+                logger.warning(f"Could not snapshot metric before edit; rollback disabled: {e}")
 
+        # Write the file. OSI validates fully inside write (raises before
+        # persisting); MetricFlow does a light structural check here and the
+        # real model validation runs on the written file below.
         try:
-            mutation = adapter.write_metric_source(name, metric_yaml, subject_path=parent_path, create=create)
-        except Exception as e:  # noqa: BLE001 - surface adapter write errors to the caller
-            logger.error(f"Failed to write OSI metric source: {e}")
+            # Empty parent_path (root-level metric) means "no categorization" —
+            # pass None so the adapter does not inject an empty subject tag.
+            mutation = adapter.write_metric_source(
+                name, metric_yaml, subject_path=(parent_path or None), create=create
+            )
+        except Exception as e:  # noqa: BLE001 - surface adapter write/validation errors
+            logger.error(f"Failed to write metric source: {e}")
             return Result[dict](
                 success=False,
                 errorCode=ErrorCode.INVALID_PARAMETERS,
                 errorMessage=str(e),
             )
 
+        # MetricFlow: run the real (model-level) validation on the written file
+        # and roll back if it fails, preserving the legacy validation strength.
+        if not is_osi:
+            try:
+                with open(mutation.file_path, encoding="utf-8") as f:
+                    written = f.read()
+            except OSError as e:
+                written = None
+                logger.warning(f"Could not re-read written metric file for validation: {e}")
+            if written is not None:
+                is_valid, error_messages = self._validate_metric_yaml(written, mutation.file_path)
+                if not is_valid:
+                    self._rollback_metric_write(adapter, name, parent_path, create, previous_source)
+                    return Result[dict](
+                        success=False,
+                        errorCode=ErrorCode.INVALID_PARAMETERS,
+                        errorMessage=f"YAML validation failed: {'; '.join(error_messages)}",
+                    )
+
         # Re-index the changed file into the KB. On failure, undo the write so
         # the file and the KB stay consistent.
-        sync_result = self._sync_osi_file_to_kb(mutation.file_path)
+        sync_result = self._sync_file_to_kb(is_osi, mutation.file_path)
         if not sync_result.get("success", False):
-            self._rollback_osi_write(adapter, name, parent_path, create, previous_source)
+            self._rollback_metric_write(adapter, name, parent_path, create, previous_source)
             return Result[dict](
                 success=False,
                 errorCode=ErrorCode.TOOL_EXECUTION_ERROR,
                 errorMessage=sync_result.get("error", "Failed to sync metric to Knowledge Base"),
             )
 
-        logger.info(f"Successfully {'created' if create else 'edited'} OSI metric: {name}")
+        logger.info(f"Successfully {'created' if create else 'edited'} metric: {name}")
         return Result[dict](success=True, data={})
 
     @staticmethod
-    def _rollback_osi_write(adapter, name, parent_path, create, previous_source) -> None:
-        """Undo a metric write after a failed KB re-sync."""
+    def _rollback_metric_write(adapter, name, parent_path, create, previous_source) -> None:
+        """Undo a metric write after a failed validation or KB re-sync."""
         try:
             if create:
                 adapter.delete_metric_source(name, subject_path=parent_path)
             elif previous_source is not None:
-                adapter.write_metric_source(name, previous_source.text, subject_path=parent_path, create=False)
+                # Restore the exact prior content; subject_path=None so no tag is re-injected.
+                adapter.write_metric_source(name, previous_source.text, subject_path=None, create=False)
         except Exception as rollback_error:  # noqa: BLE001
-            logger.error(f"Rollback of OSI metric '{name}' failed; file and KB may be inconsistent: {rollback_error}")
+            logger.error(f"Rollback of metric '{name}' failed; file and KB may be inconsistent: {rollback_error}")
 
     def _semantic_runtime_db_context(self, request=None) -> dict:
         """Build runtime DB context for semantic adapter API calls."""
@@ -299,99 +338,6 @@ class ExplorerService:
 
         except Exception as e:
             return "", f"Failed to get semantic file path: {str(e)}"
-
-    def _update_metric_in_yaml_docs(
-        self,
-        yaml_documents: list,
-        metric_name: str,
-        new_metric_data: dict,
-    ) -> tuple:
-        """Update metric in YAML documents list.
-
-        Args:
-            yaml_documents: List of YAML documents
-            metric_name: Name of the metric to update
-            new_metric_data: New metric data
-
-        Returns:
-            tuple: (updated_documents, error_message)
-                If successful, error_message is None
-                If failed, returns original documents
-        """
-        metric_found = False
-
-        for idx, doc in enumerate(yaml_documents):
-            if not doc:
-                continue
-
-            metric = doc.get("metric", {})
-            if metric.get("name") == metric_name:
-                # Update this document with new metric data
-                yaml_documents[idx] = {"metric": new_metric_data}
-                metric_found = True
-                break
-
-        if not metric_found:
-            return yaml_documents, f"Metric '{metric_name}' not found in YAML file"
-
-        return yaml_documents, None
-
-    def _write_yaml_atomic(
-        self,
-        file_path: str,
-        documents: list,
-    ) -> Optional[str]:
-        """Write YAML documents atomically.
-
-        Args:
-            file_path: Path to the YAML file
-            documents: List of YAML documents to write
-
-        Returns:
-            error_message if failed, None if successful
-        """
-        import shutil
-        import tempfile
-
-        import yaml
-
-        temp_file = None
-        try:
-            # Create temp file in same directory as target file
-            temp_file = tempfile.NamedTemporaryFile(
-                mode="w",
-                encoding="utf-8",
-                delete=False,
-                dir=os.path.dirname(file_path),
-                suffix=".tmp",
-            )
-
-            # Write all documents with explicit document separators
-            yaml.dump_all(
-                documents,
-                temp_file,
-                default_flow_style=False,
-                allow_unicode=True,
-                sort_keys=False,
-                explicit_start=True,  # Adds "---" separator
-            )
-
-            temp_file.close()
-
-            # Atomic rename (overwrites original file)
-            shutil.move(temp_file.name, file_path)
-
-            return None  # Success
-
-        except Exception as e:
-            # Clean up temp file on error
-            if temp_file and os.path.exists(temp_file.name):
-                try:
-                    os.unlink(temp_file.name)
-                except Exception:
-                    pass
-
-            return f"Failed to write YAML file: {str(e)}"
 
     async def get_subject_list(self) -> Result[SubjectListData]:
         """Get nested subject tree structure.
@@ -1115,131 +1061,15 @@ class ExplorerService:
         """
         try:
             self._require_datasource()
-            import yaml
-
-            from datus.api.models.config_models import ErrorCode
-            from datus.cli.generation_hooks import GenerationHooks
 
             logger.info(f"Creating metric at parent path: {request.subject_path}")
 
-            # subject_path is the parent directory
+            # subject_path is the parent directory; the metric name is taken from
+            # the YAML. Both OSI and MetricFlow author through the adapter (the
+            # YAML file is the source of truth), then the changed file is
+            # re-indexed into the KB.
             parent_path = request.subject_path if request.subject_path else []
-
-            # OSI metrics live in the semantic_model file, not standalone metric
-            # files: author them through the adapter (source of truth), then
-            # re-index the changed file into the KB.
-            if self._is_osi_authoring():
-                return await asyncio.to_thread(self._author_osi_metric, parent_path, request.yaml, create=True)
-
-            # Step 1: Parse YAML to extract metric name (only one document allowed)
-            try:
-                doc = yaml.safe_load(request.yaml)
-            except yaml.YAMLError as e:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage=f"Invalid YAML format: {str(e)}",
-                )
-
-            if not doc or "metric" not in doc:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage="No metric document found in YAML content",
-                )
-
-            metric_name = doc.get("metric", {}).get("name")
-            if not metric_name:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage="No metric name found in YAML content. Ensure 'metric.name' is defined.",
-                )
-
-            # Step 1.5: Override subject_tree tag with request.subject_path if present
-            if parent_path:
-                metric_data = doc.get("metric", {})
-                locked_metadata = metric_data.get("locked_metadata", {})
-                tags = locked_metadata.get("tags", [])
-
-                # Check if there's a subject_tree tag and override it
-                new_subject_tree_value = f"subject_tree: {'/'.join(parent_path)}"
-                has_subject_tree = False
-                for i, tag in enumerate(tags):
-                    if isinstance(tag, str) and tag.startswith("subject_tree:"):
-                        tags[i] = new_subject_tree_value
-                        has_subject_tree = True
-                        break
-
-                # If subject_tree tag exists, update the document
-                if has_subject_tree:
-                    locked_metadata["tags"] = tags
-                    metric_data["locked_metadata"] = locked_metadata
-                    doc["metric"] = metric_data
-                    # Update request.yaml with modified content
-                    request.yaml = yaml.dump(
-                        doc,
-                        default_flow_style=False,
-                        allow_unicode=True,
-                        sort_keys=False,
-                    )
-
-            # Step 2: Check if metric already exists in database
-
-            existing_metrics = self.metric_rag.get_metrics_detail(parent_path, metric_name)
-            if existing_metrics:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage=f"Metric '{metric_name}' already exists at path: {'/'.join(parent_path)}",
-                )
-
-            # Step 3: Determine file path. Use the agent_config's own path_manager so
-            # the project_root/subject anchoring propagates to derived paths.
-            semantic_dir = self.agent_config.path_manager.semantic_model_path(self.agent_config.current_datasource)
-            file_path = os.path.join(str(semantic_dir), "metrics", f"{metric_name}.yml")
-
-            # Step 4: Check for file conflict
-            if os.path.exists(file_path):
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage=f"File already exists: {file_path}",
-                )
-
-            # Step 4: Validate YAML
-            is_valid, error_messages = self._validate_metric_yaml(request.yaml, file_path)
-            if not is_valid:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage=f"YAML validation failed: {'; '.join(error_messages)}",
-                )
-
-            # Step 5: Write YAML file
-            with open(file_path, "w", encoding="utf-8") as f:
-                f.write(request.yaml)
-
-            # Step 6: Sync to database
-            sync_result = GenerationHooks._sync_semantic_to_db(
-                file_path=file_path,
-                agent_config=self.agent_config,
-                include_semantic_objects=False,
-                include_metrics=True,
-            )
-
-            if not sync_result.get("success", False):
-                # Rollback: delete the file if sync failed
-                if os.path.exists(file_path):
-                    os.remove(file_path)
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=sync_result.get("error", "Failed to sync metric to database"),
-                )
-
-            logger.info(f"Successfully created metric: {metric_name}")
-            return Result[dict](success=True, data={})
+            return await asyncio.to_thread(self._author_metric, parent_path, request.yaml, create=True)
 
         except Exception as e:
             logger.error(f"Failed to create metric: {e}")
@@ -1265,10 +1095,8 @@ class ExplorerService:
         """
         try:
             self._require_datasource()
-            import yaml
 
             from datus.api.models.config_models import ErrorCode
-            from datus.cli.generation_hooks import GenerationHooks
 
             logger.info(f"Editing metric at path: {request.subject_path}")
 
@@ -1279,128 +1107,18 @@ class ExplorerService:
                     errorMessage="Subject path cannot be empty",
                 )
 
-            # Extract parent path and metric name
+            # Extract parent path and metric name, then author in place through
+            # the adapter (source of truth). Both OSI and MetricFlow update the
+            # metric inside its file, preserving datasets and sibling metrics.
             parent_path = request.subject_path[:-1] if len(request.subject_path) > 1 else []
             metric_name = request.subject_path[-1]
-
-            # OSI: update the metric in place inside its semantic_model file via
-            # the adapter, preserving datasets and sibling metrics.
-            if self._is_osi_authoring():
-                return await asyncio.to_thread(
-                    self._author_osi_metric,
-                    parent_path,
-                    request.yaml,
-                    create=False,
-                    metric_name=metric_name,
-                )
-
-            # Step 1: Check if metric exists
-            existing_metrics = self.metric_rag.get_metrics_detail(parent_path, metric_name)
-            if not existing_metrics:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=f"Metric not found: {metric_name}",
-                )
-
-            # Step 2: Get yaml_path from metric data
-            metric_data = existing_metrics[0]
-            yaml_path = metric_data.get("yaml_path", "")
-
-            if not yaml_path:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=f"Metric '{metric_name}' has no yaml_path",
-                )
-
-            if not os.path.exists(yaml_path):
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=f"YAML file not found: {yaml_path}",
-                )
-
-            # Step 3: Read existing YAML file as multi-document
-            with open(yaml_path, "r", encoding="utf-8") as f:
-                original_content = f.read()
-
-            yaml_documents = list(yaml.safe_load_all(original_content))
-
-            # Step 4: Parse the new metric YAML from request (only one document allowed)
-            try:
-                new_doc = yaml.safe_load(request.yaml)
-            except yaml.YAMLError as e:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage=f"Invalid YAML format: {str(e)}",
-                )
-
-            if not new_doc or "metric" not in new_doc:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage="No metric document found in YAML content",
-                )
-
-            # Step 5: Update only the specific metric document in the existing YAML
-            new_metric_data = new_doc.get("metric")
-            updated_documents, error_msg = self._update_metric_in_yaml_docs(
-                yaml_documents, metric_name, new_metric_data
+            return await asyncio.to_thread(
+                self._author_metric,
+                parent_path,
+                request.yaml,
+                create=False,
+                metric_name=metric_name,
             )
-
-            if error_msg:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=error_msg,
-                )
-
-            # Step 6: Write updated documents atomically
-            write_error = self._write_yaml_atomic(yaml_path, updated_documents)
-            if write_error:
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=write_error,
-                )
-
-            # Step 7: Validate the updated file
-            with open(yaml_path, "r", encoding="utf-8") as f:
-                updated_content = f.read()
-
-            is_valid, error_messages = self._validate_metric_yaml(updated_content, yaml_path)
-            if not is_valid:
-                # Rollback: restore original content if validation failed
-                with open(yaml_path, "w", encoding="utf-8") as f:
-                    f.write(original_content)
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.INVALID_PARAMETERS,
-                    errorMessage=f"YAML validation failed: {'; '.join(error_messages)}",
-                )
-
-            # Step 8: Sync to database
-            sync_result = GenerationHooks._sync_semantic_to_db(
-                file_path=yaml_path,
-                agent_config=self.agent_config,
-                include_semantic_objects=False,
-                include_metrics=True,
-            )
-
-            if not sync_result.get("success", False):
-                # Rollback: restore original content if sync failed
-                with open(yaml_path, "w", encoding="utf-8") as f:
-                    f.write(original_content)
-                return Result[dict](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=sync_result.get("error", "Failed to sync metric to database"),
-                )
-
-            logger.info(f"Successfully edited metric: {metric_name}")
-            return Result[dict](success=True, data={})
 
         except Exception as e:
             logger.error(f"Failed to edit metric: {e}")
@@ -1557,27 +1275,27 @@ class ExplorerService:
                 parent_path = request.subject_path[:-1] if len(request.subject_path) > 1 else []
                 metric_name = request.subject_path[-1]
 
-                # OSI: remove the metric from its semantic_model file first (the
-                # KB row's file logic only understands MetricFlow docs). The KB
-                # delete below then drops the vector row (file edit is a no-op).
-                if self._is_osi_authoring():
-                    adapter = self._semantic_adapter()
-                    if adapter is not None:
-                        try:
-                            await asyncio.to_thread(adapter.delete_metric_source, metric_name, subject_path=parent_path)
-                        except Exception as e:  # noqa: BLE001
-                            # A real write failure must fail the request; only an
-                            # already-absent metric (file/KB drift) is benign,
-                            # otherwise the file keeps the metric while the KB row
-                            # is dropped and it "revives" on the next re-index.
-                            if await asyncio.to_thread(self._osi_metric_exists, adapter, metric_name, parent_path):
-                                logger.error(f"Failed to delete OSI metric from source file: {e}")
-                                return Result[dict](
-                                    success=False,
-                                    errorCode=ErrorCode.TOOL_EXECUTION_ERROR,
-                                    errorMessage=f"Failed to remove metric from source file: {e}",
-                                )
-                            logger.warning(f"OSI metric already absent from source file, continuing: {e}")
+                # Remove the metric from its source file first (the file is the
+                # source of truth), then drop the KB row below. The adapter owns
+                # the format-correct file edit; metric_rag.delete_metric's own
+                # file handling is then a no-op since the metric is already gone.
+                adapter = self._semantic_adapter()
+                if adapter is not None:
+                    try:
+                        await asyncio.to_thread(adapter.delete_metric_source, metric_name, subject_path=parent_path)
+                    except Exception as e:  # noqa: BLE001
+                        # A real write failure must fail the request; only an
+                        # already-absent metric (file/KB drift) is benign,
+                        # otherwise the file keeps the metric while the KB row is
+                        # dropped and it "revives" on the next re-index.
+                        if await asyncio.to_thread(self._metric_exists_in_source, adapter, metric_name, parent_path):
+                            logger.error(f"Failed to delete metric from source file: {e}")
+                            return Result[dict](
+                                success=False,
+                                errorCode=ErrorCode.TOOL_EXECUTION_ERROR,
+                                errorMessage=f"Failed to remove metric from source file: {e}",
+                            )
+                        logger.warning(f"Metric already absent from source file, continuing: {e}")
 
                 result = self.metric_rag.delete_metric(parent_path, metric_name)
                 if not result.get("success", False):

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -119,6 +119,16 @@ class ExplorerService:
 
         return GenerationTools(self.agent_config).sync_osi_to_db(file_path)
 
+    @staticmethod
+    def _osi_metric_exists(adapter, metric_name: str, parent_path: List[str]) -> bool:
+        """Whether the metric still reads from the source file (used after a
+        delete error to tell a real write failure from an already-absent metric)."""
+        try:
+            adapter.read_metric_source(metric_name, subject_path=parent_path)
+            return True
+        except Exception:  # noqa: BLE001 - any read failure means "not present"
+            return False
+
     def _author_osi_metric(
         self,
         parent_path: List[str],
@@ -130,8 +140,13 @@ class ExplorerService:
         """Validate + write an OSI metric to its source file, then re-index the KB.
 
         The OSI adapter owns file placement and structure; this method handles
-        the app-level orchestration (name resolution, validation gate, KB
-        re-sync, and rollback when the KB sync fails).
+        the app-level orchestration: name resolution, validation gate, KB
+        re-sync, and rollback so the file (source of truth) and the KB never
+        drift. On KB-sync failure a create is deleted and an edit is restored to
+        its previous content.
+
+        Runs synchronously (file I/O + KB embedding); callers off the event loop
+        should invoke it via ``asyncio.to_thread``.
         """
         from datus.api.models.config_models import ErrorCode
 
@@ -161,6 +176,15 @@ class ExplorerService:
                 errorMessage=f"YAML validation failed: {messages}",
             )
 
+        # Capture the current content so an edit can be rolled back if the KB
+        # re-sync fails (a create rolls back by deleting).
+        previous_source = None
+        if not create:
+            try:
+                previous_source = adapter.read_metric_source(name, subject_path=parent_path)
+            except Exception as e:  # noqa: BLE001 - restore is best-effort
+                logger.warning(f"Could not snapshot OSI metric before edit; rollback disabled: {e}")
+
         try:
             mutation = adapter.write_metric_source(name, metric_yaml, subject_path=parent_path, create=create)
         except Exception as e:  # noqa: BLE001 - surface adapter write errors to the caller
@@ -171,23 +195,30 @@ class ExplorerService:
                 errorMessage=str(e),
             )
 
-        # Re-index the changed file into the KB. On failure roll back a newly
-        # created metric so the file and KB do not drift.
+        # Re-index the changed file into the KB. On failure, undo the write so
+        # the file and the KB stay consistent.
         sync_result = self._sync_osi_file_to_kb(mutation.file_path)
         if not sync_result.get("success", False):
-            if create:
-                try:
-                    adapter.delete_metric_source(name, subject_path=parent_path)
-                except Exception as rollback_error:  # noqa: BLE001
-                    logger.error(f"Rollback of created OSI metric failed: {rollback_error}")
+            self._rollback_osi_write(adapter, name, parent_path, create, previous_source)
             return Result[dict](
                 success=False,
-                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                errorCode=ErrorCode.TOOL_EXECUTION_ERROR,
                 errorMessage=sync_result.get("error", "Failed to sync metric to Knowledge Base"),
             )
 
         logger.info(f"Successfully {'created' if create else 'edited'} OSI metric: {name}")
         return Result[dict](success=True, data={})
+
+    @staticmethod
+    def _rollback_osi_write(adapter, name, parent_path, create, previous_source) -> None:
+        """Undo a metric write after a failed KB re-sync."""
+        try:
+            if create:
+                adapter.delete_metric_source(name, subject_path=parent_path)
+            elif previous_source is not None:
+                adapter.write_metric_source(name, previous_source.text, subject_path=parent_path, create=False)
+        except Exception as rollback_error:  # noqa: BLE001
+            logger.error(f"Rollback of OSI metric '{name}' failed; file and KB may be inconsistent: {rollback_error}")
 
     def _semantic_runtime_db_context(self, request=None) -> dict:
         """Build runtime DB context for semantic adapter API calls."""
@@ -704,15 +735,27 @@ class ExplorerService:
             parent_path = subject_path[:-1] if len(subject_path) > 1 else []
             metric_name = subject_path[-1]
 
+            # The KB row remains the access-control gate: it enforces the full
+            # subject_path match and sub-agent scoping. Only its *content* is
+            # untrustworthy (a lossy, MetricFlow-shaped reconstruction), so we
+            # use it for existence/scoping and the file for the returned YAML.
+            metrics_detail = self.metric_rag.get_metrics_detail(parent_path, metric_name)
+            if not metrics_detail:
+                return Result[MetricInfo](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage=f"Metric not found: {metric_name}",
+                )
+
             # Source of truth is the YAML file: read it back through the semantic
             # adapter so the returned YAML is in the metric's native format (OSI
-            # or MetricFlow), not a lossy reconstruction from the KB projection.
+            # or MetricFlow) rather than the KB reconstruction.
             adapter = self._semantic_adapter()
             if adapter is not None:
                 from datus_semantic_core.authoring import AuthoringNotSupportedError
 
                 try:
-                    source = adapter.read_metric_source(metric_name, subject_path=parent_path)
+                    source = await asyncio.to_thread(adapter.read_metric_source, metric_name, subject_path=parent_path)
                     return Result[MetricInfo](
                         success=True,
                         data=MetricInfo(name=metric_name, yaml=source.text),
@@ -723,15 +766,6 @@ class ExplorerService:
                     logger.warning(f"Adapter read_metric_source failed, using KB fallback: {e}")
 
             # Fallback: reconstruct MetricFlow-shaped YAML from the KB projection.
-            metrics_detail = self.metric_rag.get_metrics_detail(parent_path, metric_name)
-
-            if not metrics_detail:
-                return Result[MetricInfo](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=f"Metric not found: {metric_name}",
-                )
-
             metric_data = metrics_detail[0]
             yaml_dict = self._metric_db_to_yaml(metric_data)
             metric_yaml = yaml.dump(
@@ -1095,7 +1129,7 @@ class ExplorerService:
             # files: author them through the adapter (source of truth), then
             # re-index the changed file into the KB.
             if self._is_osi_authoring():
-                return self._author_osi_metric(parent_path, request.yaml, create=True)
+                return await asyncio.to_thread(self._author_osi_metric, parent_path, request.yaml, create=True)
 
             # Step 1: Parse YAML to extract metric name (only one document allowed)
             try:
@@ -1252,7 +1286,13 @@ class ExplorerService:
             # OSI: update the metric in place inside its semantic_model file via
             # the adapter, preserving datasets and sibling metrics.
             if self._is_osi_authoring():
-                return self._author_osi_metric(parent_path, request.yaml, create=False, metric_name=metric_name)
+                return await asyncio.to_thread(
+                    self._author_osi_metric,
+                    parent_path,
+                    request.yaml,
+                    create=False,
+                    metric_name=metric_name,
+                )
 
             # Step 1: Check if metric exists
             existing_metrics = self.metric_rag.get_metrics_detail(parent_path, metric_name)
@@ -1524,9 +1564,20 @@ class ExplorerService:
                     adapter = self._semantic_adapter()
                     if adapter is not None:
                         try:
-                            adapter.delete_metric_source(metric_name, subject_path=parent_path)
-                        except Exception as e:  # noqa: BLE001 - continue to KB cleanup
-                            logger.warning(f"Adapter delete_metric_source failed: {e}")
+                            await asyncio.to_thread(adapter.delete_metric_source, metric_name, subject_path=parent_path)
+                        except Exception as e:  # noqa: BLE001
+                            # A real write failure must fail the request; only an
+                            # already-absent metric (file/KB drift) is benign,
+                            # otherwise the file keeps the metric while the KB row
+                            # is dropped and it "revives" on the next re-index.
+                            if await asyncio.to_thread(self._osi_metric_exists, adapter, metric_name, parent_path):
+                                logger.error(f"Failed to delete OSI metric from source file: {e}")
+                                return Result[dict](
+                                    success=False,
+                                    errorCode=ErrorCode.TOOL_EXECUTION_ERROR,
+                                    errorMessage=f"Failed to remove metric from source file: {e}",
+                                )
+                            logger.warning(f"OSI metric already absent from source file, continuing: {e}")
 
                 result = self.metric_rag.delete_metric(parent_path, metric_name)
                 if not result.get("success", False):

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -285,6 +285,12 @@ class MetricStorage(BaseSubjectEmbeddingStore):
             if existing_name not in names:
                 continue
             incoming = next(metric for metric in metrics if normalize_metric_name(metric.get("name")) == existing_name)
+            # Same id == same metric identity (ids are name-derived): a re-sync
+            # legitimately overwrites it in place — including a changed
+            # definition — since the YAML file is the source of truth. Only a
+            # *different* id sharing the name is a genuine identity collision.
+            if existing.get("id") == incoming.get("id"):
+                continue
             conflict_field = metric_definition_conflict(existing, incoming)
             if conflict_field:
                 raise ValueError(
@@ -292,7 +298,7 @@ class MetricStorage(BaseSubjectEmbeddingStore):
                     f"existing metric id '{existing.get('id')}' has a different '{conflict_field}'. "
                     "Choose a more specific metric name or update the existing metric explicitly."
                 )
-            if existing.get("id") and existing.get("id") != incoming.get("id"):
+            if existing.get("id"):
                 stale_duplicate_ids.append(str(existing["id"]))
 
         return stale_duplicate_ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,8 @@ ci = [
     "datus-storage-postgresql>=0.1.5",
     "datus-metricflow>=0.2.7",
     "datus-semantic-metricflow>=0.2.11",
+    # Required so the OSI authoring tests run in CI (rather than skipping).
+    "datus-semantic-osi>=0.1.4",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "lxml>=5.0.0",
     "markdown-it-py>=3.0.0",
     "tabulate>=0.9.0",
-    "datus-semantic-core>=0.2.1",
+    "datus-semantic-core>=0.2.2",
     # BI platform adapters (core models & interfaces)
     "datus-bi-core>=0.1.2",
     # Workflow scheduler adapters (core framework)
@@ -201,7 +201,7 @@ dev = [
 ci = [
     "datus-storage-postgresql>=0.1.5",
     "datus-metricflow>=0.2.7",
-    "datus-semantic-metricflow>=0.2.9",
+    "datus-semantic-metricflow>=0.2.11",
 ]
 
 [tool.coverage.run]

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,6 @@ markdown-it-py>=3.0.0
 tabulate>=0.9.0
 datus-storage-base==0.1.5
 datus-db-core>=0.1.4
-datus-semantic-core>=0.2.1
+datus-semantic-core>=0.2.2
 datus-bi-core>=0.1.2
 datus-scheduler-core>=0.1.1

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -448,171 +448,140 @@ class TestExplorerServiceSubjectAssets:
 
 
 @pytest.mark.asyncio
-class TestExplorerServiceCreateMetric:
-    """Tests for create_metric — metric creation with YAML validation."""
+class TestExplorerServiceMetricFlowAuthoring:
+    """create/edit/delete for MetricFlow now route through the unified
+    ``_author_metric`` (adapter is the source of truth), keeping MetricFlow's
+    real model validation via ``_validate_metric_yaml``."""
 
-    async def test_create_metric_invalid_yaml(self, real_agent_config):
-        """create_metric with invalid YAML returns error."""
+    METRIC = "metric:\n  name: revenue\n  type: aggregate\n"
+
+    def _wire(self, svc, monkeypatch, model_dir, *, validate=(True, []), sync_ok=True):
+        from types import SimpleNamespace
+
+        from datus_semantic_metricflow.authoring import MetricFlowMetricAuthor
+
+        author = MetricFlowMetricAuthor(str(model_dir))
+        # Mirror MetricFlowAdapter's *_metric_source delegation to the author.
+        adapter = SimpleNamespace(
+            read_metric_source=lambda name, subject_path=None: author.read(name),
+            write_metric_source=lambda name, source, subject_path=None, create=False: author.write(
+                name, source, subject_path=subject_path, create=create
+            ),
+            delete_metric_source=lambda name, subject_path=None: author.delete(name),
+            validate_metric_source=lambda source, metric_name=None: author.validate(source, metric_name=metric_name),
+        )
+        monkeypatch.setattr(
+            "datus.tools.func_tool.semantic_tools.SemanticTools",
+            lambda *a, **k: SimpleNamespace(adapter=adapter),
+        )
+        monkeypatch.setattr("datus.agent.node.semantic_authoring.is_osi_authoring", lambda *a, **k: False)
+        # Real MetricFlow model validation is stubbed (needs a live model); the
+        # unified path still calls it, which is what we assert.
+        monkeypatch.setattr(svc, "_validate_metric_yaml", lambda content, path: validate)
+        monkeypatch.setattr(
+            svc,
+            "_sync_file_to_kb",
+            lambda is_osi, file_path: {"success": True} if sync_ok else {"success": False, "error": "boom"},
+        )
+
+    async def test_create_missing_name_fails(self, real_agent_config, tmp_path, monkeypatch):
         from datus.api.models.explorer_models import EditMetricInput
 
         svc = ExplorerService(agent_config=real_agent_config)
-        request = EditMetricInput(
-            subject_path=["test_dir"],
-            yaml=":\n  - ][",
-        )
-        result = await svc.create_metric(request)
-        assert result.success is False
-        assert "Invalid YAML format" in result.errorMessage
-
-    async def test_create_metric_missing_metric_key(self, real_agent_config):
-        """create_metric with YAML missing 'metric' key returns error."""
-        from datus.api.models.explorer_models import EditMetricInput
-
-        svc = ExplorerService(agent_config=real_agent_config)
-        request = EditMetricInput(
-            subject_path=["test_dir"],
-            yaml="data_source:\n  name: test\n",
-        )
-        result = await svc.create_metric(request)
-        assert result.success is False
-        assert "no metric document" in result.errorMessage.lower()
-
-    async def test_create_metric_missing_name(self, real_agent_config):
-        """create_metric with metric missing 'name' returns error."""
-        from datus.api.models.explorer_models import EditMetricInput
-
-        svc = ExplorerService(agent_config=real_agent_config)
-        request = EditMetricInput(
-            subject_path=["test_dir"],
-            yaml="metric:\n  type: simple\n",
-        )
-        result = await svc.create_metric(request)
+        self._wire(svc, monkeypatch, tmp_path)
+        result = await svc.create_metric(EditMetricInput(subject_path=["d"], yaml="metric:\n  type: aggregate\n"))
         assert result.success is False
         assert "name" in result.errorMessage.lower()
 
-    async def test_create_metric_with_valid_yaml(self, real_agent_config):
-        """create_metric with valid YAML exercises the full creation path."""
-        import os
-        from unittest.mock import patch
-
-        from datus.api.models.explorer_models import EditMetricInput
-
-        svc = ExplorerService(agent_config=real_agent_config)
-        await svc.create_directory(CreateDirectoryInput(subject_path=["metric_create_test"]))
-
-        metrics_dir = (
-            real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource) / "metrics"
-        )
-        os.makedirs(metrics_dir, exist_ok=True)
-
-        request = EditMetricInput(
-            subject_path=["metric_create_test"],
-            yaml="metric:\n  name: test_revenue\n  type: measure_proxy\n  type_params:\n    measure: count_orders\n",
-        )
-        with (
-            patch.object(svc, "_validate_metric_yaml", return_value=(True, [])),
-            patch("datus.cli.generation_hooks.GenerationHooks._sync_semantic_to_db", return_value={"success": True}),
-        ):
-            result = await svc.create_metric(request)
-        assert isinstance(result, Result)
-        assert result.success is True
-        assert (metrics_dir / "test_revenue.yml").exists()
-
-    async def test_create_metric_duplicate_file_fails(self, real_agent_config):
-        """create_metric rejects when file already exists on disk."""
+    async def test_create_writes_file_and_validates(self, real_agent_config, tmp_path, monkeypatch):
         import os
 
         from datus.api.models.explorer_models import EditMetricInput
 
         svc = ExplorerService(agent_config=real_agent_config)
-        await svc.create_directory(CreateDirectoryInput(subject_path=["dup_file_dir"]))
+        validated = {}
+        self._wire(svc, monkeypatch, tmp_path)
 
-        metrics_dir = (
-            real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource) / "metrics"
-        )
-        os.makedirs(metrics_dir, exist_ok=True)
+        def fake_validate(content, path):
+            validated["called"] = True
+            return (True, [])
 
-        # Pre-create the file on disk
-        file_path = metrics_dir / "pre_existing.yml"
-        file_path.write_text("metric:\n  name: pre_existing\n")
+        monkeypatch.setattr(svc, "_validate_metric_yaml", fake_validate)
 
-        result = await svc.create_metric(
-            EditMetricInput(
-                subject_path=["dup_file_dir"],
-                yaml="metric:\n  name: pre_existing\n  type: measure_proxy\n",
-            )
-        )
+        result = await svc.create_metric(EditMetricInput(subject_path=["d"], yaml=self.METRIC))
+        assert result.success is True, result.errorMessage
+        assert os.path.exists(tmp_path / "metrics" / "revenue.yml")
+        assert validated.get("called")  # MetricFlow validation ran
+
+    async def test_create_validation_failure_rolls_back(self, real_agent_config, tmp_path, monkeypatch):
+        import os
+
+        from datus.api.models.explorer_models import EditMetricInput
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, tmp_path, validate=(False, ["bad measure"]))
+
+        result = await svc.create_metric(EditMetricInput(subject_path=["d"], yaml=self.METRIC))
         assert result.success is False
-        assert "already exists" in result.errorMessage.lower()
+        assert "bad measure" in result.errorMessage
+        assert not os.path.exists(tmp_path / "metrics" / "revenue.yml")  # rolled back
 
-    async def test_create_metric_with_subject_tree_tag(self, real_agent_config):
-        """create_metric with locked_metadata.tags subject_tree overrides the tag."""
+    async def test_create_kb_sync_failure_rolls_back(self, real_agent_config, tmp_path, monkeypatch):
         import os
 
         from datus.api.models.explorer_models import EditMetricInput
 
         svc = ExplorerService(agent_config=real_agent_config)
-        await svc.create_directory(CreateDirectoryInput(subject_path=["tagged_dir"]))
+        self._wire(svc, monkeypatch, tmp_path, sync_ok=False)
 
-        metrics_dir = (
-            real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource) / "metrics"
-        )
-        os.makedirs(metrics_dir, exist_ok=True)
+        result = await svc.create_metric(EditMetricInput(subject_path=["d"], yaml=self.METRIC))
+        assert result.success is False
+        assert not os.path.exists(tmp_path / "metrics" / "revenue.yml")  # rolled back
 
-        yaml_content = (
-            "metric:\n"
-            "  name: tagged_metric\n"
-            "  type: simple\n"
-            "  type_params:\n"
-            "    measure: cnt\n"
-            "  locked_metadata:\n"
-            "    tags:\n"
-            "      - 'subject_tree: old_path'\n"
-        )
-        request = EditMetricInput(subject_path=["tagged_dir"], yaml=yaml_content)
-        result = await svc.create_metric(request)
-        assert isinstance(result, Result)
-        assert isinstance(result.success, bool)
-
-
-@pytest.mark.asyncio
-class TestExplorerServiceEditMetric:
-    """Tests for edit_metric — metric update with YAML validation."""
-
-    async def test_edit_metric_empty_path(self, real_agent_config):
-        """edit_metric with empty path returns error."""
+    async def test_edit_empty_path_fails(self, real_agent_config):
         from datus.api.models.explorer_models import EditMetricInput
 
         svc = ExplorerService(agent_config=real_agent_config)
-        request = EditMetricInput(subject_path=[], yaml="metric:\n  name: test\n")
-        result = await svc.edit_metric(request)
+        result = await svc.edit_metric(EditMetricInput(subject_path=[], yaml=self.METRIC))
         assert result.success is False
         assert "empty" in result.errorMessage.lower()
 
-    async def test_edit_metric_nonexistent(self, real_agent_config):
-        """edit_metric for nonexistent metric returns error."""
+    async def test_edit_updates_in_place(self, real_agent_config, tmp_path, monkeypatch):
+        import yaml
+
         from datus.api.models.explorer_models import EditMetricInput
 
+        (tmp_path / "revenue.yml").write_text(self.METRIC)
         svc = ExplorerService(agent_config=real_agent_config)
-        request = EditMetricInput(
-            subject_path=["dir", "nonexistent_metric"],
-            yaml="metric:\n  name: nonexistent_metric\n  type: simple\n",
-        )
-        result = await svc.edit_metric(request)
+        self._wire(svc, monkeypatch, tmp_path)
+
+        edited = "metric:\n  name: revenue\n  type: aggregate\n  description: edited\n"
+        result = await svc.edit_metric(EditMetricInput(subject_path=["revenue"], yaml=edited))
+        assert result.success is True, result.errorMessage
+        node = yaml.safe_load((tmp_path / "revenue.yml").read_text())["metric"]
+        assert node["description"] == "edited"
+
+    async def test_edit_validation_failure_restores(self, real_agent_config, tmp_path, monkeypatch):
+        from datus.api.models.explorer_models import EditMetricInput
+
+        (tmp_path / "revenue.yml").write_text(self.METRIC)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, tmp_path, validate=(False, ["nope"]))
+
+        edited = "metric:\n  name: revenue\n  type: aggregate\n  description: edited\n"
+        result = await svc.edit_metric(EditMetricInput(subject_path=["revenue"], yaml=edited))
         assert result.success is False
-        assert "not found" in result.errorMessage.lower()
+        # Restored to the original (no 'description').
+        assert (tmp_path / "revenue.yml").read_text() == self.METRIC
 
-    async def test_edit_metric_invalid_yaml(self, real_agent_config):
-        """edit_metric with invalid YAML returns error (assuming metric exists check passes first)."""
+    async def test_edit_nonexistent_fails(self, real_agent_config, tmp_path, monkeypatch):
         from datus.api.models.explorer_models import EditMetricInput
 
         svc = ExplorerService(agent_config=real_agent_config)
-        # This will fail at "metric not found" before YAML validation, which is fine
-        request = EditMetricInput(
-            subject_path=["dir", "some_metric"],
-            yaml=":\n  - ][",
+        self._wire(svc, monkeypatch, tmp_path)
+        result = await svc.edit_metric(
+            EditMetricInput(subject_path=["ghost"], yaml="metric:\n  name: ghost\n  type: aggregate\n")
         )
-        result = await svc.edit_metric(request)
         assert result.success is False
 
 
@@ -780,80 +749,6 @@ class TestMetricDbToYaml:
         }
         result = ExplorerService._metric_db_to_yaml(data)
         assert "locked_metadata" not in result["metric"]
-
-
-class TestUpdateMetricInYamlDocs:
-    """Tests for _update_metric_in_yaml_docs helper."""
-
-    def test_updates_existing_metric(self, real_agent_config):
-        """Updates metric in document list when name matches."""
-        svc = ExplorerService(agent_config=real_agent_config)
-        docs = [
-            {"metric": {"name": "revenue", "type": "simple"}},
-            {"metric": {"name": "cost", "type": "simple"}},
-        ]
-        new_data = {"name": "revenue", "type": "derived", "description": "Updated"}
-        updated, error = svc._update_metric_in_yaml_docs(docs, "revenue", new_data)
-        assert error is None
-        assert updated[0]["metric"]["type"] == "derived"
-        assert updated[1]["metric"]["name"] == "cost"  # unchanged
-
-    def test_metric_not_found_returns_error(self, real_agent_config):
-        """Returns error message when metric name not found."""
-        svc = ExplorerService(agent_config=real_agent_config)
-        docs = [{"metric": {"name": "revenue"}}]
-        updated, error = svc._update_metric_in_yaml_docs(docs, "nonexistent", {})
-        assert error == "Metric 'nonexistent' not found in YAML file"
-        assert updated == docs
-
-    def test_skips_none_documents(self, real_agent_config):
-        """Skips None/empty documents without error."""
-        svc = ExplorerService(agent_config=real_agent_config)
-        docs = [None, {"metric": {"name": "target"}}, None]
-        new_data = {"name": "target", "type": "updated"}
-        updated, error = svc._update_metric_in_yaml_docs(docs, "target", new_data)
-        assert error is None
-
-
-class TestWriteYamlAtomic:
-    """Tests for _write_yaml_atomic — atomic file writing."""
-
-    def test_writes_yaml_documents(self, real_agent_config, tmp_path):
-        """Successfully writes YAML documents atomically."""
-        svc = ExplorerService(agent_config=real_agent_config)
-        file_path = str(tmp_path / "test.yml")
-        docs = [{"metric": {"name": "test", "type": "simple"}}]
-        error = svc._write_yaml_atomic(file_path, docs)
-        assert error is None
-        # Verify file was written
-        import yaml
-
-        with open(file_path) as f:
-            loaded = list(yaml.safe_load_all(f))
-        assert loaded[0]["metric"]["name"] == "test"
-
-    def test_writes_multiple_documents(self, real_agent_config, tmp_path):
-        """Writes multiple YAML documents with separators."""
-        svc = ExplorerService(agent_config=real_agent_config)
-        file_path = str(tmp_path / "multi.yml")
-        docs = [
-            {"metric": {"name": "m1"}},
-            {"metric": {"name": "m2"}},
-        ]
-        error = svc._write_yaml_atomic(file_path, docs)
-        assert error is None
-        import yaml
-
-        with open(file_path) as f:
-            loaded = list(yaml.safe_load_all(f))
-        assert len(loaded) == 2
-
-    def test_invalid_directory_returns_error(self, real_agent_config):
-        """Writing to nonexistent directory returns error message."""
-        svc = ExplorerService(agent_config=real_agent_config)
-        error = svc._write_yaml_atomic("/nonexistent/path/file.yml", [{"a": 1}])
-        assert error.startswith("Failed to write YAML file:")
-        assert "Failed to write" in error
 
 
 class TestGetSemanticFilePath:
@@ -1176,7 +1071,7 @@ class TestExplorerServiceOSIAuthoring:
             "datus.agent.node.semantic_authoring.is_osi_authoring",
             lambda *a, **k: True,
         )
-        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", lambda file_path: {"success": True})
+        monkeypatch.setattr(svc, "_sync_file_to_kb", lambda is_osi, file_path: {"success": True})
         # get_metric still gates on the KB row for scope/access control; the row
         # content is irrelevant since the adapter supplies the returned YAML.
         monkeypatch.setattr(svc.metric_rag, "get_metrics_detail", lambda parent, name, *a, **k: [{"name": name}])
@@ -1258,11 +1153,11 @@ class TestExplorerServiceOSIAuthoring:
         self._wire(svc, monkeypatch, adapter)
         synced = {}
 
-        def fake_sync(file_path):
+        def fake_sync(is_osi, file_path):
             synced["path"] = file_path
             return {"success": True}
 
-        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", fake_sync)
+        monkeypatch.setattr(svc, "_sync_file_to_kb", fake_sync)
 
         new_metric = (
             "name: gross_revenue\n"
@@ -1348,7 +1243,7 @@ class TestExplorerServiceOSIAuthoring:
         svc = ExplorerService(agent_config=real_agent_config)
         self._wire(svc, monkeypatch, adapter)
         # KB re-sync fails -> the newly created metric must be removed again.
-        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", lambda file_path: {"success": False, "error": "boom"})
+        monkeypatch.setattr(svc, "_sync_file_to_kb", lambda is_osi, file_path: {"success": False, "error": "boom"})
 
         new_metric = (
             "name: gross_revenue\n"
@@ -1376,7 +1271,7 @@ class TestExplorerServiceOSIAuthoring:
         adapter = self._osi_adapter(tmp_path)
         svc = ExplorerService(agent_config=real_agent_config)
         self._wire(svc, monkeypatch, adapter)
-        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", lambda file_path: {"success": False, "error": "boom"})
+        monkeypatch.setattr(svc, "_sync_file_to_kb", lambda is_osi, file_path: {"success": False, "error": "boom"})
 
         edited = (
             "name: daily_order_count\n"

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -1046,7 +1046,8 @@ class TestExplorerServiceOSIAuthoring:
     )
 
     def _osi_adapter(self, tmp_path):
-        pytest.importorskip("datus_semantic_osi")
+        # datus-semantic-osi is a guaranteed test dependency (dependency-groups
+        # dev in pyproject), so these run in CI rather than silently skipping.
         from datus_semantic_osi.adapter import DatusOSIAdapter
         from datus_semantic_osi.config import DatusOSIConfig
 
@@ -1313,3 +1314,25 @@ class TestExplorerServiceOSIAuthoring:
         )
         assert result.success is False
         assert kb_deleted["called"] is False  # KB row not dropped when file delete failed
+
+    async def test_delete_metric_absent_from_source_still_cleans_kb(self, real_agent_config, tmp_path, monkeypatch):
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+
+        # Metric already gone from the source file (file/KB drift): the not-found
+        # error is benign and the stale KB row is still cleaned up.
+        def not_found(*a, **k):
+            raise FileNotFoundError("Metric `x` was not found in ...")
+
+        monkeypatch.setattr(adapter, "delete_metric_source", not_found)
+        kb_deleted = {"called": False}
+        monkeypatch.setattr(
+            svc.metric_rag, "delete_metric", lambda *a, **k: kb_deleted.update(called=True) or {"success": True}
+        )
+
+        result = await svc.delete_subject(
+            DeleteSubjectInput(type=SubjectNodeType.METRIC, subject_path=["operations", "daily", "daily_order_count"])
+        )
+        assert result.success is True, result.errorMessage
+        assert kb_deleted["called"] is True  # stale KB row cleaned up

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -1177,6 +1177,9 @@ class TestExplorerServiceOSIAuthoring:
             lambda *a, **k: True,
         )
         monkeypatch.setattr(svc, "_sync_osi_file_to_kb", lambda file_path: {"success": True})
+        # get_metric still gates on the KB row for scope/access control; the row
+        # content is irrelevant since the adapter supplies the returned YAML.
+        monkeypatch.setattr(svc.metric_rag, "get_metrics_detail", lambda parent, name, *a, **k: [{"name": name}])
 
     async def test_get_metric_returns_osi_native_yaml(self, real_agent_config, tmp_path, monkeypatch):
         import yaml
@@ -1195,6 +1198,7 @@ class TestExplorerServiceOSIAuthoring:
     async def test_get_metric_falls_back_when_authoring_unsupported(self, real_agent_config, tmp_path, monkeypatch):
         from types import SimpleNamespace
 
+        import yaml
         from datus_semantic_core.authoring import AuthoringNotSupportedError
 
         class _NoAuthoring:
@@ -1206,12 +1210,43 @@ class TestExplorerServiceOSIAuthoring:
             "datus.tools.func_tool.semantic_tools.SemanticTools",
             lambda *a, **k: SimpleNamespace(adapter=_NoAuthoring()),
         )
+        # KB row exists (gate passes); adapter has no file source, so the
+        # response is reconstructed from the KB projection.
+        monkeypatch.setattr(
+            svc.metric_rag,
+            "get_metrics_detail",
+            lambda parent, name, *a, **k: [{"name": name, "metric_type": "simple", "base_measures": ["revenue"]}],
+        )
+
+        result = await svc.get_metric(["revenue", "daily_revenue"])
+        assert result.success is True
+        assert yaml.safe_load(result.data.yaml)["metric"]["name"] == "daily_revenue"
+
+    async def test_get_metric_not_found_when_kb_row_missing(self, real_agent_config, tmp_path, monkeypatch):
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+        # KB gate enforces scope: no row -> not found, even though the file has it.
         monkeypatch.setattr(svc.metric_rag, "get_metrics_detail", lambda *a, **k: [])
 
-        result = await svc.get_metric(["missing"])
-        # Fallback path ran and reported not-found from the KB projection.
+        result = await svc.get_metric(["wrong", "path", "daily_order_count"])
         assert result.success is False
         assert "not found" in result.errorMessage.lower()
+
+    async def test_create_metric_adapter_unavailable_fails(self, real_agent_config, monkeypatch):
+        from types import SimpleNamespace
+
+        from datus.api.models.explorer_models import EditMetricInput
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        monkeypatch.setattr("datus.agent.node.semantic_authoring.is_osi_authoring", lambda *a, **k: True)
+        monkeypatch.setattr(
+            "datus.tools.func_tool.semantic_tools.SemanticTools",
+            lambda *a, **k: SimpleNamespace(adapter=None),
+        )
+        result = await svc.create_metric(EditMetricInput(subject_path=["x"], yaml="name: m\ntype: aggregate\n"))
+        assert result.success is False
+        assert "adapter is not available" in result.errorMessage
 
     async def test_create_metric_writes_osi_file_and_syncs(self, real_agent_config, tmp_path, monkeypatch):
         import yaml
@@ -1303,3 +1338,83 @@ class TestExplorerServiceOSIAuthoring:
         assert result.success is True, result.errorMessage
         on_disk = yaml.safe_load((tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text())
         assert on_disk["semantic_model"][0]["metrics"] == []
+
+    async def test_create_metric_rolls_back_on_kb_sync_failure(self, real_agent_config, tmp_path, monkeypatch):
+        import yaml
+
+        from datus.api.models.explorer_models import EditMetricInput
+
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+        # KB re-sync fails -> the newly created metric must be removed again.
+        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", lambda file_path: {"success": False, "error": "boom"})
+
+        new_metric = (
+            "name: gross_revenue\n"
+            "description: revenue\n"
+            "expression:\n"
+            "  dialects:\n"
+            "    - dialect: STARROCKS\n"
+            "      expression: SUM(order_total)\n"
+            "custom_extensions:\n"
+            "  - vendor_name: DATUS\n"
+            '    data: \'{"dataset":"raw_orders"}\'\n'
+        )
+        result = await svc.create_metric(EditMetricInput(subject_path=["revenue"], yaml=new_metric))
+        assert result.success is False
+        assert "boom" in result.errorMessage
+        on_disk = yaml.safe_load((tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text())
+        names = [m["name"] for m in on_disk["semantic_model"][0]["metrics"]]
+        assert "gross_revenue" not in names  # rolled back
+
+    async def test_edit_metric_restores_previous_on_kb_sync_failure(self, real_agent_config, tmp_path, monkeypatch):
+        import yaml
+
+        from datus.api.models.explorer_models import EditMetricInput
+
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", lambda file_path: {"success": False, "error": "boom"})
+
+        edited = (
+            "name: daily_order_count\n"
+            "description: EDITED\n"
+            "expression:\n"
+            "  dialects:\n"
+            "    - dialect: STARROCKS\n"
+            "      expression: COUNT(DISTINCT id)\n"
+            "custom_extensions:\n"
+            "  - vendor_name: DATUS\n"
+            '    data: \'{"dataset":"raw_orders"}\'\n'
+        )
+        result = await svc.edit_metric(
+            EditMetricInput(subject_path=["operations", "daily", "daily_order_count"], yaml=edited)
+        )
+        assert result.success is False
+        on_disk = yaml.safe_load((tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text())
+        # Edit was reverted to the original description.
+        assert on_disk["semantic_model"][0]["metrics"][0]["description"] == "Daily order count."
+
+    async def test_delete_metric_real_write_failure_fails(self, real_agent_config, tmp_path, monkeypatch):
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+
+        # Simulate a real write failure: delete raises but the metric is still
+        # present in the file -> the request must fail (not silently drop the KB).
+        def boom(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(adapter, "delete_metric_source", boom)
+        kb_deleted = {"called": False}
+        monkeypatch.setattr(
+            svc.metric_rag, "delete_metric", lambda *a, **k: kb_deleted.update(called=True) or {"success": True}
+        )
+
+        result = await svc.delete_subject(
+            DeleteSubjectInput(type=SubjectNodeType.METRIC, subject_path=["operations", "daily", "daily_order_count"])
+        )
+        assert result.success is False
+        assert kb_deleted["called"] is False  # KB row not dropped when file delete failed

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -1117,3 +1117,189 @@ class TestExplorerServicePreviewMetric:
         result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"]))
         assert result.success is False
         assert "boom" in result.errorMessage
+
+
+@pytest.mark.asyncio
+class TestExplorerServiceOSIAuthoring:
+    """OSI metrics are read/written through the semantic adapter (file source of
+    truth), not reconstructed from / written as MetricFlow YAML."""
+
+    SAMPLE = (
+        "version: 0.2.0.dev0\n"
+        "semantic_model:\n"
+        "  - name: jeff_shop_live\n"
+        "    datasets:\n"
+        "      - name: raw_orders\n"
+        "        source: jeff_shop.raw_orders\n"
+        "        primary_key: [id]\n"
+        "        fields:\n"
+        "          - name: order_total\n"
+        "            expression:\n"
+        "              dialects:\n"
+        "                - dialect: STARROCKS\n"
+        "                  expression: order_total\n"
+        "    metrics:\n"
+        "      - name: daily_order_count\n"
+        "        description: Daily order count.\n"
+        "        expression:\n"
+        "          dialects:\n"
+        "            - dialect: STARROCKS\n"
+        "              expression: COUNT(DISTINCT id)\n"
+        "        custom_extensions:\n"
+        "          - vendor_name: DATUS\n"
+        '            data: \'{"dataset":"raw_orders","subject_path":["operations","daily"]}\'\n'
+    )
+
+    def _osi_adapter(self, tmp_path):
+        pytest.importorskip("datus_semantic_osi")
+        from datus_semantic_osi.adapter import DatusOSIAdapter
+        from datus_semantic_osi.config import DatusOSIConfig
+
+        model_dir = tmp_path / "jeff_shop_live"
+        model_dir.mkdir()
+        (model_dir / "jeff_shop_live.yml").write_text(self.SAMPLE)
+        config = DatusOSIConfig(
+            datasource="ds",
+            semantic_models_path=str(tmp_path),
+            db_config={"type": "starrocks"},
+        )
+        return DatusOSIAdapter(config)
+
+    def _wire(self, svc, monkeypatch, adapter):
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "datus.tools.func_tool.semantic_tools.SemanticTools",
+            lambda *a, **k: SimpleNamespace(adapter=adapter),
+        )
+        monkeypatch.setattr(
+            "datus.agent.node.semantic_authoring.is_osi_authoring",
+            lambda *a, **k: True,
+        )
+        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", lambda file_path: {"success": True})
+
+    async def test_get_metric_returns_osi_native_yaml(self, real_agent_config, tmp_path, monkeypatch):
+        import yaml
+
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+
+        result = await svc.get_metric(["operations", "daily", "daily_order_count"])
+        assert result.success is True
+        node = yaml.safe_load(result.data.yaml)
+        # OSI shape, not the MetricFlow reconstruction (no type/locked_metadata).
+        assert node["expression"]["dialects"][0]["dialect"] == "STARROCKS"
+        assert "type" not in node and "locked_metadata" not in node
+
+    async def test_get_metric_falls_back_when_authoring_unsupported(self, real_agent_config, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+
+        from datus_semantic_core.authoring import AuthoringNotSupportedError
+
+        class _NoAuthoring:
+            def read_metric_source(self, *a, **k):
+                raise AuthoringNotSupportedError("nope")
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        monkeypatch.setattr(
+            "datus.tools.func_tool.semantic_tools.SemanticTools",
+            lambda *a, **k: SimpleNamespace(adapter=_NoAuthoring()),
+        )
+        monkeypatch.setattr(svc.metric_rag, "get_metrics_detail", lambda *a, **k: [])
+
+        result = await svc.get_metric(["missing"])
+        # Fallback path ran and reported not-found from the KB projection.
+        assert result.success is False
+        assert "not found" in result.errorMessage.lower()
+
+    async def test_create_metric_writes_osi_file_and_syncs(self, real_agent_config, tmp_path, monkeypatch):
+        import yaml
+
+        from datus.api.models.explorer_models import EditMetricInput
+
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+        synced = {}
+
+        def fake_sync(file_path):
+            synced["path"] = file_path
+            return {"success": True}
+
+        monkeypatch.setattr(svc, "_sync_osi_file_to_kb", fake_sync)
+
+        new_metric = (
+            "name: gross_revenue\n"
+            "description: revenue\n"
+            "expression:\n"
+            "  dialects:\n"
+            "    - dialect: STARROCKS\n"
+            "      expression: SUM(order_total)\n"
+            "custom_extensions:\n"
+            "  - vendor_name: DATUS\n"
+            '    data: \'{"dataset":"raw_orders"}\'\n'
+        )
+        result = await svc.create_metric(EditMetricInput(subject_path=["revenue"], yaml=new_metric))
+        assert result.success is True, result.errorMessage
+        assert synced.get("path")  # KB re-sync was triggered
+        on_disk = yaml.safe_load((tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text())
+        names = [m["name"] for m in on_disk["semantic_model"][0]["metrics"]]
+        assert set(names) == {"daily_order_count", "gross_revenue"}
+
+    async def test_edit_metric_updates_in_place(self, real_agent_config, tmp_path, monkeypatch):
+        import yaml
+
+        from datus.api.models.explorer_models import EditMetricInput
+
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+
+        edited = (
+            "name: daily_order_count\n"
+            "description: Edited desc.\n"
+            "expression:\n"
+            "  dialects:\n"
+            "    - dialect: STARROCKS\n"
+            "      expression: COUNT(DISTINCT id)\n"
+            "custom_extensions:\n"
+            "  - vendor_name: DATUS\n"
+            '    data: \'{"dataset":"raw_orders"}\'\n'
+        )
+        result = await svc.edit_metric(
+            EditMetricInput(subject_path=["operations", "daily", "daily_order_count"], yaml=edited)
+        )
+        assert result.success is True, result.errorMessage
+        on_disk = yaml.safe_load((tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text())
+        model = on_disk["semantic_model"][0]
+        assert model["metrics"][0]["description"] == "Edited desc."
+        # Sibling dataset preserved.
+        assert model["datasets"][0]["name"] == "raw_orders"
+
+    async def test_create_metric_validation_failure_does_not_write(self, real_agent_config, tmp_path, monkeypatch):
+        from datus.api.models.explorer_models import EditMetricInput
+
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+        before = (tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text()
+
+        result = await svc.create_metric(EditMetricInput(subject_path=["x"], yaml=":: not yaml ::"))
+        assert result.success is False
+        assert (tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text() == before
+
+    async def test_delete_metric_removes_from_osi_file(self, real_agent_config, tmp_path, monkeypatch):
+        import yaml
+
+        adapter = self._osi_adapter(tmp_path)
+        svc = ExplorerService(agent_config=real_agent_config)
+        self._wire(svc, monkeypatch, adapter)
+        monkeypatch.setattr(svc.metric_rag, "delete_metric", lambda *a, **k: {"success": True})
+
+        result = await svc.delete_subject(
+            DeleteSubjectInput(type=SubjectNodeType.METRIC, subject_path=["operations", "daily", "daily_order_count"])
+        )
+        assert result.success is True, result.errorMessage
+        on_disk = yaml.safe_load((tmp_path / "jeff_shop_live" / "jeff_shop_live.yml").read_text())
+        assert on_disk["semantic_model"][0]["metrics"] == []

--- a/tests/unit_tests/storage/metric/test_store.py
+++ b/tests/unit_tests/storage/metric/test_store.py
@@ -164,6 +164,54 @@ class TestBatchUpsertMetricsValidation:
         with pytest.raises(ValueError, match="subject_path is required"):
             metric_storage.batch_upsert_metrics([bad_metric])
 
+    def test_resync_overwrites_same_metric_with_changed_semantic_model(self, metric_storage: MetricStorage):
+        """Re-syncing a metric whose owning model was renamed must overwrite the
+        existing row (same name == same id), not raise a name-conflict.
+
+        Metric ids are name-derived, so a same-name write is the same identity;
+        the YAML file is the source of truth on re-sync. Regression for an OSI
+        metric edit failing with 'existing metric id ... has a different
+        semantic_model_name'."""
+        metric = _make_metric(1)
+        metric["name"] = "gross_revenue"
+        metric["semantic_model_name"] = "old_model"
+        metric_storage.batch_store_metrics([metric])
+
+        renamed = _make_metric(1)
+        renamed["name"] = "gross_revenue"
+        renamed["semantic_model_name"] = "new_model"
+        renamed["description"] = "edited description"
+
+        # Must not raise despite the changed semantic_model_name.
+        metric_storage.batch_upsert_metrics([renamed])
+
+        rows = metric_storage.search_all_metrics(subject_path=["Finance", "Revenue", "gross_revenue"])
+        assert len(rows) == 1
+        assert rows[0]["semantic_model_name"] == "new_model"
+        assert rows[0]["description"] == "edited description"
+
+    def test_upsert_still_raises_for_distinct_id_name_collision(self, metric_storage: MetricStorage):
+        """A same-name row with a *different* id and a conflicting definition is
+        a genuine identity collision and must still be rejected."""
+        from datus.storage.metric.store import build_metric_id
+
+        existing = _make_metric(1)
+        existing["name"] = "gross_revenue"
+        existing["semantic_model_name"] = "model_a"
+        metric_storage.batch_store_metrics([existing])
+
+        # Force a legacy-style differing id for the same name to exercise the guard.
+        real_build = build_metric_id
+        with __import__("unittest").mock.patch(
+            "datus.storage.metric.store.build_metric_id",
+            side_effect=lambda subject_path, name: real_build(subject_path, name) + ":legacy",
+        ):
+            incoming = _make_metric(1)
+            incoming["name"] = "gross_revenue"
+            incoming["semantic_model_name"] = "model_b"
+            with pytest.raises(ValueError, match="Metric name conflict within datasource"):
+                metric_storage.batch_upsert_metrics([incoming])
+
 
 # ---------------------------------------------------------------------------
 # YAML deletion logic in delete_metric

--- a/uv.lock
+++ b/uv.lock
@@ -742,6 +742,7 @@ dependencies = [
 ci = [
     { name = "datus-metricflow" },
     { name = "datus-semantic-metricflow" },
+    { name = "datus-semantic-osi" },
     { name = "datus-storage-postgresql" },
 ]
 dev = [
@@ -776,7 +777,7 @@ requires-dist = [
     { name = "datus-bi-core", specifier = ">=0.1.2" },
     { name = "datus-db-core", specifier = ">=0.1.4" },
     { name = "datus-scheduler-core", specifier = ">=0.1.1" },
-    { name = "datus-semantic-core", specifier = ">=0.2.1" },
+    { name = "datus-semantic-core", specifier = ">=0.2.2" },
     { name = "datus-storage-base", specifier = ">=0.1.5,<0.2.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.5.2,<2.0.0" },
@@ -823,7 +824,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 ci = [
     { name = "datus-metricflow", specifier = ">=0.2.7" },
-    { name = "datus-semantic-metricflow", specifier = ">=0.2.9" },
+    { name = "datus-semantic-metricflow", specifier = ">=0.2.11" },
+    { name = "datus-semantic-osi", specifier = ">=0.1.4" },
     { name = "datus-storage-postgresql", specifier = ">=0.1.5" },
 ]
 dev = [
@@ -940,28 +942,45 @@ wheels = [
 
 [[package]]
 name = "datus-semantic-core"
-version = "0.2.1"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
+    { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/5c/e6e53f56532d2d1360c98f025b9ac54815b1a550baa10149d866872c24a9/datus_semantic_core-0.2.1.tar.gz", hash = "sha256:f1f8f43f2dab0944372f0028af3424c1dd18e5a37de23068e4e80d38d7583b5a", size = 13288, upload-time = "2026-07-13T06:27:00.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/f7/45c9ad8168af72b3d96c5e59ccd348ff5b8bda5c6924911066e54357b1e0/datus_semantic_core-0.2.2.tar.gz", hash = "sha256:d7aeb0120f560ac82f877821ca37e25297b3cf4bf538faade91dcb3e16b311be", size = 20779, upload-time = "2026-07-22T09:51:45.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/b2/9c29e92ea49485bcec9645e6ea8405011da3d101eb9e20a80ff8a177fb7b/datus_semantic_core-0.2.1-py3-none-any.whl", hash = "sha256:1ca8c1b0671f63a09175659ceac199f65664efb0d592a5495e7223c2c87de5e2", size = 10929, upload-time = "2026-07-13T06:27:00.144Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a4/40d293ee4a9b69c4727b76fa2a6927cba5965205cee35bd648104bb61e15/datus_semantic_core-0.2.2-py3-none-any.whl", hash = "sha256:1fea81362af873aada076d57e2f2ef513f2dafb4dc02668f15a5168f4fad601b", size = 18140, upload-time = "2026-07-22T09:51:44.596Z" },
 ]
 
 [[package]]
 name = "datus-semantic-metricflow"
-version = "0.2.9"
+version = "0.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datus-metricflow", extra = ["snowflake"] },
     { name = "datus-semantic-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/84/9156fb341a31fd2755c7d47361508a1c1512544de4975e22fc82563a298b/datus_semantic_metricflow-0.2.9.tar.gz", hash = "sha256:c00778827c1771156cd4eda76c38551e08a585597b028e88598124fe7a478a76", size = 22249, upload-time = "2026-07-13T06:41:36.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/5f/e54ace7d77458c052e89b8b4498d98f83763413045488d58d0cd839c408c/datus_semantic_metricflow-0.2.11.tar.gz", hash = "sha256:57ee277d7314795e0b91f50d21c11aa987e7fbe6b76fe1cb658e9d675115d5ec", size = 26984, upload-time = "2026-07-22T09:53:00.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/81/c7cf2145a332a03b189b8a4a87eb1c994d1aec125b289c66a0a95daa1922/datus_semantic_metricflow-0.2.9-py3-none-any.whl", hash = "sha256:543d4249f4c029a30c36c9c018565495b187d95b70a5ba2b4861815c8750468e", size = 23758, upload-time = "2026-07-13T06:41:35.982Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b4/821aa487500f129747d3f7fd3eee0259790ee08ddde10088bfb57279d5d5/datus_semantic_metricflow-0.2.11-py3-none-any.whl", hash = "sha256:72c86d3022bc5a2b60d82f3400c78539e71d4a34f8efccbe0688425daf182874", size = 29389, upload-time = "2026-07-22T09:52:59.415Z" },
+]
+
+[[package]]
+name = "datus-semantic-osi"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datus-semantic-core" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "sqlglot" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/2a/99540e2cbdd438350575b056d412f458b5ace187859bcb74df6e8a712b0a/datus_semantic_osi-0.1.4.tar.gz", hash = "sha256:568724d70afb599ba3cd638ab3f038b6ff6b321ae76dd01c8026ca35c0911460", size = 79632, upload-time = "2026-07-22T09:54:09.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/9a/fbbda427de826b9f9b327f6d160f9efdf7b65c81f92fec26d58662f22c29/datus_semantic_osi-0.1.4-py3-none-any.whl", hash = "sha256:35ee658090cbfd65fc2c82d1ba94665d8bf82bf13cd8b48d9ba7bf50ad397e6c", size = 66028, upload-time = "2026-07-22T09:54:08.364Z" },
 ]
 
 [[package]]
@@ -3976,8 +3995,8 @@ name = "secretstorage"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "jeepney", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/9f/11ef35cf1027c1339552ea7bfe6aaa74a8516d8b5caf6e7d338daf54fd80/secretstorage-3.4.0.tar.gz", hash = "sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c", size = 19748, upload-time = "2025-09-09T16:42:13.859Z" }
 wheels = [


### PR DESCRIPTION
## Why

`/api/v1/subject/metric` (and create/edit/delete) reconstructs metric YAML from the LanceDB projection. As a result **OSI-format metrics are returned in MetricFlow shape** (`type: aggregate` + `locked_metadata`), losing OSI-native fields (`expression.dialects`, `ai_context`, `custom_extensions`), and edit/create/delete write MetricFlow-shaped files that corrupt or miss OSI semantic-model documents.

We treat the `subject/semantic_models` YAML files as the **source of truth**, with LanceDB demoted to a derived index. This PR wires the explorer endpoints to the semantic adapter's authoring API (added in datus-semantic-adapter) so reads/writes go through the format-correct adapter (OSI / MetricFlow) instead of format logic hard-coded in the backend.

Depends on the datus-semantic-adapter authoring API (`read/write/delete/validate_metric_source` on `BaseSemanticAdapter`, implemented for OSI and MetricFlow). That surface is backend-only — not added to `SemanticTools.all_tools_name()`, never exposed as an agent/LLM tool.

## Solution

New `ExplorerService` helpers: `_semantic_adapter()`, `_is_osi_authoring()`, `_metric_name_from_yaml()`, `_sync_osi_file_to_kb()`, `_osi_metric_exists()`, `_author_osi_metric()`, `_rollback_osi_write()`.

- **get_metric**: the KB row stays the **access-control gate** — it still enforces the full `subject_path` match and sub-agent scoping, so wrong-path or cross-agent reads keep 404-ing. Only the returned *content* comes from the file (via `adapter.read_metric_source`), which is native-format and accurate; falls back to the KB reconstruction when authoring is unsupported. Note this means MetricFlow reads now also come from the file (still `{metric: ...}`-shaped, identical to the old `_metric_db_to_yaml` output) — intentional, since the file is more accurate than the lossy KB rebuild.
- **create/edit_metric**: when the adapter is OSI, author in place inside the `semantic_model.metrics` list, preserving datasets and sibling metrics and recording `subject_path` in DATUS `custom_extensions`, then re-index the changed file. To keep the file and KB consistent, a failed KB re-sync **rolls back**: a create is deleted, an edit is restored to its pre-edit snapshot. MetricFlow keeps its existing path unchanged.
- **delete (metric)**: for OSI, remove from the semantic-model file first; a **real write failure fails the request**, while an already-absent metric (file/KB drift) is tolerated so we still drop the stale KB row. This prevents a swallowed file-delete error from dropping the KB row while the file keeps the metric (which would "revive" on the next re-index).
- KB-sync failures map to `TOOL_EXECUTION_ERROR`. Adapter file I/O + KB embedding run via `asyncio.to_thread` to avoid blocking the event loop.

Multi-sub-agent isolation: access scoping is unchanged because the KB gate (`get_metrics_detail`, which applies `_sub_agent_conditions()`) still fronts every read; the adapter is only reached after that check passes.

## Test Cases

Added `TestExplorerServiceOSIAuthoring` in `tests/unit_tests/api/services/test_explorer_service.py`, driving `ExplorerService` end-to-end against a real `DatusOSIAdapter` over temp files (11 cases):
- get_metric returns OSI-native YAML; falls back to KB reconstruction when authoring unsupported; 404s when the KB row is missing (scope gate)
- create writes into the semantic-model file and re-indexes the KB; rejects invalid YAML without writing; rolls back the created metric when KB re-sync fails
- edit updates in place preserving datasets; restores the previous content when KB re-sync fails
- delete removes the metric from the OSI file; fails the request (and keeps the KB row) on a real source-file write failure
- create fails cleanly when the adapter is unavailable

`datus_semantic_osi` is guarded with `pytest.importorskip`. Full file: 82 passed, no regressions to existing MetricFlow tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics can now be authored and retrieved using semantic-adapter-managed “source of truth,” including OSI semantic models.
  * Metric create/edit/delete operations are now adapter-aware with knowledge-base re-sync.
* **Bug Fixes**
  * Prevented metrics from being incorrectly marked stale when upserting/resyncing with matching IDs.
  * Improved fallback and not-found behavior when adapter/OSI sources can’t be read.
  * Ensured validation and re-sync failures roll back OSI/adapter changes.
* **Tests**
  * Added dedicated OSI metric authoring and adapter-based metric authoring coverage; updated storage tests for identity/conflict cases.
* **Chores**
  * Updated dependency constraints for CI and semantic core.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
