### PR TITLE
[Feature] CLI '!' prefix runs agent tools & plugin CLIs with nested-command autocomplete

### DIFF
--- a/datus/cli/autocomplete.py
+++ b/datus/cli/autocomplete.py
@@ -21,6 +21,7 @@ from pygments.styles.default import DefaultStyle
 from pygments.token import Token
 
 from datus.cli.cli_styles import AUTOCOMPLETE_TOKEN_COLORS
+from datus.cli.input_modes import InputMode
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.node_models import Metric, ReferenceSql, TableSchema
 from datus.tools.db_tools import connector_registry
@@ -1484,6 +1485,171 @@ class ServiceCommandCompleter(Completer):
                 text,
                 start_position=-len(last),
                 display=display,
+                style="class:keyword",
+            )
+
+
+class BangCompleter(Completer):
+    """Completer for ``!<tool>`` / ``!<plugin>`` commands.
+
+    Fires only when the current line starts with ``!`` and the input bar is in
+    CHAT mode (in SQL/bash mode a leading ``!`` is part of the statement, so the
+    completer stays silent). Composes with the other completers under
+    ``merge_completers`` because non-``!`` input yields nothing.
+
+    Three tiers:
+
+    1. ``!<partial>`` — tool names (listed first, per the tool-before-plugin
+       dispatch order) then plugin names, each tagged in ``display_meta``.
+    2. ``!<tool> --<partial>`` — the tool's ``params_json_schema`` flags plus
+       ``--help``.
+    3. ``!<plugin> <partial>`` — the plugin's declared subcommands;
+       ``!<plugin> <cmd> --<partial>`` — that subcommand's declared flags.
+    """
+
+    def __init__(self, cli: Any):
+        # Loose reference so we reach the lazily-built ``cli.bang_command``
+        # (tool/plugin enumeration) without pinning it at construction time.
+        self.cli = cli
+
+    def get_completions(self, document: Document, complete_event=None) -> Iterable[Completion]:
+        if getattr(self.cli, "input_mode", InputMode.CHAT) is not InputMode.CHAT:
+            return
+        line = document.current_line_before_cursor
+        stripped = line.lstrip()
+        if not stripped.startswith("!"):
+            return
+        bang = getattr(self.cli, "bang_command", None)
+        if bang is None:
+            return
+
+        body = stripped[1:]
+        if " " not in body:
+            yield from self._complete_names(body, bang)
+            return
+
+        first, _, rest = body.partition(" ")
+        tools = bang.tool_map(create=False)
+        if first in tools:
+            yield from self._complete_tool_args(tools[first], rest)
+            return
+        plugins = bang.plugin_map()
+        if first in plugins:
+            yield from self._complete_plugin_args(plugins[first], rest)
+
+    # ------------------------------------------------------------------ #
+    # Tier 1: tool + plugin names
+    # ------------------------------------------------------------------ #
+
+    def _complete_names(self, body: str, bang: Any) -> Iterable[Completion]:
+        typed = body.lower()
+        tools = bang.tool_map(create=False)
+        for name in sorted(tools):
+            if typed and not name.lower().startswith(typed):
+                continue
+            desc = (getattr(tools[name], "description", "") or "").strip().split("\n", 1)[0]
+            yield Completion(
+                f"{name} ",
+                start_position=-len(body),
+                display=f"!{name}",
+                display_meta=(f"tool · {desc}" if desc else "tool")[:60],
+                style="class:keyword",
+            )
+        plugins = bang.plugin_map()
+        for name in sorted(plugins):
+            if typed and not name.lower().startswith(typed):
+                continue
+            desc = plugins[name].description or ""
+            yield Completion(
+                f"{name} ",
+                start_position=-len(body),
+                display=f"!{name}",
+                display_meta=(f"plugin · {desc}" if desc else "plugin")[:60],
+                style="class:keyword",
+            )
+
+    # ------------------------------------------------------------------ #
+    # Tier 2: tool --flag completions
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _complete_tool_args(tool: Any, rest: str) -> Iterable[Completion]:
+        tokens = rest.split(" ")
+        last = tokens[-1] if tokens else ""
+        if not last.startswith("--"):
+            return
+        if "=" in last[2:]:
+            # Cursor is past the ``=``; value-level completion is out of scope.
+            return
+        props = (tool.params_json_schema or {}).get("properties") or {}
+        suggestions: List[Tuple[str, str]] = [("--help", "show parameter schema")]
+        for pname, pinfo in props.items():
+            if pname == "self":
+                continue
+            desc = pinfo.get("description", "") or "" if isinstance(pinfo, dict) else ""
+            suggestions.append((f"--{pname}=", desc))
+        for text, desc in suggestions:
+            if not text.startswith(last):
+                continue
+            display = f"{text}  {desc[:50]}" if desc else text
+            yield Completion(text, start_position=-len(last), display=display, style="class:keyword")
+
+    # ------------------------------------------------------------------ #
+    # Tier 3: plugin subcommand + --flag completions
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _complete_plugin_args(manifest: Any, rest: str) -> Iterable[Completion]:
+        commands = list(manifest.commands)
+        if not commands:
+            return
+        tokens = rest.split(" ")
+        # Walk the settled tokens (everything but the one under the cursor) down
+        # the command tree, descending into a matching subcommand at each level.
+        # ``node`` is the deepest matched command; ``level`` is the subcommands
+        # still selectable there. A settled token that names no subcommand is a
+        # positional value — descent stops (its args belong to ``node``).
+        node = None
+        level = commands
+        settled = tokens[:-1]
+        idx = 0
+        while idx < len(settled):
+            child = next((c for c in level if c.name == settled[idx]), None)
+            if child is None:
+                break
+            node, level = child, child.subcommands
+            idx += 1
+        matched_all = idx == len(settled)
+        last = tokens[-1]
+
+        if last.startswith("--"):
+            # Flag completion for the settled command (needs a matched leaf).
+            if node is None or "=" in last[2:]:
+                return
+            for arg in node.args:
+                if not arg.name.startswith("--"):
+                    continue
+                text = f"{arg.name}="
+                if not text.startswith(last):
+                    continue
+                desc = arg.description or ""
+                display = f"{text}  {desc[:50]}" if desc else text
+                yield Completion(text, start_position=-len(last), display=display, style="class:keyword")
+            return
+
+        # Subcommand-name completion at the current level — only while every
+        # settled token matched a subcommand (no positional value typed yet).
+        if not matched_all:
+            return
+        for command in sorted(level, key=lambda c: c.name):
+            if last and not command.name.startswith(last):
+                continue
+            desc = command.description or ""
+            yield Completion(
+                f"{command.name} ",
+                start_position=-len(last),
+                display=command.name,
+                display_meta=desc[:50],
                 style="class:keyword",
             )
 

--- a/datus/cli/bang_command.py
+++ b/datus/cli/bang_command.py
@@ -1,0 +1,356 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""CLI ``!<tool> [args...]`` / ``!<plugin> <args...>`` command handler.
+
+The ``!`` prefix is a power-user escape hatch that, from the chat REPL, either:
+
+- invokes one of the agent's own function tools directly (``!list_tables``,
+  ``!search_table foo --top_n=3``) — gated by the same permission pipeline an
+  LLM-driven call gets, then rendered locally (never fed back to the model); or
+- runs an installed + activated plugin's CLI in a ``datus <plugin> ...``
+  subprocess (``!hello sync --limit=10``).
+
+**Tools are matched first**: if the first token names a live tool it wins;
+otherwise a matching plugin name dispatches to the subprocess path; otherwise the
+input is rejected with a usage hint. Argument parsing (positional +
+``--key=value``) is shared with ``/<service>.<method>`` via
+:mod:`datus.cli.tool_arg_parser`.
+
+This handler only runs in CHAT input mode — in SQL/bash mode a leading ``!`` is
+part of the statement (see :meth:`DatusCLI._parse_command`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from rich.table import Table
+
+from datus.cli import tool_arg_parser
+from datus.cli.cli_styles import TABLE_HEADER_STYLE, print_error, print_info, print_warning
+from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from agents import FunctionTool
+
+    from datus.cli.repl import DatusCLI
+    from datus.plugins.base import PluginManifest
+
+logger = get_logger(__name__)
+
+
+class BangCommand:
+    """Handler + completion source for ``!<tool>`` / ``!<plugin>`` commands."""
+
+    # Agent-orchestration / plan-mode tools that only make sense inside a live
+    # LLM turn — invoking them manually via ``!`` (with no run context) would
+    # hang or misbehave, so they are hidden from the ``!`` list and dispatch:
+    #   - ``ask_user`` needs the interaction broker attached to a running turn;
+    #   - ``task`` spawns a sub-agent under the orchestrator;
+    #   - ``confirm_plan`` / ``todo_*`` are plan-mode state helpers driven by the
+    #     agent, not standalone commands.
+    # Kept in sync (conceptually) with ``PermissionHooks._PLAN_MODE_BYPASS_TOOLS``.
+    EXCLUDED_TOOLS = frozenset(
+        {
+            "ask_user",
+            "task",
+            "confirm_plan",
+            "todo_list",
+            "todo_read",
+            "todo_write",
+            "todo_update",
+        }
+    )
+
+    def __init__(self, cli: "DatusCLI"):
+        self.cli = cli
+
+    # ------------------------------------------------------------------ #
+    # Enumeration (shared with BangCompleter and the arg-name hint)
+    # ------------------------------------------------------------------ #
+
+    def tool_map(self, create: bool = False) -> Dict[str, "FunctionTool"]:
+        """Return ``{tool_name: FunctionTool}`` from the live chat node.
+
+        ``create=True`` lazily builds the chat node when absent (execution path,
+        where blocking is fine); ``create=False`` only reads an existing node so
+        completion / hint rendering never blocks the prompt-toolkit loop.
+
+        Agent-orchestration tools in :attr:`EXCLUDED_TOOLS` are filtered out —
+        they are not standalone-invocable (see the set's docstring).
+        """
+        chat = getattr(self.cli, "chat_commands", None)
+        node = None
+        if chat is not None:
+            if create:
+                node = chat.ensure_node_for_bang()
+            else:
+                node = getattr(chat, "current_node", None)
+        tools = getattr(node, "tools", None) or []
+        return {name: t for t in tools if (name := getattr(t, "name", "")) and name not in self.EXCLUDED_TOOLS}
+
+    def plugin_map(self) -> Dict[str, "PluginManifest"]:
+        """Return ``{plugin_name: PluginManifest}`` for installed, active plugins."""
+        agent_config = getattr(self.cli, "agent_config", None)
+        if agent_config is None or not getattr(agent_config, "plugins_enabled", True):
+            return {}
+        try:
+            from datus.plugins.registry import iter_plugin_manifests
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Plugin enumeration unavailable: %s", exc)
+            return {}
+        out: Dict[str, "PluginManifest"] = {}
+        for name, manifest in iter_plugin_manifests():
+            try:
+                if agent_config.plugin_active(name):
+                    out[name] = manifest
+            except Exception:  # noqa: BLE001 - one bad plugin must not hide the rest
+                continue
+        return out
+
+    # ------------------------------------------------------------------ #
+    # Dispatch
+    # ------------------------------------------------------------------ #
+
+    def dispatch(self, text: str) -> None:
+        """Route ``text`` (the input after the leading ``!``) to a tool or plugin."""
+        text = (text or "").strip()
+        if not text or text in ("help", "?"):
+            self._print_overview()
+            return
+
+        parts = text.split(maxsplit=1)
+        first = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+
+        tools = self.tool_map(create=True)
+        if first in tools:
+            self._invoke_tool(tools[first], rest)
+            return
+
+        plugins = self.plugin_map()
+        if first in plugins:
+            self._invoke_plugin(first, rest)
+            return
+
+        print_error(
+            self.cli.console,
+            f"Unknown tool or plugin '{first}'. Run `!` to list available tools and plugins.",
+            prefix=False,
+        )
+        print_info(self.cli.console, "Usage: !<tool> [args...]  or  !<plugin> <args...>")
+
+    # ------------------------------------------------------------------ #
+    # Tool invocation
+    # ------------------------------------------------------------------ #
+
+    def _invoke_tool(self, tool: "FunctionTool", rest: str) -> None:
+        console = self.cli.console
+        if tool_arg_parser.is_help_request(rest):
+            tool_arg_parser.print_schema(console, tool)
+            return
+
+        parsed, error = tool_arg_parser.parse_args(rest, tool.params_json_schema or {})
+        if parsed is None:
+            tool_arg_parser.print_schema(console, tool, hint=error or "Could not parse arguments. Expected schema:")
+            return
+
+        from datus.cli.bash_mode import run_manual_tool_live
+
+        rest = rest.strip()
+        command = f"{tool.name} {rest}" if rest else tool.name
+
+        def _invoke() -> tuple:
+            result = asyncio.run(tool.on_invoke_tool(None, json.dumps(parsed)))
+            return self._tool_result_to_output(result)
+
+        # Gate + execute inside a live frame, then feed the result to the model as
+        # an execution turn (identical to SQL/bash modes): the call enters the
+        # conversation context and triggers a reply. Permission denials render but
+        # are not dispatched.
+        payload, dispatch = run_manual_tool_live(self.cli, tool.name, command, parsed, _invoke)
+        if dispatch and payload is not None:
+            self.cli._send_exec_turn(payload)
+
+    @staticmethod
+    def _tool_result_to_output(result: Any) -> tuple:
+        """Reduce a tool return value to ``(success, output_text)``.
+
+        ``FuncToolResult``-shaped dicts (``{success, error, result}``) are unwrapped
+        to their inner result; anything else is treated as a successful payload.
+        Structured payloads render as pretty JSON so both the styled block and the
+        model see the same readable text.
+        """
+        if isinstance(result, dict) and "success" in result:
+            success = bool(result.get("success"))
+            if not success:
+                return False, str(result.get("error") or "tool failed")
+            payload = result.get("result")
+        else:
+            success, payload = True, result
+        if isinstance(payload, str):
+            return success, payload
+        return success, json.dumps(payload, indent=2, ensure_ascii=False, default=str)
+
+    # ------------------------------------------------------------------ #
+    # Plugin invocation (subprocess)
+    # ------------------------------------------------------------------ #
+
+    def _invoke_plugin(self, name: str, rest: str) -> None:
+        """Run ``datus <plugin> <rest>`` as a subprocess via the bash pipeline.
+
+        Reuses the permission-gated bash execution + live frame; the plugin's own
+        CLI permissions apply inside the child process. The output is fed to the
+        model as an execution turn (like ``!<tool>``) so the run enters the
+        conversation and triggers a reply.
+        """
+        from datus.cli.bash_mode import run_manual_bash_live
+
+        command = f"datus {name}"
+        if rest:
+            command = f"{command} {rest}"
+        payload, dispatch = run_manual_bash_live(self.cli, command)
+        if dispatch and payload is not None:
+            self.cli._send_exec_turn(payload)
+
+    # ------------------------------------------------------------------ #
+    # Overview listing
+    # ------------------------------------------------------------------ #
+
+    def _print_overview(self) -> None:
+        console = self.cli.console
+        tools = self.tool_map(create=True)
+        plugins = self.plugin_map()
+
+        if tools:
+            table = Table(title="! tools", show_header=True, header_style=TABLE_HEADER_STYLE)
+            table.add_column("Tool")
+            table.add_column("Description")
+            for name in sorted(tools):
+                doc = (getattr(tools[name], "description", "") or "").strip().split("\n", 1)[0]
+                table.add_row(name, doc)
+            console.print(table)
+        else:
+            print_warning(console, "No tools available yet (agent still initializing).")
+
+        if plugins:
+            table = Table(title="! plugins", show_header=True, header_style=TABLE_HEADER_STYLE)
+            table.add_column("Plugin")
+            table.add_column("Description")
+            for name in sorted(plugins):
+                table.add_row(name, plugins[name].description or "")
+            console.print(table)
+
+        print_info(
+            console,
+            "Usage: !<tool> [args...]  or  !<plugin> <args...>  ·  !<tool> --help for parameters",
+        )
+
+    # ------------------------------------------------------------------ #
+    # Argument-name hint (rendered dim after the input by the TUI)
+    # ------------------------------------------------------------------ #
+
+    def param_hint(self, text: str) -> str:
+        """Return a dim ``<required> [--optional]`` hint for the current input.
+
+        Consumed by the TUI's ``AfterInput`` processor. Returns ``""`` while the
+        user is still typing the tool/plugin name, or on any error (this runs on
+        every render, so it must never raise or block — hence non-creating tool
+        access only).
+        """
+        try:
+            if not text.startswith("!"):
+                return ""
+            body = text[1:]
+            if " " not in body:
+                return ""  # still typing the tool/plugin name
+            first, _, rest = body.partition(" ")
+            tools = self.tool_map(create=False)
+            if first in tools:
+                return self._tool_param_hint(tools[first], rest)
+            plugins = self.plugin_map()
+            if first in plugins:
+                return self._plugin_param_hint(plugins[first], rest)
+            return ""
+        except Exception:  # noqa: BLE001 - a hint must never break rendering
+            return ""
+
+    @staticmethod
+    def _split_consumed(tokens: List[str]) -> tuple[set, int]:
+        """Return ``(named_keys_given, positional_count)`` from arg tokens."""
+        named: set = set()
+        positional = 0
+        for tok in tokens:
+            if tok.startswith("--"):
+                named.add(tok[2:].split("=", 1)[0])
+            else:
+                positional += 1
+        return named, positional
+
+    def _tool_param_hint(self, tool: "FunctionTool", rest: str) -> str:
+        schema = tool.params_json_schema or {}
+        props = [k for k in (schema.get("properties") or {}).keys() if k != "self"]
+        required = set(schema.get("required", []) or [])
+        try:
+            tokens = shlex.split(rest) if rest else []
+        except ValueError:
+            tokens = rest.split()
+        named_given, positional = self._split_consumed(tokens)
+        parts: List[str] = []
+        for idx, name in enumerate(props):
+            if name in named_given or idx < positional:
+                continue
+            parts.append(f"<{name}>" if name in required else f"[--{name}]")
+        return " ".join(parts)
+
+    def _plugin_param_hint(self, manifest: "PluginManifest", rest: str) -> str:
+        commands = list(manifest.commands)
+        if not commands:
+            return ""
+        # Split into settled tokens + the partial token under the cursor: a
+        # trailing space (or empty ``rest``) settles the previous token and opens
+        # a new one. While the current token is still being typed we keep showing
+        # the level's menu (it may still name a subcommand).
+        trailing = rest == "" or rest.endswith(" ")
+        words = rest.split()
+        settled = words if trailing else words[:-1]
+        # Walk settled tokens down the tree. A settled token naming no subcommand
+        # at the current level is a positional value — descent stops there and
+        # the remaining tokens are ``node``'s positional args.
+        node = None
+        level = commands
+        leftover: List[str] = []
+        idx = 0
+        while idx < len(settled):
+            child = next((c for c in level if c.name == settled[idx]), None)
+            if child is None:
+                leftover = settled[idx:]
+                break
+            node, level = child, child.subcommands
+            idx += 1
+        # Still choosing among subcommands at this level (no positional typed) →
+        # show the subcommand menu in declaration order.
+        if level and not leftover:
+            return "{" + "|".join(c.name for c in level) + "}"
+        if node is None:
+            return ""
+        named_given, positional = self._split_consumed(leftover)
+        parts: List[str] = []
+        pos_idx = 0
+        for arg in node.args:
+            if arg.name.startswith("--"):
+                if arg.name[2:].split("=", 1)[0] in named_given:
+                    continue
+                parts.append(f"[{arg.name}]")
+            else:
+                if pos_idx < positional:
+                    pos_idx += 1
+                    continue
+                pos_idx += 1
+                parts.append(f"<{arg.name}>" if arg.required else f"[{arg.name}]")
+        return " ".join(parts)

--- a/datus/cli/bash_mode.py
+++ b/datus/cli/bash_mode.py
@@ -70,6 +70,25 @@ class _SqlToolStub:
     name = "execute_sql"
 
 
+class _ToolContextShim:
+    """Generic context shim for the ``!<tool>`` permission gate.
+
+    ``PermissionHooks.on_tool_start`` reads only ``context.tool_arguments`` (a
+    JSON string of the call arguments), so a manual tool invocation gets the same
+    category / SQL-class / bash-command gating an LLM-driven call would.
+    """
+
+    def __init__(self, args: Dict[str, Any]) -> None:
+        self.tool_arguments = json.dumps(args)
+
+
+class _ToolStub:
+    """Generic ``Tool`` stand-in: ``on_tool_start`` reads only ``.name``."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
 async def _apply_plugin_transformers(
     cli: "DatusCLI", tool_name: str, category: str, args: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -118,6 +137,13 @@ class SqlGateResult(BaseModel):
     transformer/policy-rewritten) statement to execute."""
 
     sql: str
+    approved: bool = False
+    error: Optional[str] = None
+
+
+class ToolGateResult(BaseModel):
+    """Outcome of the generic ``!<tool>`` permission gate."""
+
     approved: bool = False
     error: Optional[str] = None
 
@@ -498,6 +524,82 @@ def run_sql_gate(cli: "DatusCLI", sql: str) -> SqlGateResult:
     return result
 
 
+# ── Generic tool permission gate (``!<tool> [args...]``) ───────────────────
+
+
+async def _tool_gate_stream(
+    result: ToolGateResult,
+    hooks: "PermissionHooks",
+    tool_name: str,
+    args: Dict[str, Any],
+) -> AsyncGenerator[ActionHistory, None]:
+    """Run the permission gate for a manual ``!<tool>`` call.
+
+    Fires the same ``on_tool_start`` gate an LLM-driven call gets — the hook only
+    reads ``tool.name`` + ``context.tool_arguments``, so read tools auto-allow and
+    write/``execute_sql``/``bash`` calls hit their fine-grained confirmation. Sets
+    ``result.approved``; yields nothing (the tool executes + renders in the
+    caller). Plugin transformers are NOT applied here: unlike the SQL/bash gates
+    (which bypass the ``FunctionTool`` wrapper), ``!<tool>`` invokes the real
+    ``FunctionTool.on_invoke_tool``, which already runs any transformer middleware.
+    """
+    from datus.tools.permission.permission_hooks import PermissionDeniedException
+
+    try:
+        await hooks.on_tool_start(_ToolContextShim(args), None, _ToolStub(tool_name))
+        result.approved = True
+    except PermissionDeniedException as exc:
+        result.error = str(exc)
+    except InteractionCancelled:
+        result.error = "Permission prompt cancelled"
+    except Exception as exc:
+        logger.error(f"Tool permission gate failed for '{tool_name}': {exc}", exc_info=True)
+        result.error = str(exc)
+
+    return
+    yield  # pragma: no cover - unreachable, marks the function as a generator
+
+
+def run_tool_gate(cli: "DatusCLI", tool_name: str, args: Dict[str, Any]) -> ToolGateResult:
+    """Gate a manual ``!<tool>`` invocation through the same hooks an LLM call uses.
+
+    Returns a :class:`ToolGateResult` with ``approved`` set. Read-only tools
+    auto-allow with no prompt; write / ``execute_sql`` / ``bash`` tools prompt via
+    the embedded wizard. Fails closed (``approved=False`` with an actionable
+    error) when no permission config is loaded or the hook pipeline cannot be
+    built, matching the SQL/bash gates' posture.
+    """
+    result = ToolGateResult()
+    if getattr(cli.agent_config, "permissions_config", None) is None:
+        result.error = "Tool execution unavailable: no permission configuration loaded"
+        return result
+
+    try:
+        broker = InteractionBroker()
+        hooks = _build_permission_hooks(cli, broker)
+    except Exception as exc:
+        logger.error(f"Failed to prepare tool gate: {exc}", exc_info=True)
+        result.error = f"Tool gate unavailable: {exc}"
+        return result
+
+    collector = _make_input_collector(cli)
+
+    async def _drive() -> None:
+        broker.reset_queue()
+        async for action in merge_interaction_stream(_tool_gate_stream(result, hooks, tool_name, args), broker):
+            if action.role == ActionRole.INTERACTION and action.status == ActionStatus.PROCESSING:
+                answers = await asyncio.to_thread(collector, action, cli.console)
+                await broker.submit(action.action_id, answers)
+
+    try:
+        asyncio.run(_drive())
+    except Exception as exc:
+        logger.error(f"Tool gate failed for '{tool_name}': {exc}", exc_info=True)
+        if result.error is None:
+            result.error = str(exc)
+    return result
+
+
 # ── Live execution frame (blinking ``running`` → result block) ─────────────
 
 
@@ -607,3 +709,39 @@ def run_manual_sql_live(cli: "DatusCLI", command: str, execute_fn: Callable[[str
         return payload, True
 
     return _run_with_live_frame(cli, "sql", command, _work)
+
+
+def run_manual_tool_live(
+    cli: "DatusCLI",
+    tool_name: str,
+    command: str,
+    args: Dict[str, Any],
+    invoke_fn: Callable[[], tuple],
+) -> tuple:
+    """Run a ``!<tool>`` call with a live frame; return ``(payload, dispatch)``.
+
+    Reuses :func:`run_tool_gate` for the permission gate (identical to an LLM
+    ``on_tool_start``), then calls ``invoke_fn`` — a ``() -> (success, output)``
+    closure that performs ``on_invoke_tool`` and renders the result to text.
+    Denials render their reason and are not dispatched; a successful or
+    tool-failed execution (and an unexpected invocation error) is packed into a
+    ``tool`` payload and dispatched to the model so the run enters the
+    conversation and triggers a reply.
+    """
+    from datus.cli.manual_exec import build_tool_payload
+
+    def _work():
+        gate = run_tool_gate(cli, tool_name, args)
+        if not gate.approved:
+            denial = _trim_denial(gate.error or f"Tool '{tool_name}' not permitted")
+            return build_tool_payload(command, False, "", denial, 0.0), False
+        start = time.monotonic()
+        try:
+            success, output = invoke_fn()
+        except Exception as exc:  # noqa: BLE001 - surface the failure to the model
+            logger.exception("Manual tool invocation failed for '%s'", tool_name)
+            return build_tool_payload(command, False, "", str(exc), time.monotonic() - start), True
+        duration = time.monotonic() - start
+        return build_tool_payload(command, success, output, None if success else output, duration), True
+
+    return _run_with_live_frame(cli, "tool", command, _work)

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -238,6 +238,43 @@ class ChatCommands:
         except Exception:  # noqa: BLE001
             pass
 
+    def ensure_node_for_bang(self) -> Optional["AgenticNode"]:
+        """Return the current chat node, lazily creating a default one if needed.
+
+        The ``!<tool>`` handler enumerates and invokes tools from the live chat
+        node's ``tools`` list, but ``current_node`` is created lazily on the
+        first chat turn. This builds the regular (non-subagent) node up front —
+        the same node the next chat turn would reuse (``_should_create_new_node``
+        returns ``False`` once ``current_node`` is set and no subagent is
+        active) — so a ``!<tool>`` call works before any chat has happened.
+
+        The node is built *fully* on a local reference (base tools via
+        ``setup_tools`` plus the skill/bash/memory/web tools that are otherwise
+        mounted lazily at execution time) before it is published to
+        ``self.current_node``, so ``!`` autocomplete lists the complete tool set
+        and never observes a half-mounted node. Returns ``None`` when node
+        construction fails.
+        """
+        if self.current_node is not None:
+            return self.current_node
+        try:
+            node = self._create_new_node(None)
+            if hasattr(node, "active_database"):
+                node.active_database = getattr(self.cli.cli_context, "current_db_name", "") or ""
+            if hasattr(node, "setup_tools"):
+                node.setup_tools()
+            # Mount the tools that are otherwise injected lazily during a turn
+            # (skill / bash / memory / web) so the ``!`` list is complete.
+            if hasattr(node, "_ensure_lazy_tools_mounted"):
+                node._ensure_lazy_tools_mounted()
+            self.current_subagent_name = None
+            self.current_node = node
+        except Exception as exc:  # noqa: BLE001 - never crash the REPL on a ! call
+            logger.error(f"Failed to create chat node for '!' tool execution: {exc}", exc_info=True)
+            self.current_node = None
+            return None
+        return self.current_node
+
     def create_node_input(
         self,
         user_message: str,

--- a/datus/cli/cli_styles.py
+++ b/datus/cli/cli_styles.py
@@ -179,6 +179,9 @@ STATUS_BAR_STYLE: dict[str, str] = {
     "input-prompt": "ansigreen bold",
     "input-prompt.busy": "ansibrightblack",
     "input-prompt.hint": f"italic {STATUS_BAR_FG_HINT}",
+    # Dim ``<arg> [--opt]`` hint rendered after a ``!<tool>`` / ``!<plugin>``
+    # command while typing (see ``BangCommand.param_hint``).
+    "bang-arg-hint": STATUS_BAR_FG_HINT,
     # SQL mode: red ``sql>`` prompt label (bold allowed on prompt labels) and
     # the red SQL-mode hint line pinned under the input.
     "input-prompt.sql": "ansired bold",

--- a/datus/cli/manual_exec.py
+++ b/datus/cli/manual_exec.py
@@ -53,6 +53,8 @@ MAX_OUTPUT_CHARS = 3000
 _KIND_CHROME = {
     "sql": ("sql> ", "bold red", "red"),
     "bash": ("bash> ", "bold yellow", "yellow"),
+    # ``!<tool>`` manual tool executions — distinct cyan chrome.
+    "tool": ("! ", "bold cyan", "cyan"),
 }
 
 
@@ -90,7 +92,26 @@ class BashExecPayload(BaseModel):
     error: Optional[str] = None
 
 
-_PAYLOAD_MODELS: Dict[str, type[BaseModel]] = {"sql": SqlExecPayload, "bash": BashExecPayload}
+class ToolExecPayload(BaseModel):
+    """Validated shape of a persisted ``!<tool>`` execution record.
+
+    Mirrors the bash payload: ``command`` is the ``<tool> <args>`` invocation and
+    ``output`` is the tool result rendered as text (JSON for structured returns).
+    """
+
+    kind: Literal["tool"]
+    command: str
+    success: bool
+    output: str = ""
+    meta: str = ""
+    error: Optional[str] = None
+
+
+_PAYLOAD_MODELS: Dict[str, type[BaseModel]] = {
+    "sql": SqlExecPayload,
+    "bash": BashExecPayload,
+    "tool": ToolExecPayload,
+}
 
 
 def mode_prompt(kind: str) -> Tuple[str, str]:
@@ -278,6 +299,26 @@ def build_bash_payload(
     meta = f"exit 0 in {exec_time:.2f}s" if success else f"failed in {exec_time:.2f}s"
     payload: Dict[str, Any] = {
         "kind": "bash",
+        "command": command,
+        "success": success,
+        "output": output,
+        "meta": meta,
+    }
+    if error and not success:
+        payload["error"] = error
+    return payload
+
+
+def build_tool_payload(
+    command: str, success: bool, output: str, error: Optional[str], exec_time: float
+) -> Dict[str, Any]:
+    """Build a ``!<tool>`` execution payload (output capped like bash)."""
+    output = output or ""
+    if len(output) > MAX_OUTPUT_CHARS:
+        output = output[:MAX_OUTPUT_CHARS] + "\n… [truncated]"
+    meta = f"ok in {exec_time:.2f}s" if success else f"failed in {exec_time:.2f}s"
+    payload: Dict[str, Any] = {
+        "kind": "tool",
         "command": command,
         "success": success,
         "output": output,

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -45,6 +45,7 @@ from datus.cli._cli_utils import prompt_input
 from datus.cli.agent_commands import AgentCommands
 from datus.cli.autocomplete import (
     AtReferenceCompleter,
+    BangCompleter,
     CustomPygmentsStyle,
     CustomSqlLexer,
     ServiceCommandCompleter,
@@ -104,9 +105,10 @@ _BANNER_MIN_WIDTH = 60
 class CommandType(Enum):
     """Type of command entered by the user."""
 
-    SQL = "sql"  # Regular SQL statement (SQL mode, or ``!<sql>`` in the non-TUI fallback)
+    SQL = "sql"  # Regular SQL statement (SQL mode)
     BASH = "bash"  # shell command (bash mode), run through the permission-gated bash tool
     SLASH = "slash"  # /command (session / metadata / context / agent / system)
+    BANG = "bang"  # ``!<tool>`` / ``!<plugin>`` — run a tool or plugin CLI directly
     CHAT = "chat"  # bare text routed to the default agent
     EXIT = "exit"  # exit/quit command
     UNKNOWN = "unknown"  # unrecognized /command or renamed legacy prefix
@@ -290,8 +292,10 @@ class DatusCLI:
         self.session_summarize_commands = SessionSummarizeCommands(self)
         self.memory_organize_commands = MemoryOrganizeCommands(self)
         self.service_commands = ServiceCommands(self)
+        from datus.cli.bang_command import BangCommand
         from datus.cli.datasource_commands import DatasourceCommands
 
+        self.bang_command = BangCommand(self)
         self.datasource_commands = DatasourceCommands(self)
 
         from datus.cli.background_sync import BackgroundSchemaSyncManager
@@ -739,6 +743,9 @@ class DatusCLI:
             # are queued for the next LLM turn (via the OpenAI Agents SDK
             # ``call_model_input_filter`` hook) instead of being dropped.
             pending_input_provider=self._active_pending_input_queue,
+            # Dim ``<arg> [--opt]`` hint rendered after the input while typing a
+            # ``!<tool>`` / ``!<plugin>`` command (see ``BangCommand.param_hint``).
+            param_hint_fn=self._bang_param_hint,
         )
 
         # Now that the Application exists, wire the buffer's ``on_change``
@@ -908,8 +915,8 @@ class DatusCLI:
         self.session = PromptSession(
             history=self.history,
             auto_suggest=AutoSuggestFromHistory(),
-            # No SQL highlighting in the non-TUI fallback — SQL runs via the
-            # ``!<sql>`` one-shot prefix, and plain input is model chat.
+            # No SQL highlighting in the non-TUI fallback — plain input is model
+            # chat, ``!<tool>`` runs a tool/plugin, and ``/`` runs a command.
             lexer=None,
             completer=self.create_combined_completer(),
             multiline=True,
@@ -938,12 +945,14 @@ class DatusCLI:
             visibility_provider=self._visible_subagents_for_default,
         )  # Router for @Table / @Metrics / @Sql / @Agent inline references
         self.slash_completer = SlashCommandCompleter()
+        self.bang_completer = BangCompleter(self)
 
         # Use merge_completers to combine completers
         from prompt_toolkit.completion import merge_completers
 
         return merge_completers(
             [
+                self.bang_completer,  # !<tool> / !<plugin> completer (bound to the ! prefix)
                 self.service_completer,  # .<service>.<method> dispatcher completer (highest priority)
                 self.slash_completer,  # Top-level slash commands
                 self.at_completer,  # @Table / @Metrics / @Sql inline references
@@ -995,6 +1004,8 @@ class DatusCLI:
                 self._execute_sql_mode(args)
             elif cmd_type == CommandType.BASH:
                 self._execute_bash_mode(args)
+            elif cmd_type == CommandType.BANG:
+                self._execute_bang_command(args)
             elif cmd_type == CommandType.SLASH:
                 slash_result = self._execute_slash_command(cmd, args)
                 # ``/rewind`` sets ``_prefill_input`` from inside the handler.
@@ -1201,6 +1212,7 @@ class DatusCLI:
             self._pre_load_storage()
             self._workflow_runner = self._create_workflow_runner()
             self._maybe_schedule_startup_sync()
+            self._warm_bang_node()
             # self.console.print("[dim]Agent initialized successfully in background[/]")
         except Exception as e:
             self.console.print(f"[red]Error:[/]Failed to initialize agent in background: {str(e)}")
@@ -1232,6 +1244,22 @@ class DatusCLI:
                 self.startup_warnings.append(warning)
                 logger.warning("REPL context autocomplete preload failed: %s", warning)
                 print_warning(self.console, warning)
+
+    def _warm_bang_node(self) -> None:
+        """Eagerly build the default chat node during background init so ``!``
+        autocomplete can list the agent's tools before the first chat turn.
+
+        ``current_node`` is otherwise created lazily on the first chat, leaving
+        the ``!<tool>`` completer (which reads the live node's tools without
+        forcing creation, to stay non-blocking) with nothing to show until then.
+        Warming here mounts the full tool set on the same node the first chat
+        reuses. Best-effort — a failure only degrades the ``!`` list, so it must
+        never break agent init.
+        """
+        try:
+            self.chat_commands.ensure_node_for_bang()
+        except Exception as exc:  # noqa: BLE001 - warming is best-effort
+            logger.debug("Bang-node warm skipped: %s", exc)
 
     def _maybe_schedule_startup_sync(self) -> None:
         """Kick off a one-shot background metadata sync for the default
@@ -1621,6 +1649,7 @@ class DatusCLI:
             Tuple ``(command_type, command, arguments)``:
 
             * ``SQL``    — ``command`` empty, ``arguments`` is the raw SQL
+            * ``BANG``   — ``command`` empty, ``arguments`` is the text after ``!``
             * ``SLASH``  — ``command`` is the canonical ``"/name"`` (aliases resolved)
             * ``CHAT``   — ``command`` is the default agent, ``arguments`` is the message
             * ``EXIT``   — both empty
@@ -1630,27 +1659,23 @@ class DatusCLI:
         text = text.strip()
         bash_mode = self.input_mode is InputMode.BASH
 
-        # Trailing ``;`` is only normalized on the SQL paths (SQL mode and the
-        # ``!<sql>`` chat prefix), where it is a redundant statement terminator.
-        # Chat keeps it (``Explain this;`` must reach the model verbatim) and
-        # bash keeps it (a trailing ``;`` is legal shell syntax).
+        # Trailing ``;`` is only normalized on the SQL path (SQL mode), where it
+        # is a redundant statement terminator. Chat keeps it (``Explain this;``
+        # must reach the model verbatim) and bash keeps it (a trailing ``;`` is
+        # legal shell syntax).
 
         # Exit: bare ``exit`` / ``quit`` still work; ``/exit`` and ``/quit`` flow
         # through the SLASH branch via the registry's alias map.
         if text.lower() in ("exit", "quit"):
             return CommandType.EXIT, "", ""
 
-        # ``!`` prefix, chat mode only. In the TUI ``!<sql>`` typed in chat
-        # mode runs the remainder as a one-shot SQL statement, and the non-TUI
-        # PromptSession fallback (which has no mode cycling) relies on it as
-        # its only route to SQL execution. In SQL/bash mode a leading ``!`` is
-        # part of the statement (e.g. bash history expansion), so the prefix
-        # is not interpreted there.
+        # ``!`` prefix, chat mode only: run one of the agent's tools directly
+        # (``!list_tables``) or an installed plugin's CLI (``!hello sync``),
+        # dispatched by :class:`datus.cli.bang_command.BangCommand` (tools match
+        # first). In SQL/bash mode a leading ``!`` is part of the statement
+        # (e.g. bash history expansion), so the prefix is not interpreted there.
         if text.startswith("!") and self.input_mode is InputMode.CHAT:
-            sql = text[1:].strip()
-            if sql.endswith(";"):
-                sql = sql[:-1].strip()
-            return CommandType.SQL, "", sql
+            return CommandType.BANG, "", text[1:].strip()
 
         # Slash commands (/prefix). ``/<agent> <msg>`` was removed — agent
         # selection is now exclusively handled by ``/agent``. Unknown tokens
@@ -1702,8 +1727,7 @@ class DatusCLI:
             return CommandType.BASH, "", text
 
         # Default: route free-form text to the model. SQL is never auto-detected
-        # — the user opts into execution explicitly via SQL mode (or ``!<sql>``
-        # in the non-TUI fallback).
+        # — the user opts into execution explicitly via SQL mode.
         return CommandType.CHAT, self.default_agent, text.strip()
 
     def _execute_sql_mode(self, sql: str) -> None:
@@ -1888,6 +1912,26 @@ class DatusCLI:
         payload, dispatch = run_manual_bash_live(self, command)
         if dispatch and payload is not None:
             self._send_exec_turn(payload)
+
+    def _execute_bang_command(self, text: str) -> None:
+        """Run a ``!<tool>`` / ``!<plugin>`` command via :class:`BangCommand`.
+
+        Tools are gated + invoked directly and rendered locally; plugins run in a
+        ``datus <plugin> ...`` subprocess. Neither is fed back to the model.
+        """
+        self.bang_command.dispatch(text)
+
+    def _bang_param_hint(self, text: str) -> str:
+        """Argument-name hint for the live input, consumed by the TUI's
+        ``AfterInput`` processor. ``""`` while typing the tool/plugin name.
+
+        Late-bound wrapper so ``self.bang_command`` need not exist when the app
+        is constructed.
+        """
+        bang = getattr(self, "bang_command", None)
+        if bang is None:
+            return ""
+        return bang.param_hint(text)
 
     # ── manual-execution chat turn ────────────────────────────────────────
 

--- a/datus/cli/service_commands.py
+++ b/datus/cli/service_commands.py
@@ -22,16 +22,14 @@ that method does not belong in the CLI allow-list.
 
 from __future__ import annotations
 
-import ast
 import asyncio
-import inspect
 import json
-import shlex
 import threading
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from rich.table import Table
 
+from datus.cli import tool_arg_parser
 from datus.cli._render_utils import build_kv_table, build_row_table
 from datus.cli.cli_styles import TABLE_HEADER_STYLE, print_error, print_info, print_success, print_warning
 from datus.cli.service_client import ServiceClient, ServiceClientRegistry, service_type_label
@@ -557,30 +555,7 @@ class ServiceCommands:
         self.cli.console.print(table)
 
     def _print_schema(self, tool: "FunctionTool", hint: str = "") -> None:
-        schema = tool.params_json_schema or {}
-        props = schema.get("properties") or {}
-        required = set(schema.get("required", []) or [])
-        if hint:
-            print_warning(self.cli.console, hint)
-        table = Table(
-            title=f"{tool.name} — parameters",
-            show_header=True,
-            header_style=TABLE_HEADER_STYLE,
-        )
-        table.add_column("Name")
-        table.add_column("Type")
-        table.add_column("Required")
-        table.add_column("Description")
-        for key, info in props.items():
-            if key == "self" or not isinstance(info, dict):
-                continue
-            table.add_row(
-                key,
-                str(info.get("type", "")),
-                "yes" if key in required else "",
-                info.get("description", "") or "",
-            )
-        self.cli.console.print(table)
+        tool_arg_parser.print_schema(self.cli.console, tool, hint)
 
     # Cap long cell contents (huge nested ``extra.raw`` blobs, SQL texts,
     # etc.) so a single command doesn't push the terminal through many
@@ -851,185 +826,42 @@ class ServiceCommands:
     # Argument parsing
     # ------------------------------------------------------------------ #
 
+    # Argument parsing / schema rendering is shared with the ``!<tool>`` handler
+    # (:mod:`datus.cli.bang_command`) via :mod:`datus.cli.tool_arg_parser`. These
+    # thin delegators keep the historical ``ServiceCommands`` method surface (and
+    # its ``_last_parse_error`` contract) while the logic lives in one place.
+
     @staticmethod
     def _is_help_request(args: str) -> bool:
-        try:
-            tokens = shlex.split(args) if args else []
-        except ValueError:
-            return False
-        return "--help" in tokens or "-h" in tokens
+        return tool_arg_parser.is_help_request(args)
 
     def _parse_args(self, args: str, schema: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Parse positional + ``--key=value`` arguments against a JSON schema.
 
         Returns a ``{key: coerced_value}`` dict, or ``None`` if the input is
-        malformed (quoting error, extra positional, unknown named flag).
-        When parsing fails in a way that has a specific user-facing hint
-        (e.g. typoed flag name), the hint is stored on
-        ``self._last_parse_error`` so ``_invoke`` can surface it before
-        printing the schema.
+        malformed. On failure, a specific user-facing hint is stored on
+        ``self._last_parse_error`` so ``_invoke`` can surface it before printing
+        the schema.
         """
-        self._last_parse_error = None
-        try:
-            tokens = shlex.split(args) if args else []
-        except ValueError:
-            self._last_parse_error = "Malformed arguments: unmatched quotes."
-            return None
-
-        props = (schema.get("properties") or {}) if isinstance(schema, dict) else {}
-        prop_order = [k for k in props.keys() if k != "self"]
-        valid_named = [k for k in prop_order]
-
-        positional: List[str] = []
-        named: Dict[str, str] = {}
-        for tok in tokens:
-            if tok.startswith("--"):
-                body = tok[2:]
-                if not body:
-                    self._last_parse_error = "Empty flag '--'. Expected '--<name>' or '--<name>=<value>'."
-                    return None
-                key, sep, value = body.partition("=")
-                if not sep:
-                    # Bare ``--flag`` means ``--flag=true`` for boolean fields.
-                    named[key] = "true"
-                else:
-                    named[key] = value
-            else:
-                positional.append(tok)
-
-        parsed: Dict[str, Any] = {}
-        for idx, value in enumerate(positional):
-            if idx >= len(prop_order):
-                self._last_parse_error = (
-                    f"Too many positional arguments. Method accepts {len(prop_order)} (got extra: '{value}')."
-                )
-                return None
-            key = prop_order[idx]
-            parsed[key] = self._coerce(value, props.get(key) or {})
-
-        for key, raw in named.items():
-            if key not in props:
-                # Fail fast — a silently dropped ``--limti=1`` or
-                # ``--serach=...`` is worse than a parse error because the
-                # method executes without the filter the user intended.
-                suggestions = ", ".join(valid_named) if valid_named else "(none)"
-                self._last_parse_error = f"Unknown parameter '--{key}'. Valid parameters: {suggestions}."
-                return None
-            parsed[key] = self._coerce(raw, props.get(key) or {})
-
+        parsed, error = tool_arg_parser.parse_args(args, schema)
+        self._last_parse_error = error
         return parsed
 
     @classmethod
     def _coerce(cls, raw: str, prop_schema: Dict[str, Any]) -> Any:
-        t = cls._primary_type(prop_schema)
-        if t == "integer":
-            try:
-                return int(raw)
-            except ValueError:
-                return raw
-        if t == "number":
-            try:
-                return float(raw)
-            except ValueError:
-                return raw
-        if t == "boolean":
-            return raw.strip().lower() in ("1", "true", "yes", "y")
-        if t == "array":
-            return cls._coerce_collection(raw, expect=list)
-        if t == "object":
-            return cls._coerce_collection(raw, expect=dict)
-        return raw
+        return tool_arg_parser.coerce(raw, prop_schema)
 
     @staticmethod
     def _coerce_collection(raw: str, *, expect: type) -> Any:
-        """Coerce ``raw`` to ``expect`` (``list`` or ``dict``).
-
-        Attempts, in order:
-
-        1. ``json.loads`` — standard JSON form (``["a"]`` / ``{"k": 1}``).
-        2. ``ast.literal_eval`` — Python literal form which tolerates single
-           quotes and ``None`` / ``True``. LLMs and humans frequently emit
-           ``--metrics=['sales']`` or ``--ctx={'k': 'v'}``; JSON rejects both.
-        3. For arrays only: CSV fallback (``a,b,c`` → ``["a", "b", "c"]``).
-           For objects, a parse failure returns the raw string so the tool
-           can surface a clearer type error than a silently mangled value.
-        """
-        stripped = raw.strip()
-        if stripped and stripped[0] in "[{":
-            try:
-                parsed = json.loads(stripped)
-            except json.JSONDecodeError:
-                parsed = None
-            if parsed is None:
-                try:
-                    parsed = ast.literal_eval(stripped)
-                except (SyntaxError, ValueError):
-                    parsed = None
-            if isinstance(parsed, expect):
-                return parsed
-        if expect is list:
-            return [item.strip() for item in raw.split(",") if item.strip()]
-        return raw
+        return tool_arg_parser.coerce_collection(raw, expect=expect)
 
     @staticmethod
     def _primary_type(prop_schema: Dict[str, Any]) -> str:
-        """Return the primary JSON-schema type, flattening ``anyOf`` / ``oneOf``.
-
-        ``Optional[X]`` is represented by the Agents SDK as
-        ``{"anyOf": [{"type": X}, {"type": "null"}]}`` with no top-level
-        ``type``. Naively reading ``schema["type"]`` would yield ``""`` and
-        cause ``_coerce`` to skip its conversion logic, so e.g. an
-        ``Optional[List[str]]`` parameter would receive a raw CSV string
-        instead of a list.
-        """
-        if not isinstance(prop_schema, dict):
-            return ""
-        t = prop_schema.get("type")
-        if isinstance(t, str):
-            return t
-        if isinstance(t, list):
-            for candidate in t:
-                if isinstance(candidate, str) and candidate != "null":
-                    return candidate
-        for key in ("anyOf", "oneOf"):
-            variants = prop_schema.get(key)
-            if not isinstance(variants, list):
-                continue
-            for variant in variants:
-                if not isinstance(variant, dict):
-                    continue
-                vt = variant.get("type")
-                if isinstance(vt, str) and vt != "null":
-                    return vt
-        return ""
+        return tool_arg_parser.primary_type(prop_schema)
 
     @staticmethod
     def _missing_required(method: Optional[Callable], parsed: Dict[str, Any]) -> List[str]:
-        """Return names of parameters that are truly required but not supplied.
-
-        Uses the Python signature of the bound method as the source of truth —
-        Pydantic / the Agents SDK regularly list parameters with
-        ``Optional[...] = None`` defaults in the OpenAI-style ``required``
-        array, but those are semantically optional and we should not block
-        invocation on them.
-        """
-        if method is None or not callable(method):
-            return []
-        try:
-            sig = inspect.signature(method)
-        except (TypeError, ValueError):
-            return []
-        missing: List[str] = []
-        for name, param in sig.parameters.items():
-            if name == "self":
-                continue
-            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
-                continue
-            if name in parsed:
-                continue
-            if param.default is inspect.Parameter.empty:
-                missing.append(name)
-        return missing
+        return tool_arg_parser.missing_required(method, parsed)
 
     # ------------------------------------------------------------------ #
     # Async plumbing

--- a/datus/cli/tool_arg_parser.py
+++ b/datus/cli/tool_arg_parser.py
@@ -1,0 +1,237 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Shared CLI argument parsing for JSON-schema-backed ``FunctionTool`` calls.
+
+Both the ``/<service>.<method>`` handler (:mod:`datus.cli.service_commands`) and
+the ``!<tool> [args...]`` handler (:mod:`datus.cli.bang_command`) invoke a
+``FunctionTool`` by name from the CLI. They share the same minimal argument
+grammar — positional args in schema order plus ``--key=value`` named
+overrides — coerced against the tool's ``params_json_schema``:
+
+- Positional, in schema order: ``get_dashboard 1``
+- Named overrides: ``get_chart_data 42 --limit=100``
+- Lists: ``--subject_path=a,b`` or ``--subject_path=['a','b']``
+- Bare boolean flags: ``--simple_sample_data`` means ``=true``
+
+JSON-blob input is deliberately out of scope. This module keeps the parsing
+free of any service/tool-registry coupling so both callers behave identically.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import shlex
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+from rich.console import Console
+from rich.table import Table
+
+from datus.cli.cli_styles import TABLE_HEADER_STYLE, print_warning
+
+if TYPE_CHECKING:
+    from agents import FunctionTool
+
+
+def is_help_request(args: str) -> bool:
+    """True when *args* contains a ``--help`` / ``-h`` token."""
+    try:
+        tokens = shlex.split(args) if args else []
+    except ValueError:
+        return False
+    return "--help" in tokens or "-h" in tokens
+
+
+def parse_args(args: str, schema: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Parse positional + ``--key=value`` arguments against a JSON schema.
+
+    Returns ``(parsed, None)`` on success, or ``(None, error)`` when the input
+    is malformed (quoting error, extra positional, unknown named flag). The
+    error string carries a specific user-facing hint (e.g. a typoed flag name)
+    so callers can surface it before printing the schema.
+    """
+    try:
+        tokens = shlex.split(args) if args else []
+    except ValueError:
+        return None, "Malformed arguments: unmatched quotes."
+
+    props = (schema.get("properties") or {}) if isinstance(schema, dict) else {}
+    prop_order = [k for k in props.keys() if k != "self"]
+    valid_named = [k for k in prop_order]
+
+    positional: List[str] = []
+    named: Dict[str, str] = {}
+    for tok in tokens:
+        if tok.startswith("--"):
+            body = tok[2:]
+            if not body:
+                return None, "Empty flag '--'. Expected '--<name>' or '--<name>=<value>'."
+            key, sep, value = body.partition("=")
+            if not sep:
+                # Bare ``--flag`` means ``--flag=true`` for boolean fields.
+                named[key] = "true"
+            else:
+                named[key] = value
+        else:
+            positional.append(tok)
+
+    parsed: Dict[str, Any] = {}
+    for idx, value in enumerate(positional):
+        if idx >= len(prop_order):
+            return None, (f"Too many positional arguments. Method accepts {len(prop_order)} (got extra: '{value}').")
+        key = prop_order[idx]
+        parsed[key] = coerce(value, props.get(key) or {})
+
+    for key, raw in named.items():
+        if key not in props:
+            # Fail fast — a silently dropped ``--limti=1`` or ``--serach=...`` is
+            # worse than a parse error because the method executes without the
+            # filter the user intended.
+            suggestions = ", ".join(valid_named) if valid_named else "(none)"
+            return None, f"Unknown parameter '--{key}'. Valid parameters: {suggestions}."
+        parsed[key] = coerce(raw, props.get(key) or {})
+
+    return parsed, None
+
+
+def coerce(raw: str, prop_schema: Dict[str, Any]) -> Any:
+    """Coerce a raw string token to the JSON-schema type of *prop_schema*."""
+    t = primary_type(prop_schema)
+    if t == "integer":
+        try:
+            return int(raw)
+        except ValueError:
+            return raw
+    if t == "number":
+        try:
+            return float(raw)
+        except ValueError:
+            return raw
+    if t == "boolean":
+        return raw.strip().lower() in ("1", "true", "yes", "y")
+    if t == "array":
+        return coerce_collection(raw, expect=list)
+    if t == "object":
+        return coerce_collection(raw, expect=dict)
+    return raw
+
+
+def coerce_collection(raw: str, *, expect: type) -> Any:
+    """Coerce *raw* to *expect* (``list`` or ``dict``).
+
+    Attempts, in order:
+
+    1. ``json.loads`` — standard JSON form (``["a"]`` / ``{"k": 1}``).
+    2. ``ast.literal_eval`` — Python literal form which tolerates single
+       quotes and ``None`` / ``True``. LLMs and humans frequently emit
+       ``--metrics=['sales']`` or ``--ctx={'k': 'v'}``; JSON rejects both.
+    3. For arrays only: CSV fallback (``a,b,c`` → ``["a", "b", "c"]``).
+       For objects, a parse failure returns the raw string so the tool can
+       surface a clearer type error than a silently mangled value.
+    """
+    stripped = raw.strip()
+    if stripped and stripped[0] in "[{":
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            parsed = None
+        if parsed is None:
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (SyntaxError, ValueError):
+                parsed = None
+        if isinstance(parsed, expect):
+            return parsed
+    if expect is list:
+        return [item.strip() for item in raw.split(",") if item.strip()]
+    return raw
+
+
+def primary_type(prop_schema: Dict[str, Any]) -> str:
+    """Return the primary JSON-schema type, flattening ``anyOf`` / ``oneOf``.
+
+    ``Optional[X]`` is represented by the Agents SDK as
+    ``{"anyOf": [{"type": X}, {"type": "null"}]}`` with no top-level ``type``.
+    Naively reading ``schema["type"]`` would yield ``""`` and cause
+    :func:`coerce` to skip its conversion logic, so e.g. an
+    ``Optional[List[str]]`` parameter would receive a raw CSV string instead of
+    a list.
+    """
+    if not isinstance(prop_schema, dict):
+        return ""
+    t = prop_schema.get("type")
+    if isinstance(t, str):
+        return t
+    if isinstance(t, list):
+        for candidate in t:
+            if isinstance(candidate, str) and candidate != "null":
+                return candidate
+    for key in ("anyOf", "oneOf"):
+        variants = prop_schema.get(key)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if not isinstance(variant, dict):
+                continue
+            vt = variant.get("type")
+            if isinstance(vt, str) and vt != "null":
+                return vt
+    return ""
+
+
+def missing_required(method: Optional[Callable], parsed: Dict[str, Any]) -> List[str]:
+    """Return names of parameters that are truly required but not supplied.
+
+    Uses the Python signature of the bound method as the source of truth —
+    Pydantic / the Agents SDK regularly list parameters with ``Optional[...] =
+    None`` defaults in the OpenAI-style ``required`` array, but those are
+    semantically optional and we should not block invocation on them.
+    """
+    if method is None or not callable(method):
+        return []
+    try:
+        sig = inspect.signature(method)
+    except (TypeError, ValueError):
+        return []
+    missing: List[str] = []
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        if name in parsed:
+            continue
+        if param.default is inspect.Parameter.empty:
+            missing.append(name)
+    return missing
+
+
+def print_schema(console: Console, tool: "FunctionTool", hint: str = "") -> None:
+    """Render a ``FunctionTool``'s parameter schema as a Rich table."""
+    schema = tool.params_json_schema or {}
+    props = schema.get("properties") or {}
+    required = set(schema.get("required", []) or [])
+    if hint:
+        print_warning(console, hint)
+    table = Table(
+        title=f"{tool.name} — parameters",
+        show_header=True,
+        header_style=TABLE_HEADER_STYLE,
+    )
+    table.add_column("Name")
+    table.add_column("Type")
+    table.add_column("Required")
+    table.add_column("Description")
+    for key, info in props.items():
+        if key == "self" or not isinstance(info, dict):
+            continue
+        table.add_row(
+            key,
+            str(info.get("type", "")),
+            "yes" if key in required else "",
+            info.get("description", "") or "",
+        )
+    console.print(table)

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -61,6 +61,7 @@ from prompt_toolkit.layout.containers import (
 from prompt_toolkit.layout.controls import BufferControl, DummyControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenuControl
+from prompt_toolkit.layout.processors import AfterInput, ConditionalProcessor
 from prompt_toolkit.lexers import Lexer
 from prompt_toolkit.mouse_events import MouseButton, MouseEvent, MouseEventType
 from prompt_toolkit.styles import Style
@@ -193,6 +194,7 @@ class DatusApp:
         lexer: Optional[Lexer] = None,
         style: Optional[Style] = None,
         placeholder_fn: Optional[Callable[[], str]] = None,
+        param_hint_fn: Optional[Callable[[str], str]] = None,
         input_prompt_fn: Optional[Callable[[], str]] = None,
         input_mode_fn: Optional[Callable[[], str]] = None,
         live_display_state: Optional[LiveDisplayState] = None,
@@ -213,6 +215,9 @@ class DatusApp:
         # pinned above the status bar.
         self._pending_input_provider = pending_input_provider
         self._placeholder_fn = placeholder_fn or (lambda: "")
+        # Given the live input text, returns a dim ``<arg> [--opt]`` hint rendered
+        # after the input while typing a ``!<tool>`` / ``!<plugin>`` command.
+        self._param_hint_fn = param_hint_fn or (lambda text: "")
         self._input_prompt_fn = input_prompt_fn or (lambda: "> ")
         # Returns the REPL's active input mode ("chat" / "sql" / "bash").
         # Drives the mode-coloured prompt label, the separators bracketing
@@ -318,6 +323,17 @@ class DatusApp:
             auto_suggest=None,
             style="class:input-area",
             prompt=self._get_input_prompt,
+            # Dim ``<arg> [--opt]`` hint rendered after a ``!<tool>`` / ``!<plugin>``
+            # command. ``AfterInput`` only paints on the last line, so it never
+            # collides with multi-line chat input; it collapses to nothing when
+            # the hint is empty. Gated so the transformation is skipped entirely
+            # outside ``!`` input.
+            input_processors=[
+                ConditionalProcessor(
+                    AfterInput(self._bang_hint_text, style="class:bang-arg-hint"),
+                    filter=Condition(lambda: self._input_area.text.startswith("!")),
+                )
+            ],
         )
         self._input_area.window.dont_extend_height = to_filter(True)
         self._input_area.buffer.on_text_changed += self._on_buffer_text_changed
@@ -2226,6 +2242,19 @@ class DatusApp:
             text = "> "
         style_class = "class:input-prompt.busy" if self._agent_running.is_set() else "class:input-prompt"
         return FormattedText([(style_class, text)])
+
+    def _bang_hint_text(self) -> str:
+        """Dim argument hint appended after a ``!<tool>`` / ``!<plugin>`` command.
+
+        Delegates to the REPL's ``param_hint_fn`` (``BangCommand.param_hint``),
+        which returns ``""`` while the tool/plugin name is still being typed.
+        Runs on every paint, so it never raises.
+        """
+        try:
+            hint = self._param_hint_fn(self._input_area.text)
+        except Exception:  # pragma: no cover - a hint must never break rendering
+            return ""
+        return f"  {hint}" if hint else ""
 
     def _safe_dispatch(self, text: str) -> Optional[str]:
         try:

--- a/datus/plugins/base.py
+++ b/datus/plugins/base.py
@@ -131,6 +131,42 @@ Only ``manifest_version`` is required — every other key is optional::
     # ``type: string`` with ``pattern``/``enum``; values containing
     # ``${ENV_VAR}`` placeholders are exempt from value-level validation.
 
+    commands:
+      - name: sync
+        description: "Sync tables from the source"
+        args:
+          - name: table
+            required: true
+            description: "table name"
+          - name: --limit
+            description: "max rows"
+      - name: dags                     # a command GROUP with nested subcommands
+        description: "DAG operations"
+        subcommands:
+          - name: trigger
+            description: "Trigger a DAG run"
+            args:
+              - name: dag_id
+                required: true
+              - name: --conf
+                description: "run configuration JSON"
+          - name: list
+            description: "List DAGs"
+    # Optional catalogue of the CLI subcommands the plugin's ``cli`` function
+    # accepts, used purely as DESCRIPTIVE metadata: the interactive REPL's
+    # ``!<plugin> ...`` completer lists these commands (drilling into nested
+    # subcommands token by token) and hints their argument names, and ``datus
+    # plugin info`` prints them. datus never parses plugin arguments on the
+    # plugin's behalf — the ``cli`` function still owns its own argument parsing,
+    # so keep this list in sync with what it accepts. Each entry has a ``name``
+    # (the command token) and an optional ``description``, ``args`` list, and
+    # nested ``subcommands`` list (same shape, for command groups like
+    # ``dags trigger``). Each arg has a ``name`` (positional like ``table`` or a
+    # flag like ``--limit``), optional ``required`` (bool, default false) and
+    # ``description``. A malformed command / arg / subcommand entry is warned
+    # about and dropped individually; nesting deeper than a few levels is
+    # rejected defensively.
+
 The whole plugin system is gated by ``agent.plugins_enabled`` (default
 ``true``) and by the project's ``plugins:`` whitelist in
 ``./.datus/config.yml``. Manifest parsing is defensive: a malformed section is
@@ -169,8 +205,40 @@ _MANIFEST_KEYS = frozenset(
         "system_prompt",
         "skills",
         "config_schema",
+        "commands",
     }
 )
+
+
+@dataclass(frozen=True)
+class PluginCommandArg:
+    """One declared argument of a :class:`PluginCommand` (descriptive only).
+
+    ``name`` is either a positional token (``table``) or a flag (``--limit``).
+    The plugin's own ``cli`` function still parses arguments; this metadata only
+    powers the ``!<plugin>`` completer, argument-name hints and ``datus plugin
+    info``.
+    """
+
+    name: str
+    required: bool = False
+    description: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class PluginCommand:
+    """One CLI command a plugin's ``cli`` function accepts (descriptive).
+
+    ``subcommands`` models command groups (``dags`` → ``dags trigger``): the
+    ``!<plugin>`` completer and argument-name hint walk the token path one level
+    at a time, offering the subcommand menu until a leaf is reached, then that
+    leaf's ``args``. A command may carry both ``args`` and ``subcommands``.
+    """
+
+    name: str
+    description: Optional[str] = None
+    args: List[PluginCommandArg] = field(default_factory=list)
+    subcommands: List["PluginCommand"] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -192,6 +260,7 @@ class PluginManifest:
     system_prompt: Optional[str] = None
     skills: Optional[str] = None
     config_schema: Optional[Dict[str, Any]] = None
+    commands: List[PluginCommand] = field(default_factory=list)
 
 
 def parse_code_ref(ref: Any) -> Optional[Tuple[str, str]]:
@@ -284,6 +353,106 @@ def _parse_tool_transformers(data: Dict[str, Any], name: str) -> Dict[str, List[
     return normalized
 
 
+def _parse_command_args(raw_args: Any, name: str, command_name: str) -> List[PluginCommandArg]:
+    """Normalize a command's ``args`` list; drop malformed entries individually."""
+    if raw_args is None:
+        return []
+    if not isinstance(raw_args, list):
+        logger.warning("Plugin %r command %r `args` must be a list, got %r; ignoring.", name, command_name, raw_args)
+        return []
+    parsed: List[PluginCommandArg] = []
+    for entry in raw_args:
+        if not isinstance(entry, dict):
+            logger.warning("Plugin %r command %r has a non-mapping arg %r; skipping it.", name, command_name, entry)
+            continue
+        arg_name = entry.get("name")
+        if not isinstance(arg_name, str) or not arg_name.strip():
+            logger.warning(
+                "Plugin %r command %r has an arg without a valid `name` (%r); skipping it.",
+                name,
+                command_name,
+                arg_name,
+            )
+            continue
+        description = entry.get("description")
+        if description is not None and not isinstance(description, str):
+            description = None
+        parsed.append(
+            PluginCommandArg(
+                name=arg_name.strip(),
+                required=bool(entry.get("required", False)),
+                description=description.strip() if isinstance(description, str) and description.strip() else None,
+            )
+        )
+    return parsed
+
+
+# Guard against pathological / cyclic-looking manifests: real CLI trees are two
+# or three levels deep (``glue catalog create-table``), so stop recursing well
+# before anything absurd and drop deeper subcommands with a warning.
+_MAX_COMMAND_DEPTH = 6
+
+
+def _parse_command_entry(entry: Any, name: str, path: str, depth: int) -> Optional[PluginCommand]:
+    """Normalize one ``commands`` / ``subcommands`` entry (recursively).
+
+    ``path`` is the space-joined command prefix (e.g. ``"dags"``) used only for
+    log context; ``depth`` bounds recursion. Returns ``None`` for a malformed
+    entry so the caller can drop it while keeping its siblings.
+    """
+    if not isinstance(entry, dict):
+        logger.warning("Plugin %r manifest command %r is not a mapping; skipping it.", name, entry)
+        return None
+    command_name = entry.get("name")
+    if not isinstance(command_name, str) or not command_name.strip():
+        logger.warning("Plugin %r manifest has a command without a valid `name` (%r); skipping it.", name, entry)
+        return None
+    command_name = command_name.strip()
+    full_path = f"{path} {command_name}".strip()
+    description = entry.get("description")
+    description = description.strip() if isinstance(description, str) and description.strip() else None
+    subcommands = _parse_command_list(entry.get("subcommands"), name, full_path, depth + 1)
+    return PluginCommand(
+        name=command_name,
+        description=description,
+        args=_parse_command_args(entry.get("args"), name, full_path),
+        subcommands=subcommands,
+    )
+
+
+def _parse_command_list(raw: Any, name: str, path: str, depth: int) -> List[PluginCommand]:
+    """Normalize a list of command entries at ``path`` / ``depth``.
+
+    Invalid entries are warned about and dropped individually so one bad entry
+    never discards its siblings.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        label = f"command {path!r} `subcommands`" if path else "manifest `commands`"
+        logger.warning("Plugin %r %s must be a list, got %r; ignoring.", name, label, raw)
+        return []
+    if depth > _MAX_COMMAND_DEPTH:
+        logger.warning("Plugin %r command %r nests deeper than %d levels; dropping.", name, path, _MAX_COMMAND_DEPTH)
+        return []
+    parsed: List[PluginCommand] = []
+    for entry in raw:
+        command = _parse_command_entry(entry, name, path, depth)
+        if command is not None:
+            parsed.append(command)
+    return parsed
+
+
+def _parse_commands(data: Dict[str, Any], name: str) -> List[PluginCommand]:
+    """Normalize ``commands`` into a list of :class:`PluginCommand`.
+
+    Descriptive metadata only (see the module docstring). Command groups nest via
+    each entry's ``subcommands`` list; invalid commands / args / subcommands are
+    warned about and dropped individually.
+    """
+    return _parse_command_list(data.get("commands"), name, "", 1)
+
+
 def _parse_permissions(data: Dict[str, Any], name: str) -> Dict[str, Any]:
     """Shape-check ``permissions`` (must be a mapping); detail validation is
     deferred to ``collect_plugin_cli_permissions``."""
@@ -354,6 +523,7 @@ def parse_manifest(data: Any, name: str, package_dir: Path) -> Optional[PluginMa
         system_prompt=_parse_rel_path(data, "system_prompt", name),
         skills=_parse_rel_path(data, "skills", name),
         config_schema=_parse_config_schema(data, name),
+        commands=_parse_commands(data, name),
     )
 
 

--- a/datus/plugins/registry.py
+++ b/datus/plugins/registry.py
@@ -26,7 +26,13 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
-from datus.plugins.base import MANIFEST_FILENAME, PluginManifest, parse_code_ref, read_manifest_file
+from datus.plugins.base import (
+    MANIFEST_FILENAME,
+    PluginCommand,
+    PluginManifest,
+    parse_code_ref,
+    read_manifest_file,
+)
 from datus.plugins.prompt import render_plugin_prompt
 from datus.utils.loggings import get_logger
 
@@ -665,6 +671,33 @@ def plugin_config_schema(name: str) -> List[Dict[str, Any]]:
     required = manifest.config_schema.get("required")
     required_names = {entry for entry in required if isinstance(entry, str)} if isinstance(required, list) else set()
     return _flatten_schema_properties(name, properties, required_names)
+
+
+def iter_plugin_manifests() -> List[Tuple[str, PluginManifest]]:
+    """Return ``(name, manifest)`` for every installed plugin with a valid manifest.
+
+    Skips entry points whose name is missing or whose manifest was rejected
+    during loading. Backed by the process-level manifest cache, so callers such
+    as the ``!<plugin>`` completer can enumerate plugins cheaply. Never raises.
+    """
+    out: List[Tuple[str, PluginManifest]] = []
+    for name, manifest in _loaded_manifests():
+        if isinstance(name, str) and name and manifest is not None:
+            out.append((name, manifest))
+    return out
+
+
+def plugin_commands(name: str) -> List[PluginCommand]:
+    """Return the declarative CLI ``commands`` from plugin ``name``'s manifest.
+
+    Descriptive metadata used by the ``!<plugin>`` completer / argument hints and
+    ``datus plugin info`` — never used to parse the plugin's arguments. Returns an
+    empty list when the plugin is unknown or declares no commands. Never raises.
+    """
+    manifest = load_plugin_manifest(name)
+    if manifest is None:
+        return []
+    return list(manifest.commands)
 
 
 def plugin_validate_profile(name: str, profile: Dict[str, Any]) -> List[str]:

--- a/docs/cli/execution_command.md
+++ b/docs/cli/execution_command.md
@@ -1,114 +1,67 @@
-# Tool Commands `!`
+# Tool / Plugin Commands `!`
 
 ## 1. Overview
 
-Tool commands (prefixed with `!`) provide specialized AI-powered capabilities and utility operations within the Datus-CLI environment. These commands enable schema discovery, metrics search, SQL reference search, and other intelligent data operations without leaving the interactive session.
-
-## 2. Command Categories
-
-### 2.1 Schema Discovery Commands
-
-#### `!sl` / `!schema_linking`
-Perform intelligent schema linking to discover relevant tables and columns for your query.
+The `!` prefix is a power-user escape hatch that runs, directly from the chat REPL, either one of the agent's own **tools** or an installed **plugin's** CLI — without asking the model to do it for you. It is available in **chat mode** only (in SQL/bash mode a leading `!` is part of the statement, e.g. shell history expansion).
 
 ```bash
-!sl user purchase information
-!schema_linking sales data by region
+!<tool> [args...]        # run an agent tool directly
+!<plugin> <args...>      # run an installed plugin's CLI (datus <plugin> ...)
 ```
 
-Features:
+**Tools are matched first.** If the first token names a live tool it runs as a tool; otherwise, if it names an installed + activated plugin, it dispatches to that plugin's CLI; otherwise the input is rejected with a usage hint.
 
-- Semantic search for relevant database tables
-- Table definition (DDL) display
-- Sample data preview
-- Configurable matching methods: fast, medium, slow, from_llm
-- Adjustable top_n results
+Type `!` on its own to list the available tools and plugins.
 
-Interactive prompts guide you through:
-
-- Catalog/database/schema selection
-- Number of tables to match
-- Matching method preference
-
-### 2.2 Search & Discovery Commands
-
-#### `!sm` / `!search_metrics`
-Use natural language to search for corresponding metrics in your data catalog.
+## 2. Running a tool
 
 ```bash
-!sm monthly active users
-!search_metrics revenue growth rate
+!list_tables
+!search_table user purchase --top_n=5
+!describe_table orders
 ```
 
-Allows filtering by:
+- Arguments use a simple grammar: positional values in schema order, plus `--key=value` named overrides (bare `--flag` means `--flag=true`). Lists accept `--items=a,b,c` or `--items=['a','b']`.
+- `!<tool> --help` prints the tool's parameter schema (name / type / required / description).
+- Every call goes through the **same permission pipeline** an LLM-driven tool call would: read-only tools run without a prompt, while writes (`execute_sql` with INSERT/DDL, `bash`, file writes, …) require confirmation under the active permission profile. Denied calls never execute (and are not sent to the model).
+- The call + result render as an **execution turn** (a styled block, like SQL/bash modes) and are fed to the model: the run **enters the conversation context and triggers a reply**, so you can immediately ask follow-up questions about it.
 
-- Domain
-- Layer1 (business layer)
-- Layer2 (sub-layer)
-- Top N results
+### Autocomplete
 
-#### `!sq` / `!search_sql`
-Search historical SQL queries using natural language descriptions.
+- Typing `!` opens a completion menu listing tools (first) then plugins, each tagged in the description column.
+- After a tool name, `--` completes the tool's parameter flags plus `--help`.
+- Once a tool/plugin name is chosen, a dim `<required> [--optional]` hint is shown after the input, naming the remaining arguments as you type.
+
+## 3. Running a plugin CLI
 
 ```bash
-!sq queries about user retention
-!search_sql monthly sales reports
+!hello sync orders --limit=100
+!hello status
 ```
 
-Returns:
+- `!<plugin> <args...>` runs `datus <plugin> <args...>` as a subprocess. The command is permission-gated like any bash command, and the plugin's own CLI permissions apply inside the child process. Its output is fed to the model as an execution turn (same as `!<tool>`), so it enters the conversation and triggers a reply.
+- A plugin can declare its commands and arguments in its `datus-plugin.yml` manifest under `commands:` (see the plugin manifest reference). When present, the `!<plugin>` completer lists them and hints their argument names. Command groups nest via `subcommands:`, so the completer drills in one level at a time (`!airflow dags ` → `list`, `trigger`, …).
 
-- SQL query text with syntax highlighting
-- Query summary and comments
-- Tags and categorization
-- Domain/layer metadata
-- File path and relevance distance
-
-### 2.3 Utility Commands
-
-#### `!save`
-Save the last query result to a file.
-
-```bash
-!save
+```yaml
+# datus-plugin.yml (excerpt)
+commands:
+  - name: ls                        # a flat command with arguments
+    description: List objects under a prefix
+    args:
+      - {name: uri, required: true, description: s3://bucket/prefix}
+      - {name: --recursive, description: recurse into sub-prefixes}
+  - name: dags                      # a command group with nested subcommands
+    description: DAG operations
+    subcommands:
+      - name: trigger
+        args:
+          - {name: dag_id, required: true}
+          - {name: --conf, description: run configuration JSON}
+      - name: list
 ```
 
-Interactive options:
+## 4. Notes
 
-- File type: json, csv, sql, or all
-- Output directory (defaults to ~/.datus/output)
-- Custom filename
-
-#### `!bash <command>`
-Execute safe bash commands (security restricted).
-
-```bash
-!bash pwd
-!bash ls -la
-!bash cat config.yaml
-```
-
-**Security**: Only whitelisted commands are allowed:
-
-- `pwd` - Print working directory
-- `ls` - List files
-- `cat` - Display file contents
-- `head` - Show file beginning
-- `tail` - Show file end
-- `echo` - Display text
-
-Commands not in the whitelist will be rejected with a security warning.
-
-## 3. Best Practices
-
-1. **Start with Schema Linking** - Use `!sl` to discover relevant tables before writing queries
-2. **Leverage Search** - Use `!sm` and `!sq` to find existing metrics and queries before creating new ones
-3. **Save Results** - Use `!save` to preserve important query results
-4. **Security First** - Be aware of bash command restrictions when using `!bash`
-
-## 4. Security Considerations
-
-- Tool commands run with the same privileges as the Datus-CLI process
-- Bash commands are restricted to a whitelist of safe operations
-- `!bash` commands timeout after 10 seconds to prevent hanging
-- All operations are logged for audit purposes
-- API credentials and database connections are handled securely
+- `!` runs only in chat mode. Use `Tab` to cycle input modes (chat → sql → bash) for SQL / shell execution instead.
+- Tool commands run with the same privileges as the Datus-CLI process; the permission profile (`/permission`) governs which tool actions prompt or are blocked.
+- Plugin execution is gated by `agent.plugins_enabled` and the project's plugin activation — only installed and active plugins are reachable via `!`.

--- a/docs/cli/execution_command.zh.md
+++ b/docs/cli/execution_command.zh.md
@@ -1,115 +1,67 @@
-# 工具命令 `!`
+# 工具 / 插件命令 `!`
 
-## 1. 概览
+## 1. 概述
 
-以 `!` 为前缀的工具命令，为 Datus-CLI 会话提供一系列 AI 加持的能力与实用操作。你可以在不离开交互式终端的前提下，完成模式发现、指标搜索、SQL 参考搜索等智能数据任务。
-
-## 2. 命令分类
-
-### 2.1 模式发现命令
-
-#### `!sl` / `!schema_linking`
-执行智能模式匹配，为你的问题查找相关的数据表与字段。
+`!` 前缀是一个面向高级用户的"逃生舱"：在对话 REPL 中直接运行 agent 的某个**工具**，或某个已安装**插件**的 CLI——无需让模型代劳。它仅在 **chat 模式**下生效（在 SQL/bash 模式下，开头的 `!` 属于语句本身，例如 shell 的历史展开）。
 
 ```bash
-!sl user purchase information
-!schema_linking sales data by region
+!<tool> [args...]        # 直接运行一个 agent 工具
+!<plugin> <args...>      # 运行某个已安装插件的 CLI（datus <plugin> ...）
 ```
 
-特性：
+**优先匹配工具。** 若首个 token 命中某个在线工具，则按工具执行；否则若命中某个已安装且已激活的插件，则分发到该插件的 CLI；两者都不命中时，报错并给出用法提示。
 
-- 语义级别搜索相关数据库表
-- 展示表定义（DDL）
-- 预览样例数据
-- 可选匹配模式：fast、medium、slow、from_llm
-- 可设置 top_n 返回数量
+单独输入 `!` 可列出可用的工具与插件。
 
-交互式提示将引导你完成：
-
-- 选择 catalog / database / schema
-- 指定匹配数据表数量
-- 选择偏好的匹配方式
-
-### 2.2 搜索发现命令
-
-#### `!sm` / `!search_metrics`
-使用自然语言在数据目录中搜索对应的指标。
+## 2. 运行工具
 
 ```bash
-!sm monthly active users
-!search_metrics revenue growth rate
+!list_tables
+!search_table user purchase --top_n=5
+!describe_table orders
 ```
 
-支持以下筛选条件：
+- 参数语法很简单：按 schema 顺序的位置参数，加上 `--key=value` 具名覆盖（裸 `--flag` 等价于 `--flag=true`）。列表支持 `--items=a,b,c` 或 `--items=['a','b']`。
+- `!<tool> --help` 会打印该工具的参数 schema（名称 / 类型 / 是否必填 / 描述）。
+- 每次调用都会经过与 LLM 驱动调用**完全相同的权限管线**：只读工具无需确认即可运行，而写操作（含 INSERT/DDL 的 `execute_sql`、`bash`、文件写入等）在当前权限档位下需要确认。被拒绝的调用不会执行（也不会发给模型）。
+- 调用与结果会渲染为一个**执行 turn**（带样式的块，和 SQL/bash 模式一样）并喂给模型：本次执行**进入对话上下文并触发一次回复**，你可以紧接着追问相关内容。
 
-- Domain
-- Layer1（业务层）
-- Layer2（子层）
-- Top N 结果
+### 自动补全
 
-#### `!sq` / `!search_sql`
-使用自然语言描述搜索历史 SQL。
+- 输入 `!` 会弹出补全菜单，先列工具、后列插件，并在描述列标注类型。
+- 在工具名之后输入 `--` 可补全该工具的参数 flag 以及 `--help`。
+- 选定工具/插件名后，输入行尾会以浅灰色显示 `<必填> [--可选]` 提示，随输入进度提示剩余参数名。
+
+## 3. 运行插件 CLI
 
 ```bash
-!sq queries about user retention
-!search_sql monthly sales reports
+!hello sync orders --limit=100
+!hello status
 ```
 
-返回内容包括：
+- `!<plugin> <args...>` 会以子进程方式运行 `datus <plugin> <args...>`。该命令像普通 bash 命令一样受权限门控，并且插件自身的 CLI 权限在子进程内同样生效。其输出会作为执行 turn 喂给模型（与 `!<tool>` 一致），进入对话并触发一次回复。
+- 插件可以在其 `datus-plugin.yml` manifest 的 `commands:` 下声明命令与参数（见插件 manifest 参考）。声明后，`!<plugin>` 补全器会列出它们并提示其参数名。命令分组通过 `subcommands:` 嵌套，补全器会逐级下钻（`!airflow dags ` → `list`、`trigger` …）。
 
-- SQL 文本（语法高亮）
-- 查询摘要与备注
-- 标签与分类
-- 域/层级元数据
-- 文件路径与相关度（距离分数）
-
-### 2.3 实用命令
-
-#### `!save`
-将最近一次查询结果保存到文件。
-
-```bash
-!save
+```yaml
+# datus-plugin.yml（节选）
+commands:
+  - name: ls                        # 带参数的扁平命令
+    description: List objects under a prefix
+    args:
+      - {name: uri, required: true, description: s3://bucket/prefix}
+      - {name: --recursive, description: recurse into sub-prefixes}
+  - name: dags                      # 带嵌套子命令的命令分组
+    description: DAG operations
+    subcommands:
+      - name: trigger
+        args:
+          - {name: dag_id, required: true}
+          - {name: --conf, description: run configuration JSON}
+      - name: list
 ```
 
-交互式选项：
+## 4. 说明
 
-- 文件类型：json、csv、sql 或 all
-- 输出目录（默认 `~/.datus/output`）
-- 自定义文件名
-
-#### `!bash <command>`
-执行安全的 Bash 命令（有限制）。
-
-```bash
-!bash pwd
-!bash ls -la
-!bash cat config.yaml
-```
-
-**安全策略**：仅允许白名单命令：
-
-- `pwd` —— 查看当前目录
-- `ls` —— 列出目录内容
-- `cat` —— 展示文件内容
-- `head` —— 查看文件开头
-- `tail` —— 查看文件末尾
-- `echo` —— 输出文本
-
-不在白名单内的命令会被拒绝并提示安全警告。
-
-## 3. 最佳实践
-
-1. **先做模式匹配** —— 使用 `!sl` 寻找相关表，再编写查询
-2. **善用搜索** —— 使用 `!sm`、`!sq` 优先复用已有指标与查询
-3. **保存成果** —— 通过 `!save` 保存重要的查询结果
-4. **关注安全** —— 使用 `!bash` 时注意白名单限制
-
-## 4. 安全注意事项
-
-- 工具命令与 Datus-CLI 进程共享权限
-- Bash 命令被限制在安全白名单内
-- `!bash` 默认 10 秒超时，防止卡死
-- 所有操作都会记录日志以供审计
-- API 凭证与数据库连接均经过安全处理
-
+- `!` 只在 chat 模式下运行。若要执行 SQL / shell，请用 `Tab` 循环切换输入模式（chat → sql → bash）。
+- 工具命令与 Datus-CLI 进程同权限运行；权限档位（`/permission`）决定哪些工具操作会弹确认或被阻止。
+- 插件执行受 `agent.plugins_enabled` 和项目级插件激活控制——只有已安装且已激活的插件才能通过 `!` 访问。

--- a/tests/unit_tests/cli/test_autocomplete.py
+++ b/tests/unit_tests/cli/test_autocomplete.py
@@ -20,6 +20,7 @@ from prompt_toolkit.document import Document
 from datus.cli.autocomplete import (
     AtReferenceCompleter,
     AtReferenceParser,
+    BangCompleter,
     CustomPygmentsStyle,
     CustomSqlLexer,
     DynamicAtReferenceCompleter,
@@ -28,6 +29,8 @@ from datus.cli.autocomplete import (
     insert_into_dict,
     insert_into_dict_with_dict,
 )
+from datus.cli.input_modes import InputMode
+from datus.plugins.base import PluginCommand, PluginCommandArg, PluginManifest
 
 # ---------------------------------------------------------------------------
 # SQLCompleter
@@ -956,3 +959,148 @@ class TestAtReferenceCompleterAgent:
         completions = list(completer.get_completions(doc, None))
         texts = {c.text for c in completions}
         assert {"gen_sql", "gen_report"}.issubset(texts)
+
+
+# ---------------------------------------------------------------------------
+# BangCompleter (!<tool> / !<plugin>)
+# ---------------------------------------------------------------------------
+
+
+def _fake_tool(name, *, schema=None, description=""):
+    tool = MagicMock()
+    tool.name = name
+    tool.description = description
+    tool.params_json_schema = schema if schema is not None else {"properties": {}}
+    return tool
+
+
+def _hello_manifest():
+    from pathlib import Path
+
+    return PluginManifest(
+        name="hello",
+        package_dir=Path("."),
+        description="Hello plugin",
+        commands=[
+            PluginCommand(
+                name="sync",
+                description="sync tables",
+                args=[PluginCommandArg("table", required=True), PluginCommandArg("--limit")],
+            ),
+            PluginCommand(name="status", description="show status"),
+        ],
+    )
+
+
+def _airflow_manifest():
+    from pathlib import Path
+
+    return PluginManifest(
+        name="airflow",
+        package_dir=Path("."),
+        description="Airflow plugin",
+        commands=[
+            PluginCommand(
+                name="dags",
+                description="DAG operations",
+                subcommands=[
+                    PluginCommand(
+                        name="trigger",
+                        args=[PluginCommandArg("dag_id", required=True), PluginCommandArg("--conf")],
+                    ),
+                    PluginCommand(name="list"),
+                ],
+            ),
+            PluginCommand(name="version"),
+        ],
+    )
+
+
+class _FakeBang:
+    def __init__(self, tools=None, plugins=None):
+        self._tools = tools or {}
+        self._plugins = plugins or {}
+
+    def tool_map(self, create=False):
+        return self._tools
+
+    def plugin_map(self):
+        return self._plugins
+
+
+def _bang_cli(tools=None, plugins=None, input_mode=InputMode.CHAT):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(input_mode=input_mode, bang_command=_FakeBang(tools, plugins))
+
+
+def _complete(completer, text):
+    doc = Document(text, cursor_position=len(text))
+    return list(completer.get_completions(doc, None))
+
+
+class TestBangCompleter:
+    def test_lists_tools_before_plugins(self):
+        cli = _bang_cli(
+            tools={"list_tables": _fake_tool("list_tables", description="List tables")},
+            plugins={"hello": _hello_manifest()},
+        )
+        comps = _complete(BangCompleter(cli), "!")
+        texts = [c.text for c in comps]
+        assert texts == ["list_tables ", "hello "]
+        metas = [c.display_meta_text for c in comps]
+        assert metas[0].startswith("tool")
+        assert metas[1].startswith("plugin")
+
+    def test_filters_names_by_prefix(self):
+        cli = _bang_cli(
+            tools={"list_tables": _fake_tool("list_tables"), "search_table": _fake_tool("search_table")},
+        )
+        texts = [c.text for c in _complete(BangCompleter(cli), "!sea")]
+        assert texts == ["search_table "]
+
+    def test_tool_flag_completion(self):
+        schema = {"properties": {"query_text": {"type": "string"}, "top_n": {"type": "integer"}}}
+        cli = _bang_cli(tools={"search_table": _fake_tool("search_table", schema=schema)})
+        texts = [c.text for c in _complete(BangCompleter(cli), "!search_table --")]
+        assert "--help" in texts
+        assert "--query_text=" in texts
+        assert "--top_n=" in texts
+
+    def test_plugin_subcommand_completion(self):
+        cli = _bang_cli(plugins={"hello": _hello_manifest()})
+        texts = [c.text for c in _complete(BangCompleter(cli), "!hello ")]
+        assert texts == ["status ", "sync "]  # sorted
+
+    def test_plugin_flag_completion(self):
+        cli = _bang_cli(plugins={"hello": _hello_manifest()})
+        texts = [c.text for c in _complete(BangCompleter(cli), "!hello sync --")]
+        assert texts == ["--limit="]
+
+    def test_plugin_group_lists_subcommands(self):
+        cli = _bang_cli(plugins={"airflow": _airflow_manifest()})
+        texts = [c.text for c in _complete(BangCompleter(cli), "!airflow dags ")]
+        assert texts == ["list ", "trigger "]  # sorted within the group
+
+    def test_plugin_group_filters_subcommands_by_prefix(self):
+        cli = _bang_cli(plugins={"airflow": _airflow_manifest()})
+        texts = [c.text for c in _complete(BangCompleter(cli), "!airflow dags tri")]
+        assert texts == ["trigger "]
+
+    def test_plugin_leaf_flag_completion(self):
+        cli = _bang_cli(plugins={"airflow": _airflow_manifest()})
+        texts = [c.text for c in _complete(BangCompleter(cli), "!airflow dags trigger --")]
+        assert texts == ["--conf="]
+
+    def test_plugin_top_level_lists_groups(self):
+        cli = _bang_cli(plugins={"airflow": _airflow_manifest()})
+        texts = [c.text for c in _complete(BangCompleter(cli), "!airflow ")]
+        assert texts == ["dags ", "version "]
+
+    def test_silent_outside_chat_mode(self):
+        cli = _bang_cli(tools={"list_tables": _fake_tool("list_tables")}, input_mode=InputMode.BASH)
+        assert _complete(BangCompleter(cli), "!li") == []
+
+    def test_silent_without_bang_prefix(self):
+        cli = _bang_cli(tools={"list_tables": _fake_tool("list_tables")})
+        assert _complete(BangCompleter(cli), "list") == []

--- a/tests/unit_tests/cli/test_bang_command.py
+++ b/tests/unit_tests/cli/test_bang_command.py
@@ -1,0 +1,411 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/cli/bang_command.py.
+
+Covers the ``!<tool>`` / ``!<plugin>`` dispatcher:
+- tool/plugin enumeration (node tools + active plugins)
+- tool-before-plugin dispatch priority + unknown-token error
+- tool invocation gated by ``run_tool_gate`` (denied never executes)
+- plugin invocation via the ``datus <plugin> ...`` subprocess path
+- the dim argument-name hint (``param_hint``)
+"""
+
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from datus.cli.bang_command import BangCommand
+from datus.cli.input_modes import InputMode
+from datus.plugins.base import PluginCommand, PluginCommandArg, PluginManifest
+
+
+def _make_tool(name, *, schema=None, description="", result=None):
+    tool = MagicMock()
+    tool.name = name
+    tool.description = description
+    tool.params_json_schema = schema if schema is not None else {"properties": {}}
+    tool.on_invoke_tool = AsyncMock(return_value=result if result is not None else {"success": 1, "result": "ok"})
+    return tool
+
+
+def _make_cli(tools=None, node_exists=True, plugins_enabled=True):
+    node = SimpleNamespace(tools=list(tools or [])) if node_exists else None
+    chat = MagicMock()
+    chat.current_node = node
+    chat.ensure_node_for_bang = MagicMock(return_value=node)
+    agent_config = MagicMock()
+    agent_config.plugins_enabled = plugins_enabled
+    agent_config.plugin_active = MagicMock(return_value=True)
+    return SimpleNamespace(
+        console=Console(file=io.StringIO(), no_color=True, width=200),
+        chat_commands=chat,
+        agent_config=agent_config,
+        service_commands=MagicMock(),
+        input_mode=InputMode.CHAT,
+        _send_exec_turn=MagicMock(),
+    )
+
+
+def _hello_manifest():
+    return PluginManifest(
+        name="hello",
+        package_dir=Path("."),
+        description="Hello plugin",
+        commands=[
+            PluginCommand(
+                name="sync",
+                description="sync tables",
+                args=[PluginCommandArg("table", required=True), PluginCommandArg("--limit")],
+            ),
+            PluginCommand(name="status", description="show status"),
+        ],
+    )
+
+
+def _airflow_manifest():
+    """A two-level command tree: a ``dags`` group plus a flat ``version`` command."""
+    return PluginManifest(
+        name="airflow",
+        package_dir=Path("."),
+        description="Airflow plugin",
+        commands=[
+            PluginCommand(
+                name="dags",
+                description="DAG operations",
+                subcommands=[
+                    PluginCommand(
+                        name="trigger",
+                        description="Trigger a DAG run",
+                        args=[PluginCommandArg("dag_id", required=True), PluginCommandArg("--conf")],
+                    ),
+                    PluginCommand(name="list", description="List DAGs"),
+                ],
+            ),
+            PluginCommand(name="version", description="Server version"),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Enumeration
+# ---------------------------------------------------------------------------
+
+
+class TestEnumeration:
+    def test_tool_map_reads_live_node_tools(self):
+        cli = _make_cli(tools=[_make_tool("list_tables"), _make_tool("search_table")])
+        bang = BangCommand(cli)
+        assert set(bang.tool_map()) == {"list_tables", "search_table"}
+
+    def test_tool_map_excludes_orchestration_tools(self):
+        """Agent-orchestration / plan-mode tools are hidden from ``!``."""
+        names = ["list_tables", "ask_user", "task", "confirm_plan", "todo_write", "execute_sql"]
+        cli = _make_cli(tools=[_make_tool(n) for n in names])
+        bang = BangCommand(cli)
+        assert set(bang.tool_map()) == {"list_tables", "execute_sql"}
+
+    def test_excluded_tool_name_is_not_dispatched_as_tool(self):
+        """A first token naming an excluded tool falls through to the unknown path
+        (not invoked as a tool)."""
+        tool = _make_tool("task")
+        cli = _make_cli(tools=[tool])
+        bang = BangCommand(cli)
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[]):
+            bang.dispatch("task")
+        tool.on_invoke_tool.assert_not_awaited()
+        assert "Unknown tool or plugin 'task'" in cli.console.file.getvalue()
+
+    def test_tool_map_create_lazily_builds_node(self):
+        cli = _make_cli(node_exists=False)
+        # ensure_node_for_bang returns a node with one tool the second time.
+        node = SimpleNamespace(tools=[_make_tool("list_tables")])
+        cli.chat_commands.ensure_node_for_bang = MagicMock(return_value=node)
+        bang = BangCommand(cli)
+        assert bang.tool_map(create=False) == {}
+        assert set(bang.tool_map(create=True)) == {"list_tables"}
+        cli.chat_commands.ensure_node_for_bang.assert_called_once()
+
+    def test_plugin_map_lists_active_plugins(self):
+        cli = _make_cli()
+        bang = BangCommand(cli)
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]):
+            plugins = bang.plugin_map()
+        assert set(plugins) == {"hello"}
+
+    def test_plugin_map_filters_inactive(self):
+        cli = _make_cli()
+        cli.agent_config.plugin_active = MagicMock(return_value=False)
+        bang = BangCommand(cli)
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]):
+            assert bang.plugin_map() == {}
+
+    def test_plugin_map_empty_when_plugins_disabled(self):
+        cli = _make_cli(plugins_enabled=False)
+        bang = BangCommand(cli)
+        assert bang.plugin_map() == {}
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_tool_matches_before_plugin(self):
+        """A first token naming both a tool and a plugin resolves to the tool."""
+        tool = _make_tool("hello", schema={"properties": {}})
+        cli = _make_cli(tools=[tool])
+        bang = BangCommand(cli)
+        with (
+            patch("datus.cli.bash_mode.run_manual_tool_live", return_value=(None, False)) as run_tool,
+            patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]),
+            patch("datus.cli.bash_mode.run_manual_bash_live") as run_plugin,
+        ):
+            bang.dispatch("hello")
+        run_tool.assert_called_once()
+        assert run_tool.call_args.args[1] == "hello"  # tool_name
+        run_plugin.assert_not_called()
+
+    def test_plugin_dispatch_feeds_model(self):
+        cli = _make_cli(tools=[])
+        bang = BangCommand(cli)
+        payload = {"kind": "bash", "command": "datus hello sync", "success": True}
+        with (
+            patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]),
+            patch("datus.cli.bash_mode.run_manual_bash_live", return_value=(payload, True)) as run_plugin,
+        ):
+            bang.dispatch("hello sync mytable --limit=5")
+        run_plugin.assert_called_once()
+        assert run_plugin.call_args.args[1] == "datus hello sync mytable --limit=5"
+        cli._send_exec_turn.assert_called_once_with(payload)
+
+    def test_plugin_denied_not_dispatched(self):
+        cli = _make_cli(tools=[])
+        bang = BangCommand(cli)
+        with (
+            patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]),
+            patch("datus.cli.bash_mode.run_manual_bash_live", return_value=(None, False)),
+        ):
+            bang.dispatch("hello status")
+        cli._send_exec_turn.assert_not_called()
+
+    def test_unknown_token_prints_error(self):
+        cli = _make_cli(tools=[])
+        bang = BangCommand(cli)
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[]):
+            bang.dispatch("nope")
+        assert "Unknown tool or plugin 'nope'" in cli.console.file.getvalue()
+
+    def test_empty_prints_overview(self):
+        cli = _make_cli(tools=[_make_tool("list_tables", description="List tables")])
+        bang = BangCommand(cli)
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[]):
+            bang.dispatch("")
+        out = cli.console.file.getvalue()
+        assert "list_tables" in out
+
+
+# ---------------------------------------------------------------------------
+# Tool invocation
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeTool:
+    def test_help_prints_schema_and_does_not_execute(self):
+        tool = _make_tool("search_table", schema={"properties": {"query_text": {"type": "string"}}})
+        cli = _make_cli(tools=[tool])
+        bang = BangCommand(cli)
+        bang.dispatch("search_table --help")
+        tool.on_invoke_tool.assert_not_awaited()
+        cli._send_exec_turn.assert_not_called()
+        assert "search_table" in cli.console.file.getvalue()
+
+    def test_parse_error_prints_schema_and_does_not_execute(self):
+        tool = _make_tool("search_table", schema={"properties": {"query_text": {"type": "string"}}})
+        cli = _make_cli(tools=[tool])
+        bang = BangCommand(cli)
+        bang.dispatch("search_table --bogus=1")
+        tool.on_invoke_tool.assert_not_awaited()
+        cli._send_exec_turn.assert_not_called()
+        assert "search_table" in cli.console.file.getvalue()
+
+    def test_dispatches_exec_turn_with_parsed_args(self):
+        """An approved tool call runs via ``run_manual_tool_live`` and the resulting
+        payload is fed to the model via ``_send_exec_turn``; the invoke closure
+        passes the parsed args to ``on_invoke_tool``."""
+        tool = _make_tool(
+            "search_table",
+            schema={"properties": {"query_text": {"type": "string"}, "top_n": {"type": "integer"}}},
+            result={"success": 1, "result": [{"table": "t1"}]},
+        )
+        cli = _make_cli(tools=[tool])
+        bang = BangCommand(cli)
+        payload = {"kind": "tool", "command": "search_table foo --top_n=3", "success": True}
+        with patch("datus.cli.bash_mode.run_manual_tool_live", return_value=(payload, True)) as run_tool:
+            bang.dispatch("search_table foo --top_n=3")
+        cli_arg, tool_name, command, args, invoke_fn = run_tool.call_args.args
+        assert cli_arg is cli
+        assert tool_name == "search_table"
+        assert command == "search_table foo --top_n=3"
+        assert args == {"query_text": "foo", "top_n": 3}
+        # The closure performs the actual invocation with the parsed args.
+        success, output = invoke_fn()
+        tool.on_invoke_tool.assert_awaited_once()
+        _ctx, args_json = tool.on_invoke_tool.await_args.args
+        assert json.loads(args_json) == {"query_text": "foo", "top_n": 3}
+        assert success is True
+        assert "t1" in output
+        cli._send_exec_turn.assert_called_once_with(payload)
+
+    def test_denied_not_dispatched(self):
+        tool = _make_tool("execute_sql", schema={"properties": {"sql": {"type": "string"}}})
+        cli = _make_cli(tools=[tool])
+        bang = BangCommand(cli)
+        denial_payload = {"kind": "tool", "command": "execute_sql", "success": False}
+        with patch("datus.cli.bash_mode.run_manual_tool_live", return_value=(denial_payload, False)):
+            bang.dispatch('execute_sql "DROP TABLE t"')
+        cli._send_exec_turn.assert_not_called()
+
+
+class TestToolResultToOutput:
+    def test_func_tool_result_success_unwrapped(self):
+        success, output = BangCommand._tool_result_to_output({"success": 1, "result": [{"a": 1}]})
+        assert success is True
+        assert '"a": 1' in output
+
+    def test_func_tool_result_failure_uses_error(self):
+        success, output = BangCommand._tool_result_to_output({"success": 0, "error": "nope"})
+        assert success is False
+        assert output == "nope"
+
+    def test_plain_string_result(self):
+        assert BangCommand._tool_result_to_output("hi") == (True, "hi")
+
+    def test_plain_payload_json_encoded(self):
+        success, output = BangCommand._tool_result_to_output({"rows": 3})
+        assert success is True
+        assert '"rows": 3' in output
+
+
+# ---------------------------------------------------------------------------
+# Argument-name hint
+# ---------------------------------------------------------------------------
+
+
+class TestParamHint:
+    def _bang_with_plugin(self, tools=None):
+        cli = _make_cli(tools=tools or [])
+        bang = BangCommand(cli)
+        return cli, bang
+
+    def test_empty_while_typing_name(self):
+        _cli, bang = self._bang_with_plugin(tools=[_make_tool("search_table")])
+        assert bang.param_hint("!sea") == ""
+
+    def test_non_bang_returns_empty(self):
+        _cli, bang = self._bang_with_plugin()
+        assert bang.param_hint("select 1") == ""
+
+    def test_tool_hint_shows_required_and_optional(self):
+        tool = _make_tool(
+            "search_table",
+            schema={
+                "properties": {"query_text": {"type": "string"}, "top_n": {"type": "integer"}},
+                "required": ["query_text"],
+            },
+        )
+        _cli, bang = self._bang_with_plugin(tools=[tool])
+        hint = bang.param_hint("!search_table ")
+        assert "<query_text>" in hint
+        assert "[--top_n]" in hint
+
+    def test_tool_hint_drops_consumed_positional(self):
+        tool = _make_tool(
+            "search_table",
+            schema={
+                "properties": {"query_text": {"type": "string"}, "top_n": {"type": "integer"}},
+                "required": ["query_text"],
+            },
+        )
+        _cli, bang = self._bang_with_plugin(tools=[tool])
+        hint = bang.param_hint("!search_table foo ")
+        assert "<query_text>" not in hint
+        assert "[--top_n]" in hint
+
+    def test_tool_hint_drops_named_given(self):
+        tool = _make_tool(
+            "search_table",
+            schema={
+                "properties": {"query_text": {"type": "string"}, "top_n": {"type": "integer"}},
+                "required": ["query_text"],
+            },
+        )
+        _cli, bang = self._bang_with_plugin(tools=[tool])
+        hint = bang.param_hint("!search_table --top_n=3 ")
+        assert "[--top_n]" not in hint
+        assert "<query_text>" in hint
+
+    def test_plugin_hint_lists_commands(self):
+        _cli, bang = self._bang_with_plugin()
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]):
+            hint = bang.param_hint("!hello ")
+        assert hint == "{sync|status}"
+
+    def test_plugin_hint_shows_command_args(self):
+        _cli, bang = self._bang_with_plugin()
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]):
+            hint = bang.param_hint("!hello sync ")
+        assert "<table>" in hint
+        assert "[--limit]" in hint
+
+    def test_plugin_hint_drops_consumed_arg(self):
+        _cli, bang = self._bang_with_plugin()
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("hello", _hello_manifest())]):
+            hint = bang.param_hint("!hello sync mytable ")
+        assert "<table>" not in hint
+        assert "[--limit]" in hint
+
+    # -- nested command groups (dags -> dags trigger) ----------------------
+
+    def test_plugin_hint_lists_group_subcommands(self):
+        _cli, bang = self._bang_with_plugin()
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("airflow", _airflow_manifest())]):
+            hint = bang.param_hint("!airflow dags ")
+        assert hint == "{trigger|list}"
+
+    def test_plugin_hint_leaf_subcommand_args(self):
+        _cli, bang = self._bang_with_plugin()
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("airflow", _airflow_manifest())]):
+            hint = bang.param_hint("!airflow dags trigger ")
+        assert "<dag_id>" in hint
+        assert "[--conf]" in hint
+
+    def test_plugin_hint_leaf_drops_consumed_positional(self):
+        _cli, bang = self._bang_with_plugin()
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("airflow", _airflow_manifest())]):
+            hint = bang.param_hint("!airflow dags trigger mydag ")
+        assert "<dag_id>" not in hint
+        assert "[--conf]" in hint
+
+    def test_plugin_hint_top_level_menu_before_group_chosen(self):
+        _cli, bang = self._bang_with_plugin()
+        with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[("airflow", _airflow_manifest())]):
+            hint = bang.param_hint("!airflow ")
+        assert hint == "{dags|version}"
+
+
+@pytest.mark.parametrize("text", ["!", "!  ", "!help"])
+def test_dispatch_overview_variants_do_not_raise(text):
+    cli = _make_cli(tools=[])
+    bang = BangCommand(cli)
+    with patch("datus.plugins.registry.iter_plugin_manifests", return_value=[]):
+        bang.dispatch(text[1:].strip())
+    # Overview always prints the usage line.
+    assert "Usage:" in cli.console.file.getvalue()

--- a/tests/unit_tests/cli/test_bash_mode.py
+++ b/tests/unit_tests/cli/test_bash_mode.py
@@ -627,3 +627,137 @@ class TestRunSqlGate:
         assert gate.approved is True
         assert gate.sql == "SELECT 1 WHERE x=1"
         node.db_func_tool._enforce_sql_policy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_tool_gate (generic permission gate for ``!<tool>``)
+# ---------------------------------------------------------------------------
+
+
+class TestToolShimContract:
+    def test_context_shim_round_trips_through_hook_parser(self):
+        """The generic shim exposes the call args as ``tool_arguments`` exactly
+        as the hook's parser expects."""
+        from datus.cli.bash_mode import _ToolContextShim
+
+        hooks = object.__new__(PermissionHooks)
+        args = hooks._parse_tool_args(_ToolContextShim({"query_text": "foo", "top_n": 3}))
+        assert args == {"query_text": "foo", "top_n": 3}
+
+    def test_tool_stub_exposes_name(self):
+        from datus.cli.bash_mode import _ToolStub
+
+        assert _ToolStub("search_table").name == "search_table"
+
+
+class TestRunToolGate:
+    def test_read_tool_auto_allows_without_prompt(self):
+        """A read/unknown-category tool auto-allows under the normal profile with
+        no prompt (category ``tools`` → ALLOW)."""
+        from datus.cli.bash_mode import run_tool_gate
+
+        gate = run_tool_gate(_sql_cli(), "list_tables", {})
+        assert gate.approved is True
+        assert gate.error is None
+
+    def test_execute_sql_read_auto_allows(self):
+        """Routing is by ``tool.name``: an ``execute_sql`` call with a read
+        statement hits the SQL handler and auto-allows."""
+        from datus.cli.bash_mode import run_tool_gate
+
+        gate = run_tool_gate(_sql_cli(), "execute_sql", {"sql": "SELECT 1"})
+        assert gate.approved is True
+
+    def test_execute_sql_write_ask_approved_via_collector(self):
+        from datus.cli.bash_mode import run_tool_gate
+
+        cli = _sql_cli()
+        with patch("datus.cli.bash_mode._make_input_collector", return_value=lambda a, c: [["y"]]):
+            gate = run_tool_gate(cli, "execute_sql", {"sql": "DELETE FROM t WHERE id=1"})
+        assert gate.approved is True
+
+    def test_execute_sql_write_ask_rejected_blocks(self):
+        from datus.cli.bash_mode import run_tool_gate
+
+        cli = _sql_cli()
+        with patch("datus.cli.bash_mode._make_input_collector", return_value=lambda a, c: [[""]]):
+            gate = run_tool_gate(cli, "execute_sql", {"sql": "DELETE FROM t WHERE id=1"})
+        assert gate.approved is False
+        assert gate.error
+
+    def test_no_permission_config_fails_closed(self):
+        from datus.cli.bash_mode import run_tool_gate
+
+        cli = _sql_cli()
+        cli.agent_config.permissions_config = None
+        gate = run_tool_gate(cli, "list_tables", {})
+        assert gate.approved is False
+        assert gate.error
+
+    def test_hook_construction_failure_fails_closed(self):
+        from datus.cli.bash_mode import run_tool_gate
+
+        cli = _sql_cli()
+        with patch("datus.cli.bash_mode._build_permission_hooks", side_effect=RuntimeError("boom")):
+            gate = run_tool_gate(cli, "list_tables", {})
+        assert gate.approved is False
+        assert gate.error
+
+
+class TestRunManualToolLive:
+    """``run_manual_tool_live`` gates, executes, and packs a ``tool`` payload.
+
+    ``_run_with_live_frame`` (terminal rendering) is bypassed so the gate +
+    execute + payload logic is exercised headlessly.
+    """
+
+    @staticmethod
+    def _bypass_frame():
+        return patch("datus.cli.bash_mode._run_with_live_frame", side_effect=lambda cli, kind, cmd, work: work())
+
+    def test_success_builds_tool_payload_and_dispatches(self):
+        from datus.cli.bash_mode import ToolGateResult, run_manual_tool_live
+
+        cli = _make_cli()
+        invoke = MagicMock(return_value=(True, "3 tables"))
+        with (
+            patch("datus.cli.bash_mode.run_tool_gate", return_value=ToolGateResult(approved=True)),
+            self._bypass_frame(),
+        ):
+            payload, dispatch = run_manual_tool_live(cli, "list_tables", "list_tables", {}, invoke)
+        assert dispatch is True
+        assert payload["kind"] == "tool"
+        assert payload["success"] is True
+        assert payload["output"] == "3 tables"
+        invoke.assert_called_once()
+
+    def test_denied_not_dispatched_and_invoke_not_called(self):
+        from datus.cli.bash_mode import ToolGateResult, run_manual_tool_live
+
+        cli = _make_cli()
+        invoke = MagicMock()
+        with (
+            patch(
+                "datus.cli.bash_mode.run_tool_gate",
+                return_value=ToolGateResult(approved=False, error="PERMISSION_DENIED: nope"),
+            ),
+            self._bypass_frame(),
+        ):
+            payload, dispatch = run_manual_tool_live(cli, "execute_sql", "execute_sql", {"sql": "drop t"}, invoke)
+        assert dispatch is False
+        assert payload["success"] is False
+        invoke.assert_not_called()
+
+    def test_invoke_exception_dispatched_as_failure(self):
+        from datus.cli.bash_mode import ToolGateResult, run_manual_tool_live
+
+        cli = _make_cli()
+        invoke = MagicMock(side_effect=RuntimeError("kaboom"))
+        with (
+            patch("datus.cli.bash_mode.run_tool_gate", return_value=ToolGateResult(approved=True)),
+            self._bypass_frame(),
+        ):
+            payload, dispatch = run_manual_tool_live(cli, "list_tables", "list_tables", {}, invoke)
+        assert dispatch is True
+        assert payload["success"] is False
+        assert "kaboom" in (payload.get("error") or "")

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -4185,7 +4185,44 @@ class TestExecMessageBypass:
         monkeypatch.setattr(chat_cmd, "_should_create_new_node", lambda subagent_name=None: False)
         monkeypatch.setattr(chat_cmd, "_is_agent_switch", lambda subagent_name=None: False)
         chat_cmd.current_node = node
-        monkeypatch.setattr(chat_cmd, "create_node_input", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")))
+        monkeypatch.setattr(chat_cmd, "create_node_input", MagicMock(side_effect=RuntimeError("stop")))
 
         chat_cmd._execute_chat("what is @revenue", interactive=True)
         chat_cmd.cli.at_completer.parse_at_context.assert_called_once_with("what is @revenue")
+
+
+class TestEnsureNodeForBang:
+    """Lazy chat-node creation for the ``!<tool>`` handler."""
+
+    def test_creates_and_fully_mounts_node(self, real_agent_config, mock_llm_create):
+        cmds = _make_chat_commands(real_agent_config)
+        assert cmds.current_node is None
+        fake_node = MagicMock()
+        with patch.object(cmds, "_create_new_node", return_value=fake_node):
+            node = cmds.ensure_node_for_bang()
+        assert node is fake_node
+        assert cmds.current_node is fake_node
+        assert cmds.current_subagent_name is None
+        # Base tools + the lazily-injected skill/bash/memory/web tools are mounted
+        # so the ``!`` list is complete.
+        fake_node.setup_tools.assert_called_once()
+        fake_node._ensure_lazy_tools_mounted.assert_called_once()
+
+    def test_creates_real_regular_node(self, real_agent_config, mock_llm_create):
+        cmds = _make_chat_commands(real_agent_config)
+        node = cmds.ensure_node_for_bang()
+        # A regular (non-subagent) chat node is created and cached.
+        assert node.id == "chat_cli"
+        assert cmds.current_node is node
+
+    def test_reuses_existing_node(self, real_agent_config, mock_llm_create):
+        cmds = _make_chat_commands(real_agent_config)
+        first = cmds._create_new_node()
+        cmds.current_node = first
+        assert cmds.ensure_node_for_bang() is first
+
+    def test_returns_none_on_construction_failure(self, real_agent_config, mock_llm_create):
+        cmds = _make_chat_commands(real_agent_config)
+        with patch.object(cmds, "_create_new_node", side_effect=RuntimeError("boom")):
+            assert cmds.ensure_node_for_bang() is None
+        assert cmds.current_node is None

--- a/tests/unit_tests/cli/test_manual_exec.py
+++ b/tests/unit_tests/cli/test_manual_exec.py
@@ -28,6 +28,7 @@ from datus.cli.manual_exec import (
     build_sql_error_payload,
     build_sql_message_payload,
     build_sql_payload,
+    build_tool_payload,
     decode_exec_message,
     encode_exec_message,
     exec_preview,
@@ -81,6 +82,28 @@ class TestEncodeDecode:
         assert decoded["success"] is False
         assert decoded["error"] == "syntax error"
         assert decoded["meta"] == "failed"
+
+    def test_tool_round_trip(self):
+        payload = build_tool_payload("search_table foo", True, '[{"table": "t1"}]', None, 0.12)
+        decoded = decode_exec_message(encode_exec_message(payload))
+        assert decoded["kind"] == "tool"
+        assert decoded["command"] == "search_table foo"
+        assert decoded["success"] is True
+        assert decoded["output"] == '[{"table": "t1"}]'
+        assert decoded["meta"] == "ok in 0.12s"
+
+    def test_tool_failure_round_trip(self):
+        payload = build_tool_payload("execute_sql", False, "", "denied", 0.0)
+        decoded = decode_exec_message(encode_exec_message(payload))
+        assert decoded["kind"] == "tool"
+        assert decoded["success"] is False
+        assert decoded["error"] == "denied"
+        assert decoded["meta"] == "failed in 0.00s"
+
+    def test_tool_output_capped(self):
+        payload = build_tool_payload("dump", True, "x" * (MAX_OUTPUT_CHARS + 500), None, 0.01)
+        assert payload["output"].endswith("… [truncated]")
+        assert len(payload["output"]) < MAX_OUTPUT_CHARS + 100
 
     def test_unicode_command_survives(self):
         payload = build_sql_message_payload("SELECT '名前' AS 列", True, "success in 0.01s")
@@ -173,8 +196,25 @@ class TestExecPreview:
         message = encode_exec_message(build_bash_payload("ls -la", True, "", None, 0.01))
         assert exec_preview(message) == "bash> ls -la"
 
+    def test_tool_preview(self):
+        message = encode_exec_message(build_tool_payload("search_table foo", True, "out", None, 0.01))
+        assert exec_preview(message) == "! search_table foo"
+
     def test_plain_message_preview_passthrough(self):
         assert exec_preview("hello world") == "hello world"
+
+    def test_tool_render_shows_command_and_output(self):
+        payload = build_tool_payload("list_tables", True, "t1\nt2", None, 0.02)
+        rendered = _render_text(payload)
+        assert "! list_tables" in rendered
+        assert "t1" in rendered
+        assert "ok in 0.02s" in rendered
+
+    def test_tool_markdown_renders_output_fence(self):
+        message = encode_exec_message(build_tool_payload("list_tables", True, "t1", None, 0.02))
+        md = exec_to_markdown(message)
+        assert md.startswith("`!`")
+        assert "t1" in md
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -298,6 +298,7 @@ class TestCommandType:
         assert CommandType.SQL.value == "sql"
         assert CommandType.BASH.value == "bash"
         assert CommandType.SLASH.value == "slash"
+        assert CommandType.BANG.value == "bang"
         assert CommandType.CHAT.value == "chat"
         assert CommandType.EXIT.value == "exit"
         assert CommandType.UNKNOWN.value == "unknown"
@@ -329,23 +330,22 @@ class TestParseCommand:
         assert cmd_type == CommandType.SLASH
         assert cmd == "/exit"
 
-    def test_bang_prefix_runs_sql_one_shot(self, cli):
-        """``!<sql>`` in chat mode runs one-shot SQL (the non-TUI fallback's
-        only route to SQL execution): the ``!`` is stripped and the remainder
-        is returned as the SQL to execute."""
-        cmd_type, cmd, args = cli._parse_command("!SELECT * FROM t")
-        assert cmd_type == CommandType.SQL
+    def test_bang_prefix_dispatches_to_bang_command(self, cli):
+        """``!<tool>`` in chat mode routes to BANG dispatch: the ``!`` is stripped
+        and the remainder becomes the tool/plugin invocation text."""
+        cmd_type, cmd, args = cli._parse_command("!list_tables")
+        assert cmd_type == CommandType.BANG
         assert cmd == ""
-        assert args == "SELECT * FROM t"
+        assert args == "list_tables"
 
     def test_bang_prefix_only_strips_leading_bang(self, cli):
-        cmd_type, _, args = cli._parse_command("!  SHOW TABLES")
-        assert cmd_type == CommandType.SQL
-        assert args == "SHOW TABLES"
+        cmd_type, _, args = cli._parse_command("!  search_table foo")
+        assert cmd_type == CommandType.BANG
+        assert args == "search_table foo"
 
     def test_bang_prefix_ignored_in_bash_mode(self, cli):
         """In bash mode a leading ``!`` belongs to the command (history
-        expansion) and must not trigger the one-shot SQL path."""
+        expansion) and must not trigger the BANG dispatch path."""
         cli.input_mode = InputMode.BASH
         cmd_type, _, args = cli._parse_command("!ls")
         assert cmd_type == CommandType.BASH

--- a/tests/unit_tests/cli/test_tool_arg_parser.py
+++ b/tests/unit_tests/cli/test_tool_arg_parser.py
@@ -1,0 +1,197 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/cli/tool_arg_parser.py.
+
+The shared positional + ``--key=value`` parser backing both ``/<service>.<method>``
+and ``!<tool>``. Covers: type coercion (int/number/bool/array/object incl. Python
+literal + CSV fallbacks), ``anyOf``/``oneOf`` type flattening, positional/named
+binding, and the error paths (extra positional, unknown flag, unmatched quotes).
+"""
+
+import io
+
+import pytest
+from rich.console import Console
+
+from datus.cli import tool_arg_parser as tap
+
+
+class TestIsHelpRequest:
+    @pytest.mark.parametrize("args", ["--help", "-h", "foo --help", "42 -h"])
+    def test_help_tokens_detected(self, args):
+        assert tap.is_help_request(args) is True
+
+    @pytest.mark.parametrize("args", ["", "foo", "--helpme", "--limit=1"])
+    def test_non_help_returns_false(self, args):
+        assert tap.is_help_request(args) is False
+
+    def test_unmatched_quotes_is_not_help(self):
+        assert tap.is_help_request("'unclosed --help") is False
+
+
+class TestParseArgs:
+    def test_positional_bind_in_schema_order(self):
+        schema = {"properties": {"a": {"type": "string"}, "b": {"type": "integer"}}}
+        parsed, err = tap.parse_args("foo 42", schema)
+        assert err is None
+        assert parsed == {"a": "foo", "b": 42}
+
+    def test_named_override(self):
+        schema = {"properties": {"a": {"type": "string"}, "b": {"type": "integer"}}}
+        parsed, err = tap.parse_args("--b=99 --a=hi", schema)
+        assert err is None
+        assert parsed == {"a": "hi", "b": 99}
+
+    def test_positional_then_named(self):
+        schema = {"properties": {"a": {"type": "string"}, "b": {"type": "integer"}}}
+        parsed, err = tap.parse_args("first --b=7", schema)
+        assert err is None
+        assert parsed == {"a": "first", "b": 7}
+
+    def test_bare_flag_is_true(self):
+        schema = {"properties": {"flag": {"type": "boolean"}}}
+        assert tap.parse_args("--flag", schema)[0] == {"flag": True}
+        assert tap.parse_args("--flag=true", schema)[0] == {"flag": True}
+        assert tap.parse_args("--flag=no", schema)[0] == {"flag": False}
+
+    def test_unknown_flag_reports_valid_names(self):
+        schema = {"properties": {"a": {"type": "string"}, "limit": {"type": "integer"}}}
+        parsed, err = tap.parse_args("--bogus=x --a=ok", schema)
+        assert parsed is None
+        assert err == "Unknown parameter '--bogus'. Valid parameters: a, limit."
+
+    def test_too_many_positional(self):
+        schema = {"properties": {"a": {"type": "string"}}}
+        parsed, err = tap.parse_args("first second", schema)
+        assert parsed is None
+        assert err == "Too many positional arguments. Method accepts 1 (got extra: 'second')."
+
+    def test_unmatched_quotes(self):
+        parsed, err = tap.parse_args("'unclosed", {"properties": {}})
+        assert parsed is None
+        assert err == "Malformed arguments: unmatched quotes."
+
+    def test_empty_flag(self):
+        parsed, err = tap.parse_args("--", {"properties": {"a": {"type": "string"}}})
+        assert parsed is None
+        assert "Empty flag" in err
+
+    def test_empty_args_returns_empty_dict(self):
+        parsed, err = tap.parse_args("", {"properties": {"a": {"type": "string"}}})
+        assert err is None
+        assert parsed == {}
+
+    def test_self_property_is_skipped_for_positionals(self):
+        schema = {"properties": {"self": {"type": "string"}, "a": {"type": "string"}}}
+        parsed, err = tap.parse_args("val", schema)
+        assert err is None
+        assert parsed == {"a": "val"}
+
+
+class TestCoerce:
+    def test_integer(self):
+        assert tap.coerce("42", {"type": "integer"}) == 42
+        assert tap.coerce("nope", {"type": "integer"}) == "nope"
+
+    def test_number(self):
+        assert tap.coerce("3.5", {"type": "number"}) == 3.5
+
+    @pytest.mark.parametrize("raw,expected", [("1", True), ("true", True), ("yes", True), ("0", False), ("no", False)])
+    def test_boolean(self, raw, expected):
+        assert tap.coerce(raw, {"type": "boolean"}) is expected
+
+    def test_array_json(self):
+        assert tap.coerce('["a","b"]', {"type": "array"}) == ["a", "b"]
+
+    def test_array_python_literal(self):
+        assert tap.coerce("['a','b']", {"type": "array"}) == ["a", "b"]
+
+    def test_array_csv_fallback(self):
+        assert tap.coerce("a,b,c", {"type": "array"}) == ["a", "b", "c"]
+
+    def test_object_json(self):
+        assert tap.coerce('{"k": 1}', {"type": "object"}) == {"k": 1}
+
+    def test_object_python_literal(self):
+        assert tap.coerce("{'k': 1}", {"type": "object"}) == {"k": 1}
+
+    def test_object_unparseable_returns_raw(self):
+        assert tap.coerce("not-a-dict", {"type": "object"}) == "not-a-dict"
+
+    def test_optional_array_via_anyof_coerces_list(self):
+        """``Optional[List[str]]`` (``anyOf`` with null) must still coerce a CSV."""
+        schema = {"properties": {"items": {"anyOf": [{"type": "array"}, {"type": "null"}]}}}
+        parsed, err = tap.parse_args("--items=a,b,c", schema)
+        assert err is None
+        assert parsed == {"items": ["a", "b", "c"]}
+
+
+class TestPrimaryType:
+    def test_scalar(self):
+        assert tap.primary_type({"type": "integer"}) == "integer"
+
+    def test_type_list_skips_null(self):
+        assert tap.primary_type({"type": ["string", "null"]}) == "string"
+
+    def test_anyof_skips_null(self):
+        assert tap.primary_type({"anyOf": [{"type": "null"}, {"type": "array"}]}) == "array"
+
+    def test_oneof(self):
+        assert tap.primary_type({"oneOf": [{"type": "integer"}]}) == "integer"
+
+    def test_empty_and_none(self):
+        assert tap.primary_type({}) == ""
+        assert tap.primary_type(None) == ""
+
+
+class TestMissingRequired:
+    def test_reports_all_missing(self):
+        def target(a, b, c):
+            return None
+
+        assert sorted(tap.missing_required(target, {"a": 1})) == ["b", "c"]
+
+    def test_skips_optional_with_none_default(self):
+        def target(a, metrics=None):
+            return None
+
+        assert tap.missing_required(target, {"metrics": ["x"]}) == ["a"]
+
+    def test_none_method_returns_empty(self):
+        assert tap.missing_required(None, {}) == []
+
+    def test_skips_self_and_varargs(self):
+        def target(self, *args, **kwargs):
+            return None
+
+        assert tap.missing_required(target, {}) == []
+
+
+class TestPrintSchema:
+    def test_renders_name_type_required_description(self):
+        console = Console(file=io.StringIO(), no_color=True, width=200)
+        tool = type(
+            "T",
+            (),
+            {
+                "name": "search_table",
+                "params_json_schema": {
+                    "properties": {
+                        "self": {"type": "string"},
+                        "query_text": {"type": "string", "description": "the query"},
+                        "top_n": {"type": "integer"},
+                    },
+                    "required": ["query_text"],
+                },
+            },
+        )()
+        tap.print_schema(console, tool, hint="bad flag")
+        out = console.file.getvalue()
+        assert "search_table" in out
+        assert "query_text" in out
+        assert "the query" in out
+        assert "top_n" in out
+        # ``self`` is filtered out of the rendered rows.
+        assert "bad flag" in out

--- a/tests/unit_tests/plugins/test_manifest.py
+++ b/tests/unit_tests/plugins/test_manifest.py
@@ -7,8 +7,11 @@
 from pathlib import Path
 
 from datus.plugins.base import (
+    _MAX_COMMAND_DEPTH,
     MANIFEST_FILENAME,
     MANIFEST_VERSION,
+    PluginCommand,
+    PluginCommandArg,
     PluginManifest,
     parse_code_ref,
     parse_manifest,
@@ -187,6 +190,172 @@ def test_parse_manifest_invalid_config_schema_dropped(caplog):
 def test_parse_manifest_non_dict_config_schema_dropped():
     manifest = parse_manifest({"manifest_version": 1, "config_schema": ["a"]}, "hello", PKG)
     assert manifest.config_schema is None
+
+
+# ---------------------------------------------------------------------------
+# parse_manifest — commands (descriptive CLI catalogue)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_manifest_commands_full():
+    data = {
+        "manifest_version": 1,
+        "commands": [
+            {
+                "name": "sync",
+                "description": "Sync tables",
+                "args": [
+                    {"name": "table", "required": True, "description": "table name"},
+                    {"name": "--limit", "description": "max rows"},
+                ],
+            },
+            {"name": "status"},
+        ],
+    }
+    manifest = parse_manifest(data, "hello", PKG)
+    assert manifest.commands == [
+        PluginCommand(
+            name="sync",
+            description="Sync tables",
+            args=[
+                PluginCommandArg(name="table", required=True, description="table name"),
+                PluginCommandArg(name="--limit", required=False, description="max rows"),
+            ],
+        ),
+        PluginCommand(name="status", description=None, args=[]),
+    ]
+
+
+def test_parse_manifest_commands_default_empty():
+    manifest = parse_manifest({"manifest_version": 1}, "hello", PKG)
+    assert manifest.commands == []
+
+
+def test_parse_manifest_commands_non_list_dropped(caplog):
+    with caplog.at_level("WARNING"):
+        manifest = parse_manifest({"manifest_version": 1, "commands": "sync"}, "hello", PKG)
+    assert manifest.commands == []
+
+
+def test_parse_manifest_commands_bad_entries_salvaged(caplog):
+    """A command without a valid name, and a malformed arg, are dropped
+    individually while the rest survives."""
+    data = {
+        "manifest_version": 1,
+        "commands": [
+            "not-a-dict",
+            {"description": "no name here"},
+            {
+                "name": "sync",
+                "args": [
+                    "not-a-dict",
+                    {"required": True},  # arg without name
+                    {"name": "table", "required": True},
+                ],
+            },
+        ],
+    }
+    with caplog.at_level("WARNING"):
+        manifest = parse_manifest(data, "hello", PKG)
+    assert manifest.commands == [
+        PluginCommand(name="sync", description=None, args=[PluginCommandArg(name="table", required=True)])
+    ]
+
+
+def test_parse_manifest_commands_non_list_args_dropped(caplog):
+    with caplog.at_level("WARNING"):
+        manifest = parse_manifest(
+            {"manifest_version": 1, "commands": [{"name": "sync", "args": "table"}]}, "hello", PKG
+        )
+    assert manifest.commands == [PluginCommand(name="sync")]
+
+
+def test_parse_manifest_commands_nested_subcommands():
+    """A command group nests subcommands (each with its own args) recursively."""
+    data = {
+        "manifest_version": 1,
+        "commands": [
+            {
+                "name": "dags",
+                "description": "DAG operations",
+                "subcommands": [
+                    {
+                        "name": "trigger",
+                        "args": [
+                            {"name": "dag_id", "required": True},
+                            {"name": "--conf", "description": "run config"},
+                        ],
+                    },
+                    {"name": "list"},
+                ],
+            }
+        ],
+    }
+    manifest = parse_manifest(data, "airflow", PKG)
+    assert manifest.commands == [
+        PluginCommand(
+            name="dags",
+            description="DAG operations",
+            args=[],
+            subcommands=[
+                PluginCommand(
+                    name="trigger",
+                    args=[
+                        PluginCommandArg(name="dag_id", required=True),
+                        PluginCommandArg(name="--conf", description="run config"),
+                    ],
+                ),
+                PluginCommand(name="list"),
+            ],
+        )
+    ]
+
+
+def test_parse_manifest_subcommands_bad_entries_salvaged(caplog):
+    """Malformed subcommand entries are dropped individually, siblings survive."""
+    data = {
+        "manifest_version": 1,
+        "commands": [
+            {
+                "name": "dags",
+                "subcommands": [
+                    "not-a-dict",
+                    {"description": "no name"},
+                    {"name": "list"},
+                ],
+            }
+        ],
+    }
+    with caplog.at_level("WARNING"):
+        manifest = parse_manifest(data, "airflow", PKG)
+    assert manifest.commands == [PluginCommand(name="dags", subcommands=[PluginCommand(name="list")])]
+
+
+def test_parse_manifest_subcommands_non_list_dropped(caplog):
+    with caplog.at_level("WARNING"):
+        manifest = parse_manifest(
+            {"manifest_version": 1, "commands": [{"name": "dags", "subcommands": "list"}]}, "airflow", PKG
+        )
+    assert manifest.commands == [PluginCommand(name="dags", subcommands=[])]
+
+
+def test_parse_manifest_subcommands_depth_capped(caplog):
+    """Nesting deeper than the recursion cap is dropped rather than parsed forever."""
+    # Build commands nested one level beyond the cap.
+    entry: dict = {"name": "leaf"}
+    for level in range(_MAX_COMMAND_DEPTH + 1):
+        entry = {"name": f"g{level}", "subcommands": [entry]}
+    with caplog.at_level("WARNING"):
+        manifest = parse_manifest({"manifest_version": 1, "commands": [entry]}, "deep", PKG)
+
+    # Walk down; the chain is truncated at the cap (deepest kept level has no subcommands).
+    node = manifest.commands[0]
+    depth = 1
+    while node.subcommands:
+        node = node.subcommands[0]
+        depth += 1
+    assert depth == _MAX_COMMAND_DEPTH
+    assert any("deeper than" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/plugins/test_registry.py
+++ b/tests/unit_tests/plugins/test_registry.py
@@ -92,6 +92,43 @@ def test_iter_plugin_entry_points(plugin_env):
     assert {ep.name for ep in registry.iter_plugin_entry_points()} == {"hello", "dagster"}
 
 
+COMMANDS_YAML = (
+    "manifest_version: 1\n"
+    "commands:\n"
+    "  - name: sync\n"
+    "    description: Sync tables\n"
+    "    args:\n"
+    "      - {name: table, required: true}\n"
+    "      - {name: --limit}\n"
+)
+
+
+def test_iter_plugin_manifests_lists_valid(plugin_env):
+    plugin_env("hello", MINIMAL + "description: Hi.\n")
+    plugin_env("dagster", MINIMAL)
+    assert {name for name, _ in registry.iter_plugin_manifests()} == {"hello", "dagster"}
+
+
+def test_iter_plugin_manifests_skips_missing_manifest(plugin_env):
+    plugin_env("hello", MINIMAL)
+    plugin_env("broken", manifest_yaml=None)  # importable, but no datus-plugin.yml
+    assert {name for name, _ in registry.iter_plugin_manifests()} == {"hello"}
+
+
+def test_plugin_commands_parsed(plugin_env):
+    plugin_env("hello", COMMANDS_YAML)
+    cmds = registry.plugin_commands("hello")
+    assert [c.name for c in cmds] == ["sync"]
+    assert cmds[0].args[0].name == "table"
+    assert cmds[0].args[0].required is True
+    assert cmds[0].args[1].name == "--limit"
+
+
+def test_plugin_commands_unknown_returns_empty(plugin_env):
+    plugin_env("hello", MINIMAL)
+    assert registry.plugin_commands("mystery") == []
+
+
 def test_lookup_never_raises_on_entry_points_failure(monkeypatch):
     def boom():
         raise RuntimeError("entry_points exploded")


### PR DESCRIPTION
## Why

The chat REPL had no way to run a tool or a plugin's CLI directly — everything went through the model. The `!` prefix was a thin one-shot `!<sql>` shortcut. Power users want an escape hatch to invoke a specific tool or plugin command by hand, with autocomplete, while staying inside the agent's permission model and conversation.

## Solution

Redefine the chat-mode `!` prefix (SQL/bash modes are unaffected — a leading `!` there is part of the statement):

- `!<tool> [args...]` runs one of the agent's own function tools directly; `!<plugin> <args...>` runs an installed + active plugin's CLI as a `datus <plugin> ...` subprocess. **Tools are matched first.** This **replaces** the old `!<sql>` shortcut (use `Tab` to switch to SQL mode).
- Both paths go through the **same permission pipeline** an LLM-driven call gets (read-only auto-runs, writes/`execute_sql`/`bash` confirm), render as a styled **execution turn**, and **feed the result back to the model** — the run enters the conversation and triggers a reply.
- New `datus/cli/bang_command.py` (dispatch + tool/plugin enumeration + arg hint) and `datus/cli/tool_arg_parser.py` (shared positional/`--key=value` parser, also adopted by `ServiceCommands` to remove duplication).
- `bash_mode.run_tool_gate` / `run_manual_tool_live` gate + execute a tool in a live frame; `manual_exec` grows a `tool` execution-turn kind.
- **Autocomplete + hints**: `BangCompleter` lists tools (then plugins), tool `--flags`, and plugin subcommands; a dim `<required> [--optional]` hint follows the input line (`tui/app.py` `AfterInput`).
- **Plugin `commands:` catalogue** (descriptive metadata only — datus never parses plugin args): powers completion / hints / `datus plugin info`. Command groups **nest via `subcommands:`**, so completion and the hint drill down one level at a time (`!airflow dags trigger `). `PluginCommand` gains a recursive `subcommands` field with a defensive depth cap.
- `!` tools are scoped to the current node; orchestration tools (`ask_user`, `task`, `confirm_plan`, `todo_*`) are excluded.

Docs `docs/cli/execution_command.md(.zh.md)` rewritten for the new semantics.

## Test Cases

All unit-level (CI tier), fully mocked:

- `tests/unit_tests/cli/test_bang_command.py` — tool-before-plugin dispatch, unknown-token error, `--help`, permission-denied not dispatched, exec-turn feeding, flat + **nested** argument-name hints.
- `tests/unit_tests/cli/test_tool_arg_parser.py` — positional / `--key=value` / type coercion / `Optional[List]` `anyOf` / missing-required / unknown-flag.
- `tests/unit_tests/cli/test_autocomplete.py` — `BangCompleter` name/flag tiers and **nested** plugin subcommand drill-down.
- `tests/unit_tests/cli/test_bash_mode.py` — `run_tool_gate`, tool shim contract, `run_manual_tool_live` (approve / deny / exception).
- `tests/unit_tests/cli/test_manual_exec.py` — `tool` execution-turn payload build / render / round-trip.
- `tests/unit_tests/plugins/test_manifest.py` — `commands` parse incl. **nested subcommands**, malformed-entry salvage, recursion depth cap.
- `tests/unit_tests/cli/test_repl.py`, `test_chat_commands.py`, `tests/unit_tests/plugins/test_registry.py` — `BANG` classification, `ensure_node_for_bang`, `plugin_commands`.

Impacted unit suites pass locally; `ruff format --check` / `ruff check` clean; `ci/audit_tests.py --diff-only` reports P0=0, P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat-mode `!` commands for directly running available tools and installed plugins.
  * Added autocomplete for tools, plugins, subcommands, and supported flags.
  * Added inline hints for required and optional command arguments.
  * Added `--help` support and clearer parameter schema displays.
  * Added plugin manifest support for nested command and argument metadata.
  * Applied permission checks and execution feedback to manual tool calls.

* **Documentation**
  * Updated command documentation in English and Chinese with usage, permissions, autocomplete, and plugin guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->