### PR TITLE
[BugFix] Fix nightly CI dependency installation and stale tool registry tests

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --locked
+          uv sync --locked --group ci
           # No --upgrade: keep the locked framework packages; adapters only add
           # their own missing deps instead of bumping fastapi/starlette/etc.
           uv pip install --no-cache-dir \

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -161,7 +161,8 @@ class TestGenMetricsAgenticNodeInit:
         registry = node.tool_registry.to_dict()
         assert registry.get("end_metric_generation") == "semantic_tools"
         assert registry.get("check_semantic_object_exists") == "semantic_tools"
-        assert registry.get("read_query") == "db_tools"
+        assert registry.get("execute_sql") == "db_tools"
+        assert "read_query" not in registry
         assert registry.get("write_file") == "filesystem_tools"
 
 

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -115,7 +115,8 @@ class TestGenVisualDashboardInit:
         registry = node.tool_registry.to_dict()
         for name in ("read_file", "write_file", "edit_file", "delete_file"):
             assert registry.get(name) == "filesystem_tools"
-        assert registry.get("read_query") == "db_tools"
+        assert registry.get("execute_sql") == "db_tools"
+        assert "read_query" not in registry
         assert "semantic_tools" in registry.values()
 
     def test_metric_discovery_tools_exposed_when_metrics_present(self, real_agent_config, mock_llm_create, monkeypatch):

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -133,7 +133,8 @@ class TestGenVisualReportInit:
         for name in ("read_file", "write_file", "edit_file", "delete_file"):
             assert registry.get(name) == "filesystem_tools"
         # db_tools and semantic_tools also surface under their own categories.
-        assert registry.get("read_query") == "db_tools"
+        assert registry.get("execute_sql") == "db_tools"
+        assert "read_query" not in registry
         assert "semantic_tools" in registry.values()
 
     def test_metric_discovery_tools_exposed_when_metrics_present(self, real_agent_config, mock_llm_create, monkeypatch):

--- a/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_skill_creator_agentic_node.py
@@ -190,7 +190,8 @@ class TestSkillCreatorAgenticNodeTools:
         node._populate_tool_registry()
         registry = node.tool_registry.to_dict()
         assert registry.get("write_file") == "filesystem_tools"
-        assert registry.get("read_query") == "db_tools"
+        assert registry.get("execute_sql") == "db_tools"
+        assert "read_query" not in registry
         assert registry.get("load_skill") == "skills"
 
     def test_has_ask_user_tool(self, real_agent_config, mock_llm_create):


### PR DESCRIPTION
## Summary

- install the locked CI dependency group in the nightly workflow so OSI authoring tests can import `datus-semantic-osi`
- update four node registry tests to assert the unified `execute_sql` tool contract
- verify internal `read_query` dispatch remains absent from the agent-facing registry

## Root cause

Nightly used `uv sync --locked` while the OSI package is declared in the `ci` dependency group. Separately, four tests still expected `read_query` to be registered after PR #1182 intentionally removed internal SQL dispatch helpers from the agent-facing tool surface.

## Impact

The full unit-test stage no longer fails on a missing OSI package or assertions that contradict the current database tool contract.

## Validation

- `uv lock --check`
- `uv sync --locked --group ci`
- 160 targeted tests passed, including `TestExplorerServiceOSIAuthoring` and the four affected node test files
- Ruff checks passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated nightly dependency installation to use the dedicated CI dependency group while preserving locked versions.

- **Tests**
  - Updated agent tool-registry coverage to reflect the current database tool availability and categorization.
  - Verified that supported SQL execution tools remain exposed consistently across reporting, dashboard, metrics, and skill-creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->