### PR TITLE
[BugFix] Resolve metric models from structured source SQL

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -23,6 +23,7 @@ from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.generation_tools import GenerationTools
 from datus.tools.func_tool.metric_queryability import (
     extract_metric_queryability_contracts,
+    extract_metric_queryability_contracts_from_sources,
     summarize_queryability_contracts,
 )
 from datus.utils.exceptions import DatusException, ErrorCode
@@ -190,6 +191,8 @@ class GenMetricsAgenticNode(AgenticNode):
             return
         if resolution["status"] == "ambiguous":
             self._raise_osi_semantic_model_selection_error(resolution)
+        if resolution["status"] == "invalid":
+            self._raise_osi_source_query_error(resolution)
         if self._is_subagent:
             raise DatusException(
                 ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
@@ -231,6 +234,8 @@ class GenMetricsAgenticNode(AgenticNode):
         if selected is None:
             if post_resolution["status"] == "ambiguous":
                 self._raise_osi_semantic_model_selection_error(post_resolution)
+            if post_resolution["status"] == "invalid":
+                self._raise_osi_source_query_error(post_resolution)
             raise DatusException(
                 ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
                 message_args={
@@ -260,6 +265,16 @@ class GenMetricsAgenticNode(AgenticNode):
                     "Specify semantic_model_name or reference a dataset from the intended model."
                 )
             },
+        )
+
+    @staticmethod
+    def _raise_osi_source_query_error(resolution: Dict[str, Any]) -> None:
+        errors = "; ".join(
+            f"{item.get('source_sql_name')}: {item.get('error')}" for item in resolution.get("parse_errors") or []
+        )
+        raise DatusException(
+            ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
+            message_args={"error_message": f"invalid structured source SQL: {errors or resolution.get('reason')}"},
         )
 
     def _ensure_bash_tool_in_tools(self) -> None:
@@ -635,7 +650,12 @@ class GenMetricsAgenticNode(AgenticNode):
         if not user_input:
             return
         user_message = getattr(user_input, "user_message", "") or ""
-        contracts = extract_metric_queryability_contracts(user_message)
+        source_queries = getattr(user_input, "source_queries", None) or []
+        contracts = (
+            extract_metric_queryability_contracts_from_sources(source_queries)
+            if source_queries
+            else extract_metric_queryability_contracts(user_message)
+        )
         candidate_plan = self._extract_precomputed_candidate_plan(user_message)
         metric_aliases = self._metric_aliases_from_candidate_plan(candidate_plan)
         blocked_sources = self._blocked_queryability_sources_from_candidate_plan(candidate_plan)

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -24,6 +24,7 @@ into the prompt at render time (see ``required_authoring_skills``).
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 import weakref
 from contextlib import asynccontextmanager
@@ -265,6 +266,37 @@ def _model_covers_table(model: Dict[str, Any], table: Any) -> bool:
     return any(_table_references_match(table, reference) for reference in references)
 
 
+def _is_query_backed_dataset(dataset: Dict[str, Any]) -> bool:
+    extensions = dataset.get("custom_extensions") or []
+    if isinstance(extensions, dict):
+        extensions = [extensions]
+    for extension in extensions:
+        if not isinstance(extension, dict):
+            continue
+        vendor_name = str(extension.get("vendor_name") or "").strip()
+        if vendor_name and vendor_name.upper() != "DATUS":
+            continue
+        data = extension.get("data")
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+        if isinstance(data, dict) and str(data.get("source_type") or "").strip().lower() == "query":
+            return True
+    return False
+
+
+def _dataset_table_references(agent_config: Any, dataset: Dict[str, Any], dataset_source: str) -> list[str]:
+    if not dataset_source or not _is_query_backed_dataset(dataset):
+        return [dataset_source] if dataset_source else []
+    references, _source_names, parse_errors = _source_query_table_references(
+        agent_config,
+        [{"source_sql_name": str(dataset.get("name") or "query_backed_dataset"), "sql": dataset_source}],
+    )
+    return references if not parse_errors else [dataset_source]
+
+
 def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any]]:
     """Discover Ossie semantic models already authored for the active datasource.
 
@@ -308,9 +340,13 @@ def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any
                 if dataset_source:
                     dataset_sources.append(dataset_source)
                     table_lookup_names.update(_table_lookup_names(dataset_source))
-                table_reference = dataset_source or dataset_name
-                if table_reference and table_reference not in table_references:
-                    table_references.append(table_reference)
+                dataset_references = _dataset_table_references(agent_config, dataset, dataset_source)
+                if not dataset_references and dataset_name:
+                    dataset_references = [dataset_name]
+                for table_reference in dataset_references:
+                    table_lookup_names.update(_table_lookup_names(table_reference))
+                    if table_reference not in table_references:
+                        table_references.append(table_reference)
             discovered.append(
                 {
                     "semantic_model_name": model_name,
@@ -344,6 +380,70 @@ def _dedupe_table_references(values: Iterable[Any]) -> list[str]:
             seen.add(key)
             references.append(text)
     return references
+
+
+def _source_query_value(source_query: Any, field_name: str) -> Any:
+    if isinstance(source_query, dict):
+        return source_query.get(field_name)
+    return getattr(source_query, field_name, None)
+
+
+def _source_query_dialect(agent_config: Any) -> str:
+    try:
+        db_config = agent_config.current_db_config()
+    except Exception:
+        db_config = None
+    candidates = (
+        getattr(db_config, "type", ""),
+        getattr(db_config, "db_type", ""),
+        getattr(db_config, "dialect", ""),
+        getattr(agent_config, "db_type", ""),
+    )
+    for candidate in candidates:
+        value = getattr(candidate, "value", candidate)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "snowflake"
+
+
+def _source_query_parse_dialects(primary_dialect: str) -> list[Optional[str]]:
+    candidates: list[Optional[str]] = [primary_dialect]
+    if primary_dialect.strip().lower() == "starrocks":
+        candidates.append("mysql")
+    candidates.append(None)
+    return list(dict.fromkeys(candidates))
+
+
+def _source_query_table_references(
+    agent_config: Any,
+    source_queries: Iterable[Any],
+) -> tuple[list[str], list[str], list[dict[str, str]]]:
+    """Parse authoritative source SQL without consulting its rendered prompt."""
+    from datus.utils.sql_utils import extract_table_names_strict
+
+    references: list[str] = []
+    source_names: list[str] = []
+    parse_errors: list[dict[str, str]] = []
+    dialects = _source_query_parse_dialects(_source_query_dialect(agent_config))
+
+    for index, source_query in enumerate(source_queries, 1):
+        source_name = str(_source_query_value(source_query, "source_sql_name") or f"sql_{index}").strip()
+        sql = str(_source_query_value(source_query, "sql") or "").strip()
+        source_names.append(source_name)
+        if not sql:
+            parse_errors.append({"source_sql_name": source_name, "error": "source SQL is empty"})
+            continue
+        first_error: Optional[Exception] = None
+        for dialect in dialects:
+            try:
+                references.extend(extract_table_names_strict(sql, dialect=dialect, ignore_empty=True))
+                break
+            except Exception as exc:
+                first_error = first_error or exc
+        else:
+            parse_errors.append({"source_sql_name": source_name, "error": str(first_error)})
+
+    return _dedupe_table_references(references), source_names, parse_errors
 
 
 def _metric_request_table_references(
@@ -415,6 +515,9 @@ def _existing_model_resolution(
     reason: str,
     requested_name: str = "",
     referenced_tables: Optional[Iterable[str]] = None,
+    evidence_source: str = "",
+    source_sql_names: Optional[Iterable[str]] = None,
+    parse_errors: Optional[Iterable[Dict[str, str]]] = None,
 ) -> Dict[str, Any]:
     result: Dict[str, Any] = {
         "status": status,
@@ -427,6 +530,12 @@ def _existing_model_resolution(
         result["requested_name"] = requested_name
     if referenced_tables:
         result["referenced_tables"] = list(referenced_tables)
+    if evidence_source:
+        result["evidence_source"] = evidence_source
+    if source_sql_names:
+        result["source_sql_names"] = list(source_sql_names)
+    if parse_errors:
+        result["parse_errors"] = list(parse_errors)
     return result
 
 
@@ -443,6 +552,22 @@ def resolve_existing_osi_semantic_model(
     then a unique model covering every referenced dataset. A single model is a
     safe datasource default; otherwise ambiguity is returned to the caller.
     """
+    source_queries = getattr(user_input, "source_queries", None) or []
+    source_tables: list[str] = []
+    source_sql_names: list[str] = []
+    evidence_source = ""
+    if source_queries:
+        source_tables, source_sql_names, parse_errors = _source_query_table_references(agent_config, source_queries)
+        if parse_errors:
+            return _existing_model_resolution(
+                "invalid",
+                reason="one or more structured source queries could not be parsed",
+                evidence_source="source_queries",
+                source_sql_names=source_sql_names,
+                parse_errors=parse_errors,
+            )
+        evidence_source = "source_queries"
+
     models = discover_osi_semantic_models(agent_config)
     requested_name = _requested_semantic_model_name(user_input, request_text)
     if requested_name:
@@ -456,6 +581,9 @@ def resolve_existing_osi_semantic_model(
                 candidates=target.get("candidates"),
                 requested_name=requested_name,
                 reason=target.get("reason") or "the explicit model name is ambiguous",
+                referenced_tables=source_tables,
+                evidence_source=evidence_source,
+                source_sql_names=source_sql_names,
             )
         if target.get("exists"):
             return _existing_model_resolution(
@@ -464,19 +592,30 @@ def resolve_existing_osi_semantic_model(
                 candidates=[target],
                 requested_name=requested_name,
                 reason="explicit semantic model name",
+                referenced_tables=source_tables,
+                evidence_source=evidence_source,
+                source_sql_names=source_sql_names,
             )
         return _existing_model_resolution(
             "missing",
             requested_name=requested_name,
             reason="the explicitly requested semantic model does not exist",
+            referenced_tables=source_tables,
+            evidence_source=evidence_source,
+            source_sql_names=source_sql_names,
         )
 
-    tables = _dedupe_table_references(
-        [
-            *_metric_request_table_references(user_input, request_text, models),
-            *(referenced_tables or []),
-        ]
-    )
+    if source_queries:
+        tables = _dedupe_table_references([*source_tables, *(referenced_tables or [])])
+    else:
+        tables = _dedupe_table_references(
+            [
+                *_metric_request_table_references(user_input, request_text, models),
+                *(referenced_tables or []),
+            ]
+        )
+        evidence_source = "legacy_request"
+
     if tables:
         matches = [model for model in models if all(_model_covers_table(model, table) for table in tables)]
         if len(matches) == 1:
@@ -486,6 +625,8 @@ def resolve_existing_osi_semantic_model(
                 candidates=matches,
                 referenced_tables=tables,
                 reason="referenced datasets uniquely identify the semantic model",
+                evidence_source=evidence_source,
+                source_sql_names=source_sql_names,
             )
         if len(matches) > 1:
             return _existing_model_resolution(
@@ -493,6 +634,8 @@ def resolve_existing_osi_semantic_model(
                 candidates=matches,
                 referenced_tables=tables,
                 reason="referenced datasets occur in multiple semantic models",
+                evidence_source=evidence_source,
+                source_sql_names=source_sql_names,
             )
         partial_matches = [model for model in models if any(_model_covers_table(model, table) for table in tables)]
         if len(partial_matches) > 1:
@@ -501,12 +644,16 @@ def resolve_existing_osi_semantic_model(
                 candidates=partial_matches,
                 referenced_tables=tables,
                 reason="referenced datasets are split across multiple semantic models",
+                evidence_source=evidence_source,
+                source_sql_names=source_sql_names,
             )
         return _existing_model_resolution(
             "missing",
             candidates=partial_matches,
             referenced_tables=tables,
             reason="no semantic model contains all referenced datasets",
+            evidence_source=evidence_source,
+            source_sql_names=source_sql_names,
         )
 
     if len(models) == 1:
@@ -515,14 +662,23 @@ def resolve_existing_osi_semantic_model(
             selected=models[0],
             candidates=models,
             reason="only one semantic model exists for the datasource",
+            evidence_source=evidence_source,
+            source_sql_names=source_sql_names,
         )
     if len(models) > 1:
         return _existing_model_resolution(
             "ambiguous",
             candidates=models,
             reason="multiple semantic models exist and the request does not identify a dataset",
+            evidence_source=evidence_source,
+            source_sql_names=source_sql_names,
         )
-    return _existing_model_resolution("missing", reason="no semantic model exists for the datasource")
+    return _existing_model_resolution(
+        "missing",
+        reason="no semantic model exists for the datasource",
+        evidence_source=evidence_source,
+        source_sql_names=source_sql_names,
+    )
 
 
 def _new_osi_semantic_model_name(business_domain: str, fact_tables: Iterable[str]) -> tuple[str, str]:

--- a/datus/schemas/semantic_agentic_node_models.py
+++ b/datus/schemas/semantic_agentic_node_models.py
@@ -9,12 +9,25 @@ This module defines the input and output models for the SemanticAgenticNode,
 providing structured validation for semantic model generation interactions.
 """
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from datus.schemas.at_context import AtContextInput
 from datus.schemas.base import BaseResult
+
+
+class SourceQueryEvidence(BaseModel):
+    """Structured success-story SQL carried independently from the LLM prompt."""
+
+    source_sql_name: str = Field(..., description="Stable source-query name, for example sql_1")
+    sql: str = Field(..., description="Original SQL from the success-story row")
+    question: str = Field(default="", description="Business question associated with the SQL")
+    external_knowledge: str = Field(default="", description="Optional row-scoped business evidence")
+    source_id: str = Field(default="", description="Optional provenance source identifier")
+    source_type: str = Field(default="success_story", description="Optional provenance source type")
+    source_context_ids: List[str] = Field(default_factory=list, description="Optional provenance context IDs")
+    source_metadata: Dict[str, Any] = Field(default_factory=dict, description="Optional provenance metadata")
 
 
 class SemanticNodeInput(AtContextInput):
@@ -41,6 +54,13 @@ class SemanticNodeInput(AtContextInput):
     dimension_tables: Optional[list[str]] = Field(
         default=None,
         description="Dimension tables used by the model; recorded for context but excluded from model naming",
+    )
+    source_queries: List[SourceQueryEvidence] = Field(
+        default_factory=list,
+        description=(
+            "Original success-story SQL queries used as authoritative programmatic evidence. "
+            "Unlike reference_sql, these queries are not @Sql context."
+        ),
     )
     max_turns: Optional[int] = Field(default=None, description="Maximum conversation turns; None uses node config")
     workspace_root: Optional[str] = Field(default=None, description="Root directory path for filesystem MCP server")

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -14,8 +14,8 @@ from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_OSI,
     discover_osi_semantic_models,
-    osi_semantic_models_cover_tables,
     resolve_authoring_format,
+    resolve_existing_osi_semantic_model,
 )
 from datus.configuration.agent_config import AgentConfig
 from datus.prompts.prompt_manager import get_prompt_manager
@@ -25,7 +25,7 @@ from datus.schemas.action_history import (
     ActionStatus,
 )
 from datus.schemas.batch_events import BatchEventEmitter, BatchEventHelper
-from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
 from datus.storage.knowledge_provenance import (
     METRIC_ARTIFACT_TYPE,
     KnowledgeProvenanceStore,
@@ -108,6 +108,36 @@ def _source_provenance_from_row(row: Any, row_index: int, success_story: str) ->
         "source_type": source_type,
         "source_context_ids": context_ids,
         "source_metadata": metadata,
+    }
+
+
+def _source_query_from_row(row: Any, row_index: int, success_story: str) -> Optional[SourceQueryEvidence]:
+    sql = _clean_cell(row.get("sql"))
+    if not sql:
+        return None
+    provenance = _source_provenance_from_row(row, row_index, success_story) or {}
+    return SourceQueryEvidence(
+        source_sql_name=f"sql_{row_index + 1}",
+        sql=sql,
+        question=_clean_cell(row.get("question")),
+        external_knowledge=_clean_cell(row.get("external_knowledge")),
+        source_id=provenance.get("source_id")
+        or _clean_cell(row.get("source_id"))
+        or f"{Path(success_story).name}:{row_index}",
+        source_type=provenance.get("source_type") or _clean_cell(row.get("source_type")) or "success_story",
+        source_context_ids=provenance.get("source_context_ids", []),
+        source_metadata=provenance.get("source_metadata") or _parse_source_metadata(row.get("source_metadata")),
+    )
+
+
+def _source_provenance_from_query(source_query: SourceQueryEvidence) -> Optional[dict[str, Any]]:
+    if not source_query.source_context_ids:
+        return None
+    return {
+        "source_id": source_query.source_id,
+        "source_type": source_query.source_type,
+        "source_context_ids": list(source_query.source_context_ids),
+        "source_metadata": dict(source_query.source_metadata),
     }
 
 
@@ -245,31 +275,58 @@ def _metrics_authoring_format(agent_config: AgentConfig) -> str:
     return resolve_authoring_format(agent_config)
 
 
+def _success_story_model_resolution_error(resolution: dict[str, Any]) -> str:
+    status = resolution.get("status")
+    if status == "invalid":
+        errors = "; ".join(
+            f"{item.get('source_sql_name')}: {item.get('error')}" for item in resolution.get("parse_errors") or []
+        )
+        return f"Invalid success-story source SQL: {errors or resolution.get('reason')}"
+    if status == "ambiguous":
+        candidates = ", ".join(
+            str(model.get("semantic_model_name") or model.get("semantic_model_file") or "")
+            for model in resolution.get("candidates") or []
+        )
+        return (
+            "A success-story CSV must resolve to exactly one semantic model; "
+            f"the referenced tables span or match multiple models: {candidates or 'unknown'}"
+        )
+    tables = ", ".join(resolution.get("referenced_tables") or [])
+    return "No single semantic model covers all tables referenced by the success-story CSV" + (
+        f": {tables}" if tables else ""
+    )
+
+
 async def _ensure_semantic_models_for_metrics(
     agent_config: AgentConfig,
     success_story: str,
-    success_story_records: list[dict[str, Any]],
-    sql_list: list[str],
+    source_queries: list[SourceQueryEvidence],
     action_callback: Optional[Callable[["ActionHistory"], None]] = None,
-) -> tuple[bool, str, list[str]]:
+) -> tuple[bool, str, list[str], Optional[str]]:
+    success_story_records = [{"sql": source.sql, "question": source.question} for source in source_queries]
+    sql_list = [source.sql for source in source_queries]
+
     if _metrics_authoring_format(agent_config) == AUTHORING_FORMAT_OSI:
         from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
 
         before_models = discover_osi_semantic_models(agent_config)
-        requested_table_groups = [extract_tables_from_sql_list([sql], agent_config) for sql in sql_list]
-        requested_tables = list(dict.fromkeys(table for table_group in requested_table_groups for table in table_group))
-        existing_models_cover_request = not requested_tables or all(
-            not table_group or osi_semantic_models_cover_tables(agent_config, table_group)
-            for table_group in requested_table_groups
+        source_input = SemanticNodeInput(user_message="", source_queries=source_queries)
+        resolution = resolve_existing_osi_semantic_model(
+            agent_config,
+            user_input=source_input,
         )
-        if before_models and existing_models_cover_request:
+        if resolution["status"] == "found":
+            selected = resolution["selected"]
             logger.info(
-                "Reusing %d existing OSI semantic model file(s) for metric bootstrap",
-                len(before_models),
+                "Reusing OSI semantic model '%s' for all %d success-story source queries",
+                selected["semantic_model_name"],
+                len(source_queries),
             )
-            return True, "", []
+            return True, "", [], selected["semantic_model_name"]
+        if resolution["status"] in {"ambiguous", "invalid"}:
+            return False, _success_story_model_resolution_error(resolution), [], None
 
-        logger.info("Generating OSI semantic model(s) for metric bootstrap")
+        logger.info("Generating one OSI semantic model target for the success-story CSV")
         success, error = await init_success_story_semantic_model_async(
             agent_config,
             success_story,
@@ -278,19 +335,31 @@ async def _ensure_semantic_models_for_metrics(
             action_callback=action_callback,
         )
         if not success:
-            return False, error, []
+            return False, error, [], None
         after_models = discover_osi_semantic_models(agent_config)
         if not after_models:
-            return False, "OSI semantic model generation did not create a model file", []
+            return False, "OSI semantic model generation did not create a model file", [], None
+        post_resolution = resolve_existing_osi_semantic_model(
+            agent_config,
+            user_input=source_input,
+        )
+        if post_resolution["status"] != "found":
+            return False, _success_story_model_resolution_error(post_resolution), [], None
         before_files = {model["semantic_model_file"] for model in before_models}
         created_files = sorted(
             model["semantic_model_file"] for model in after_models if model["semantic_model_file"] not in before_files
         )
-        return True, "", created_files
+        selected = post_resolution["selected"]
+        logger.info(
+            "Resolved all %d success-story source queries to OSI semantic model '%s'",
+            len(source_queries),
+            selected["semantic_model_name"],
+        )
+        return True, "", created_files, selected["semantic_model_name"]
 
     all_tables = extract_tables_from_sql_list(sql_list, agent_config)
     if not all_tables:
-        return True, "", []
+        return True, "", [], None
 
     logger.info(f"Found {len(all_tables)} tables in success story SQL: {all_tables}")
     sql_evidence_by_table = extract_table_sql_evidence(success_story_records, agent_config)
@@ -307,7 +376,7 @@ async def _ensure_semantic_models_for_metrics(
     if error:
         logger.warning(f"Semantic model generation had partial failures: {error}")
 
-    return success, error, created_tables
+    return success, error, created_tables, None
 
 
 def _build_existing_metric_catalog(agent_config: AgentConfig) -> list[dict[str, Any]]:
@@ -619,7 +688,7 @@ def _unique_metric_catalog_by_name(
 
 
 async def _generate_metrics_batch(
-    batch_queries: list[str],
+    batch_sources: list[SourceQueryEvidence],
     batch_idx: int,
     agent_config: AgentConfig,
     subject_tree: Optional[list],
@@ -628,10 +697,18 @@ async def _generate_metrics_batch(
     action_callback: Optional[Callable[["ActionHistory"], None]],
     candidate_plan_json: Optional[str] = None,
     existing_metric_catalog_json: Optional[str] = None,
+    semantic_model_name: Optional[str] = None,
 ) -> tuple[bool, str, Optional[dict[str, Any]]]:
     """Process a single batch of SQL queries for metrics extraction."""
+    rendered_queries = []
+    for source in batch_sources:
+        query_number = source.source_sql_name.removeprefix("sql_")
+        rendered = f"Query {query_number}:\nQuestion: {source.question}\nSQL:\n{source.sql}"
+        if source.external_knowledge:
+            rendered += f"\nExternal Knowledge:\n{source.external_knowledge}"
+        rendered_queries.append(rendered)
     batch_message = "Analyze the following SQL queries and extract core metrics:\n\n" + "\n\n---\n\n".join(
-        batch_queries
+        rendered_queries
     )
 
     if existing_metric_catalog_json:
@@ -666,6 +743,8 @@ async def _generate_metrics_batch(
 
     metrics_input = SemanticNodeInput(
         user_message=batch_message,
+        source_queries=batch_sources,
+        semantic_model_name=semantic_model_name,
         catalog=runtime_db_context.get("catalog")
         or runtime_db_context.get("catalog_name")
         or current_db_config.catalog,
@@ -784,6 +863,43 @@ async def init_success_story_metrics_async(
         )
         return True, "", {"checked": True, "metrics_count": metric_rag.get_metrics_size()}
 
+    df = pd.read_csv(success_story)
+
+    # Emit task started
+    event_helper.task_started(total_items=len(df), success_story=success_story)
+
+    missing_columns = [column for column in ("question", "sql") if column not in df.columns]
+    if missing_columns:
+        error_msg = f"Success story CSV is missing required columns: {missing_columns}"
+        logger.error(error_msg)
+        event_helper.task_failed(error=error_msg)
+        return False, error_msg, None
+
+    source_queries: list[SourceQueryEvidence] = []
+    for idx, row in df.iterrows():
+        source_query = _source_query_from_row(row, idx, success_story)
+        if source_query is not None:
+            source_queries.append(source_query)
+    if not source_queries:
+        error_msg = "Success story CSV contains no SQL rows"
+        logger.error(error_msg)
+        event_helper.task_failed(error=error_msg)
+        return False, error_msg, None
+
+    # Step 0: Resolve one semantic model for the entire CSV before metric batching.
+    success, error, _created_semantic_models, semantic_model_name = await _ensure_semantic_models_for_metrics(
+        agent_config,
+        success_story,
+        source_queries,
+        action_callback=action_callback,
+    )
+
+    if not success:
+        error_msg = f"Failed to create semantic models: {error}"
+        logger.error(error_msg)
+        event_helper.task_failed(error=error_msg)
+        return False, error_msg, None
+
     if build_mode == "overwrite":
         from datus.storage.metric.store import MetricRAG
 
@@ -797,36 +913,9 @@ async def init_success_story_metrics_async(
         if cleared_provenance:
             logger.info("Cleared %d stale metric provenance row(s)", cleared_provenance)
 
-    df = pd.read_csv(success_story)
-
-    # Emit task started
-    event_helper.task_started(total_items=len(df), success_story=success_story)
-
-    # Step 0: Check and create missing semantic models
-    success_story_records = []
-    sql_entries: list[dict[str, Any]] = []
-    for idx, row in df.iterrows():
-        sql = row.get("sql")
-        if not sql:
-            continue
-        question = row.get("question")
-        success_story_records.append({"sql": sql, "question": question})
-        sql_entries.append({"name": f"sql_{idx + 1}", "sql": sql, "question": question})
-    sql_list = [record["sql"] for record in success_story_records]
-    success, error, _created_semantic_models = await _ensure_semantic_models_for_metrics(
-        agent_config,
-        success_story,
-        success_story_records,
-        sql_list,
-        action_callback=action_callback,
-    )
-
-    if not success:
-        error_msg = f"Failed to create semantic models: {error}"
-        logger.error(error_msg)
-        event_helper.task_failed(error=error_msg)
-        return False, error_msg, None
-
+    sql_entries = [
+        {"name": source.source_sql_name, "sql": source.sql, "question": source.question} for source in source_queries
+    ]
     existing_metric_catalog = _build_existing_metric_catalog(agent_config)
     existing_metric_catalog_json = _json_dump_compact(existing_metric_catalog)
     candidate_plan = _build_candidate_plan(sql_entries, existing_metric_catalog_json, agent_config)
@@ -836,26 +925,13 @@ async def init_success_story_metrics_async(
         candidate_plan.get("available"),
     )
 
-    # Build query records for all rows. Optional source-context columns are only
-    # used by benchmark provenance mode and do not affect normal bootstrap data.
-    all_query_records: list[dict[str, Any]] = []
-    for idx, row in df.iterrows():
-        sql = row["sql"]
-        question = row["question"]
-        all_query_records.append(
-            {
-                "source_sql_name": f"sql_{idx + 1}",
-                "query": f"Query {idx + 1}:\nQuestion: {question}\nSQL:\n{sql}",
-                "source": _source_provenance_from_row(row, idx, success_story),
-            }
-        )
-
     # Split into batches
-    batches = [all_query_records[i : i + batch_size] for i in range(0, len(all_query_records), batch_size)]
+    batches = [source_queries[i : i + batch_size] for i in range(0, len(source_queries), batch_size)]
     total_batches = len(batches)
 
     logger.info(
-        f"Processing {len(df)} SQL queries in {total_batches} batch(es) (batch_size={batch_size}) for metrics extraction"
+        f"Processing {len(source_queries)} SQL queries in {total_batches} batch(es) "
+        f"(batch_size={batch_size}) for metrics extraction"
     )
 
     event_helper.task_processing(total_items=total_batches)
@@ -867,13 +943,14 @@ async def init_success_story_metrics_async(
     skipped_batches = 0
 
     for batch_idx, batch_records in enumerate(batches):
-        batch_queries = [record["query"] for record in batch_records]
-        batch_sources = {record["source_sql_name"] for record in batch_records}
+        batch_sources = {record.source_sql_name for record in batch_records}
         batch_candidate_plan = _candidate_plan_for_sources(candidate_plan, batch_sources)
         batch_candidate_plan_json = _json_dump_compact(batch_candidate_plan) if batch_candidate_plan else ""
-        source_entries = [record["source"] for record in batch_records if record.get("source")]
+        source_entries = [
+            source for record in batch_records if (source := _source_provenance_from_query(record)) is not None
+        ]
 
-        logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_queries)} queries)")
+        logger.info(f"Processing batch {batch_idx + 1}/{total_batches} ({len(batch_records)} queries)")
 
         metric_ids_before = _metric_ids_in_storage(agent_config) if source_entries else set()
 
@@ -969,7 +1046,7 @@ async def init_success_story_metrics_async(
             continue
 
         success, error, batch_result = await _generate_metrics_batch(
-            batch_queries,
+            batch_records,
             batch_idx,
             agent_config,
             subject_tree,
@@ -978,6 +1055,7 @@ async def init_success_story_metrics_async(
             action_callback,
             candidate_plan_json=batch_candidate_plan_json,
             existing_metric_catalog_json=existing_metric_catalog_json,
+            semantic_model_name=semantic_model_name,
         )
 
         if success and batch_result is not None:

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -16,7 +16,7 @@ from datus.cli.generation_hooks import GenerationHooks
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionStatus
 from datus.schemas.batch_events import BatchEvent, BatchStage
-from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
 from datus.utils.loggings import get_logger
 from datus.utils.terminal_utils import suppress_keyboard_input
 
@@ -113,23 +113,25 @@ async def init_success_story_semantic_model_async(
         logger.error(error_msg)
         return False, error_msg
 
-    # Collect all SQL queries and questions
-    all_sqls = df["sql"].tolist()
-    all_questions = df["question"].tolist()
-
-    # Validate data alignment
-    if len(all_sqls) != len(all_questions):
-        error_msg = (
-            f"Success story CSV '{csv_path}' has mismatched column lengths: "
-            f"sql={len(all_sqls)}, question={len(all_questions)}"
+    source_queries: list[SourceQueryEvidence] = []
+    for idx, row in df.iterrows():
+        sql = _success_story_cell(row, "sql")
+        if not sql:
+            continue
+        source_queries.append(
+            SourceQueryEvidence(
+                source_sql_name=f"sql_{idx + 1}",
+                sql=sql,
+                question=_success_story_cell(row, "question"),
+                external_knowledge=_success_story_cell(row, "external_knowledge"),
+            )
         )
-        logger.error(error_msg)
-        return False, error_msg
 
-    if len(all_sqls) == 0:
-        error_msg = f"Success story CSV '{csv_path}' contains no data rows"
+    if not source_queries:
+        error_msg = f"Success story CSV '{csv_path}' contains no SQL rows"
         logger.error(error_msg)
         return False, error_msg
+    all_sqls = [source.sql for source in source_queries]
 
     if build_mode not in _VALID_BUILD_MODES:
         error_msg = (
@@ -203,10 +205,11 @@ async def init_success_story_semantic_model_async(
 
     # Build comprehensive context from all rows
     context_message = "Generate semantic models for the following SQL queries:\n\n"
-    for idx, (sql, question) in enumerate(zip(all_sqls, all_questions), 1):
-        context_message += f"Query {idx}:\n"
-        context_message += f"Question: {question}\n"
-        context_message += f"SQL:\n{sql}\n\n"
+    for source in source_queries:
+        query_number = source.source_sql_name.removeprefix("sql_")
+        context_message += f"Query {query_number}:\n"
+        context_message += f"Question: {source.question}\n"
+        context_message += f"SQL:\n{source.sql}\n\n"
 
     current_db_config = agent_config.current_db_config()
     runtime_db_context_getter = getattr(agent_config, "runtime_db_context", None)
@@ -225,6 +228,7 @@ async def init_success_story_semantic_model_async(
 
     semantic_input = SemanticNodeInput(
         user_message=context_message,
+        source_queries=source_queries,
         catalog=runtime_db_context.get("catalog")
         or runtime_db_context.get("catalog_name")
         or current_db_config.catalog,

--- a/datus/tools/func_tool/metric_queryability.py
+++ b/datus/tools/func_tool/metric_queryability.py
@@ -60,6 +60,27 @@ def extract_metric_queryability_contracts(text: Optional[str]) -> List[Dict[str,
     return contracts
 
 
+def extract_metric_queryability_contracts_from_sources(
+    source_queries: Iterable[Any],
+) -> List[Dict[str, Any]]:
+    """Build contracts directly from structured source SQL."""
+    contracts: List[Dict[str, Any]] = []
+    for index, source_query in enumerate(source_queries, 1):
+        if isinstance(source_query, dict):
+            source_name = source_query.get("source_sql_name")
+            sql = source_query.get("sql")
+        else:
+            source_name = getattr(source_query, "source_sql_name", None)
+            sql = getattr(source_query, "sql", None)
+        contract = _contract_from_sql(
+            str(sql or ""),
+            source=str(source_name or f"sql_{index}"),
+        )
+        if contract:
+            contracts.append(contract)
+    return contracts
+
+
 def summarize_queryability_contracts(contracts: Iterable[Dict[str, Any]]) -> str:
     parts = []
     for contract in contracts:

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -413,6 +413,18 @@ class SubAgentTaskTool:
                     "retry_subagent": "gen_metrics",
                 },
             )
+        if resolution["status"] == "invalid":
+            parse_errors = resolution.get("parse_errors") or []
+            details = "; ".join(f"{item.get('source_sql_name')}: {item.get('error')}" for item in parse_errors)
+            return FuncToolResult(
+                success=0,
+                error=f"Invalid structured source SQL: {details or resolution.get('reason')}",
+                result={
+                    "code": "semantic_model_source_sql_invalid",
+                    "parse_errors": parse_errors,
+                    "retry_subagent": "gen_metrics",
+                },
+            )
 
         target_dir = osi_semantic_model_directory(self.agent_config)
 
@@ -1098,7 +1110,7 @@ class SubAgentTaskTool:
         """
         node_input = self._build_typed_subagent_input(node, prompt, db_ctx=db_ctx)
         at_ctx = self._parent_at_context()
-        return apply_at_context(
+        node_input = apply_at_context(
             node_input,
             schemas=at_ctx.get("schemas"),
             metrics=at_ctx.get("metrics"),
@@ -1106,6 +1118,17 @@ class SubAgentTaskTool:
             external_knowledge=at_ctx.get("external_knowledge"),
             context_hints=at_ctx.get("context_hints"),
         )
+        self._inherit_semantic_source_queries(node_input)
+        return node_input
+
+    def _inherit_semantic_source_queries(self, node_input: Any) -> None:
+        """Forward bootstrap SQL only between semantic nodes, outside @-context."""
+        from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+
+        parent_input = getattr(self._parent_node, "input", None)
+        if not isinstance(parent_input, SemanticNodeInput) or not isinstance(node_input, SemanticNodeInput):
+            return
+        node_input.source_queries = list(parent_input.source_queries)
 
     def _parent_at_context(self) -> Dict[str, Any]:
         """Resolved @-context (schemas/metrics/reference_sql/knowledge) the parent carries.

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -121,6 +121,20 @@ def extract_table_names(sql, dialect="snowflake", ignore_empty=False) -> List[st
     except Exception as e:
         logger.warning(f"Error parsing SQL {sql}, error: {e}")
         return []
+    return _table_names_from_expression(parsed, dialect=dialect, ignore_empty=ignore_empty)
+
+
+def extract_table_names_strict(sql, dialect="snowflake", ignore_empty=False) -> List[str]:
+    """Extract table names and raise when sqlglot cannot parse the SQL."""
+    read_dialect = parse_read_dialect(dialect)
+    parsed = sqlglot.parse_one(sql, read=read_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+    if parsed is None:
+        raise ValueError("SQL parser returned no expression")
+    return _table_names_from_expression(parsed, dialect=dialect, ignore_empty=ignore_empty)
+
+
+def _table_names_from_expression(parsed, *, dialect: str, ignore_empty: bool) -> List[str]:
+    """Collect physical table names from an already parsed sqlglot expression."""
     table_names = []
 
     # Get all CTE names

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -29,7 +29,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
-from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
 from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
@@ -270,7 +270,18 @@ class TestGenMetricsAgenticNodeExecution:
             encoding="utf-8",
         )
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.input = SemanticNodeInput(user_message="Generate revenue metrics from orders")
+        node.input = SemanticNodeInput(
+            user_message=(
+                "Analyze the following SQL queries and extract core metrics:\n"
+                "Query 1:\nSQL:\nSELECT SUM(amount) FROM commerce.orders"
+            ),
+            source_queries=[
+                SourceQueryEvidence(
+                    source_sql_name="sql_1",
+                    sql="SELECT SUM(amount) FROM commerce.orders",
+                )
+            ],
+        )
         node.sub_agent_task_tool.task = AsyncMock()
         ctx = StreamRunContext(user_input=node.input, action_history_manager=ActionHistoryManager())
 
@@ -283,6 +294,29 @@ class TestGenMetricsAgenticNodeExecution:
         enhanced = node._build_enhanced_message(node.input)
         assert "sales" in enhanced
         assert "ops.yml" in enhanced
+
+    @pytest.mark.asyncio
+    async def test_direct_osi_metrics_rejects_invalid_structured_source_before_bootstrap(
+        self, real_agent_config, mock_llm_create
+    ):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(
+            user_message="SQL:\nSELECT COUNT(*) FROM commerce.orders",
+            source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
+        )
+        node.sub_agent_task_tool.task = AsyncMock()
+
+        actions = [action async for action in node.execute_stream(ActionHistoryManager())]
+
+        node.sub_agent_task_tool.task.assert_not_awaited()
+        assert actions[-1].action_type == "error"
+        assert actions[-1].status == ActionStatus.FAILED
+        assert "invalid structured source SQL" in str(actions[-1].output)
+        assert "sql_9" in str(actions[-1].output)
+        assert mock_llm_create.call_history == []
 
     @pytest.mark.asyncio
     async def test_osi_target_is_request_scoped_when_session_switches_models(self, real_agent_config, mock_llm_create):

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -9,6 +9,7 @@ import yaml
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_METRICFLOW,
     AUTHORING_FORMAT_OSI,
+    _source_query_dialect,
     default_optional_skills,
     default_osi_semantic_model_file,
     default_osi_semantic_model_name,
@@ -20,6 +21,9 @@ from datus.agent.node.semantic_authoring import (
     resolve_osi_semantic_model_target,
     resolve_semantic_adapter_type,
 )
+from datus.configuration.agent_config import DbConfig
+from datus.schemas.node_models import ReferenceSql
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
 from datus.utils.exceptions import DatusException, ErrorCode
 
 
@@ -315,6 +319,203 @@ def test_existing_osi_metric_target_rejects_tables_split_across_models(tmp_path)
 
     assert resolution["status"] == "ambiguous"
     assert resolution["reason"] == "referenced datasets are split across multiple semantic models"
+
+
+def test_existing_osi_metric_target_uses_structured_source_sql_instead_of_batch_prompt(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "campaign.yml",
+        "campaign_management",
+        [{"name": "campaign", "source": "analytics.campaign"}],
+    )
+    user_input = SemanticNodeInput(
+        user_message=(
+            "Analyze the following SQL queries and extract core metrics:\n\n"
+            "Query 2:\nQuestion: campaign count\nSQL:\nSELECT COUNT(*) FROM analytics.campaign"
+        ),
+        source_queries=[
+            SourceQueryEvidence(
+                source_sql_name="sql_2",
+                question="campaign count",
+                sql="SELECT COUNT(*) FROM analytics.campaign",
+            )
+        ],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(
+        config,
+        user_input=user_input,
+        request_text=user_input.user_message,
+    )
+
+    assert resolution["status"] == "found"
+    assert resolution["selected"]["semantic_model_name"] == "campaign_management"
+    assert resolution["referenced_tables"] == ["analytics.campaign"]
+    assert resolution["evidence_source"] == "source_queries"
+    assert resolution["source_sql_names"] == ["sql_2"]
+
+
+def test_structured_source_sql_does_not_change_reference_sql_context(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "orders.yml",
+        "orders",
+        [{"name": "orders", "source": "sales.orders"}],
+    )
+    _write_osi_model(
+        tmp_path,
+        "payments.yml",
+        "payments",
+        [{"name": "payments", "source": "finance.payments"}],
+    )
+    user_input = SemanticNodeInput(
+        user_message="Generate order metrics",
+        source_queries=[SourceQueryEvidence(source_sql_name="sql_1", sql="SELECT COUNT(*) FROM sales.orders")],
+        reference_sql=[ReferenceSql(name="payment_example", sql="SELECT SUM(amount) FROM finance.payments")],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
+
+    assert resolution["status"] == "found"
+    assert resolution["selected"]["semantic_model_name"] == "orders"
+    assert resolution["referenced_tables"] == ["sales.orders"]
+    assert user_input.reference_sql[0].name == "payment_example"
+
+
+def test_reference_sql_still_resolves_model_without_structured_sources(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "payments.yml",
+        "payments",
+        [{"name": "payments", "source": "finance.payments"}],
+    )
+    user_input = SemanticNodeInput(
+        user_message="Generate payment metrics",
+        reference_sql=[ReferenceSql(name="payment_example", sql="SELECT SUM(amount) FROM finance.payments")],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
+
+    assert resolution["status"] == "found"
+    assert resolution["selected"]["semantic_model_name"] == "payments"
+    assert resolution["evidence_source"] == "legacy_request"
+
+
+def test_invalid_structured_source_sql_does_not_fallback_to_prompt(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "orders.yml",
+        "orders",
+        [{"name": "orders", "source": "sales.orders"}],
+    )
+    user_input = SemanticNodeInput(
+        user_message="SQL:\nSELECT COUNT(*) FROM sales.orders",
+        source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(
+        config,
+        user_input=user_input,
+        request_text=user_input.user_message,
+    )
+
+    assert resolution["status"] == "invalid"
+    assert resolution["evidence_source"] == "source_queries"
+    assert resolution["parse_errors"][0]["source_sql_name"] == "sql_9"
+
+
+def test_invalid_structured_source_sql_is_rejected_before_explicit_model_selection(tmp_path):
+    config = _osi_config(tmp_path)
+    _write_osi_model(
+        tmp_path,
+        "orders.yml",
+        "orders",
+        [{"name": "orders", "source": "sales.orders"}],
+    )
+    user_input = SemanticNodeInput(
+        user_message="Generate order metrics",
+        semantic_model_name="orders",
+        source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
+
+    assert resolution["status"] == "invalid"
+    assert resolution["parse_errors"][0]["source_sql_name"] == "sql_9"
+
+
+def test_structured_source_sql_uses_mysql_fallback_for_starrocks_datetime_cast(tmp_path):
+    config = _osi_config(tmp_path)
+    config.current_db_config = lambda: DbConfig(type="starrocks")
+    _write_osi_model(
+        tmp_path,
+        "campaign.yml",
+        "campaign_management",
+        [{"name": "activities", "source": "v_udata_ac_info"}],
+    )
+    user_input = SemanticNodeInput(
+        user_message="Analyze the following SQL queries",
+        source_queries=[
+            SourceQueryEvidence(
+                source_sql_name="sql_13",
+                sql=(
+                    "SELECT CAST(start_time AS DATETIME) AS start_at, COUNT(*) "
+                    "FROM v_udata_ac_info GROUP BY CAST(start_time AS DATETIME)"
+                ),
+            )
+        ],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
+
+    assert _source_query_dialect(config) == "starrocks"
+    assert resolution["status"] == "found"
+    assert resolution["selected"]["semantic_model_name"] == "campaign_management"
+    assert resolution["referenced_tables"] == ["v_udata_ac_info"]
+
+
+def test_existing_osi_metric_target_indexes_query_backed_dataset_source_tables(tmp_path):
+    config = _osi_config(tmp_path)
+    config.current_db_config = lambda: DbConfig(type="starrocks")
+    query_source = (
+        "SELECT a.suserid, c.city_level "
+        "FROM ac_manage.dim_mgamejp_account_allinfo_nf AS a "
+        "JOIN ac_manage.dim_uf_player_gameinfo_mf AS c ON a.suserid = c.userid"
+    )
+    _write_osi_model(
+        tmp_path,
+        "account.yml",
+        "account_analytics",
+        [
+            {
+                "name": "account_player_gameinfo",
+                "source": query_source,
+                "custom_extensions": [
+                    {
+                        "vendor_name": "DATUS",
+                        "data": '{"source_type":"query"}',
+                    }
+                ],
+            }
+        ],
+    )
+    user_input = SemanticNodeInput(
+        user_message="Analyze the following SQL queries",
+        source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql=query_source)],
+    )
+
+    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
+
+    assert resolution["status"] == "found"
+    assert resolution["selected"]["semantic_model_name"] == "account_analytics"
+    assert set(resolution["referenced_tables"]) == {
+        "ac_manage.dim_mgamejp_account_allinfo_nf",
+        "ac_manage.dim_uf_player_gameinfo_mf",
+    }
 
 
 def test_osi_target_creates_a_different_file_for_an_unrelated_fact(tmp_path):

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from datus.schemas.semantic_agentic_node_models import SourceQueryEvidence
 from datus.storage.metric.metric_init import (
     BIZ_NAME,
     DEFAULT_METRICS_BATCH_SIZE,
@@ -18,10 +19,16 @@ from datus.storage.metric.metric_init import (
     _extract_metric_artifact_ids,
     _generate_metrics_batch,
     _source_provenance_from_row,
+    _source_query_from_row,
     _sync_metric_provenance,
     _unique_metric_catalog_by_name,
     init_semantic_yaml_metrics,
 )
+
+
+def _source_query(sql: str, name: str = "sql_1", question: str = "") -> SourceQueryEvidence:
+    return SourceQueryEvidence(source_sql_name=name, sql=sql, question=question)
+
 
 # ---------------------------------------------------------------------------
 # _action_status_value
@@ -636,7 +643,12 @@ class TestEnsureSemanticModelsForMetrics:
         async def fake_init(agent_config, success_story, emit=None, build_mode="overwrite", action_callback=None):
             target_path.parent.mkdir(parents=True)
             target_path.write_text(
-                "version: 0.2.0.dev0\nsemantic_model:\n  - name: orders_analytics\n",
+                "version: 0.2.0.dev0\n"
+                "semantic_model:\n"
+                "  - name: orders_analytics\n"
+                "    datasets:\n"
+                "      - name: orders\n"
+                "        source: orders\n",
                 encoding="utf-8",
             )
             captured["build_mode"] = build_mode
@@ -648,31 +660,79 @@ class TestEnsureSemanticModelsForMetrics:
                 "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
                 side_effect=fake_init,
             ) as init_mock,
-            patch(
-                "datus.storage.metric.metric_init.extract_tables_from_sql_list",
-                return_value=["orders"],
-            ) as extract_mock,
             patch("datus.storage.metric.metric_init.ensure_semantic_models_exist") as ensure_mock,
         ):
-            ok, error, created = await _ensure_semantic_models_for_metrics(
+            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
                 config,
                 "success_story.csv",
-                [{"sql": "SELECT COUNT(*) FROM orders", "question": "How many orders?"}],
-                ["SELECT COUNT(*) FROM orders"],
+                [_source_query("SELECT COUNT(*) FROM orders", question="How many orders?")],
                 action_callback=action_callback,
             )
 
         assert ok is True
         assert error == ""
         assert created == [target_file]
+        assert model_name == "orders_analytics"
         init_mock.assert_called_once()
-        extract_mock.assert_called_once()
         ensure_mock.assert_not_called()
         assert captured["build_mode"] == "incremental"
         assert captured["action_callback"] is action_callback
 
     @pytest.mark.asyncio
-    async def test_osi_reuses_separate_models_for_independent_queries(self, tmp_path):
+    async def test_osi_accepts_generated_query_backed_model_for_join_source(self, tmp_path):
+        from unittest.mock import patch
+
+        target_file = "subject/semantic_models/warehouse/account_analytics.yml"
+        target_path = tmp_path / target_file
+        query_source = (
+            "SELECT a.suserid, c.city_level "
+            "FROM ac_manage.dim_mgamejp_account_allinfo_nf AS a "
+            "JOIN ac_manage.dim_uf_player_gameinfo_mf AS c ON a.suserid = c.userid"
+        )
+        config = SimpleNamespace(
+            project_root=str(tmp_path),
+            current_datasource="warehouse",
+            current_db_config=lambda: SimpleNamespace(type="starrocks"),
+            resolve_semantic_adapter=lambda requested=None: "osi",
+        )
+
+        async def fake_init(agent_config, success_story, emit=None, build_mode="overwrite", action_callback=None):
+            target_path.parent.mkdir(parents=True)
+            target_path.write_text(
+                "version: 0.2.0.dev0\n"
+                "semantic_model:\n"
+                "  - name: account_analytics\n"
+                "    datasets:\n"
+                "      - name: account_player_gameinfo\n"
+                "        source: |\n"
+                "          SELECT a.suserid, c.city_level\n"
+                "          FROM ac_manage.dim_mgamejp_account_allinfo_nf AS a\n"
+                "          JOIN ac_manage.dim_uf_player_gameinfo_mf AS c ON a.suserid = c.userid\n"
+                "        custom_extensions:\n"
+                "          - vendor_name: DATUS\n"
+                '            data: \'{"source_type":"query"}\'\n',
+                encoding="utf-8",
+            )
+            return True, ""
+
+        with patch(
+            "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
+            side_effect=fake_init,
+        ) as init_mock:
+            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
+                config,
+                "success_story.csv",
+                [_source_query(query_source, "sql_9")],
+            )
+
+        assert ok is True
+        assert error == ""
+        assert created == [target_file]
+        assert model_name == "account_analytics"
+        init_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_osi_rejects_success_story_split_across_models(self, tmp_path):
         from unittest.mock import patch
 
         model_dir = tmp_path / "subject" / "semantic_models" / "warehouse"
@@ -700,37 +760,26 @@ class TestEnsureSemanticModelsForMetrics:
             current_datasource="warehouse",
             resolve_semantic_adapter=lambda requested=None: "osi",
         )
-        sql_list = [
-            "SELECT COUNT(*) FROM analytics.fact_orders",
-            "SELECT SUM(amount) FROM finance.fact_payments",
+        source_queries = [
+            _source_query("SELECT COUNT(*) FROM analytics.fact_orders", "sql_1"),
+            _source_query("SELECT SUM(amount) FROM finance.fact_payments", "sql_2"),
         ]
-
-        def extract_tables(sqls, _config):
-            sql = sqls[0]
-            if "fact_orders" in sql:
-                return ["analytics.fact_orders"]
-            return ["finance.fact_payments"]
 
         with (
             patch(
                 "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async"
             ) as init_mock,
-            patch(
-                "datus.storage.metric.metric_init.extract_tables_from_sql_list",
-                side_effect=extract_tables,
-            ) as extract_mock,
         ):
-            ok, error, created = await _ensure_semantic_models_for_metrics(
+            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
                 config,
                 "success_story.csv",
-                [{"sql": sql, "question": sql} for sql in sql_list],
-                sql_list,
+                source_queries,
             )
 
-        assert ok is True
-        assert error == ""
+        assert ok is False
+        assert "exactly one semantic model" in error
         assert created == []
-        assert extract_mock.call_count == 2
+        assert model_name is None
         init_mock.assert_not_called()
 
     @pytest.mark.asyncio
@@ -759,16 +808,16 @@ class TestEnsureSemanticModelsForMetrics:
             ),
             patch("datus.storage.metric.metric_init.ensure_semantic_models_exist", side_effect=fake_ensure),
         ):
-            ok, error, created = await _ensure_semantic_models_for_metrics(
+            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
                 config,
                 "success_story.csv",
-                records,
-                sql_list,
+                [_source_query(sql_list[0], question=records[0]["question"])],
             )
 
         assert ok is True
         assert error == ""
         assert created == ["customers", "orders"]
+        assert model_name is None
 
 
 # ---------------------------------------------------------------------------
@@ -778,6 +827,24 @@ class TestEnsureSemanticModelsForMetrics:
 
 @pytest.mark.ci
 class TestMetricProvenanceHelpers:
+    def test_source_query_from_row_keeps_sql_and_source_identity_without_context_ids(self):
+        result = _source_query_from_row(
+            {
+                "question": "Revenue?",
+                "sql": "SELECT SUM(amount) FROM orders",
+                "external_knowledge": "amount excludes tax",
+            },
+            2,
+            "/tmp/orders.csv",
+        )
+
+        assert result is not None
+        assert result.source_sql_name == "sql_3"
+        assert result.sql == "SELECT SUM(amount) FROM orders"
+        assert result.source_id == "orders.csv:2"
+        assert result.external_knowledge == "amount excludes tax"
+        assert result.source_context_ids == []
+
     def test_source_provenance_from_row_reads_context_columns(self):
         row = {
             "source_context_id": "metric:seed:7; metric:task:21",
@@ -920,18 +987,22 @@ class TestGenerateMetricsBatch:
             patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
         ):
             ok, err, result = await _generate_metrics_batch(
-                ["Query 1:\nQuestion: rev?\nSQL:\nSELECT 1"],
+                [_source_query("SELECT 1", question="rev?")],
                 0,
                 mock_config,
                 None,
                 None,
                 BatchEventHelper("test", None),
                 None,
+                semantic_model_name="orders_analytics",
             )
 
         assert ok is True
         assert err == ""
         assert result == {"metrics": ["revenue"]}
+        assert mock_node.input.semantic_model_name == "orders_analytics"
+        assert mock_node.input.source_queries[0].sql == "SELECT 1"
+        assert "Analyze the following SQL queries" in mock_node.input.user_message
 
     @pytest.mark.asyncio
     async def test_success_captures_synced_metric_artifact_ids(self):
@@ -969,7 +1040,7 @@ class TestGenerateMetricsBatch:
             patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
         ):
             ok, err, result = await _generate_metrics_batch(
-                ["Query 1:\nQuestion: rev?\nSQL:\nSELECT 1"],
+                [_source_query("SELECT 1", question="rev?")],
                 0,
                 mock_config,
                 None,
@@ -1011,7 +1082,7 @@ class TestGenerateMetricsBatch:
             patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
         ):
             ok, err, result = await _generate_metrics_batch(
-                ["Query 1:\nQuestion: q?\nSQL:\nSELECT 1"],
+                [_source_query("SELECT 1", question="q?")],
                 0,
                 mock_config,
                 None,
@@ -1053,7 +1124,7 @@ class TestGenerateMetricsBatch:
             patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
         ):
             ok, err, result = await _generate_metrics_batch(
-                ["Query 1:\nQuestion: q?\nSQL:\nSELECT 1"],
+                [_source_query("SELECT 1", question="q?")],
                 0,
                 mock_config,
                 None,
@@ -1090,7 +1161,7 @@ class TestGenerateMetricsBatch:
             patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", return_value=mock_node),
         ):
             ok, err, result = await _generate_metrics_batch(
-                ["Query 1:\nQuestion: q?\nSQL:\nSELECT 1"],
+                [_source_query("SELECT 1", question="q?")],
                 0,
                 mock_config,
                 None,
@@ -1182,6 +1253,59 @@ class TestBatchSplitting:
         assert ok is True
         assert err == ""
         assert len(result["metrics"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_all_batches_reuse_file_level_semantic_model(self):
+        from unittest.mock import AsyncMock, patch
+
+        import pandas as pd
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.metric.metric_init import init_success_story_metrics_async
+
+        captured_inputs = []
+
+        class CapturingNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+
+            async def execute_stream(self, _ahm):
+                captured_inputs.append(self.input)
+                action = MagicMock()
+                action.status = ActionStatus.SUCCESS
+                action.action_type = "gen_metrics_response"
+                action.output = {"metrics": ["revenue"]}
+                action.messages = "ok"
+                yield action
+
+        mock_config = MagicMock()
+        mock_config.project_name = "test"
+        mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
+        mock_pm = MagicMock()
+        mock_pm.get_latest_version.return_value = "1.0"
+        ensure = AsyncMock(return_value=(True, "", [], "orders_analytics"))
+        rows = [{"question": f"q{i}", "sql": f"SELECT SUM(amount) FROM orders WHERE id = {i}"} for i in range(3)]
+
+        with (
+            patch("datus.storage.metric.store.MetricRAG", MagicMock()),
+            patch("datus.storage.metric.metric_init._ensure_semantic_models_for_metrics", ensure),
+            patch("datus.storage.metric.metric_init._build_candidate_plan", return_value={"available": False}),
+            patch("datus.storage.metric.metric_init.get_prompt_manager", return_value=mock_pm),
+            patch("datus.storage.metric.metric_init.GenMetricsAgenticNode", CapturingNode),
+            patch("datus.storage.metric.metric_init.pd.read_csv", return_value=pd.DataFrame(rows)),
+        ):
+            ok, err, _result = await init_success_story_metrics_async(
+                agent_config=mock_config,
+                success_story="orders.csv",
+                batch_size=2,
+            )
+
+        assert ok is True
+        assert err == ""
+        assert ensure.await_count == 1
+        assert len(ensure.await_args.args[2]) == 3
+        assert [len(node_input.source_queries) for node_input in captured_inputs] == [2, 1]
+        assert {node_input.semantic_model_name for node_input in captured_inputs} == {"orders_analytics"}
 
     @pytest.mark.asyncio
     async def test_partial_batch_failure_continues(self):

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -1025,12 +1025,14 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
         mock_db_config.database = "db"
         mock_db_config.schema = "public"
         mock_config.current_db_config.return_value = mock_db_config
+        captured_inputs = []
 
         class MockSemanticNode:
             def __init__(self, *args, **kwargs):
                 self.input = None
 
             async def execute_stream(self, action_history_manager):
+                captured_inputs.append(self.input)
                 action = SimpleNamespace(
                     status=ActionStatus.SUCCESS,
                     action_type="gen_semantic_model_response",
@@ -1048,6 +1050,8 @@ class TestInitSuccessStorySemanticModelAsyncLLMPath:
 
         assert success is True
         assert error == ""
+        assert captured_inputs[0].source_queries[0].source_sql_name == "sql_1"
+        assert captured_inputs[0].source_queries[0].sql == "SELECT 1"
 
     @pytest.mark.asyncio
     async def test_success_path_emits_events(self, tmp_path, monkeypatch):

--- a/tests/unit_tests/tools/func_tool/test_metric_queryability.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_queryability.py
@@ -4,7 +4,11 @@
 
 """Unit tests for metric queryability contract helpers."""
 
-from datus.tools.func_tool.metric_queryability import summarize_queryability_contracts
+from datus.schemas.semantic_agentic_node_models import SourceQueryEvidence
+from datus.tools.func_tool.metric_queryability import (
+    extract_metric_queryability_contracts_from_sources,
+    summarize_queryability_contracts,
+)
 
 
 class TestSummarizeQueryabilityContracts:
@@ -38,3 +42,20 @@ class TestSummarizeQueryabilityContracts:
     def test_without_time_hints_has_no_grain_guidance(self):
         contracts = [{"source": "sql_1", "dimension_hints": ["region"], "metric_hints": ["orders"]}]
         assert "time_granularity" not in summarize_queryability_contracts(contracts)
+
+
+class TestExtractMetricQueryabilityContractsFromSources:
+    def test_preserves_structured_source_name(self):
+        contracts = extract_metric_queryability_contracts_from_sources(
+            [
+                SourceQueryEvidence(
+                    source_sql_name="sql_9",
+                    sql="SELECT region, SUM(amount) AS revenue FROM orders GROUP BY region",
+                )
+            ]
+        )
+
+        assert len(contracts) == 1
+        assert contracts[0]["source"] == "sql_9"
+        assert contracts[0]["dimension_hints"] == ["region"]
+        assert contracts[0]["metric_hints"] == ["revenue"]

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -852,6 +852,28 @@ class TestTaskExecution:
         execute_node.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_osi_gen_metrics_rejects_invalid_structured_source_sql(self, task_tool, tmp_path):
+        from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
+
+        task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
+        task_tool.agent_config.current_datasource = "test_db"
+        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
+        parent = MagicMock()
+        parent.input = SemanticNodeInput(
+            user_message="SQL:\nSELECT COUNT(*) FROM main.orders",
+            source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
+        )
+        task_tool.set_parent_node(parent)
+
+        with patch.object(task_tool, "_execute_node") as execute_node:
+            result = await task_tool.task(type="gen_metrics", prompt="Generate order metrics")
+
+        assert result.success == 0
+        assert result.result["code"] == "semantic_model_source_sql_invalid"
+        assert result.result["parse_errors"][0]["source_sql_name"] == "sql_9"
+        execute_node.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_semantic_authoring_tasks_are_serialized_across_tool_instances(
         self, task_tool, monkeypatch, tmp_path
     ):
@@ -1732,6 +1754,26 @@ class TestBuildNodeInputBuiltIn:
         assert isinstance(result, SemanticNodeInput)
         assert result.user_message == "orders table"
         assert result.database is None
+
+    def test_semantic_model_node_inherits_source_queries_separately_from_reference_sql(self, task_tool):
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+        from datus.schemas.node_models import ReferenceSql
+        from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
+
+        parent = MagicMock()
+        parent.input = SemanticNodeInput(
+            user_message="Generate metrics",
+            source_queries=[SourceQueryEvidence(source_sql_name="sql_1", sql="SELECT COUNT(*) FROM sales.orders")],
+            reference_sql=[ReferenceSql(name="example", sql="SELECT SUM(amount) FROM finance.payments")],
+        )
+        task_tool.set_parent_node(parent)
+
+        mock_node = Mock(spec=GenSemanticModelAgenticNode)
+        result = task_tool._build_node_input(mock_node, "Create the prerequisite model")
+
+        assert result.source_queries == parent.input.source_queries
+        assert result.reference_sql == parent.input.reference_sql
+        assert result.source_queries[0].sql != result.reference_sql[0].sql
 
     def test_metrics_node_input(self, task_tool):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode


### PR DESCRIPTION
## Summary

- carry original success-story SQL as structured evidence, independently of rendered LLM prompts and `reference_sql`
- resolve each success-story file to one OSI semantic model before metrics batching, then reuse that target across batches
- fail closed on invalid SQL, with StarRocks dialect fallback and query-backed dataset table indexing

## Root cause

Batch prompts beginning with `Analyze the following...` were parsed as SQL/table evidence, so `the` could be treated as a table and valid semantic models were rejected. Batch-local resolution also lacked a stable file-level semantic model target.

## Behavior

- A success-story CSV must resolve to exactly one semantic model; this change does not add cross-model grouping.
- Legacy callers without structured sources keep the existing request/reference-SQL behavior.
- Query-backed datasets map the physical tables in their source SQL back to the owning semantic model.

## Validation

- 469 targeted unit tests passed
- Ruff format/check and `git diff --check` passed
- Parsed the real Baisheng 53-query success story and Tencent split 22/4/1-query success stories with no parse errors, no spurious `the` table, and the expected single-model resolution
- Confirmed the original Tencent mobile FPS join resolves through its query-backed dataset

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured SQL evidence support for semantic-model and metric generation workflows.
  * Improved semantic-model discovery by identifying referenced tables from source queries and reusing one model across metric batches.
  * Preserved source names and provenance throughout metric generation.

* **Bug Fixes**
  * Added clear validation errors for invalid or unparseable source SQL.
  * Prevented invalid SQL from triggering unnecessary model bootstrapping or generation.
  * Improved SQL table detection across supported dialects, including StarRocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->