### PR TITLE
[Feature] Batch table-columns endpoint with in-memory column cache

### DIFF
--- a/datus/api/models/table_models.py
+++ b/datus/api/models/table_models.py
@@ -53,7 +53,7 @@ class GetTableDetailData(BaseModel):
 class GetTablesColumnsInput(BaseModel):
     """Batch table-columns input (autocomplete prefetch)."""
 
-    tables: List[str] = Field(
+    tables: list[str] = Field(
         ...,
         description="Full table names, e.g. ['db.schema.orders', 'db.schema.users']",
     )
@@ -63,13 +63,13 @@ class TableColumns(BaseModel):
     """Columns for a single table."""
 
     table: str = Field(..., description="Full table name as requested")
-    columns: List[ColumnInfo] = Field(..., description="Column information")
+    columns: list[ColumnInfo] = Field(..., description="Column information")
 
 
 class GetTablesColumnsData(BaseModel):
     """Batch table-columns result. Tables that fail to resolve are omitted."""
 
-    tables: List[TableColumns] = Field(..., description="Per-table columns")
+    tables: list[TableColumns] = Field(..., description="Per-table columns")
 
 
 # ========== SemanticModel Models ==========

--- a/datus/api/models/table_models.py
+++ b/datus/api/models/table_models.py
@@ -59,11 +59,20 @@ class GetTablesColumnsInput(BaseModel):
     )
 
 
+class TableColumnBrief(BaseModel):
+    """Slim column shape for autocomplete — no default_value (unused there)."""
+
+    name: str = Field(..., description="Column name")
+    type: str = Field(..., description="Column data type")
+    nullable: bool = Field(..., description="Whether column is nullable")
+    pk: bool = Field(default=False, description="Whether column is primary key")
+
+
 class TableColumns(BaseModel):
     """Columns for a single table."""
 
     table: str = Field(..., description="Full table name as requested")
-    columns: list[ColumnInfo] = Field(..., description="Column information")
+    columns: list[TableColumnBrief] = Field(..., description="Column information")
 
 
 class GetTablesColumnsData(BaseModel):

--- a/datus/api/models/table_models.py
+++ b/datus/api/models/table_models.py
@@ -50,6 +50,28 @@ class GetTableDetailData(BaseModel):
     table: TableDetailData
 
 
+class GetTablesColumnsInput(BaseModel):
+    """Batch table-columns input (autocomplete prefetch)."""
+
+    tables: List[str] = Field(
+        ...,
+        description="Full table names, e.g. ['db.schema.orders', 'db.schema.users']",
+    )
+
+
+class TableColumns(BaseModel):
+    """Columns for a single table."""
+
+    table: str = Field(..., description="Full table name as requested")
+    columns: List[ColumnInfo] = Field(..., description="Column information")
+
+
+class GetTablesColumnsData(BaseModel):
+    """Batch table-columns result. Tables that fail to resolve are omitted."""
+
+    tables: List[TableColumns] = Field(..., description="Per-table columns")
+
+
 # ========== SemanticModel Models ==========
 
 

--- a/datus/api/routes/table_routes.py
+++ b/datus/api/routes/table_routes.py
@@ -11,6 +11,8 @@ from datus.api.models.base_models import Result
 from datus.api.models.table_models import (
     GetSemanticModelData,
     GetTableDetailData,
+    GetTablesColumnsData,
+    GetTablesColumnsInput,
     SemanticModelInput,
     ValidateSemanticModelData,
 )
@@ -36,6 +38,21 @@ async def get_table_detail(
 ) -> Result[GetTableDetailData]:
     """Get table detail."""
     return await asyncio.to_thread(svc.datasource.get_table_schema, table)
+
+
+@router.post(
+    "/table/columns",
+    response_model=Result[GetTablesColumnsData],
+    summary="Get Columns For Multiple Tables",
+    description="Batch-fetch column metadata for a list of tables (autocomplete prefetch). "
+    "Results are cached in memory; tables that fail to resolve are omitted.",
+)
+async def get_tables_columns(
+    request: GetTablesColumnsInput,
+    svc: ServiceDep,
+) -> Result[GetTablesColumnsData]:
+    """Batch table columns."""
+    return await asyncio.to_thread(svc.datasource.get_tables_columns, request.tables)
 
 
 # ========== SemanticModel Endpoints ==========

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -22,6 +22,7 @@ from datus.api.models.table_models import (
     GetTableDetailData,
     GetTablesColumnsData,
     SemanticModelInput,
+    TableColumnBrief,
     TableColumns,
     TableDetailData,
     ValidateSemanticModelData,
@@ -496,7 +497,11 @@ class DatasourceService:
         for full_path in tables:
             detail = self.get_table_schema(full_path)
             if detail.success and detail.data is not None:
-                results.append(TableColumns(table=full_path, columns=detail.data.table.columns))
+                columns = [
+                    TableColumnBrief(name=c.name, type=c.type, nullable=c.nullable, pk=c.pk)
+                    for c in detail.data.table.columns
+                ]
+                results.append(TableColumns(table=full_path, columns=columns))
         return Result(success=True, data=GetTablesColumnsData(tables=results))
 
     def _get_semantic_model(

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -4,6 +4,7 @@ Service for handling Database Management operations.
 
 import os
 import tempfile
+import threading
 from typing import List, Optional
 
 from datus_db_core import BaseSqlConnector
@@ -37,6 +38,9 @@ from datus.utils.time_utils import now_utc_iso
 logger = get_logger(__name__)
 # Database types that do NOT support schema switching
 _NO_SCHEMA_TYPES = {"sqlite", "duckdb", "mysql"}
+# Default cap on tables per /table/columns batch; override with
+# ``api.max_prefetch_tables`` in agent.yml.
+_DEFAULT_MAX_PREFETCH_TABLES = 500
 
 
 class DatasourceService:
@@ -59,7 +63,10 @@ class DatasourceService:
         self.current_db_name = None
         # In-memory column cache keyed by resolved table identity, so repeated
         # table/detail + autocomplete prefetch requests don't re-hit the source.
-        self._columns_cache: dict[str, List[ColumnInfo]] = {}
+        # The lock serializes the not-thread-safe connector across concurrent
+        # asyncio.to_thread detail/batch requests.
+        self._columns_cache: dict[str, list[ColumnInfo]] = {}
+        self._schema_lock = threading.Lock()
         self._initialize_connection()
 
     def _ensure_semantic_rag(self) -> SemanticModelRAG:
@@ -395,56 +402,63 @@ class DatasourceService:
                 table_name = name_parts["table_name"]
 
                 cache_key = f"{catalog_name}.{database_name}.{schema_name}.{table_name}"
-                cached = self._columns_cache.get(cache_key)
-                if cached is not None:
+
+                def _detail(cols: list[ColumnInfo]) -> Result[GetTableDetailData]:
                     return Result(
                         success=True,
-                        data=GetTableDetailData(table=TableDetailData(name=table_name, columns=cached, indexes=[])),
+                        data=GetTableDetailData(table=TableDetailData(name=table_name, columns=cols, indexes=[])),
                     )
 
-                schema_info = self.current_db_connector.get_schema(
-                    catalog_name=catalog_name,
-                    database_name=database_name,
-                    schema_name=schema_name,
-                    table_name=table_name,
-                )
-                if not schema_info:
-                    return Result(
-                        success=False,
-                        errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                        errorMessage=f"Table '{table_name}' not found or schema not available",
+                cached = self._columns_cache.get(cache_key)
+                if cached is not None:
+                    return _detail(cached)
+
+                # Serialize the not-thread-safe connector; re-check the cache
+                # inside the lock (double-checked) so each table is fetched once
+                # even under concurrent detail/batch requests.
+                with self._schema_lock:
+                    cached = self._columns_cache.get(cache_key)
+                    if cached is not None:
+                        return _detail(cached)
+
+                    schema_info = self.current_db_connector.get_schema(
+                        catalog_name=catalog_name,
+                        database_name=database_name,
+                        schema_name=schema_name,
+                        table_name=table_name,
                     )
+                    if not schema_info:
+                        return Result(
+                            success=False,
+                            errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                            errorMessage=f"Table '{table_name}' not found or schema not available",
+                        )
 
-                # Convert schema info to ColumnInfo objects
-                columns = []
-                if isinstance(schema_info, list):
-                    for _i, col in enumerate(schema_info):
-                        if isinstance(col, dict):
-                            column_info = ColumnInfo(
-                                name=col.get("name", ""),
-                                type=col.get("type", ""),
-                                nullable=col.get("notnull", 1) == 0,  # SQLite style: notnull=0 means nullable
-                                default_value=col.get("dflt_value"),
-                                pk=col.get("pk", 0) == 1,
-                            )
-                        else:
-                            # Handle string or other formats
-                            column_info = ColumnInfo(
-                                name=str(col),
-                                type="TEXT",
-                                nullable=True,
-                                default_value=None,
-                                pk=False,
-                            )
-                        columns.append(column_info)
-                else:
-                    # Handle other schema formats
-                    columns = []
+                    # Convert schema info to ColumnInfo objects
+                    columns: list[ColumnInfo] = []
+                    if isinstance(schema_info, list):
+                        for _i, col in enumerate(schema_info):
+                            if isinstance(col, dict):
+                                column_info = ColumnInfo(
+                                    name=col.get("name", ""),
+                                    type=col.get("type", ""),
+                                    nullable=col.get("notnull", 1) == 0,  # SQLite style: notnull=0 means nullable
+                                    default_value=col.get("dflt_value"),
+                                    pk=col.get("pk", 0) == 1,
+                                )
+                            else:
+                                # Handle string or other formats
+                                column_info = ColumnInfo(
+                                    name=str(col),
+                                    type="TEXT",
+                                    nullable=True,
+                                    default_value=None,
+                                    pk=False,
+                                )
+                            columns.append(column_info)
 
-                self._columns_cache[cache_key] = columns
-                data = GetTableDetailData(table=TableDetailData(name=table_name, columns=columns, indexes=[]))
-
-                return Result(success=True, data=data)
+                    self._columns_cache[cache_key] = columns
+                    return _detail(columns)
 
             except Exception as e:
                 return Result(
@@ -461,13 +475,24 @@ class DatasourceService:
                 errorMessage=str(e),
             )
 
-    def get_tables_columns(self, tables: List[str]) -> Result[GetTablesColumnsData]:
+    def get_tables_columns(self, tables: list[str]) -> Result[GetTablesColumnsData]:
         """Batch-fetch columns for multiple tables (autocomplete prefetch).
 
         Reuses get_table_schema (and its column cache) per table. Tables that
-        fail to resolve are omitted rather than failing the whole batch.
+        fail to resolve are omitted rather than failing the whole batch. The
+        request is capped at ``api.max_prefetch_tables`` (agent.yml) to bound
+        per-request datasource work.
         """
-        results: List[TableColumns] = []
+        api_config = getattr(self.agent_config, "api_config", {}) or {}
+        max_tables = int(api_config.get("max_prefetch_tables", _DEFAULT_MAX_PREFETCH_TABLES))
+        if len(tables) > max_tables:
+            return Result(
+                success=False,
+                errorCode=ErrorCode.INVALID_PARAMETERS,
+                errorMessage=f"Too many tables requested ({len(tables)}); max is {max_tables}",
+            )
+
+        results: list[TableColumns] = []
         for full_path in tables:
             detail = self.get_table_schema(full_path)
             if detail.success and detail.data is not None:

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -19,7 +19,9 @@ from datus.api.models.table_models import (
     ColumnInfo,
     GetSemanticModelData,
     GetTableDetailData,
+    GetTablesColumnsData,
     SemanticModelInput,
+    TableColumns,
     TableDetailData,
     ValidateSemanticModelData,
 )
@@ -55,6 +57,9 @@ class DatasourceService:
 
         self.current_db_connector = None
         self.current_db_name = None
+        # In-memory column cache keyed by resolved table identity, so repeated
+        # table/detail + autocomplete prefetch requests don't re-hit the source.
+        self._columns_cache: dict[str, List[ColumnInfo]] = {}
         self._initialize_connection()
 
     def _ensure_semantic_rag(self) -> SemanticModelRAG:
@@ -389,6 +394,14 @@ class DatasourceService:
                 schema_name = name_parts["schema_name"] or getattr(self.current_db_connector, "schema_name", "")
                 table_name = name_parts["table_name"]
 
+                cache_key = f"{catalog_name}.{database_name}.{schema_name}.{table_name}"
+                cached = self._columns_cache.get(cache_key)
+                if cached is not None:
+                    return Result(
+                        success=True,
+                        data=GetTableDetailData(table=TableDetailData(name=table_name, columns=cached, indexes=[])),
+                    )
+
                 schema_info = self.current_db_connector.get_schema(
                     catalog_name=catalog_name,
                     database_name=database_name,
@@ -428,6 +441,7 @@ class DatasourceService:
                     # Handle other schema formats
                     columns = []
 
+                self._columns_cache[cache_key] = columns
                 data = GetTableDetailData(table=TableDetailData(name=table_name, columns=columns, indexes=[]))
 
                 return Result(success=True, data=data)
@@ -446,6 +460,19 @@ class DatasourceService:
                 errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
                 errorMessage=str(e),
             )
+
+    def get_tables_columns(self, tables: List[str]) -> Result[GetTablesColumnsData]:
+        """Batch-fetch columns for multiple tables (autocomplete prefetch).
+
+        Reuses get_table_schema (and its column cache) per table. Tables that
+        fail to resolve are omitted rather than failing the whole batch.
+        """
+        results: List[TableColumns] = []
+        for full_path in tables:
+            detail = self.get_table_schema(full_path)
+            if detail.success and detail.data is not None:
+                results.append(TableColumns(table=full_path, columns=detail.data.table.columns))
+        return Result(success=True, data=GetTablesColumnsData(tables=results))
 
     def _get_semantic_model(
         self,

--- a/tests/unit_tests/api/routes/test_table_routes.py
+++ b/tests/unit_tests/api/routes/test_table_routes.py
@@ -1,0 +1,47 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for datus/api/routes/table_routes.py — table endpoints."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.api.models.base_models import Result
+from datus.api.models.table_models import (
+    ColumnInfo,
+    GetTablesColumnsData,
+    GetTablesColumnsInput,
+    TableColumns,
+)
+from datus.api.routes.table_routes import get_table_detail, get_tables_columns
+
+
+class TestGetTableDetail:
+    @pytest.mark.asyncio
+    async def test_delegates_to_service(self):
+        svc = MagicMock()
+        svc.datasource.get_table_schema.return_value = Result(success=True)
+
+        result = await get_table_detail(svc, table="db.public.orders")
+
+        assert result.success is True
+        svc.datasource.get_table_schema.assert_called_once_with("db.public.orders")
+
+
+class TestGetTablesColumns:
+    @pytest.mark.asyncio
+    async def test_delegates_to_service_with_tables(self):
+        svc = MagicMock()
+        data = GetTablesColumnsData(
+            tables=[TableColumns(table="db.public.orders", columns=[ColumnInfo(name="id", type="INT", nullable=False)])]
+        )
+        svc.datasource.get_tables_columns.return_value = Result(success=True, data=data)
+
+        request = GetTablesColumnsInput(tables=["db.public.orders", "db.public.users"])
+        result = await get_tables_columns(request, svc)
+
+        assert result.success is True
+        assert [t.table for t in result.data.tables] == ["db.public.orders"]
+        svc.datasource.get_tables_columns.assert_called_once_with(["db.public.orders", "db.public.users"])

--- a/tests/unit_tests/api/routes/test_table_routes.py
+++ b/tests/unit_tests/api/routes/test_table_routes.py
@@ -10,9 +10,9 @@ import pytest
 
 from datus.api.models.base_models import Result
 from datus.api.models.table_models import (
-    ColumnInfo,
     GetTablesColumnsData,
     GetTablesColumnsInput,
+    TableColumnBrief,
     TableColumns,
 )
 from datus.api.routes.table_routes import get_table_detail, get_tables_columns
@@ -35,7 +35,12 @@ class TestGetTablesColumns:
     async def test_delegates_to_service_with_tables(self):
         svc = MagicMock()
         data = GetTablesColumnsData(
-            tables=[TableColumns(table="db.public.orders", columns=[ColumnInfo(name="id", type="INT", nullable=False)])]
+            tables=[
+                TableColumns(
+                    table="db.public.orders",
+                    columns=[TableColumnBrief(name="id", type="INT", nullable=False)],
+                )
+            ]
         )
         svc.datasource.get_tables_columns.return_value = Result(success=True, data=data)
 

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -472,3 +472,53 @@ class TestGetTableSchema:
         svc = DatasourceService(agent_config=real_agent_config)
         result = svc.get_table_schema("totally_fake_table_xyz")
         assert result.success is False
+
+    def test_get_table_schema_caches_columns(self, real_agent_config):
+        """Second lookup is served from cache without re-hitting the connector."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        spy = MagicMock(wraps=svc.current_db_connector.get_schema)
+        svc.current_db_connector.get_schema = spy
+
+        first = svc.get_table_schema("schools")
+        second = svc.get_table_schema("schools")
+
+        assert first.success is True and second.success is True
+        assert [c.name for c in second.data.table.columns] == [c.name for c in first.data.table.columns]
+        assert spy.call_count == 1
+
+
+class TestGetTablesColumns:
+    """Tests for the batch get_tables_columns (autocomplete prefetch)."""
+
+    def test_returns_columns_for_known_tables(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        result = svc.get_tables_columns(["schools"])
+        assert result.success is True
+        assert [t.table for t in result.data.tables] == ["schools"]
+        assert result.data.tables[0].columns[0].name != ""
+
+    def test_omits_unresolved_tables(self, real_agent_config):
+        """A bad name is skipped rather than failing the whole batch."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        result = svc.get_tables_columns(["schools", "totally_fake_table_xyz"])
+        assert result.success is True
+        assert [t.table for t in result.data.tables] == ["schools"]
+
+    def test_populates_shared_cache(self, real_agent_config):
+        """Columns fetched by the batch are reused by a later single-table detail."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        spy = MagicMock(wraps=svc.current_db_connector.get_schema)
+        svc.current_db_connector.get_schema = spy
+
+        svc.get_tables_columns(["schools"])
+        detail = svc.get_table_schema("schools")
+
+        assert detail.success is True
+        assert spy.call_count == 1
+
+    def test_over_limit_returns_validation_error(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.agent_config.api_config = {"max_prefetch_tables": 1}
+        result = svc.get_tables_columns(["schools", "frpm"])
+        assert result.success is False
+        assert result.errorCode == "INVALID_PARAMETERS"

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -495,7 +495,10 @@ class TestGetTablesColumns:
         result = svc.get_tables_columns(["schools"])
         assert result.success is True
         assert [t.table for t in result.data.tables] == ["schools"]
-        assert result.data.tables[0].columns[0].name != ""
+        col = result.data.tables[0].columns[0]
+        assert col.name != "" and col.type != ""
+        # Slim shape: no default_value in the prefetch payload.
+        assert not hasattr(col, "default_value")
 
     def test_omits_unresolved_tables(self, real_agent_config):
         """A bad name is skipped rather than failing the whole batch."""


### PR DESCRIPTION
## What

Support the SQL editor's autocomplete **column prefetch** (Datus-saas PR #664) with a batch endpoint and an in-memory column cache.

### `POST /api/v1/table/columns`
Fetch column metadata for a list of tables in one round-trip:
```json
{ "tables": ["db.schema.orders", "db.schema.users"] }
```
Returns per-table columns; tables that fail to resolve are **omitted** (a bad name never fails the whole batch). Reuses the existing per-table `get_table_schema`, so column shape is identical to `GET /api/v1/table/detail`.

### In-memory column cache
`DatasourceService` now caches columns keyed by resolved table identity (`catalog.database.schema.table`). **Both** `/table/detail` and `/table/columns` read/write this cache, so repeated detail lookups and the prefetch batch no longer re-hit the datasource. (`get_table_schema` already always returned empty `indexes`/null `rows`, so caching just the columns is lossless.)

## Why
The saas editor prefetches every catalog table's columns on project entry so field completion is instant. Without batching that is N HTTP calls; without caching it re-describes tables on every session/edit. This endpoint + cache make prefetch cheap and idempotent.

## Notes
- Cache lifetime = the datasource service instance; no invalidation (schema drift persists until the process/service is recycled) — acceptable for autocomplete metadata, matching the client-side cache.
- Single connector is not concurrency-safe, so the batch resolves tables sequentially in a worker thread (`asyncio.to_thread`).

## Test plan
- [x] `ruff format` + `ruff check` clean
- [x] `py_compile` + pydantic model round-trip for the new models
- [ ] Manual: `POST /api/v1/table/columns` with a mix of valid/invalid table names → valid ones returned with columns, invalid omitted; second call served from cache

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve column metadata for multiple tables in a single request.
  * Supports autocomplete prefetching for fully qualified table names.
  * Tables with unavailable schema information are omitted from successful results.
  * Repeated column lookups are served faster through in-memory caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/v1/table/columns` to fetch column metadata for multiple fully-qualified tables in one request.
  * Supports autocomplete-style prefetch and omits tables whose schema can’t be resolved.
* **Performance Improvements**
  * Added in-memory caching for resolved table column details to speed up repeat requests.
  * Added a configurable per-request limit for the maximum number of tables that can be prefetched.
* **Tests**
  * Expanded unit tests for the new route and for batch behavior, caching reuse, and limit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->