### PR TITLE
[BugFix] list catalogs for in-memory DuckDB (incl. attached iceberg)

### DIFF
--- a/datus/tools/db_tools/duckdb_connector.py
+++ b/datus/tools/db_tools/duckdb_connector.py
@@ -97,6 +97,12 @@ class DuckdbConnector(BaseSqlConnector, SchemaNamespaceMixin, MigrationTargetMix
         # ``SQLiteConnector.__init__`` for the full rationale.
         if config.database_name:
             self._default_database = config.database_name
+        elif self.db_path == ":memory:":
+            # In-memory DuckDB has no file stem, and DuckDB names the database
+            # ``memory`` (not ``:memory:``). Leave the default empty so metadata
+            # listing falls back to enumerating every attached database — the
+            # ``memory`` db plus any ATTACHed iceberg REST catalog (e.g. ``lake``).
+            self._default_database = ""
         else:
             from datus.configuration.agent_config import file_stem_from_uri
 

--- a/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
+++ b/tests/unit_tests/tools/db_tools/test_duckdb_connector.py
@@ -55,6 +55,24 @@ def test_database_name_visible_across_threads(tmp_path):
         connector.close()
 
 
+def test_in_memory_default_database_is_empty():
+    """In-memory DuckDB must not derive a bogus ``:memory:`` database name.
+
+    ``file_stem_from_uri(":memory:")`` yields ``":memory:"`` (no file stem to
+    strip), but DuckDB names the in-memory database ``memory``. Pinning the
+    connector to ``":memory:"`` made every metadata query filter on a name that
+    matches no database, so ``catalog/list`` returned an empty list. Leaving the
+    default empty lets listing fall back to enumerating all attached databases.
+    """
+    connector = DuckdbConnector(DuckDBConfig(db_path=":memory:"))
+    try:
+        assert connector.database_name == ""
+        # get_databases() must surface the real in-memory database name.
+        assert "memory" in connector.get_databases()
+    finally:
+        connector.close()
+
+
 def test_coexist_with_sqlalchemy_duckdb_engine(db_path):
     """Regression: a second connection via SQLAlchemy+duckdb_engine on the same
     file in the same process must succeed. Pre-fix, DuckDB rejected it with


### PR DESCRIPTION
## Problem

For the `airflow_etl_pipeline` demo project, `GET /api/v1/catalog/list` returned an empty list:

```json
{"success":true,"data":{"databases":[]},"errorCode":null,"errorMessage":null}
```

The project's datasource is an in-memory DuckDB (`uri: duckdb:///:memory:`) used as a query engine over an attached Iceberg REST catalog (`lake`).

## Root cause

`DuckdbConnector.__init__` derives its default database name from the URI via `file_stem_from_uri(":memory:")`. Since `":memory:"` has no `.` extension, `os.path.splitext` returns it unchanged → the connector's `database_name` becomes `":memory:"`.

But DuckDB names the in-memory database **`memory`**, not `:memory:`. In `DatabaseService._get_connection_info`, a non-empty `connector.database_name` pins the listing to `db_names = [":memory:"]` (never calling `get_databases()`), and the subsequent `get_schemas(database_name=":memory:")` filters on a name that matches no database → empty schemas → empty result.

Verified against real duckdb:

```
duckdb_databases()                    -> memory / system / temp
duckdb_schemas() WHERE db=':memory:'  -> []      (empty)
duckdb_schemas() WHERE db='memory'    -> main
```

## Fix

Treat in-memory DuckDB as having no default database, so `_get_connection_info` falls back to `get_databases()` and enumerates every attached database — the `memory` db plus any `ATTACH`ed Iceberg REST catalog (the demo's `lake`).

## Tests

- New regression test `test_in_memory_default_database_is_empty`.
- `test_duckdb_connector.py` (20), `test_connector_duckdb.py` (8), `test_database_service.py` (40) all green.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of in-memory DuckDB connections.
  * Database metadata now correctly identifies the active in-memory database and any attached catalogs.
  * Prevented incorrect naming of the default database for in-memory connections.

* **Tests**
  * Added coverage to verify in-memory database naming and metadata discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->