### PR TITLE
[Feature] Support managed multi-tenant plugin runtime config

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2578,7 +2578,7 @@ class AgenticNode(Node):
         if not isinstance(allowed_patterns, list) or not allowed_patterns:
             allowed_patterns = ["*"]
         try:
-            from datus.tools.func_tool.bash_tool import BashTool
+            from datus.tools.func_tool.bash_tool import BashExecutionContext, BashTool
 
             # Datus home stays readable inside the sandbox: skills, templates
             # and plugins live there and are read/executed via bash.
@@ -2589,6 +2589,22 @@ class AgenticNode(Node):
                 sandbox_read_dirs.append(str(get_path_manager(agent_config=self.agent_config).datus_home))
             except Exception as exc:
                 logger.debug("Failed to resolve datus home for sandbox read dirs: %s", exc)
+
+            execution_context_provider = None
+            if not getattr(self.agent_config, "config_mutable", True):
+                from datus.plugins.runtime_context import prepare_plugin_invocation
+
+                def _managed_plugin_context(command: str):
+                    prepared = prepare_plugin_invocation(command, self.agent_config)
+                    if prepared is None:
+                        return None
+                    return BashExecutionContext(
+                        command=prepared.command,
+                        env=prepared.env,
+                        sandbox_read_dirs=prepared.sandbox_read_dirs,
+                    )
+
+                execution_context_provider = _managed_plugin_context
 
             self.bash_tool = BashTool(
                 workspace_root=self._resolve_workspace_root(),
@@ -2603,6 +2619,7 @@ class AgenticNode(Node):
                 # the AgentConfig object and this tool sees it next call.
                 sandbox_settings=getattr(self.agent_config, "bash_sandbox", None),
                 sandbox_read_dirs=sandbox_read_dirs,
+                execution_context_provider=execution_context_provider,
             )
             logger.debug(f"Setup bash tool with workspace: {self.bash_tool.workspace_root}")
         except Exception as e:

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2296,6 +2296,7 @@ class AgenticNode(Node):
                 config=skills_config,
                 permission_manager=self.permission_manager,
                 config_mutable=self._resolve_config_mutable(),
+                agent_config=self.agent_config,
             )
             logger.debug(
                 f"Skill manager initialized for node '{self.get_node_name()}' "
@@ -2342,6 +2343,7 @@ class AgenticNode(Node):
                 self.skill_manager = SkillManager(
                     permission_manager=self.permission_manager,
                     config_mutable=self._resolve_config_mutable(),
+                    agent_config=self.agent_config,
                 )
                 logger.info(
                     f"Created default SkillManager for node '{self.get_node_name()}' "
@@ -2398,6 +2400,7 @@ class AgenticNode(Node):
             self.skill_manager = SkillManager(
                 permission_manager=self.permission_manager,
                 config_mutable=self._resolve_config_mutable(),
+                agent_config=self.agent_config,
             )
 
         from xml.sax.saxutils import quoteattr as xml_quoteattr

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -240,6 +240,7 @@ class ChatAgenticNode(AgenticNode):
                 config=skills_config,
                 permission_manager=self.permission_manager,
                 config_mutable=self._resolve_config_mutable(),
+                agent_config=self.agent_config,
             )
             self.skill_func_tool = SkillFuncTool(
                 manager=self.skill_manager,

--- a/datus/agent/node/deliverable_node.py
+++ b/datus/agent/node/deliverable_node.py
@@ -220,10 +220,9 @@ class DeliverableAgenticNode(AgenticNode):
             if registry is None:
                 # Create a default registry so the hook can still dispatch
                 # validators declared in the standard skill directories.
-                from datus.tools.skill_tools.skill_config import SkillConfig
                 from datus.tools.skill_tools.skill_registry import SkillRegistry
 
-                registry = SkillRegistry(config=SkillConfig())
+                registry = SkillRegistry(agent_config=self.agent_config)
             validation_cfg = getattr(self.agent_config, "validation_config", None)
             enabled = bool(getattr(validation_cfg, "skill_validators_enabled", True)) if validation_cfg else True
 

--- a/datus/agent/node/gen_skill_agentic_node.py
+++ b/datus/agent/node/gen_skill_agentic_node.py
@@ -167,6 +167,7 @@ class SkillCreatorAgenticNode(AgenticNode):
             skill_manager = SkillManager(
                 permission_manager=self.permission_manager,
                 config_mutable=self._resolve_config_mutable(),
+                agent_config=self.agent_config,
             )
             self.skill_func_tool_instance = SkillFuncTool(
                 manager=skill_manager,

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -636,33 +636,9 @@ def _split_plugin_globals(args: "list[str]") -> "tuple[str | None, str | None, l
     (``bash_rules._normalize_datus_plugin_argv``) so plugin-declared rules
     match profile-qualified invocations — keep the two in sync.
     """
-    profile: "str | None" = None
-    config: "str | None" = None
-    i = 0
-    n = len(args)
-    while i < n:
-        tok = args[i]
-        if tok in ("--profile", "--config"):
-            if i + 1 >= n:
-                # Missing value — hand the token back to the plugin unchanged.
-                break
-            value = args[i + 1]
-            if tok == "--profile":
-                profile = value
-            else:
-                config = value
-            i += 2
-            continue
-        if tok.startswith("--profile="):
-            profile = tok.split("=", 1)[1]
-            i += 1
-            continue
-        if tok.startswith("--config="):
-            config = tok.split("=", 1)[1]
-            i += 1
-            continue
-        break
-    return profile, config, args[i:]
+    from datus.plugins.runtime_context import split_plugin_globals
+
+    return split_plugin_globals(args)
 
 
 def _dispatch_plugin_command(argv: "list[str]") -> "int | None":
@@ -694,6 +670,19 @@ def _dispatch_plugin_command(argv: "list[str]") -> "int | None":
     err_console = Console(stderr=True)
 
     profile_name, config_path, rest = _split_plugin_globals(argv[1:])
+    runtime_context = None
+    try:
+        from datus.plugins.runtime_context import has_plugin_config_global, load_runtime_context_from_env
+
+        runtime_context = load_runtime_context_from_env(expected_plugin=name)
+        if runtime_context is not None and has_plugin_config_global(argv[1:]):
+            raise ValueError(
+                "`--config` is unavailable for managed plugin commands; the AuthProvider AgentConfig is authoritative"
+            )
+    except Exception as exc:  # noqa: BLE001 - malformed runtime data must fail closed
+        logger.error("Failed to decode runtime config for plugin '%s': %s", name, exc)
+        print_error(err_console, f"datus {name}: {exc}")
+        return 3
 
     # A managed plugin lives in its own ``~/.datus/plugins/{name}/`` directory;
     # append it to ``sys.path`` so the entry-point probe can see it. Plugins
@@ -703,7 +692,12 @@ def _dispatch_plugin_command(argv: "list[str]") -> "int | None":
     # manifest never executes plugin code, and the ``cli`` ref is imported only
     # after every gate below has passed), so the ``plugins_enabled`` master
     # switch is still honoured before any third-party module-level code runs.
-    if store.plugin_dir(name).is_dir():
+    if runtime_context is not None and runtime_context.plugin_path:
+        store.activate_paths([runtime_context.plugin_path])
+    elif runtime_context is not None:
+        # A site-packages plugin is already visible to this interpreter.
+        pass
+    elif store.plugin_dir(name).is_dir():
         store.activate_name(name)
     else:
         from datus.configuration.agent_config_loader import get_plugin_paths
@@ -714,28 +708,32 @@ def _dispatch_plugin_command(argv: "list[str]") -> "int | None":
     # must not even be imported, so the master switch is checked before
     # ``resolve_code_ref`` runs the plugin's module-level code.
     if not plugin_entry_point_exists(name):
+        if runtime_context is not None:
+            print_error(err_console, f"datus {name}: runtime plugin `{name}` is not installed or discoverable")
+            return 3
         return None
 
     try:
-        from datus.configuration.agent_config_loader import load_agent_config
+        if runtime_context is not None:
+            profile = runtime_context.profile
+        else:
+            from datus.configuration.agent_config_loader import load_agent_config
 
-        kwargs = {"config": config_path} if config_path else {}
-        agent_config = load_agent_config(**kwargs)
-        if not getattr(agent_config, "plugins_enabled", True):
-            print_error(err_console, f"datus {name}: plugins are disabled (`agent.plugins_enabled: false`)")
-            return 3
-        # Respect per-project activation: a plugin the project's ``plugins:``
-        # whitelist does not enable is inactive, so its own CLI is refused (the
-        # ``datus plugin ...`` management commands remain available to re-enable
-        # it).
-        if hasattr(agent_config, "plugin_active") and not agent_config.plugin_active(name):
-            print_error(
-                err_console,
-                f"datus {name}: plugin `{name}` is not active for this project. "
-                f"Enable it with `datus plugin enable {name}` or via `/plugins`.",
-            )
-            return 3
-        profile = agent_config.get_plugin_profile(name, profile_name)
+            kwargs = {"config": config_path} if config_path else {}
+            agent_config = load_agent_config(**kwargs)
+            if not getattr(agent_config, "plugins_enabled", True):
+                print_error(err_console, f"datus {name}: plugins are disabled (`agent.plugins_enabled: false`)")
+                return 3
+            # Respect per-project activation: a plugin the project's
+            # ``plugins:`` whitelist does not enable is inactive.
+            if hasattr(agent_config, "plugin_active") and not agent_config.plugin_active(name):
+                print_error(
+                    err_console,
+                    f"datus {name}: plugin `{name}` is not active for this project. "
+                    f"Enable it with `datus plugin enable {name}` or via `/plugins`.",
+                )
+                return 3
+            profile = agent_config.get_plugin_profile(name, profile_name)
     except Exception as exc:  # noqa: BLE001 - surface a clean error, do not crash
         logger.error("Failed to resolve config for plugin '%s': %s", name, exc)
         print_error(err_console, f"datus {name}: {exc}")
@@ -743,6 +741,9 @@ def _dispatch_plugin_command(argv: "list[str]") -> "int | None":
 
     manifest = load_plugin_manifest(name)
     if manifest is None:
+        if runtime_context is not None:
+            print_error(err_console, f"datus {name}: runtime plugin `{name}` has no valid manifest")
+            return 3
         # Entry point exists but the manifest is missing/rejected (already
         # warned about); fall through so a same-named ``datus.cli_commands``
         # handler still gets its chance.

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -982,6 +982,22 @@ class AgentConfig:
             if isinstance(raw_plugin_paths, list)
             else []
         )
+        # Make managed-store and ``agent.plugin_paths`` plugins discoverable
+        # before permissions and skills are initialized below. This must happen
+        # inside AgentConfig construction rather than only in
+        # ``load_agent_config``: multi-tenant AuthProviders construct
+        # request-scoped AgentConfig instances directly and may have no local
+        # configuration file at all.
+        try:
+            from datus.plugins import store
+
+            store.activate(
+                self.active_plugin_names(),
+                plugins_enabled=self.plugins_enabled,
+                extra_paths=self.plugin_paths,
+            )
+        except Exception as e:  # noqa: BLE001 - a bad plugin dir must never block config construction
+            logger.debug("plugin sys.path activation failed: %s", e)
         # Plugin config: plugin name -> profile name -> profile config dict.
         # Populated from ``agent.plugins`` by ``init_plugin_services``.
         self.plugin_services: Dict[str, Dict[str, Dict[str, Any]]] = {}
@@ -1456,7 +1472,7 @@ class AgentConfig:
         try:
             from datus.tools.skill_tools.skill_config import SkillConfig
 
-            return SkillConfig.from_dict(skills_raw)
+            return SkillConfig.from_dict(skills_raw, agent_config=self)
         except Exception as e:
             logger.warning(f"Failed to initialize skills config: {e}")
             return None

--- a/datus/configuration/agent_config_loader.py
+++ b/datus/configuration/agent_config_loader.py
@@ -521,22 +521,6 @@ def load_agent_config(reload: bool = False, create_if_missing: bool = False, **k
     except Exception as e:
         logger.warning(f"Failed to initialize tracing: {e}")
 
-    # Append this project's enabled plugin directories (~/.datus/plugins/<name>/
-    # unioned with ``agent.plugin_paths`` mounts) to sys.path so their
-    # ``datus.plugins`` entry points are discovered before skills / prompt
-    # sections / permissions / tool transformers are collected.
-    # Path-only injection — the plugin package is imported lazily on use.
-    try:
-        from datus.plugins import store
-
-        store.activate(
-            agent_config.active_plugin_names(),
-            plugins_enabled=getattr(agent_config, "plugins_enabled", True),
-            extra_paths=getattr(agent_config, "plugin_paths", None),
-        )
-    except Exception as e:  # noqa: BLE001 - a bad plugin dir must never block config load
-        logger.debug("plugin sys.path activation failed: %s", e)
-
     return agent_config
 
 

--- a/datus/plugins/runtime_context.py
+++ b/datus/plugins/runtime_context.py
@@ -1,0 +1,366 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Request-scoped runtime context for managed plugin CLI subprocesses.
+
+In a multi-tenant API deployment the authoritative :class:`AgentConfig` may
+exist only in the parent process (it is supplied by an AuthProvider), while a
+``datus <plugin>`` command runs in a fresh subprocess.  This module carries the
+minimum invocation-specific configuration across that process boundary without
+requiring an on-disk ``agent.yml``.
+
+The context is intentionally passed through one command-scoped environment
+variable.  It contains only the invoked plugin's resolved profile and, when
+needed, the exact plugin directory selected by the normal managed-store /
+``agent.plugin_paths`` precedence.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import shlex
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from datus.tools.permission.bash_rules import split_pipeline
+
+RUNTIME_CONTEXT_ENV = "DATUS_PLUGIN_RUNTIME_CONTEXT"
+RUNTIME_CONTEXT_VERSION = 1
+RUNTIME_CONTEXT_PREFIX = "v1."
+MAX_RUNTIME_CONTEXT_SIZE = 64 * 1024
+_DATUS_COMMAND_WORD_RE = re.compile(r"(?<![A-Za-z0-9_.-])datus(?![A-Za-z0-9_.-])")
+
+
+class PluginRuntimeContextError(ValueError):
+    """Safe, user-facing failure while preparing or decoding runtime context."""
+
+
+@dataclass(frozen=True)
+class PluginRuntimeContext:
+    """Configuration consumed by one ``datus <plugin>`` subprocess."""
+
+    plugin_name: str
+    profile: Dict[str, Any]
+    plugin_path: Optional[str] = None
+    version: int = RUNTIME_CONTEXT_VERSION
+
+    def encode(self) -> str:
+        """Return the versioned, ASCII-only environment value."""
+        try:
+            raw = json.dumps(
+                {
+                    "version": self.version,
+                    "plugin_name": self.plugin_name,
+                    "profile": self.profile,
+                    "plugin_path": self.plugin_path,
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError) as exc:
+            raise PluginRuntimeContextError(
+                f"Plugin profile for `{self.plugin_name}` is not JSON-serializable"
+            ) from exc
+        encoded = RUNTIME_CONTEXT_PREFIX + base64.urlsafe_b64encode(raw).decode("ascii")
+        if len(encoded.encode("ascii")) > MAX_RUNTIME_CONTEXT_SIZE:
+            raise PluginRuntimeContextError(
+                f"Plugin runtime context for `{self.plugin_name}` exceeds {MAX_RUNTIME_CONTEXT_SIZE // 1024} KiB"
+            )
+        return encoded
+
+    @classmethod
+    def decode(cls, value: str, *, expected_plugin: Optional[str] = None) -> "PluginRuntimeContext":
+        """Validate and decode an environment value without logging its contents."""
+        if not isinstance(value, str) or not value.startswith(RUNTIME_CONTEXT_PREFIX):
+            raise PluginRuntimeContextError("Unsupported plugin runtime context version")
+        if len(value.encode("utf-8", errors="ignore")) > MAX_RUNTIME_CONTEXT_SIZE:
+            raise PluginRuntimeContextError(f"Plugin runtime context exceeds {MAX_RUNTIME_CONTEXT_SIZE // 1024} KiB")
+        encoded = value[len(RUNTIME_CONTEXT_PREFIX) :]
+        try:
+            raw = base64.b64decode(encoded, altchars=b"-_", validate=True)
+            data = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PluginRuntimeContextError("Malformed plugin runtime context") from exc
+        if not isinstance(data, dict):
+            raise PluginRuntimeContextError("Malformed plugin runtime context")
+        if data.get("version") != RUNTIME_CONTEXT_VERSION:
+            raise PluginRuntimeContextError("Unsupported plugin runtime context version")
+        plugin_name = data.get("plugin_name")
+        profile = data.get("profile")
+        plugin_path = data.get("plugin_path")
+        if not isinstance(plugin_name, str) or not plugin_name:
+            raise PluginRuntimeContextError("Plugin runtime context has no valid plugin name")
+        if expected_plugin is not None and plugin_name != expected_plugin:
+            raise PluginRuntimeContextError(f"Plugin runtime context is for `{plugin_name}`, not `{expected_plugin}`")
+        if not isinstance(profile, dict):
+            raise PluginRuntimeContextError("Plugin runtime context profile must be an object")
+        if plugin_path is not None and (not isinstance(plugin_path, str) or not plugin_path.strip()):
+            raise PluginRuntimeContextError("Plugin runtime context path must be a non-empty string")
+        return cls(
+            plugin_name=plugin_name,
+            profile=profile,
+            plugin_path=plugin_path,
+            version=RUNTIME_CONTEXT_VERSION,
+        )
+
+
+@dataclass(frozen=True)
+class PreparedPluginInvocation:
+    """Bash execution overrides for one managed plugin invocation."""
+
+    command: str
+    env: Dict[str, str]
+    sandbox_read_dirs: List[str]
+
+
+def split_plugin_globals(args: List[str]) -> Tuple[Optional[str], Optional[str], List[str]]:
+    """Consume leading ``--profile`` / ``--config`` options for a plugin."""
+    profile: Optional[str] = None
+    config: Optional[str] = None
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token in ("--profile", "--config"):
+            if i + 1 >= len(args):
+                break
+            if token == "--profile":
+                profile = args[i + 1]
+            else:
+                config = args[i + 1]
+            i += 2
+            continue
+        if token.startswith("--profile="):
+            profile = token.split("=", 1)[1]
+            i += 1
+            continue
+        if token.startswith("--config="):
+            config = token.split("=", 1)[1]
+            i += 1
+            continue
+        break
+    return profile, config, args[i:]
+
+
+def has_plugin_config_global(args: List[str]) -> bool:
+    """Return whether leading plugin globals contain any ``--config`` form.
+
+    Unlike :func:`split_plugin_globals`, this also recognizes a trailing
+    ``--config`` with no value. Local CLI dispatch preserves that malformed
+    token for backwards compatibility, but managed dispatch must reject every
+    attempt to select a file-backed config.
+    """
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token == "--config" or token.startswith("--config="):
+            return True
+        if token == "--profile":
+            if i + 1 >= len(args):
+                return False
+            i += 2
+            continue
+        if token.startswith("--profile="):
+            i += 1
+            continue
+        return False
+    return False
+
+
+def load_runtime_context_from_env(*, expected_plugin: Optional[str] = None) -> Optional[PluginRuntimeContext]:
+    """Return the runtime context from this process, or ``None`` when absent."""
+    value = os.environ.get(RUNTIME_CONTEXT_ENV)
+    if value is None:
+        return None
+    return PluginRuntimeContext.decode(value, expected_plugin=expected_plugin)
+
+
+def prepare_plugin_invocation(command: str, agent_config: Any) -> Optional[PreparedPluginInvocation]:
+    """Prepare a managed ``datus <plugin>`` command or pure pipeline.
+
+    Returns ``None`` for commands with no plugin CLI segment.  Commands that
+    contain a plugin invocation but cannot be bridged safely fail closed rather
+    than falling back to a local config file.
+    """
+    segments = split_pipeline(command)
+    if segments is None or _has_unsupported_shell_controls(command):
+        if _contains_datus_command(command):
+            raise PluginRuntimeContextError(
+                "Managed plugin commands support a single command or a pure `|` pipeline only"
+            )
+        return None
+
+    plugin_segments: List[Tuple[int, List[str]]] = []
+    for index, segment in enumerate(segments):
+        try:
+            argv = shlex.split(segment)
+        except ValueError as exc:
+            if "datus" in segment:
+                raise PluginRuntimeContextError(f"Invalid managed plugin command syntax: {exc}") from exc
+            return None
+        if argv and Path(argv[0]).name == "datus":
+            plugin_segments.append((index, argv))
+        elif any(Path(token).name == "datus" for token in argv):
+            raise PluginRuntimeContextError(
+                "Managed plugin commands must invoke `datus` directly at the start of a pipeline segment"
+            )
+
+    if not plugin_segments:
+        return None
+    if len(plugin_segments) != 1:
+        raise PluginRuntimeContextError("A managed Bash command may invoke only one plugin CLI")
+
+    segment_index, argv = plugin_segments[0]
+    if len(argv) < 2 or argv[1].startswith("-"):
+        return None
+    plugin_name = argv[1]
+
+    from datus.plugins import store
+
+    if plugin_name in store.RESERVED_PLUGIN_NAMES:
+        return None
+    if not store.is_valid_name(plugin_name):
+        raise PluginRuntimeContextError(f"Invalid plugin name `{plugin_name}`")
+
+    plugin_args = argv[2:]
+    profile_name, _config_path, _rest = split_plugin_globals(plugin_args)
+    if has_plugin_config_global(plugin_args):
+        raise PluginRuntimeContextError(
+            "`--config` is unavailable for managed plugin commands; the AuthProvider AgentConfig is authoritative"
+        )
+    if not getattr(agent_config, "plugins_enabled", True):
+        raise PluginRuntimeContextError("Plugins are disabled (`agent.plugins_enabled: false`)")
+    if hasattr(agent_config, "plugin_active") and not agent_config.plugin_active(plugin_name):
+        raise PluginRuntimeContextError(f"Plugin `{plugin_name}` is not active for this project")
+
+    plugin_path = _resolve_plugin_path(agent_config, plugin_name)
+    profile = agent_config.get_plugin_profile(plugin_name, profile_name)
+    runtime = PluginRuntimeContext(
+        plugin_name=plugin_name,
+        profile=profile,
+        plugin_path=str(plugin_path) if plugin_path is not None else None,
+    )
+    encoded = runtime.encode()
+
+    # The payload initially enters Bash through its environment.  The prologue
+    # copies it into a randomly-named, non-exported shell variable and unsets
+    # the exported name before the pipeline is spawned.  The inline assignment
+    # then exposes it only to the datus segment; sibling pipeline commands do
+    # not inherit it.
+    internal_var = f"__datus_plugin_ctx_{uuid.uuid4().hex}"
+    while internal_var in command:
+        internal_var = f"__datus_plugin_ctx_{uuid.uuid4().hex}"
+    wrapped_segments = list(segments)
+    wrapped_segments[segment_index] = f'{RUNTIME_CONTEXT_ENV}="${{{internal_var}}}" {wrapped_segments[segment_index]}'
+    wrapped_command = f'{internal_var}="${{{RUNTIME_CONTEXT_ENV}}}"; unset {RUNTIME_CONTEXT_ENV}; ' + " | ".join(
+        wrapped_segments
+    )
+    read_dirs = [str(plugin_path)] if plugin_path is not None else []
+    return PreparedPluginInvocation(
+        command=wrapped_command,
+        env={RUNTIME_CONTEXT_ENV: encoded},
+        sandbox_read_dirs=read_dirs,
+    )
+
+
+def _resolve_plugin_path(agent_config: Any, plugin_name: str) -> Optional[Path]:
+    """Resolve the selected plugin directory using normal store precedence."""
+    from datus.plugins import store
+    from datus.plugins.registry import plugin_entry_point_exists
+
+    managed = store.plugin_dir(plugin_name)
+    if managed.is_dir() and store.plugin_name_for_dir(managed) == plugin_name:
+        return managed.resolve()
+    for name, directory in store.iter_extra_plugin_dirs(getattr(agent_config, "plugin_paths", None)):
+        if name == plugin_name:
+            return directory.resolve()
+    if plugin_entry_point_exists(plugin_name):
+        # Installed in the current interpreter's site-packages; sys.prefix is
+        # already readable in the sandbox and the child uses the same Python.
+        return None
+    raise PluginRuntimeContextError(
+        f"No installed plugin named `{plugin_name}` was found in the managed store, "
+        "`agent.plugin_paths`, or the current Python environment"
+    )
+
+
+def _contains_datus_command(command: str) -> bool:
+    """Conservative detection used only to prevent unsafe local-config fallback."""
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars="|&;<>()`")
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return "datus" in command
+    command_start = True
+    for token in tokens:
+        if token in {"|", "||", "|&", "&&", ";", "&", "(", ")", "`"}:
+            command_start = True
+            continue
+        if command_start:
+            if "=" in token and not token.startswith("="):
+                continue
+            if Path(token).name == "datus":
+                return True
+            command_start = False
+    # shlex intentionally keeps the contents of double quotes together. Bash
+    # still evaluates command substitutions inside them, so conservatively
+    # recognize a datus command word in those compound tokens as well.
+    for token in tokens:
+        if ("$(" in token or "`" in token) and _DATUS_COMMAND_WORD_RE.search(token):
+            return True
+    return False
+
+
+def _has_unsupported_shell_controls(command: str) -> bool:
+    """Detect top-level shell controls while allowing literals inside quotes.
+
+    A plugin argument such as ``python -c 'a=1; print(a)'`` is safe to retain
+    in a pure pipeline, while a top-level ``;``/``&&``/redirection or command
+    substitution would change which processes receive the runtime context.
+    """
+    in_single = in_double = False
+    i = 0
+    while i < len(command):
+        char = command[i]
+        if char == "\\" and not in_single:
+            i += 2
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            i += 1
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            i += 1
+            continue
+        if in_single:
+            i += 1
+            continue
+        if char == "`":
+            return True
+        if char == "$" and i + 1 < len(command) and command[i + 1] in "({":
+            return True
+        if not in_double and (char in ";&<>()\n"):
+            return True
+        i += 1
+    return False
+
+
+__all__ = [
+    "MAX_RUNTIME_CONTEXT_SIZE",
+    "PreparedPluginInvocation",
+    "PluginRuntimeContext",
+    "PluginRuntimeContextError",
+    "RUNTIME_CONTEXT_ENV",
+    "has_plugin_config_global",
+    "load_runtime_context_from_env",
+    "prepare_plugin_invocation",
+    "split_plugin_globals",
+]

--- a/datus/tools/func_tool/bash_sandbox.py
+++ b/datus/tools/func_tool/bash_sandbox.py
@@ -260,6 +260,7 @@ def build_policy(
     workspace_root: Path,
     dynamic_write_dirs: Sequence[Any] = (),
     extra_read_dirs: Sequence[str] = (),
+    runtime_read_dirs: Sequence[str] = (),
 ) -> SandboxPolicy:
     """Merge defaults, configuration and per-call dirs into a resolved policy.
 
@@ -270,11 +271,16 @@ def build_policy(
     Readable: the python interpreter prefixes (the ``python`` shim in
     ``BashTool._shell_prefix`` points at ``sys.executable``, whose venv often
     lives outside the workspace), caller-injected ``extra_read_dirs`` (datus
-    home, so skills/templates stay usable) and ``settings.allow_read``.
+    home, so skills/templates stay usable), validated per-invocation
+    ``runtime_read_dirs`` and ``settings.allow_read``.
 
     Strict mode ignores the caller-injected ``dynamic_write_dirs`` and
     ``extra_read_dirs`` entirely — in a multi-tenant deployment those point
     into the shared ``~/.datus`` tree, which strict tenants must not touch.
+    ``runtime_read_dirs`` survive strict mode because they are narrow,
+    invocation-scoped capabilities (for example the exact plugin directory
+    whose metadata name matched the command). Callers MUST validate them
+    before passing them here; raw user paths never belong in this parameter.
     Filtering here (rather than at each call site) makes the guarantee hold
     no matter who constructs the tool. Oversized-output archiving keeps
     working: the redirect file is opened by the parent process and inherited
@@ -297,7 +303,9 @@ def build_policy(
     )
     readable = [
         root
-        for root in _normalize_roots([sys.prefix, sys.base_prefix, *extra_read_dirs, *settings.allow_read])
+        for root in _normalize_roots(
+            [sys.prefix, sys.base_prefix, *extra_read_dirs, *runtime_read_dirs, *settings.allow_read]
+        )
         if root not in writable
     ]
     return SandboxPolicy(

--- a/datus/tools/func_tool/bash_tool.py
+++ b/datus/tools/func_tool/bash_tool.py
@@ -22,6 +22,7 @@ import signal
 import subprocess
 import sys
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -48,6 +49,20 @@ MAX_OUTPUT_SIZE = 50000
 BASH_ARCHIVE_THRESHOLD = 8000
 # Single-line preview length carried inline in the archive marker.
 BASH_ARCHIVE_PREVIEW_CHARS = 1000
+
+
+@dataclass(frozen=True)
+class BashExecutionContext:
+    """Per-invocation subprocess overrides produced after permission checks.
+
+    ``command`` is the internal command actually handed to Bash; callers and
+    logs continue to use the original command.  ``env`` is merged only into
+    this child process, never into process-global ``os.environ``.
+    """
+
+    command: str
+    env: Dict[str, str]
+    sandbox_read_dirs: List[str]
 
 
 class BashTool:
@@ -97,6 +112,7 @@ class BashTool:
         output_dir_provider: Optional[Callable[[], Optional[Path]]] = None,
         sandbox_settings: Optional[bash_sandbox.SandboxSettings] = None,
         sandbox_read_dirs: Optional[List[str]] = None,
+        execution_context_provider: Optional[Callable[[str], Optional[BashExecutionContext]]] = None,
     ):
         """Initialize the bash tool.
 
@@ -124,6 +140,10 @@ class BashTool:
             sandbox_read_dirs: Extra read-only roots for the sandbox policy
                 beyond the built-in defaults (e.g. the datus home so skills
                 and templates stay readable).
+            execution_context_provider: Optional request-scoped callback run
+                after the original command passes pattern/permission checks.
+                It may return an internal command, child-only environment
+                values and validated per-call sandbox read roots.
         """
         self.workspace_root = Path(workspace_root).resolve()
         self.allowed_patterns = list(allowed_patterns) if allowed_patterns else []
@@ -133,6 +153,7 @@ class BashTool:
         self._output_dir_provider = output_dir_provider
         self.sandbox_settings = sandbox_settings
         self.sandbox_read_dirs = list(sandbox_read_dirs) if sandbox_read_dirs else []
+        self.execution_context_provider = execution_context_provider
         # Monotonic per-instance counter zero-padded into archive filenames so a
         # directory listing sorts in command-invocation order. Paired with a
         # per-instance random token so a recreated/resumed BashTool (which
@@ -209,10 +230,23 @@ class BashTool:
                 ),
             )
 
+        execution_context: Optional[BashExecutionContext] = None
+        if self.execution_context_provider is not None:
+            try:
+                execution_context = self.execution_context_provider(command)
+            except ValueError as exc:
+                return FuncToolResult(success=0, error=str(exc))
+            except Exception as exc:  # pragma: no cover - defensive provider boundary
+                logger.error("Failed to prepare command runtime context (identity=%s): %s", self.identity, exc)
+                return FuncToolResult(success=0, error="Failed to prepare command runtime context")
+
         effective_timeout = self._resolve_timeout(timeout)
+        spawn_command = execution_context.command if execution_context is not None else command
+        invocation_env = execution_context.env if execution_context is not None else None
+        runtime_read_dirs = execution_context.sandbox_read_dirs if execution_context is not None else []
 
         try:
-            argv = self._build_spawn_argv(command)
+            argv = self._build_spawn_argv(spawn_command)
         except ValueError as e:
             return FuncToolResult(success=0, error=f"Invalid command syntax: {e}")
 
@@ -224,6 +258,7 @@ class BashTool:
                 workspace_root=self.workspace_root,
                 dynamic_write_dirs=[output_dir] if output_dir else [],
                 extra_read_dirs=self.sandbox_read_dirs,
+                runtime_read_dirs=runtime_read_dirs,
             )
             try:
                 argv = bash_sandbox.wrap_argv(argv, policy)
@@ -235,8 +270,14 @@ class BashTool:
                 # a huge output never buffers in memory; decide by file size
                 # afterwards. Timeout is handled inside so the partial file is
                 # still surfaced.
-                return self._execute_with_redirect(argv, command, output_dir, effective_timeout)
-            return self._execute_in_memory(argv, effective_timeout)
+                return self._execute_with_redirect(
+                    argv,
+                    command,
+                    output_dir,
+                    effective_timeout,
+                    invocation_env=invocation_env,
+                )
+            return self._execute_in_memory(argv, effective_timeout, invocation_env=invocation_env)
         except subprocess.TimeoutExpired:
             logger.error("Command timed out (identity=%s): %s", self.identity, command)
             return FuncToolResult(success=0, error=f"Command timed out after {effective_timeout} seconds")
@@ -329,7 +370,14 @@ class BashTool:
             return None
         return path
 
-    def _execute_with_redirect(self, argv: List[str], command: str, output_dir: Path, timeout: int) -> FuncToolResult:
+    def _execute_with_redirect(
+        self,
+        argv: List[str],
+        command: str,
+        output_dir: Path,
+        timeout: int,
+        invocation_env: Optional[Dict[str, str]] = None,
+    ) -> FuncToolResult:
         """Run the command with stdout/stderr redirected to a file on disk.
 
         stderr is merged into the stdout file (``stderr=STDOUT``) so interleaved
@@ -356,7 +404,7 @@ class BashTool:
                 stdout=fh,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
-                env=self._get_safe_env(),
+                env=self._get_safe_env(invocation_env),
                 # New session/process group so a timeout can kill the whole
                 # pipeline (all stages), not just the bash launcher.
                 start_new_session=(os.name == "posix"),
@@ -421,7 +469,12 @@ class BashTool:
         except OSError:  # pragma: no cover - best effort cleanup
             pass
 
-    def _execute_in_memory(self, argv: List[str], timeout: int) -> FuncToolResult:
+    def _execute_in_memory(
+        self,
+        argv: List[str],
+        timeout: int,
+        invocation_env: Optional[Dict[str, str]] = None,
+    ) -> FuncToolResult:
         """Fallback path (no offload dir): capture output in memory + truncate."""
         proc = subprocess.Popen(
             argv,
@@ -430,7 +483,7 @@ class BashTool:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            env=self._get_safe_env(),
+            env=self._get_safe_env(invocation_env),
             # Detach the child from the agent's stdin. Without this the child
             # inherits datus's terminal stdin and any command that reads it
             # (``cat``, ``read``, ``python`` awaiting input, an interactive
@@ -576,7 +629,7 @@ class BashTool:
     def _sandbox_active(self) -> bool:
         return self.sandbox_settings is not None and self.sandbox_settings.enabled
 
-    def _get_safe_env(self) -> dict:
+    def _get_safe_env(self, invocation_env: Optional[Dict[str, str]] = None) -> dict:
         """Build the environment for command execution.
 
         Starts from ``os.environ`` and overlays ``self.extra_env`` so callers
@@ -595,6 +648,8 @@ class BashTool:
             env = os.environ.copy()
         if self.extra_env:
             env.update(self.extra_env)
+        if invocation_env:
+            env.update(invocation_env)
         return env
 
     def available_tools(self) -> List[Tool]:

--- a/datus/tools/skill_tools/skill_config.py
+++ b/datus/tools/skill_tools/skill_config.py
@@ -80,16 +80,20 @@ def _entry_point_skill_directories() -> List[str]:
     return found
 
 
-def _plugins_system_enabled() -> bool:
+def _plugins_system_enabled(agent_config: Optional[Any] = None) -> bool:
     """Whether the datus-plugin system is enabled in the loaded agent config.
 
     ``agent.plugins_enabled: false`` is the master switch that disables all
-    plugin functionality, including plugin-bundled skills. This reads the
-    already-loaded ``ConfigurationManager`` singleton (never triggers a config
-    load) because ``SkillConfig`` may be constructed without an ``AgentConfig``
-    in reach (default factory, ``skill_cli``). Defaults to enabled when no
-    config has been loaded yet (e.g. unit tests building SkillConfig directly).
+    plugin functionality, including plugin-bundled skills. When an
+    ``AgentConfig`` is supplied it is authoritative; this is required by
+    multi-tenant API deployments where the request config comes from an
+    AuthProvider and no local config file exists. Legacy callers without an
+    ``AgentConfig`` fall back to the already-loaded ``ConfigurationManager``
+    singleton (and never trigger a config load).
     """
+    if agent_config is not None:
+        return bool(getattr(agent_config, "plugins_enabled", True))
+
     try:
         from datus.configuration import agent_config_loader
 
@@ -107,35 +111,40 @@ def _plugins_system_enabled() -> bool:
     return _coerce_bool(value, True)
 
 
-def _plugin_skill_directories() -> List[str]:
+def _plugin_skill_directories(agent_config: Optional[Any] = None) -> List[str]:
     """Skill directories contributed by ``datus.plugins`` packages.
 
     Delegates to :func:`datus.plugins.registry.plugin_skill_directories` (lazy
     import to avoid an import cycle). Returns an empty list when the plugin
-    system is disabled (``agent.plugins_enabled: false``). Only *active*
-    plugins for the current project contribute — the project's ``plugins:``
-    whitelist in ``./.datus/config.yml`` (resolved via
-    :func:`datus.plugins.activation.active_names_for_cwd`) gates discovery so a
-    deactivated plugin's skills are not surfaced. Any failure resolves to an
-    empty list so skill discovery never blocks startup.
+    system is disabled (``agent.plugins_enabled: false``). When
+    ``agent_config`` is supplied, its active-plugin whitelist is used directly;
+    otherwise the legacy CWD-level ``./.datus/config.yml`` lookup is retained
+    for standalone CLI callers. Any failure resolves to an empty list so skill
+    discovery never blocks startup.
     """
-    if not _plugins_system_enabled():
+    if not _plugins_system_enabled(agent_config):
         return []
     try:
-        from datus.plugins.activation import active_names_for_cwd
         from datus.plugins.registry import plugin_skill_directories
 
-        return plugin_skill_directories(active_names=active_names_for_cwd())
+        if agent_config is not None:
+            getter = getattr(agent_config, "active_plugin_names", None)
+            active_names = getter() if callable(getter) else None
+        else:
+            from datus.plugins.activation import active_names_for_cwd
+
+            active_names = active_names_for_cwd()
+        return plugin_skill_directories(active_names=active_names)
     except Exception as exc:  # noqa: BLE001 - defensive: never break discovery
         logger.debug("plugin skill-directory discovery failed: %s", exc)
         return []
 
 
-def _adapter_skill_directories() -> List[str]:
+def _adapter_skill_directories(agent_config: Optional[Any] = None) -> List[str]:
     """Directories contributed by plugins (``datus.plugins``) then legacy
     adapters (``datus.skills``), de-duplicated with plugins taking precedence."""
     dirs: List[str] = []
-    for ep_dir in _plugin_skill_directories():
+    for ep_dir in _plugin_skill_directories(agent_config):
         if not _contains_directory(dirs, ep_dir):
             dirs.append(ep_dir)
     for ep_dir in _entry_point_skill_directories():
@@ -144,7 +153,7 @@ def _adapter_skill_directories() -> List[str]:
     return dirs
 
 
-def _default_skill_directories() -> List[str]:
+def _default_skill_directories(agent_config: Optional[Any] = None) -> List[str]:
     """Default scan order: project → user → plugin/adapter entry points → packaged built-ins.
 
     The first two entries match the documented user-facing locations and always
@@ -154,7 +163,7 @@ def _default_skill_directories() -> List[str]:
     built-in, but never a user override. The packaged directory is appended last.
     """
     dirs: List[str] = ["./.datus/skills", "~/.datus/skills"]
-    for ep_dir in _adapter_skill_directories():
+    for ep_dir in _adapter_skill_directories(agent_config):
         if not _contains_directory(dirs, ep_dir):
             dirs.append(ep_dir)
     builtin = _builtin_skills_dir()
@@ -218,17 +227,19 @@ class SkillConfig(BaseModel):
     install_dir: str = Field(default="~/.datus/skills", description="Directory for marketplace-installed skills")
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SkillConfig":
+    def from_dict(cls, data: Dict[str, Any], *, agent_config: Optional[Any] = None) -> "SkillConfig":
         """Create SkillConfig from dictionary (agent.yml format).
 
         Args:
             data: Dictionary with skills configuration
+            agent_config: Optional request-scoped AgentConfig. When supplied,
+                plugin skill discovery uses this instance's activation state
+                rather than process-global/CWD configuration.
 
         Returns:
             SkillConfig instance
         """
-        if not data:
-            return cls()
+        data = data or {}
 
         # Always append plugin/adapter-contributed (entry-point) and packaged
         # built-in directories to whatever the user listed so a deployer can
@@ -236,10 +247,10 @@ class SkillConfig(BaseModel):
         # ``init``, ``hello``) by overriding ``skills.directories`` in agent.yml.
         directories = data.get("directories")
         if directories is None:
-            directories = _default_skill_directories()
+            directories = _default_skill_directories(agent_config)
         else:
             directories = list(directories)
-            for ep_dir in _adapter_skill_directories():
+            for ep_dir in _adapter_skill_directories(agent_config):
                 if not _contains_directory(directories, ep_dir):
                     directories.append(ep_dir)
             builtin = _builtin_skills_dir()

--- a/datus/tools/skill_tools/skill_manager.py
+++ b/datus/tools/skill_tools/skill_manager.py
@@ -20,6 +20,7 @@ from datus.tools.skill_tools.skill_config import SkillConfig, SkillMetadata
 from datus.tools.skill_tools.skill_registry import SkillRegistry
 
 if TYPE_CHECKING:
+    from datus.configuration.agent_config import AgentConfig
     from datus.tools.permission.permission_manager import PermissionManager
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class SkillManager:
         permission_manager: Optional["PermissionManager"] = None,
         registry: Optional[SkillRegistry] = None,
         config_mutable: bool = True,
+        agent_config: Optional["AgentConfig"] = None,
     ):
         """Initialize the skill manager.
 
@@ -67,10 +69,13 @@ class SkillManager:
                 this deployment. When False (chat API / gateway), skills
                 declaring ``requires_mutable_config: true`` are hidden from
                 listings and refused on load.
+            agent_config: Optional request-scoped AgentConfig used when
+                ``config`` is omitted. This keeps plugin skill discovery
+                tenant-local instead of consulting CWD configuration.
         """
-        self.config = config or SkillConfig()
+        self.config = config or SkillConfig.from_dict({}, agent_config=agent_config)
         self.permission_manager = permission_manager
-        self.registry = registry or SkillRegistry(config=self.config)
+        self.registry = registry or SkillRegistry(config=self.config, agent_config=agent_config)
         self.config_mutable = bool(config_mutable)
 
         # Scan directories on initialization

--- a/datus/tools/skill_tools/skill_registry.py
+++ b/datus/tools/skill_tools/skill_registry.py
@@ -13,11 +13,14 @@ import logging
 import re
 import threading
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import yaml
 
 from datus.tools.skill_tools.skill_config import SkillConfig, SkillMetadata
+
+if TYPE_CHECKING:
+    from datus.configuration.agent_config import AgentConfig
 
 logger = logging.getLogger(__name__)
 
@@ -52,14 +55,21 @@ class SkillRegistry:
         content = registry.load_skill_content("sql-optimization")
     """
 
-    def __init__(self, config: Optional[SkillConfig] = None, directories: Optional[List[str]] = None):
+    def __init__(
+        self,
+        config: Optional[SkillConfig] = None,
+        directories: Optional[List[str]] = None,
+        agent_config: Optional["AgentConfig"] = None,
+    ):
         """Initialize the skill registry.
 
         Args:
             config: SkillConfig with directories and settings
             directories: Override directories (for testing)
+            agent_config: Optional request-scoped AgentConfig used to build
+                defaults without consulting CWD/project configuration.
         """
-        self.config = config or SkillConfig()
+        self.config = config or SkillConfig.from_dict({}, agent_config=agent_config)
         self._directories = directories or self.config.directories
         self._skills: Dict[str, SkillMetadata] = {}
         self._scanned = False

--- a/docs/plugin/development.md
+++ b/docs/plugin/development.md
@@ -464,6 +464,10 @@ Run `datus hello <name>` to greet someone. ...
 See the [Skills](../skills/introduction.md) docs for the full frontmatter
 field reference.
 
+In a multi-tenant API deployment, discovery is scoped by the request's
+`AgentConfig` (`plugins_enabled`, active plugins, `plugin_paths`, and
+`skills`); plugin skills do not depend on a local `./.datus/config.yml`.
+
 Make sure the skill files are included in the wheel (they are data, not
 Python). Hatchling packages every file under the package directory by default,
 so nothing extra is needed unless the files are VCS-ignored (then list them

--- a/docs/plugin/development.md
+++ b/docs/plugin/development.md
@@ -239,6 +239,14 @@ belongs to the plugin. `datus hello greet --profile staging` therefore passes
 `["greet", "--profile", "staging"]` through untouched — your subcommands are
 free to define their own `--profile` option.
 
+In a read-only multi-tenant API session, Datus may obtain the profile from the
+request's in-memory `AgentConfig` and bridge it through a subprocess-scoped
+environment value. This transport is host-owned: your plugin should continue
+to use the supplied `profile` argument and may read its own values from that
+dict. Do not depend on the internal environment value. In this mode
+`--profile` works, while `--config` and compound shell forms other than a plain
+`|` pipeline are rejected.
+
 Return an integer exit code (`None` means `0`). Suggested conventions:
 
 | Code | Meaning |

--- a/docs/plugin/development.zh.md
+++ b/docs/plugin/development.zh.md
@@ -432,6 +432,10 @@ Run `datus hello <name>` to greet someone. ...
 
 完整 frontmatter 字段参考见 [Skills](../skills/introduction.zh.md) 文档。
 
+在多租户 API 部署中,skill 发现由当前请求的 `AgentConfig` 限定
+(`plugins_enabled`、激活 plugin、`plugin_paths` 和 `skills`),plugin skill 不依赖
+本地 `./.datus/config.yml`。
+
 确保 skill 文件被打进 wheel(它们是数据,不是 Python 代码)。Hatchling 默认打包
 包目录下所有文件,除非文件被 VCS 忽略(那样需要在
 `[tool.hatch.build.targets.wheel] artifacts` 列出);setuptools 必须显式声明:

--- a/docs/plugin/development.zh.md
+++ b/docs/plugin/development.zh.md
@@ -215,6 +215,12 @@ Datus 全局参数消费;从第一个命令 token 起的一切都属于 plugin�
 `datus hello greet --profile staging` 会原样传入
 `["greet", "--profile", "staging"]`——你的子命令可以自由定义自己的 `--profile`。
 
+在只读的多租户 API 会话中,Datus 可能从当前请求的内存 `AgentConfig` 取得
+profile,并通过仅对子进程生效的环境变量完成桥接。该传输由宿主管理:plugin 应继续
+使用传入的 `profile` 参数,也允许从这个字典读取自己的配置;不要依赖内部环境变量。
+此模式支持 `--profile`,但会拒绝 `--config`,也会拒绝普通 `|` 管道以外的复合
+shell 形式。
+
 返回整数退出码(`None` 视为 `0`)。建议的约定:
 
 | 退出码 | 含义 |

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -145,6 +145,12 @@ versioned environment value. The plugin still receives the resolved dict as
 the normal `profile` argument to `main(argv, profile)`; plugin code does not
 need to read the environment variable.
 
+Plugin skill discovery follows the same rule: `plugins_enabled`, the active
+plugin whitelist, `plugin_paths`, and `skills` directories are resolved from
+that request's `AgentConfig`. It does not fall back to another tenant's loaded
+configuration or to `./.datus/config.yml`. Standalone CLI skill commands that
+do not hold an `AgentConfig` keep the local project-file behavior.
+
 This bridge accepts one direct plugin invocation, optionally as one stage of a
 plain `|` pipeline. It deliberately fails closed for multiple `datus`
 invocations and for shell control forms such as `&&`, `;`, redirection, command

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -134,6 +134,26 @@ effect on the next `datus <plugin>` invocation; no restart is needed.
 Some plugins ship a `<name>-setup` skill that writes this configuration for
 you — see [Using a plugin with the agent](#using-a-plugin-with-the-agent).
 
+### Managed API runtime configuration
+
+In a multi-tenant `datus-api` deployment, an `AuthProvider` can supply a
+request-scoped `AgentConfig` without writing `agent.yml`. When that config is
+read-only (`config_mutable: false`) and the agent runs `datus <name> ...`
+through Bash, Datus resolves the selected plugin path and profile in the API
+process and passes that snapshot to only the plugin subprocess through a
+versioned environment value. The plugin still receives the resolved dict as
+the normal `profile` argument to `main(argv, profile)`; plugin code does not
+need to read the environment variable.
+
+This bridge accepts one direct plugin invocation, optionally as one stage of a
+plain `|` pipeline. It deliberately fails closed for multiple `datus`
+invocations and for shell control forms such as `&&`, `;`, redirection, command
+substitution, and `|&`. `--profile` remains supported and is resolved against
+the request's `AgentConfig`; `--config` is rejected because the AuthProvider
+configuration is authoritative. The encoded runtime snapshot is capped at
+64 KiB. Sibling pipeline stages do not inherit it, and the parent process
+environment is never modified.
+
 ### Which profile runs
 
 When you run `datus <name> ...`, the active profile is resolved in this order:

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -125,6 +125,11 @@ plugin 路径与 profile,再通过带版本的环境变量把这份快照只传�
 子进程。plugin 仍通过常规的 `main(argv, profile)` 的 `profile` 参数取得解析后的
 字典,无需自行读取该环境变量。
 
+plugin skill 发现遵循相同规则:`plugins_enabled`、激活 plugin 白名单、
+`plugin_paths` 和 `skills` 目录均以当前请求的 `AgentConfig` 为准,不会回退到其他
+租户已加载的配置或 `./.datus/config.yml`。只有拿不到 `AgentConfig` 的独立 CLI
+skill 命令才保留本地项目配置文件行为。
+
 此桥接允许一次直接的 plugin 调用,也允许它作为普通 `|` 管道中的一个 stage。
 若命令包含多个 `datus` 调用,或使用 `&&`、`;`、重定向、命令替换、`|&` 等 shell
 控制形式,则会 fail closed。`--profile` 仍受支持,并针对当前请求的 `AgentConfig`

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -116,6 +116,21 @@ Datus 按以下顺序解析 config 文件:显式 `--config` → `./conf/agent.ym
 有些插件自带 `<name>-setup` skill,可以替你写好这段配置——见
 [与 agent 配合使用](#agent)。
 
+### 托管 API 的运行时配置
+
+在多租户 `datus-api` 部署中,`AuthProvider` 可以为每个请求直接提供内存中的
+`AgentConfig`,无需写入 `agent.yml`。当该配置只读(`config_mutable: false`),且
+agent 通过 Bash 执行 `datus <name> ...` 时,Datus 会在 API 进程内解析选中的
+plugin 路径与 profile,再通过带版本的环境变量把这份快照只传给目标 plugin
+子进程。plugin 仍通过常规的 `main(argv, profile)` 的 `profile` 参数取得解析后的
+字典,无需自行读取该环境变量。
+
+此桥接允许一次直接的 plugin 调用,也允许它作为普通 `|` 管道中的一个 stage。
+若命令包含多个 `datus` 调用,或使用 `&&`、`;`、重定向、命令替换、`|&` 等 shell
+控制形式,则会 fail closed。`--profile` 仍受支持,并针对当前请求的 `AgentConfig`
+解析;`--config` 会被拒绝,因为 AuthProvider 提供的配置是权威来源。编码后的运行时
+快照上限为 64 KiB。管道中的其他 stage 不会继承它,父进程环境也不会被修改。
+
 ### 哪个 profile 生效 {#which-profile-runs}
 
 执行 `datus <name> ...` 时,激活 profile 按以下顺序解析:

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -1159,8 +1159,10 @@ class TestBashToolToggle:
             agent_config=mock_agent_config,
         )
 
-        assert node.bash_tool is not None
-        assert node.bash_tool.execution_context_provider is not None
+        from datus.tools.func_tool.bash_tool import BashTool
+
+        assert isinstance(node.bash_tool, BashTool)
+        assert node.bash_tool.execution_context_provider.__name__ == "_managed_plugin_context"
 
     def test_mutable_local_config_does_not_wire_runtime_provider(self, mock_agent_config):
         self._wire_permissions(mock_agent_config)
@@ -1173,7 +1175,9 @@ class TestBashToolToggle:
             agent_config=mock_agent_config,
         )
 
-        assert node.bash_tool is not None
+        from datus.tools.func_tool.bash_tool import BashTool
+
+        assert isinstance(node.bash_tool, BashTool)
         assert node.bash_tool.execution_context_provider is None
 
 

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -1147,6 +1147,35 @@ class TestBashToolToggle:
         assert isinstance(node.bash_tool, BashTool)
         assert node.bash_tool.allowed_patterns == ["*"]
 
+    def test_read_only_managed_config_wires_plugin_runtime_provider(self, mock_agent_config):
+        """Only managed/read-only AgentConfig instances bridge plugin CLI config."""
+        self._wire_permissions(mock_agent_config)
+        mock_agent_config.config_mutable = False
+
+        node = MinimalAgenticNode(
+            node_id="bash_managed_plugin_context",
+            description="Test node",
+            node_type="chat",
+            agent_config=mock_agent_config,
+        )
+
+        assert node.bash_tool is not None
+        assert node.bash_tool.execution_context_provider is not None
+
+    def test_mutable_local_config_does_not_wire_runtime_provider(self, mock_agent_config):
+        self._wire_permissions(mock_agent_config)
+        mock_agent_config.config_mutable = True
+
+        node = MinimalAgenticNode(
+            node_id="bash_local_plugin_context",
+            description="Test node",
+            node_type="chat",
+            agent_config=mock_agent_config,
+        )
+
+        assert node.bash_tool is not None
+        assert node.bash_tool.execution_context_provider is None
+
 
 class TestRequiredSkillsInjection:
     """``REQUIRED_SKILLS`` host-injection primitive (``_inject_required_skills``)."""

--- a/tests/unit_tests/cli/test_plugin_dispatch.py
+++ b/tests/unit_tests/cli/test_plugin_dispatch.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 from datus.cli import main as cli_main
 from datus.cli.main import _dispatch_plugin_command, _split_plugin_globals
 from datus.plugins.base import PluginManifest
+from datus.plugins.runtime_context import RUNTIME_CONTEXT_ENV, PluginRuntimeContext
 
 # ── _split_plugin_globals ────────────────────────────────────────────────────
 
@@ -289,3 +290,80 @@ def test_dispatch_cli_bool_rc_maps_to_exit_semantics(monkeypatch):
     assert _dispatch_plugin_command(["hello", "version"]) == 0
     _patch_dispatch(monkeypatch, profile_dict={}, cli_func=_StubCli(rc=False))
     assert _dispatch_plugin_command(["hello", "version"]) == 1
+
+
+# ── managed runtime context ──────────────────────────────────────────────────
+
+
+def test_runtime_context_bypasses_file_loader(monkeypatch):
+    load_calls = []
+    stub_cfg = _patch_dispatch(monkeypatch, profile_dict={"from": "file"}, load_calls=load_calls)
+    runtime_profile = {"name": "tenant-a", "token": "secret-a"}
+    monkeypatch.setenv(
+        RUNTIME_CONTEXT_ENV,
+        PluginRuntimeContext(plugin_name="hello", profile=runtime_profile).encode(),
+    )
+
+    rc = _dispatch_plugin_command(["hello", "--profile", "tenant-a", "version"])
+
+    assert rc == 7
+    assert load_calls == []
+    assert stub_cfg.requested == {}
+    assert _StubCli.last["profile"] == runtime_profile
+    assert _StubCli.last["argv"] == ["version"]
+
+
+def test_runtime_context_rejects_config_override(monkeypatch, capsys):
+    _patch_dispatch(monkeypatch, profile_dict={})
+    monkeypatch.setenv(
+        RUNTIME_CONTEXT_ENV,
+        PluginRuntimeContext(plugin_name="hello", profile={}).encode(),
+    )
+
+    assert _dispatch_plugin_command(["hello", "--config", "/tmp/other.yml", "version"]) == 3
+    assert "--config" in " ".join(capsys.readouterr().err.split())
+
+
+def test_runtime_context_rejects_config_flag_without_value(monkeypatch, capsys):
+    _patch_dispatch(monkeypatch, profile_dict={})
+    monkeypatch.setenv(
+        RUNTIME_CONTEXT_ENV,
+        PluginRuntimeContext(plugin_name="hello", profile={}).encode(),
+    )
+
+    assert _dispatch_plugin_command(["hello", "--config"]) == 3
+    assert "--config" in " ".join(capsys.readouterr().err.split())
+
+
+def test_runtime_context_mismatch_fails_closed(monkeypatch, capsys):
+    load_calls = []
+    _patch_dispatch(monkeypatch, profile_dict={}, load_calls=load_calls)
+    monkeypatch.setenv(
+        RUNTIME_CONTEXT_ENV,
+        PluginRuntimeContext(plugin_name="other", profile={}).encode(),
+    )
+
+    assert _dispatch_plugin_command(["hello", "version"]) == 3
+    assert load_calls == []
+    assert "not `hello`" in " ".join(capsys.readouterr().err.split())
+
+
+def test_runtime_context_missing_plugin_does_not_fall_through(monkeypatch, capsys):
+    monkeypatch.setattr("datus.plugins.registry.plugin_entry_point_exists", lambda name: False)
+    monkeypatch.setattr("datus.plugins.store.activate_paths", lambda paths: [])
+    monkeypatch.setenv(
+        RUNTIME_CONTEXT_ENV,
+        PluginRuntimeContext(plugin_name="hello", profile={}).encode(),
+    )
+
+    assert _dispatch_plugin_command(["hello", "version"]) == 3
+    assert "not installed or discoverable" in " ".join(capsys.readouterr().err.split())
+
+
+def test_malformed_runtime_context_does_not_load_file(monkeypatch):
+    load_calls = []
+    _patch_dispatch(monkeypatch, profile_dict={}, load_calls=load_calls)
+    monkeypatch.setenv(RUNTIME_CONTEXT_ENV, "v1.not-base64!")
+
+    assert _dispatch_plugin_command(["hello", "version"]) == 3
+    assert load_calls == []

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2964,6 +2964,24 @@ class TestPluginPathsConfig:
         assert cfg.plugin_paths == []
         assert "plugin_paths must be a list" in caplog.text
 
+    def test_activates_request_plugin_paths_during_construction(self, tmp_path, monkeypatch):
+        """Direct AuthProvider construction must not depend on the YAML loader."""
+        calls = []
+
+        def activate(active_names, plugins_enabled=True, extra_paths=None):
+            calls.append((active_names, plugins_enabled, extra_paths))
+            return []
+
+        monkeypatch.setattr("datus.plugins.store.activate", activate)
+
+        self._make(
+            tmp_path,
+            plugin_paths=[" /srv/tenant/plugin "],
+            active_plugins={"tenant-plugin": {"enabled": True}},
+        )
+
+        assert calls == [({"tenant-plugin"}, True, ["/srv/tenant/plugin"])]
+
 
 class TestPromptManagerAttribute:
     """``AgentConfig.prompt_manager`` — the runtime prompt-template override.

--- a/tests/unit_tests/plugins/test_runtime_context.py
+++ b/tests/unit_tests/plugins/test_runtime_context.py
@@ -1,0 +1,251 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Tests for managed plugin CLI runtime-context bridging."""
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from datus.plugins import runtime_context
+from datus.tools.func_tool.bash_tool import BashExecutionContext, BashTool
+
+
+class _Config:
+    plugins_enabled = True
+    plugin_paths = []
+    config_mutable = False
+
+    def __init__(self, profile=None, active=True):
+        self.profile = profile or {"name": "prod", "token": "tenant-secret"}
+        self.active = active
+        self.requested = None
+
+    def plugin_active(self, name):
+        return self.active
+
+    def get_plugin_profile(self, name, profile=None):
+        self.requested = (name, profile)
+        return dict(self.profile)
+
+
+def test_context_round_trip_unicode():
+    original = runtime_context.PluginRuntimeContext(
+        plugin_name="hello",
+        profile={"name": "生产", "token": "s3cr3t"},
+        plugin_path="/opt/plugins/hello",
+    )
+    decoded = runtime_context.PluginRuntimeContext.decode(original.encode(), expected_plugin="hello")
+    assert decoded == original
+
+
+def test_context_rejects_wrong_plugin_and_malformed_value():
+    encoded = runtime_context.PluginRuntimeContext("hello", {}).encode()
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="not `other`"):
+        runtime_context.PluginRuntimeContext.decode(encoded, expected_plugin="other")
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="Malformed"):
+        runtime_context.PluginRuntimeContext.decode("v1.not-base64!")
+
+
+def test_context_rejects_non_json_profile():
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="not JSON-serializable"):
+        runtime_context.PluginRuntimeContext("hello", {"bad": object()}).encode()
+
+
+def test_context_rejects_payload_over_size_limit():
+    profile = {"value": "x" * runtime_context.MAX_RUNTIME_CONTEXT_SIZE}
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="exceeds 64 KiB"):
+        runtime_context.PluginRuntimeContext("hello", profile).encode()
+
+
+def test_prepare_plain_command_resolves_explicit_profile(monkeypatch, tmp_path):
+    plugin_dir = tmp_path / "hello"
+    plugin_dir.mkdir()
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dir)
+    config = _Config()
+
+    prepared = runtime_context.prepare_plugin_invocation(
+        "datus hello --profile staging greet Alice",
+        config,
+    )
+
+    assert prepared is not None
+    assert config.requested == ("hello", "staging")
+    assert prepared.sandbox_read_dirs == [str(plugin_dir)]
+    decoded = runtime_context.PluginRuntimeContext.decode(
+        prepared.env[runtime_context.RUNTIME_CONTEXT_ENV],
+        expected_plugin="hello",
+    )
+    assert decoded.profile["token"] == "tenant-secret"
+    assert runtime_context.RUNTIME_CONTEXT_ENV in prepared.command
+    assert "tenant-secret" not in prepared.command
+
+
+def test_prepare_pipeline_injects_only_datus_segment(monkeypatch, tmp_path):
+    plugin_dir = tmp_path / "hello"
+    plugin_dir.mkdir()
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dir)
+
+    prepared = runtime_context.prepare_plugin_invocation(
+        "printf input | datus hello run | grep ok",
+        _Config(),
+    )
+
+    assert prepared is not None
+    segments = prepared.command.split(" | ")
+    assert runtime_context.RUNTIME_CONTEXT_ENV in segments[1]
+    assert runtime_context.RUNTIME_CONTEXT_ENV not in segments[2]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "datus hello run && echo done",
+        "echo before; datus hello run",
+        "datus hello run > out.txt",
+        "datus hello run |& grep ok",
+        "datus hello run | datus hello inspect",
+        "(datus hello run)",
+        "echo $(datus hello run)",
+        'echo "$(datus hello run)"',
+        "echo `datus hello run`",
+    ],
+)
+def test_prepare_rejects_unsupported_managed_shell_forms(command):
+    with pytest.raises(runtime_context.PluginRuntimeContextError):
+        runtime_context.prepare_plugin_invocation(command, _Config())
+
+
+def test_prepare_rejects_managed_config_override(monkeypatch):
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="--config"):
+        runtime_context.prepare_plugin_invocation("datus hello --config tenant.yml run", _Config())
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="--config"):
+        runtime_context.prepare_plugin_invocation("datus hello --config", _Config())
+
+
+def test_prepare_non_datus_command_is_ignored():
+    assert runtime_context.prepare_plugin_invocation("printf hello | grep ell", _Config()) is None
+
+
+def test_bash_pipeline_scopes_context_to_plugin_segment(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    plugin_dir = tmp_path / "hello"
+    plugin_dir.mkdir()
+    fake_datus = workspace / "datus"
+    fake_datus.write_text(
+        "#!/bin/bash\n"
+        "python -c 'import os; "
+        'print("plugin=" + str(bool(os.environ.get("DATUS_PLUGIN_RUNTIME_CONTEXT"))))\'\n',
+        encoding="utf-8",
+    )
+    fake_datus.chmod(0o755)
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dir)
+
+    config = _Config()
+
+    def provider(command):
+        prepared = runtime_context.prepare_plugin_invocation(command, config)
+        if prepared is None:
+            return None
+        return BashExecutionContext(
+            command=prepared.command,
+            env=prepared.env,
+            sandbox_read_dirs=prepared.sandbox_read_dirs,
+        )
+
+    tool = BashTool(
+        workspace_root=str(workspace),
+        allowed_patterns=["*"],
+        extra_env={"PATH": f"{workspace}{os.pathsep}{os.environ.get('PATH', '')}"},
+        execution_context_provider=provider,
+    )
+    result = tool.bash(
+        "datus hello run | "
+        "python -c 'import os,sys; "
+        "print(sys.stdin.read().strip()); "
+        'print("sibling=" + str(bool(os.environ.get("DATUS_PLUGIN_RUNTIME_CONTEXT"))))\''
+    )
+
+    assert result.success == 1
+    assert "plugin=True" in result.result
+    assert "sibling=False" in result.result
+
+
+def test_bash_provider_does_not_mutate_parent_environment(monkeypatch, tmp_path):
+    plugin_dir = tmp_path / "hello"
+    plugin_dir.mkdir()
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dir)
+    before = os.environ.get(runtime_context.RUNTIME_CONTEXT_ENV)
+
+    def provider(command):
+        prepared = runtime_context.prepare_plugin_invocation(command, _Config())
+        assert prepared is not None
+        return BashExecutionContext(prepared.command, prepared.env, prepared.sandbox_read_dirs)
+
+    tool = BashTool(
+        workspace_root=str(tmp_path),
+        allowed_patterns=["*"],
+        execution_context_provider=provider,
+    )
+    # No real datus execution is needed to prove the provider did not mutate
+    # the parent; use the child env builder directly with the prepared value.
+    context = provider("datus hello run")
+    child_env = tool._get_safe_env(context.env)
+    assert runtime_context.RUNTIME_CONTEXT_ENV in child_env
+    assert os.environ.get(runtime_context.RUNTIME_CONTEXT_ENV) == before
+
+
+def test_concurrent_tenants_keep_profiles_isolated_on_redirect_path(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    plugin_dir = tmp_path / "hello"
+    plugin_dir.mkdir()
+    fake_datus = workspace / "datus"
+    fake_datus.write_text(
+        "#!/usr/bin/env python3\n"
+        "import base64\n"
+        "import json\n"
+        "import os\n"
+        "\n"
+        'value = os.environ["DATUS_PLUGIN_RUNTIME_CONTEXT"]\n'
+        'payload = value.split(".", 1)[1]\n'
+        'data = json.loads(base64.urlsafe_b64decode(payload).decode("utf-8"))\n'
+        'print(data["profile"]["token"])\n',
+        encoding="utf-8",
+    )
+    fake_datus.chmod(0o755)
+    monkeypatch.delenv(runtime_context.RUNTIME_CONTEXT_ENV, raising=False)
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dir)
+
+    def run_for_tenant(token):
+        config = _Config(profile={"name": token, "token": token})
+
+        def provider(command):
+            prepared = runtime_context.prepare_plugin_invocation(command, config)
+            assert prepared is not None
+            return BashExecutionContext(prepared.command, prepared.env, prepared.sandbox_read_dirs)
+
+        tool = BashTool(
+            workspace_root=str(workspace),
+            allowed_patterns=["*"],
+            extra_env={"PATH": f"{workspace}{os.pathsep}{os.environ.get('PATH', '')}"},
+            output_dir_provider=lambda: output_dir,
+            execution_context_provider=provider,
+        )
+        return tool.bash("datus hello show-profile")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(run_for_tenant, ["tenant-a-secret", "tenant-b-secret"]))
+
+    assert [result.success for result in results] == [1, 1]
+    assert [result.result.strip() for result in results] == [
+        "tenant-a-secret",
+        "tenant-b-secret",
+    ]
+    assert runtime_context.RUNTIME_CONTEXT_ENV not in os.environ

--- a/tests/unit_tests/plugins/test_runtime_context.py
+++ b/tests/unit_tests/plugins/test_runtime_context.py
@@ -71,7 +71,7 @@ def test_prepare_plain_command_resolves_explicit_profile(monkeypatch, tmp_path):
         config,
     )
 
-    assert prepared is not None
+    assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
     assert config.requested == ("hello", "staging")
     assert prepared.sandbox_read_dirs == [str(plugin_dir)]
     decoded = runtime_context.PluginRuntimeContext.decode(
@@ -93,7 +93,7 @@ def test_prepare_pipeline_injects_only_datus_segment(monkeypatch, tmp_path):
         _Config(),
     )
 
-    assert prepared is not None
+    assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
     segments = prepared.command.split(" | ")
     assert runtime_context.RUNTIME_CONTEXT_ENV in segments[1]
     assert runtime_context.RUNTIME_CONTEXT_ENV not in segments[2]
@@ -183,7 +183,7 @@ def test_bash_provider_does_not_mutate_parent_environment(monkeypatch, tmp_path)
 
     def provider(command):
         prepared = runtime_context.prepare_plugin_invocation(command, _Config())
-        assert prepared is not None
+        assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
         return BashExecutionContext(prepared.command, prepared.env, prepared.sandbox_read_dirs)
 
     tool = BashTool(
@@ -228,7 +228,7 @@ def test_concurrent_tenants_keep_profiles_isolated_on_redirect_path(monkeypatch,
 
         def provider(command):
             prepared = runtime_context.prepare_plugin_invocation(command, config)
-            assert prepared is not None
+            assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
             return BashExecutionContext(prepared.command, prepared.env, prepared.sandbox_read_dirs)
 
         tool = BashTool(

--- a/tests/unit_tests/tools/func_tool/test_bash_sandbox.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_sandbox.py
@@ -248,6 +248,16 @@ class TestBuildPolicyStrict:
         assert str(shared_read.resolve()) in policy.readable_roots
         assert str(shared_write.resolve()) in policy.writable_roots
 
+    def test_validated_runtime_read_dirs_survive_strict(self, tmp_path, workspace):
+        plugin_dir = tmp_path / "tenant_plugin"
+        plugin_dir.mkdir()
+        policy = build_policy(
+            SandboxSettings(mode=bash_sandbox.MODE_STRICT),
+            workspace,
+            runtime_read_dirs=[str(plugin_dir)],
+        )
+        assert str(plugin_dir.resolve()) in policy.readable_roots
+
     def test_workspace_tmp_and_python_env_survive(self, workspace):
         policy = build_policy(SandboxSettings(mode=bash_sandbox.MODE_STRICT), workspace)
         assert str(workspace.resolve()) in policy.writable_roots

--- a/tests/unit_tests/tools/skill_tools/test_skill_config.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_config.py
@@ -344,10 +344,10 @@ class TestPluginSkillDirectories:
             def active_plugin_names(self):
                 raise AssertionError("disabled plugins must not be enumerated")
 
-        monkeypatch.setattr(
-            "datus.plugins.registry.plugin_skill_directories",
-            lambda **_kwargs: (_ for _ in ()).throw(AssertionError("disabled plugins must not be discovered")),
-        )
+        def fail_plugin_discovery(**_kwargs):
+            raise AssertionError("disabled plugins must not be discovered")
+
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", fail_plugin_discovery)
         _patch_entry_points(monkeypatch, [])
 
         config = SkillConfig.from_dict({}, agent_config=RuntimeConfig())

--- a/tests/unit_tests/tools/skill_tools/test_skill_config.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_config.py
@@ -298,6 +298,62 @@ class TestPluginSkillDirectories:
         dirs = _default_skill_directories()
         assert dirs[:2] == ["./.datus/skills", "~/.datus/skills"]
 
+    def test_request_agent_config_is_authoritative(self, monkeypatch, tmp_path):
+        """AuthProvider config must win over process/CWD plugin activation."""
+        tenant_a_dir = tmp_path / "tenant-a-skills"
+        tenant_b_dir = tmp_path / "tenant-b-skills"
+        tenant_a_dir.mkdir()
+        tenant_b_dir.mkdir()
+        calls = []
+
+        def plugin_dirs(*, active_names):
+            calls.append(active_names)
+            return [str(tenant_a_dir)] if active_names == {"tenant-a"} else [str(tenant_b_dir)]
+
+        class RuntimeConfig:
+            plugins_enabled = True
+
+            def __init__(self, active_names):
+                self._active_names = active_names
+
+            def active_plugin_names(self):
+                return self._active_names
+
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", plugin_dirs)
+        monkeypatch.setattr(
+            "datus.plugins.activation.active_names_for_cwd",
+            lambda: (_ for _ in ()).throw(AssertionError("CWD config must not be read")),
+        )
+        _patch_entry_points(monkeypatch, [])
+
+        tenant_a = SkillConfig.from_dict({}, agent_config=RuntimeConfig({"tenant-a"}))
+        tenant_b = SkillConfig.from_dict({}, agent_config=RuntimeConfig({"tenant-b"}))
+
+        assert str(tenant_a_dir) in tenant_a.directories
+        assert str(tenant_b_dir) not in tenant_a.directories
+        assert str(tenant_b_dir) in tenant_b.directories
+        assert str(tenant_a_dir) not in tenant_b.directories
+        assert calls == [{"tenant-a"}, {"tenant-b"}]
+
+    def test_request_agent_config_master_switch_is_authoritative(self, monkeypatch):
+        """A tenant-level master switch must not fall back to global config."""
+
+        class RuntimeConfig:
+            plugins_enabled = False
+
+            def active_plugin_names(self):
+                raise AssertionError("disabled plugins must not be enumerated")
+
+        monkeypatch.setattr(
+            "datus.plugins.registry.plugin_skill_directories",
+            lambda **_kwargs: (_ for _ in ()).throw(AssertionError("disabled plugins must not be discovered")),
+        )
+        _patch_entry_points(monkeypatch, [])
+
+        config = SkillConfig.from_dict({}, agent_config=RuntimeConfig())
+
+        assert config.directories[:2] == ["./.datus/skills", "~/.datus/skills"]
+
 
 class _FakeManager:
     def __init__(self, data):

--- a/tests/unit_tests/tools/skill_tools/test_skill_registry_unit.py
+++ b/tests/unit_tests/tools/skill_tools/test_skill_registry_unit.py
@@ -31,6 +31,34 @@ def skill_dir(tmp_path):
 
 
 class TestSkillRegistryScanAndAccess:
+    def test_default_registry_uses_request_agent_config(self, skill_dir, monkeypatch):
+        """A registry without explicit SkillConfig still stays tenant-scoped."""
+
+        class RuntimeConfig:
+            plugins_enabled = True
+
+            @staticmethod
+            def active_plugin_names():
+                return {"tenant-plugin"}
+
+        seen = []
+
+        def plugin_dirs(*, active_names):
+            seen.append(active_names)
+            return [str(skill_dir)]
+
+        monkeypatch.setattr("datus.plugins.registry.plugin_skill_directories", plugin_dirs)
+        monkeypatch.setattr(
+            "datus.plugins.activation.active_names_for_cwd",
+            lambda: (_ for _ in ()).throw(AssertionError("CWD config must not be read")),
+        )
+
+        registry = SkillRegistry(agent_config=RuntimeConfig())
+        registry.scan_directories()
+
+        assert registry.skill_exists("test-skill")
+        assert seen == [{"tenant-plugin"}]
+
     def test_scan_discovers_skills(self, skill_dir):
         config = SkillConfig(directories=[str(skill_dir)])
         registry = SkillRegistry(config=config)


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

Managed multi-tenant API deployments receive all runtime configuration through the AuthProvider-provided `AgentConfig` and may not have a local `.datus/config.yml`. Plugin CLI subprocesses and skill discovery previously fell back to process/CWD configuration, so they could miss tenant-specific plugin paths, profiles, activation state, and skill directories.

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

- Bridge the request-scoped plugin profile and path to managed `datus <plugin>` subprocesses through `DATUS_PLUGIN_RUNTIME_CONTEXT`.
- Scope the environment payload to the plugin segment of a Bash pipeline and keep the plugin's own profile loading behavior available.
- Reject unsupported managed shell forms and file-backed `--config` overrides to prevent configuration leakage or ambiguity.
- Propagate the AuthProvider-provided `AgentConfig` through skill configuration, management, and registry discovery.
- Use request-scoped `plugins_enabled`, active plugin names, `plugin_paths`, and skill settings while preserving standalone CLI fallback to project/CWD configuration.
- Activate plugin paths during direct `AgentConfig` construction and remove duplicate loader activation.

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

- Added unit coverage for runtime-context serialization and validation, Bash pipeline scoping, tenant isolation, managed plugin dispatch, plugin-path activation, and request-scoped skill discovery.
- No nightly tests were added because the behavior is deterministic configuration and subprocess routing with no external services.
- Focused plugin, skill, configuration, sandbox, and CLI suites: 953 passed.
- Focused AgentConfig and SkillRegistry suites: 451 passed.
- Updated test suites after audit cleanup: 139 passed.
- Isolated PR acceptance suite without the developer-local `.datus/config.yml`: 215 passed.
- Test-quality audit: P0=0, P1=0.
- Ruff format and lint checks passed; `git diff --check` passed.
- The full local PR harness reached 17,159 passed with 84.96% overall coverage and 84.00% diff coverage; remaining failures were caused by developer-local project configuration and unavailable optional/newer semantic adapter modules, not the changed plugin or skill paths.

## Backport

<!-- The checklist below is auto-generated and refreshed by
     .github/workflows/sync-backport-checklist.yml whenever the PR is opened
     or updated. Tick the release branches you want this PR backported to;
     on merge, the bot will post a `@Mergifyio backport <branch>` comment. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed API runtime configuration that passes a request-scoped plugin profile into plugin subprocesses with sandboxed read access.
  * Enabled request-scoped skill discovery and skill tooling using the active request configuration.
* **Bug Fixes**
  * Improved fail-closed handling for malformed or unsupported managed plugin invocations, including explicit rejection of request `--config` overrides.
  * Prevented runtime context from affecting unrelated commands in pipelines.
* **Documentation**
  * Updated plugin development docs with managed runtime constraints, profile handling, and supported shell forms.
* **Tests**
  * Expanded unit tests for managed dispatch, runtime validation, skill discovery scoping, and sandbox policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->