### PR TITLE
[BugFix] Hide project permission grants for immutable config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,13 @@ Resolution order: `.datus/config.yml` → `agent.target` in `agent.yml`.
 - **New LLM model (new SDK/auth)**: file in `datus/models/`, inherit `LLMBaseModel` (`base.py`), register in `MODEL_TYPE_MAP`, add to `PROVIDER_MODELS` in `tests/regression/test_regression_llm.py`
 - **New MCP tool**: function in `datus/tools/func_tool/`, register in MCP server tool list
 
+### Permission Configuration Mutability
+
+- `AgentConfig.config_mutable` controls whether permission prompts may offer project-scoped persistence.
+- When `config_mutable=False` (multi-tenant API/gateway configurations supplied through `AgentConfig`), Bash and SQL prompts offer only once/session/deny choices; they must never offer or write project grants to `./.datus/config.yml`.
+- Existing `project_bash_allow` and `project_sql_allow` grants supplied through `AgentConfig` remain effective in read-only configuration mode.
+- CLI flows default to `config_mutable=True` and retain project-scoped persistence.
+
 ## Guardrails
 
 - **No direct DB imports**: use `ConnectorRegistry` / `db_manager_instance`

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -3808,6 +3808,7 @@ class AgenticNode(Node):
                 non_interactive=non_interactive,
                 proxied_tool_names=self.proxied_tool_names,
                 project_root=getattr(self.agent_config, "project_root", None),
+                config_mutable=self._resolve_config_mutable(),
                 bash_classifier=create_bash_classifier(bash_rules, self.agent_config),
             )
             logger.debug(

--- a/datus/cli/bash_mode.py
+++ b/datus/cli/bash_mode.py
@@ -280,6 +280,7 @@ def _build_permission_hooks(cli: "DatusCLI", broker: InteractionBroker) -> "Perm
         tool_registry=registry,
         non_interactive=False,
         project_root=getattr(cli.agent_config, "project_root", None),
+        config_mutable=bool(getattr(cli.agent_config, "config_mutable", True)),
         bash_classifier=create_bash_classifier(bash_rules, cli.agent_config),
     )
 

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -267,6 +267,7 @@ class PermissionHooks(AgentHooks):
         non_interactive: bool = False,
         proxied_tool_names: Optional[Set[str]] = None,
         project_root: Optional[str] = None,
+        config_mutable: bool = True,
         bash_classifier: Optional["BashCommandClassifier"] = None,
     ):
         """Initialize the permission hooks.
@@ -305,6 +306,11 @@ class PermissionHooks(AgentHooks):
                 file auto-allows instead of prompting. ``None`` falls back to the
                 current working directory. Also used as the write target for
                 project-level bash allow grants (``.datus/config.yml``).
+            config_mutable: Whether project configuration may be persisted.
+                When ``False`` (for example, the multi-tenant API), permission
+                prompts omit the project-level choice while retaining once and
+                session approvals. Existing project grants supplied through
+                ``AgentConfig`` still apply.
             bash_classifier: Optional LLM classifier for bash commands (reserved
                 seam, see ``bash_classifier.py``). Consulted only when the
                 static bash rules yield ASK with ``safety_forced=False``; a
@@ -319,6 +325,7 @@ class PermissionHooks(AgentHooks):
         self.non_interactive = non_interactive
         self.proxied_tool_names = proxied_tool_names
         self.project_root = project_root
+        self.config_mutable = bool(config_mutable)
         self.bash_classifier = bash_classifier
 
     # Plan-mode tooling is always allowed regardless of permission profile:
@@ -864,7 +871,7 @@ class PermissionHooks(AgentHooks):
             # opted into project-scope grants for destructive statements too —
             # but never for ``unknown``: persisting a grant that auto-allows
             # every future unparseable statement would be a blank cheque.
-            offer_project = kind != SQLType.UNKNOWN.value
+            offer_project = self.config_mutable and kind != SQLType.UNKNOWN.value
             choice = await self._request_sql_confirmation(sql, kind, sql_class, offer_project=offer_project)
             if choice == "y":
                 logger.info("User approved execute_sql (%s, once)", kind)
@@ -1149,11 +1156,15 @@ class PermissionHooks(AgentHooks):
             # relax per project). Never for safety-ceiling asks, and not for
             # user-authored ask rules — the user's own posture lives in their
             # agent.yml, not behind a one-keypress override.
-            offer_project = not decision.safety_forced and (
-                decision.source == BashDecisionSource.DEFAULT
-                or (
-                    decision.source == BashDecisionSource.ASK_RULE
-                    and self.permission_manager.is_plugin_ask_pattern(decision.matched_pattern)
+            offer_project = (
+                self.config_mutable
+                and not decision.safety_forced
+                and (
+                    decision.source == BashDecisionSource.DEFAULT
+                    or (
+                        decision.source == BashDecisionSource.ASK_RULE
+                        and self.permission_manager.is_plugin_ask_pattern(decision.matched_pattern)
+                    )
                 )
             )
             choice = await self._request_bash_confirmation(command, decision, offer_project=offer_project)

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1807,6 +1807,16 @@ class TestEnsurePermissionHooksProxyWiring:
         kwargs = ph_cls.call_args.kwargs
         assert kwargs["proxied_tool_names"] == set()
 
+    def test_passes_config_mutable_from_agent_config(self):
+        """Multi-tenant API nodes suppress project-level permission choices."""
+        node = self._prepare_node(set())
+        node.agent_config = SimpleNamespace(config_mutable=False)
+
+        with patch("datus.tools.permission.permission_hooks.PermissionHooks") as ph_cls:
+            node._ensure_permission_hooks()
+
+        assert ph_cls.call_args.kwargs["config_mutable"] is False
+
 
 # ---------------------------------------------------------------------------
 # _ensure_tool_transformers (plugin tool argument middleware wiring)

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -1789,6 +1789,7 @@ class TestExecuteSqlClassRules:
         non_interactive=False,
         project_root=None,
         project_sql_allows=None,
+        config_mutable=True,
     ):
         registry = ToolRegistry()
         tool_mock = MagicMock()
@@ -1802,6 +1803,7 @@ class TestExecuteSqlClassRules:
             tool_registry=registry,
             non_interactive=non_interactive,
             project_root=project_root,
+            config_mutable=config_mutable,
         )
 
     @staticmethod
@@ -1992,6 +1994,16 @@ class TestExecuteSqlClassRules:
 
         event = mock_broker.request.await_args.args[0][0]
         assert event.choices["p"] == "Allow 'drop' (project)"
+
+    @pytest.mark.asyncio
+    async def test_project_choice_not_offered_when_config_is_immutable(self, mock_broker):
+        hooks = self._make_hooks(mock_broker, self._auto_config(), config_mutable=False)
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("DROP TABLE t"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert set(event.choices) == {"y", "a", "n"}
 
     @pytest.mark.asyncio
     async def test_rejection_raises(self, mock_broker):
@@ -2199,6 +2211,7 @@ class TestBashCommandPermission:
         rules=None,
         non_interactive=False,
         project_root=None,
+        config_mutable=True,
         bash_classifier=None,
         default=PermissionLevel.ASK,
     ):
@@ -2223,6 +2236,7 @@ class TestBashCommandPermission:
             tool_registry=registry,
             non_interactive=non_interactive,
             project_root=project_root,
+            config_mutable=config_mutable,
             bash_classifier=bash_classifier,
         )
         return hooks, manager
@@ -2374,6 +2388,20 @@ class TestBashCommandPermission:
 
         event = mock_broker.request.await_args.args[0][0]
         assert "p" in event.choices
+
+    @pytest.mark.asyncio
+    async def test_unmatched_command_omits_project_choice_when_config_is_immutable(self, mock_broker):
+        hooks, _ = self._make_hooks(
+            mock_broker,
+            bash_commands={"allow": ["git log:*"]},
+            config_mutable=False,
+        )
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert set(event.choices) == {"y", "a", "n"}
 
     @pytest.mark.asyncio
     async def test_classifier_high_confidence_allow_skips_prompt(self, mock_broker):


### PR DESCRIPTION
## Why

Multi-tenant API configurations are supplied through AgentConfig with config_mutable=False and do not use the local project config file as their source of truth. Permission prompts still offered project-scoped Bash and SQL approvals, which could incorrectly write grants to the API server workspace.

## Solution

Propagate AgentConfig.config_mutable into PermissionHooks and only offer project-scoped Bash or SQL choices when configuration is mutable. Once, session, and deny choices remain available. Existing project_bash_allow and project_sql_allow grants supplied by AgentConfig continue to apply. CLI flows retain mutable configuration by default. Document the contract in CLAUDE.md.

## Test Cases

- Added Bash and SQL unit coverage proving the project choice is omitted when config_mutable=False.
- Added AgenticNode wiring coverage for config_mutable propagation.
- Impacted unit suites: 5944 passed, 1 skipped, 1 xfailed.
- Related permission/API/CLI regression subset: 232 passed.
- Test audit: P0=0, P1=0; Ruff and diff checks passed.
- The full local PR harness was attempted; its fixed acceptance suite was blocked by the developer workspace .datus/config.yml overriding the test datasource with tencent. The impacted suites completed successfully.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission prompts now respect whether configuration changes are allowed.
  * When configuration is read-only, project-level permission persistence is unavailable, while one-time and session approvals remain available.
  * Existing project-level permissions continue to work as expected.
  * Editable configurations retain the option to save project-level permission grants.

* **Documentation**
  * Added guidance explaining permission behavior for editable and read-only configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->