### PR TITLE
[BugFix] Make Escape interruption immediate and consistent

### DIFF
--- a/datus/cli/action_display/display.py
+++ b/datus/cli/action_display/display.py
@@ -11,7 +11,13 @@ from rich.console import Console
 from rich.text import Text
 
 from datus.cli.action_display.renderers import ActionContentGenerator, ActionRenderer, is_task_anchor_input
-from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
+from datus.schemas.action_history import (
+    INTERRUPTED_ACTION_TYPE,
+    SUBAGENT_COMPLETE_ACTION_TYPE,
+    ActionHistory,
+    ActionRole,
+    ActionStatus,
+)
 from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
@@ -157,6 +163,7 @@ class ActionHistoryDisplay:
         subagent_groups: Dict[Optional[str], dict] = {}
         pending_task_tool_skips = 0
         deferred_groups: List[Tuple[dict, ActionHistory]] = []
+        is_interrupted_turn = any(action.action_type == INTERRUPTED_ACTION_TYPE for action in actions)
 
         # Pre-scan to identify which top-level ``task`` tool calls wrap a
         # sub-agent. ``subagent_complete.parent_action_id`` carries the
@@ -219,16 +226,17 @@ class ActionHistoryDisplay:
         # the end-of-turn full-screen reprint clears scrollback, and skipping
         # them is what makes that text disappear after the redraw.
         last_plain_response_idx: Optional[int] = None
-        for i in range(len(actions) - 1, -1, -1):
-            a = actions[i]
-            if (
-                a.role == ActionRole.ASSISTANT
-                and a.depth == 0
-                and a.action_type == "response"
-                and a.status == ActionStatus.SUCCESS
-            ):
-                last_plain_response_idx = i
-                break
+        if not is_interrupted_turn:
+            for i in range(len(actions) - 1, -1, -1):
+                a = actions[i]
+                if (
+                    a.role == ActionRole.ASSISTANT
+                    and a.depth == 0
+                    and a.action_type == "response"
+                    and a.status == ActionStatus.SUCCESS
+                ):
+                    last_plain_response_idx = i
+                    break
 
         for idx, action in enumerate(actions):
             # INTERACTION actions: only shown during live interaction, skip in history replay

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -22,7 +22,7 @@ from rich.text import Text
 
 from datus.cli._render_utils import format_io_tokens
 from datus.cli.cli_styles import ACTION_ROLE_COLOR_NAMES, CODE_THEME, render_user_scrollback_text
-from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.schemas.action_history import INTERRUPTED_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -760,6 +760,12 @@ class ActionRenderer:
 
     def render_main_action(self, action: ActionHistory, verbose: bool) -> List[RenderableType]:
         """Render a depth=0 completed action directly as Rich objects."""
+        # In-memory replay marker added when a response-started turn is
+        # interrupted.  It is deliberately not persisted as a model action,
+        # but must survive Ctrl+O/sidebar full-screen transcript rebuilds.
+        if action.action_type == INTERRUPTED_ACTION_TYPE:
+            return [Text.from_markup("[yellow]Interrupted[/yellow]")]
+
         # Manual SQL/bash execution (input-bar sql>/bash> mode): render the
         # terminal frame as the styled execution block.
         if action.action_type == "manual_exec":

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -24,7 +24,13 @@ from datus.cli.action_display.renderers import (
     parse_task_tool_input,
     render_assistant_response_markdown,
 )
-from datus.schemas.action_history import SUBAGENT_COMPLETE_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
+from datus.schemas.action_history import (
+    INTERRUPTED_ACTION_TYPE,
+    SUBAGENT_COMPLETE_ACTION_TYPE,
+    ActionHistory,
+    ActionRole,
+    ActionStatus,
+)
 from datus.utils.loggings import get_logger
 
 if TYPE_CHECKING:
@@ -123,6 +129,28 @@ class InlineStreamingContext:
         self.display = display_instance
         self._history_turns: List[Tuple[str, List[ActionHistory]]] = history_turns or []
         self._current_user_message = current_user_message
+        # Input text restored by ESC when the turn is cancelled before the
+        # model produces anything.  It normally matches
+        # ``_current_user_message`` but callers may replace it with the
+        # pre-transformation text (for example before an @Agent dispatch hint
+        # is appended).
+        self._editable_user_message = current_user_message
+        # Set by the action producer as soon as it observes the first
+        # assistant/tool/interaction event.  This deliberately does not wait
+        # for the refresh thread to paint a delta.
+        self._model_response_started = threading.Event()
+        # Latched by ESC when it wins the race before the first response
+        # event. The chat layer consumes this after async cancellation has
+        # fully unwound, then rolls the entire user turn back.
+        self._unanswered_rollback_requested = threading.Event()
+        # Generic cancellation latch. Unlike the notice event, this remains
+        # set after ``__exit__`` so the chat layer can skip final-response
+        # rendering even after the visible notice has been flushed.
+        self._interrupt_requested = threading.Event()
+        # ESC requests this only when response output has already started.
+        # ``__exit__`` prints the notice after draining the partial response,
+        # preserving the natural output order.
+        self._interrupted_notice_requested = threading.Event()
         self._sync_mode = sync_mode
         self._processed_index = 0
         self._tick = 0
@@ -216,6 +244,44 @@ class InlineStreamingContext:
     def set_event_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """Set the asyncio event loop for broker.submit calls from daemon thread."""
         self._event_loop = loop
+
+    def set_editable_user_message(self, message: str) -> None:
+        """Set the original input text that ESC may restore for editing."""
+        self._editable_user_message = message
+
+    @property
+    def editable_user_message(self) -> str:
+        """Original user input suitable for restoring into the input buffer."""
+        return self._editable_user_message
+
+    def mark_model_response_started(self) -> None:
+        """Latch that the model has produced an observable response event."""
+        self._model_response_started.set()
+
+    @property
+    def has_model_response_started(self) -> bool:
+        """Whether any model response event has arrived for this turn."""
+        return self._model_response_started.is_set()
+
+    def request_interrupted_notice(self) -> None:
+        """Request an ``Interrupted`` line after partial output is drained."""
+        self._interrupt_requested.set()
+        self._interrupted_notice_requested.set()
+
+    def request_unanswered_rollback(self) -> None:
+        """Latch that ESC cancelled this turn before any model response."""
+        self._interrupt_requested.set()
+        self._unanswered_rollback_requested.set()
+
+    @property
+    def unanswered_rollback_requested(self) -> bool:
+        """Whether this turn should be removed and restored into the editor."""
+        return self._unanswered_rollback_requested.is_set()
+
+    @property
+    def interrupt_requested(self) -> bool:
+        """Whether this streaming turn was cancelled by the user."""
+        return self._interrupt_requested.is_set()
 
     def set_input_collector(self, collector: Callable[[ActionHistory, Console], Optional[List[List[str]]]]) -> None:
         """Set the synchronous input collector callback for INTERACTION actions.
@@ -451,6 +517,10 @@ class InlineStreamingContext:
         self._active_message_id = None
         self._stop_event.clear()
         self._paused = False
+        self._model_response_started.clear()
+        self._unanswered_rollback_requested.clear()
+        self._interrupt_requested.clear()
+        self._interrupted_notice_requested.clear()
         # Fresh turn: forget which response we've already finalized so the
         # next stream's first paired completion triggers the full dedupe
         # + reprint cycle again.
@@ -497,6 +567,10 @@ class InlineStreamingContext:
                     self._stream_body_finalized = True
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.debug("Markdown tail flush on exit failed: %s", exc)
+
+        if self._interrupted_notice_requested.is_set():
+            self._interrupted_notice_requested.clear()
+            self._print_to_append_area("[yellow]Interrupted[/yellow]")
 
         # Unregister
         if self.display._current_context is self:
@@ -620,6 +694,12 @@ class InlineStreamingContext:
             if self._history_turns:
 
                 def _render_turn_response(turn_actions: List[ActionHistory]) -> None:
+                    # Interrupted turns contain only a partial trace plus the
+                    # replay marker rendered by ``render_action_history``.
+                    # Never promote their last assistant event to a final
+                    # response during a later live Ctrl+O rebuild.
+                    if any(action.action_type == INTERRUPTED_ACTION_TYPE for action in turn_actions):
+                        return
                     # Prefer the wrapper action (e.g. ``chat_response``) since
                     # ``render_action_history`` already skips it. Fall back to
                     # plain ``response`` for providers that don't emit a
@@ -1527,6 +1607,7 @@ class InlineStreamingContext:
                 delta = raw
         if not delta:
             return
+        self.mark_model_response_started()
         self._markdown_stream_has_streamed = True
         if action.action_id:
             self._markdown_active_stream_ids.add(action.action_id)

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -31,7 +31,7 @@ from datus.cli.cli_styles import (
 )
 from datus.cli.execution_state import ExecutionInterrupted, PendingInputQueue, auto_submit_interaction
 from datus.cli.list_selector_app import ListItem, ListSelectorApp
-from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.schemas.action_history import INTERRUPTED_ACTION_TYPE, ActionHistory, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
 from datus.utils.loggings import get_logger
 from datus.utils.terminal_utils import EscapeGuard, interrupt_on_escape
@@ -451,6 +451,7 @@ class ChatCommands:
             self.console.print("[yellow]Please provide a message to chat with the AI.[/]")
             return
 
+        editable_message = message
         try:
             # Manual-execution turns (SQL/bash run from the input bar) carry a
             # marker-encoded payload whose command may legitimately contain
@@ -460,6 +461,12 @@ class ChatCommands:
 
             if is_exec_message(message):
                 at_tables, at_metrics, at_sqls = [], [], []
+                from datus.cli.manual_exec import decode_exec_message
+
+                exec_payload = decode_exec_message(message)
+                if exec_payload is not None:
+                    command = str(exec_payload.get("command", ""))
+                    editable_message = f"!{command}" if exec_payload.get("kind") == "tool" else command
             else:
                 at_tables, at_metrics, at_sqls, at_agent = self.cli.at_completer.parse_at_context(message)
                 # ``@Agent <name>`` is a per-turn routing hint, not a default-agent
@@ -577,6 +584,12 @@ class ChatCommands:
             pending_non_thinking = None
 
             if interactive:
+                action_checkpoint = self.cli.actions.checkpoint()
+                node_action_checkpoint = len(getattr(current_node, "actions", []))
+                session_manager = current_node.session_manager
+                session_checkpoint = session_manager.checkpoint_turn(current_node.session_id)
+                output_checkpoint = None
+                execution_interrupted = False
 
                 async def run_chat_stream():
                     """Run chat stream — INTERACTION actions flow into incremental_actions."""
@@ -589,6 +602,11 @@ class ChatCommands:
                             action_history_manager=self.cli.actions
                         )
                         async for action in action_stream:
+                            if (
+                                action.role in {ActionRole.ASSISTANT, ActionRole.TOOL, ActionRole.INTERACTION}
+                                and action.action_type not in {"compact_progress", "compact_summary"}
+                            ):
+                                streaming_ctx.mark_model_response_started()
                             # Token-usage updates drive the status bar / API
                             # ``usage`` events only; they carry no chat content
                             # and must never render as a transcript line. Sub-agent
@@ -672,6 +690,7 @@ class ChatCommands:
                     interaction_broker=current_node.interaction_broker,
                     streaming_deltas=streaming_deltas,
                 )
+                streaming_ctx.set_editable_user_message(editable_message)
                 # Reprint the CLI banner at the top after Ctrl+O clears the screen.
                 banner_callback = getattr(self.cli, "_print_welcome", None)
                 if banner_callback is not None:
@@ -683,6 +702,7 @@ class ChatCommands:
                 # mid-stream Ctrl+O verbose toggle wipes the viewport for real.
                 tui_output_buffer = getattr(self.cli, "_tui_output_buffer", None)
                 if tui_output_buffer is not None:
+                    output_checkpoint = tui_output_buffer.checkpoint()
                     streaming_ctx.set_clear_screen_callback(tui_output_buffer.clear)
 
                 # In TUI mode the persistent prompt_toolkit Application owns
@@ -706,14 +726,73 @@ class ChatCommands:
                     with esc_cm as esc_guard, streaming_ctx:
                         streaming_ctx.set_input_collector(self._make_input_collector(esc_guard))
                         try:
-                            self.cli.run_on_bg_loop(run_chat_stream())
+                            self.cli.run_on_bg_loop(
+                                run_chat_stream(),
+                                interrupt_controller=current_node.interrupt_controller,
+                            )
                         except KeyboardInterrupt:
+                            execution_interrupted = True
                             current_node.interrupt_controller.interrupt()
                             if current_node.pending_input_queue is not None:
                                 current_node.pending_input_queue.clear()
                             logger.info("KeyboardInterrupt caught, execution interrupted gracefully")
                         except ExecutionInterrupted:
+                            execution_interrupted = True
+                            current_node._drop_running_turn_usage_on_exit = True
+                            if current_node.pending_input_queue is not None:
+                                current_node.pending_input_queue.clear()
                             logger.info("ExecutionInterrupted caught, execution stopped gracefully")
+                    # A cooperative controller checkpoint can finish the
+                    # stream normally before Task.cancel is delivered. The
+                    # ESC-time latch, rather than the exception path, is the
+                    # authoritative rollback decision.
+                    rollback_unanswered = bool(
+                        getattr(streaming_ctx, "unanswered_rollback_requested", False)
+                    )
+                    turn_interrupted = execution_interrupted or bool(
+                        getattr(streaming_ctx, "interrupt_requested", False)
+                    )
+                    if rollback_unanswered:
+                        self._rollback_unanswered_turn(
+                            current_node=current_node,
+                            incremental_actions=incremental_actions,
+                            action_checkpoint=action_checkpoint,
+                            node_action_checkpoint=node_action_checkpoint,
+                            session_manager=session_manager,
+                            session_checkpoint=session_checkpoint,
+                            output_buffer=tui_output_buffer,
+                            output_checkpoint=output_checkpoint,
+                        )
+                        current_node.interrupt_controller.reset()
+                        return
+                    if turn_interrupted:
+                        # Partial output (and the Interrupted notice) has
+                        # already been flushed by the streaming context. Do
+                        # not reinterpret the last intermediate/tool action as
+                        # a final response.  The turn is nevertheless durable:
+                        # the node/session layer has already recorded its user
+                        # message and any partial actions.  Keep the same turn
+                        # in the in-memory replay list before returning, or a
+                        # later full-screen repaint (Ctrl+O/sidebar reflow)
+                        # clears the visible user row even though /resume can
+                        # reconstruct it from SQLite.
+                        interrupted_actions = list(incremental_actions)
+                        interrupted_actions.append(
+                            ActionHistory.create_action(
+                                role=ActionRole.SYSTEM,
+                                action_type=INTERRUPTED_ACTION_TYPE,
+                                messages="Interrupted",
+                                input_data={},
+                                output_data={},
+                                status=ActionStatus.SUCCESS,
+                            )
+                        )
+                        self.last_actions = interrupted_actions
+                        self.all_turn_actions.append((message, interrupted_actions))
+                        # Clear the reusable controller before the next Enter
+                        # starts a fresh run.
+                        current_node.interrupt_controller.reset()
+                        return
                     streamed_body = bool(getattr(streaming_ctx, "has_streamed_response", False))
                 finally:
                     self.current_streaming_ctx = None
@@ -803,11 +882,17 @@ class ChatCommands:
                 )
                 with ns_streaming_ctx:
                     try:
-                        self.cli.run_on_bg_loop(run_stream())
+                        self.cli.run_on_bg_loop(
+                            run_stream(),
+                            interrupt_controller=current_node.interrupt_controller,
+                        )
                     except KeyboardInterrupt:
                         current_node.interrupt_controller.interrupt()
                         logger.info("KeyboardInterrupt caught, execution interrupted gracefully")
                     except ExecutionInterrupted:
+                        current_node._drop_running_turn_usage_on_exit = True
+                        if current_node.pending_input_queue is not None:
+                            current_node.pending_input_queue.clear()
                         logger.info("ExecutionInterrupted caught, execution stopped gracefully")
                 streamed_body = bool(getattr(ns_streaming_ctx, "has_streamed_response", False))
 
@@ -880,6 +965,37 @@ class ChatCommands:
             # Drop the in-progress reference so a later sidebar reflow does
             # not replay actions from a turn that has already finished.
             self._current_incremental_actions = None
+
+    def _rollback_unanswered_turn(
+        self,
+        *,
+        current_node,
+        incremental_actions: List[ActionHistory],
+        action_checkpoint: int,
+        node_action_checkpoint: int,
+        session_manager,
+        session_checkpoint,
+        output_buffer,
+        output_checkpoint,
+    ) -> None:
+        """Remove an ESC-cancelled, unanswered turn from every transcript."""
+        try:
+            session_manager.rollback_turn(current_node.session_id, session_checkpoint)
+        except Exception:  # pragma: no cover - rollback remains best-effort on damaged DBs
+            logger.exception("Failed to roll back unanswered SQLite turn")
+
+        self.cli.actions.rollback_to(action_checkpoint)
+        node_actions = getattr(current_node, "actions", None)
+        if isinstance(node_actions, list):
+            del node_actions[node_action_checkpoint:]
+        incremental_actions.clear()
+        current_node.running_turn_usage = None
+        pending_queue = getattr(current_node, "pending_input_queue", None)
+        if pending_queue is not None:
+            pending_queue.clear()
+
+        if output_buffer is not None and output_checkpoint is not None:
+            output_buffer.rollback(output_checkpoint)
 
     def _render_final_response(self, final_action: "ActionHistory", skip_markdown_body: bool = False) -> None:
         """Render the final response output (SQL, markdown, etc.) from a node action.
@@ -1309,7 +1425,7 @@ class ChatCommands:
         Returns:
             Extracted report content or None if not found
         """
-        if not response:
+        if not response or not isinstance(response, str):
             return None
 
         try:
@@ -1521,6 +1637,11 @@ class ChatCommands:
             attached — otherwise Ctrl+O verbose mode hides blocking validation
             details from runs whose retry budget was exhausted.
             """
+            # Response-started ESC turns intentionally have no final response.
+            # Their partial trace plus the replay-only Interrupted marker were
+            # already rendered by ``render_action_history`` above.
+            if any(action.action_type == INTERRUPTED_ACTION_TYPE for action in turn_actions):
+                return
             final_action = self._find_node_final_action(turn_actions)
             if not final_action or final_action.depth != 0:
                 return

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -602,10 +602,11 @@ class ChatCommands:
                             action_history_manager=self.cli.actions
                         )
                         async for action in action_stream:
-                            if (
-                                action.role in {ActionRole.ASSISTANT, ActionRole.TOOL, ActionRole.INTERACTION}
-                                and action.action_type not in {"compact_progress", "compact_summary"}
-                            ):
+                            if action.role in {
+                                ActionRole.ASSISTANT,
+                                ActionRole.TOOL,
+                                ActionRole.INTERACTION,
+                            } and action.action_type not in {"compact_progress", "compact_summary"}:
                                 streaming_ctx.mark_model_response_started()
                             # Token-usage updates drive the status bar / API
                             # ``usage`` events only; they carry no chat content
@@ -746,9 +747,7 @@ class ChatCommands:
                     # stream normally before Task.cancel is delivered. The
                     # ESC-time latch, rather than the exception path, is the
                     # authoritative rollback decision.
-                    rollback_unanswered = bool(
-                        getattr(streaming_ctx, "unanswered_rollback_requested", False)
-                    )
+                    rollback_unanswered = bool(getattr(streaming_ctx, "unanswered_rollback_requested", False))
                     turn_interrupted = execution_interrupted or bool(
                         getattr(streaming_ctx, "interrupt_requested", False)
                     )

--- a/datus/cli/execution_state.py
+++ b/datus/cli/execution_state.py
@@ -11,7 +11,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional
+from typing import TYPE_CHECKING, AsyncGenerator, Callable, Dict, List, Optional
 
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.utils.loggings import get_logger
@@ -33,10 +33,55 @@ class InterruptController:
 
     def __init__(self):
         self._interrupted = threading.Event()
+        self._callback_lock = threading.Lock()
+        self._cancel_callbacks: Dict[str, Callable[[], None]] = {}
 
     def interrupt(self):
-        """Signal that execution should be interrupted."""
-        self._interrupted.set()
+        """Signal interruption and wake any registered async operation.
+
+        The event preserves the cooperative polling API used by tools and
+        model adapters.  Cancellation callbacks provide the wake-up path for
+        operations currently parked in an ``await`` (for example, waiting for
+        the next LLM stream event), so interruption does not depend on the
+        upstream API returning first.
+        """
+        with self._callback_lock:
+            if self._interrupted.is_set():
+                return
+            self._interrupted.set()
+            callbacks = tuple(self._cancel_callbacks.values())
+
+        # Call outside the lock: callbacks may schedule work on another event
+        # loop and must never block registration/unregistration.
+        for callback in callbacks:
+            try:
+                callback()
+            except Exception:
+                logger.exception("Interrupt cancellation callback failed")
+
+    def register_cancel_callback(self, callback: Callable[[], None]) -> str:
+        """Register a wake-up callback for the active async operation.
+
+        If interruption won the race before registration, invoke the callback
+        immediately.  The returned token must be passed to
+        :meth:`unregister_cancel_callback` when the operation finishes.
+        """
+        token = uuid.uuid4().hex
+        with self._callback_lock:
+            self._cancel_callbacks[token] = callback
+            interrupted = self._interrupted.is_set()
+
+        if interrupted:
+            try:
+                callback()
+            except Exception:
+                logger.exception("Late interrupt cancellation callback failed")
+        return token
+
+    def unregister_cancel_callback(self, token: str) -> None:
+        """Remove a previously registered cancellation callback."""
+        with self._callback_lock:
+            self._cancel_callbacks.pop(token, None)
 
     @property
     def is_interrupted(self) -> bool:
@@ -50,7 +95,8 @@ class InterruptController:
 
     def reset(self):
         """Clear the interrupt signal for a new execution cycle."""
-        self._interrupted.clear()
+        with self._callback_lock:
+            self._interrupted.clear()
 
 
 class PendingInputQueue:

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -572,11 +572,7 @@ class DatusCLI:
         editable_message: Optional[str] = None
         streaming_ctx = getattr(chat_commands, "current_streaming_ctx", None) if chat_commands else None
         has_model_response = bool(getattr(streaming_ctx, "has_model_response_started", False))
-        if (
-            restore_unanswered_input
-            and streaming_ctx is not None
-            and not has_model_response
-        ):
+        if restore_unanswered_input and streaming_ctx is not None and not has_model_response:
             editable_message = getattr(streaming_ctx, "editable_user_message", None)
             streaming_ctx.request_unanswered_rollback()
         elif restore_unanswered_input and streaming_ctx is not None and has_model_response:
@@ -1218,6 +1214,7 @@ class DatusCLI:
         Returns:
             The coroutine's return value.
         """
+
         async def _run_cancellable():
             if interrupt_controller is None:
                 return await coro

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -65,6 +65,7 @@ from datus.cli.cli_styles import (
 )
 from datus.cli.context_commands import ContextCommands
 from datus.cli.effort_commands import EffortCommands
+from datus.cli.execution_state import ExecutionInterrupted, InterruptController
 from datus.cli.init_commands import InitCommands
 from datus.cli.input_modes import MODE_CHROME, InputMode, next_input_mode
 from datus.cli.language_commands import LanguageCommands
@@ -564,15 +565,37 @@ class DatusCLI:
         current_node = getattr(chat_commands, "current_node", None)
         return getattr(current_node, "pending_input_queue", None) if current_node else None
 
-    def _interrupt_agent(self) -> None:
+    def _interrupt_agent(self, *, restore_unanswered_input: bool = False) -> None:
         chat_commands = getattr(self, "chat_commands", None)
         current_node = getattr(chat_commands, "current_node", None) if chat_commands else None
         controller = getattr(current_node, "interrupt_controller", None) if current_node else None
+        editable_message: Optional[str] = None
+        streaming_ctx = getattr(chat_commands, "current_streaming_ctx", None) if chat_commands else None
+        has_model_response = bool(getattr(streaming_ctx, "has_model_response_started", False))
+        if (
+            restore_unanswered_input
+            and streaming_ctx is not None
+            and not has_model_response
+        ):
+            editable_message = getattr(streaming_ctx, "editable_user_message", None)
+            streaming_ctx.request_unanswered_rollback()
+        elif restore_unanswered_input and streaming_ctx is not None and has_model_response:
+            streaming_ctx.request_interrupted_notice()
         if controller is not None:
             try:
+                # Active Task.cancel reaches the node as CancelledError rather
+                # than its cooperative ExecutionInterrupted branch. Preserve
+                # the pre-existing Ctrl+C/partial-turn usage semantics; the
+                # unanswered ESC rollback explicitly clears this snapshot.
+                if current_node is not None:
+                    current_node._drop_running_turn_usage_on_exit = False
                 controller.interrupt()
             except Exception as exc:  # pragma: no cover - defensive
+                if current_node is not None:
+                    current_node._drop_running_turn_usage_on_exit = True
                 logger.debug(f"interrupt_controller.interrupt failed: {exc}")
+        if editable_message is not None and self.tui_app is not None:
+            self.tui_app.restore_input_after_dispatch(editable_message)
 
     def _compute_pane_width(self, sidebar_visible: bool) -> int:
         """Width in cells available to the left output pane.
@@ -868,19 +891,18 @@ class DatusCLI:
         def _esc(event):  # noqa: ANN001
             """Escape: interrupt the running agent loop.
 
-            prompt_toolkit debounces ESC so this handler only fires for a
-            standalone key press, not for the leading byte of arrow-key
-            escape sequences (``\\x1b[A`` etc.). While idle it returns to chat
-            mode if a non-chat input mode is active, otherwise it is a no-op
-            so default Buffer behavior (no-op for ESC in insert mode) is
-            preserved.
+            DatusApp keeps prompt_toolkit's escape-sequence debounce at 10 ms,
+            which still distinguishes arrow keys (``\\x1b[A`` etc.) while
+            giving standalone ESC the same immediate feel as Ctrl+C. While
+            idle it returns to chat mode if a non-chat input mode is active,
+            otherwise it is a no-op.
             """
             if not self.tui_app._agent_running.is_set():
                 if self.input_mode is not InputMode.CHAT:
                     self._set_input_mode(InputMode.CHAT)
                     event.app.invalidate()
                 return
-            self._interrupt_agent()
+            self._interrupt_agent(restore_unanswered_input=True)
 
         @self.tui_app.key_bindings.add("c-c")
         def _c_c(event):  # noqa: ANN001
@@ -1171,7 +1193,7 @@ class DatusCLI:
         # is the standard way to bridge from a foreign thread into an asyncio loop.
         self._bg_loop.call_soon_threadsafe(lambda: self._bg_loop.create_task(_runner()))
 
-    def run_on_bg_loop(self, coro):
+    def run_on_bg_loop(self, coro, *, interrupt_controller: Optional[InterruptController] = None):
         """Run a coroutine on the persistent background event loop and block until done.
 
         ``asyncio.run(coro)`` creates and then tears down a fresh loop on every
@@ -1188,11 +1210,60 @@ class DatusCLI:
 
         Args:
             coro: Coroutine to execute on ``_bg_loop``.
+            interrupt_controller: Optional controller whose interrupt signal
+                actively cancels the background asyncio Task.  This wakes an
+                API stream currently parked waiting for its next event instead
+                of waiting for a later cooperative polling checkpoint.
 
         Returns:
             The coroutine's return value.
         """
-        future = asyncio.run_coroutine_threadsafe(coro, self._bg_loop)
+        async def _run_cancellable():
+            if interrupt_controller is None:
+                return await coro
+
+            loop = asyncio.get_running_loop()
+            task = asyncio.current_task()
+            if task is None:  # pragma: no cover - asyncio always supplies one
+                return await coro
+            cancel_requested = threading.Event()
+
+            def _cancel_task() -> None:
+                # ``interrupt()`` normally runs on the prompt_toolkit/input
+                # thread.  Task.cancel is not cross-thread safe, so always
+                # marshal it onto the background loop.
+                cancel_requested.set()
+                try:
+                    loop.call_soon_threadsafe(task.cancel)
+                except RuntimeError:
+                    # Loop already stopped during shutdown.
+                    pass
+
+            token = interrupt_controller.register_cancel_callback(_cancel_task)
+            try:
+                return await coro
+            except asyncio.CancelledError:
+                # Preserve ordinary cancellation (for example application
+                # shutdown).  Only user-triggered cancellation becomes the
+                # chat-layer's existing graceful interrupt exception.  Keep a
+                # local latch because the node resets its reusable controller
+                # at stream startup; a very early key press can otherwise win
+                # registration but have its event flag cleared before
+                # CancelledError is delivered.
+                if cancel_requested.is_set() or interrupt_controller.is_interrupted:
+                    raise ExecutionInterrupted("Execution interrupted by user") from None
+                raise
+            finally:
+                interrupt_controller.unregister_cancel_callback(token)
+                # The controller is reused by the next chat turn. Leaving the
+                # event latched makes that turn's callback fire immediately
+                # during registration, swallowing the first Enter after a
+                # cancel. Reset only after this task has fully unwound, so
+                # same-turn early interrupts remain reliable.
+                if cancel_requested.is_set():
+                    interrupt_controller.reset()
+
+        future = asyncio.run_coroutine_threadsafe(_run_cancellable(), self._bg_loop)
         try:
             return future.result()
         except KeyboardInterrupt:

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -1782,6 +1782,7 @@ class DatusApp:
 
     def set_input_text(self, text: str) -> None:
         """Prefill the input buffer (e.g. for ``.rewind``). Thread-safe."""
+
         def _apply() -> None:
             self._set_input_text_now(text)
 

--- a/datus/cli/tui/app.py
+++ b/datus/cli/tui/app.py
@@ -298,6 +298,8 @@ class DatusApp:
         self._search_buffer = Buffer(multiline=False, on_text_changed=self._on_search_text_changed)
 
         self._agent_running = threading.Event()
+        self._dispatch_state_lock = threading.Lock()
+        self._input_restore_after_dispatch: Optional[str] = None
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="datus-tui-worker")
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._exit_code: int = 0
@@ -599,6 +601,11 @@ class DatusApp:
             mouse_support=self._mouse_support_enabled,
             erase_when_done=False,
         )
+        # prompt_toolkit defaults to waiting 500 ms before deciding that a
+        # lone ESC byte is not the prefix of an arrow/function-key sequence.
+        # Keep a tiny sequencing window, but make standalone ESC cancellation
+        # perceptually as immediate as Ctrl+C.
+        self._app.ttimeoutlen = 0.01
 
         # Live state now drives the streaming tail inside the scrollable
         # output pane (via ``TUIOutputBuffer.tokens()``) — its invalidate
@@ -1775,12 +1782,8 @@ class DatusApp:
 
     def set_input_text(self, text: str) -> None:
         """Prefill the input buffer (e.g. for ``.rewind``). Thread-safe."""
-        buffer = self._input_area.buffer
-        document_cls = buffer.document.__class__
-
         def _apply() -> None:
-            buffer.document = document_cls(text)
-            self._app.invalidate()
+            self._set_input_text_now(text)
 
         if self._loop is None:
             # Application has not started yet — direct mutation is safe because
@@ -1792,6 +1795,26 @@ class DatusApp:
         except RuntimeError:
             # Loop already closed; the buffer won't be observed anyway.
             pass
+
+    def restore_input_after_dispatch(self, text: str) -> None:
+        """Restore cancelled input only after the worker releases run state.
+
+        Showing the text while ``_agent_running`` is still set makes an
+        immediate Enter route it into the pending-input queue. Deferring the
+        mutation until ``_on_dispatch_done`` makes restoration and the idle
+        transition atomic from the prompt loop's point of view.
+        """
+        with self._dispatch_state_lock:
+            if self._agent_running.is_set():
+                self._input_restore_after_dispatch = text
+                return
+        self.set_input_text(text)
+
+    def _set_input_text_now(self, text: str) -> None:
+        buffer = self._input_area.buffer
+        document_cls = buffer.document.__class__
+        buffer.document = document_cls(text)
+        self._app.invalidate()
 
     def invalidate(self) -> None:
         """Trigger a redraw from any thread."""
@@ -2059,16 +2082,21 @@ class DatusApp:
         the input was rejected because the agent is already running or the
         text is blank).
         """
-        if self._agent_running.is_set():
-            return None
         if not text.strip():
             return None
+        with self._dispatch_state_lock:
+            if self._agent_running.is_set():
+                return None
+            self._agent_running.set()
         if self._loop is None:
             # Application has not started yet — run synchronously.
-            self._safe_dispatch(text)
+            try:
+                self._safe_dispatch(text)
+            finally:
+                with self._dispatch_state_lock:
+                    self._agent_running.clear()
             return None
 
-        self._agent_running.set()
         self._app.invalidate()
         # Snapshot ContextVars on the prompt_toolkit loop thread so the worker
         # sees bindings (e.g. ``set_current_path_manager``) set during startup.
@@ -2266,8 +2294,18 @@ class DatusApp:
             return None
 
     def _on_dispatch_done(self, future: Future) -> None:
-        self._agent_running.clear()
-        self.invalidate()
+        with self._dispatch_state_lock:
+            self._agent_running.clear()
+            restored_input = self._input_restore_after_dispatch
+            self._input_restore_after_dispatch = None
+        # This callback runs on the prompt_toolkit event-loop thread. Apply
+        # the document before returning to input processing, so the first
+        # Enter after cancellation submits normally instead of seeing a
+        # transient busy state or an empty buffer.
+        if restored_input is not None:
+            self._set_input_text_now(restored_input)
+        else:
+            self.invalidate()
         try:
             result = future.result()
         except BaseException:  # pragma: no cover - already logged

--- a/datus/cli/tui/output_buffer.py
+++ b/datus/cli/tui/output_buffer.py
@@ -34,6 +34,7 @@ configured ``on_change`` callback is fired; wire it to
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple
 
 from prompt_toolkit.data_structures import Point
@@ -51,6 +52,14 @@ from datus.cli.tui.selection import (
 )
 
 _StyledToken = Tuple[str, str]
+
+
+@dataclass(frozen=True)
+class OutputBufferCheckpoint:
+    """Committed output state immediately before a cancellable chat turn."""
+
+    committed: Tuple[List[_StyledToken], ...]
+    partial: str
 
 
 class _BufferSnapshot:
@@ -93,9 +102,10 @@ class _BufferSnapshot:
 class TUIOutputBuffer:
     """Captures Rich console output and surfaces it as prompt_toolkit tokens.
 
-    The buffer is append-only. There is no maximum line cap — the user
-    explicitly chose unlimited history retention (see the plan). A future
-    iteration may add ``agent.tui.output_max_lines`` config.
+    Normal rendering is append-only, with a checkpoint/rollback escape hatch
+    for an unanswered turn cancelled before it becomes transcript history.
+    There is no maximum line cap. A future iteration may add
+    ``agent.tui.output_max_lines`` config.
     """
 
     def __init__(
@@ -299,6 +309,30 @@ class TUIOutputBuffer:
             self._cache_snapshot_partial = None
             self._cache_snapshot_live = None
         if had_content:
+            self._on_change()
+
+    def checkpoint(self) -> OutputBufferCheckpoint:
+        """Capture the committed transcript before starting a chat turn."""
+        with self._lock:
+            return OutputBufferCheckpoint(tuple(self._committed), self._partial)
+
+    def rollback(self, checkpoint: OutputBufferCheckpoint) -> None:
+        """Restore a previous transcript checkpoint and invalidate caches."""
+        with self._lock:
+            changed = tuple(self._committed) != checkpoint.committed or self._partial != checkpoint.partial
+            self._committed = list(checkpoint.committed)
+            self._partial = checkpoint.partial
+            self._last_line_count = len(self._committed) + (1 if self._partial else 0)
+            self._committed_version += 1
+            self._cache_tokens = None
+            self._cache_committed_version = -1
+            self._cache_partial = None
+            self._cache_live_lines = None
+            self._cache_snapshot = None
+            self._cache_snapshot_version = -1
+            self._cache_snapshot_partial = None
+            self._cache_snapshot_live = None
+        if changed:
             self._on_change()
 
     # ── wiring helpers ────────────────────────────────────────────

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -275,8 +275,7 @@ class SessionManager:
                     )
                 if self._table_exists(conn, "user_message_context"):
                     conn.execute(
-                        "DELETE FROM user_message_context "
-                        "WHERE session_id = ? AND user_turn_number > ?",
+                        "DELETE FROM user_message_context WHERE session_id = ? AND user_turn_number > ?",
                         (session_id, checkpoint.max_user_turn_number),
                     )
                 if self._table_exists(conn, "running_turn_usage"):

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -10,6 +10,7 @@ import os
 import re
 import sqlite3
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -31,6 +32,15 @@ if TYPE_CHECKING:
 
 
 DEFAULT_CHAT_AGENT = "chat"
+
+
+@dataclass(frozen=True)
+class SessionTurnCheckpoint:
+    """Durable session boundary captured immediately before a new turn."""
+
+    max_message_id: int = 0
+    max_sequence_number: int = 0
+    max_user_turn_number: int = 0
 
 
 def extract_agent_from_session_id(session_id: str) -> str:
@@ -175,6 +185,113 @@ class SessionManager:
         # Clearing history is a session rebuild: drop the frozen system prompt
         # so the next turn re-bakes it instead of replaying pre-clear context.
         self.delete_system_prompt_snapshot(session_id)
+
+    def checkpoint_turn(self, session_id: str) -> Optional[SessionTurnCheckpoint]:
+        """Capture the SQLite boundary before dispatching a model turn.
+
+        The database can legitimately not exist yet for a brand-new node; in
+        that case the empty checkpoint still identifies everything written by
+        the upcoming turn.
+        """
+        self._validate_session_id(session_id)
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if not os.path.exists(db_path):
+            return SessionTurnCheckpoint()
+
+        try:
+            with sqlite3.connect(db_path, timeout=5.0) as conn:
+                max_message_id = 0
+                max_sequence_number = 0
+                max_user_turn_number = 0
+                if self._table_exists(conn, "agent_messages"):
+                    row = conn.execute(
+                        "SELECT COALESCE(MAX(id), 0) FROM agent_messages WHERE session_id = ?",
+                        (session_id,),
+                    ).fetchone()
+                    max_message_id = int(row[0] or 0) if row else 0
+                if self._table_exists(conn, "message_structure"):
+                    row = conn.execute(
+                        "SELECT COALESCE(MAX(sequence_number), 0), "
+                        "COALESCE(MAX(user_turn_number), 0) "
+                        "FROM message_structure WHERE session_id = ?",
+                        (session_id,),
+                    ).fetchone()
+                    if row:
+                        max_sequence_number = int(row[0] or 0)
+                        max_user_turn_number = int(row[1] or 0)
+                return SessionTurnCheckpoint(
+                    max_message_id=max_message_id,
+                    max_sequence_number=max_sequence_number,
+                    max_user_turn_number=max_user_turn_number,
+                )
+        except sqlite3.Error as exc:
+            logger.warning("Failed to checkpoint session %s before turn: %s", session_id, exc)
+            # Never substitute an empty boundary for a failed read: doing so
+            # could make a later rollback delete pre-existing history.
+            return None
+
+    def rollback_turn(self, session_id: str, checkpoint: Optional[SessionTurnCheckpoint]) -> None:
+        """Atomically remove everything persisted after *checkpoint*.
+
+        ``AdvancedSQLiteSession.pop_item`` only removes ``agent_messages`` and
+        leaves orphaned ``message_structure`` metadata. This repository-owned
+        rollback deletes both sides, along with usage rows for the cancelled
+        turn, so the next model call observes the exact pre-turn session.
+        """
+        self._validate_session_id(session_id)
+        if checkpoint is None:
+            logger.warning("Skipping unanswered-turn rollback for %s: no safe checkpoint", session_id)
+            return
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if not os.path.exists(db_path):
+            return
+
+        try:
+            with sqlite3.connect(db_path, timeout=5.0) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                if self._table_exists(conn, "message_structure"):
+                    conn.execute(
+                        "DELETE FROM message_structure "
+                        "WHERE session_id = ? AND "
+                        "(sequence_number > ? OR message_id IN ("
+                        "SELECT id FROM agent_messages WHERE session_id = ? AND id > ?"
+                        "))",
+                        (
+                            session_id,
+                            checkpoint.max_sequence_number,
+                            session_id,
+                            checkpoint.max_message_id,
+                        ),
+                    )
+                if self._table_exists(conn, "agent_messages"):
+                    conn.execute(
+                        "DELETE FROM agent_messages WHERE session_id = ? AND id > ?",
+                        (session_id, checkpoint.max_message_id),
+                    )
+                if self._table_exists(conn, "turn_usage"):
+                    conn.execute(
+                        "DELETE FROM turn_usage WHERE session_id = ? AND user_turn_number > ?",
+                        (session_id, checkpoint.max_user_turn_number),
+                    )
+                if self._table_exists(conn, "user_message_context"):
+                    conn.execute(
+                        "DELETE FROM user_message_context "
+                        "WHERE session_id = ? AND user_turn_number > ?",
+                        (session_id, checkpoint.max_user_turn_number),
+                    )
+                if self._table_exists(conn, "running_turn_usage"):
+                    conn.execute("DELETE FROM running_turn_usage WHERE session_id = ?", (session_id,))
+                conn.commit()
+        except sqlite3.Error as exc:
+            logger.warning("Failed to roll back unanswered turn for session %s: %s", session_id, exc)
+
+    @staticmethod
+    def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+        return row is not None
 
     # ------------------------------------------------------------------
     # System-prompt snapshot persistence

--- a/datus/schemas/action_history.py
+++ b/datus/schemas/action_history.py
@@ -40,6 +40,7 @@ class ActionStatus(str, Enum):
 
 
 SUBAGENT_COMPLETE_ACTION_TYPE = "subagent_complete"
+INTERRUPTED_ACTION_TYPE = "interrupted"
 
 
 class ActionHistory(BaseModel):
@@ -124,6 +125,21 @@ class ActionHistoryManager:
         """Clear all actions"""
         self.actions.clear()
         self.current_action_id = None
+
+    def checkpoint(self) -> int:
+        """Return a marker that can be used to roll back later additions."""
+        return len(self.actions)
+
+    def rollback_to(self, checkpoint: int) -> None:
+        """Discard actions appended after *checkpoint*.
+
+        CLI cancellation uses this when ESC arrives before the model has
+        produced a response, making the unsubmitted-looking turn disappear
+        from the same in-memory history that future turns receive.
+        """
+        checkpoint = max(0, min(int(checkpoint), len(self.actions)))
+        del self.actions[checkpoint:]
+        self.current_action_id = self.actions[-1].action_id if self.actions else None
 
     def find_action_by_id(self, action_id: str) -> Optional[ActionHistory]:
         """Find an action by its action_id"""

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -1894,6 +1894,38 @@ class TestStreamingMarkdown:
         ctx._finalize_markdown_stream()
         assert ctx.has_streamed_response is False
 
+    def test_model_response_started_is_latched_independently_of_rendering(self):
+        ctx, _live_state, _buf = self._make_ctx()
+        ctx.set_editable_user_message("original question")
+
+        assert ctx.has_model_response_started is False
+        assert ctx.editable_user_message == "original question"
+
+        ctx.mark_model_response_started()
+
+        assert ctx.has_model_response_started is True
+        assert ctx.has_streamed_response is False
+
+    def test_interrupted_notice_prints_after_context_exit(self):
+        ctx, _live_state, buf = self._make_ctx()
+
+        with ctx:
+            ctx.request_interrupted_notice()
+            assert "Interrupted" not in buf.getvalue()
+
+        assert "Interrupted" in buf.getvalue()
+        assert ctx.interrupt_requested is True
+
+    def test_unanswered_rollback_request_is_latched_for_chat_cleanup(self):
+        ctx, _live_state, _buf = self._make_ctx()
+
+        with ctx:
+            assert ctx.unanswered_rollback_requested is False
+            assert ctx.interrupt_requested is False
+            ctx.request_unanswered_rollback()
+            assert ctx.unanswered_rollback_requested is True
+            assert ctx.interrupt_requested is True
+
 
 @pytest.mark.ci
 class TestCompactRendering:

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -38,6 +38,7 @@ from rich.console import Console
 
 from datus.cli.chat_commands import ChatCommands, _is_model_config_error
 from datus.cli.cli_context import CliContext
+from datus.cli.execution_state import ExecutionInterrupted, InterruptController, PendingInputQueue
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 
 # ===========================================================================
@@ -83,7 +84,7 @@ class MinimalCLI:
         streaming turn raises ``AttributeError``.
         """
 
-    def run_on_bg_loop(self, coro):
+    def run_on_bg_loop(self, coro, **_kwargs):
         """Simple synchronous stand-in for ``DatusCLI.run_on_bg_loop``.
 
         The real implementation routes through a persistent background loop to
@@ -616,6 +617,11 @@ class TestExtractReportFromJson:
         cmds = _make_chat_commands(real_agent_config)
         result = cmds._extract_report_from_json("")
         assert result is None
+
+    def test_dict_input_returns_none(self, real_agent_config, mock_llm_create):
+        """Intermediate tool output must never be parsed as final report text."""
+        cmds = _make_chat_commands(real_agent_config)
+        assert cmds._extract_report_from_json({"response": "partial"}) is None
 
     def test_valid_json_with_report_field(self, real_agent_config, mock_llm_create):
         """Valid JSON with 'report' field extracts the report content."""
@@ -3476,7 +3482,7 @@ class MinimalCLIExtended:
     def prompt_input(self, message="", multiline=False, default="", **kw):
         return default
 
-    def run_on_bg_loop(self, coro):
+    def run_on_bg_loop(self, coro, **_kwargs):
         import asyncio
 
         return asyncio.run(coro)
@@ -3495,6 +3501,173 @@ def cli(real_agent_config):
 @pytest.fixture
 def chat_cmd(cli):
     return ChatCommands(cli)
+
+
+def test_rollback_unanswered_turn_cleans_all_in_memory_and_output_state(chat_cmd):
+    kept = ActionHistory.create_action(
+        role=ActionRole.ASSISTANT,
+        action_type="response",
+        messages="kept",
+        input_data={},
+    )
+    cancelled = ActionHistory.create_action(
+        role=ActionRole.USER,
+        action_type="chat_request",
+        messages="cancelled",
+        input_data={},
+    )
+    chat_cmd.cli.actions.add_action(kept)
+    action_checkpoint = chat_cmd.cli.actions.checkpoint()
+    chat_cmd.cli.actions.add_action(cancelled)
+
+    node = MagicMock()
+    node.session_id = "chat_session_cancelled"
+    node.actions = [kept, cancelled]
+    node.running_turn_usage = object()
+    session_manager = MagicMock()
+    output_buffer = MagicMock()
+    checkpoint = object()
+
+    incremental = [cancelled]
+    chat_cmd._rollback_unanswered_turn(
+        current_node=node,
+        incremental_actions=incremental,
+        action_checkpoint=action_checkpoint,
+        node_action_checkpoint=1,
+        session_manager=session_manager,
+        session_checkpoint=checkpoint,
+        output_buffer=output_buffer,
+        output_checkpoint=checkpoint,
+    )
+
+    assert chat_cmd.cli.actions.get_actions() == [kept]
+    assert node.actions == [kept]
+    assert incremental == []
+    assert node.running_turn_usage is None
+    session_manager.rollback_turn.assert_called_once_with(node.session_id, checkpoint)
+    output_buffer.rollback.assert_called_once_with(checkpoint)
+
+
+def test_interrupted_turn_skips_final_action_render_and_resets_controller(chat_cmd, monkeypatch):
+    class FakeStreamingContext:
+        def __init__(self):
+            self.unanswered_rollback_requested = False
+            self.interrupt_requested = False
+            self.has_streamed_response = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def set_editable_user_message(self, _message):
+            pass
+
+        def set_clear_header_callback(self, _callback):
+            pass
+
+        def set_input_collector(self, _collector):
+            pass
+
+        def set_event_loop(self, _loop):
+            pass
+
+        def mark_model_response_started(self):
+            pass
+
+        def request_interrupted_notice(self):
+            self.interrupt_requested = True
+
+    streaming_ctx = FakeStreamingContext()
+
+    class FakeDisplay:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def display_streaming_actions(self, *_args, **_kwargs):
+            return streaming_ctx
+
+    controller = InterruptController()
+    controller_reset = MagicMock(wraps=controller.reset)
+    controller.reset = controller_reset
+    node = MagicMock()
+    node.session_id = "chat_session_interrupted"
+    node.pending_input_queue = PendingInputQueue()
+    node.interrupt_controller = controller
+    node.actions = []
+    node.db_func_tool = None
+    node.get_node_name.return_value = "chat"
+    node.session_manager.checkpoint_turn.return_value = object()
+
+    intermediate = ActionHistory.create_action(
+        role=ActionRole.TOOL,
+        action_type="partial_tool",
+        messages="partial",
+        input_data={},
+        output_data={"response": {"partial": True}},
+        status=ActionStatus.SUCCESS,
+    )
+
+    async def interrupted_stream(*_args, **_kwargs):
+        yield intermediate
+        streaming_ctx.request_interrupted_notice()
+        raise ExecutionInterrupted("cancelled")
+
+    node.execute_stream_with_interactions = interrupted_stream
+    chat_cmd.current_node = node
+    chat_cmd.cli._use_tui = True
+    chat_cmd.cli._tui_output_buffer = None
+    monkeypatch.setattr(chat_cmd, "_should_create_new_node", lambda _name=None: False)
+    monkeypatch.setattr(chat_cmd, "_is_agent_switch", lambda _name=None: False)
+    monkeypatch.setattr(
+        chat_cmd,
+        "create_node_input",
+        lambda *_args, **_kwargs: (MagicMock(database=""), "chat"),
+    )
+    monkeypatch.setattr("datus.cli.chat_commands.ActionHistoryDisplay", FakeDisplay)
+    render_final = MagicMock()
+    monkeypatch.setattr(chat_cmd, "_render_final_response", render_final)
+
+    chat_cmd._execute_chat("cancel me", interactive=True)
+
+    render_final.assert_not_called()
+    controller_reset.assert_called()
+    assert controller.is_interrupted is False
+    assert chat_cmd.last_actions[0] is intermediate
+    assert chat_cmd.last_actions[-1].action_type == "interrupted"
+    assert chat_cmd.all_turn_actions == [("cancel me", chat_cmd.last_actions)]
+
+
+def test_interrupted_turn_user_row_survives_full_screen_reprint(chat_cmd):
+    """Ctrl+O/sidebar repaint keeps a response-started interrupted turn."""
+    interrupted_action = ActionHistory.create_action(
+        role=ActionRole.ASSISTANT,
+        action_type="response",
+        messages="partial answer before escape",
+        input_data={},
+        output_data={"raw_output": "partial answer before escape"},
+        status=ActionStatus.SUCCESS,
+    )
+    interrupted_marker = ActionHistory.create_action(
+        role=ActionRole.SYSTEM,
+        action_type="interrupted",
+        messages="Interrupted",
+        input_data={},
+        output_data={},
+        status=ActionStatus.SUCCESS,
+    )
+    chat_cmd.all_turn_actions = [
+        ("keep this interrupted question", [interrupted_action, interrupted_marker])
+    ]
+    chat_cmd.last_actions = [interrupted_action, interrupted_marker]
+
+    chat_cmd._full_screen_reprint(verbose=True)
+
+    output = chat_cmd.console.file.getvalue()
+    assert "keep this interrupted question" in output
+    assert output.count("partial answer before escape") == 1
+    assert "Interrupted" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -3657,9 +3657,7 @@ def test_interrupted_turn_user_row_survives_full_screen_reprint(chat_cmd):
         output_data={},
         status=ActionStatus.SUCCESS,
     )
-    chat_cmd.all_turn_actions = [
-        ("keep this interrupted question", [interrupted_action, interrupted_marker])
-    ]
+    chat_cmd.all_turn_actions = [("keep this interrupted question", [interrupted_action, interrupted_marker])]
     chat_cmd.last_actions = [interrupted_action, interrupted_marker]
 
     chat_cmd._full_screen_reprint(verbose=True)

--- a/tests/unit_tests/cli/test_execution_state.py
+++ b/tests/unit_tests/cli/test_execution_state.py
@@ -81,6 +81,47 @@ class TestInterruptController:
             ctrl.reset()
             assert ctrl.is_interrupted is False
 
+    def test_interrupt_invokes_registered_cancel_callback(self):
+        ctrl = InterruptController()
+        calls = []
+
+        token = ctrl.register_cancel_callback(lambda: calls.append("cancel"))
+        ctrl.interrupt()
+
+        assert calls == ["cancel"]
+        ctrl.unregister_cancel_callback(token)
+
+    def test_repeated_interrupt_does_not_recancel_active_operation(self):
+        ctrl = InterruptController()
+        calls = []
+
+        token = ctrl.register_cancel_callback(lambda: calls.append("cancel"))
+        ctrl.interrupt()
+        ctrl.interrupt()
+
+        assert calls == ["cancel"]
+        ctrl.unregister_cancel_callback(token)
+
+    def test_late_cancel_callback_runs_immediately(self):
+        ctrl = InterruptController()
+        calls = []
+        ctrl.interrupt()
+
+        token = ctrl.register_cancel_callback(lambda: calls.append("cancel"))
+
+        assert calls == ["cancel"]
+        ctrl.unregister_cancel_callback(token)
+
+    def test_unregistered_cancel_callback_does_not_run(self):
+        ctrl = InterruptController()
+        calls = []
+
+        token = ctrl.register_cancel_callback(lambda: calls.append("cancel"))
+        ctrl.unregister_cancel_callback(token)
+        ctrl.interrupt()
+
+        assert calls == []
+
 
 # ===========================================================================
 # PendingInteraction Tests

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rich.console import Console
 
+from datus.cli.execution_state import ExecutionInterrupted, InterruptController
 from datus.cli.input_modes import InputMode
 from datus.cli.repl import CommandType, DatusCLI
 
@@ -1556,3 +1557,145 @@ class TestRunOnBgLoop:
         except concurrent.futures.CancelledError:
             pass
         assert stopped_cleanly.wait(timeout=1.0)
+
+    def test_interrupt_controller_cancels_parked_bg_task(self, bg_cli):
+        """Interrupt wakes a coroutine parked in an API-like await."""
+        import asyncio
+        import threading
+
+        controller = InterruptController()
+        started = threading.Event()
+        cancelled = threading.Event()
+        finished = threading.Event()
+        raised = {}
+
+        async def waiting_for_api():
+            started.set()
+            try:
+                await asyncio.sleep(30.0)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        def run():
+            try:
+                bg_cli.run_on_bg_loop(waiting_for_api(), interrupt_controller=controller)
+            except BaseException as exc:
+                raised["exception"] = exc
+            finally:
+                finished.set()
+
+        worker = threading.Thread(target=run)
+        worker.start()
+        assert started.wait(timeout=1.0)
+
+        controller.interrupt()
+
+        assert cancelled.wait(timeout=1.0)
+        assert finished.wait(timeout=1.0)
+        worker.join(timeout=1.0)
+        assert isinstance(raised.get("exception"), ExecutionInterrupted)
+        assert controller.is_interrupted is False
+
+        async def next_turn():
+            return "submitted"
+
+        # Reusing the node/controller must not immediately cancel the first
+        # submission after ESC.
+        assert bg_cli.run_on_bg_loop(next_turn(), interrupt_controller=controller) == "submitted"
+
+    def test_external_task_cancel_is_not_user_interrupt(self, bg_cli):
+        """Cancellation without an interrupt flag remains CancelledError."""
+        import asyncio
+        import concurrent.futures
+        import threading
+
+        controller = InterruptController()
+        started = threading.Event()
+        task_holder = {}
+
+        async def externally_cancelled():
+            task_holder["task"] = asyncio.current_task()
+            started.set()
+            await asyncio.sleep(30.0)
+
+        def cancel_from_loop():
+            task_holder["task"].cancel()
+
+        with pytest.raises(concurrent.futures.CancelledError):
+            worker = threading.Thread(
+                target=lambda: (
+                    started.wait(timeout=1.0),
+                    bg_cli._bg_loop.call_soon_threadsafe(cancel_from_loop),
+                )
+            )
+            worker.start()
+            try:
+                bg_cli.run_on_bg_loop(externally_cancelled(), interrupt_controller=controller)
+            finally:
+                worker.join(timeout=1.0)
+
+    def test_early_interrupt_survives_node_controller_reset(self, bg_cli):
+        """A startup reset cannot make a requested cancel look external."""
+        import asyncio
+
+        controller = InterruptController()
+
+        async def interrupt_then_reset():
+            controller.interrupt()
+            # Mirrors execute_stream_with_interactions resetting the reusable
+            # controller at the beginning of a turn.
+            controller.reset()
+            await asyncio.sleep(30.0)
+
+        with pytest.raises(ExecutionInterrupted):
+            bg_cli.run_on_bg_loop(interrupt_then_reset(), interrupt_controller=controller)
+
+
+class TestInterruptAgent:
+    @staticmethod
+    def _setup(cli, *, response_started: bool):
+        controller = MagicMock()
+        node = SimpleNamespace(interrupt_controller=controller)
+        streaming_ctx = SimpleNamespace(
+            has_model_response_started=response_started,
+            editable_user_message="question to edit",
+            request_interrupted_notice=MagicMock(),
+            request_unanswered_rollback=MagicMock(),
+        )
+        cli.chat_commands = SimpleNamespace(
+            current_node=node,
+            current_streaming_ctx=streaming_ctx,
+        )
+        cli.tui_app = MagicMock()
+        return controller
+
+    def test_escape_restores_input_before_first_model_response(self, cli):
+        controller = self._setup(cli, response_started=False)
+
+        cli._interrupt_agent(restore_unanswered_input=True)
+
+        controller.interrupt.assert_called_once_with()
+        cli.tui_app.restore_input_after_dispatch.assert_called_once_with("question to edit")
+        cli.chat_commands.current_streaming_ctx.request_unanswered_rollback.assert_called_once_with()
+        cli.chat_commands.current_streaming_ctx.request_interrupted_notice.assert_not_called()
+
+    def test_escape_only_cancels_after_model_response_started(self, cli):
+        controller = self._setup(cli, response_started=True)
+
+        cli._interrupt_agent(restore_unanswered_input=True)
+
+        controller.interrupt.assert_called_once_with()
+        cli.tui_app.restore_input_after_dispatch.assert_not_called()
+        cli.chat_commands.current_streaming_ctx.request_unanswered_rollback.assert_not_called()
+        cli.chat_commands.current_streaming_ctx.request_interrupted_notice.assert_called_once_with()
+
+    def test_ctrl_c_never_restores_input(self, cli):
+        controller = self._setup(cli, response_started=False)
+
+        cli._interrupt_agent()
+
+        controller.interrupt.assert_called_once_with()
+        cli.tui_app.restore_input_after_dispatch.assert_not_called()
+        cli.chat_commands.current_streaming_ctx.request_unanswered_rollback.assert_not_called()
+        cli.chat_commands.current_streaming_ctx.request_interrupted_notice.assert_not_called()

--- a/tests/unit_tests/cli/tui/test_app.py
+++ b/tests/unit_tests/cli/tui/test_app.py
@@ -567,6 +567,35 @@ def test_set_input_text_replaces_buffer(tui_app: DatusApp) -> None:
     assert tui_app.input_buffer.text == ""
 
 
+def test_escape_timeout_is_near_immediate(tui_app: DatusApp) -> None:
+    assert tui_app.application.ttimeoutlen == pytest.approx(0.01)
+
+
+def test_cancelled_input_restores_after_dispatch_and_first_enter_submits(tui_app: DatusApp) -> None:
+    tui_app.agent_running.set()
+    tui_app.restore_input_after_dispatch("edit this")
+
+    # Restoration is intentionally invisible while Enter would still take
+    # the running-agent queue path.
+    assert tui_app.input_buffer.text == ""
+
+    finished = Future()
+    finished.set_result(None)
+    tui_app._on_dispatch_done(finished)
+    assert not tui_app.agent_running.is_set()
+    assert tui_app.input_buffer.text == "edit this"
+
+    from prompt_toolkit.keys import Keys
+
+    handler = _binding_for_key(tui_app, Keys.ControlM)
+    event = mock.MagicMock()
+    event.app.current_buffer = tui_app.input_buffer
+    handler(event)
+
+    assert tui_app._test_dispatch_log == ["edit this"]
+    assert tui_app.input_buffer.text == ""
+
+
 def test_safe_dispatch_reraises_system_exit(tui_app: DatusApp) -> None:
     """SystemExit is the one exception type we must not swallow — callers
     rely on it to propagate out of the executor so graceful shutdown can

--- a/tests/unit_tests/cli/tui/test_output_buffer.py
+++ b/tests/unit_tests/cli/tui/test_output_buffer.py
@@ -49,6 +49,19 @@ def test_partial_line_is_buffered_until_newline_arrives():
     assert _flatten_text(buf.tokens()) == "partial continued"
 
 
+def test_checkpoint_rollback_removes_cancelled_turn_output():
+    buf = TUIOutputBuffer()
+    buf.write("previous answer\n")
+    checkpoint = buf.checkpoint()
+
+    buf.write("cancelled user message\n")
+    buf.write("partial model")
+    buf.rollback(checkpoint)
+
+    assert _flatten_text(buf.tokens()) == "previous answer"
+    assert buf.line_count() == 1
+
+
 def test_ansi_color_codes_are_preserved_in_tokens():
     buf = TUIOutputBuffer()
     buf.write("\x1b[31mred\x1b[0m\n")

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -226,6 +226,71 @@ class TestSessionManagerExecution:
         session_via_get = sm.get_session("alias-test")
         assert session_via_create is session_via_get
 
+    def test_rollback_turn_removes_messages_structure_and_usage_after_checkpoint(self, sm):
+        import asyncio
+
+        session_id = "rollback-unanswered"
+        session = sm.get_session(session_id)
+        asyncio.run(
+            session.add_items(
+                [
+                    {"role": "user", "content": "kept question"},
+                    {"role": "assistant", "content": "kept answer"},
+                ]
+            )
+        )
+        checkpoint = sm.checkpoint_turn(session_id)
+
+        asyncio.run(session.add_items([{"role": "user", "content": "cancelled question"}]))
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "INSERT INTO turn_usage "
+                "(session_id, branch_id, user_turn_number, total_tokens) VALUES (?, 'main', 2, 99)",
+                (session_id,),
+            )
+            conn.execute(SessionManager._RUNNING_TURN_USAGE_DDL)
+            conn.execute(
+                "INSERT INTO running_turn_usage "
+                "(session_id, user_turn_number, cumulative_json, context_length) "
+                "VALUES (?, 2, '{}', 1000)",
+                (session_id,),
+            )
+            conn.execute(SessionManager._USER_MESSAGE_CONTEXT_DDL)
+            conn.execute(
+                "INSERT INTO user_message_context "
+                "(session_id, user_turn_number, context_json) VALUES (?, 2, '{}')",
+                (session_id,),
+            )
+            conn.commit()
+
+        sm.rollback_turn(session_id, checkpoint)
+
+        assert asyncio.run(session.get_items()) == [
+            {"role": "user", "content": "kept question"},
+            {"role": "assistant", "content": "kept answer"},
+        ]
+        with sqlite3.connect(db_path) as conn:
+            assert conn.execute(
+                "SELECT COUNT(*) FROM agent_messages WHERE session_id = ?", (session_id,)
+            ).fetchone()[0] == 2
+            assert conn.execute(
+                "SELECT COUNT(*) FROM message_structure WHERE session_id = ?", (session_id,)
+            ).fetchone()[0] == 2
+            assert conn.execute(
+                "SELECT COUNT(*) FROM message_structure s "
+                "LEFT JOIN agent_messages m ON m.id = s.message_id WHERE m.id IS NULL"
+            ).fetchone()[0] == 0
+            assert conn.execute(
+                "SELECT COUNT(*) FROM turn_usage WHERE session_id = ?", (session_id,)
+            ).fetchone()[0] == 0
+            assert conn.execute(
+                "SELECT COUNT(*) FROM running_turn_usage WHERE session_id = ?", (session_id,)
+            ).fetchone()[0] == 0
+            assert conn.execute(
+                "SELECT COUNT(*) FROM user_message_context WHERE session_id = ?", (session_id,)
+            ).fetchone()[0] == 0
+
     # -- clear_session --
 
     def test_clear_session_removes_messages(self, sm):

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -258,8 +258,7 @@ class TestSessionManagerExecution:
             )
             conn.execute(SessionManager._USER_MESSAGE_CONTEXT_DDL)
             conn.execute(
-                "INSERT INTO user_message_context "
-                "(session_id, user_turn_number, context_json) VALUES (?, 2, '{}')",
+                "INSERT INTO user_message_context (session_id, user_turn_number, context_json) VALUES (?, 2, '{}')",
                 (session_id,),
             )
             conn.commit()
@@ -271,25 +270,36 @@ class TestSessionManagerExecution:
             {"role": "assistant", "content": "kept answer"},
         ]
         with sqlite3.connect(db_path) as conn:
-            assert conn.execute(
-                "SELECT COUNT(*) FROM agent_messages WHERE session_id = ?", (session_id,)
-            ).fetchone()[0] == 2
-            assert conn.execute(
-                "SELECT COUNT(*) FROM message_structure WHERE session_id = ?", (session_id,)
-            ).fetchone()[0] == 2
-            assert conn.execute(
-                "SELECT COUNT(*) FROM message_structure s "
-                "LEFT JOIN agent_messages m ON m.id = s.message_id WHERE m.id IS NULL"
-            ).fetchone()[0] == 0
-            assert conn.execute(
-                "SELECT COUNT(*) FROM turn_usage WHERE session_id = ?", (session_id,)
-            ).fetchone()[0] == 0
-            assert conn.execute(
-                "SELECT COUNT(*) FROM running_turn_usage WHERE session_id = ?", (session_id,)
-            ).fetchone()[0] == 0
-            assert conn.execute(
-                "SELECT COUNT(*) FROM user_message_context WHERE session_id = ?", (session_id,)
-            ).fetchone()[0] == 0
+            assert (
+                conn.execute("SELECT COUNT(*) FROM agent_messages WHERE session_id = ?", (session_id,)).fetchone()[0]
+                == 2
+            )
+            assert (
+                conn.execute("SELECT COUNT(*) FROM message_structure WHERE session_id = ?", (session_id,)).fetchone()[0]
+                == 2
+            )
+            assert (
+                conn.execute(
+                    "SELECT COUNT(*) FROM message_structure s "
+                    "LEFT JOIN agent_messages m ON m.id = s.message_id WHERE m.id IS NULL"
+                ).fetchone()[0]
+                == 0
+            )
+            assert (
+                conn.execute("SELECT COUNT(*) FROM turn_usage WHERE session_id = ?", (session_id,)).fetchone()[0] == 0
+            )
+            assert (
+                conn.execute("SELECT COUNT(*) FROM running_turn_usage WHERE session_id = ?", (session_id,)).fetchone()[
+                    0
+                ]
+                == 0
+            )
+            assert (
+                conn.execute(
+                    "SELECT COUNT(*) FROM user_message_context WHERE session_id = ?", (session_id,)
+                ).fetchone()[0]
+                == 0
+            )
 
     # -- clear_session --
 


### PR DESCRIPTION
## Why

Escape interruption in the full-screen CLI was delayed until the active API call returned. The cancellation paths also diverged depending on whether a model response had started: unanswered turns could leave visible, in-memory, or SQLite state behind, while response-started turns could lose their user row after a Ctrl+O transcript rebuild. A cancelled dispatch could additionally consume the next Enter key, and intermediate dictionary payloads could reach string-only final-response handling.

## Solution

- Cancel the active background asyncio task immediately from the shared interrupt controller so Escape and Ctrl+C use the same low-latency path.
- Track whether an observable model response has started. Unanswered Escape cancellation restores the editable input after dispatch teardown and rolls the turn back from the TUI output buffer, action histories, SQLite messages, structure rows, and usage rows.
- Preserve response-started interrupted turns and render a replay-only `Interrupted` marker so Ctrl+O and sidebar transcript rebuilds retain the user row, partial response, and cancellation state.
- Reset the reusable interrupt controller before accepting the next turn, preventing the first Enter after cancellation from being swallowed.
- Handle non-string intermediate response payloads defensively and skip final-response rendering for interrupted turns.

The interruption marker is kept only in the in-memory display history; it is not persisted as a model action.

## Test Cases

Added and updated deterministic unit tests for:

- immediate task cancellation and callback registration lifecycle
- Escape behavior before and after the first model response
- deferred input restoration and first-Enter handling after cancellation
- rollback of TUI output, in-memory actions, SQLite messages, structure rows, and usage rows
- interrupted-turn replay across Ctrl+O/full-screen transcript rebuilds
- defensive handling of dictionary response payloads

No nightly tests were added because this behavior is fully exercised with mocked local CLI/TUI and session-manager tests and requires no external service.

Verification:

- `uv run ruff format datus/ tests/ && uv run ruff check --fix datus/ tests/`
- `uv run ruff format --check datus/ tests/ && uv run ruff check datus/ tests/`
- `uv run python ci/run-pr-tests.py datus/main`: 5,628 passed, 2 skipped, 0 failed; 91% diff coverage
- `uv run python ci/audit_tests.py --repo-root . --diff-only datus/main`: P0=0, P1=0

## Backport

<!-- The checklist below is auto-generated and refreshed by
     .github/workflows/sync-backport-checklist.yml whenever the PR is opened
     or updated. Tick the release branches you want this PR backported to;
     on merge, the bot will post a `@Mergifyio backport <branch>` comment. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint/rollback behavior for cancelled turns across streaming, chat execution, session persistence, and TUI output.
  * Improved Escape cancellation: faster response and optional restoration of unanswered input.
  * Added coordinated interruption cancellation via registered callbacks.

* **Bug Fixes**
  * Prevented interrupted turns from being shown as completed final answers during replay/full-screen rebuild.

* **Tests**
  * Expanded coverage for interruption handling, rollback correctness, input restoration, and cancellation-callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->