### PR TITLE
[Feature] Support adapter-defined database namespaces

### DIFF
--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -30,6 +30,7 @@ from datus.api.models.table_models import (
 from datus.cli.generation_hooks import GenerationHooks
 from datus.configuration.agent_config_loader import AgentConfig
 from datus.storage.semantic_model.store import SemanticModelRAG
+from datus.tools.db_tools.capabilities import supports_namespace
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_table_name_parts
@@ -169,10 +170,8 @@ class DatasourceService:
         database as ``current``. Request-level filters (database_name,
         schema_name, catalog_name) narrow the result set when provided.
         """
-        from datus_db_core import connector_registry
-
         dialect = getattr(connector, "dialect", "unknown")
-        has_schema = connector_registry.support_schema(dialect)
+        has_schema = supports_namespace("schema", connector=connector, dialect=dialect)
         catalog_name = request.catalog_name or getattr(connector, "catalog_name", None)
         now = now_utc_iso()
 
@@ -443,9 +442,13 @@ class DatasourceService:
                                 column_info = ColumnInfo(
                                     name=col.get("name", ""),
                                     type=col.get("type", ""),
-                                    nullable=col.get("notnull", 1) == 0,  # SQLite style: notnull=0 means nullable
-                                    default_value=col.get("dflt_value"),
-                                    pk=col.get("pk", 0) == 1,
+                                    nullable=(
+                                        bool(col["nullable"])
+                                        if "nullable" in col
+                                        else col.get("notnull", 1) == 0  # SQLite: notnull=0 means nullable
+                                    ),
+                                    default_value=col.get("default_value", col.get("dflt_value")),
+                                    pk=bool(col.get("pk", False)),
                                 )
                             else:
                                 # Handle string or other formats

--- a/datus/cli/generation_hooks.py
+++ b/datus/cli/generation_hooks.py
@@ -28,8 +28,8 @@ from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
 from datus.tools.db_tools import connector_registry
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
-from datus.utils.constants import DBType
 from datus.utils.loggings import get_logger
+from datus.utils.sql_utils import parse_table_name_parts
 
 logger = get_logger(__name__)
 
@@ -1038,32 +1038,17 @@ class GenerationHooks(AgentHooks):
 
                 # Try to parse hierarchy from sql_table if it's fully qualified
                 if sql_table:
-                    parts = [p.strip() for p in sql_table.split(".") if p.strip()]
-                    if len(parts) > 0:
-                        table_name = parts[-1]
-
-                        # Replicate DBFuncTool._determine_field_order logic for parsing
-                        dialect = agent_config.db_type
-                        possible_fields = []
-                        if connector_registry.support_catalog(dialect):
-                            possible_fields.append("catalog")
-                        if connector_registry.support_database(dialect) or dialect == DBType.SQLITE:
-                            possible_fields.append("database")
-                        if connector_registry.support_schema(dialect):
-                            possible_fields.append("schema")
-
-                        # Assign parts from right to left (excluding the table name itself)
-                        idx = len(parts) - 2
-                        for field in reversed(possible_fields):
-                            if idx < 0:
-                                break
-                            if field == "schema":
-                                schema_name = parts[idx]
-                            elif field == "database":
-                                database_name = parts[idx]
-                            elif field == "catalog":
-                                catalog_name = parts[idx]
-                            idx -= 1
+                    parsed = parse_table_name_parts(sql_table, agent_config.db_type)
+                    table_name = parsed["table_name"] or table_name
+                    catalog_name = parsed["catalog_name"] or catalog_name
+                    database_name = parsed["database_name"] or database_name
+                    # A parser-resolved database/project prefix makes the parsed
+                    # schema authoritative. This is important for adapters whose
+                    # two-part form is database.table: an old configured schema
+                    # must not turn it back into database.schema.table.
+                    schema_name = (
+                        parsed["schema_name"] if parsed["database_name"] else parsed["schema_name"] or schema_name
+                    )
 
                 # Clear schema_name if dialect doesn't support it (e.g. StarRocks, MySQL)
                 if not connector_registry.support_schema(agent_config.db_type):

--- a/datus/cli/metadata_commands.py
+++ b/datus/cli/metadata_commands.py
@@ -15,7 +15,7 @@ from rich.panel import Panel
 
 from datus.cli._render_utils import build_row_table
 from datus.cli.cli_styles import TABLE_HEADER_STYLE, print_empty_set, print_error, print_success, print_warning
-from datus.tools.db_tools import connector_registry
+from datus.tools.db_tools.capabilities import supports_namespace
 from datus.utils.constants import DBType
 from datus.utils.loggings import get_logger
 
@@ -164,7 +164,7 @@ class MetadataCommands:
     def cmd_schemas(self, args: str):
         """List all schemas in the current database."""
         dialect = self.cli.db_connector.dialect
-        if not connector_registry.support_schema(dialect):
+        if not supports_namespace("schema", connector=self.cli.db_connector, dialect=dialect):
             print_error(self.cli.console, f"The {dialect} database does not support schema", prefix=False)
             return
         result = self.cli.db_connector.get_schemas(
@@ -194,7 +194,7 @@ class MetadataCommands:
     def cmd_switch_schema(self, args: str):
         """Switch current schema."""
         dialect = self.cli.db_connector.dialect
-        if not connector_registry.support_schema(dialect):
+        if not supports_namespace("schema", connector=self.cli.db_connector, dialect=dialect):
             print_error(self.cli.console, f"The {dialect} database does not support schema", prefix=False)
             return
         schema_name = args.strip()

--- a/datus/cli/screen/catalog_screen.py
+++ b/datus/cli/screen/catalog_screen.py
@@ -6,7 +6,7 @@ import json
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
-from datus_db_core import BaseSqlConnector, connector_registry
+from datus_db_core import BaseSqlConnector
 from rich import box
 from rich.console import Group
 from rich.table import Table
@@ -28,6 +28,7 @@ from datus.cli.screen.context_screen import ContextScreen
 from datus.storage.catalog_manager import CatalogUpdater
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
+from datus.tools.db_tools.capabilities import supports_namespace
 from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_pretty_str
@@ -374,6 +375,9 @@ class CatalogScreen(ContextScreen):
             self._catalog_updater = CatalogUpdater(self._agent_config)
         return self._catalog_updater
 
+    def _supports(self, namespace: str) -> bool:
+        return supports_namespace(namespace, connector=self.db_connector, dialect=str(self.db_type))
+
     def compose(self) -> ComposeResult:
         """Compose the layout of the screen."""
         yield Header(show_clock=True, name="Catalogs")
@@ -451,9 +455,7 @@ class CatalogScreen(ContextScreen):
             if self.db_type in (DBType.SQLITE, DBType.DUCKDB):
                 # Built-in single-database connectors: show the known database directly
                 self._add_db_name(tree, self.database_name)
-            elif connector_registry.support_catalog(self.db_type) and not connector_registry.support_schema(
-                self.db_type
-            ):
+            elif self._supports("catalog") and not self._supports("schema"):
                 # Catalog-first dialects (e.g. StarRocks): catalog → database → tables
                 self._load_catalogs_lazy(tree)
             else:
@@ -1126,7 +1128,7 @@ class CatalogScreen(ContextScreen):
 
         # Add loading indicator
         if node_type == "database":
-            if connector_registry.support_schema(self.db_type):
+            if self._supports("schema"):
                 node.add_leaf("⏳ Loading schemas...", data={"type": "loading"})
             else:
                 node.add_leaf("⏳ Loading tables...", data={"type": "loading"})
@@ -1160,7 +1162,7 @@ class CatalogScreen(ContextScreen):
 
     def _add_db_name(self, tree: TextualTree, db_name: str):
         db_node = tree.root.add(f"📁 {db_name}", data={"type": "database", "name": db_name})
-        support_schema = connector_registry.support_schema(self.db_type)
+        support_schema = self._supports("schema")
         db_node.add_leaf(
             f"⏳ Loading {'schemas' if support_schema else 'tables'}...",
             data={"type": "loading"},
@@ -1213,12 +1215,12 @@ class CatalogScreen(ContextScreen):
 
         try:
             if node_type == "database":
-                if connector_registry.support_schema(self.db_type):
+                if self._supports("schema"):
                     self._load_schemas_for_database(node)
                 else:
                     self._load_tables_for_schema(node)
             elif node_type == "catalog":
-                if connector_registry.support_database(self.db_type):
+                if self._supports("database"):
                     self._load_databases_for_catalog(node)
                 else:
                     self._load_schemas_for_database(node)
@@ -1288,10 +1290,10 @@ class CatalogScreen(ContextScreen):
 
     def _load_tables_for_schema(self, schema_node: TreeNode) -> None:
         """Load tables for a schema node."""
-        if not connector_registry.support_schema(self.db_type):
+        if not self._supports("schema"):
             schema_name = ""
             db_name = schema_node.data.get("name")
-            if not connector_registry.support_catalog(self.db_type):
+            if not self._supports("catalog"):
                 catalog_name = ""
             else:
                 catalog_name = "" if not schema_node.parent else schema_node.parent.data.get("name")
@@ -1301,16 +1303,16 @@ class CatalogScreen(ContextScreen):
             parent = schema_node.parent
             if not parent:
                 return
-            if connector_registry.support_database(self.db_type):
+            if self._supports("database"):
                 db_name = parent.data.get("name")
-                if connector_registry.support_catalog(self.db_type):
+                if self._supports("catalog"):
                     parent = parent.parent
                     catalog_name = "" if not parent or not parent.data else parent.data.get("name")
                 else:
                     catalog_name = ""
             else:
                 db_name = ""
-                catalog_name = "" if not connector_registry.support_catalog(self.db_type) else parent.data.get("name")
+                catalog_name = "" if not self._supports("catalog") else parent.data.get("name")
 
         try:
             tables = self.db_connector.get_tables(

--- a/datus/cli/screen/catalog_screen.py
+++ b/datus/cli/screen/catalog_screen.py
@@ -455,8 +455,8 @@ class CatalogScreen(ContextScreen):
             if self.db_type in (DBType.SQLITE, DBType.DUCKDB):
                 # Built-in single-database connectors: show the known database directly
                 self._add_db_name(tree, self.database_name)
-            elif self._supports("catalog") and not self._supports("schema"):
-                # Catalog-first dialects (e.g. StarRocks): catalog → database → tables
+            elif self._supports("catalog"):
+                # Catalog-first dialects may expose database, schema, or both below the catalog.
                 self._load_catalogs_lazy(tree)
             else:
                 # Standard dialects: database → [schema →] tables
@@ -1237,31 +1237,45 @@ class CatalogScreen(ContextScreen):
         """Clear all caches to free memory."""
         _fetch_schema_with_cache.cache_clear()
 
-    def _load_schemas_for_database(self, db_node: TreeNode) -> None:
-        """Load schemas for a database node."""
-        db_name = str(db_node.label).replace("📁 ", "")
+    def _load_schemas_for_database(self, parent_node: TreeNode) -> None:
+        """Load schemas below a database or directly below a catalog."""
+        node_name = str(parent_node.label).replace("📁 ", "")
+        node_data = parent_node.data or {}
+        if node_data.get("type") == "catalog":
+            catalog_name = str(node_data.get("name") or node_name)
+            db_name = ""
+        else:
+            catalog_name = str(node_data.get("catalog") or "")
+            db_name = str(node_data.get("name") or node_name)
         try:
-            self.db_connector.switch_context(database_name=db_name)
-            schemas = self.db_connector.get_schemas()
+            self.db_connector.switch_context(catalog_name=catalog_name, database_name=db_name)
+            schemas = self.db_connector.get_schemas(catalog_name=catalog_name, database_name=db_name)
 
             if not schemas:
-                db_node.add_leaf("📂 No schemas found", data={"type": "empty"})
+                parent_node.add_leaf("📂 No schemas found", data={"type": "empty"})
                 return
 
             for schema_name in schemas:
-                schema_node = db_node.add(
-                    f"📂 {schema_name}", data={"type": "schema", "name": schema_name, "database": db_name}
+                schema_node = parent_node.add(
+                    f"📂 {schema_name}",
+                    data={
+                        "type": "schema",
+                        "name": schema_name,
+                        "database": db_name,
+                        "catalog": catalog_name,
+                    },
                 )
                 schema_node.add_leaf("⏳ Loading tables...", data={"type": "loading"})
         except DatusException as e:
-            logger.error(f"Failed to load schemas for database {db_name}: {str(e)}")
+            context_name = db_name or catalog_name
+            logger.error(f"Failed to load schemas for {context_name}: {str(e)}")
             if e.code == ErrorCode.DB_EXECUTION_TIMEOUT.code:
-                db_node.add_leaf(
+                parent_node.add_leaf(
                     "⏱️ Timeout loading schemas (press 'r' to retry)",
-                    data={"type": "timeout", "operation": "schemas", "parent": db_name},
+                    data={"type": "timeout", "operation": "schemas", "parent": context_name},
                 )
             else:
-                db_node.add_leaf("❌ Error loading schemas", data={"type": "error"})
+                parent_node.add_leaf("❌ Error loading schemas", data={"type": "error"})
 
     def _load_databases_for_catalog(self, catalog_node: TreeNode) -> None:
         """Load databases for a catalog node."""

--- a/datus/prompts/database_notes.py
+++ b/datus/prompts/database_notes.py
@@ -1,0 +1,24 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Resolve adapter-provided SQL generation guidance with legacy fallbacks."""
+
+from typing import Any
+
+from datus.tools.db_tools import connector_registry
+
+
+def get_database_notes(database_type: str) -> str:
+    getter = getattr(connector_registry, "get_sql_generation_notes", None)
+    notes: Any = getter(database_type) if callable(getter) else None
+    if callable(notes):
+        notes = notes()
+    if notes:
+        return f"\n{str(notes).strip()}"
+    if (database_type or "").lower() == "snowflake":
+        return (
+            "\nEnclose all column names in double quotes to comply with Snowflake syntax requirements and avoid errors. "
+            "When referencing table names in Snowflake SQL, include both the database_name and schema_name."
+        )
+    return ""

--- a/datus/prompts/gen_sql.py
+++ b/datus/prompts/gen_sql.py
@@ -9,6 +9,7 @@ from datus.utils.loggings import get_logger
 from datus.utils.message_utils import build_structured_content
 
 from ..utils.json_utils import to_pretty_str
+from .database_notes import get_database_notes
 from .prompt_manager import get_prompt_manager
 
 logger = get_logger(__name__)
@@ -64,14 +65,8 @@ def get_sql_prompt(
         logger.warning("Context is too long, truncating to %s characters" % max_context_length)
         processed_context = processed_context[:max_context_length] + "\n... (truncated)"
 
-    # Add Snowflake specific notes
-    database_notes = ""
+    database_notes = get_database_notes(database_type)
     knowledge_content = "" if not external_knowledge else f"External Knowledge:\n{external_knowledge}"
-    if database_type.lower() == "snowflake":
-        database_notes = (
-            "\nEnclose all column names in double quotes to comply with Snowflake syntax requirements and avoid erros. "
-            "When referencing table names in Snowflake SQL, you must include both the database_name and schema_name."
-        )
 
     processed_metrics = ""
     if metrics:

--- a/datus/prompts/reasoning_sql_with_mcp.py
+++ b/datus/prompts/reasoning_sql_with_mcp.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from datus.schemas.node_models import TableSchema, TableValue
 from datus.utils.loggings import get_logger
 
+from .database_notes import get_database_notes
 from .prompt_manager import get_prompt_manager
 
 logger = get_logger(__name__)
@@ -104,13 +105,7 @@ def get_reasoning_prompt(
         logger.warning("Context is too long, truncating to %s characters" % max_context_length)
         processed_context = processed_context[:max_context_length] + "\n... (truncated)"
 
-    # Add Snowflake specific notes
-    database_notes = ""
-    if database_type.lower() == "snowflake":
-        database_notes = (
-            "\nEnclose all column names in double quotes to comply with Snowflake syntax requirements and avoid errors."
-            "When referencing table names in Snowflake SQL, you must include both the database_name and schema_name."
-        )
+    database_notes = get_database_notes(database_type)
 
     user_content = get_prompt_manager(agent_config=agent_config).render_template(
         "reasoning_user",

--- a/datus/storage/kb_retrieval/store.py
+++ b/datus/storage/kb_retrieval/store.py
@@ -21,11 +21,11 @@ from datus.schemas.node_models import TableSchema, TableValue
 from datus.storage.base import StorageBase
 from datus.storage.datasource_scope import DATASOURCE_ID_COLUMN, datasource_condition, resolve_datasource_id
 from datus.storage.fts import FtsField, FtsIndexStatus, FtsSpec
-from datus.tools.db_tools import connector_registry
 from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import json2csv
 from datus.utils.loggings import get_logger
+from datus.utils.sql_utils import parse_table_name_parts
 
 if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
@@ -1082,16 +1082,10 @@ class MetadataFtsRAG:
         schema_name: str = "",
         dialect: str = DBType.SQLITE,
     ) -> tuple[str, str, str, str]:
-        parts = full_table.split(".")
-        table_name = parts[-1]
-        if len(parts) == 4:
-            return parts[0], parts[1], parts[2], table_name
-        if len(parts) == 3:
-            if connector_registry.support_catalog(dialect) and not connector_registry.support_schema(dialect):
-                return parts[0], parts[1], "", table_name
-            return catalog_name, parts[0], parts[1], table_name
-        if len(parts) == 2:
-            if not connector_registry.support_schema(dialect):
-                return catalog_name, parts[0], "", table_name
-            return catalog_name, database_name, parts[0], table_name
-        return catalog_name, database_name, schema_name, table_name
+        parsed = parse_table_name_parts(full_table, dialect)
+        return (
+            parsed["catalog_name"] or catalog_name,
+            parsed["database_name"] or database_name,
+            parsed["schema_name"] or schema_name,
+            parsed["table_name"],
+        )

--- a/datus/storage/schema_metadata/local_init.py
+++ b/datus/storage/schema_metadata/local_init.py
@@ -5,12 +5,13 @@
 import asyncio
 from typing import Any, Dict, List, Optional, Set
 
-from datus_db_core import BaseSqlConnector, connector_registry
+from datus_db_core import BaseSqlConnector
 
 from datus.configuration.agent_config import AgentConfig, DbConfig
 from datus.schemas.base import TABLE_TYPE
 from datus.schemas.batch_events import BatchEventEmitter, BatchEventHelper
 from datus.storage.schema_metadata.store import SchemaWithValueRAG
+from datus.tools.db_tools.capabilities import supports_namespace
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.constants import DBType
 from datus.utils.loggings import get_logger
@@ -296,7 +297,8 @@ def init_other_three_level_schema(
         catalog_name = catalog_name or sql_connector.default_catalog()
     elif hasattr(sql_connector, "catalog_name"):
         catalog_name = catalog_name or getattr(sql_connector, "catalog_name", "")
-    if not connector_registry.support_schema(db_type):
+    has_schema = supports_namespace("schema", connector=sql_connector, dialect=db_type)
+    if not has_schema:
         schema_name = ""
     elif not schema_name and hasattr(sql_connector, "schema_name"):
         schema_name = getattr(sql_connector, "schema_name", "")
@@ -345,7 +347,7 @@ def init_other_three_level_schema(
                 table["catalog_name"] = catalog_name
             if not table.get("database_name"):
                 table["database_name"] = database_name
-            if not connector_registry.support_schema(db_type):
+            if not has_schema:
                 table["schema_name"] = ""
             elif not table.get("schema_name"):
                 table["schema_name"] = schema_name
@@ -370,7 +372,7 @@ def init_other_three_level_schema(
                 view["catalog_name"] = catalog_name
             if not view.get("database_name"):
                 view["database_name"] = database_name
-            if not connector_registry.support_schema(db_type):
+            if not has_schema:
                 view["schema_name"] = ""
             elif not view.get("schema_name"):
                 view["schema_name"] = schema_name
@@ -393,7 +395,7 @@ def init_other_three_level_schema(
                 mv["catalog_name"] = catalog_name
             if not mv.get("database_name"):
                 mv["database_name"] = database_name
-            if not connector_registry.support_schema(db_type):
+            if not has_schema:
                 mv["schema_name"] = ""
             elif not mv.get("schema_name"):
                 mv["schema_name"] = schema_name

--- a/datus/storage/schema_metadata/store.py
+++ b/datus/storage/schema_metadata/store.py
@@ -15,10 +15,10 @@ from datus.storage.base import BaseEmbeddingStore, WhereExpr
 from datus.storage.datasource_scope import add_datasource_scope_to_rows, datasource_condition, resolve_datasource_id
 from datus.storage.embedding_models import EmbeddingModel
 from datus.storage.fts import FtsField, FtsSpec
-from datus.tools.db_tools import connector_registry
 from datus.utils.constants import DBType
 from datus.utils.json_utils import json2csv
 from datus.utils.loggings import get_logger
+from datus.utils.sql_utils import parse_table_name_parts
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -414,64 +414,16 @@ class SchemaWithValueRAG:
         # Parse table names and build where clause
         table_conditions = []
         for full_table in tables:
-            parts = full_table.split(".")
-            table_name = parts[-1]
-            if len(parts) == 4:
-                cat, db, sch = parts[0], parts[1], parts[2]
-                table_conditions.append(
-                    _build_where_clause(
-                        table_name=table_name,
-                        catalog_name=cat,
-                        database_name=db,
-                        schema_name=sch,
-                        table_type="full",
-                    )
+            parsed = parse_table_name_parts(full_table, dialect)
+            table_conditions.append(
+                _build_where_clause(
+                    table_name=parsed["table_name"],
+                    catalog_name=parsed["catalog_name"] or catalog_name,
+                    database_name=parsed["database_name"] or database_name,
+                    schema_name=parsed["schema_name"] or schema_name,
+                    table_type="full",
                 )
-            elif len(parts) == 3:
-                # Format depends on dialect capabilities:
-                # - catalog + no schema (e.g., StarRocks): catalog.database.table
-                # - with schema (e.g., PostgreSQL, Snowflake): database.schema.table
-                if connector_registry.support_catalog(dialect) and not connector_registry.support_schema(dialect):
-                    cat, db, sch = parts[0], parts[1], ""
-                else:
-                    cat, db, sch = catalog_name, parts[0], parts[1]
-
-                table_conditions.append(
-                    _build_where_clause(
-                        table_name=table_name,
-                        catalog_name=cat,
-                        database_name=db,
-                        schema_name=sch,
-                        table_type="full",
-                    )
-                )
-            elif len(parts) == 2:
-                # No schema layer: part[0] is database_name
-                # Has schema layer: part[0] is schema_name
-                if not connector_registry.support_schema(dialect):
-                    cat, db, sch = catalog_name, parts[0], ""
-                else:
-                    cat, db, sch = catalog_name, database_name, parts[0]
-
-                table_conditions.append(
-                    _build_where_clause(
-                        table_name=table_name,
-                        catalog_name=cat,
-                        database_name=db,
-                        schema_name=sch,
-                        table_type="full",
-                    )
-                )
-            else:
-                table_conditions.append(
-                    _build_where_clause(
-                        table_name=table_name,
-                        catalog_name=catalog_name,
-                        database_name=database_name,
-                        schema_name=schema_name,
-                        table_type="full",
-                    )
-                )
+            )
 
         combined_condition = None
         if table_conditions:

--- a/datus/storage/scoped_filter.py
+++ b/datus/storage/scoped_filter.py
@@ -11,14 +11,13 @@ apply a scope filter at query time against the shared global storage.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from datus_storage_base.conditions import Node, and_, eq, like, or_
 
-from datus.tools.db_tools import connector_registry
-from datus.utils.constants import DBType
 from datus.utils.loggings import get_logger
 from datus.utils.reference_paths import split_reference_path
+from datus.utils.sql_utils import parse_table_name_parts
 
 logger = get_logger(__name__)
 
@@ -155,30 +154,12 @@ def _table_condition_for_token(token: str, dialect: str = "") -> Optional[Node]:
 
     Uses right-aligned field mapping based on the dialect's supported fields.
     """
-    parts = [p.strip() for p in token.split(".") if p.strip()]
-    if not parts:
+    parsed = parse_table_name_parts(token, dialect)
+    if not parsed["table_name"]:
         return None
 
-    field_order: List[str] = []
-    if connector_registry.support_catalog(dialect):
-        field_order.append("catalog_name")
-    if connector_registry.support_database(dialect) or dialect == DBType.SQLITE:
-        field_order.append("database_name")
-    if connector_registry.support_schema(dialect):
-        field_order.append("schema_name")
-    field_order.append("table_name")
-
-    values: Dict[str, str] = {f: "" for f in field_order}
-    num_fields = len(field_order)
-    trimmed_parts = parts[-num_fields:]
-    start_field_idx = max(0, num_fields - len(trimmed_parts))
-    for i, part in enumerate(trimmed_parts):
-        field_idx = start_field_idx + i
-        if field_idx < num_fields:
-            values[field_order[field_idx]] = part
-
     conditions: List[Node] = []
-    for field, value in values.items():
+    for field, value in parsed.items():
         if not value:
             continue
         conditions.append(_value_condition(field, value))

--- a/datus/tools/db_tools/__init__.py
+++ b/datus/tools/db_tools/__init__.py
@@ -4,6 +4,7 @@
 
 from datus_db_core import AdapterMetadata, BaseSqlConnector, ConnectorRegistry, connector_registry
 
+from .capabilities import get_effective_capabilities, supports_namespace
 from .sqlite_connector import SQLiteConnector
 
 __all__ = [
@@ -13,6 +14,8 @@ __all__ = [
     "connector_registry",
     "ConnectorRegistry",
     "AdapterMetadata",
+    "get_effective_capabilities",
+    "supports_namespace",
 ]
 
 

--- a/datus/tools/db_tools/capabilities.py
+++ b/datus/tools/db_tools/capabilities.py
@@ -1,0 +1,36 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Helpers for connector capabilities that may depend on live configuration."""
+
+from typing import Any, Optional, Set
+
+from datus_db_core import connector_registry
+
+
+def get_effective_capabilities(connector: Optional[Any] = None, dialect: str = "") -> Set[str]:
+    """Return instance capabilities when available, otherwise registry defaults."""
+    if connector is not None:
+        getter = getattr(connector, "get_effective_capabilities", None)
+        if callable(getter):
+            capabilities = getter()
+            if isinstance(capabilities, (set, frozenset, list, tuple)):
+                return set(capabilities)
+        dialect = dialect or getattr(connector, "dialect", "")
+    getter = getattr(connector_registry, "get_capabilities", None)
+    if callable(getter):
+        return set(getter(dialect))
+    return {
+        namespace
+        for namespace, supported in (
+            ("catalog", connector_registry.support_catalog(dialect)),
+            ("database", connector_registry.support_database(dialect)),
+            ("schema", connector_registry.support_schema(dialect)),
+        )
+        if supported
+    }
+
+
+def supports_namespace(namespace: str, connector: Optional[Any] = None, dialect: str = "") -> bool:
+    return namespace in get_effective_capabilities(connector=connector, dialect=dialect)

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -14,7 +14,7 @@ from fnmatch import fnmatchcase
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union
 
 from agents import Tool
-from datus_db_core import BaseSqlConnector, connector_registry
+from datus_db_core import BaseSqlConnector
 
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.agent_models import SubAgentConfig
@@ -24,6 +24,7 @@ from datus.storage.schema_metadata import create_metadata_rag
 from datus.storage.schema_metadata.store import SchemaWithValueRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
+from datus.tools.db_tools.capabilities import get_effective_capabilities, supports_namespace
 from datus.tools.db_tools.db_manager import DBManager, db_manager_instance
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.utils.compress_utils import DataCompressor
@@ -31,6 +32,7 @@ from datus.utils.constants import DBType, SQLType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.mcp_decorators import mcp_tool, mcp_tool_class
+from datus.utils.sql_utils import parse_table_name_parts
 
 logger = get_logger(__name__)
 
@@ -414,12 +416,13 @@ class DBFuncTool:
 
     def _determine_field_order(self) -> Sequence[str]:
         dialect = getattr(self._primary_connector, "dialect", "") or ""
+        capabilities = get_effective_capabilities(self._primary_connector, dialect)
         fields: List[str] = []
-        if connector_registry.support_catalog(dialect):
+        if "catalog" in capabilities:
             fields.append("catalog")
-        if connector_registry.support_database(dialect) or dialect == DBType.SQLITE:
+        if "database" in capabilities or dialect == DBType.SQLITE:
             fields.append("database")
-        if connector_registry.support_schema(dialect):
+        if "schema" in capabilities:
             fields.append("schema")
         fields.append("table")
         return fields
@@ -472,22 +475,16 @@ class DBFuncTool:
         token = (token or "").strip()
         if not token:
             return None
-        parts = [self._normalize_identifier_part(part) for part in token.split(".") if part.strip()]
-        if not parts:
+        dialect = getattr(self._primary_connector, "dialect", "") or ""
+        parsed = parse_table_name_parts(token, dialect)
+        if not parsed.get("table_name"):
             return None
-        # Align parts from right to left (table is always rightmost)
-        # e.g., for "public.wb_health_population" with field_order ["database", "schema", "table"]:
-        #   - parts = ["public", "wb_health_population"]
-        #   - align from right: schema="public", table="wb_health_population"
-        # When parts > fields, keep only the rightmost num_fields parts
-        values: Dict[str, str] = {field: "" for field in self._field_order}
-        num_fields = len(self._field_order)
-        trimmed_parts = parts[-num_fields:]
-        start_field_idx = max(0, num_fields - len(trimmed_parts))
-        for i, part in enumerate(trimmed_parts):
-            field_idx = start_field_idx + i
-            if field_idx < num_fields:
-                values[self._field_order[field_idx]] = part
+        values = {
+            "catalog": parsed.get("catalog_name", ""),
+            "database": parsed.get("database_name", ""),
+            "schema": parsed.get("schema_name", ""),
+            "table": parsed.get("table_name", ""),
+        }
         return ScopedTablePattern(raw=token, **values)
 
     def _get_semantic_model(
@@ -741,9 +738,17 @@ class DBFuncTool:
         database_value = self._normalize_identifier_part(database)
         schema_value = self._normalize_identifier_part(schema)
 
-        dialect = self._dialect_for_datasource(datasource)
-        if not connector_registry.support_catalog(dialect):
-            if catalog_value and not database_value and connector_registry.support_database(dialect):
+        try:
+            connector = self._get_connector(datasource)
+        except Exception:
+            connector = self.connector
+        dialect = getattr(connector, "dialect", "") or ""
+        if not supports_namespace("catalog", connector=connector, dialect=dialect):
+            if (
+                catalog_value
+                and not database_value
+                and supports_namespace("database", connector=connector, dialect=dialect)
+            ):
                 database_value = catalog_value
             catalog_value = ""
 
@@ -762,15 +767,16 @@ class DBFuncTool:
             schema=self._default_field_value("schema", schema),
             table=self._normalize_identifier_part(raw_name),
         )
-        parts = [self._normalize_identifier_part(part) for part in raw_name.split(".") if part.strip()]
-        if parts:
-            coordinate.table = parts[-1]
-            idx = len(parts) - 2
-            for field in reversed(self._field_order[:-1]):
-                if idx < 0:
-                    break
-                setattr(coordinate, field, parts[idx])
-                idx -= 1
+        dialect = getattr(self.connector, "dialect", "") or ""
+        parsed = parse_table_name_parts(raw_name, dialect)
+        for field, parsed_field in (
+            ("catalog", "catalog_name"),
+            ("database", "database_name"),
+            ("schema", "schema_name"),
+            ("table", "table_name"),
+        ):
+            if parsed.get(parsed_field):
+                setattr(coordinate, field, self._normalize_identifier_part(parsed[parsed_field]))
         return coordinate
 
     def _table_matches_scope(self, coordinate: TableCoordinate) -> bool:
@@ -927,9 +933,19 @@ class DBFuncTool:
                 dialects.add(normalized)
         return dialects
 
+    def _configured_supports(self, namespace: str) -> bool:
+        primary_dialect = self._dialect_name(getattr(self.connector, "dialect", ""))
+        if namespace in get_effective_capabilities(self.connector, primary_dialect):
+            return True
+        return any(
+            namespace in get_effective_capabilities(dialect=dialect)
+            for dialect in self._configured_tool_dialects()
+            if dialect != primary_dialect
+        )
+
     def _excluded_tool_params(self) -> set[str]:
         excluded: set[str] = set()
-        if not any(connector_registry.support_catalog(dialect) for dialect in self._configured_tool_dialects()):
+        if not self._configured_supports("catalog"):
             excluded.add("catalog")
         return excluded
 
@@ -939,17 +955,16 @@ class DBFuncTool:
     def available_tools(self) -> List[Tool]:
         bound_tools = []
         methods_to_convert: List[Callable] = [self.list_tables, self.describe_table]
-        configured_dialects = self._configured_tool_dialects()
 
         if self.has_schema:
             methods_to_convert.append(self.search_table)
 
         methods_to_convert.append(self.execute_sql)
 
-        if any(connector_registry.support_database(dialect) for dialect in configured_dialects):
+        if self._configured_supports("database"):
             bound_tools.append(self.to_function_tool(self.list_databases))
 
-        if any(connector_registry.support_schema(dialect) for dialect in configured_dialects):
+        if self._configured_supports("schema"):
             bound_tools.append(self.to_function_tool(self.list_schemas))
 
         for bound_method in methods_to_convert:

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -704,7 +704,12 @@ class DBFuncTool:
         # Strip common quoting characters
         return normalized.strip("`\"'[]")
 
-    def _default_field_value(self, field: str, explicit: Optional[str]) -> str:
+    def _default_field_value(
+        self,
+        field: str,
+        explicit: Optional[str],
+        connector: Optional[BaseSqlConnector] = None,
+    ) -> str:
         if field not in self._field_order:
             return ""
         if explicit:
@@ -716,8 +721,9 @@ class DBFuncTool:
             "schema": "schema_name",
         }
         fallback_attr = fallback_attr_map.get(field)
-        if fallback_attr and hasattr(self.connector, fallback_attr):
-            return self._normalize_identifier_part(getattr(self.connector, fallback_attr))
+        source_connector = connector or self.connector
+        if fallback_attr and hasattr(source_connector, fallback_attr):
+            return self._normalize_identifier_part(getattr(source_connector, fallback_attr))
         return ""
 
     def _dialect_for_datasource(self, datasource: Optional[str] = "") -> str:
@@ -760,14 +766,16 @@ class DBFuncTool:
         catalog: Optional[str] = "",
         database: Optional[str] = "",
         schema: Optional[str] = "",
+        connector: Optional[BaseSqlConnector] = None,
     ) -> TableCoordinate:
+        routed_connector = connector or self.connector
         coordinate = TableCoordinate(
-            catalog=self._default_field_value("catalog", catalog),
-            database=self._default_field_value("database", database),
-            schema=self._default_field_value("schema", schema),
+            catalog=self._default_field_value("catalog", catalog, routed_connector),
+            database=self._default_field_value("database", database, routed_connector),
+            schema=self._default_field_value("schema", schema, routed_connector),
             table=self._normalize_identifier_part(raw_name),
         )
-        dialect = getattr(self.connector, "dialect", "") or ""
+        dialect = getattr(routed_connector, "dialect", "") or ""
         parsed = parse_table_name_parts(raw_name, dialect)
         for field, parsed_field in (
             ("catalog", "catalog_name"),
@@ -790,6 +798,7 @@ class DBFuncTool:
         catalog: Optional[str],
         database: Optional[str],
         schema: Optional[str],
+        connector: BaseSqlConnector,
     ) -> List[Dict[str, Any]]:
         if not self._scoped_patterns:
             return list(entries)
@@ -801,6 +810,7 @@ class DBFuncTool:
                 catalog=catalog,
                 database=database,
                 schema=schema,
+                connector=connector,
             )
             if self._table_matches_scope(coordinate):
                 filtered.append(entry)
@@ -848,19 +858,20 @@ class DBFuncTool:
             wildcard_allowed = True
         return wildcard_allowed
 
-    def _check_sql_table_scope(self, sql: str) -> List[str]:
+    def _check_sql_table_scope(self, sql: str, connector: Optional[BaseSqlConnector] = None) -> List[str]:
         """Return table names from *sql* that fall outside the scoped context."""
         if not self._scoped_patterns:
             return []
         from datus.utils.sql_utils import extract_table_names
 
-        dialect = getattr(self._primary_connector, "dialect", "") or ""
+        routed_connector = connector or self._primary_connector
+        dialect = getattr(routed_connector, "dialect", "") or ""
         table_names = extract_table_names(sql, dialect=dialect, ignore_empty=True)
         if not table_names:
             return []  # can't parse → allow (SHOW/DESCRIBE/EXPLAIN have no tables)
         out_of_scope: List[str] = []
         for name in table_names:
-            coordinate = self._build_table_coordinate(raw_name=name)
+            coordinate = self._build_table_coordinate(raw_name=name, connector=routed_connector)
             if not self._table_matches_scope(coordinate):
                 out_of_scope.append(name)
         return out_of_scope
@@ -1211,7 +1222,7 @@ class DBFuncTool:
                 except Exception as e:
                     logger.debug(f"get_materialized_views unavailable on {connector.dialect}: {e}")
 
-            filtered_result = self._filter_table_entries(result, catalog, database, schema_name)
+            filtered_result = self._filter_table_entries(result, catalog, database, schema_name, connector)
             return FuncToolResult(result=filtered_result)
         except Exception as e:
             return FuncToolResult(success=0, error=str(e))
@@ -1263,11 +1274,13 @@ class DBFuncTool:
                 schema_name,
                 datasource,
             )
+            connector = self._get_connector(datasource, database)
             coordinate = self._build_table_coordinate(
                 raw_name=table_name,
                 catalog=catalog,
                 database=database,
                 schema=schema_name,
+                connector=connector,
             )
 
             if not self._table_matches_scope(coordinate):
@@ -1667,7 +1680,7 @@ class DBFuncTool:
                     sql_type,
                 )
 
-        out_of_scope = self._check_sql_table_scope(sql)
+        out_of_scope = self._check_sql_table_scope(sql, connector)
         if out_of_scope:
             return (
                 FuncToolResult(
@@ -1738,11 +1751,13 @@ class DBFuncTool:
                 schema_name,
                 datasource,
             )
+            connector = self._get_connector(datasource, database)
             coordinate = self._build_table_coordinate(
                 raw_name=table_name,
                 catalog=catalog,
                 database=database,
                 schema=schema_name,
+                connector=connector,
             )
             if not self._table_matches_scope(coordinate):
                 return FuncToolResult(
@@ -1823,7 +1838,7 @@ class DBFuncTool:
                 error="DML statements (INSERT/UPDATE/DELETE) must run through the write path.",
             )
 
-        out_of_scope = self._check_sql_table_scope(cleaned)
+        out_of_scope = self._check_sql_table_scope(cleaned, connector)
         if out_of_scope:
             return FuncToolResult(
                 success=0,
@@ -1936,7 +1951,7 @@ class DBFuncTool:
                     ),
                 )
 
-            out_of_scope = self._check_sql_table_scope(normalized_sql)
+            out_of_scope = self._check_sql_table_scope(normalized_sql, connector)
             if out_of_scope:
                 return FuncToolResult(
                     success=0,

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -174,7 +174,13 @@ def _table_names_from_expression(parsed, *, dialect: str, ignore_empty: bool) ->
         if table_name.lower() in cte_names:
             continue
         if _registry_hook("get_identifier_parser", dialect):
-            table_names.append(".".join(part for part in (db, schema, table_name) if part))
+            parts = []
+            if not ignore_empty or db:
+                parts.append(db)
+            if not ignore_empty or schema:
+                parts.append(schema)
+            parts.append(table_name)
+            table_names.append(".".join(parts))
             continue
 
         full_name = []
@@ -244,7 +250,13 @@ def parse_table_name_parts(full_table_name: str, dialect: str = "snowflake") -> 
     raw_dialect = (dialect or "").strip().lower()
     identifier_parser = _registry_hook("get_identifier_parser", raw_dialect)
     if identifier_parser:
-        return identifier_parser(full_table_name)
+        parsed = identifier_parser(full_table_name)
+        expected_fields = {"catalog_name", "database_name", "schema_name", "table_name"}
+        if not isinstance(parsed, dict) or not expected_fields.issubset(parsed):
+            raise ValueError(
+                "Adapter identifier parser must return catalog_name, database_name, schema_name, and table_name"
+            )
+        return {field: str(parsed[field] or "") for field in expected_fields}
 
     dialect = parse_dialect(raw_dialect)
 

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -15,9 +15,19 @@ from datus.utils.loggings import get_logger
 logger = get_logger(__name__)
 
 
+def _registry_hook(name: str, dialect: str):
+    from datus.tools.db_tools import connector_registry
+
+    getter = getattr(connector_registry, name, None)
+    return getter(dialect) if callable(getter) else None
+
+
 def parse_read_dialect(dialect: str = "snowflake") -> str:
     """Map SQL dialect to the appropriate read dialect for sqlglot parsing."""
     db = (dialect or "").strip().lower()
+    registered = _registry_hook("get_parser_dialect", db)
+    if registered:
+        return registered
     if db in ("postgres", "postgresql", "redshift", "greenplum"):
         return "postgres"
     if db in ("spark", "databricks", "hive", "starrocks"):
@@ -30,6 +40,9 @@ def parse_read_dialect(dialect: str = "snowflake") -> str:
 def parse_dialect(dialect: str = "snowflake") -> str:
     """Map SQL dialect to the dialect for sqlglot parsing."""
     db = (dialect or "").strip().lower()
+    registered = _registry_hook("get_parser_dialect", db)
+    if registered:
+        return registered
     if db in ("postgres", "postgresql"):
         return "postgres"
     if db in ("mssql", "sqlserver"):
@@ -61,7 +74,8 @@ def parse_metadata_from_ddl(sql: str, dialect: str = "snowflake") -> Dict[str, A
             ]
         }
     """
-    dialect = parse_dialect(dialect)
+    raw_dialect = (dialect or "").strip().lower()
+    dialect = parse_dialect(raw_dialect)
 
     try:
         result = {"table": {"name": "", "schema_name": "", "database_name": ""}, "columns": []}
@@ -77,8 +91,16 @@ def parse_metadata_from_ddl(sql: str, dialect: str = "snowflake") -> Dict[str, A
             if isinstance(table_name, str):
                 table_name = table_name.strip('"').strip("`").strip("[]")
             result["table"]["name"] = table_name
-            result["table"]["schema_name"] = tb_info.db
-            result["table"]["database_name"] = tb_info.catalog
+            identifier_parser = _registry_hook("get_identifier_parser", raw_dialect)
+            if identifier_parser:
+                parsed_name = identifier_parser(
+                    ".".join(part for part in (tb_info.catalog, tb_info.db, table_name) if part)
+                )
+                result["table"]["schema_name"] = parsed_name["schema_name"]
+                result["table"]["database_name"] = parsed_name["database_name"]
+            else:
+                result["table"]["schema_name"] = tb_info.db
+                result["table"]["database_name"] = tb_info.catalog
             if tb_info.comments:
                 result["table"]["comment"] = tb_info.comments
 
@@ -151,6 +173,10 @@ def _table_names_from_expression(parsed, *, dialect: str, ignore_empty: bool) ->
         # Skip if the table is a CTE
         if table_name.lower() in cte_names:
             continue
+        if _registry_hook("get_identifier_parser", dialect):
+            table_names.append(".".join(part for part in (db, schema, table_name) if part))
+            continue
+
         full_name = []
 
         if dialect in ["mysql", "oracle", "postgres", "postgresql"]:
@@ -215,7 +241,12 @@ def parse_table_name_parts(full_table_name: str, dialect: str = "snowflake") -> 
         - "database.schema.table" -> {"catalog_name": "", "database_name": "database",
                                       "schema_name": "schema", "table_name": "table"}
     """
-    dialect = parse_dialect(dialect)
+    raw_dialect = (dialect or "").strip().lower()
+    identifier_parser = _registry_hook("get_identifier_parser", raw_dialect)
+    if identifier_parser:
+        return identifier_parser(full_table_name)
+
+    dialect = parse_dialect(raw_dialect)
 
     # Build field mapping dynamically from registry capabilities
     def _build_field_mapping(d: str) -> list:

--- a/datus/validation/target_extractor.py
+++ b/datus/validation/target_extractor.py
@@ -102,7 +102,7 @@ def extract_ddl_target(
     if not isinstance(target_expr, expressions.Table):
         return None
 
-    return _table_to_target(target_expr, datasource, active_database, dialect=normalized_dialect)
+    return _table_to_target(target_expr, datasource, active_database, dialect=dialect or normalized_dialect)
 
 
 def extract_dml_target(
@@ -150,7 +150,7 @@ def extract_dml_target(
     if not isinstance(target_expr, expressions.Table):
         return None
 
-    return _table_to_target(target_expr, datasource, active_database, dialect=normalized_dialect)
+    return _table_to_target(target_expr, datasource, active_database, dialect=dialect or normalized_dialect)
 
 
 def _dialect_has_catalog(dialect: str) -> bool:
@@ -216,6 +216,20 @@ def _table_to_target(
     sql_catalog_slot = _identifier_name(table_expr.args.get("catalog")) or None
 
     datasource_key = datasource or None
+    from datus.tools.db_tools import connector_registry
+
+    getter = getattr(connector_registry, "get_identifier_parser", None)
+    identifier_parser = getter(dialect) if callable(getter) else None
+    if identifier_parser:
+        parsed = identifier_parser(".".join(part for part in (sql_catalog_slot, schema, name) if part))
+        return TableTarget(
+            catalog=parsed["catalog_name"] or None,
+            datasource=datasource_key,
+            database=parsed["database_name"] or active_database or "",
+            db_schema=parsed["schema_name"] or None,
+            table=parsed["table_name"],
+        )
+
     catalog: Optional[str] = None
     # The *physical* database is the connector's active namespace. We deliberately do NOT
     # fall back to the datasource key: a datasource name is not a database, and feeding it

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -467,6 +467,25 @@ class TestGetTableSchema:
             assert col.name != ""
             assert col.type != ""
 
+    def test_get_table_schema_uses_connector_nullable_contract(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.current_db_connector.get_schema = MagicMock(
+            return_value=[
+                {
+                    "name": "id",
+                    "type": "BIGINT",
+                    "nullable": True,
+                    "default_value": None,
+                    "pk": False,
+                }
+            ]
+        )
+
+        result = svc.get_table_schema("orders")
+
+        assert result.success is True
+        assert result.data.table.columns[0].nullable is True
+
     def test_get_table_schema_nonexistent_table(self, real_agent_config):
         """Nonexistent table returns failure."""
         svc = DatasourceService(agent_config=real_agent_config)

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -474,7 +474,7 @@ class TestGetTableSchema:
                 {
                     "name": "id",
                     "type": "BIGINT",
-                    "nullable": True,
+                    "nullable": False,
                     "default_value": None,
                     "pk": False,
                 }
@@ -484,7 +484,7 @@ class TestGetTableSchema:
         result = svc.get_table_schema("orders")
 
         assert result.success is True
-        assert result.data.table.columns[0].nullable is True
+        assert result.data.table.columns[0].nullable is False
 
     def test_get_table_schema_nonexistent_table(self, real_agent_config):
         """Nonexistent table returns failure."""

--- a/tests/unit_tests/cli/screen/test_catalog_screen.py
+++ b/tests/unit_tests/cli/screen/test_catalog_screen.py
@@ -1,8 +1,75 @@
 import io
+from unittest.mock import MagicMock
 
+import pytest
 from rich.console import Console
 
 from datus.cli.screen.catalog_screen import CatalogScreen
+
+
+@pytest.mark.parametrize(
+    "capabilities",
+    [
+        {"catalog", "schema"},
+        {"catalog", "database", "schema"},
+    ],
+)
+def test_catalog_capabilities_always_build_catalog_first_tree(capabilities):
+    screen = object.__new__(CatalogScreen)
+    tree = MagicMock()
+    helper = MagicMock()
+    screen.query_one = MagicMock(side_effect=[tree, helper])
+    screen.db_connector = MagicMock()
+    screen.db_type = "flexdb"
+    screen.database_name = ""
+    screen._supports = lambda namespace: namespace in capabilities
+    screen._load_catalogs_lazy = MagicMock()
+    screen._load_databases_lazy = MagicMock()
+
+    screen._build_catalog_tree()
+
+    screen._load_catalogs_lazy.assert_called_once_with(tree)
+    screen._load_databases_lazy.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("node_data", "expected_catalog", "expected_database"),
+    [
+        ({"type": "catalog", "name": "catalog_a"}, "catalog_a", ""),
+        ({"type": "database", "name": "database_a", "catalog": "catalog_a"}, "catalog_a", "database_a"),
+    ],
+)
+def test_schema_loading_preserves_catalog_and_database_coordinates(
+    node_data,
+    expected_catalog,
+    expected_database,
+):
+    screen = object.__new__(CatalogScreen)
+    screen.db_connector = MagicMock()
+    screen.db_connector.get_schemas.return_value = ["analytics"]
+    parent_node = MagicMock()
+    parent_node.label = node_data["name"]
+    parent_node.data = node_data
+
+    screen._load_schemas_for_database(parent_node)
+
+    screen.db_connector.switch_context.assert_called_once_with(
+        catalog_name=expected_catalog,
+        database_name=expected_database,
+    )
+    screen.db_connector.get_schemas.assert_called_once_with(
+        catalog_name=expected_catalog,
+        database_name=expected_database,
+    )
+    parent_node.add.assert_called_once_with(
+        "📂 analytics",
+        data={
+            "type": "schema",
+            "name": "analytics",
+            "database": expected_database,
+            "catalog": expected_catalog,
+        },
+    )
 
 
 def test_catalog_screen_builds_generic_record_from_table_semantic_profile():

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from datus_db_core import connector_registry
 
 from datus.cli.generation_hooks import (
     GenerationCancelledException,
@@ -1242,6 +1243,64 @@ class TestSyncSemanticToDbBooleanCoercion:
         assert len(table_rows) >= 1
         assert type(table_rows[0]["create_metric"]) is bool
         assert type(table_rows[0]["is_partition"]) is bool
+
+
+def test_sync_qualified_database_table_clears_stale_schema(agent_config, tmp_path):
+    yaml_file = tmp_path / "orders.yml"
+    yaml_file.write_text(
+        """
+data_source:
+  name: orders
+  sql_table: project_a.orders
+  dimensions:
+    - name: status
+      type: CATEGORICAL
+      expr: status
+""",
+        encoding="utf-8",
+    )
+    db_config = MagicMock()
+    db_config.catalog = ""
+    db_config.database = "project_a"
+    db_config.schema = "stale_schema"
+    agent_config.current_db_config.return_value = db_config
+    agent_config.db_type = "flexdb"
+
+    def parse_identifier(identifier):
+        parts = identifier.split(".")
+        return {
+            "catalog_name": "",
+            "database_name": parts[0] if len(parts) > 1 else "",
+            "schema_name": parts[1] if len(parts) == 3 else "",
+            "table_name": parts[-1],
+        }
+
+    saved_connectors = connector_registry._connectors.copy()
+    saved_metadata = connector_registry._metadata.copy()
+    saved_capabilities = connector_registry._capabilities.copy()
+    mock_semantic_rag = MagicMock()
+    try:
+        connector_registry.register(
+            "flexdb",
+            object,
+            capabilities={"database", "schema"},
+            identifier_parser=parse_identifier,
+        )
+        with (
+            patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
+            patch("datus.cli.generation_hooks.MetricRAG", return_value=MagicMock()),
+        ):
+            result = GenerationHooks._sync_semantic_to_db(str(yaml_file), agent_config)
+    finally:
+        connector_registry._connectors = saved_connectors
+        connector_registry._metadata = saved_metadata
+        connector_registry._capabilities = saved_capabilities
+
+    assert result["success"], result.get("error")
+    rows = mock_semantic_rag.upsert_batch.call_args.args[0]
+    table_row = next(row for row in rows if row["kind"] == "table")
+    assert table_row["fq_name"] == "project_a.orders"
+    assert table_row["schema_name"] == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/cli/test_generation_hooks.py
+++ b/tests/unit_tests/cli/test_generation_hooks.py
@@ -1245,7 +1245,7 @@ class TestSyncSemanticToDbBooleanCoercion:
         assert type(table_rows[0]["is_partition"]) is bool
 
 
-def test_sync_qualified_database_table_clears_stale_schema(agent_config, tmp_path):
+def test_sync_qualified_database_table_clears_stale_schema(agent_config, tmp_path, monkeypatch):
     yaml_file = tmp_path / "orders.yml"
     yaml_file.write_text(
         """
@@ -1275,16 +1275,16 @@ data_source:
             "table_name": parts[-1],
         }
 
-    saved_connectors = connector_registry._connectors.copy()
-    saved_metadata = connector_registry._metadata.copy()
-    saved_capabilities = connector_registry._capabilities.copy()
+    snapshot_attrs = ("_connectors", "_metadata", "_capabilities", "_uri_builders", "_context_resolvers")
+    snapshots = {attr: getattr(connector_registry, attr).copy() for attr in snapshot_attrs}
     mock_semantic_rag = MagicMock()
     try:
-        connector_registry.register(
-            "flexdb",
-            object,
-            capabilities={"database", "schema"},
-            identifier_parser=parse_identifier,
+        connector_registry.register_handlers("flexdb", capabilities={"database", "schema"})
+        monkeypatch.setattr(
+            connector_registry,
+            "get_identifier_parser",
+            lambda dialect: parse_identifier if dialect == "flexdb" else None,
+            raising=False,
         )
         with (
             patch("datus.cli.generation_hooks.SemanticModelRAG", return_value=mock_semantic_rag),
@@ -1292,9 +1292,10 @@ data_source:
         ):
             result = GenerationHooks._sync_semantic_to_db(str(yaml_file), agent_config)
     finally:
-        connector_registry._connectors = saved_connectors
-        connector_registry._metadata = saved_metadata
-        connector_registry._capabilities = saved_capabilities
+        for attr, saved in snapshots.items():
+            live = getattr(connector_registry, attr)
+            live.clear()
+            live.update(saved)
 
     assert result["success"], result.get("error")
     rows = mock_semantic_rag.upsert_batch.call_args.args[0]

--- a/tests/unit_tests/cli/test_metadata_commands.py
+++ b/tests/unit_tests/cli/test_metadata_commands.py
@@ -202,16 +202,14 @@ class TestCmdTables:
 class TestCmdSchemas:
     def test_unsupported_dialect(self):
         cli = _make_cli(db_type=DBType.SQLITE)
-        with patch("datus.cli.metadata_commands.connector_registry") as mock_reg:
-            mock_reg.support_schema.return_value = False
+        with patch("datus.cli.metadata_commands.supports_namespace", return_value=False):
             meta = MetadataCommands(cli)
             meta.cmd_schemas("")
         cli.console.print.assert_called()
 
     def test_empty_schemas(self):
         cli = _make_cli(db_type="snowflake")
-        with patch("datus.cli.metadata_commands.connector_registry") as mock_reg:
-            mock_reg.support_schema.return_value = True
+        with patch("datus.cli.metadata_commands.supports_namespace", return_value=True):
             cli.db_connector.get_schemas.return_value = []
             meta = MetadataCommands(cli)
             meta.cmd_schemas("")
@@ -220,8 +218,7 @@ class TestCmdSchemas:
 
     def test_with_schemas(self):
         cli = _make_cli(db_type="snowflake")
-        with patch("datus.cli.metadata_commands.connector_registry") as mock_reg:
-            mock_reg.support_schema.return_value = True
+        with patch("datus.cli.metadata_commands.supports_namespace", return_value=True):
             cli.db_connector.get_schemas.return_value = ["public", "private"]
             meta = MetadataCommands(cli)
             meta.cmd_schemas("")
@@ -239,24 +236,21 @@ class TestCmdSchemas:
 class TestCmdSwitchSchema:
     def test_unsupported_dialect(self):
         cli = _make_cli(db_type=DBType.SQLITE)
-        with patch("datus.cli.metadata_commands.connector_registry") as mock_reg:
-            mock_reg.support_schema.return_value = False
+        with patch("datus.cli.metadata_commands.supports_namespace", return_value=False):
             meta = MetadataCommands(cli)
             meta.cmd_switch_schema("public")
         cli.console.print.assert_called()
 
     def test_empty_name(self):
         cli = _make_cli()
-        with patch("datus.cli.metadata_commands.connector_registry") as mock_reg:
-            mock_reg.support_schema.return_value = True
+        with patch("datus.cli.metadata_commands.supports_namespace", return_value=True):
             meta = MetadataCommands(cli)
             meta.cmd_switch_schema("")
         cli.console.print.assert_called()
 
     def test_success(self):
         cli = _make_cli()
-        with patch("datus.cli.metadata_commands.connector_registry") as mock_reg:
-            mock_reg.support_schema.return_value = True
+        with patch("datus.cli.metadata_commands.supports_namespace", return_value=True):
             meta = MetadataCommands(cli)
             meta.cmd_switch_schema("myschema")
         assert cli.cli_context.current_schema == "myschema"

--- a/tests/unit_tests/prompts/test_database_notes.py
+++ b/tests/unit_tests/prompts/test_database_notes.py
@@ -63,7 +63,13 @@ def test_adapter_notes_reach_both_sql_prompt_builders(monkeypatch):
     assert notes in reasoning_call.kwargs["database_notes"]
 
 
-def test_snowflake_legacy_notes_are_preserved():
+def test_snowflake_legacy_notes_are_preserved(monkeypatch):
+    monkeypatch.setattr(
+        connector_registry,
+        "get_sql_generation_notes",
+        lambda _dialect: None,
+        raising=False,
+    )
     notes = get_database_notes("snowflake")
     assert "double quotes" in notes
     assert "database_name and schema_name" in notes

--- a/tests/unit_tests/prompts/test_database_notes.py
+++ b/tests/unit_tests/prompts/test_database_notes.py
@@ -1,24 +1,66 @@
 # Copyright 2025-present DatusAI, Inc.
 # Licensed under the Apache License, Version 2.0.
 
+from unittest.mock import MagicMock, patch
+
 from datus_db_core import connector_registry
 
 from datus.prompts.database_notes import get_database_notes
+from datus.prompts.gen_sql import get_sql_prompt
+from datus.prompts.reasoning_sql_with_mcp import get_reasoning_prompt
 
 
-def test_adapter_sql_generation_notes_are_used():
-    saved_connectors = connector_registry._connectors.copy()
-    saved_metadata = connector_registry._metadata.copy()
-    try:
-        connector_registry.register(
-            "flexdb",
-            object,
-            sql_generation_notes="Use project.table or project.schema.table.",
+def test_adapter_sql_generation_notes_are_used(monkeypatch):
+    monkeypatch.setattr(
+        connector_registry,
+        "get_sql_generation_notes",
+        lambda dialect: "Use project.table or project.schema.table." if dialect == "flexdb" else None,
+        raising=False,
+    )
+
+    assert "project.schema.table" in get_database_notes("flexdb")
+
+
+def test_adapter_notes_reach_both_sql_prompt_builders(monkeypatch):
+    notes = "Use project.table or project.schema.table."
+    monkeypatch.setattr(
+        connector_registry,
+        "get_sql_generation_notes",
+        lambda dialect: notes if dialect == "flexdb" else None,
+        raising=False,
+    )
+
+    sql_prompt_manager = MagicMock()
+    sql_prompt_manager.render_template.return_value = "rendered"
+    with patch("datus.prompts.gen_sql.get_prompt_manager", return_value=sql_prompt_manager):
+        get_sql_prompt(
+            database_type="flexdb",
+            table_schemas="",
+            data_details=[],
+            metrics=[],
+            question="question",
         )
-        assert "project.schema.table" in get_database_notes("flexdb")
-    finally:
-        connector_registry._connectors = saved_connectors
-        connector_registry._metadata = saved_metadata
+    sql_user_call = next(
+        call for call in sql_prompt_manager.render_template.call_args_list if call.args[0] == "gen_sql_user"
+    )
+    assert notes in sql_user_call.kwargs["database_notes"]
+
+    reasoning_prompt_manager = MagicMock()
+    reasoning_prompt_manager.render_template.return_value = "rendered"
+    with patch(
+        "datus.prompts.reasoning_sql_with_mcp.get_prompt_manager",
+        return_value=reasoning_prompt_manager,
+    ):
+        get_reasoning_prompt(
+            database_type="flexdb",
+            table_schemas=[],
+            data_details=[],
+            metrics="",
+            question="question",
+            context=[],
+        )
+    reasoning_call = reasoning_prompt_manager.render_template.call_args
+    assert notes in reasoning_call.kwargs["database_notes"]
 
 
 def test_snowflake_legacy_notes_are_preserved():

--- a/tests/unit_tests/prompts/test_database_notes.py
+++ b/tests/unit_tests/prompts/test_database_notes.py
@@ -1,0 +1,27 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+from datus_db_core import connector_registry
+
+from datus.prompts.database_notes import get_database_notes
+
+
+def test_adapter_sql_generation_notes_are_used():
+    saved_connectors = connector_registry._connectors.copy()
+    saved_metadata = connector_registry._metadata.copy()
+    try:
+        connector_registry.register(
+            "flexdb",
+            object,
+            sql_generation_notes="Use project.table or project.schema.table.",
+        )
+        assert "project.schema.table" in get_database_notes("flexdb")
+    finally:
+        connector_registry._connectors = saved_connectors
+        connector_registry._metadata = saved_metadata
+
+
+def test_snowflake_legacy_notes_are_preserved():
+    notes = get_database_notes("snowflake")
+    assert "double quotes" in notes
+    assert "database_name and schema_name" in notes

--- a/tests/unit_tests/storage/schema_metadata/test_local_init.py
+++ b/tests/unit_tests/storage/schema_metadata/test_local_init.py
@@ -641,9 +641,8 @@ class TestInitOtherThreeLevelSchema:
                 "datus.storage.schema_metadata.local_init.exists_table_value",
                 return_value=({}, set()),
             ),
-            patch("datus.storage.schema_metadata.local_init.connector_registry") as mock_registry,
+            patch("datus.storage.schema_metadata.local_init.supports_namespace", return_value=False),
         ):
-            mock_registry.support_schema.return_value = False
             init_other_three_level_schema(
                 mock_store,
                 agent_config,
@@ -677,9 +676,8 @@ class TestInitOtherThreeLevelSchema:
                 "datus.storage.schema_metadata.local_init.exists_table_value",
                 return_value=({}, set()),
             ),
-            patch("datus.storage.schema_metadata.local_init.connector_registry") as mock_registry,
+            patch("datus.storage.schema_metadata.local_init.supports_namespace", return_value=False),
         ):
-            mock_registry.support_schema.return_value = False
             init_other_three_level_schema(
                 mock_store,
                 agent_config,
@@ -710,9 +708,8 @@ class TestInitOtherThreeLevelSchema:
                 "datus.storage.schema_metadata.local_init.exists_table_value",
                 return_value=({}, set()),
             ),
-            patch("datus.storage.schema_metadata.local_init.connector_registry") as mock_registry,
+            patch("datus.storage.schema_metadata.local_init.supports_namespace", return_value=False),
         ):
-            mock_registry.support_schema.return_value = False
             init_other_three_level_schema(
                 mock_store,
                 agent_config,
@@ -744,9 +741,8 @@ class TestInitOtherThreeLevelSchema:
                 "datus.storage.schema_metadata.local_init.exists_table_value",
                 return_value=({}, set()),
             ),
-            patch("datus.storage.schema_metadata.local_init.connector_registry") as mock_registry,
+            patch("datus.storage.schema_metadata.local_init.supports_namespace", return_value=False),
         ):
-            mock_registry.support_schema.return_value = False
             init_other_three_level_schema(
                 mock_store,
                 agent_config,

--- a/tests/unit_tests/tools/db_tools/test_capabilities.py
+++ b/tests/unit_tests/tools/db_tools/test_capabilities.py
@@ -26,7 +26,8 @@ def test_instance_capabilities_override_registered_maximum():
         assert supports_namespace("database", connector=connector)
         assert not supports_namespace("schema", connector=connector)
     finally:
-        connector_registry._capabilities = saved
+        connector_registry._capabilities.clear()
+        connector_registry._capabilities.update(saved)
 
 
 def test_static_capabilities_remain_fallback_for_existing_adapters():
@@ -35,4 +36,5 @@ def test_static_capabilities_remain_fallback_for_existing_adapters():
         connector_registry.register_handlers("legacydb", capabilities={"database", "schema"})
         assert get_effective_capabilities(dialect="legacydb") == {"database", "schema"}
     finally:
-        connector_registry._capabilities = saved
+        connector_registry._capabilities.clear()
+        connector_registry._capabilities.update(saved)

--- a/tests/unit_tests/tools/db_tools/test_capabilities.py
+++ b/tests/unit_tests/tools/db_tools/test_capabilities.py
@@ -1,0 +1,38 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+from datus_db_core import connector_registry
+
+from datus.tools.db_tools.capabilities import get_effective_capabilities, supports_namespace
+
+
+class DynamicConnector:
+    dialect = "flexdb"
+
+    def __init__(self, capabilities):
+        self.capabilities = capabilities
+
+    def get_effective_capabilities(self):
+        return self.capabilities
+
+
+def test_instance_capabilities_override_registered_maximum():
+    saved = connector_registry._capabilities.copy()
+    try:
+        connector_registry.register_handlers("flexdb", capabilities={"database", "schema"})
+        connector = DynamicConnector({"database"})
+
+        assert get_effective_capabilities(connector) == {"database"}
+        assert supports_namespace("database", connector=connector)
+        assert not supports_namespace("schema", connector=connector)
+    finally:
+        connector_registry._capabilities = saved
+
+
+def test_static_capabilities_remain_fallback_for_existing_adapters():
+    saved = connector_registry._capabilities.copy()
+    try:
+        connector_registry.register_handlers("legacydb", capabilities={"database", "schema"})
+        assert get_effective_capabilities(dialect="legacydb") == {"database", "schema"}
+    finally:
+        connector_registry._capabilities = saved

--- a/tests/unit_tests/tools/db_tools/test_capabilities.py
+++ b/tests/unit_tests/tools/db_tools/test_capabilities.py
@@ -9,10 +9,10 @@ from datus.tools.db_tools.capabilities import get_effective_capabilities, suppor
 class DynamicConnector:
     dialect = "flexdb"
 
-    def __init__(self, capabilities):
+    def __init__(self, capabilities: set[str]) -> None:
         self.capabilities = capabilities
 
-    def get_effective_capabilities(self):
+    def get_effective_capabilities(self) -> set[str]:
         return self.capabilities
 
 

--- a/tests/unit_tests/tools/db_tools/test_db_func_tools.py
+++ b/tests/unit_tests/tools/db_tools/test_db_func_tools.py
@@ -1763,6 +1763,57 @@ class TestDBFuncToolMultiConnector:
         assert len(result.result) == 2
         mock_connector.get_tables.assert_called_once()
 
+    def test_table_coordinates_use_routed_connector_dialect(self, mock_agent_config, monkeypatch):
+        """Secondary datasource identifiers must be parsed with that datasource's dialect."""
+        from datus.tools.db_tools.db_manager import DBManager
+
+        primary = Mock()
+        primary.dialect = "sqlite"
+        primary.database_name = "local"
+        primary.catalog_name = ""
+        primary.schema_name = ""
+
+        secondary = Mock()
+        secondary.dialect = "flexdb"
+        secondary.database_name = "project_a"
+        secondary.catalog_name = ""
+        secondary.schema_name = ""
+        secondary.get_schema.return_value = [{"name": "id", "type": "BIGINT"}]
+        secondary.get_tables_with_ddl.return_value = [
+            {
+                "identifier": "project_a.orders",
+                "database_name": "project_a",
+                "schema_name": "",
+                "table_name": "orders",
+                "definition": "CREATE TABLE orders (id BIGINT)",
+            }
+        ]
+
+        db_manager = Mock(spec=DBManager)
+        db_manager.get_conn.side_effect = lambda datasource, database="": secondary if datasource == "db2" else primary
+        parse_identifier = Mock(
+            return_value={
+                "catalog_name": "",
+                "database_name": "project_a",
+                "schema_name": "",
+                "table_name": "orders",
+            }
+        )
+        monkeypatch.setattr("datus.tools.func_tool.database.parse_table_name_parts", parse_identifier)
+
+        tool = DBFuncTool(
+            db_manager,
+            agent_config=mock_agent_config,
+            default_datasource="db1",
+        )
+
+        assert tool.describe_table("project_a.orders", datasource="db2").success == 1
+        assert tool.get_table_ddl("project_a.orders", datasource="db2").success == 1
+        assert [item.args for item in parse_identifier.call_args_list] == [
+            ("project_a.orders", "flexdb"),
+            ("project_a.orders", "flexdb"),
+        ]
+
     def test_read_query_with_database_parameter(self, mock_agent_config):
         """Test that read_query accepts database parameter in multi-connector mode."""
         from datus.tools.db_tools.db_manager import DBManager

--- a/tests/unit_tests/utils/test_sql_utils.py
+++ b/tests/unit_tests/utils/test_sql_utils.py
@@ -28,7 +28,13 @@ from datus.utils.sql_utils import (
     strip_sql_comments,
 )
 
-_CONNECTOR_REGISTRY_SNAPSHOT_ATTRS = ("_capabilities", "_uri_builders", "_context_resolvers")
+_CONNECTOR_REGISTRY_SNAPSHOT_ATTRS = (
+    "_connectors",
+    "_metadata",
+    "_capabilities",
+    "_uri_builders",
+    "_context_resolvers",
+)
 
 
 def _snapshot_connector_registry():
@@ -1063,6 +1069,10 @@ class TestParseReadDialect:
     def test_whitespace_trimmed(self):
         assert parse_read_dialect("  postgres  ") == "postgres"
 
+    def test_adapter_registered_parser_dialect(self):
+        connector_registry.register("flexdb", object, parser_dialect="hive")
+        assert parse_read_dialect("flexdb") == "hive"
+
 
 # ---------------------------------------------------------------------------
 # parse_dialect
@@ -1073,6 +1083,10 @@ class TestParseDialect:
     def test_postgres(self):
         assert parse_dialect("postgres") == "postgres"
         assert parse_dialect("postgresql") == "postgres"
+
+    def test_adapter_registered_parser_dialect(self):
+        connector_registry.register("flexdb", object, parser_dialect="hive")
+        assert parse_dialect("flexdb") == "hive"
 
     def test_tsql(self):
         assert parse_dialect("mssql") == "tsql"
@@ -1454,6 +1468,32 @@ class TestParseTableNamePartsExtended:
         # More parts than expected - takes last N
         result = parse_table_name_parts("extra.catalog.db.schema.table", dialect="snowflake")
         assert result["table_name"] == "table"
+
+    def test_adapter_identifier_parser_handles_flexible_namespaces(self):
+        def parser(identifier):
+            parts = identifier.split(".")
+            return {
+                "catalog_name": "",
+                "database_name": parts[0] if len(parts) > 1 else "",
+                "schema_name": parts[1] if len(parts) == 3 else "",
+                "table_name": parts[-1],
+            }
+
+        connector_registry.register(
+            "flexdb",
+            object,
+            capabilities={"database", "schema"},
+            parser_dialect="hive",
+            identifier_parser=parser,
+        )
+
+        assert parse_table_name_parts("project_a.orders", "flexdb") == {
+            "catalog_name": "",
+            "database_name": "project_a",
+            "schema_name": "",
+            "table_name": "orders",
+        }
+        assert parse_table_name_parts("project_a.analytics.orders", "flexdb")["schema_name"] == "analytics"
 
     def test_unknown_dialect_fallback(self):
         # Unknown dialect falls through to default behavior

--- a/tests/unit_tests/utils/test_sql_utils.py
+++ b/tests/unit_tests/utils/test_sql_utils.py
@@ -620,6 +620,24 @@ def test_extract_table_names():
         assert set(extract_table_names(sql_two_part, dialect=dialect, ignore_empty=True)) == {"foo.bar"}
 
 
+def test_extract_table_names_adapter_hook_honors_ignore_empty(monkeypatch):
+    monkeypatch.setattr(
+        connector_registry,
+        "get_parser_dialect",
+        lambda dialect: "hive" if dialect == "flexdb" else None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        connector_registry,
+        "get_identifier_parser",
+        lambda dialect: (lambda identifier: identifier) if dialect == "flexdb" else None,
+        raising=False,
+    )
+
+    assert extract_table_names("SELECT * FROM orders", dialect="flexdb") == ["..orders"]
+    assert extract_table_names("SELECT * FROM orders", dialect="flexdb", ignore_empty=True) == ["orders"]
+
+
 def test_parse_full_tables():
     table_meta = parse_table_name_parts("test.abc", dialect=DBType.DUCKDB)
     assert table_meta["schema_name"] == "test"
@@ -1069,8 +1087,13 @@ class TestParseReadDialect:
     def test_whitespace_trimmed(self):
         assert parse_read_dialect("  postgres  ") == "postgres"
 
-    def test_adapter_registered_parser_dialect(self):
-        connector_registry.register("flexdb", object, parser_dialect="hive")
+    def test_adapter_registered_parser_dialect(self, monkeypatch):
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "hive" if dialect == "flexdb" else None,
+            raising=False,
+        )
         assert parse_read_dialect("flexdb") == "hive"
 
 
@@ -1084,8 +1107,13 @@ class TestParseDialect:
         assert parse_dialect("postgres") == "postgres"
         assert parse_dialect("postgresql") == "postgres"
 
-    def test_adapter_registered_parser_dialect(self):
-        connector_registry.register("flexdb", object, parser_dialect="hive")
+    def test_adapter_registered_parser_dialect(self, monkeypatch):
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "hive" if dialect == "flexdb" else None,
+            raising=False,
+        )
         assert parse_dialect("flexdb") == "hive"
 
     def test_tsql(self):
@@ -1469,7 +1497,7 @@ class TestParseTableNamePartsExtended:
         result = parse_table_name_parts("extra.catalog.db.schema.table", dialect="snowflake")
         assert result["table_name"] == "table"
 
-    def test_adapter_identifier_parser_handles_flexible_namespaces(self):
+    def test_adapter_identifier_parser_handles_flexible_namespaces(self, monkeypatch):
         def parser(identifier):
             parts = identifier.split(".")
             return {
@@ -1479,12 +1507,18 @@ class TestParseTableNamePartsExtended:
                 "table_name": parts[-1],
             }
 
-        connector_registry.register(
-            "flexdb",
-            object,
-            capabilities={"database", "schema"},
-            parser_dialect="hive",
-            identifier_parser=parser,
+        connector_registry.register_handlers("flexdb", capabilities={"database", "schema"})
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "hive" if dialect == "flexdb" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            connector_registry,
+            "get_identifier_parser",
+            lambda dialect: parser if dialect == "flexdb" else None,
+            raising=False,
         )
 
         assert parse_table_name_parts("project_a.orders", "flexdb") == {
@@ -1494,6 +1528,17 @@ class TestParseTableNamePartsExtended:
             "table_name": "orders",
         }
         assert parse_table_name_parts("project_a.analytics.orders", "flexdb")["schema_name"] == "analytics"
+
+    def test_adapter_identifier_parser_must_return_complete_contract(self, monkeypatch):
+        monkeypatch.setattr(
+            connector_registry,
+            "get_identifier_parser",
+            lambda dialect: (lambda identifier: {"table_name": identifier}) if dialect == "flexdb" else None,
+            raising=False,
+        )
+
+        with pytest.raises(ValueError, match="must return"):
+            parse_table_name_parts("orders", "flexdb")
 
     def test_unknown_dialect_fallback(self):
         # Unknown dialect falls through to default behavior

--- a/tests/unit_tests/validation/test_target_extractor.py
+++ b/tests/unit_tests/validation/test_target_extractor.py
@@ -140,7 +140,7 @@ class TestExtractDDLTarget:
             table="CUSTOMER",
         )
 
-    def test_adapter_identifier_parser_controls_two_and_three_part_names(self):
+    def test_adapter_identifier_parser_controls_two_and_three_part_names(self, monkeypatch):
         def parser(identifier):
             parts = identifier.split(".")
             return {
@@ -150,12 +150,18 @@ class TestExtractDDLTarget:
                 "table_name": parts[-1],
             }
 
-        connector_registry.register(
-            "flexdb",
-            object,
-            capabilities={"database", "schema"},
-            parser_dialect="hive",
-            identifier_parser=parser,
+        connector_registry.register_handlers("flexdb", capabilities={"database", "schema"})
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "hive" if dialect == "flexdb" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            connector_registry,
+            "get_identifier_parser",
+            lambda dialect: parser if dialect == "flexdb" else None,
+            raising=False,
         )
 
         two_level = extract_ddl_target(

--- a/tests/unit_tests/validation/test_target_extractor.py
+++ b/tests/unit_tests/validation/test_target_extractor.py
@@ -30,7 +30,7 @@ def _register_test_capabilities():
     so future ``register_handlers`` calls (or changes to the method itself)
     can't leak into unrelated tests via execution order.
     """
-    snapshot_attrs = ("_capabilities", "_uri_builders", "_context_resolvers")
+    snapshot_attrs = ("_connectors", "_metadata", "_capabilities", "_uri_builders", "_context_resolvers")
     snapshots = {
         attr: {k: (set(v) if isinstance(v, set) else v) for k, v in getattr(connector_registry, attr).items()}
         for attr in snapshot_attrs
@@ -138,6 +138,43 @@ class TestExtractDDLTarget:
             database="SNOWFLAKE_SAMPLE_DATA",
             db_schema="TPCH_SF1",
             table="CUSTOMER",
+        )
+
+    def test_adapter_identifier_parser_controls_two_and_three_part_names(self):
+        def parser(identifier):
+            parts = identifier.split(".")
+            return {
+                "catalog_name": "",
+                "database_name": parts[0] if len(parts) > 1 else "",
+                "schema_name": parts[1] if len(parts) == 3 else "",
+                "table_name": parts[-1],
+            }
+
+        connector_registry.register(
+            "flexdb",
+            object,
+            capabilities={"database", "schema"},
+            parser_dialect="hive",
+            identifier_parser=parser,
+        )
+
+        two_level = extract_ddl_target(
+            "CREATE TABLE project_a.orders (id BIGINT)",
+            "source",
+            dialect="flexdb",
+        )
+        three_level = extract_ddl_target(
+            "CREATE TABLE project_a.analytics.orders (id BIGINT)",
+            "source",
+            dialect="flexdb",
+        )
+
+        assert two_level == TableTarget(datasource="source", database="project_a", table="orders")
+        assert three_level == TableTarget(
+            datasource="source",
+            database="project_a",
+            db_schema="analytics",
+            table="orders",
         )
 
     def test_two_part_identifier_catalog_is_none(self):


### PR DESCRIPTION
## Why

Some database adapters have namespace capabilities that depend on the
configured service instance. A static dialect-level capability set cannot
represent both namespace models, and database-specific conditionals in the
Agent would make every new adapter harder to integrate.

## What changed

- resolve catalog/database/schema capabilities from the live connector when available, with the existing registry as a backward-compatible fallback
- let adapters provide a parser dialect, identifier parser, and SQL-generation guidance through optional registry hooks
- use the shared identifier parser across SQL metadata, target extraction, RAG scoping, generation hooks, and database tools
- use effective capabilities in metadata bootstrap, catalog navigation, metadata commands, API responses, and tool exposure
- preserve existing Snowflake prompt guidance through the generic adapter-notes path
- normalize connector column metadata through the `nullable`/`default_value` contract while retaining SQLite-style fallbacks
- remove duplicated right-aligned table-name parsing from Agent call sites

The Agent contains no MaxCompute- or ODPS-specific branches.

## Compatibility

All new registry methods are feature-detected. Datus-agent remains compatible
with `datus-db-core >=0.1.4`; an adapter that uses the new hooks can require a
newer core version itself.

## Validation

- `347 passed` — SQL parsing, target extraction, generation hooks, and capability tests
- `439 passed` — expanded storage, prompts, generation, and database-service regression suite
- full Ruff check passed
- `git diff --check` passed
- verified end-to-end with both two-level and three-level MaxCompute projects through the adapter implementation

## Related

- Datus-ai/datus-db-adapters#82

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
## Summary by CodeRabbit

* **Improvements**
  * Improved support for database-specific catalogs, databases, and schemas.
  * Enhanced handling of fully qualified table names across connectors.
  * Improved schema and column metadata detection, including nullability, defaults, and primary keys.
  * Added connector-specific SQL generation guidance, with improved Snowflake instructions.
  * Improved catalog navigation, schema switching, table filtering, and semantic synchronization across database types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved namespace support detection for catalogs, databases, and schemas based on actual adapter capabilities, enhancing browsing and schema/table switching behavior.
  * Enhanced handling of fully qualified table names across filtering, SQL generation, semantic sync, and metadata retrieval.
  * Improved schema and column metadata mapping (including nullability, defaults, and primary keys) and more consistent schema normalization when namespaces aren’t supported.
  * Improved SQL prompt guidance by sourcing adapter-provided database notes, with updated Snowflake-specific fallback messaging.
* **Tests**
  * Expanded unit coverage for namespace capability resolution, qualified-name parsing, SQL prompt notes, and schema/column mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->