### PR TITLE
[BugFix] Fold plugin state into the DatusService config fingerprint

### DIFF
--- a/datus/api/services/datus_service.py
+++ b/datus/api/services/datus_service.py
@@ -7,11 +7,35 @@ and a project-scoped ChatTaskManager into a single cached instance.
 import dataclasses
 import hashlib
 import json
+from typing import Any
 
 from datus.configuration.agent_config import AgentConfig
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+# Constant marker folded into the fingerprint when the plugin snapshot itself
+# fails. Constant (not an error string) so a failing snapshot keeps producing
+# one stable fingerprint instead of evicting the cached service every request.
+_PLUGIN_STATE_UNAVAILABLE = "unavailable"
+
+
+def _plugin_state(agent_config: AgentConfig) -> Any:
+    """Return the plugin-state snapshot to fold into the config fingerprint.
+
+    Kept outside the ``dataclasses.asdict`` failure path: a config object that
+    predates the accessor contributes ``None`` rather than degrading the whole
+    fingerprint to the ``id:`` fallback (which would defeat content-based
+    caching for hosts that build a fresh AgentConfig per request).
+    """
+    getter = getattr(agent_config, "plugin_state_signature", None)
+    if not callable(getter):
+        return None
+    try:
+        return getter()
+    except Exception as e:
+        logger.warning(f"Failed to snapshot plugin state for AgentConfig fingerprint: {e}")
+        return _PLUGIN_STATE_UNAVAILABLE
 
 
 class DatusService:
@@ -72,10 +96,20 @@ class DatusService:
     def compute_fingerprint(agent_config: AgentConfig) -> str:
         """Compute a stable content-based fingerprint for an AgentConfig.
 
+        Hashes the declared dataclass fields plus
+        ``AgentConfig.plugin_state_signature()`` — the plugin master switch,
+        activation whitelist, ``agent.plugins`` profiles and ``plugin_paths``.
+        None of that is reachable through ``dataclasses.asdict``, so without it
+        a plugin being toggled, re-profiled, re-pinned or remounted would keep
+        serving the cached ``DatusService`` built from the previous state.
+
         Falls back to an id-based string if the config cannot be serialized.
         """
         try:
-            payload = dataclasses.asdict(agent_config)
+            payload = {
+                "config": dataclasses.asdict(agent_config),
+                "plugins": _plugin_state(agent_config),
+            }
             serialized = json.dumps(payload, sort_keys=True, default=str)
             return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
         except Exception as e:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -1681,6 +1681,47 @@ class AgentConfig:
             return []
         return activation.active_profile
 
+    def plugin_state_signature(self) -> Dict[str, Any]:
+        """JSON-serializable snapshot of this config's plugin state.
+
+        ``DatusService.compute_fingerprint`` hashes ``dataclasses.asdict``, which
+        only sees declared fields — every plugin input lives in instance
+        attributes instead (master switch, activation whitelist,
+        ``agent.plugins`` profiles, ``plugin_paths``). Folding this snapshot into
+        the fingerprint is what makes a cached per-project ``DatusService``
+        rebuild on the next request after a plugin is enabled/disabled,
+        re-profiled, re-pinned, or remounted.
+
+        Config-only by design: the installed version in ``~/.datus/plugins`` is
+        deliberately NOT read here. Detecting an out-of-process version swap
+        would cost a filesystem scan on every request and buy nothing — the
+        rebuild reuses the same AgentConfig object, and manifests/entry points
+        stay pinned by ``registry._PLUGIN_CACHE`` and by whatever the process
+        already imported. In-process installs already handle themselves
+        (``plugin_service._refresh`` invalidates those caches); an out-of-process
+        version swap has to reach the host as a new AgentConfig — e.g. a
+        ``plugin_paths`` entry pointing at the new versioned directory, which
+        this snapshot does catch.
+
+        Built by hand rather than promoting the attributes to dataclass fields so
+        ``PluginActivation`` values are flattened and the payload stays stable
+        under ``json.dumps(..., default=str)``.
+        """
+        activation = {
+            name: {
+                "enabled": act.enabled,
+                "active_profile": list(act.active_profile) if act.active_profile is not None else None,
+            }
+            for name, act in getattr(self, "_active_plugins", {}).items()
+        }
+        return {
+            "enabled": bool(getattr(self, "plugins_enabled", True)),
+            "section_present": bool(getattr(self, "_plugins_section_present", False)),
+            "paths": list(getattr(self, "plugin_paths", None) or []),
+            "activation": activation,
+            "profiles": getattr(self, "plugin_services", None) or {},
+        }
+
     def get_plugin_profile(self, plugin: str, profile: Optional[str] = None) -> Dict[str, Any]:
         """Resolve the active profile config dict for ``plugin``.
 

--- a/tests/unit_tests/api/services/test_datus_service.py
+++ b/tests/unit_tests/api/services/test_datus_service.py
@@ -153,3 +153,63 @@ class TestDatusServiceBehavior:
         svc._task_manager.shutdown = AsyncMock(side_effect=RuntimeError("boom"))
         await svc.shutdown()
         svc._task_manager.shutdown.assert_awaited_once()
+
+
+class TestFingerprintPluginState:
+    """Plugin changes must move the fingerprint so the cached service rebuilds.
+
+    None of this state is a declared ``AgentConfig`` dataclass field, so before
+    the plugin snapshot was folded in, ``DatusServiceCache`` kept serving a
+    ``DatusService`` built from the previous plugin set.
+    """
+
+    def test_plugin_profile_config_change(self, real_agent_config):
+        real_agent_config.init_plugin_services({"hello": {"prod": {"api_base_url": "https://one"}}})
+        before = DatusService.compute_fingerprint(real_agent_config)
+
+        real_agent_config.init_plugin_services({"hello": {"prod": {"api_base_url": "https://two"}}})
+
+        assert DatusService.compute_fingerprint(real_agent_config) != before
+
+    def test_plugin_disabled_for_project(self, real_agent_config):
+        before = DatusService.compute_fingerprint(real_agent_config)
+
+        real_agent_config.set_plugin_activation("hello", enabled=False, persist=False)
+
+        assert DatusService.compute_fingerprint(real_agent_config) != before
+
+    def test_plugins_master_switch_toggle(self, real_agent_config):
+        before = DatusService.compute_fingerprint(real_agent_config)
+
+        real_agent_config.plugins_enabled = False
+
+        assert DatusService.compute_fingerprint(real_agent_config) != before
+
+    def test_active_profile_pin_change(self, real_agent_config):
+        real_agent_config.set_plugin_activation("hello", enabled=True, active_profiles=["staging"], persist=False)
+        before = DatusService.compute_fingerprint(real_agent_config)
+
+        real_agent_config.set_plugin_activation("hello", active_profiles=["prod"], persist=False)
+
+        assert DatusService.compute_fingerprint(real_agent_config) != before
+
+    def test_plugin_paths_change(self, real_agent_config, tmp_path):
+        before = DatusService.compute_fingerprint(real_agent_config)
+
+        real_agent_config.plugin_paths = [str(tmp_path / "mounted-plugin")]
+
+        assert DatusService.compute_fingerprint(real_agent_config) != before
+
+    def test_plugin_snapshot_failure_stays_stable(self, real_agent_config, monkeypatch):
+        """A snapshot that raises degrades to one constant marker, not churn."""
+
+        def boom(self):
+            raise RuntimeError("snapshot exploded")
+
+        monkeypatch.setattr("datus.configuration.agent_config.AgentConfig.plugin_state_signature", boom, raising=True)
+
+        first = DatusService.compute_fingerprint(real_agent_config)
+        second = DatusService.compute_fingerprint(real_agent_config)
+
+        assert first == second
+        assert not first.startswith("id:")

--- a/tests/unit_tests/api/services/test_datus_service_cache.py
+++ b/tests/unit_tests/api/services/test_datus_service_cache.py
@@ -392,3 +392,50 @@ class TestShutdown:
         await cache.shutdown()  # should not raise
         assert len(cache._cache) == 0
         svc_ok.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestPluginChangeRebuild:
+    """Cross-component: real config + real service + real cache.
+
+    Replays what ``get_datus_service`` does per request — recompute the
+    fingerprint from the live AgentConfig, hand it to the cache — to pin that a
+    plugin change actually swaps the cached instance instead of only moving a
+    hash in isolation.
+    """
+
+    @staticmethod
+    async def _request(cache, agent_config):
+        from datus.api.services.datus_service import DatusService
+
+        async def factory():
+            return DatusService(agent_config=agent_config, project_id="p")
+
+        return await cache.get_or_create(
+            "p", factory, expected_fingerprint=DatusService.compute_fingerprint(agent_config)
+        )
+
+    async def test_plugin_profile_change_rebuilds_on_next_request(self, real_agent_config):
+        cache = DatusServiceCache()
+        try:
+            real_agent_config.init_plugin_services({"hello": {"prod": {"api_base_url": "https://one"}}})
+            first = await self._request(cache, real_agent_config)
+            # Unchanged plugin state must reuse the cached instance.
+            assert await self._request(cache, real_agent_config) is first
+
+            real_agent_config.init_plugin_services({"hello": {"prod": {"api_base_url": "https://two"}}})
+
+            assert await self._request(cache, real_agent_config) is not first
+        finally:
+            await cache.shutdown()
+
+    async def test_plugin_disable_rebuilds_on_next_request(self, real_agent_config):
+        cache = DatusServiceCache()
+        try:
+            first = await self._request(cache, real_agent_config)
+
+            real_agent_config.plugins_enabled = False
+
+            assert await self._request(cache, real_agent_config) is not first
+        finally:
+            await cache.shutdown()

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2983,6 +2983,87 @@ class TestPluginPathsConfig:
         assert calls == [({"tenant-plugin"}, True, ["/srv/tenant/plugin"])]
 
 
+class TestPluginStateSignature:
+    """``plugin_state_signature`` — the plugin half of the SaaS config fingerprint.
+
+    ``DatusService.compute_fingerprint`` hashes ``dataclasses.asdict`` plus this
+    snapshot; every plugin input lives in instance attributes that ``asdict``
+    cannot see, so these tests pin that each one reaches the payload.
+    """
+
+    def _make(self, tmp_path, **extra):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            project_root=str(tmp_path),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            skip_init_dirs=True,
+            **extra,
+        )
+
+    def test_reports_config_side_plugin_state(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            plugin_paths=["/srv/tenant/plugin"],
+            plugins={"hello": {"prod": {"api_base_url": "https://prod"}}},
+            active_plugins={"hello": {"enabled": True, "active_profile": ["prod"]}},
+        )
+
+        signature = cfg.plugin_state_signature()
+
+        assert signature["enabled"] is True
+        assert signature["section_present"] is True
+        assert signature["paths"] == ["/srv/tenant/plugin"]
+        assert signature["activation"] == {"hello": {"enabled": True, "active_profile": ["prod"]}}
+        assert signature["profiles"]["hello"]["prod"]["api_base_url"] == "https://prod"
+
+    def test_absent_section_reports_no_whitelist(self, tmp_path):
+        signature = self._make(tmp_path).plugin_state_signature()
+        assert signature["section_present"] is False
+        assert signature["activation"] == {}
+        assert signature["paths"] == []
+
+    def test_unpinned_plugin_keeps_active_profile_none(self, tmp_path):
+        """``None`` (all profiles) must stay distinct from ``[]`` (none pinned)."""
+        cfg = self._make(tmp_path, active_plugins={"hello": {"enabled": True}})
+        assert cfg.plugin_state_signature()["activation"] == {"hello": {"enabled": True, "active_profile": None}}
+
+    def test_master_switch_reported(self, tmp_path):
+        cfg = self._make(tmp_path, plugins_enabled=False)
+        assert cfg.plugin_state_signature()["enabled"] is False
+
+    def test_is_json_serializable(self, tmp_path):
+        """The host hashes it through ``json.dumps`` — no dataclass leaks."""
+        import json
+
+        cfg = self._make(
+            tmp_path,
+            plugin_paths=["/srv/tenant/plugin"],
+            plugins={"hello": {"prod": {"api_base_url": "https://prod"}}},
+            active_plugins={"hello": {"enabled": True, "active_profile": ["prod"]}},
+        )
+
+        assert json.loads(json.dumps(cfg.plugin_state_signature())) == cfg.plugin_state_signature()
+
+    def test_reads_no_filesystem_state(self, tmp_path):
+        """Runs on every API request — it must stay a pure in-memory read.
+
+        A managed-store scan here would cost I/O per request and buy nothing: the
+        rebuild it triggers reuses the same AgentConfig and the process keeps its
+        already-loaded manifests.
+        """
+        from datus.plugins import store
+
+        cfg = self._make(tmp_path, active_plugins={"hello": {"enabled": True}})
+        store.write_meta(cfg.path_manager.plugins_dir / "hello", {"name": "hello", "version": "1.0"})
+        before = cfg.plugin_state_signature()
+
+        store.write_meta(cfg.path_manager.plugins_dir / "hello", {"name": "hello", "version": "2.0"})
+
+        assert cfg.plugin_state_signature() == before
+
+
 class TestPromptManagerAttribute:
     """``AgentConfig.prompt_manager`` — the runtime prompt-template override.
 


### PR DESCRIPTION
## Why

`DatusService.compute_fingerprint()` hashes `dataclasses.asdict(agent_config)`, which only sees **declared dataclass fields**. Every plugin input lives in instance attributes instead (`plugins_enabled`, `_active_plugins`, `_plugins_section_present`, `plugin_services`, `plugin_paths`), so none of these changes moved the fingerprint:

- a plugin being enabled/disabled for a project (or the `agent.plugins_enabled` master switch)
- an `agent.plugins.<plugin>.<profile>` config edit
- an `active_profile` re-pin
- an `agent.plugin_paths` mount change

`DatusServiceCache` evicts on fingerprint mismatch, so in a multi-tenant API deployment the cached per-project `DatusService` kept serving sub-services built from the previous plugin state until the process restarted or something else in the config happened to change.

## Solution

Add `AgentConfig.plugin_state_signature()` — a JSON-serializable snapshot of the plugin state — and hash it alongside the asdict payload:

```python
payload = {"config": dataclasses.asdict(agent_config), "plugins": _plugin_state(agent_config)}
```

Key decisions:

- **Config-only, no filesystem read.** An earlier draft also scanned the managed store (`~/.datus/plugins/*/datus-plugin.json`) so an out-of-process version swap would move the fingerprint. Dropped: it costs a scan on every request and buys nothing, because the rebuild reuses the same `AgentConfig` object and manifests/entry points stay pinned by the process-level `registry._PLUGIN_CACHE` and by whatever the process already imported. In-process installs already handle themselves (`plugin_service._refresh()` invalidates those caches); an out-of-process swap has to reach the host as a new `AgentConfig` — e.g. a `plugin_paths` entry pointing at the new versioned directory, which this snapshot does catch. The rationale is recorded in the method docstring and pinned by a test.
- **Built by hand rather than promoting the attributes to dataclass fields**, so `PluginActivation` values are flattened and the payload stays stable under `json.dumps(..., default=str)`. `active_profile` keeps `None` (all profiles) distinct from `[]` (none pinned).
- **`_plugin_state()` sits outside the asdict failure path.** A config object predating the accessor contributes `None` instead of degrading the whole fingerprint to the `id:` fallback; a snapshot that raises contributes a *constant* marker, so a failure produces one stable fingerprint rather than evicting the cached service on every request.

## Test Cases

All unit-tier (deterministic, no external calls); no integration/nightly test was needed since the behaviour is pure in-memory config hashing.

- `tests/unit_tests/configuration/test_agent_config.py::TestPluginStateSignature` — each field reaches the payload; `None` vs `[]` for `active_profile`; master switch; JSON-serializability; and `test_reads_no_filesystem_state`, which rewrites a plugin's on-disk `datus-plugin.json` version and asserts the signature is **unchanged**, pinning the per-request purity contract against a future regression back into disk I/O.
- `tests/unit_tests/api/services/test_datus_service.py::TestFingerprintPluginState` — one case per change that must move the fingerprint (profile config, project-level disable, master switch, `active_profile` re-pin, `plugin_paths`), plus a case asserting a raising snapshot yields a stable, non-`id:` fingerprint.
- `tests/unit_tests/api/services/test_datus_service_cache.py::TestPluginChangeRebuild` — cross-component: real `AgentConfig` + real `DatusService` + real `DatusServiceCache`, replaying what `get_datus_service` does per request (recompute the fingerprint, hand it to the cache). Pins that unchanged plugin state reuses the cached instance and that a plugin change swaps it on the next request — i.e. the fingerprint change actually rebuilds, not just moves a hash in isolation.

Local gates: `ruff format --check` / `ruff check` clean; `ci/audit_tests.py --diff-only` reports P0=0, P1=0; `ci/run-pr-tests.py` diff coverage **93%**. The harness reports pre-existing failures (`tests/integration/storage/test_platform_doc*`, `test_doc_search`, `test_func_tools_db`, `test_cli_commands`, and `tests/unit_tests/api/services/test_explorer_service.py`) that reproduce identically on `main` with these changes reverted — no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cached services now refresh when plugin settings change, including activation, profiles, paths, or configuration.
  * Plugin state is included in service fingerprinting for more reliable cache behavior.
  * Fingerprints remain stable if plugin state inspection fails.

* **Tests**
  * Added coverage for plugin configuration changes, cache rebuilding, fingerprint stability, and JSON-serializable plugin state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->