### PR TITLE
[Feature] Add Amazon Bedrock Converse provider

### DIFF
--- a/ci/provider-coverage.yml
+++ b/ci/provider-coverage.yml
@@ -15,6 +15,17 @@ providers:
       nodeids:
         - tests/integration/models/test_other_models.py::TestOpenAIModel
 
+  bedrock:
+    required_env: []
+    deterministic:
+      nodeids:
+        - tests/unit_tests/models/test_bedrock_model.py::TestBedrockModel
+        - tests/unit_tests/models/test_litellm_adapter.py::TestBedrockModelName
+        - tests/unit_tests/configuration/test_agent_config.py::TestProviderConfigurationDispatch
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
   deepseek:
     required_env:
       - DEEPSEEK_API_KEY

--- a/conf/providers.yml
+++ b/conf/providers.yml
@@ -105,6 +105,17 @@ providers:
       - google/gemini-2.5-pro
       - deepseek/deepseek-chat
 
+  # Amazon Bedrock Runtime — authenticated by the standard AWS credential
+  # chain and routed through the model-agnostic Converse API.
+  bedrock:
+    type: bedrock
+    auth_type: aws
+    default_model: us.anthropic.claude-sonnet-5
+    models:
+      - us.anthropic.claude-sonnet-5
+      - us.amazon.nova-2-lite-v1:0
+      - openai.gpt-oss-20b-1:0
+
   # Coding Plan providers (vendor Anthropic-compatible endpoints)
   alibaba_coding:
     type: claude

--- a/datus/cli/interactive_init.py
+++ b/datus/cli/interactive_init.py
@@ -227,7 +227,56 @@ class InteractiveInit:
             return self._finalize_provider(
                 provider, provider_info, configure_claude_subscription(self.console, provider, provider_info)
             )
+        if auth_type == "aws":
+            return self._configure_aws_provider(provider, provider_info)
         return self._configure_api_key_provider(provider, provider_info)
+
+    def _configure_aws_provider(self, provider: str, provider_info: dict) -> bool:
+        """Select and probe a Bedrock model using the AWS credential chain."""
+        from datus.configuration.agent_config import _aws_provider_available
+
+        provider_options = provider_info.get("provider_options") or {}
+        if not isinstance(provider_options, dict):
+            provider_options = {}
+        if not _aws_provider_available(provider_options):
+            self.console.print(
+                "❌ AWS credentials or region not found. Run `aws configure` or `aws sso login`, "
+                "set a region, and retry."
+            )
+            return False
+
+        models = provider_info.get("models", [])
+        if models:
+            self.console.print("- Select your model:")
+            model_name = select_choice(
+                self.console,
+                {str(model): str(model) for model in models},
+                default=provider_info.get("default_model", str(models[0])),
+                allow_free_text=True,
+            )
+        else:
+            model_name = Prompt.ask("- Enter your Bedrock model or inference profile ID").strip()
+
+        self._pending_probe = {
+            "type": provider_info.get("type", provider),
+            "api_key": "",
+            "model": model_name,
+            "auth_type": "aws",
+            "provider_options": provider_options,
+        }
+        self.console.print("→ Testing Bedrock connectivity...")
+        ok, err = self._test_llm_connectivity()
+        if not ok:
+            self.console.print(f"❌ Bedrock connectivity test failed: {err}\n")
+            return False
+
+        self.console.print(" ✅ Bedrock model test successful\n")
+        provider_config = {"auth_type": "aws"}
+        if provider_options:
+            provider_config["provider_options"] = provider_options
+        self.config["agent"]["providers"][provider] = provider_config
+        self._pending_target = ProjectTarget(provider=provider, model=model_name)
+        return True
 
     def _configure_api_key_provider(self, provider: str, provider_info: dict) -> bool:
         """Prompt for API key + base URL, test connectivity, stage credentials."""
@@ -530,6 +579,7 @@ class InteractiveInit:
                 top_p=probe.get("top_p"),
                 auth_type=probe.get("auth_type", "api_key"),
                 default_headers=probe.get("default_headers"),
+                provider_options=probe.get("provider_options") or {},
             )
 
             from datus.models.base import LLMBaseModel

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -506,7 +506,12 @@ class Application:
         """
         import os
 
-        from datus.configuration.agent_config import _aws_provider_available, _load_provider_catalog, resolve_env
+        from datus.configuration.agent_config import (
+            _aws_provider_available,
+            _load_provider_catalog,
+            _resolve_provider_options,
+            resolve_env,
+        )
 
         providers_raw = raw.get("providers") or {}
         user_entry = providers_raw.get(provider) if isinstance(providers_raw, dict) else None
@@ -542,8 +547,11 @@ class Application:
             except Exception:
                 return False
         if auth_type == "aws":
-            provider_options = user_entry.get("provider_options") or {}
-            return _aws_provider_available(provider_options if isinstance(provider_options, dict) else {})
+            provider_options = _resolve_provider_options(
+                user_entry.get("provider_options"),
+                field_name=f"agent.providers.{provider}.provider_options",
+            )
+            return _aws_provider_available(provider_options)
 
         api_key = user_entry.get("api_key")
         if api_key and resolve_env(str(api_key)).strip() and not resolve_env(str(api_key)).startswith("<MISSING:"):

--- a/datus/cli/main.py
+++ b/datus/cli/main.py
@@ -506,7 +506,7 @@ class Application:
         """
         import os
 
-        from datus.configuration.agent_config import _load_provider_catalog, resolve_env
+        from datus.configuration.agent_config import _aws_provider_available, _load_provider_catalog, resolve_env
 
         providers_raw = raw.get("providers") or {}
         user_entry = providers_raw.get(provider) if isinstance(providers_raw, dict) else None
@@ -541,6 +541,9 @@ class Application:
                 return OAuthManager().is_authenticated()
             except Exception:
                 return False
+        if auth_type == "aws":
+            provider_options = user_entry.get("provider_options") or {}
+            return _aws_provider_available(provider_options if isinstance(provider_options, dict) else {})
 
         api_key = user_entry.get("api_key")
         if api_key and resolve_env(str(api_key)).strip() and not resolve_env(str(api_key)).startswith("<MISSING:"):

--- a/datus/cli/model_app.py
+++ b/datus/cli/model_app.py
@@ -71,6 +71,7 @@ _MAX_LIST_ROWS = 15
 # no config migration is required.
 _DISPLAY_NAME_OVERRIDES: Dict[str, str] = {
     "claude_subscription": "claude code",
+    "bedrock": "AWS Bedrock",
 }
 
 
@@ -402,6 +403,8 @@ class ModelApp:
             return None
         if auth_type == "oauth":
             return ModelSelection(kind="needs_oauth", provider=provider)
+        if auth_type == "aws":
+            self._error_message = self._aws_setup_message()
         return None
 
     # ─────────────────────────────────────────────────────────────────
@@ -674,6 +677,8 @@ class ModelApp:
                     tags.append("coding plan")
                 if auth_type in ("subscription", "oauth"):
                     tags.append(auth_type)
+                if auth_type == "aws":
+                    tags.append("AWS credentials")
                 if tags:
                     suffix = f"  ({', '.join(tags)})"
             # \u2713 = ✓ for configured; "[needs setup]" stays as a word tag
@@ -912,6 +917,8 @@ class ModelApp:
             # caller by exiting with a ``needs_oauth`` result.
             self._result = ModelSelection(kind="needs_oauth", provider=provider)
             self._finish(self._result)
+        elif auth_type == "aws":
+            self._error_message = self._aws_setup_message()
         else:
             self._error_message = f"Unknown auth_type `{auth_type}` for provider `{provider}`"
 
@@ -938,6 +945,8 @@ class ModelApp:
         elif auth_type == "oauth":
             self._result = ModelSelection(kind="needs_oauth", provider=provider)
             self._finish(self._result)
+        elif auth_type == "aws":
+            self._error_message = self._aws_setup_message()
         else:
             self._error_message = f"Unknown auth_type `{auth_type}` for provider `{provider}`"
 
@@ -1094,6 +1103,13 @@ class ModelApp:
             return token or None
         except Exception:
             return None
+
+    @staticmethod
+    def _aws_setup_message() -> str:
+        return (
+            "AWS credentials or region not found. Configure the standard AWS credential chain "
+            "(for example `aws configure` or `aws sso login`) and set a region, then reopen /model."
+        )
 
     # ─────────────────────────────────────────────────────────────────
     # Key bindings

--- a/datus/cli/provider_model_catalog.py
+++ b/datus/cli/provider_model_catalog.py
@@ -78,6 +78,7 @@ PROTECTED_PROVIDERS = frozenset(
         "zai_coding",
         "minimax_coding",
         "kimi_coding",
+        "bedrock",
         "claude_subscription",
         "codex",
     }

--- a/datus/conf/providers.yml
+++ b/datus/conf/providers.yml
@@ -105,6 +105,17 @@ providers:
       - google/gemini-2.5-pro
       - deepseek/deepseek-chat
 
+  # Amazon Bedrock Runtime — authenticated by the standard AWS credential
+  # chain and routed through the model-agnostic Converse API.
+  bedrock:
+    type: bedrock
+    auth_type: aws
+    default_model: us.anthropic.claude-sonnet-5
+    models:
+      - us.anthropic.claude-sonnet-5
+      - us.amazon.nova-2-lite-v1:0
+      - openai.gpt-oss-20b-1:0
+
   # Coding Plan providers (vendor Anthropic-compatible endpoints)
   alibaba_coding:
     type: claude

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -418,8 +418,12 @@ class ModelConfig:
     # Model-specific parameters
     temperature: Optional[float] = None  # Some models like kimi-k2.5 require temperature=1
     top_p: Optional[float] = None  # Some models like kimi-k2.5 require top_p=0.95
-    auth_type: str = "api_key"  # "api_key" | "oauth" | "subscription"
+    auth_type: str = "api_key"  # "api_key" | "oauth" | "subscription" | "aws"
     use_native_api: bool = False  # Use native Anthropic client instead of LiteLLM
+    # Provider-specific, non-secret request options. Bedrock accepts AWS region,
+    # profile/role and custom runtime endpoint settings here; access keys remain
+    # in the standard AWS credential chain and must not be stored in agent.yml.
+    provider_options: Dict[str, Any] = field(default_factory=dict)
     # SSL/TLS verification for this model's endpoint. Mirrors httpx/litellm `verify`:
     #   True  -> verify against system/certifi CAs (default)
     #   False -> disable verification (discouraged; MITM-exposed)
@@ -445,6 +449,7 @@ class ProviderConfig:
     api_key: Optional[str] = None
     base_url: Optional[str] = None
     auth_type: str = "api_key"
+    provider_options: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -2505,6 +2510,7 @@ class AgentConfig:
             model=model_name,
             base_url=str(base_url) if base_url else None,
             auth_type=auth_type,
+            provider_options=dict(user_cfg.provider_options),
             **model_kwargs,
         )
 
@@ -2620,6 +2626,7 @@ class AgentConfig:
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         auth_type: str = "api_key",
+        provider_options: Optional[Dict[str, Any]] = None,
         persist: bool = True,
     ) -> None:
         """Record provider-level credentials in memory and (optionally) on disk.
@@ -2636,6 +2643,8 @@ class AgentConfig:
             entry.base_url = base_url or None
         if auth_type:
             entry.auth_type = auth_type
+        if provider_options is not None:
+            entry.provider_options = dict(provider_options)
         self.providers[provider] = entry
         if persist:
             _persist_provider_section(provider, entry)
@@ -2682,7 +2691,8 @@ class AgentConfig:
         ``api_key`` providers: either the user set an explicit key in
         ``agent.providers`` *or* the shipped env var fallback resolves to a
         non-empty value. ``subscription`` / ``oauth`` providers defer to
-        ``datus.auth`` helpers that inspect on-disk tokens.
+        ``datus.auth`` helpers that inspect on-disk tokens. ``aws`` providers
+        use the boto3 credential chain plus a resolved region.
         """
         catalog = self.provider_catalog
         providers_meta = catalog.get("providers", {}) if isinstance(catalog, dict) else {}
@@ -2707,6 +2717,9 @@ class AgentConfig:
                 return OAuthManager().is_authenticated()
             except Exception:
                 return False
+        if auth_type == "aws":
+            user_cfg = self.providers.get(provider, ProviderConfig())
+            return _aws_provider_available(user_cfg.provider_options)
 
         user_cfg = self.providers.get(provider, ProviderConfig())
         if user_cfg.api_key:
@@ -3043,12 +3056,46 @@ def _load_provider_configs(raw: Dict[str, Any]) -> Dict[str, ProviderConfig]:
             )
         api_key_raw = cfg.get("api_key")
         base_url_raw = cfg.get("base_url")
+        provider_options_raw = cfg.get("provider_options") or {}
+        if not isinstance(provider_options_raw, dict):
+            raise DatusException(
+                ErrorCode.COMMON_FIELD_INVALID,
+                message=f"agent.providers.{name}.provider_options must be a mapping.",
+            )
         out[name] = ProviderConfig(
             api_key=str(api_key_raw) if api_key_raw is not None else None,
             base_url=str(base_url_raw) if base_url_raw is not None else None,
             auth_type=str(cfg.get("auth_type", "api_key")),
+            provider_options=_resolve_nested_value(provider_options_raw),
         )
     return out
+
+
+def _aws_provider_available(provider_options: Optional[Mapping[str, Any]] = None) -> bool:
+    """Return whether the standard AWS credential chain and a region resolve.
+
+    This intentionally performs no Bedrock request. It is used by config repair
+    and the ``/model`` picker, where a network call would add latency and cost.
+    The selected model is still probed by the init wizard before it is saved.
+    """
+    options = dict(provider_options or {})
+    try:
+        import boto3
+
+        profile = options.get("aws_profile_name") or os.getenv("AWS_PROFILE")
+        session = boto3.Session(profile_name=str(profile) if profile else None)
+        credentials = session.get_credentials()
+        region = (
+            options.get("aws_region_name")
+            or os.getenv("AWS_REGION_NAME")
+            or os.getenv("AWS_REGION")
+            or os.getenv("AWS_DEFAULT_REGION")
+            or session.region_name
+        )
+        return credentials is not None and bool(region)
+    except Exception as exc:
+        logger.debug("AWS credential-chain discovery failed: %s", exc)
+        return False
 
 
 def _load_provider_catalog() -> Dict[str, Any]:
@@ -3092,6 +3139,8 @@ def _persist_provider_section(provider: str, entry: "ProviderConfig") -> None:
             payload["base_url"] = entry.base_url
         if entry.auth_type and entry.auth_type != "api_key":
             payload["auth_type"] = entry.auth_type
+        if entry.provider_options:
+            payload["provider_options"] = dict(entry.provider_options)
         current[provider] = payload
         cfg_mgr.update_item("providers", current, delete_old_key=False, save=True)
     except Exception as e:  # pragma: no cover - defensive
@@ -3150,6 +3199,7 @@ def load_model_config(data: dict) -> ModelConfig:
         top_p=float(top_p) if top_p is not None else None,
         auth_type=data.get("auth_type", "api_key"),
         use_native_api=data.get("use_native_api", False),
+        provider_options=_resolve_nested_value(data.get("provider_options") or {}),
         ssl_verify=_load_ssl_verify(data),
     )
 

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -3041,6 +3041,55 @@ def _resolve_nested_value(value: Any) -> Any:
     return value
 
 
+_MISSING_PROVIDER_OPTION = object()
+
+
+def _drop_missing_provider_options(value: Any) -> Any:
+    """Remove unresolved ``${ENV_VAR}`` values from provider options.
+
+    Optional AWS options commonly point at environment variables. When one is
+    unset, treating ``<MISSING:...>`` as a literal profile or region prevents
+    boto3 from falling back to its standard credential chain.
+    """
+    if isinstance(value, str) and value.startswith("<MISSING:"):
+        return _MISSING_PROVIDER_OPTION
+    if isinstance(value, dict):
+        resolved = {}
+        for key, item in value.items():
+            cleaned = _drop_missing_provider_options(item)
+            if cleaned is not _MISSING_PROVIDER_OPTION:
+                resolved[key] = cleaned
+        return resolved
+    if isinstance(value, list):
+        resolved = []
+        for item in value:
+            cleaned = _drop_missing_provider_options(item)
+            if cleaned is not _MISSING_PROVIDER_OPTION:
+                resolved.append(cleaned)
+        return resolved
+    if isinstance(value, tuple):
+        resolved = []
+        for item in value:
+            cleaned = _drop_missing_provider_options(item)
+            if cleaned is not _MISSING_PROVIDER_OPTION:
+                resolved.append(cleaned)
+        return tuple(resolved)
+    return value
+
+
+def _resolve_provider_options(raw: Any, *, field_name: str = "provider_options") -> Dict[str, Any]:
+    """Validate, resolve, and normalize a provider-options mapping."""
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise DatusException(
+            ErrorCode.COMMON_FIELD_INVALID,
+            message=f"{field_name} must be a mapping.",
+        )
+    resolved = _resolve_nested_value(dict(raw))
+    return _drop_missing_provider_options(resolved)
+
+
 def _load_provider_configs(raw: Dict[str, Any]) -> Dict[str, ProviderConfig]:
     """Parse ``agent.providers`` YAML section into :class:`ProviderConfig` map."""
     out: Dict[str, ProviderConfig] = {}
@@ -3056,17 +3105,14 @@ def _load_provider_configs(raw: Dict[str, Any]) -> Dict[str, ProviderConfig]:
             )
         api_key_raw = cfg.get("api_key")
         base_url_raw = cfg.get("base_url")
-        provider_options_raw = cfg.get("provider_options") or {}
-        if not isinstance(provider_options_raw, dict):
-            raise DatusException(
-                ErrorCode.COMMON_FIELD_INVALID,
-                message=f"agent.providers.{name}.provider_options must be a mapping.",
-            )
         out[name] = ProviderConfig(
             api_key=str(api_key_raw) if api_key_raw is not None else None,
             base_url=str(base_url_raw) if base_url_raw is not None else None,
             auth_type=str(cfg.get("auth_type", "api_key")),
-            provider_options=_resolve_nested_value(provider_options_raw),
+            provider_options=_resolve_provider_options(
+                cfg.get("provider_options"),
+                field_name=f"agent.providers.{name}.provider_options",
+            ),
         )
     return out
 
@@ -3199,7 +3245,7 @@ def load_model_config(data: dict) -> ModelConfig:
         top_p=float(top_p) if top_p is not None else None,
         auth_type=data.get("auth_type", "api_key"),
         use_native_api=data.get("use_native_api", False),
-        provider_options=_resolve_nested_value(data.get("provider_options") or {}),
+        provider_options=_resolve_provider_options(data.get("provider_options")),
         ssl_verify=_load_ssl_verify(data),
     )
 

--- a/datus/models/README.md
+++ b/datus/models/README.md
@@ -52,6 +52,12 @@ Currently, only Claude uses a separate implementation; all other models inherit 
 - Google Generative AI client integration
 - LiteLLM integration for unified token counting
 
+**`bedrock_model.py`** - Amazon Bedrock models
+- Uses LiteLLM's Bedrock Converse route across model vendors
+- Authenticates through the standard AWS credential chain (profiles or IAM roles)
+- Supports generation, prompt-constrained JSON, tools, and tool streaming
+- Intentionally excludes embeddings and Bedrock Mantle/Responses
+
 ### Utility Modules
 
 **`session_manager.py`** - Multi-turn conversation management

--- a/datus/models/base.py
+++ b/datus/models/base.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import hashlib
+import json
 import os
 import threading
 from abc import ABC, abstractmethod
@@ -40,6 +41,7 @@ class LLMBaseModel(ABC):  # Changed from BaseModel to LLMBaseModel
         LLMProvider.OPENROUTER: "OpenRouterModel",
         LLMProvider.MINIMAX: "MiniMaxModel",
         LLMProvider.GLM: "GLMModel",
+        LLMProvider.BEDROCK: "BedrockModel",
     }
 
     # Module-level LRU cache for instantiated models. Keyed on the
@@ -91,12 +93,16 @@ class LLMBaseModel(ABC):  # Changed from BaseModel to LLMBaseModel
             if target_config.api_key
             else ""
         )
+        provider_options_digest = hashlib.sha1(
+            json.dumps(target_config.provider_options or {}, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()[:12]
         cache_key: Tuple = (
             model_type,
             target_config.model,
             target_config.base_url or "",
             api_key_digest,
             target_config.auth_type,
+            provider_options_digest,
             scope or "",
             # Include reasoning-related fields so ``/effort`` and a toggled
             # ``enable_thinking`` produce a fresh adapter instead of reusing

--- a/datus/models/bedrock_model.py
+++ b/datus/models/bedrock_model.py
@@ -1,0 +1,86 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Amazon Bedrock model provider using the unified Converse API."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+from datus.configuration.agent_config import ModelConfig
+from datus.models.openai_compatible import OpenAICompatibleModel
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+class BedrockModel(OpenAICompatibleModel):
+    """Route Datus LLM calls through Amazon Bedrock Runtime Converse.
+
+    Authentication is delegated to the standard AWS credential chain. Static
+    access keys are intentionally not accepted as model configuration; local
+    users can select an AWS profile, while deployed workloads should use an
+    IAM role (for example EKS Pod Identity or IRSA).
+    """
+
+    _ALLOWED_PROVIDER_OPTIONS = frozenset(
+        {
+            "aws_region_name",
+            "aws_profile_name",
+            "aws_role_name",
+            "aws_session_name",
+            "aws_bedrock_runtime_endpoint",
+        }
+    )
+
+    def __init__(self, model_config: ModelConfig, **kwargs):
+        super().__init__(model_config, **kwargs)
+        logger.debug("Using Amazon Bedrock Converse model: %s", self.litellm_adapter.litellm_model_name)
+
+    def _get_api_key(self) -> str:
+        """Bedrock Runtime uses AWS credentials rather than an LLM API key."""
+        return ""
+
+    def _get_base_url(self) -> Optional[str]:
+        """Let boto3 resolve the regional Bedrock Runtime endpoint."""
+        return None
+
+    def _default_sampling_params(self) -> Dict[str, float]:
+        """Do not inject cross-vendor sampling defaults into Bedrock calls."""
+        return {}
+
+    def _json_response_format(self) -> Optional[Dict[str, str]]:
+        """Use prompt-based JSON output across the heterogeneous Bedrock catalog.
+
+        Bedrock Converse has no uniform JSON-mode control. In particular,
+        forwarding OpenAI's ``response_format`` through LiteLLM causes Nova 2
+        Lite to return an empty object. The shared parser still accepts raw or
+        fenced JSON from the model response.
+        """
+        return None
+
+    def _get_provider_request_options(self) -> Dict[str, Any]:
+        raw_options = dict(self.model_config.provider_options or {})
+        unknown = sorted(set(raw_options) - self._ALLOWED_PROVIDER_OPTIONS)
+        if unknown:
+            raise ValueError(
+                "Unsupported Bedrock provider_options: "
+                f"{', '.join(unknown)}. Allowed: {', '.join(sorted(self._ALLOWED_PROVIDER_OPTIONS))}"
+            )
+
+        options = {key: value for key, value in raw_options.items() if value not in (None, "")}
+        if "aws_region_name" not in options:
+            region = os.getenv("AWS_REGION_NAME") or os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+            if not region:
+                try:
+                    import boto3
+
+                    profile = options.get("aws_profile_name") or os.getenv("AWS_PROFILE")
+                    region = boto3.Session(profile_name=str(profile) if profile else None).region_name
+                except Exception as exc:
+                    logger.debug("Unable to resolve AWS region from boto3 session: %s", exc)
+            if region:
+                options["aws_region_name"] = region
+        return options

--- a/datus/models/litellm_adapter.py
+++ b/datus/models/litellm_adapter.py
@@ -11,7 +11,7 @@ Provides:
 3. Integration with openai-agents SDK's LitellmModel
 """
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 from urllib.parse import urlparse
 
 from datus.utils.loggings import get_logger
@@ -138,6 +138,7 @@ class LiteLLMAdapter:
         "openrouter": "openrouter/",  # OpenRouter unified gateway
         "minimax": "openai/",  # MiniMax - OpenAI-compatible API
         "glm": "openai/",  # Zhipu GLM - OpenAI-compatible API
+        "bedrock": "bedrock/converse/",  # Amazon Bedrock unified Converse API
     }
 
     # Provider-specific base URLs (if not using default)
@@ -151,6 +152,7 @@ class LiteLLMAdapter:
         "openrouter": None,  # Use LiteLLM default (https://openrouter.ai/api/v1)
         "minimax": "https://api.minimaxi.com/v1",  # MiniMax OpenAI-compatible endpoint
         "glm": "https://open.bigmodel.cn/api/paas/v4",  # Zhipu GLM OpenAI-compatible endpoint
+        "bedrock": None,  # Boto3 resolves the regional bedrock-runtime endpoint
     }
 
     # Model name prefixes for auto-detection
@@ -199,6 +201,7 @@ class LiteLLMAdapter:
         enable_thinking: bool = False,
         reasoning_effort: Optional[str] = None,
         default_headers: Optional[Dict[str, str]] = None,
+        provider_options: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the LiteLLM adapter.
@@ -212,6 +215,7 @@ class LiteLLMAdapter:
             reasoning_effort: One of off|minimal|low|medium|high. Takes precedence
                 over ``enable_thinking`` when set; ``None`` defers to the bool.
             default_headers: Optional custom HTTP headers (e.g., User-Agent for Coding Plan endpoints)
+            provider_options: Provider-specific request parameters passed to LiteLLM
         """
         # Auto-detect provider from model name if provider is generic
         detected_provider = self._detect_provider_from_model(provider, model, base_url)
@@ -222,6 +226,7 @@ class LiteLLMAdapter:
         self._enable_thinking = enable_thinking
         self._reasoning_effort = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
         self.default_headers = default_headers
+        self.provider_options = dict(provider_options or {})
         self._litellm_model_name = None
 
     def _detect_provider_from_model(self, provider: str, model: str, base_url: Optional[str] = None) -> str:
@@ -246,7 +251,7 @@ class LiteLLMAdapter:
         """
         # Skip auto-detection for providers that must not be overridden
         # (e.g., openrouter models contain provider/ prefix that would trigger false detection)
-        if provider.lower() == "openrouter":
+        if provider.lower() in {"openrouter", "bedrock"}:
             return provider
 
         model_lower = model.lower()
@@ -313,6 +318,17 @@ class LiteLLMAdapter:
             - openai + custom base_url + Qwen3.5-397B -> openai/Qwen3.5-397B
         """
         prefix = self.MODEL_PREFIX_MAP.get(self.provider, "")
+
+        # Bedrock is the routing platform, not the underlying model vendor.
+        # Force the unified Converse route even for model names such as
+        # ``deepseek.v3.2`` that would otherwise trigger vendor auto-detection.
+        if self.provider == "bedrock":
+            if self.model.startswith("bedrock/converse/"):
+                return self.model
+            if self.model.startswith("bedrock/invoke/"):
+                raise ValueError("BedrockModel supports the Converse route only; use bedrock/converse/<model-id>")
+            model = self.model.removeprefix("bedrock/")
+            return f"bedrock/converse/{model}"
 
         # OpenRouter models always need the openrouter/ prefix,
         # even when model name contains / (e.g., anthropic/claude-sonnet-4)
@@ -485,6 +501,8 @@ class LiteLLMAdapter:
         if self.default_headers:
             kwargs["extra_headers"] = self.default_headers
 
+        kwargs.update(self.provider_options)
+
         return kwargs
 
 
@@ -496,6 +514,7 @@ def create_litellm_adapter(
     enable_thinking: bool = False,
     reasoning_effort: Optional[str] = None,
     default_headers: Optional[Dict[str, str]] = None,
+    provider_options: Optional[Dict[str, Any]] = None,
 ) -> LiteLLMAdapter:
     """
     Factory function to create a LiteLLM adapter.
@@ -509,6 +528,7 @@ def create_litellm_adapter(
         reasoning_effort: One of off|minimal|low|medium|high; takes precedence
             over ``enable_thinking`` when set.
         default_headers: Optional custom HTTP headers
+        provider_options: Provider-specific request parameters
 
     Returns:
         Configured LiteLLMAdapter instance
@@ -521,4 +541,5 @@ def create_litellm_adapter(
         enable_thinking=enable_thinking,
         reasoning_effort=reasoning_effort,
         default_headers=default_headers,
+        provider_options=provider_options,
     )

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -256,6 +256,7 @@ class OpenAICompatibleModel(LLMBaseModel):
         self.api_key = self._get_api_key()
         self.base_url = self._get_base_url()
         self.default_headers = dict(self.model_config.default_headers) if self.model_config.default_headers else None
+        self.provider_request_options = self._get_provider_request_options()
 
         # Resolve SSL/TLS verification for this endpoint (e.g. a private gateway CA).
         # When configured, it takes priority over the SSL_VERIFY / SSL_CERT_FILE env
@@ -304,6 +305,7 @@ class OpenAICompatibleModel(LLMBaseModel):
             enable_thinking=model_config.enable_thinking,
             reasoning_effort=model_config.reasoning_effort,
             default_headers=self.default_headers,
+            provider_options=self.provider_request_options,
         )
 
         # Context for tracing ToDo: replace it with Context object
@@ -319,6 +321,25 @@ class OpenAICompatibleModel(LLMBaseModel):
     def _get_base_url(self) -> Optional[str]:
         """Get base URL from config. Override in subclasses if needed."""
         return self.model_config.base_url
+
+    def _get_provider_request_options(self) -> Dict[str, Any]:
+        """Return provider-specific LiteLLM request options.
+
+        The base contract is deliberately empty so arbitrary config cannot
+        overwrite core completion arguments. Providers opt in with a narrow
+        allowlist in their own implementation.
+        """
+        return {}
+
+    def _default_sampling_params(self) -> Dict[str, float]:
+        """Return implicit sampling defaults for the direct completion path."""
+        if hasattr(self, "_uses_completion_tokens_parameter") and self._uses_completion_tokens_parameter():
+            return {}
+        return {"temperature": 0.7, "top_p": 1.0}
+
+    def _json_response_format(self) -> Optional[Dict[str, str]]:
+        """Return the provider-native JSON mode request, when reliable."""
+        return {"type": "json_object"}
 
     def _is_official_openai_api(self) -> bool:
         """Return True only for official OpenAI API endpoints."""
@@ -567,18 +588,8 @@ class OpenAICompatibleModel(LLMBaseModel):
 
         def _generate_operation():
             # Use LiteLLM model name for unified provider support
-            params = {
-                "model": self.litellm_adapter.litellm_model_name,
-                "api_key": self.api_key,
-            }
-
-            # Add base_url if specified
-            if self.base_url:
-                params["api_base"] = self.base_url
-
-            # Add custom headers for Coding Plan endpoints
-            if self.default_headers:
-                params["extra_headers"] = self.default_headers
+            params = self.litellm_adapter.get_completion_kwargs()
+            default_sampling = self._default_sampling_params()
 
             # Anthropic rejects requests carrying BOTH ``temperature`` and
             # ``top_p`` with HTTP 400 / ``invalid_request_error`` (the
@@ -604,9 +615,8 @@ class OpenAICompatibleModel(LLMBaseModel):
             elif self.model_config.temperature is not None:
                 # Use temperature from model config (e.g., kimi-k2.5 requires temperature=1)
                 params["temperature"] = self.model_config.temperature
-            elif not hasattr(self, "_uses_completion_tokens_parameter") or not self._uses_completion_tokens_parameter():
-                # Add default temperature only for non-reasoning models
-                params["temperature"] = 0.7
+            elif "temperature" in default_sampling:
+                params["temperature"] = default_sampling["temperature"]
 
             # Add top_p: same priority + same explicit-None contract as
             # temperature above, EXCEPT for Anthropic where we never send it.
@@ -618,9 +628,8 @@ class OpenAICompatibleModel(LLMBaseModel):
             elif self.model_config.top_p is not None:
                 # Use top_p from model config (e.g., kimi-k2.5 requires top_p=0.95)
                 params["top_p"] = self.model_config.top_p
-            elif not hasattr(self, "_uses_completion_tokens_parameter") or not self._uses_completion_tokens_parameter():
-                # Add default top_p only for non-reasoning models
-                params["top_p"] = 1.0
+            elif "top_p" in default_sampling:
+                params["top_p"] = default_sampling["top_p"]
 
             # Resolve max_tokens / max_completion_tokens.
             # Priority: kwargs > model_specs.max_tokens. If neither is set, omit
@@ -739,9 +748,10 @@ class OpenAICompatibleModel(LLMBaseModel):
         Returns:
             Parsed JSON dictionary
         """
-        # Set JSON mode
         json_kwargs = kwargs.copy()
-        json_kwargs["response_format"] = {"type": "json_object"}
+        response_format = self._json_response_format()
+        if response_format is not None:
+            json_kwargs["response_format"] = response_format
 
         # Pass through enable_thinking if provided
         enable_thinking_param = json_kwargs.pop("enable_thinking", None)
@@ -1069,6 +1079,12 @@ class OpenAICompatibleModel(LLMBaseModel):
 
         if self.default_headers:
             model_settings_kwargs["extra_headers"] = self.default_headers
+
+        provider_request_options = getattr(self, "provider_request_options", None)
+        if provider_request_options:
+            existing_extra_args = dict(model_settings_kwargs.get("extra_args") or {})
+            existing_extra_args.update(provider_request_options)
+            model_settings_kwargs["extra_args"] = existing_extra_args
 
         effort = self.litellm_adapter.reasoning_effort_level
         if effort:

--- a/datus/models/sdk_patches.py
+++ b/datus/models/sdk_patches.py
@@ -180,6 +180,7 @@ _original_usage_model_dump = None
 _original_usage_model_dump_json = None
 _original_usage_init = None
 _original_showwarning = None
+_patched_showwarning = None
 
 # Cache reasoning_content from API responses, keyed by model name within the
 # current execution context. This avoids leaking one session's hidden reasoning
@@ -590,9 +591,15 @@ def _redirect_pydantic_serializer_warnings_to_log() -> None:
     serializer messages to ``logger.debug`` while leaving every other warning
     untouched.
     """
-    global _original_showwarning
+    global _original_showwarning, _patched_showwarning
 
     if _original_showwarning is not None:
+        # Test runners and observability libraries may replace the process-wide
+        # hook after Datus is imported. Re-applying the SDK patches must restore
+        # the Datus wrapper instead of treating the stale saved original as
+        # proof that the wrapper is still installed.
+        if _patched_showwarning is not None:
+            warnings.showwarning = _patched_showwarning
         return
 
     _original_showwarning = warnings.showwarning
@@ -608,7 +615,8 @@ def _redirect_pydantic_serializer_warnings_to_log() -> None:
             return
         _original_showwarning(message, category, filename, lineno, file, line)
 
-    warnings.showwarning = _showwarning
+    _patched_showwarning = _showwarning
+    warnings.showwarning = _patched_showwarning
 
 
 def _patch_litellm_usage_serialization() -> None:
@@ -793,7 +801,7 @@ def remove_sdk_patches() -> None:
     """
     global _original_items_to_messages, _original_acompletion, _original_completion
     global _original_usage_model_dump, _original_usage_model_dump_json, _original_usage_init
-    global _original_showwarning
+    global _original_showwarning, _patched_showwarning
 
     import litellm
     from agents.models.chatcmpl_converter import Converter
@@ -834,6 +842,7 @@ def remove_sdk_patches() -> None:
     if _original_showwarning is not None:
         warnings.showwarning = _original_showwarning
         _original_showwarning = None
+        _patched_showwarning = None
         logger.info("Removed SDK patch: warnings.showwarning (Pydantic serializer warnings)")
 
     _reasoning_content_cache.clear()

--- a/datus/utils/constants.py
+++ b/datus/utils/constants.py
@@ -32,6 +32,7 @@ class LLMProvider(StrEnum):
     GPT = "gpt"  # Alternative name for OpenAI
     CODEX = "codex"  # OpenAI Codex (ChatGPT subscription, OAuth authentication)
     OPENROUTER = "openrouter"  # OpenRouter unified AI gateway
+    BEDROCK = "bedrock"  # Amazon Bedrock (AWS credential-chain authentication)
 
 
 class EmbeddingProvider(StrEnum):

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -205,6 +205,7 @@ Providers are defined in `conf/providers.yml` and activated by adding credential
 | `minimax` | `MiniMax-M2.7`, `MiniMax-M2.5` | `minimax` | API key |
 | `glm` | `glm-5`, `glm-4.7` | `glm` | API key |
 | `openrouter` | `anthropic/claude-sonnet-4`, `openai/gpt-4o` | `openrouter` | API key |
+| `bedrock` | Claude Sonnet 5, Nova 2 Lite, GPT-OSS 20B | `bedrock` (Converse) | AWS credential chain |
 
 !!! tip "OpenRouter — one key, 300+ models"
     `openrouter` is a unified gateway: a single `OPENROUTER_API_KEY` routes to any
@@ -218,6 +219,77 @@ Providers are defined in `conf/providers.yml` and activated by adding credential
 |----------|----------------|------|-------|
 | `claude_subscription` | `claude` | Claude subscription token | The wizard first tries to auto-detect a local subscription credential and otherwise prompts for `sk-ant-oat01-...` |
 | `codex` | `codex` | OAuth | Uses locally available Codex OAuth credentials and verifies connectivity |
+
+### Amazon Bedrock Converse
+
+Datus routes Bedrock requests through the model-agnostic
+[Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html).
+It does not store AWS access keys in `agent.yml`; authentication uses the standard
+AWS credential chain. For local development, configure an AWS CLI profile and region:
+
+```bash
+aws configure
+aws sts get-caller-identity
+```
+
+SSO profiles work as well; run `aws sso login --profile <profile>` before starting
+Datus. Deployed workloads should use an IAM role. The role or user needs
+`bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` for the selected
+model or inference-profile resources, and the model must be enabled in the target
+AWS region.
+
+The default profile and region need no YAML options:
+
+```yaml
+agent:
+  providers:
+    bedrock:
+      auth_type: aws
+```
+
+To pin a non-default profile or region:
+
+```yaml
+agent:
+  providers:
+    bedrock:
+      auth_type: aws
+      provider_options:
+        aws_profile_name: analytics-dev
+        aws_region_name: us-east-1
+```
+
+Use Bedrock model or cross-region inference-profile IDs, not the model names used
+by vendors' direct APIs. The built-in picker contains models that completed the
+Datus text, JSON, SQL-tool, and streaming-tool certification:
+
+| Bedrock ID | Certification |
+|---|---|
+| `us.anthropic.claude-sonnet-5` | Certified |
+| `us.amazon.nova-2-lite-v1:0` | Certified |
+| `openai.gpt-oss-20b-1:0` | Certified |
+| `deepseek.v3.2` | Text and JSON only; not certified for Datus tool use |
+| `google.gemma-3-12b-it` | Text and JSON only; not certified for Datus tool use |
+
+The last two IDs can still be entered manually for non-agentic inference. Run the
+billable certification suite explicitly when evaluating a new model:
+
+```bash
+AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+  pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
+
+# Also evaluate the optional GPT-OSS, DeepSeek, and Gemma entries:
+DATUS_BEDROCK_CERTIFY_OPTIONAL=1 AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+  pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
+```
+
+These tests are intentionally not part of nightly CI. Bedrock usage is billed to
+the AWS account using the selected model's input/output token rates; agent tool
+tests can make multiple model calls. See
+[Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/).
+
+This integration covers LLM inference only. It does not add Bedrock embeddings,
+vector storage, or Bedrock Mantle/Responses support.
 
 ### Coding Plan providers
 

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -275,11 +275,12 @@ The last two IDs can still be entered manually for non-agentic inference. Run th
 billable certification suite explicitly when evaluating a new model:
 
 ```bash
-AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+DATUS_BEDROCK_CERTIFY=1 AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
   pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
 
 # Also evaluate the optional GPT-OSS, DeepSeek, and Gemma entries:
-DATUS_BEDROCK_CERTIFY_OPTIONAL=1 AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+DATUS_BEDROCK_CERTIFY=1 DATUS_BEDROCK_CERTIFY_OPTIONAL=1 \
+  AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
   pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
 ```
 

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -27,12 +27,15 @@ agent:
 
 Chat API 请求可通过请求体中的 `language` 字段按任务覆盖该默认值（详见 [Chat API](../API/chat.zh.md)）。CLI 无覆盖参数，直接沿用 yaml 中的默认。
 
-### 模型提供方（models） {#models-configuration}
-为智能体配置可用的 LLM 提供方：
+### 模型配置（自定义条目） {#models-configuration}
 
-**每个提供方条目的必填参数：**
+`agent.models` 用于配置自托管或私有部署的 LLM endpoint。OpenAI、DeepSeek、
+Bedrock 等标准 provider 应配置在 `agent.providers` 中。
 
-- **提供方键名 (`models.<key>`)** —— 逻辑标识符，由 `agent.target` 和节点 `model` 字段引用（可自定义命名）
+**每个自定义条目的必填参数：**
+
+- **条目键名 (`models.<key>`)** —— 逻辑标识符，由
+  `target: {custom: <key>}` 或节点 `model` 字段引用
 - `type`：接口类型（与厂商适配）
 - `base_url`：接口基础地址
 - `api_key`：访问密钥（支持环境变量）
@@ -41,9 +44,8 @@ Chat API 请求可通过请求体中的 `language` 字段按任务覆盖该默�
 
 ```yaml
 agent:
-  target: provider_name
   models:
-    provider_name:
+    my-internal:
       type: provider_type
       base_url: https://api.example.com/v1
       api_key: ${API_KEY_ENV_VAR}
@@ -110,10 +112,12 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 
 ## 支持的提供方
 
-初始化/配置向导中的 provider，最终都会写入 `agent.models`，并通过 `agent.target` 指定默认模型。也就是说：
+Provider 由 `conf/providers.yml` 定义，并通过 `agent.providers` 保存认证信息。
+使用 `/model` 命令配置和切换 provider：
 
-- 你在 `datus-agent configure` 里选择的 provider 名称，就是 `agent.models.<provider>` 的键名
-- 你也可以在后续手动编辑 `agent.yml`，把某个节点单独切换到另一套模型配置
+- Provider 凭证保存在 `agent.yml` 的 `agent.providers.<name>` 下
+- 当前 provider/model 保存在项目的 `.datus/config.yml` 中，由 `/model` 写入
+- 节点级 `model` 覆盖仍可引用 `agent.models` 中的自定义 endpoint
 
 ### 通用 provider
 
@@ -197,11 +201,12 @@ API 中使用的模型名。内置选择器只展示通过 Datus 文本、JSON�
 会产生 AWS 费用的认证套件：
 
 ```bash
-AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+DATUS_BEDROCK_CERTIFY=1 AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
   pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
 
 # 同时评估可选的 GPT-OSS、DeepSeek 和 Gemma：
-DATUS_BEDROCK_CERTIFY_OPTIONAL=1 AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+DATUS_BEDROCK_CERTIFY=1 DATUS_BEDROCK_CERTIFY_OPTIONAL=1 \
+  AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
   pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
 ```
 

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -128,6 +128,7 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 | `minimax` | `MiniMax-M2.7`、`MiniMax-M2.5` | `minimax` | API Key |
 | `glm` | `glm-5`、`glm-4.7` | `glm` | API Key |
 | `openrouter` | `anthropic/claude-sonnet-4`、`openai/gpt-4o` | `openrouter` | API Key |
+| `bedrock` | Claude Sonnet 5、Nova 2 Lite、GPT-OSS 20B | `bedrock`（Converse） | AWS 凭证链 |
 
 !!! tip "OpenRouter —— 一把 Key，300+ 模型"
     `openrouter` 是统一网关：一个 `OPENROUTER_API_KEY` 即可路由到任意厂商。
@@ -140,6 +141,76 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 |---|---|---|---|
 | `claude_subscription` | `claude` | Claude 订阅 token | 优先自动探测本地订阅凭据，失败时可手动粘贴 `sk-ant-oat01-...` |
 | `codex` | `codex` | OAuth | 读取本地 Codex OAuth 凭据并校验连通性 |
+
+### Amazon Bedrock Converse
+
+Datus 通过模型无关的
+[Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html)
+调用 Bedrock，不会把 AWS Access Key 写入 `agent.yml`，而是使用标准 AWS
+凭证链。本地开发先配置 AWS CLI profile 和 region：
+
+```bash
+aws configure
+aws sts get-caller-identity
+```
+
+AWS SSO profile 也可以使用；启动 Datus 前先执行
+`aws sso login --profile <profile>`。部署环境建议使用 IAM Role。对应用户或
+Role 需要对目标模型或 inference profile 具备 `bedrock:InvokeModel` 和
+`bedrock:InvokeModelWithResponseStream` 权限，并且目标模型已在当前 region
+开通。
+
+使用默认 profile 和 region 时无需写入额外选项：
+
+```yaml
+agent:
+  providers:
+    bedrock:
+      auth_type: aws
+```
+
+如需固定非默认 profile 或 region：
+
+```yaml
+agent:
+  providers:
+    bedrock:
+      auth_type: aws
+      provider_options:
+        aws_profile_name: analytics-dev
+        aws_region_name: us-east-1
+```
+
+这里使用的是 Bedrock model ID 或跨区 inference profile ID，不是厂商直连
+API 中使用的模型名。内置选择器只展示通过 Datus 文本、JSON、SQL 工具调用
+和流式工具调用认证的模型：
+
+| Bedrock ID | 认证结果 |
+|---|---|
+| `us.anthropic.claude-sonnet-5` | 已认证 |
+| `us.amazon.nova-2-lite-v1:0` | 已认证 |
+| `openai.gpt-oss-20b-1:0` | 已认证 |
+| `deepseek.v3.2` | 文本和 JSON 可用；未通过 Datus 工具调用认证 |
+| `google.gemma-3-12b-it` | 文本和 JSON 可用；未通过 Datus 工具调用认证 |
+
+后两个 ID 仍可手动输入，用于非 agentic 推理。评估新模型时需要显式运行
+会产生 AWS 费用的认证套件：
+
+```bash
+AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+  pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
+
+# 同时评估可选的 GPT-OSS、DeepSeek 和 Gemma：
+DATUS_BEDROCK_CERTIFY_OPTIONAL=1 AWS_PROFILE=default AWS_REGION_NAME=us-east-1 \
+  pytest -m bedrock_certification tests/integration/models/test_bedrock_model.py
+```
+
+这些用例不会进入 nightly。Bedrock 费用计入当前 AWS 账号，按所选模型的输入/
+输出 token 价格计算；Agent 工具认证可能发生多轮模型调用。价格以
+[Amazon Bedrock 定价](https://aws.amazon.com/cn/bedrock/pricing/)为准。
+
+本次接入范围仅包含 LLM 推理，不包含 Bedrock Embeddings、向量存储，也不包含
+Bedrock Mantle/Responses。
 
 ### Coding Plan provider
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
     "litellm>=1.67.4.post1,<2",
+    # Bedrock is a first-class provider; do not rely on a transitive boto3 install.
+    "boto3>=1.40,<2",
     "pydantic>=2.11.7,<3.0",
     "lancedb==0.34.0",
     # This library is required by lancedb

--- a/pytest.ini
+++ b/pytest.ini
@@ -35,3 +35,4 @@ markers =
     benchmark: benchmark harness and evaluator tests
     regression: mark tests as "regression_test"
     integration: mark tests as integration tests (multi-component, slower)
+    bedrock_certification: manual AWS Bedrock model certification tests (never selected by nightly)

--- a/tests/integration/models/test_bedrock_model.py
+++ b/tests/integration/models/test_bedrock_model.py
@@ -9,7 +9,7 @@ import os
 
 import boto3
 import pytest
-from agents import set_tracing_disabled
+from agents.tracing import DefaultTraceProvider, get_trace_provider, set_trace_provider
 
 from datus.configuration.agent_config import ModelConfig
 from datus.models.bedrock_model import BedrockModel
@@ -17,11 +17,17 @@ from datus.schemas.action_history import ActionHistoryManager
 from datus.tools.func_tool import db_function_tools
 from tests.conftest import load_acceptance_config
 
-set_tracing_disabled(True)
-
-pytestmark = [pytest.mark.integration, pytest.mark.bedrock_certification]
-
+_CERTIFICATION_ENABLED = os.getenv("DATUS_BEDROCK_CERTIFY") == "1"
 _OPTIONAL_MODELS_ENABLED = os.getenv("DATUS_BEDROCK_CERTIFY_OPTIONAL") == "1"
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.bedrock_certification,
+    pytest.mark.skipif(
+        not _CERTIFICATION_ENABLED,
+        reason="set DATUS_BEDROCK_CERTIFY=1 to run billable AWS Bedrock certification",
+    ),
+]
+
 BEDROCK_MODELS = [
     pytest.param("us.anthropic.claude-sonnet-5", id="claude-sonnet-5"),
     pytest.param("us.amazon.nova-2-lite-v1:0", id="nova-2-lite"),
@@ -90,6 +96,19 @@ BEDROCK_TOOL_MODELS = [
         ],
     ),
 ]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def isolated_tracing_provider():
+    """Disable tracing only while the opt-in certification module executes."""
+    previous_provider = get_trace_provider()
+    provider = DefaultTraceProvider()
+    provider.set_disabled(True)
+    set_trace_provider(provider)
+    try:
+        yield
+    finally:
+        set_trace_provider(previous_provider)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/models/test_bedrock_model.py
+++ b/tests/integration/models/test_bedrock_model.py
@@ -1,0 +1,207 @@
+"""Manual Amazon Bedrock Converse certification matrix.
+
+These tests make billable AWS calls. They are deliberately excluded from
+nightly/provider-health selection and run only when explicitly requested.
+"""
+
+import asyncio
+import os
+
+import boto3
+import pytest
+from agents import set_tracing_disabled
+
+from datus.configuration.agent_config import ModelConfig
+from datus.models.bedrock_model import BedrockModel
+from datus.schemas.action_history import ActionHistoryManager
+from datus.tools.func_tool import db_function_tools
+from tests.conftest import load_acceptance_config
+
+set_tracing_disabled(True)
+
+pytestmark = [pytest.mark.integration, pytest.mark.bedrock_certification]
+
+_OPTIONAL_MODELS_ENABLED = os.getenv("DATUS_BEDROCK_CERTIFY_OPTIONAL") == "1"
+BEDROCK_MODELS = [
+    pytest.param("us.anthropic.claude-sonnet-5", id="claude-sonnet-5"),
+    pytest.param("us.amazon.nova-2-lite-v1:0", id="nova-2-lite"),
+    pytest.param(
+        "openai.gpt-oss-20b-1:0",
+        id="gpt-oss-20b",
+        marks=pytest.mark.skipif(
+            not _OPTIONAL_MODELS_ENABLED,
+            reason="set DATUS_BEDROCK_CERTIFY_OPTIONAL=1 to certify optional models",
+        ),
+    ),
+    pytest.param(
+        "deepseek.v3.2",
+        id="deepseek-v3.2",
+        marks=pytest.mark.skipif(
+            not _OPTIONAL_MODELS_ENABLED,
+            reason="set DATUS_BEDROCK_CERTIFY_OPTIONAL=1 to certify optional models",
+        ),
+    ),
+    pytest.param(
+        "google.gemma-3-12b-it",
+        id="gemma-3-12b-it",
+        marks=pytest.mark.skipif(
+            not _OPTIONAL_MODELS_ENABLED,
+            reason="set DATUS_BEDROCK_CERTIFY_OPTIONAL=1 to certify optional models",
+        ),
+    ),
+]
+BEDROCK_TOOL_MODELS = [
+    pytest.param("us.anthropic.claude-sonnet-5", id="claude-sonnet-5"),
+    pytest.param("us.amazon.nova-2-lite-v1:0", id="nova-2-lite"),
+    pytest.param(
+        "openai.gpt-oss-20b-1:0",
+        id="gpt-oss-20b",
+        marks=pytest.mark.skipif(
+            not _OPTIONAL_MODELS_ENABLED,
+            reason="set DATUS_BEDROCK_CERTIFY_OPTIONAL=1 to certify optional models",
+        ),
+    ),
+    pytest.param(
+        "deepseek.v3.2",
+        id="deepseek-v3.2",
+        marks=[
+            pytest.mark.skipif(
+                not _OPTIONAL_MODELS_ENABLED,
+                reason="set DATUS_BEDROCK_CERTIFY_OPTIONAL=1 to certify optional models",
+            ),
+            pytest.mark.xfail(
+                strict=True,
+                reason="Bedrock DeepSeek v3.2 does not emit Converse tool calls",
+            ),
+        ],
+    ),
+    pytest.param(
+        "google.gemma-3-12b-it",
+        id="gemma-3-12b-it",
+        marks=[
+            pytest.mark.skipif(
+                not _OPTIONAL_MODELS_ENABLED,
+                reason="set DATUS_BEDROCK_CERTIFY_OPTIONAL=1 to certify optional models",
+            ),
+            pytest.mark.xfail(
+                strict=True,
+                reason="Bedrock Gemma 3 12B IT does not emit Converse tool calls",
+            ),
+        ],
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def aws_provider_options() -> dict[str, str]:
+    """Resolve the same local AWS credential chain used by BedrockModel."""
+    profile = os.getenv("AWS_PROFILE")
+    session = boto3.Session(profile_name=profile or None)
+    if session.get_credentials() is None:
+        pytest.skip("AWS credentials are not available")
+
+    region = (
+        os.getenv("AWS_REGION_NAME")
+        or os.getenv("AWS_REGION")
+        or os.getenv("AWS_DEFAULT_REGION")
+        or session.region_name
+    )
+    if not region:
+        pytest.skip("AWS region is not configured")
+
+    options = {"aws_region_name": region}
+    if profile:
+        options["aws_profile_name"] = profile
+    return options
+
+
+@pytest.fixture(scope="module")
+def ssb_tools():
+    config = load_acceptance_config(datasource="ssb_sqlite")
+    return db_function_tools(config)
+
+
+def _create_model(model_id: str, provider_options: dict[str, str]) -> BedrockModel:
+    config = ModelConfig(
+        type="bedrock",
+        auth_type="aws",
+        api_key="",
+        model=model_id,
+        provider_options=provider_options,
+    )
+    return BedrockModel(model_config=config)
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_MODELS)
+def test_generate(model_id, aws_provider_options):
+    model = _create_model(model_id, aws_provider_options)
+    result = model.generate("Reply with exactly: bedrock-ok", max_tokens=200)
+
+    assert isinstance(result, str)
+    assert result.strip()
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_MODELS)
+def test_generate_json(model_id, aws_provider_options):
+    model = _create_model(model_id, aws_provider_options)
+    result = model.generate_with_json_output(
+        'Return only this JSON object exactly: {"status": "ok"}',
+        max_tokens=300,
+    )
+
+    assert isinstance(result, dict)
+    assert result.get("status") == "ok"
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_TOOL_MODELS)
+@pytest.mark.asyncio
+async def test_tool_call(model_id, aws_provider_options, ssb_tools):
+    model = _create_model(model_id, aws_provider_options)
+    result = await model.generate_with_tools(
+        prompt=(
+            "database_type='sqlite' task='You must call execute_sql with "
+            "SELECT c_name FROM customer WHERE c_custkey = 1 and return the exact value. "
+            "Do not answer from memory or calculate it yourself.'"
+        ),
+        output_type=str,
+        tools=ssb_tools,
+        instruction=(
+            "You are a SQLite expert working with the Star Schema Benchmark database. "
+            "Use the database tools to answer the question."
+        ),
+        max_turns=5,
+    )
+
+    assert isinstance(result, dict)
+    assert result.get("content")
+    assert result.get("sql_contexts"), "the model must execute at least one SQL query"
+
+
+@pytest.mark.parametrize("model_id", BEDROCK_TOOL_MODELS)
+@pytest.mark.asyncio
+async def test_tool_call_stream(model_id, aws_provider_options, ssb_tools):
+    model = _create_model(model_id, aws_provider_options)
+    action_history_manager = ActionHistoryManager()
+    action_count = 0
+
+    async for action in model.generate_with_tools_stream(
+        prompt=(
+            "database_type='sqlite' task='You must call execute_sql with "
+            "SELECT s_name FROM supplier WHERE s_suppkey = 1 and return the exact value. "
+            "Do not answer from memory or calculate it yourself.'"
+        ),
+        output_type=str,
+        tools=ssb_tools,
+        instruction=(
+            "You are a SQLite expert working with the Star Schema Benchmark database. "
+            "Use the database tools to answer the question."
+        ),
+        max_turns=5,
+        action_history_manager=action_history_manager,
+    ):
+        assert action is not None
+        action_count += 1
+
+    await asyncio.sleep(0)
+    assert action_count > 0
+    assert any(action.action_type == "execute_sql" for action in action_history_manager.get_actions())

--- a/tests/unit_tests/cli/test_interactive_init.py
+++ b/tests/unit_tests/cli/test_interactive_init.py
@@ -632,6 +632,58 @@ class TestConfigureLLM:
             assert init._pending_target is None
             assert "openai" not in init.config["agent"]["providers"]
 
+    def test_aws_provider_uses_credential_chain_and_stages_target(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            init = InteractiveInit(user_home=tmpdir)
+            provider_info = {
+                "type": "bedrock",
+                "auth_type": "aws",
+                "default_model": "us.anthropic.claude-sonnet-5",
+                "models": ["us.anthropic.claude-sonnet-5"],
+                "provider_options": {"aws_region_name": "us-east-1"},
+            }
+
+            with (
+                patch("datus.configuration.agent_config._aws_provider_available", return_value=True),
+                patch(
+                    "datus.cli.interactive_init.select_choice",
+                    return_value="us.anthropic.claude-sonnet-5",
+                ),
+                patch.object(init, "_test_llm_connectivity", return_value=(True, "")),
+            ):
+                result = init._configure_aws_provider("bedrock", provider_info)
+
+            assert result is True
+            assert init.config["agent"]["providers"]["bedrock"] == {
+                "auth_type": "aws",
+                "provider_options": {"aws_region_name": "us-east-1"},
+            }
+            assert init._pending_probe["api_key"] == ""
+            assert init._pending_probe["provider_options"] == {"aws_region_name": "us-east-1"}
+            assert init._pending_target.provider == "bedrock"
+            assert init._pending_target.model == "us.anthropic.claude-sonnet-5"
+
+    def test_aws_provider_fails_before_probe_without_local_credentials(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            init = InteractiveInit(user_home=tmpdir)
+
+            with (
+                patch("datus.configuration.agent_config._aws_provider_available", return_value=False),
+                patch.object(init, "_test_llm_connectivity") as probe,
+            ):
+                result = init._configure_aws_provider(
+                    "bedrock",
+                    {
+                        "type": "bedrock",
+                        "auth_type": "aws",
+                        "models": ["us.anthropic.claude-sonnet-5"],
+                    },
+                )
+
+            assert result is False
+            probe.assert_not_called()
+            assert init._pending_target is None
+
 
 # ---------------------------------------------------------------------------
 # do_init_sql_and_log_result: edge cases

--- a/tests/unit_tests/cli/test_main.py
+++ b/tests/unit_tests/cli/test_main.py
@@ -373,6 +373,59 @@ class TestRepairProjectOverrides:
         mock_pick.assert_not_called()
         mock_save.assert_not_called()
 
+    def test_keeps_bedrock_target_with_env_provider_options(self, monkeypatch):
+        """Raw startup repair resolves AWS option env vars before probing boto3."""
+        from datus.configuration.project_config import ProjectOverride, ProjectTarget
+
+        monkeypatch.setenv("DATUS_TEST_AWS_PROFILE", "analytics-dev")
+        monkeypatch.setenv("DATUS_TEST_AWS_REGION", "us-east-1")
+        app = Application()
+        args = SimpleNamespace(config=None)
+        override = ProjectOverride(
+            target=ProjectTarget(
+                provider="bedrock",
+                model="us.anthropic.claude-sonnet-5",
+            )
+        )
+        raw = {
+            "providers": {
+                "bedrock": {
+                    "auth_type": "aws",
+                    "provider_options": {
+                        "aws_profile_name": "${DATUS_TEST_AWS_PROFILE}",
+                        "aws_region_name": "${DATUS_TEST_AWS_REGION}",
+                    },
+                }
+            },
+            "services": {"datasources": {}},
+        }
+        session = MagicMock(region_name=None)
+        session.get_credentials.return_value = MagicMock()
+
+        def session_for_profile(*, profile_name):
+            if profile_name != "analytics-dev":
+                raise RuntimeError("profile was not resolved")
+            return session
+
+        with (
+            patch("datus.configuration.project_config.load_project_override", return_value=override),
+            patch(
+                "datus.configuration.agent_config_loader.configuration_manager",
+                return_value=self._mock_mgr(raw),
+            ),
+            patch(
+                "datus.configuration.agent_config._load_provider_catalog",
+                return_value={"providers": {"bedrock": {"auth_type": "aws"}}},
+            ),
+            patch("boto3.Session", side_effect=session_for_profile) as mock_session,
+            patch("datus.configuration.project_config.save_project_override") as mock_save,
+        ):
+            app._repair_project_overrides(args)
+
+        mock_session.assert_called_once_with(profile_name="analytics-dev")
+        mock_save.assert_not_called()
+        assert override.target.provider == "bedrock"
+
     def test_clears_stale_target_silently(self):
         """Stale target → cleared to None (no prompt), db kept, config saved."""
         from datus.configuration.project_config import ProjectOverride

--- a/tests/unit_tests/cli/test_model_app.py
+++ b/tests/unit_tests/cli/test_model_app.py
@@ -49,6 +49,12 @@ def _stub_agent_config(**overrides):
                 "models": ["code-1"],
                 "auth_type": "oauth",
             },
+            "bedrock": {
+                "type": "bedrock",
+                "auth_type": "aws",
+                "default_model": "us.anthropic.claude-sonnet-5",
+                "models": ["us.anthropic.claude-sonnet-5"],
+            },
         },
     }
     cfg.providers = {}
@@ -165,6 +171,26 @@ class TestProviderList:
         assert isinstance(result, ModelSelection)
         assert result.kind == "needs_oauth"
         assert result.provider == "codex"
+
+    def test_unconfigured_bedrock_shows_aws_setup_message(self):
+        cfg = _stub_agent_config()
+        cfg.provider_available = MagicMock(return_value=False)
+        app = ModelApp(cfg, Console(file=io.StringIO(), no_color=True))
+        visible = app._providers_for_tab(_Tab.PROVIDERS)
+        app._list_cursor = visible.index("bedrock")
+        app._on_provider_enter()
+        assert app._view == _View.PROVIDER_LIST
+        assert "AWS credentials or region not found" in app._error_message
+
+    def test_available_bedrock_enters_model_list(self):
+        cfg = _stub_agent_config()
+        cfg.provider_available = MagicMock(side_effect=lambda name: name in {"openai", "bedrock"})
+        app = ModelApp(cfg, Console(file=io.StringIO(), no_color=True))
+        visible = app._providers_for_tab(_Tab.PROVIDERS)
+        app._list_cursor = visible.index("bedrock")
+        app._on_provider_enter()
+        assert app._view == _View.PROVIDER_MODELS
+        assert app._provider_models == ["us.anthropic.claude-sonnet-5"]
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -13,6 +13,7 @@ CI-level: zero external deps, zero network.
 """
 
 import argparse
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -2145,6 +2146,12 @@ class TestProviderConfigurationDispatch:
                     "default_model": "anthropic/claude-sonnet-4",
                     "models": ["anthropic/claude-sonnet-4", "openai/gpt-4o"],
                 },
+                "bedrock": {
+                    "type": "bedrock",
+                    "auth_type": "aws",
+                    "default_model": "us.anthropic.claude-sonnet-5",
+                    "models": ["us.anthropic.claude-sonnet-5"],
+                },
             },
             "model_overrides": {
                 "kimi-k2.5": {"temperature": 1.0, "top_p": 0.95},
@@ -2224,6 +2231,30 @@ class TestProviderConfigurationDispatch:
         assert active.temperature == 1.0
         assert active.top_p == 0.95
 
+    def test_bedrock_provider_options_flow_to_model_config(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            providers={
+                "bedrock": {
+                    "auth_type": "aws",
+                    "provider_options": {
+                        "aws_region_name": "us-east-1",
+                        "aws_profile_name": "dev",
+                    },
+                }
+            },
+            target_provider="bedrock",
+            target_model="us.anthropic.claude-sonnet-5",
+        )
+        active = cfg.active_model()
+        assert active.type == "bedrock"
+        assert active.api_key == ""
+        assert active.auth_type == "aws"
+        assert active.provider_options == {
+            "aws_region_name": "us-east-1",
+            "aws_profile_name": "dev",
+        }
+
     def test_env_fallback_used_when_user_api_key_empty(self, tmp_path, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "env-secret")
         cfg = self._make(
@@ -2295,6 +2326,30 @@ class TestProviderConfigurationDispatch:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         cfg = self._make(tmp_path)
         assert cfg.provider_available("openai") is False
+
+    def test_bedrock_available_with_aws_credentials_and_region(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            providers={
+                "bedrock": {
+                    "auth_type": "aws",
+                    "provider_options": {"aws_region_name": "us-east-1"},
+                }
+            },
+        )
+        session = MagicMock()
+        session.get_credentials.return_value = MagicMock()
+        with patch("boto3.Session", return_value=session):
+            assert cfg.provider_available("bedrock") is True
+
+    def test_bedrock_unavailable_without_region(self, tmp_path, monkeypatch):
+        for name in ("AWS_REGION_NAME", "AWS_REGION", "AWS_DEFAULT_REGION"):
+            monkeypatch.delenv(name, raising=False)
+        cfg = self._make(tmp_path, providers={"bedrock": {"auth_type": "aws"}})
+        session = MagicMock(region_name=None)
+        session.get_credentials.return_value = MagicMock()
+        with patch("boto3.Session", return_value=session):
+            assert cfg.provider_available("bedrock") is False
 
     # ── reasoning_effort ───────────────────────────────────────────
 

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -634,6 +634,32 @@ class TestLoadModelConfig:
         cfg = load_model_config(data)
         assert cfg.base_url == "https://api.example.com"
 
+    def test_provider_options_resolve_env_and_drop_missing_values(self, monkeypatch):
+        monkeypatch.setenv("AWS_REGION_NAME_TEST", "us-east-1")
+        monkeypatch.delenv("AWS_PROFILE_NAME_TEST", raising=False)
+        cfg = load_model_config(
+            {
+                "type": "bedrock",
+                "model": "us.amazon.nova-2-lite-v1:0",
+                "provider_options": {
+                    "aws_region_name": "${AWS_REGION_NAME_TEST}",
+                    "aws_profile_name": "${AWS_PROFILE_NAME_TEST}",
+                },
+            }
+        )
+        assert cfg.provider_options == {"aws_region_name": "us-east-1"}
+
+    @pytest.mark.parametrize("value", ["profile", [], False])
+    def test_provider_options_reject_non_mapping(self, value):
+        with pytest.raises(DatusException, match="provider_options must be a mapping"):
+            load_model_config(
+                {
+                    "type": "bedrock",
+                    "model": "us.amazon.nova-2-lite-v1:0",
+                    "provider_options": value,
+                }
+            )
+
     def test_to_dict(self):
         cfg = ModelConfig(type="openai", api_key="sk", model="gpt-4")
         d = cfg.to_dict()

--- a/tests/unit_tests/models/test_base.py
+++ b/tests/unit_tests/models/test_base.py
@@ -163,3 +163,28 @@ class TestCreateModelCache:
             on = LLMBaseModel.create_model(self._agent_config(cfg_on))
         assert off is not on
         assert module.OpenAIModel.call_count == 2
+
+    def test_different_provider_options_yield_new_instance(self):
+        """AWS profile/region changes must not reuse a stale Bedrock client."""
+        self._fresh_cache()
+        cfg_east = ModelConfig(
+            type="bedrock",
+            api_key="",
+            model="us.anthropic.claude-sonnet-5",
+            auth_type="aws",
+            provider_options={"aws_region_name": "us-east-1"},
+        )
+        cfg_west = ModelConfig(
+            type="bedrock",
+            api_key="",
+            model="us.anthropic.claude-sonnet-5",
+            auth_type="aws",
+            provider_options={"aws_region_name": "us-west-2"},
+        )
+        module = MagicMock()
+        module.BedrockModel = MagicMock(side_effect=lambda **kw: MagicMock(name="Instance"))
+        with patch.dict("sys.modules", {"datus.models.bedrock_model": module}):
+            east = LLMBaseModel.create_model(self._agent_config(cfg_east))
+            west = LLMBaseModel.create_model(self._agent_config(cfg_west))
+        assert east is not west
+        assert module.BedrockModel.call_count == 2

--- a/tests/unit_tests/models/test_bedrock_model.py
+++ b/tests/unit_tests/models/test_bedrock_model.py
@@ -1,0 +1,119 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Deterministic tests for the Amazon Bedrock Converse provider."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datus.configuration.agent_config import ModelConfig
+from datus.models.bedrock_model import BedrockModel
+
+pytestmark = pytest.mark.ci
+
+
+def _config(model: str = "us.anthropic.claude-sonnet-5", **kwargs) -> ModelConfig:
+    provider_options = kwargs.pop("provider_options", {"aws_region_name": "us-east-1"})
+    return ModelConfig(
+        type="bedrock",
+        api_key="",
+        model=model,
+        auth_type="aws",
+        provider_options=provider_options,
+        **kwargs,
+    )
+
+
+def _response(content: str = "ok") -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    response.choices[0].message.reasoning_content = None
+    response.choices[0].finish_reason = "stop"
+    response.model = "bedrock-model"
+    response.usage.prompt_tokens = 2
+    response.usage.completion_tokens = 1
+    response.usage.total_tokens = 3
+    return response
+
+
+class TestBedrockModel:
+    def test_initializes_without_api_key(self):
+        model = BedrockModel(_config())
+        assert model.api_key == ""
+        assert model.base_url is None
+        assert model.litellm_adapter.provider == "bedrock"
+
+    def test_uses_converse_route(self):
+        model = BedrockModel(_config())
+        assert model.litellm_adapter.litellm_model_name == ("bedrock/converse/us.anthropic.claude-sonnet-5")
+
+    def test_generate_forwards_aws_options_without_sampling_defaults(self):
+        model = BedrockModel(
+            _config(
+                provider_options={
+                    "aws_region_name": "us-east-1",
+                    "aws_profile_name": "dev",
+                }
+            )
+        )
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=_response()) as completion:
+            assert model.generate("hello", max_tokens=32) == "ok"
+
+        kwargs = completion.call_args.kwargs
+        assert kwargs["model"] == "bedrock/converse/us.anthropic.claude-sonnet-5"
+        assert kwargs["aws_region_name"] == "us-east-1"
+        assert kwargs["aws_profile_name"] == "dev"
+        assert kwargs["max_tokens"] == 32
+        assert "api_key" not in kwargs
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+
+    def test_explicit_sampling_parameter_is_preserved(self):
+        model = BedrockModel(_config())
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=_response()) as completion:
+            model.generate("hello", temperature=0.2)
+        assert completion.call_args.kwargs["temperature"] == 0.2
+
+    def test_json_output_uses_prompt_contract_without_openai_response_format(self):
+        model = BedrockModel(_config())
+        with patch.object(model, "generate", return_value='{"status": "ok"}') as generate:
+            assert model.generate_with_json_output("return JSON") == {"status": "ok"}
+        assert "response_format" not in generate.call_args.kwargs
+
+    def test_agent_model_settings_receive_aws_options(self):
+        model = BedrockModel(_config())
+        agent = model._build_agent(
+            instruction="Use tools when needed.",
+            output_type=str,
+            strict_json_schema=True,
+            connected_servers={},
+            tools=[],
+        )
+        assert agent.model_settings.extra_args["aws_region_name"] == "us-east-1"
+
+    def test_rejects_unapproved_provider_option(self):
+        config = _config()
+        config.provider_options["aws_secret_access_key"] = "must-not-be-stored"
+        with pytest.raises(ValueError, match="Unsupported Bedrock provider_options"):
+            BedrockModel(config)
+
+    def test_resolves_region_from_boto3_profile(self, monkeypatch):
+        monkeypatch.delenv("AWS_REGION_NAME", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        config = _config()
+        config.provider_options = {"aws_profile_name": "dev"}
+        session = MagicMock(region_name="us-west-2")
+        with patch("boto3.Session", return_value=session) as session_cls:
+            model = BedrockModel(config)
+        session_cls.assert_called_once_with(profile_name="dev")
+        assert model.provider_request_options["aws_region_name"] == "us-west-2"
+
+
+def test_model_type_map_registers_bedrock():
+    from datus.models.base import LLMBaseModel
+
+    assert LLMBaseModel.MODEL_TYPE_MAP["bedrock"] == "BedrockModel"

--- a/tests/unit_tests/models/test_litellm_adapter.py
+++ b/tests/unit_tests/models/test_litellm_adapter.py
@@ -115,6 +115,7 @@ class TestLiteLLMAdapterModelName:
             ("gemini", "gemini-2.5-pro", "gemini/gemini-2.5-pro"),
             ("qwen", "qwen3-coder", "dashscope/qwen3-coder"),
             ("kimi", "kimi-k2.5", "moonshot/kimi-k2.5"),
+            ("bedrock", "us.anthropic.claude-sonnet-5", "bedrock/converse/us.anthropic.claude-sonnet-5"),
         ],
     )
     def test_litellm_model_name(self, provider, model, expected_litellm_name):
@@ -178,6 +179,27 @@ class TestOpenRouterModelName:
         assert adapter.litellm_model_name == "openrouter/anthropic/claude-sonnet-4"
 
 
+class TestBedrockModelName:
+    def test_bedrock_deepseek_model_stays_on_bedrock(self):
+        adapter = LiteLLMAdapter(provider="bedrock", model="deepseek.v3.2", api_key="")
+        assert adapter.provider == "bedrock"
+        assert adapter.litellm_model_name == "bedrock/converse/deepseek.v3.2"
+
+    def test_bedrock_prefix_is_canonicalized_to_converse(self):
+        adapter = LiteLLMAdapter(provider="bedrock", model="bedrock/us.amazon.nova-2-lite-v1:0", api_key="")
+        assert adapter.litellm_model_name == "bedrock/converse/us.amazon.nova-2-lite-v1:0"
+
+    def test_existing_converse_prefix_is_not_duplicated(self):
+        model = "bedrock/converse/openai.gpt-oss-20b-1:0"
+        adapter = LiteLLMAdapter(provider="bedrock", model=model, api_key="")
+        assert adapter.litellm_model_name == model
+
+    def test_invoke_route_is_rejected(self):
+        adapter = LiteLLMAdapter(provider="bedrock", model="bedrock/invoke/anthropic.claude-v2", api_key="")
+        with pytest.raises(ValueError, match="Converse route only"):
+            _ = adapter.litellm_model_name
+
+
 class TestGetCompletionKwargs:
     def test_includes_model(self):
         adapter = LiteLLMAdapter(provider="openai", model="gpt-4o", api_key="sk-test")
@@ -202,6 +224,18 @@ class TestGetCompletionKwargs:
         adapter.base_url = None
         kwargs = adapter.get_completion_kwargs()
         assert "api_base" not in kwargs
+
+    def test_provider_options_are_forwarded(self):
+        adapter = LiteLLMAdapter(
+            provider="bedrock",
+            model="us.amazon.nova-2-lite-v1:0",
+            api_key="",
+            provider_options={"aws_region_name": "us-east-1", "aws_profile_name": "dev"},
+        )
+        kwargs = adapter.get_completion_kwargs()
+        assert kwargs["aws_region_name"] == "us-east-1"
+        assert kwargs["aws_profile_name"] == "dev"
+        assert "api_key" not in kwargs
 
 
 class TestGetAgentsSdkModel:

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -69,6 +69,14 @@ def _make_model(model_config=None):
     mock_litellm_adapter.is_thinking_model = False
     mock_litellm_adapter.reasoning_effort_level = None
     mock_litellm_adapter.get_agents_sdk_model.return_value = MagicMock()
+    completion_kwargs = {"model": "openai/gpt-4"}
+    if model_config.api_key:
+        completion_kwargs["api_key"] = model_config.api_key
+    if model_config.base_url:
+        completion_kwargs["api_base"] = model_config.base_url
+    if model_config.default_headers:
+        completion_kwargs["extra_headers"] = model_config.default_headers
+    mock_litellm_adapter.get_completion_kwargs.return_value = completion_kwargs
 
     with (
         patch("datus.models.openai_compatible.LiteLLMAdapter", return_value=mock_litellm_adapter),

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -996,6 +996,20 @@ class TestApplyAndRemoveSdkPatches:
         finally:
             remove_sdk_patches()
 
+    def test_apply_sdk_patches_restores_warning_hook_replaced_by_external_code(self):
+        """Re-applying restores the Datus hook after a runner or library replaces it."""
+        remove_sdk_patches()
+        original_showwarning = warnings.showwarning
+        apply_sdk_patches()
+        patched_showwarning = warnings.showwarning
+        try:
+            warnings.showwarning = lambda *args, **kwargs: None
+            apply_sdk_patches()
+            assert warnings.showwarning is patched_showwarning
+        finally:
+            remove_sdk_patches()
+        assert warnings.showwarning is original_showwarning
+
 
 class TestPatchedCompletionSync:
     """Tests for the sync litellm.completion patch (Kimi reasoning_content)."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "(python_full_version >= '3.14' and platform_machine != 'arm64') or (python_full_version >= '3.14' and sys_platform != 'darwin')",
@@ -690,6 +690,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "anyio" },
     { name = "beautifulsoup4" },
+    { name = "boto3" },
     { name = "charset-normalizer" },
     { name = "datus-bi-core" },
     { name = "datus-db-core" },
@@ -773,6 +774,7 @@ requires-dist = [
     { name = "anthropic", specifier = "==0.51.0" },
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "boto3", specifier = ">=1.40,<2" },
     { name = "charset-normalizer", specifier = ">=3.4.2" },
     { name = "datus-bi-core", specifier = ">=0.1.2" },
     { name = "datus-db-core", specifier = ">=0.1.4" },
@@ -1374,6 +1376,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1384,6 +1387,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1394,6 +1398,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },


### PR DESCRIPTION
## Summary

- Add Amazon Bedrock as a first-class Datus LLM provider through the LiteLLM Bedrock Converse route and the standard AWS credential chain.
- Persist provider-specific AWS options, expose Bedrock in CLI initialization and model selection, and document AWS setup, IAM permissions, billing, and model configuration in English and Chinese.
- Add deterministic unit coverage plus a manual, billable AWS certification suite that is excluded from nightly and provider-health jobs.
- Keep this change scoped to LLM inference; embeddings, vector storage, and Mantle are unchanged.

## AWS certification

Tested in `us-east-1` with the standard AWS profile chain.

| Bedrock model | Text | JSON | Tool call | Streaming tool call | Default catalog |
| --- | --- | --- | --- | --- | --- |
| `us.anthropic.claude-sonnet-5` | Pass | Pass | Pass | Pass | Yes |
| `us.amazon.nova-2-lite-v1:0` | Pass | Pass | Pass | Pass | Yes |
| `openai.gpt-oss-20b-1:0` | Pass | Pass | Pass | Pass | Yes |
| `deepseek.v3.2` | Pass | Pass | Expected xfail | Expected xfail | No, manual opt-in |
| `google.gemma-3-12b-it` | Pass | Pass | Expected xfail | Expected xfail | No, manual opt-in |

DeepSeek and Gemma currently complete plain-text and structured-output certification, but the tested Bedrock endpoints do not emit Converse tool calls even with forced tool-choice prompts. They therefore remain explicit, on-demand model IDs rather than catalog defaults.

Manual billable test command:

```bash
DATUS_BEDROCK_CERTIFY=1 DATUS_BEDROCK_CERTIFY_OPTIONAL=1 AWS_PROFILE=default AWS_REGION_NAME=us-east-1 uv run pytest tests/integration/models/test_bedrock_model.py -m bedrock_certification -v
```

Result: `16 passed, 4 xfailed`.

## Validation

- `uv run python ci/run-pr-tests.py upstream/main`: `6958 passed`, `0 failed`, `1 xfailed`; diff coverage `82%`
- Related configuration/CLI unit suites: `343 passed`
- Certification default-off check: `20 skipped` without `DATUS_BEDROCK_CERTIFY=1`
- Bedrock live certification: `16 passed`, `4 xfailed`
- `uv run ruff check` and `uv run ruff format --check`
- English and Chinese strict MkDocs builds
- `uv lock` and `uv sync --locked --group ci`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added Amazon Bedrock as an LLM provider using AWS authentication and the Converse API.
  * Added interactive setup for selecting Bedrock models and configuring AWS profiles, regions, and related options.
  * Added support for text generation, structured JSON responses, tool use, and streaming.
* **Documentation**
  * Added English and Chinese setup guidance, supported model details, permissions, and certification instructions.
* **Bug Fixes**
  * Improved provider availability checks and configuration handling for AWS credentials and regions.
* **Tests**
  * Added unit, integration, and optional Bedrock certification coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Amazon Bedrock provider (AWS auth) using the Converse API, including model support and provider options.
  * Extended interactive setup and the model UI flow to configure Bedrock and guide missing AWS credential/region setup.
* **Documentation**
  * Updated English and Chinese docs with Bedrock configuration, required IAM permissions, and certification/testing notes.
* **Bug Fixes**
  * Improved AWS credential/region availability detection and ensured provider-option changes create distinct model instances.
* **Tests**
  * Added unit coverage for Bedrock setup/config/UI and adapter behavior, plus optional integration certification matrix tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->