### PR TITLE
[BugFix] Move OSI metric target binding into gen_metrics

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -510,6 +510,8 @@ class GenMetricsAgenticNode(AgenticNode):
         if not isinstance(response_content, str):
             response_content = str(response_content) if response_content else ""
 
+        blocker_code = blocker_code.strip().lower() if isinstance(blocker_code, str) else blocker_code
+        skip_reason = skip_reason.strip().lower() if isinstance(skip_reason, str) else skip_reason
         if status is not None and status not in {"generated", "skipped", "blocked"}:
             raise RuntimeError(f"Unsupported metric generation status: {status!r}")
         if skip_reason is not None and skip_reason != "not_a_metric":

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -17,7 +17,7 @@ from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.stream_run_context import StreamRunContext
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
-from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SemanticNodeResult
+from datus.schemas.semantic_agentic_node_models import GenMetricsNodeResult, SemanticNodeInput
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.generation_tools import GenerationTools
@@ -47,7 +47,7 @@ class GenMetricsAgenticNode(AgenticNode):
     """
 
     NODE_NAME = "gen_metrics"
-    result_class = SemanticNodeResult
+    result_class = GenMetricsNodeResult
 
     def __init__(
         self,
@@ -107,6 +107,10 @@ class GenMetricsAgenticNode(AgenticNode):
         self.semantic_discovery_tools = None
         self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
         self.generation_tools: Optional[GenerationTools] = None
+        from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
+
+        self.osi_target_state = OsiSemanticModelTargetState()
+        self.osi_target_tools = None
         self.ask_user_tool = None
         self.hooks = None
         self.generation_evidence = GenerationEvidence()
@@ -138,144 +142,22 @@ class GenMetricsAgenticNode(AgenticNode):
 
         self.tools = []
 
-        # Setup db_tools.*, semantic_discovery_tools.*, generation_tools.*, filesystem_tools.*, semantic_tools.*
+        self._setup_osi_target_tools()
         self._setup_db_tools()
         self._setup_semantic_discovery_tools()
         self._setup_generation_tools()
         self._setup_filesystem_tools()
         self._setup_semantic_tools()
-        self._setup_semantic_model_bootstrap()
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
 
         logger.info(f"Setup {len(self.tools)} tools for {self.NODE_NAME}: {[tool.name for tool in self.tools]}")
 
-    def _setup_semantic_model_bootstrap(self) -> None:
-        """Create a host-only semantic-model runner for directly selected OSI metrics."""
-        from datus.agent.node.semantic_authoring import is_osi_authoring
-
-        self.sub_agent_task_tool = None
-        if self._is_subagent or not is_osi_authoring(self.agent_config):
-            return
-
-        from datus.tools.func_tool.sub_agent_task_tool import SubAgentTaskTool
-
-        self.sub_agent_task_tool = SubAgentTaskTool(
-            agent_config=self.agent_config,
-            allowed_subagents=["gen_semantic_model"],
-            parent_node_name=self.get_node_name(),
-        )
-        self.sub_agent_task_tool.set_action_bus(self.action_bus)
-        self.sub_agent_task_tool.set_interaction_broker(self.interaction_broker)
-        self.sub_agent_task_tool.set_parent_node(self)
-
     async def _before_stream(self, ctx: StreamRunContext) -> None:
-        """Resolve or bootstrap the prerequisite OSI semantic model before metrics."""
+        """Reset request-local authoring state before the agent loop."""
         await super()._before_stream(ctx)
-
-        from datus.agent.node.semantic_authoring import (
-            is_osi_authoring,
-            resolve_existing_osi_semantic_model,
-        )
-
-        if not is_osi_authoring(self.agent_config):
-            return
-
-        resolution = resolve_existing_osi_semantic_model(
-            self.agent_config,
-            user_input=ctx.user_input,
-            request_text=ctx.user_input.user_message,
-        )
-        if resolution["status"] == "found":
-            self._set_osi_semantic_model_target(ctx.user_input, resolution["selected"])
-            return
-        if resolution["status"] == "ambiguous":
-            self._raise_osi_semantic_model_selection_error(resolution)
-        if resolution["status"] == "invalid":
-            self._raise_osi_source_query_error(resolution)
-        if self._is_subagent:
-            raise DatusException(
-                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
-                message_args={
-                    "error_message": (
-                        "no OSI semantic model contains the requested datasets; "
-                        "run gen_semantic_model first, then retry gen_metrics"
-                    )
-                },
-            )
-        if self.sub_agent_task_tool is None:
-            raise DatusException(
-                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
-                message_args={"error_message": "gen_semantic_model runner is unavailable"},
-            )
-
-        result = await self.sub_agent_task_tool.task(
-            type="gen_semantic_model",
-            prompt=(
-                "Create the OSI semantic model prerequisite for the metric request below. "
-                "Author semantic objects only; do not generate metrics.\n\n"
-                f"Original metric request:\n{ctx.user_input.user_message}"
-            ),
-            description="Create required OSI semantic model",
-        )
-        if not result.success:
-            raise DatusException(
-                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
-                message_args={"error_message": result.error or "gen_semantic_model failed"},
-            )
-
-        post_resolution = resolve_existing_osi_semantic_model(
-            self.agent_config,
-            user_input=ctx.user_input,
-            request_text=ctx.user_input.user_message,
-        )
-        selected = post_resolution.get("selected") if post_resolution["status"] == "found" else None
-
-        if selected is None:
-            if post_resolution["status"] == "ambiguous":
-                self._raise_osi_semantic_model_selection_error(post_resolution)
-            if post_resolution["status"] == "invalid":
-                self._raise_osi_source_query_error(post_resolution)
-            raise DatusException(
-                ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
-                message_args={
-                    "error_message": "gen_semantic_model completed without creating a resolvable OSI semantic model"
-                },
-            )
-
-        self._set_osi_semantic_model_target(ctx.user_input, selected)
-        logger.info("Bootstrapped prerequisite OSI semantic model: %s", selected["semantic_model_file"])
-
-    @staticmethod
-    def _set_osi_semantic_model_target(user_input: SemanticNodeInput, model: Dict[str, Any]) -> None:
-        """Attach the selected model name so the upstream resolver supplies its real file."""
-        user_input.semantic_model_name = model["semantic_model_name"]
-
-    @staticmethod
-    def _raise_osi_semantic_model_selection_error(resolution: Dict[str, Any]) -> None:
-        candidates = ", ".join(
-            f"{model['semantic_model_name']} ({model['semantic_model_file']})"
-            for model in resolution.get("candidates") or []
-        )
-        raise DatusException(
-            ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
-            message_args={
-                "error_message": (
-                    f"semantic model selection is ambiguous: {candidates}. "
-                    "Specify semantic_model_name or reference a dataset from the intended model."
-                )
-            },
-        )
-
-    @staticmethod
-    def _raise_osi_source_query_error(resolution: Dict[str, Any]) -> None:
-        errors = "; ".join(
-            f"{item.get('source_sql_name')}: {item.get('error')}" for item in resolution.get("parse_errors") or []
-        )
-        raise DatusException(
-            ErrorCode.SEMANTIC_MODEL_BOOTSTRAP_FAILED,
-            message_args={"error_message": f"invalid structured source SQL: {errors or resolution.get('reason')}"},
-        )
+        self.generation_evidence.reset()
+        self.osi_target_state.reset()
 
     def _ensure_bash_tool_in_tools(self) -> None:
         """Keep OSI metric authoring on its metrics-only filesystem surface."""
@@ -307,6 +189,10 @@ class GenMetricsAgenticNode(AgenticNode):
         if inherited_memory_node is None:
             inherited_memory_node = get_inherited_memory(current_node)
         session_data_dir = kwargs.pop("session_data_dir", None) or self._resolve_session_data_dir()
+        mutation_callback = kwargs.pop(
+            "mutation_callback",
+            self.generation_evidence.invalidate_artifact_evidence,
+        )
         return MetricFilesystemFuncTool(
             root_path=root_path,
             current_node=current_node,
@@ -314,7 +200,9 @@ class GenMetricsAgenticNode(AgenticNode):
             strict=strict,
             inherited_memory_node=inherited_memory_node,
             session_data_dir=session_data_dir,
+            mutation_callback=mutation_callback,
             authoring_format=resolve_authoring_format(self.agent_config),
+            osi_target_state=self.osi_target_state,
             **kwargs,
         )
 
@@ -340,11 +228,11 @@ class GenMetricsAgenticNode(AgenticNode):
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
                 authoring_format=authoring_format,
+                osi_target_state=self.osi_target_state,
+                require_bound_osi_target=authoring_format == "osi",
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
-            if authoring_format == "osi":
-                self.tools.append(trans_to_function_tool(self.generation_tools.resolve_osi_semantic_model_target))
             self.tools.append(trans_to_function_tool(self.generation_tools.end_metric_generation))
             if authoring_format != "osi":
                 self.tools.append(trans_to_function_tool(self.generation_tools.end_semantic_model_generation))
@@ -352,6 +240,26 @@ class GenMetricsAgenticNode(AgenticNode):
 
         except Exception as e:
             logger.error(f"Failed to setup generation tools: {e}")
+
+    def _setup_osi_target_tools(self) -> None:
+        """Expose live inventory and exact binding without touching DB or RAG."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        if not is_osi_authoring(self.agent_config):
+            return
+        from datus.tools.func_tool import OsiSemanticModelTargetTools, trans_to_function_tool
+
+        self.osi_target_tools = OsiSemanticModelTargetTools(
+            self.agent_config,
+            target_state=self.osi_target_state,
+            generation_evidence=self.generation_evidence,
+        )
+        self.tools.extend(
+            [
+                trans_to_function_tool(self.osi_target_tools.list_existing_osi_semantic_models),
+                trans_to_function_tool(self.osi_target_tools.bind_osi_semantic_model_target),
+            ]
+        )
 
     def _setup_skill_func_tools(self) -> None:
         """Default the optional skill set from the active authoring format."""
@@ -412,17 +320,18 @@ class GenMetricsAgenticNode(AgenticNode):
     def _setup_semantic_discovery_tools(self):
         """Setup read-only semantic discovery tools."""
         try:
-            if not self.db_func_tool:
-                logger.warning("DBFuncTool not initialized, skipping semantic_discovery_tools setup")
-                return
-
             from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
 
-            self.semantic_discovery_tools = SemanticDiscoveryTools(self.db_func_tool)
-            self.tools.extend(self.semantic_discovery_tools.available_tools())
+            self.semantic_discovery_tools = SemanticDiscoveryTools(
+                self.db_func_tool,
+                agent_config=self.agent_config,
+                sub_agent_name=self.NODE_NAME,
+            )
+            discovery_tools = self.semantic_discovery_tools.available_tools()
+            self.tools.extend(discovery_tools)
             logger.debug(
-                "Added semantic discovery tools: analyze_table_relationships, get_multiple_tables_ddl, "
-                "analyze_column_usage_patterns, analyze_metric_candidates_from_history"
+                "Added semantic discovery tools: %s",
+                [tool.name for tool in discovery_tools],
             )
         except Exception as e:
             logger.error(f"Failed to setup semantic discovery tools: {e}")
@@ -473,22 +382,9 @@ class GenMetricsAgenticNode(AgenticNode):
         context["has_ask_user_tool"] = self.ask_user_tool is not None
         context.update(build_datasource_prompt_context(self.agent_config))
 
-        from datus.agent.node.semantic_authoring import (
-            default_osi_semantic_model_file,
-            default_osi_semantic_model_name,
-            resolve_authoring_format,
-        )
+        from datus.agent.node.semantic_authoring import resolve_authoring_format
 
         context["authoring_format"] = resolve_authoring_format(self.agent_config)
-        # Request-scoped target details belong in the enhanced user message;
-        # this context is frozen in the per-session system-prompt snapshot.
-        context["requested_semantic_model_name"] = ""
-        context["requested_business_domain"] = ""
-        context["requested_fact_tables"] = []
-        context["requested_dimension_tables"] = []
-        context["osi_target_resolved"] = False
-        context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
-        context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
 
         # Handle subject_tree context based on whether predefined or query from storage
         if self.subject_tree:
@@ -508,19 +404,29 @@ class GenMetricsAgenticNode(AgenticNode):
         user_input: SemanticNodeInput,
         extra_enhanced_parts: Optional[List[str]] = None,
     ) -> str:
-        """Add the resolved Ossie target to this turn instead of the cached system prompt."""
-        from datus.agent.node.semantic_authoring import osi_semantic_model_turn_context
+        """Expose a structured caller hint without resolving it on the host."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
 
         parts = list(extra_enhanced_parts or [])
-        target_context = osi_semantic_model_turn_context(self.agent_config, user_input)
-        if target_context:
-            parts.append(target_context)
+        semantic_model_name = str(getattr(user_input, "semantic_model_name", "") or "").strip()
+        semantic_model_file = str(getattr(user_input, "semantic_model_file", "") or "").strip()
+        if is_osi_authoring(self.agent_config) and (semantic_model_name or semantic_model_file):
+            hints = ["## OSI Semantic Model Selection Hint for This Turn"]
+            if semantic_model_file:
+                hints.append(f"- Requested semantic model file: `{semantic_model_file}`")
+            if semantic_model_name:
+                hints.append(f"- Requested semantic model name: `{semantic_model_name}`")
+            hints.append(
+                "Treat these as unverified hints: call `bind_osi_semantic_model_target` with the exact "
+                "selectors, then inspect the live inventory if binding fails."
+            )
+            parts.append("\n".join(hints))
         return super()._build_enhanced_message(user_input, parts)
 
     def _system_prompt_snapshot_meta(self, prompt_version: Optional[str]) -> Dict[str, str]:
         """Invalidate snapshots created before semantic targets became request-scoped."""
         meta = super()._system_prompt_snapshot_meta(prompt_version)
-        meta["semantic_target_scope"] = "per_turn_v1"
+        meta["semantic_target_scope"] = "agent_bound_v3"
         return meta
 
     def _get_system_prompt(
@@ -586,7 +492,7 @@ class GenMetricsAgenticNode(AgenticNode):
         self._set_metric_queryability_contracts_from_input(ctx.user_input)
         return self._prepare_template_context(ctx.user_input)
 
-    def _build_success_result(self, ctx: StreamRunContext) -> SemanticNodeResult:
+    def _build_success_result(self, ctx: StreamRunContext) -> GenMetricsNodeResult:
         response_content = ctx.response_content
         if not response_content and ctx.last_successful_output:
             raw_output = ctx.last_successful_output.get("raw_output", "")
@@ -595,8 +501,8 @@ class GenMetricsAgenticNode(AgenticNode):
             else:
                 response_content = str(ctx.last_successful_output)
 
-        semantic_model_files, metric_file, status, extracted_output = self._extract_metric_and_output_from_response(
-            {"content": response_content}
+        semantic_model_files, metric_file, status, blocker_code, skip_reason, extracted_output = (
+            self._extract_metric_and_output_from_response({"content": response_content})
         )
         if extracted_output:
             response_content = extracted_output
@@ -604,21 +510,57 @@ class GenMetricsAgenticNode(AgenticNode):
         if not isinstance(response_content, str):
             response_content = str(response_content) if response_content else ""
 
-        self._finalize_metric_generation(
-            semantic_model_files=semantic_model_files,
-            metric_file=metric_file,
-            status=status,
-        )
+        if status is not None and status not in {"generated", "skipped", "blocked"}:
+            raise RuntimeError(f"Unsupported metric generation status: {status!r}")
+        if skip_reason is not None and skip_reason != "not_a_metric":
+            raise RuntimeError(f"Unsupported metric generation skip_reason: {skip_reason!r}")
+        if skip_reason is not None and status != "skipped":
+            raise RuntimeError("skip_reason is only valid when status='skipped'.")
+        normalized_status = status
+        if normalized_status == "blocked":
+            if metric_file or self.osi_target_state.authored_metric_names:
+                raise RuntimeError(
+                    "status='blocked' is only valid before metric authoring and with metric_file set to null."
+                )
+            if blocker_code not in {
+                "semantic_model_required",
+                "semantic_model_selection_required",
+                "semantic_model_target_invalid",
+            }:
+                raise RuntimeError("status='blocked' requires a supported semantic-model blocker_code.")
+            if self.osi_target_tools is None:
+                raise RuntimeError("status='blocked' is only supported for OSI metric generation.")
+            final_metric_file = None
+        else:
+            self._finalize_metric_generation(
+                semantic_model_files=semantic_model_files,
+                metric_file=metric_file,
+                status=normalized_status,
+                skip_reason=skip_reason,
+            )
+            target_state = getattr(self, "osi_target_state", None)
+            bound = target_state.bound if target_state is not None else None
+            final_metric_file = (
+                str(bound["semantic_model_file"])
+                if bound is not None and target_state.authored_metric_names
+                else metric_file
+            )
+            if normalized_status is None:
+                normalized_status = "generated" if final_metric_file else "skipped"
 
         tokens_used = 0
         if self.execution_mode == "interactive":
             tokens_used = self._extract_total_tokens(ctx.action_history_manager.get_actions())
 
-        return SemanticNodeResult(
-            success=True,
+        return GenMetricsNodeResult(
+            success=normalized_status != "blocked",
+            error=response_content if normalized_status == "blocked" else None,
             response=response_content,
-            semantic_models=[metric_file] if metric_file else [],
+            semantic_models=[final_metric_file] if final_metric_file else [],
             tokens_used=int(tokens_used),
+            status=normalized_status,
+            blocker_code=blocker_code if normalized_status == "blocked" else None,
+            skip_reason=skip_reason if normalized_status == "skipped" else None,
         )
 
     @staticmethod
@@ -764,6 +706,7 @@ class GenMetricsAgenticNode(AgenticNode):
         semantic_model_files: Optional[List[str] | str],
         metric_file: Optional[str],
         status: Optional[str],
+        skip_reason: Optional[str] = None,
     ) -> None:
         """Ensure generated metric artifacts are published without relying on one LLM tool call."""
         from datus.agent.node.semantic_authoring import is_osi_authoring
@@ -773,6 +716,7 @@ class GenMetricsAgenticNode(AgenticNode):
                 semantic_model_files=semantic_model_files,
                 metric_file=metric_file,
                 status=status,
+                skip_reason=skip_reason,
             )
             return
 
@@ -862,58 +806,91 @@ class GenMetricsAgenticNode(AgenticNode):
         )
         if not self._tool_succeeded(publish_result):
             raise RuntimeError(f"Metric KB sync failed: {self._tool_error(publish_result)}")
-        self.generation_evidence.mark_kb_sync("metric")
 
     def _finalize_osi_metric_generation(
         self,
         semantic_model_files: Optional[List[str] | str],
         metric_file: Optional[str],
         status: Optional[str],
+        skip_reason: Optional[str],
     ) -> None:
-        """Finalize OSI-authored metrics without using MetricFlow YAML preflight."""
+        """Validate and publish only the exact target bound during this request."""
+        del semantic_model_files
         normalized_status = status.strip().lower() if isinstance(status, str) else status
+        bound = self.osi_target_state.bound
+        metric_names = list(self.osi_target_state.authored_metric_names)
 
         if normalized_status == "skipped":
-            if metric_file:
+            if metric_file or metric_names:
                 raise RuntimeError(
-                    "Metric generation returned status='skipped' with a non-null metric_file. "
-                    "Skipped responses must set metric_file to null; generated metric files must be published."
+                    "Metric generation cannot return status='skipped' after authoring metrics "
+                    "or with a non-null metric_file."
+                )
+            if skip_reason != "not_a_metric":
+                raise RuntimeError(
+                    "OSI status='skipped' is only valid for a non-metric request with skip_reason='not_a_metric'. "
+                    "Existing requested metrics must be idempotently upserted and published."
                 )
             return
-
-        if self.generation_evidence.metric_kb_sync_passed:
-            return
-
-        if normalized_status and not metric_file:
+        if self.osi_target_state.last_error_code:
             raise RuntimeError(
-                f"Metric generation returned status='{normalized_status}' without a metric_file. "
-                "Non-skipped OSI metric responses must include metric_file or call end_metric_generation."
+                "The OSI target selection is unresolved after a failed bind. "
+                "Bind a valid target again or return a matching blocked result."
+            )
+        if bound is None:
+            raise RuntimeError(
+                "OSI metric generation must bind an existing semantic model or return a supported blocked result."
+            )
+        if not metric_names:
+            raise RuntimeError(
+                "No metrics were authored or scheduled for idempotent publish in the bound OSI semantic model. "
+                "Pass every requested metric through upsert_osi_metrics, including unchanged existing definitions."
             )
 
-        if not metric_file:
+        abs_metric_file = str(bound["absolute_path"])
+        try:
+            self.osi_target_state.require_current_revision(abs_metric_file)
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        artifact_validated = self.generation_evidence.semantic_artifact_validation_passed(
+            bound["semantic_model_name"],
+            abs_metric_file,
+        )
+        if self.generation_evidence.has_metric_kb_sync(metric_names) and artifact_validated:
             return
 
+        if metric_file:
+            try:
+                reported = self._resolve_metric_artifact_path(metric_file, "metric")
+            except RuntimeError:
+                reported = ""
+            if reported and reported != abs_metric_file:
+                logger.warning(
+                    "Ignoring LLM-reported metric_file %s; publishing bound target %s",
+                    metric_file,
+                    bound["semantic_model_file"],
+                )
+
         if not self.generation_tools:
-            raise RuntimeError("Metric generation produced a metric_file, but generation tools are unavailable.")
+            raise RuntimeError("Metrics were authored in a bound OSI target, but generation tools are unavailable.")
         self._set_metric_queryability_contracts_from_input(getattr(self, "input", None))
 
         if not getattr(self, "semantic_tools", None):
-            raise RuntimeError("Metric generation produced a metric_file, but validate_semantic is unavailable.")
-        abs_metric_file = self._resolve_metric_artifact_path(metric_file, "metric")
+            raise RuntimeError("Metrics were authored in a bound OSI target, but validate_semantic is unavailable.")
         model_names = self.generation_tools.extract_osi_model_names(abs_metric_file)
-        if len(model_names) != 1:
-            raise RuntimeError("The generated Ossie metric artifact must declare exactly one semantic model.")
-        validation_result = self.semantic_tools.validate_semantic(
-            semantic_model_name=model_names[0],
-            checks=["authoring_quality"],
-        )
-        self.generation_evidence.record_validation_result(validation_result)
-        if not self._tool_succeeded(validation_result):
-            raise RuntimeError(
-                f"validate_semantic failed before publishing OSI metrics: {self._tool_error(validation_result)}"
+        if model_names != [bound["semantic_model_name"]]:
+            raise RuntimeError("The bound OSI artifact no longer declares the selected semantic model.")
+        if not artifact_validated:
+            validation_result = self.semantic_tools.validate_semantic(
+                semantic_model_name=bound["semantic_model_name"],
             )
+            self.generation_evidence.record_validation_result(validation_result)
+            if not self._tool_succeeded(validation_result):
+                raise RuntimeError(
+                    f"validate_semantic failed before publishing OSI metrics: {self._tool_error(validation_result)}"
+                )
 
-        metric_names = self.generation_tools.extract_osi_metric_names(abs_metric_file)
         if metric_names and not self.generation_evidence.has_metric_dry_run(metric_names):
             query_metrics = getattr(getattr(self, "semantic_tools", None), "query_metrics", None)
             if not callable(query_metrics):
@@ -925,33 +902,31 @@ class GenMetricsAgenticNode(AgenticNode):
                     "query_metrics(dry_run=True) failed for generated OSI metric(s) "
                     f"{', '.join(metric_names)}: {self._tool_error(dry_run_result)}"
                 )
-        if metric_names and not self.generation_evidence.has_required_queryability_dry_runs(metric_names):
-            missing_contracts = self.generation_evidence.missing_queryability_contracts(metric_names)
-            raise DatusException(
-                ErrorCode.COMMON_VALIDATION_FAILED,
-                "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions before "
-                "publishing metrics. Run a dry-run query for the generated metric names with the matching "
-                "dimensions/time grain, fix semantic model join or dimension issues, and retry. "
-                f"Missing: {summarize_queryability_contracts(missing_contracts)}",
-            )
-
         publish_result = self.generation_tools.end_metric_generation(
             metric_file=abs_metric_file,
             semantic_model_files=[],
         )
         if not self._tool_succeeded(publish_result):
             raise RuntimeError(f"OSI metric KB sync failed: {self._tool_error(publish_result)}")
-        self.generation_evidence.mark_kb_sync("metric")
 
     def _extract_metric_and_output_from_response(
         self, output: dict
-    ) -> tuple[Optional[List[str]], Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[
+        Optional[List[str]],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+    ]:
         """
         Extract semantic model files, metric file, status and formatted output from model response.
 
         Per prompt template requirements, LLM should return JSON format:
         {"semantic_model_files": ["path.yml"], "metric_file": "path.yml",
-         "status": "generated" | "skipped", "output": "markdown text"}
+         "status": "generated" | "skipped" | "blocked", "blocker_code": null,
+         "skip_reason": null | "not_a_metric",
+         "output": "markdown text"}
 
         ``status`` is optional for backward compatibility; absent values are treated as ``"generated"``.
 
@@ -959,7 +934,8 @@ class GenMetricsAgenticNode(AgenticNode):
             output: Output dictionary from model generation
 
         Returns:
-            Tuple of (semantic_model_files, metric_file, status, output_string).
+            Tuple of (semantic_model_files, metric_file, status, blocker_code,
+            skip_reason, output_string).
         """
         try:
             from datus.utils.json_utils import strip_json_str
@@ -974,13 +950,22 @@ class GenMetricsAgenticNode(AgenticNode):
                 metric_file = content.get("metric_file")
                 status = content.get("status")
                 normalized_status = status.strip().lower() if isinstance(status, str) else None
+                blocker_code = content.get("blocker_code")
+                skip_reason = content.get("skip_reason")
 
                 if (metric_file and isinstance(metric_file, str)) or normalized_status:
                     logger.debug(
                         f"Extracted from dict: semantic_model_files={semantic_model_files}, "
                         f"metric_file={metric_file}, status={normalized_status}"
                     )
-                    return semantic_model_files, metric_file, normalized_status, output_text
+                    return (
+                        semantic_model_files,
+                        metric_file,
+                        normalized_status,
+                        blocker_code,
+                        skip_reason,
+                        output_text,
+                    )
 
                 logger.warning(f"Dict format but missing expected keys or invalid format: {content.keys()}")
 
@@ -999,6 +984,8 @@ class GenMetricsAgenticNode(AgenticNode):
                             metric_file = parsed.get("metric_file")
                             status = parsed.get("status")
                             normalized_status = status.strip().lower() if isinstance(status, str) else None
+                            blocker_code = parsed.get("blocker_code")
+                            skip_reason = parsed.get("skip_reason")
 
                             if (metric_file and isinstance(metric_file, str)) or normalized_status:
                                 logger.debug(
@@ -1006,18 +993,25 @@ class GenMetricsAgenticNode(AgenticNode):
                                     f"semantic_model_files={semantic_model_files}, "
                                     f"metric_file={metric_file}, status={normalized_status}"
                                 )
-                                return semantic_model_files, metric_file, normalized_status, output_text
+                                return (
+                                    semantic_model_files,
+                                    metric_file,
+                                    normalized_status,
+                                    blocker_code,
+                                    skip_reason,
+                                    output_text,
+                                )
 
                             logger.warning(f"Parsed JSON but missing expected keys or invalid format: {parsed.keys()}")
                     except Exception as e:
                         logger.warning(f"Failed to parse cleaned JSON: {e}. Cleaned content: {cleaned_json[:200]}")
 
             logger.warning(f"Could not extract metric_file from response. Content type: {type(content)}")
-            return None, None, None, None
+            return None, None, None, None, None, None
 
         except Exception as e:
             logger.error(f"Unexpected error extracting metric_file: {e}", exc_info=True)
-            return None, None, None, None
+            return None, None, None, None, None, None
 
     @staticmethod
     def _normalize_semantic_model_files(content: Dict[str, Any]) -> List[str]:

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -98,6 +98,10 @@ class GenSemanticModelAgenticNode(AgenticNode):
         self.filesystem_func_tool: Optional[FilesystemFuncTool] = None
         self.generation_tools: Optional[GenerationTools] = None
         self.semantic_discovery_tools: Optional[SemanticDiscoveryTools] = None
+        from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
+
+        self.osi_target_state = OsiSemanticModelTargetState()
+        self.osi_target_tools = None
         self.ask_user_tool = None
         self.hooks = None
         self.generation_evidence = GenerationEvidence()
@@ -132,6 +136,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
 
         self.tools = []
 
+        self._setup_osi_target_tools()
         self._setup_db_tools()
         self._setup_semantic_discovery_tools()
         self._setup_semantic_tools()
@@ -145,6 +150,12 @@ class GenSemanticModelAgenticNode(AgenticNode):
         # Setup hooks (only in interactive mode)
         if self.execution_mode == "interactive":
             self._setup_hooks()
+
+    async def _before_stream(self, ctx: StreamRunContext) -> None:
+        """Reset request-local authoring state before the agent loop."""
+        await super()._before_stream(ctx)
+        self.generation_evidence.reset()
+        self.osi_target_state.reset()
 
     def _setup_db_tools(self):
         """Setup database tools."""
@@ -230,7 +241,12 @@ class GenSemanticModelAgenticNode(AgenticNode):
         try:
             from datus.agent.node.semantic_authoring import is_osi_authoring
 
-            self.filesystem_func_tool = self._make_filesystem_tool()
+            filesystem_kwargs = {
+                "mutation_callback": self._record_semantic_model_mutation,
+            }
+            if is_osi_authoring(self.agent_config):
+                filesystem_kwargs["mutation_guard"] = self.osi_target_state.require_planned_path
+            self.filesystem_func_tool = self._make_filesystem_tool(**filesystem_kwargs)
             filesystem_tools = self.filesystem_func_tool.available_tools()
             if is_osi_authoring(self.agent_config):
                 filesystem_tools = [tool for tool in filesystem_tools if tool.name != "delete_file"]
@@ -238,6 +254,14 @@ class GenSemanticModelAgenticNode(AgenticNode):
             logger.debug("Added filesystem tools: read_file, write_file, edit_file, glob, grep")
         except Exception as e:
             logger.error(f"Failed to setup filesystem tools: {e}")
+
+    def _record_semantic_model_mutation(self) -> None:
+        """Invalidate publish evidence and freeze an authored OSI plan."""
+        self.generation_evidence.invalidate_artifact_evidence()
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        if is_osi_authoring(self.agent_config):
+            self.osi_target_state.record_planned_write()
 
     def _setup_generation_tools(self):
         """Setup generation tools."""
@@ -250,16 +274,30 @@ class GenSemanticModelAgenticNode(AgenticNode):
                 self.agent_config,
                 generation_evidence=self.generation_evidence,
                 authoring_format=authoring_format,
+                osi_target_state=self.osi_target_state,
             )
 
             self.tools.append(trans_to_function_tool(self.generation_tools.check_semantic_object_exists))
-            if authoring_format == "osi":
-                self.tools.append(trans_to_function_tool(self.generation_tools.resolve_osi_semantic_model_target))
             self.tools.append(trans_to_function_tool(self.generation_tools.end_semantic_model_generation))
             logger.debug("Added semantic-model generation tools for authoring_format=%s", authoring_format)
 
         except Exception as e:
             logger.error(f"Failed to setup generation tools: {e}")
+
+    def _setup_osi_target_tools(self) -> None:
+        """Expose only semantic-model target planning on this node."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        if not is_osi_authoring(self.agent_config):
+            return
+        from datus.tools.func_tool import OsiSemanticModelTargetTools, trans_to_function_tool
+
+        self.osi_target_tools = OsiSemanticModelTargetTools(
+            self.agent_config,
+            target_state=self.osi_target_state,
+            generation_evidence=self.generation_evidence,
+        )
+        self.tools.append(trans_to_function_tool(self.osi_target_tools.plan_osi_semantic_model_target))
 
     def _setup_skill_func_tools(self) -> None:
         """Default the optional skill set from the active authoring format."""
@@ -332,22 +370,9 @@ class GenSemanticModelAgenticNode(AgenticNode):
         context["has_ask_user_tool"] = self.ask_user_tool is not None
         context.update(build_datasource_prompt_context(self.agent_config))
 
-        from datus.agent.node.semantic_authoring import (
-            default_osi_semantic_model_file,
-            default_osi_semantic_model_name,
-            resolve_authoring_format,
-        )
+        from datus.agent.node.semantic_authoring import resolve_authoring_format
 
         context["authoring_format"] = resolve_authoring_format(self.agent_config)
-        # Request-scoped target details belong in the enhanced user message;
-        # this context is frozen in the per-session system-prompt snapshot.
-        context["requested_semantic_model_name"] = ""
-        context["requested_business_domain"] = ""
-        context["requested_fact_tables"] = []
-        context["requested_dimension_tables"] = []
-        context["osi_target_resolved"] = False
-        context["default_osi_semantic_model_name"] = default_osi_semantic_model_name(self.agent_config)
-        context["default_osi_semantic_model_file"] = default_osi_semantic_model_file(self.agent_config)
         context["osi_authoring_spec"] = ""
         if context["authoring_format"] == "osi":
             # The OSI core spec document ships with the adapter package so the
@@ -381,7 +406,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
     def _system_prompt_snapshot_meta(self, prompt_version: Optional[str]) -> Dict[str, str]:
         """Invalidate snapshots created before semantic targets became request-scoped."""
         meta = super()._system_prompt_snapshot_meta(prompt_version)
-        meta["semantic_target_scope"] = "per_turn_v1"
+        meta["semantic_target_scope"] = "agent_bound_v2"
         return meta
 
     def _get_system_prompt(
@@ -458,6 +483,10 @@ class GenSemanticModelAgenticNode(AgenticNode):
         semantic_model_files, extracted_output = self._extract_semantic_model_and_output_from_response(
             {"content": response_content}
         )
+        target_state = getattr(self, "osi_target_state", None)
+        planned = target_state.planned if target_state is not None else None
+        if planned is not None:
+            semantic_model_files = [str(planned["semantic_model_file"])]
         if extracted_output:
             response_content = extracted_output
 
@@ -505,45 +534,26 @@ class GenSemanticModelAgenticNode(AgenticNode):
         db_schema=None,
     ) -> None:
         """Validate and publish semantic model artifacts without relying on one LLM tool call."""
+        from datus.agent.node.semantic_authoring import is_osi_authoring
+
+        if is_osi_authoring(self.agent_config):
+            self._finalize_osi_semantic_model_generation()
+            return
+
         if not semantic_model_files or self.generation_evidence.semantic_kb_sync_passed:
             return
 
-        from datus.agent.node.semantic_authoring import is_osi_authoring
-
-        osi_target = None
-        validation_passed = self.generation_evidence.validation_passed
-        if is_osi_authoring(self.agent_config):
-            if len(semantic_model_files) != 1:
-                raise RuntimeError("Ossie semantic model generation must publish exactly one target file.")
-            if not getattr(self, "generation_tools", None):
-                raise RuntimeError("Cannot resolve the generated Ossie model name without generation tools.")
-            resolved = self.generation_tools._resolve_generation_path(semantic_model_files[0], "semantic")
-            if not resolved:
-                raise RuntimeError("The generated Ossie file is outside the Knowledge Base sandbox.")
-            model_names = self.generation_tools.extract_osi_model_names(resolved)
-            if len(model_names) != 1:
-                raise RuntimeError("The generated Ossie file must declare exactly one semantic model.")
-            osi_target = (resolved, model_names[0])
-            validation_passed = self.generation_evidence.semantic_artifact_validation_passed(model_names[0], resolved)
-
-        if not validation_passed:
+        if not self.generation_evidence.validation_passed:
             if not getattr(self, "semantic_func_tool", None):
                 raise RuntimeError(
                     "Semantic model generation produced semantic_model_files, but validate_semantic is unavailable."
                 )
-            validation_kwargs = {"scope": "semantic_model"}
-            if osi_target is not None:
-                resolved, model_name = osi_target
-                validation_kwargs["semantic_model_name"] = model_name
-            validation_result = self.semantic_func_tool.validate_semantic(**validation_kwargs)
+            validation_result = self.semantic_func_tool.validate_semantic(scope="semantic_model")
             self.generation_evidence.record_validation_result(validation_result)
             if not self._tool_succeeded(validation_result):
                 raise RuntimeError(
                     f"validate_semantic failed before publishing semantic models: {self._tool_error(validation_result)}"
                 )
-            if osi_target is not None:
-                if not self.generation_evidence.record_semantic_artifact_validation(model_name, resolved):
-                    raise RuntimeError("Cannot bind semantic validation evidence to the generated Ossie artifact.")
 
         synced_files = []
         failed_files = []
@@ -565,6 +575,42 @@ class GenSemanticModelAgenticNode(AgenticNode):
             )
 
         logger.info(f"Auto-saved {len(synced_files)} semantic models to database")
+
+    def _finalize_osi_semantic_model_generation(self) -> None:
+        """Run the same exact-target gate whether or not the LLM called the end tool."""
+        if not getattr(self, "generation_tools", None):
+            raise RuntimeError("OSI semantic model generation tools are unavailable.")
+
+        try:
+            semantic_model_file, resolved, model_name = self.generation_tools._resolve_planned_osi_semantic_target()
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        if self.generation_evidence.semantic_kb_sync_passed:
+            if self.generation_evidence.semantic_artifact_validation_passed(model_name, resolved):
+                return
+            self.generation_evidence.invalidate_artifact_evidence()
+
+        if not self.generation_evidence.semantic_artifact_validation_passed(model_name, resolved):
+            if not getattr(self, "semantic_func_tool", None):
+                raise RuntimeError(
+                    "Semantic model generation produced a planned OSI target, but validate_semantic is unavailable."
+                )
+            validation_result = self.semantic_func_tool.validate_semantic(
+                scope="semantic_model",
+                semantic_model_name=model_name,
+            )
+            self.generation_evidence.record_validation_result(validation_result)
+            if not self._tool_succeeded(validation_result):
+                raise RuntimeError(
+                    f"validate_semantic failed before publishing semantic models: {self._tool_error(validation_result)}"
+                )
+            if not self.generation_evidence.record_semantic_artifact_validation(model_name, resolved):
+                raise RuntimeError("Cannot bind semantic validation evidence to the planned OSI artifact.")
+
+        publish_result = self.generation_tools.end_semantic_model_generation([semantic_model_file])
+        if not self._tool_succeeded(publish_result):
+            raise RuntimeError(f"OSI semantic model KB sync failed: {self._tool_error(publish_result)}")
 
     def _extract_semantic_model_and_output_from_response(self, output: dict) -> tuple[list[str], Optional[str]]:
         """

--- a/datus/agent/node/gen_semantic_model_agentic_node.py
+++ b/datus/agent/node/gen_semantic_model_agentic_node.py
@@ -582,7 +582,7 @@ class GenSemanticModelAgenticNode(AgenticNode):
             raise RuntimeError("OSI semantic model generation tools are unavailable.")
 
         try:
-            semantic_model_file, resolved, model_name = self.generation_tools._resolve_planned_osi_semantic_target()
+            semantic_model_file, resolved, model_name = self.generation_tools.resolve_planned_osi_semantic_target()
         except ValueError as exc:
             raise RuntimeError(str(exc)) from exc
 

--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -24,12 +24,11 @@ into the prompt at render time (see ``required_authoring_skills``).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import re
 import weakref
 from contextlib import asynccontextmanager
-from contextvars import ContextVar
-from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
@@ -39,10 +38,6 @@ AUTHORING_FORMAT_METRICFLOW = "metricflow"
 AUTHORING_FORMAT_OSI = "osi"
 
 _SEMANTIC_AUTHORING_LOCKS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
-_HELD_SEMANTIC_AUTHORING_KEYS: ContextVar[frozenset[str]] = ContextVar(
-    "held_semantic_authoring_keys",
-    default=frozenset(),
-)
 
 # Authoring specification skills injected into the system prompt on every run,
 # keyed by node name then authoring format. These carry the full YAML format
@@ -118,88 +113,6 @@ def _normalize_model_name(value: Any) -> str:
     return text
 
 
-def _declared_field_names(value: Any) -> set[str]:
-    if is_dataclass(value):
-        return {field.name for field in fields(value)}
-
-    for attr_name in ("model_fields", "__fields__"):
-        field_map = getattr(value, attr_name, None) or getattr(type(value), attr_name, None)
-        if isinstance(field_map, dict):
-            return set(field_map)
-
-    annotations = getattr(type(value), "__annotations__", None)
-    return set(annotations) if isinstance(annotations, dict) else set()
-
-
-def _config_field_value(config: Any, field_name: str) -> Any:
-    if isinstance(config, dict):
-        value = config.get(field_name, "")
-    elif field_name in _declared_field_names(config):
-        value = getattr(config, field_name, "")
-    else:
-        return ""
-    return "" if callable(value) else value
-
-
-def default_osi_semantic_model_name(agent_config: Any = None) -> str:
-    """Return the default OSI semantic model name for the current authoring scope."""
-    candidates = []
-    if agent_config is not None:
-        runtime_context = {}
-        runtime_context_getter = getattr(agent_config, "runtime_db_context", None)
-        if callable(runtime_context_getter):
-            try:
-                runtime_context = runtime_context_getter() or {}
-            except Exception:
-                runtime_context = {}
-        if isinstance(runtime_context, dict):
-            candidates.extend(
-                [
-                    runtime_context.get("database"),
-                    runtime_context.get("database_name"),
-                    runtime_context.get("schema"),
-                    runtime_context.get("db_schema"),
-                    runtime_context.get("schema_name"),
-                    runtime_context.get("catalog"),
-                    runtime_context.get("catalog_name"),
-                ]
-            )
-        try:
-            db_config = agent_config.current_db_config()
-        except Exception:
-            db_config = None
-        if db_config is not None:
-            candidates.extend(
-                [
-                    _config_field_value(db_config, "database"),
-                    _config_field_value(db_config, "schema"),
-                    _config_field_value(db_config, "catalog"),
-                ]
-            )
-        candidates.extend(
-            [
-                getattr(agent_config, "current_datasource", ""),
-                getattr(agent_config, "project_name", ""),
-            ]
-        )
-
-    for candidate in candidates:
-        normalized = _normalize_model_name(candidate)
-        if normalized:
-            return normalized
-    return "semantic_model"
-
-
-def default_osi_semantic_model_file(agent_config: Any = None) -> str:
-    """Return the project-relative default YAML path for OSI domain authoring."""
-    datasource = ""
-    if agent_config is not None:
-        datasource = str(getattr(agent_config, "current_datasource", "") or "").strip()
-    if not datasource:
-        datasource = "default"
-    return f"subject/semantic_models/{datasource}/{default_osi_semantic_model_name(agent_config)}.yml"
-
-
 def _osi_semantic_model_dir(agent_config: Any = None) -> Optional[Path]:
     """Return the active datasource's semantic-model directory when resolvable."""
     if agent_config is None:
@@ -251,18 +164,18 @@ def _table_reference(value: Any) -> tuple[str, str, bool]:
 
 
 def _table_references_match(left: Any, right: Any) -> bool:
-    """Match qualified references exactly, falling back only for unqualified input."""
+    """Match a requested table without discarding explicit qualification."""
     left_qualified, left_leaf, left_is_qualified = _table_reference(left)
     right_qualified, right_leaf, right_is_qualified = _table_reference(right)
     if not left_leaf or not right_leaf:
         return False
-    if left_is_qualified and right_is_qualified:
-        return left_qualified == right_qualified
+    if left_is_qualified:
+        return right_is_qualified and left_qualified == right_qualified
     return left_leaf == right_leaf
 
 
 def _model_covers_table(model: Dict[str, Any], table: Any) -> bool:
-    references = model.get("table_references") or model.get("dataset_sources") or model.get("dataset_names") or []
+    references = model.get("table_references") or []
     return any(_table_references_match(table, reference) for reference in references)
 
 
@@ -294,80 +207,234 @@ def _dataset_table_references(agent_config: Any, dataset: Dict[str, Any], datase
         agent_config,
         [{"source_sql_name": str(dataset.get("name") or "query_backed_dataset"), "sql": dataset_source}],
     )
-    return references if not parse_errors else [dataset_source]
+    return references if not parse_errors else []
 
 
-def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any]]:
-    """Discover Ossie semantic models already authored for the active datasource.
+def validate_osi_core_document(document: Any) -> Optional[str]:
+    """Validate one parsed document with the OSI package's canonical schema."""
+    if not isinstance(document, dict):
+        return "YAML document must be an object"
+    try:
+        from datus_semantic_osi.errors import OSIValidationError
+        from datus_semantic_osi.profile import validate_osi_core_schema
+    except ImportError as exc:
+        return f"OSI schema validator is unavailable: {exc}"
 
-    The result is intentionally filesystem-backed rather than vector-store-backed:
-    target selection must preserve the durable model name and file even before or
-    after Knowledge Base synchronization.
+    try:
+        validate_osi_core_schema(document)
+    except OSIValidationError as exc:
+        return str(exc)
+    return None
+
+
+def inspect_osi_semantic_model_inventory(agent_config: Any = None) -> Dict[str, Any]:
+    """Inspect every YAML file in the active datasource semantic-model tree.
+
+    ``models`` contains schema-valid targets that metrics may bind. A parsed
+    single-model document with a stable name remains in ``recoverable_models``
+    when only core-schema validation fails, so semantic authoring can repair it
+    without weakening metric binding.
     """
     model_dir = _osi_semantic_model_dir(agent_config)
     if model_dir is None or not model_dir.is_dir():
-        return []
+        return {
+            "models": [],
+            "recoverable_models": [],
+            "issues": [],
+            "discovery_warnings": [],
+            "files_scanned": 0,
+        }
 
     datasource = str(getattr(agent_config, "current_datasource", "") or "default").strip() or "default"
+    model_root = model_dir.resolve(strict=False)
     discovered: list[Dict[str, Any]] = []
-    paths = sorted([*model_dir.glob("*.yml"), *model_dir.glob("*.yaml")])
+    recoverable: list[Dict[str, Any]] = []
+    issues: list[Dict[str, Any]] = []
+    discovery_warnings: list[Dict[str, Any]] = []
+    paths = sorted(
+        path
+        for path in {*model_dir.rglob("*.yml"), *model_dir.rglob("*.yaml")}
+        if "metrics" not in path.relative_to(model_dir).parts
+    )
     for path in paths:
+        relative_path = path.relative_to(model_dir).as_posix()
+        semantic_model_file = f"subject/semantic_models/{datasource}/{relative_path}"
         try:
-            document = yaml.safe_load(path.read_text(encoding="utf-8"))
-        except (OSError, yaml.YAMLError):
-            continue
-        models = document.get("semantic_model") if isinstance(document, dict) else None
-        if not isinstance(models, list):
-            continue
-        for model in models:
-            if not isinstance(model, dict):
-                continue
-            model_name = str(model.get("name") or "").strip()
-            if not model_name:
-                continue
-            dataset_names: list[str] = []
-            dataset_sources: list[str] = []
-            table_references: list[str] = []
-            table_lookup_names: set[str] = set()
-            for dataset in model.get("datasets") or []:
-                if not isinstance(dataset, dict):
-                    continue
-                dataset_name = str(dataset.get("name") or "").strip()
-                dataset_source = str(dataset.get("source") or "").strip()
-                if dataset_name:
-                    dataset_names.append(dataset_name)
-                    table_lookup_names.update(_table_lookup_names(dataset_name))
-                if dataset_source:
-                    dataset_sources.append(dataset_source)
-                    table_lookup_names.update(_table_lookup_names(dataset_source))
-                dataset_references = _dataset_table_references(agent_config, dataset, dataset_source)
-                if not dataset_references and dataset_name:
-                    dataset_references = [dataset_name]
-                for table_reference in dataset_references:
-                    table_lookup_names.update(_table_lookup_names(table_reference))
-                    if table_reference not in table_references:
-                        table_references.append(table_reference)
-            discovered.append(
+            absolute_path = path.resolve(strict=True)
+            absolute_path.relative_to(model_root)
+        except (OSError, ValueError) as exc:
+            issues.append(
                 {
-                    "semantic_model_name": model_name,
-                    "semantic_model_file": f"subject/semantic_models/{datasource}/{path.name}",
+                    "code": "invalid_semantic_model_path",
+                    "semantic_model_file": semantic_model_file,
                     "absolute_path": str(path),
-                    "dataset_names": dataset_names,
-                    "dataset_sources": dataset_sources,
-                    "table_references": table_references,
-                    "table_lookup_names": sorted(table_lookup_names),
+                    "error": str(exc),
                 }
             )
-    return discovered
+            continue
+        try:
+            content = absolute_path.read_bytes()
+            document = yaml.safe_load(content.decode("utf-8"))
+        except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+            issues.append(
+                {
+                    "code": "invalid_yaml",
+                    "semantic_model_file": semantic_model_file,
+                    "absolute_path": str(path),
+                    "error": str(exc),
+                }
+            )
+            continue
+        models = document.get("semantic_model") if isinstance(document, dict) else None
+        if not isinstance(models, list) or not models:
+            issues.append(
+                {
+                    "code": "invalid_semantic_model_document",
+                    "semantic_model_file": semantic_model_file,
+                    "absolute_path": str(path),
+                    "error": "YAML must contain a non-empty semantic_model list",
+                }
+            )
+            continue
+        if len(models) != 1:
+            issues.append(
+                {
+                    "code": "multiple_models_in_file",
+                    "semantic_model_file": semantic_model_file,
+                    "absolute_path": str(path),
+                    "error": "Metric authoring requires exactly one semantic model per YAML file",
+                }
+            )
+            continue
+        model = models[0]
+        if not isinstance(model, dict):
+            issues.append(
+                {
+                    "code": "invalid_semantic_model_entry",
+                    "semantic_model_file": semantic_model_file,
+                    "absolute_path": str(path),
+                    "model_index": 0,
+                    "error": "semantic_model entries must be YAML objects",
+                }
+            )
+            continue
+        model_name = str(model.get("name") or "").strip()
+        if not model_name:
+            issues.append(
+                {
+                    "code": "missing_semantic_model_name",
+                    "semantic_model_file": semantic_model_file,
+                    "absolute_path": str(path),
+                    "model_index": 0,
+                    "error": "semantic_model.name is required",
+                }
+            )
+            continue
+
+        identity = {
+            "semantic_model_name": model_name,
+            "semantic_model_file": semantic_model_file,
+            "absolute_path": str(absolute_path),
+            "artifact_sha256": hashlib.sha256(content).hexdigest(),
+        }
+        schema_error = validate_osi_core_document(document)
+        if schema_error:
+            issue_code = (
+                "osi_schema_validator_unavailable"
+                if schema_error.startswith("OSI schema validator is unavailable:")
+                else "invalid_osi_core_schema"
+            )
+            issues.append(
+                {
+                    "code": issue_code,
+                    **identity,
+                    "error": schema_error,
+                }
+            )
+            if issue_code == "invalid_osi_core_schema":
+                recoverable.append({**identity, "repair_required": True})
+            continue
+
+        dataset_summaries: list[Dict[str, str]] = []
+        table_references: list[str] = []
+        for dataset in model.get("datasets") or []:
+            if not isinstance(dataset, dict):
+                continue
+            dataset_name = str(dataset.get("name") or "").strip()
+            dataset_source = str(dataset.get("source") or "").strip()
+            query_backed = _is_query_backed_dataset(dataset)
+            dataset_summaries.append(
+                {
+                    key: value
+                    for key, value in {
+                        "name": dataset_name,
+                        "source": dataset_source if not query_backed else "",
+                        "description": str(dataset.get("description") or "").strip(),
+                    }.items()
+                    if value
+                }
+            )
+            dataset_references = _dataset_table_references(agent_config, dataset, dataset_source)
+            if dataset_source and query_backed and not dataset_references:
+                discovery_warnings.append(
+                    {
+                        "code": "query_backed_dataset_tables_unknown",
+                        "semantic_model_file": semantic_model_file,
+                        "absolute_path": str(path),
+                        "model_index": 0,
+                        "dataset_name": dataset_name,
+                        "error": (
+                            f"Cannot extract physical tables from query-backed dataset {dataset_name or '<unnamed>'!r}"
+                        ),
+                    }
+                )
+            if not dataset_references and dataset_name and not query_backed:
+                dataset_references = [dataset_name]
+            for table_reference in dataset_references:
+                if table_reference not in table_references:
+                    table_references.append(table_reference)
+        discovered.append(
+            {
+                **identity,
+                "description": str(model.get("description") or "").strip(),
+                "datasets": dataset_summaries,
+                "table_references": table_references,
+            }
+        )
+    models_by_name: Dict[str, list[Dict[str, Any]]] = {}
+    for model in [*discovered, *recoverable]:
+        models_by_name.setdefault(model["semantic_model_name"], []).append(model)
+    for model_name, duplicates in models_by_name.items():
+        if len(duplicates) < 2:
+            continue
+        for duplicate in duplicates:
+            issues.append(
+                {
+                    "code": "duplicate_semantic_model_name",
+                    "semantic_model_name": model_name,
+                    "semantic_model_file": duplicate["semantic_model_file"],
+                    "absolute_path": duplicate["absolute_path"],
+                    "error": (f"semantic_model.name {model_name!r} is declared by multiple YAML files"),
+                }
+            )
+    duplicate_names = {
+        issue["semantic_model_name"] for issue in issues if issue.get("code") == "duplicate_semantic_model_name"
+    }
+    if duplicate_names:
+        discovered = [model for model in discovered if model["semantic_model_name"] not in duplicate_names]
+        recoverable = [model for model in recoverable if model["semantic_model_name"] not in duplicate_names]
+    return {
+        "models": discovered,
+        "recoverable_models": recoverable,
+        "issues": issues,
+        "discovery_warnings": discovery_warnings,
+        "files_scanned": len(paths),
+    }
 
 
-def osi_semantic_models_cover_tables(agent_config: Any, tables: Iterable[str]) -> bool:
-    """Return whether one existing Ossie model covers every requested table."""
-    models = discover_osi_semantic_models(agent_config)
-    if not models:
-        return False
-    requested = [str(table).strip() for table in tables if str(table).strip()]
-    return bool(requested) and any(all(_model_covers_table(model, table) for table in requested) for model in models)
+def discover_osi_semantic_models(agent_config: Any = None) -> list[Dict[str, Any]]:
+    """Return filesystem-backed OSI models for compatibility callers."""
+    return inspect_osi_semantic_model_inventory(agent_config)["models"]
 
 
 def _dedupe_table_references(values: Iterable[Any]) -> list[str]:
@@ -446,241 +513,6 @@ def _source_query_table_references(
     return _dedupe_table_references(references), source_names, parse_errors
 
 
-def _metric_request_table_references(
-    user_input: Any,
-    request_text: str,
-    models: Iterable[Dict[str, Any]],
-) -> list[str]:
-    """Extract deterministic table hints carried by a metric request."""
-    references: list[Any] = []
-    references.extend(getattr(user_input, "fact_tables", None) or [])
-    references.extend(getattr(user_input, "dimension_tables", None) or [])
-
-    for schema in getattr(user_input, "schemas", None) or []:
-        parts = [
-            getattr(schema, "catalog_name", ""),
-            getattr(schema, "database_name", ""),
-            getattr(schema, "schema_name", ""),
-            getattr(schema, "table_name", ""),
-        ]
-        qualified = ".".join(str(part) for part in parts if part)
-        references.append(qualified or getattr(schema, "identifier", ""))
-
-    try:
-        from datus.utils.sql_utils import extract_table_names
-
-        for reference_sql in getattr(user_input, "reference_sql", None) or []:
-            references.extend(extract_table_names(getattr(reference_sql, "sql", ""), ignore_empty=True))
-        if re.search(r"\b(?:select|with)\b", str(request_text or ""), flags=re.IGNORECASE):
-            references.extend(extract_table_names(request_text, ignore_empty=True))
-    except Exception:
-        pass
-
-    if not any(str(value or "").strip() for value in references):
-        from_match = re.search(r"\bfrom\s+[`\"[]?([A-Za-z_][\w.]*)", str(request_text or ""), re.IGNORECASE)
-        if from_match:
-            references.append(from_match.group(1))
-
-    if not any(str(value or "").strip() for value in references):
-        text = str(request_text or "").lower()
-        for model in models:
-            for value in [*(model.get("dataset_names") or []), *(model.get("dataset_sources") or [])]:
-                leaf = re.split(r"[./]", str(value or ""))[-1].strip().strip('`"[]').lower()
-                if leaf and re.search(rf"(?<![\w]){re.escape(leaf)}(?![\w])", text):
-                    references.append(value)
-
-    return _dedupe_table_references(references)
-
-
-def _requested_semantic_model_name(user_input: Any, request_text: str) -> str:
-    declared = str(getattr(user_input, "semantic_model_name", "") or "").strip()
-    if declared:
-        return declared
-    for pattern in (
-        r"\bsemantic_model_name\s*[:=]\s*[`\"']?([A-Za-z0-9_.-]+)",
-        r"\bsemantic\s+model\s+(?:named|name\s*[:=])\s*[`\"']?([A-Za-z0-9_.-]+)",
-        r"semantic\s*model\s*(?:名称为|名为)\s*[`\"']?([\w.-]+)",
-    ):
-        match = re.search(pattern, str(request_text or ""), flags=re.IGNORECASE)
-        if match:
-            return match.group(1).strip()
-    return ""
-
-
-def _existing_model_resolution(
-    status: str,
-    *,
-    selected: Optional[Dict[str, Any]] = None,
-    candidates: Optional[Iterable[Dict[str, Any]]] = None,
-    reason: str,
-    requested_name: str = "",
-    referenced_tables: Optional[Iterable[str]] = None,
-    evidence_source: str = "",
-    source_sql_names: Optional[Iterable[str]] = None,
-    parse_errors: Optional[Iterable[Dict[str, str]]] = None,
-) -> Dict[str, Any]:
-    result: Dict[str, Any] = {
-        "status": status,
-        "candidates": list(candidates or []),
-        "reason": reason,
-    }
-    if selected is not None:
-        result["selected"] = selected
-    if requested_name:
-        result["requested_name"] = requested_name
-    if referenced_tables:
-        result["referenced_tables"] = list(referenced_tables)
-    if evidence_source:
-        result["evidence_source"] = evidence_source
-    if source_sql_names:
-        result["source_sql_names"] = list(source_sql_names)
-    if parse_errors:
-        result["parse_errors"] = list(parse_errors)
-    return result
-
-
-def resolve_existing_osi_semantic_model(
-    agent_config: Any,
-    *,
-    user_input: Any = None,
-    request_text: str = "",
-    referenced_tables: Optional[Iterable[str]] = None,
-) -> Dict[str, Any]:
-    """Select an existing Ossie model for metric authoring without guessing.
-
-    Source YAML is authoritative. Selection prefers an explicit model name,
-    then a unique model covering every referenced dataset. A single model is a
-    safe datasource default; otherwise ambiguity is returned to the caller.
-    """
-    source_queries = getattr(user_input, "source_queries", None) or []
-    source_tables: list[str] = []
-    source_sql_names: list[str] = []
-    evidence_source = ""
-    if source_queries:
-        source_tables, source_sql_names, parse_errors = _source_query_table_references(agent_config, source_queries)
-        if parse_errors:
-            return _existing_model_resolution(
-                "invalid",
-                reason="one or more structured source queries could not be parsed",
-                evidence_source="source_queries",
-                source_sql_names=source_sql_names,
-                parse_errors=parse_errors,
-            )
-        evidence_source = "source_queries"
-
-    models = discover_osi_semantic_models(agent_config)
-    requested_name = _requested_semantic_model_name(user_input, request_text)
-    if requested_name:
-        target = resolve_osi_semantic_model_target(
-            agent_config,
-            semantic_model_name=requested_name,
-        )
-        if target.get("ambiguous"):
-            return _existing_model_resolution(
-                "ambiguous",
-                candidates=target.get("candidates"),
-                requested_name=requested_name,
-                reason=target.get("reason") or "the explicit model name is ambiguous",
-                referenced_tables=source_tables,
-                evidence_source=evidence_source,
-                source_sql_names=source_sql_names,
-            )
-        if target.get("exists"):
-            return _existing_model_resolution(
-                "found",
-                selected=target,
-                candidates=[target],
-                requested_name=requested_name,
-                reason="explicit semantic model name",
-                referenced_tables=source_tables,
-                evidence_source=evidence_source,
-                source_sql_names=source_sql_names,
-            )
-        return _existing_model_resolution(
-            "missing",
-            requested_name=requested_name,
-            reason="the explicitly requested semantic model does not exist",
-            referenced_tables=source_tables,
-            evidence_source=evidence_source,
-            source_sql_names=source_sql_names,
-        )
-
-    if source_queries:
-        tables = _dedupe_table_references([*source_tables, *(referenced_tables or [])])
-    else:
-        tables = _dedupe_table_references(
-            [
-                *_metric_request_table_references(user_input, request_text, models),
-                *(referenced_tables or []),
-            ]
-        )
-        evidence_source = "legacy_request"
-
-    if tables:
-        matches = [model for model in models if all(_model_covers_table(model, table) for table in tables)]
-        if len(matches) == 1:
-            return _existing_model_resolution(
-                "found",
-                selected=matches[0],
-                candidates=matches,
-                referenced_tables=tables,
-                reason="referenced datasets uniquely identify the semantic model",
-                evidence_source=evidence_source,
-                source_sql_names=source_sql_names,
-            )
-        if len(matches) > 1:
-            return _existing_model_resolution(
-                "ambiguous",
-                candidates=matches,
-                referenced_tables=tables,
-                reason="referenced datasets occur in multiple semantic models",
-                evidence_source=evidence_source,
-                source_sql_names=source_sql_names,
-            )
-        partial_matches = [model for model in models if any(_model_covers_table(model, table) for table in tables)]
-        if len(partial_matches) > 1:
-            return _existing_model_resolution(
-                "ambiguous",
-                candidates=partial_matches,
-                referenced_tables=tables,
-                reason="referenced datasets are split across multiple semantic models",
-                evidence_source=evidence_source,
-                source_sql_names=source_sql_names,
-            )
-        return _existing_model_resolution(
-            "missing",
-            candidates=partial_matches,
-            referenced_tables=tables,
-            reason="no semantic model contains all referenced datasets",
-            evidence_source=evidence_source,
-            source_sql_names=source_sql_names,
-        )
-
-    if len(models) == 1:
-        return _existing_model_resolution(
-            "found",
-            selected=models[0],
-            candidates=models,
-            reason="only one semantic model exists for the datasource",
-            evidence_source=evidence_source,
-            source_sql_names=source_sql_names,
-        )
-    if len(models) > 1:
-        return _existing_model_resolution(
-            "ambiguous",
-            candidates=models,
-            reason="multiple semantic models exist and the request does not identify a dataset",
-            evidence_source=evidence_source,
-            source_sql_names=source_sql_names,
-        )
-    return _existing_model_resolution(
-        "missing",
-        reason="no semantic model exists for the datasource",
-        evidence_source=evidence_source,
-        source_sql_names=source_sql_names,
-    )
-
-
 def _new_osi_semantic_model_name(business_domain: str, fact_tables: Iterable[str]) -> tuple[str, str]:
     normalized_domain = _normalize_model_name(business_domain)
     if normalized_domain:
@@ -698,19 +530,27 @@ def _new_osi_semantic_model_name(business_domain: str, fact_tables: Iterable[str
     return "", "missing_core_fact_table"
 
 
-def _undiscovered_target_occupant(agent_config: Any, target_file: str) -> Optional[Dict[str, Any]]:
-    """Return a fail-closed record when a target path exists but was not discoverable."""
-    model_dir = _osi_semantic_model_dir(agent_config)
-    if model_dir is None:
-        return None
-    target_path = model_dir / Path(target_file).name
-    if not target_path.exists():
-        return None
-    return {
-        "semantic_model_name": target_path.stem or "unknown",
-        "semantic_model_file": target_file,
-        "absolute_path": str(target_path),
-    }
+def _inventory_path_occupants(inventory: Dict[str, Any], target_file: str) -> list[Dict[str, Any]]:
+    """Return every inventory record occupying one semantic-model path."""
+    occupants: list[Dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    for records in (
+        inventory["models"],
+        inventory["recoverable_models"],
+        inventory["issues"],
+    ):
+        for record in records:
+            if record.get("semantic_model_file") != target_file:
+                continue
+            absolute_path = str(record.get("absolute_path") or "")
+            if absolute_path in seen_paths:
+                continue
+            seen_paths.add(absolute_path)
+            occupant = dict(record)
+            occupant["_identity_known"] = bool(occupant.get("semantic_model_name"))
+            occupant.setdefault("semantic_model_name", Path(target_file).stem or "unknown")
+            occupants.append(occupant)
+    return occupants
 
 
 def _ambiguous_osi_target(
@@ -725,7 +565,7 @@ def _ambiguous_osi_target(
         "reason": reason,
         "candidates": [
             {
-                "semantic_model_name": model["semantic_model_name"],
+                "semantic_model_name": model.get("semantic_model_name") or "unknown",
                 "semantic_model_file": model["semantic_model_file"],
             }
             for model in models
@@ -734,7 +574,7 @@ def _ambiguous_osi_target(
     }
 
 
-def resolve_osi_semantic_model_target(
+def plan_osi_semantic_model_target(
     agent_config: Any = None,
     semantic_model_name: str = "",
     business_domain: str = "",
@@ -751,16 +591,17 @@ def resolve_osi_semantic_model_target(
     """
     facts = [str(value).strip() for value in (fact_tables or []) if str(value).strip()]
     dimensions = [str(value).strip() for value in (dimension_tables or []) if str(value).strip()]
-    existing_models = discover_osi_semantic_models(agent_config)
+    inventory = inspect_osi_semantic_model_inventory(agent_config)
+    duplicate_models = [issue for issue in inventory["issues"] if issue.get("code") == "duplicate_semantic_model_name"]
+    existing_models = inventory["models"]
+    named_models = [*existing_models, *inventory["recoverable_models"], *duplicate_models]
     datasource = str(getattr(agent_config, "current_datasource", "") or "default").strip() or "default"
 
     explicit_name = _normalize_model_name(semantic_model_name)
     if explicit_name:
         target_file = f"subject/semantic_models/{datasource}/{explicit_name}.yml"
         matches = [
-            model
-            for model in existing_models
-            if _normalize_model_name(model.get("semantic_model_name")) == explicit_name
+            model for model in named_models if _normalize_model_name(model.get("semantic_model_name")) == explicit_name
         ]
         if len(matches) == 1:
             target = dict(matches[0])
@@ -773,21 +614,18 @@ def resolve_osi_semantic_model_target(
                 dimensions,
                 "The explicit semantic model name matches multiple existing files.",
             )
-        occupied_file = [model for model in existing_models if model["semantic_model_file"] == target_file]
+        occupied_file = _inventory_path_occupants(inventory, target_file)
         if occupied_file:
+            reason = (
+                "The target filename is already occupied by a differently named semantic model."
+                if all(model["_identity_known"] for model in occupied_file)
+                else "The target filename already exists but is not a safely recoverable semantic model."
+            )
             return _ambiguous_osi_target(
                 "explicit_name",
                 occupied_file,
                 dimensions,
-                "The target filename is already occupied by a differently named semantic model.",
-            )
-        undiscovered_file = _undiscovered_target_occupant(agent_config, target_file)
-        if undiscovered_file:
-            return _ambiguous_osi_target(
-                "explicit_name",
-                [undiscovered_file],
-                dimensions,
-                "The target filename already exists but does not contain a safely discoverable semantic model.",
+                reason,
             )
         return {
             "semantic_model_name": explicit_name,
@@ -818,9 +656,7 @@ def resolve_osi_semantic_model_target(
             dimensions,
             "A business domain or core fact table is required to name a new semantic model safely.",
         )
-    same_name = [
-        model for model in existing_models if _normalize_model_name(model.get("semantic_model_name")) == new_name
-    ]
+    same_name = [model for model in named_models if _normalize_model_name(model.get("semantic_model_name")) == new_name]
     if len(same_name) == 1:
         target = dict(same_name[0])
         target.update({"exists": True, "matched_by": matched_by, "dimension_tables": dimensions})
@@ -833,21 +669,18 @@ def resolve_osi_semantic_model_target(
             "The inferred semantic model name matches multiple existing files.",
         )
     target_file = f"subject/semantic_models/{datasource}/{new_name}.yml"
-    occupied_file = [model for model in existing_models if model["semantic_model_file"] == target_file]
+    occupied_file = _inventory_path_occupants(inventory, target_file)
     if occupied_file:
+        reason = (
+            "The inferred target filename is already occupied by a differently named semantic model."
+            if all(model["_identity_known"] for model in occupied_file)
+            else "The inferred target filename already exists but is not a safely recoverable semantic model."
+        )
         return _ambiguous_osi_target(
             matched_by,
             occupied_file,
             dimensions,
-            "The inferred target filename is already occupied by a differently named semantic model.",
-        )
-    undiscovered_file = _undiscovered_target_occupant(agent_config, target_file)
-    if undiscovered_file:
-        return _ambiguous_osi_target(
-            matched_by,
-            [undiscovered_file],
-            dimensions,
-            "The inferred target filename already exists but does not contain a safely discoverable semantic model.",
+            reason,
         )
     return {
         "semantic_model_name": new_name,
@@ -859,7 +692,7 @@ def resolve_osi_semantic_model_target(
 
 
 def osi_semantic_model_turn_context(agent_config: Any, user_input: Any) -> str:
-    """Render request-scoped Ossie target details for the user message.
+    """Render raw request-scoped Ossie authoring intent for the user message.
 
     Semantic-model intent can change between turns in one persisted session, so
     these values must never be frozen into the session system-prompt snapshot.
@@ -878,43 +711,19 @@ def osi_semantic_model_turn_context(agent_config: Any, user_input: Any) -> str:
     if not (requested_name or business_domain or fact_tables or dimension_tables):
         return ""
 
-    target = resolve_osi_semantic_model_target(
-        agent_config,
-        semantic_model_name=requested_name,
-        business_domain=business_domain,
-        fact_tables=fact_tables,
-        dimension_tables=dimension_tables,
-    )
     lines = [
-        "## Ossie Semantic Model Target for This Turn",
-        "This block is request-scoped and supersedes any semantic-model target mentioned in earlier turns.",
+        "## Ossie Semantic Model Intent for This Turn",
+        "This structured intent is request-scoped and supersedes values from earlier turns.",
     ]
     if requested_name:
-        lines.append(f"- Selected semantic model name: `{requested_name}`")
+        lines.append(f"- Requested semantic model name: `{requested_name}`")
     if business_domain:
         lines.append(f"- Business domain: `{business_domain}`")
     if fact_tables:
         lines.append(f"- Fact tables: `{', '.join(fact_tables)}`")
     if dimension_tables:
         lines.append(f"- Dimension tables: `{', '.join(dimension_tables)}`")
-
-    if target.get("ambiguous"):
-        lines.append(f"- Resolution status: ambiguous ({target.get('reason') or 'target is not unique'})")
-        candidates = target.get("candidates") or []
-        if candidates:
-            rendered = ", ".join(
-                f"{candidate['semantic_model_name']} ({candidate['semantic_model_file']})" for candidate in candidates
-            )
-            lines.append(f"- Candidates: {rendered}")
-        lines.append("Do not guess; call `resolve_osi_semantic_model_target` and require clarification if needed.")
-    else:
-        lines.extend(
-            [
-                f"- Resolved semantic model name: `{target['semantic_model_name']}`",
-                f"- Resolved semantic model file: `{target['semantic_model_file']}`",
-                "Use this exact name and file for this turn.",
-            ]
-        )
+    lines.append("Pass this intent to `plan_osi_semantic_model_target`; only the tool result binds the target.")
     return "\n".join(lines)
 
 
@@ -939,19 +748,9 @@ def _semantic_authoring_lock(agent_config: Any = None) -> asyncio.Lock:
 
 @asynccontextmanager
 async def semantic_authoring_guard(agent_config: Any = None):
-    """Serialize semantic writes while allowing nested host delegation."""
-    key = semantic_authoring_lock_key(agent_config)
-    held_keys = _HELD_SEMANTIC_AUTHORING_KEYS.get()
-    if key in held_keys:
-        yield
-        return
-
+    """Serialize semantic writes for one project datasource."""
     async with _semantic_authoring_lock(agent_config):
-        token = _HELD_SEMANTIC_AUTHORING_KEYS.set(held_keys | {key})
-        try:
-            yield
-        finally:
-            _HELD_SEMANTIC_AUTHORING_KEYS.reset(token)
+        yield
 
 
 def required_authoring_skills(agent_config: Any, node_name: str) -> str:

--- a/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_metrics_system_2.0.j2
@@ -45,20 +45,16 @@ Record the classification as defined in the `<required_skill>` specification{% i
 - Restrict filesystem reads/writes/reuse to `{{ kind_subdir }}/...`. Never read, edit, or pass paths from a sibling datasource directory such as `subject/semantic_models/other_datasource/...`.
 {% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource_dialect | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
 - OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
-{% if osi_target_resolved %}- Resolved semantic model name: `{{ default_osi_semantic_model_name }}`
-- Resolved semantic model file: `{{ default_osi_semantic_model_file }}`
-{% else %}- Semantic model target is not resolved yet. Identify the metric's core fact table, then call `resolve_osi_semantic_model_target(..., require_existing=true)` and use its returned file.
-{% endif %}{% if requested_semantic_model_name %}- User-specified semantic model name: `{{ requested_semantic_model_name }}` (highest priority)
-{% endif %}
+- Semantic model target is not bound yet. Treat any YAML path or model name in the request as a selection hint and call `bind_osi_semantic_model_target` with it. If no exact hint is present or binding fails, call `list_existing_osi_semantic_models` and select from the live inventory.
 {% endif %}
 
 ## Workflow
 
-1. **Discover existing assets**: Call `list_metrics()` and build an existing metric catalog. Do not recreate metrics that already exist — but note that "already exists" requires the same aggregation AND the same window/offset semantics; cumulative/window/period-over-period variants of a published base metric are NEW metrics.
+1. **Discover existing assets**: Call `list_metrics()` and build an existing metric catalog. Reconcile requested metrics with existing definitions — but note that "already exists" requires the same aggregation AND the same window/offset semantics; cumulative/window/period-over-period variants of a published base metric are NEW metrics.
 2. **Understand the request**: Confirm scope per the rules above. For provided historical SQL, call `analyze_metric_candidates_from_history` with the existing metric catalog before writing any files, and follow the candidate handling rules in the `<required_skill>` specification.
-3. **Ensure model prerequisites**: Check `check_semantic_object_exists(name, kind='table')` for involved tables{% if authoring_format == "osi" %}. Classify fact and dimension tables, then call `resolve_osi_semantic_model_target(semantic_model_name, business_domain, fact_tables, dimension_tables, require_existing=true)`. The target OSI model must already exist. Load the returned file to learn dataset names, fields, time fields, and relationships. If it is missing or ambiguous, stop and report that `gen_semantic_model` or an explicit model name is required; never create or modify datasets, fields, or relationships in this workflow{% else %}. If a semantic model is missing, load the `metricflow-semantic-authoring` skill from `<available_skills>` and follow it to create the model{% endif %}.
-4. **Author metrics**: Check `check_semantic_object_exists(name, kind='metric')` for each metric, then write the metric YAML per the `<required_skill>` specification{% if authoring_format == "osi" %} using `upsert_osi_metrics`; it creates new metrics and may replace an existing metric by name when an update is required{% endif %}.
-5. **Validate (MUST PASS)**: {% if authoring_format == "osi" %}Call `validate_semantic(semantic_model_name="{% if osi_target_resolved %}{{ default_osi_semantic_model_name }}{% else %}<semantic_model_name returned by resolve_osi_semantic_model_target>{% endif %}")` so only the resolved model runs full backend validation. If it fails, fix that model's metric definitions with another `upsert_osi_metrics` call{% else %}Call `validate_semantic`. If it fails, fix with `edit_file`{% endif %} and retry until it passes. Do NOT proceed until validation passes.
+3. **Bind the existing model**:{% if authoring_format == "osi" %} For requests that remain metric candidates after step 2, if the request names a YAML path or semantic model, call `bind_osi_semantic_model_target` with that exact selector. If it does not bind, call `list_existing_osi_semantic_models` and compare every candidate using the request SQL tables, dataset names/sources/descriptions, and business meaning; use `read_file` for plausible candidates when the compact inventory is insufficient. Bind the one unique target before any object check or write. If no valid model exists, return `status: "blocked"` with `semantic_model_required` or `semantic_model_target_invalid`. If multiple candidates remain materially plausible, use `ask_user` when available; otherwise return `semantic_model_selection_required`. Then read the bound file and call `check_semantic_object_exists` for involved tables. Never create or modify datasets, fields, or relationships in this workflow{% else %} Check `check_semantic_object_exists(name, kind='table')` for involved tables. If a semantic model is missing, load the `metricflow-semantic-authoring` skill from `<available_skills>` and follow it to create the model{% endif %}.
+4. **Author metrics**: Check `check_semantic_object_exists(name, kind='metric')` for each metric, then write the metric YAML per the `<required_skill>` specification{% if authoring_format == "osi" %} using `upsert_osi_metrics`. Pass every requested metric candidate through this tool, including the exact unchanged object already present in the bound YAML. The tool records an idempotent publish scope without rewriting unchanged YAML, so a previous interrupted publish can recover{% endif %}.
+5. **Validate (MUST PASS)**: {% if authoring_format == "osi" %}Call `validate_semantic(semantic_model_name="<bound semantic model name>")` without a custom `checks` subset, so only the bound model runs the adapter's complete default validation profile. If it fails, fix that model's metric definitions with another `upsert_osi_metrics` call{% else %}Call `validate_semantic`. If it fails, fix with `edit_file`{% endif %} and retry until it passes. Do NOT proceed until validation passes.
 6. **Dry-run**: Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric. If the source SQL groups by dimensions or a time grain, dry-run with matching `dimensions` / `time_granularity`; use `get_dimensions` for exact names. Collect each generated SQL into `metric_sqls_json`.
 7. **Publish**: After validation and dry-run pass, call `end_metric_generation(metric_file, semantic_model_files, metric_sqls_json)` ONCE{% if authoring_format == "osi" %}, passing `semantic_model_files=[]` because this workflow did not change semantic objects{% endif %}. Do not rely on the final JSON host fallback — it is only a last-resort guard. If no metrics were generated, do NOT call `end_metric_generation`.
 
@@ -69,13 +65,17 @@ Record the classification as defined in the `<required_skill>` specification{% i
 {% if authoring_format == "osi" %}```json
 {
   "semantic_model_files": [],
-  "metric_file": "subject/semantic_models/<datasource>/<resolved_model_name>.yml",
+  "metric_file": "<bound semantic model file>",
   "status": "generated",
+  "blocker_code": null,
+  "skip_reason": null,
   "output": "brief summary"
 }
 ```
 
-- `status`: `"generated"` when at least one metric was published; `"skipped"` ONLY when nothing was authored in this batch — then `metric_file` MUST be `null`.
+- `status`: `"generated"` when every requested metric candidate was validated and published, including unchanged existing definitions; `"skipped"` only when the request is not a metric; `"blocked"` when semantic-model selection cannot proceed.
+- For `"skipped"`, set `skip_reason` to `"not_a_metric"` and `metric_file` to `null`. Existing metrics are never a skipped outcome: idempotently upsert and publish them.
+- For `"blocked"`, set `metric_file` to `null` and `blocker_code` to exactly one of `semantic_model_required`, `semantic_model_selection_required`, or `semantic_model_target_invalid`.
 - Every candidate from the discovery tool MUST end this run either published via `end_metric_generation` or listed in `output` with a concrete blocker. "Covered by an existing base metric" is never a valid blocker for a cumulative/window/period-over-period candidate.
 {% else %}```json
 {

--- a/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
+++ b/datus/prompts/prompt_templates/gen_semantic_model_system_2.0.j2
@@ -14,12 +14,7 @@ The complete authoring specification for this run — YAML structure, field clas
   (resolves to `{{ semantic_model_dir }}` on disk)
 {% if authoring_format == "osi" %}{% import "_osi_dialect_map.j2" as osi_dialect_map %}{% set datasource_type = current_datasource_dialect | default('', true) | lower %}- Active datasource: `{{ current_datasource | default('unknown', true) }}`
 - OSI expression dialect for this run: `{{ osi_dialect_map.expression_dialect(datasource_type) }}` — the active datasource's dialect. Write expressions in this datasource's native SQL and use this exact value in every `expression.dialects[].dialect`.
-{% if osi_target_resolved %}- Resolved semantic model name: `{{ default_osi_semantic_model_name }}`
-- Resolved semantic model file: `{{ default_osi_semantic_model_file }}`
-{% else %}- Semantic model target is not resolved yet. After classifying fact and dimension tables, call `resolve_osi_semantic_model_target` and use its returned name and file exactly.
-{% endif %}{% if requested_semantic_model_name %}- User-specified semantic model name: `{{ requested_semantic_model_name }}` (highest priority)
-{% endif %}{% if requested_business_domain %}- Provided business domain: `{{ requested_business_domain }}`
-{% endif %}
+- Semantic model target is not planned yet. After classifying fact and dimension tables, call `plan_osi_semantic_model_target` and use its returned name and file exactly.
 {% if osi_authoring_spec %}
 ## OSI Core Authoring Specification (from the active semantic adapter)
 
@@ -40,7 +35,7 @@ The authoritative document shape you author against, including the Datus executi
 {% else %}   - If critical requirements are missing, stop guessing and explain what information is needed.
 {% endif %}
 1. **Inspect the tables**
-   - Use `get_table_ddl` (or `get_multiple_tables_ddl` for several tables) to retrieve complete table structures.
+   - Use `describe_table` (or `get_multiple_tables_ddl` for several tables) to retrieve complete table structures.
    - Extract column comments (COMMENT) from DDL and keep them in their ORIGINAL language (e.g. Chinese). DO NOT TRANSLATE.
    - For multiple tables, discover join relationships with `analyze_table_relationships`.
 
@@ -48,7 +43,7 @@ The authoritative document shape you author against, including the Datus executi
 
 2. **Resolve the stable semantic model target**{% if authoring_format == "osi" %}
    - Classify involved tables into fact tables and dimension tables. Put the core fact table first.
-   - Call `resolve_osi_semantic_model_target(semantic_model_name, business_domain, fact_tables, dimension_tables)` before any file mutation.
+   - Call `plan_osi_semantic_model_target(semantic_model_name, business_domain, fact_tables, dimension_tables)` before any file mutation.
    - Naming priority is: explicit `semantic_model_name`; reuse an existing model containing the core fact table; inferred business domain; core fact table fallback.
    - Dimension tables never participate in the name. Adding a dimension to an existing model MUST reuse its current name and file.
    - If the resolver reports ambiguity, do not guess; ask for or require an explicit semantic model name.
@@ -69,7 +64,7 @@ The authoritative document shape you author against, including the Datus executi
 {% endif %}
 
 5. **Validate (MANDATORY — DO NOT SKIP)**
-{% if authoring_format == "osi" %}   - Call `validate_semantic(scope="semantic_model", semantic_model_name="{% if osi_target_resolved %}{{ default_osi_semantic_model_name }}{% else %}<semantic_model_name returned by resolve_osi_semantic_model_target>{% endif %}")`. This validates only the resolved target model; never merge or rewrite another model to satisfy validation.
+{% if authoring_format == "osi" %}   - Call `validate_semantic(scope="semantic_model", semantic_model_name="<semantic_model_name returned by plan_osi_semantic_model_target>")` without a custom `checks` subset. This runs the adapter's complete default profile on only the planned target model; never merge or rewrite another model to satisfy validation.
 {% else %}   - Call `validate_semantic(scope="semantic_model")`.
 {% endif %}   - If validation fails: analyze the error, fix the target YAML with `edit_file` (actually execute the fix — do not just describe it), then call the same targeted `validate_semantic` again. Repeat until it passes.
    - **ABSOLUTE RULE**: You MUST NOT return the final JSON response until `validate_semantic` returns success.

--- a/datus/resources/skills/osi-metrics-authoring/SKILL.md
+++ b/datus/resources/skills/osi-metrics-authoring/SKILL.md
@@ -23,7 +23,7 @@ CRITICAL MODEL RULE — **build the model once, then only upsert metrics**:
 - Never use general filesystem writes to create or modify datasets, fields, or relationships. If the target model is missing, stop and report that `gen_semantic_model` must run first.
 - A given logical dataset has one canonical definition shared by all metrics. Reuse that dataset by name in each metric's DATUS `dataset` hint.
 
-The OSI expression dialect is shown in the system prompt Workspace section. Resolve the existing target semantic model with `resolve_osi_semantic_model_target(..., require_existing=true)` after identifying the core fact table; use the returned file exactly (`<osi_dialect>` below stands for that dialect).
+The OSI expression dialect is shown in the system prompt Workspace section. Bind one existing target with `bind_osi_semantic_model_target` before writing metrics. A path or model name supplied in the request is only a selection hint; if it is absent or does not bind, call `list_existing_osi_semantic_models` and compare the live candidates using SQL tables, dataset metadata, and business meaning (`<osi_dialect>` below stands for the active dialect).
 
 ## What you produce
 
@@ -101,22 +101,23 @@ Datus execution hints such as `dataset`, `time_dimension`, `metric_kind`, `input
 
 ## Hard skip gate
 
-Before writing any YAML, classify the source SQL:
+Before binding a target or writing YAML, classify the source SQL:
 
 - If the SQL has no aggregate output (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, ratio, rolling/cumulative aggregate, etc.) and primarily returns row-level fields (`SELECT DISTINCT ac_name, ac_code, ...`, list/detail/ranking), then it is not a metric request.
 - For non-metric SQL, do not invent convenience metrics such as `*_count`, `*_avg_duration`, `*_max_sr`, or `*_min_sr` just because the table contains those columns.
-- For non-metric SQL, do not call `upsert_osi_metrics`, `validate_semantic`, `query_metrics`, or `end_metric_generation`. Report `status: "skipped"` with `metric_file: null` in the final JSON.
+- For non-metric SQL, do not bind a target and do not call `upsert_osi_metrics`, `validate_semantic`, `query_metrics`, or `end_metric_generation`. Report `status: "skipped"`, `skip_reason: "not_a_metric"`, and `metric_file: null` in the final JSON.
 - For TopN per group / ranking-window SQL (`ROW_NUMBER`, `RANK`, `DENSE_RANK`) do the same: skip metric generation. A derived dataset/view may be a future modeling task, but it is outside this `gen_metrics` run.
 
 ## Workflow notes
 
-- FIRST, classify fact and dimension tables and resolve the existing model target. An explicit semantic model name wins; otherwise the resolver reuses the model containing the core fact table. Dimension tables do not affect the model name. Load the returned file to learn dataset names, fields, time fields, and relationships. If the file is missing or ambiguous, stop and report the prerequisite. Call `list_metrics()` to see metrics that already exist.
+- For requests classified as metrics, bind an existing model target before object checks or writes. Try an exact YAML path or model name from the request, then fall back to the complete live inventory. Compare candidates using physical SQL tables, dataset names/sources/descriptions, and business meaning; read plausible files when necessary. Bind only one unique target. If several remain plausible, ask the user when possible or return the selection-required blocker. Load the bound file to learn dataset names, fields, time fields, relationships, and existing metrics. Call `list_metrics()` for the published metric catalog as supplementary context.
 - For provided SQL/history, call `analyze_metric_candidates_from_history` before writing files. Use `direct_metric_candidates` for base metrics and fixed `period_over_period` final metrics; use `derived_metric_candidates` only for second-stage OSI metrics that explicitly depend on published input metrics. If it returns `metric_generation_skips`, skip those SQLs instead of writing metric YAML.
 - Candidate-plan compliance: every candidate in `direct_metric_candidates` and `derived_metric_candidates` (including cumulative, rolling-window, and period_over_period candidates) MUST end this run either published via `end_metric_generation` or listed in your final `output` with a concrete blocker such as a validation failure. "Covered by an existing base metric" is never a valid blocker for a cumulative/window/period_over_period candidate.
-- Reference, reconcile, reuse: point each metric's DATUS `dataset` hint at an existing dataset. If a metric with the same meaning and correct definition already exists (`check_semantic_object_exists(name, kind='metric')`), reuse/skip it. If the user requests an update or the stored definition is incorrect, replace it by name with `upsert_osi_metrics`. "Same meaning" requires the same aggregation AND the same window/offset semantics: a base aggregate never covers its cumulative/rolling/period-over-period variants, so `running_x`/`moving_x`/`previous_x` candidates must still be published when only `x` exists. For a derived metric, make sure its input metrics already exist.
+- Reference and reconcile: point each metric's DATUS `dataset` hint at an existing dataset. "Same meaning" requires the same aggregation AND the same window/offset semantics: a base aggregate never covers its cumulative/rolling/period-over-period variants, so `running_x`/`moving_x`/`previous_x` candidates must still be published when only `x` exists. For a derived metric, make sure its input metrics already exist.
+- Every requested metric candidate must pass through `upsert_osi_metrics`, validation, dry-run, and publish even when the bound YAML already contains the correct definition. Reuse that exact metric object unchanged; the upsert is a byte-preserving no-op but records the exact publish scope. This makes retries repair a prior run that wrote YAML but stopped before KB sync. Existing metrics are not a `skipped` outcome.
 - From SQL: find the table (FROM), aggregate expression(s), and business conditions vs query-time ranges. Anchor the metric on the aggregated table's existing dataset; encode metric-specific conditions with CASE inside the metric expression.
 - When a required business input is missing or ambiguous, ASK for the business semantics; do not guess.
 - Call `upsert_osi_metrics(path="<target model file>", metrics_json="<JSON array of complete OSI metric objects>")` once per coherent metric batch. This tool preserves datasets and relationships, appends new metrics, and replaces existing metrics by name.
-- Call `validate_semantic(scope="all")` after upserting OSI metrics and fix metric errors with another `upsert_osi_metrics` call until validation passes.
+- Call `validate_semantic(semantic_model_name="<bound semantic model name>")` after upserting OSI metrics and fix metric errors with another `upsert_osi_metrics` call until the adapter's complete default validation profile passes. Do not pass a custom `checks` subset.
 - Call `query_metrics(metrics=[...], dry_run=True)` for every generated metric name before publishing.
 - After validation and dry-run pass, call `end_metric_generation(metric_file="<target model file>", semantic_model_files=[], metric_sqls_json="<dry-run SQL JSON>")`.

--- a/datus/resources/skills/osi-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/osi-semantic-authoring/SKILL.md
@@ -18,7 +18,7 @@ Describe tables as strict **OSI (Open Semantic Interchange) core schema** docume
 
 CRITICAL BOUNDARY: You author **OSI core semantics only**. You do NOT write MetricFlow `data_source:`, `measures:`, `identifiers:`, `agg_time_dimension`, `create_metric`, or any execution-engine YAML. The Datus OSI compiler lowers OSI core documents to the configured backend.
 
-The OSI expression dialect is shown in the system prompt Workspace section. Resolve the target model name and file with `resolve_osi_semantic_model_target` after identifying the fact and dimension tables; use the returned values exactly (`<osi_dialect>` below stands for that dialect).
+The OSI expression dialect is shown in the system prompt Workspace section. Plan the target model name and file with `plan_osi_semantic_model_target` after identifying the fact and dimension tables; use the returned values exactly (`<osi_dialect>` below stands for that dialect).
 
 ## Field roles — the three-way decision
 
@@ -105,5 +105,5 @@ WRONG (do not do this): declaring `loan_balance` or `npl_rate` as fields **with*
 - For an existing target, keep its current semantic model name and preserve all unrelated datasets, relationships, and metrics. Never replace the file with a partial document containing only the requested objects.
 - Inspect the table schema and comments (`describe_table` reports `pk`/`nullable` facts when the database declares them); map columns to roles per the table above.
 - When a critical modeling choice is ambiguous (which column set is the grain, which is the primary time dimension), ASK before generating.
-- Call `validate_semantic(scope="semantic_model")` after writing or editing the OSI semantic model and fix errors with `edit_file` until it passes; treat warnings about "aggregates column X which is also a dimension" as instructions to drop that field's `dimension:` block or the field itself.
+- Call `validate_semantic(scope="semantic_model", semantic_model_name="<planned semantic model name>")` without a custom `checks` subset after writing or editing the OSI semantic model, and fix errors with `edit_file` until the adapter's complete default profile passes; treat warnings about "aggregates column X which is also a dimension" as instructions to drop that field's `dimension:` block or the field itself.
 - After validation passes, call `end_semantic_model_generation(semantic_model_files=[...])`. In OSI mode this syncs OSI datasets to the Knowledge Base without using MetricFlow YAML.

--- a/datus/schemas/semantic_agentic_node_models.py
+++ b/datus/schemas/semantic_agentic_node_models.py
@@ -9,7 +9,7 @@ This module defines the input and output models for the SemanticAgenticNode,
 providing structured validation for semantic model generation interactions.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -42,6 +42,10 @@ class SemanticNodeInput(AtContextInput):
     semantic_model_name: Optional[str] = Field(
         default=None,
         description="Explicit stable semantic model name; takes priority over inferred naming in Ossie mode",
+    )
+    semantic_model_file: Optional[str] = Field(
+        default=None,
+        description="Optional semantic model file hint; the agent must verify it before use",
     )
     business_domain: Optional[str] = Field(
         default=None,
@@ -88,3 +92,23 @@ class SemanticNodeResult(BaseResult):
         default_factory=list, description="List of generated semantic model file paths (single table or multi-table)"
     )
     tokens_used: int = Field(default=0, description="Total tokens used in this interaction")
+
+
+class GenMetricsNodeResult(SemanticNodeResult):
+    """Metric generation result, including an actionable blocked outcome."""
+
+    status: Optional[Literal["generated", "skipped", "blocked"]] = Field(
+        default=None,
+        description="Metric generation outcome; None is reserved for execution errors.",
+    )
+    blocker_code: Optional[
+        Literal[
+            "semantic_model_required",
+            "semantic_model_selection_required",
+            "semantic_model_target_invalid",
+        ]
+    ] = Field(default=None, description="Actionable prerequisite when status is blocked")
+    skip_reason: Optional[Literal["not_a_metric"]] = Field(
+        default=None,
+        description="Why metric generation was skipped; only non-metric requests may skip in OSI mode.",
+    )

--- a/datus/storage/metric/metric_init.py
+++ b/datus/storage/metric/metric_init.py
@@ -15,7 +15,6 @@ from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_OSI,
     discover_osi_semantic_models,
     resolve_authoring_format,
-    resolve_existing_osi_semantic_model,
 )
 from datus.configuration.agent_config import AgentConfig
 from datus.prompts.prompt_manager import get_prompt_manager
@@ -275,91 +274,73 @@ def _metrics_authoring_format(agent_config: AgentConfig) -> str:
     return resolve_authoring_format(agent_config)
 
 
-def _success_story_model_resolution_error(resolution: dict[str, Any]) -> str:
-    status = resolution.get("status")
-    if status == "invalid":
-        errors = "; ".join(
-            f"{item.get('source_sql_name')}: {item.get('error')}" for item in resolution.get("parse_errors") or []
-        )
-        return f"Invalid success-story source SQL: {errors or resolution.get('reason')}"
-    if status == "ambiguous":
-        candidates = ", ".join(
-            str(model.get("semantic_model_name") or model.get("semantic_model_file") or "")
-            for model in resolution.get("candidates") or []
-        )
-        return (
-            "A success-story CSV must resolve to exactly one semantic model; "
-            f"the referenced tables span or match multiple models: {candidates or 'unknown'}"
-        )
-    tables = ", ".join(resolution.get("referenced_tables") or [])
-    return "No single semantic model covers all tables referenced by the success-story CSV" + (
-        f": {tables}" if tables else ""
-    )
-
-
 async def _ensure_semantic_models_for_metrics(
     agent_config: AgentConfig,
     success_story: str,
     source_queries: list[SourceQueryEvidence],
     action_callback: Optional[Callable[["ActionHistory"], None]] = None,
-) -> tuple[bool, str, list[str], Optional[str]]:
+) -> tuple[bool, str, Optional[dict[str, str]]]:
     success_story_records = [{"sql": source.sql, "question": source.question} for source in source_queries]
     sql_list = [source.sql for source in source_queries]
 
     if _metrics_authoring_format(agent_config) == AUTHORING_FORMAT_OSI:
-        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
-
-        before_models = discover_osi_semantic_models(agent_config)
-        source_input = SemanticNodeInput(user_message="", source_queries=source_queries)
-        resolution = resolve_existing_osi_semantic_model(
-            agent_config,
-            user_input=source_input,
+        from datus.storage.semantic_model.semantic_model_init import (
+            SEMANTIC_MODEL_RESPONSE_ACTION_TYPE,
+            init_success_story_semantic_model_async,
         )
-        if resolution["status"] == "found":
-            selected = resolution["selected"]
-            logger.info(
-                "Reusing OSI semantic model '%s' for all %d success-story source queries",
-                selected["semantic_model_name"],
-                len(source_queries),
-            )
-            return True, "", [], selected["semantic_model_name"]
-        if resolution["status"] in {"ambiguous", "invalid"}:
-            return False, _success_story_model_resolution_error(resolution), [], None
 
-        logger.info("Generating one OSI semantic model target for the success-story CSV")
+        selected_files: list[str] = []
+
+        def capture_semantic_result(action: "ActionHistory") -> None:
+            if (
+                _action_status_value(action) == ActionStatus.SUCCESS.value
+                and getattr(action, "action_type", "") == SEMANTIC_MODEL_RESPONSE_ACTION_TYPE
+                and isinstance(getattr(action, "output", None), dict)
+            ):
+                files = action.output.get("semantic_models")
+                if isinstance(files, str):
+                    files = [files]
+                if isinstance(files, list):
+                    selected_files.extend(str(path).strip() for path in files if str(path).strip())
+            if action_callback is not None:
+                action_callback(action)
+
+        logger.info("Letting gen_semantic_model plan or reuse the OSI target for the success-story CSV")
         success, error = await init_success_story_semantic_model_async(
             agent_config,
             success_story,
             emit=None,
             build_mode="incremental",
-            action_callback=action_callback,
+            action_callback=capture_semantic_result,
+            require_exact_osi_target=True,
         )
         if not success:
-            return False, error, [], None
-        after_models = discover_osi_semantic_models(agent_config)
-        if not after_models:
-            return False, "OSI semantic model generation did not create a model file", [], None
-        post_resolution = resolve_existing_osi_semantic_model(
-            agent_config,
-            user_input=source_input,
+            return False, error, None
+        live_models = discover_osi_semantic_models(agent_config)
+        if not live_models:
+            return False, "OSI semantic model generation did not produce a valid model file", None
+        selected_paths = {path.replace("\\", "/").removeprefix("./") for path in selected_files}
+        selected_models = [
+            model
+            for model in live_models
+            if model["semantic_model_file"] in selected_paths
+            or str(Path(model["absolute_path"]).resolve(strict=False)) in selected_paths
+        ]
+        if len(selected_models) != 1:
+            return False, "gen_semantic_model did not report one exact OSI semantic-model target", None
+        selected_model = selected_models[0]
+        return (
+            True,
+            "",
+            {
+                "semantic_model_name": selected_model["semantic_model_name"],
+                "semantic_model_file": selected_model["semantic_model_file"],
+            },
         )
-        if post_resolution["status"] != "found":
-            return False, _success_story_model_resolution_error(post_resolution), [], None
-        before_files = {model["semantic_model_file"] for model in before_models}
-        created_files = sorted(
-            model["semantic_model_file"] for model in after_models if model["semantic_model_file"] not in before_files
-        )
-        selected = post_resolution["selected"]
-        logger.info(
-            "Resolved all %d success-story source queries to OSI semantic model '%s'",
-            len(source_queries),
-            selected["semantic_model_name"],
-        )
-        return True, "", created_files, selected["semantic_model_name"]
 
     all_tables = extract_tables_from_sql_list(sql_list, agent_config)
     if not all_tables:
-        return True, "", [], None
+        return True, "", None
 
     logger.info(f"Found {len(all_tables)} tables in success story SQL: {all_tables}")
     sql_evidence_by_table = extract_table_sql_evidence(success_story_records, agent_config)
@@ -376,7 +357,7 @@ async def _ensure_semantic_models_for_metrics(
     if error:
         logger.warning(f"Semantic model generation had partial failures: {error}")
 
-    return success, error, created_tables, None
+    return success, error, None
 
 
 def _build_existing_metric_catalog(agent_config: AgentConfig) -> list[dict[str, Any]]:
@@ -697,7 +678,7 @@ async def _generate_metrics_batch(
     action_callback: Optional[Callable[["ActionHistory"], None]],
     candidate_plan_json: Optional[str] = None,
     existing_metric_catalog_json: Optional[str] = None,
-    semantic_model_name: Optional[str] = None,
+    semantic_model_target: Optional[dict[str, str]] = None,
 ) -> tuple[bool, str, Optional[dict[str, Any]]]:
     """Process a single batch of SQL queries for metrics extraction."""
     rendered_queries = []
@@ -744,7 +725,8 @@ async def _generate_metrics_batch(
     metrics_input = SemanticNodeInput(
         user_message=batch_message,
         source_queries=batch_sources,
-        semantic_model_name=semantic_model_name,
+        semantic_model_name=(semantic_model_target or {}).get("semantic_model_name"),
+        semantic_model_file=(semantic_model_target or {}).get("semantic_model_file"),
         catalog=runtime_db_context.get("catalog")
         or runtime_db_context.get("catalog_name")
         or current_db_config.catalog,
@@ -887,7 +869,7 @@ async def init_success_story_metrics_async(
         return False, error_msg, None
 
     # Step 0: Resolve one semantic model for the entire CSV before metric batching.
-    success, error, _created_semantic_models, semantic_model_name = await _ensure_semantic_models_for_metrics(
+    success, error, semantic_model_target = await _ensure_semantic_models_for_metrics(
         agent_config,
         success_story,
         source_queries,
@@ -1055,7 +1037,7 @@ async def init_success_story_metrics_async(
             action_callback,
             candidate_plan_json=batch_candidate_plan_json,
             existing_metric_catalog_json=existing_metric_catalog_json,
-            semantic_model_name=semantic_model_name,
+            semantic_model_target=semantic_model_target,
         )
 
         if success and batch_result is not None:

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -66,6 +66,7 @@ async def init_success_story_semantic_model_async(
     *,
     build_mode: str = "overwrite",
     action_callback: Optional[Callable[["ActionHistory"], None]] = None,
+    require_exact_osi_target: bool = False,
 ) -> tuple[bool, str]:
     """
     Async version: Initialize ONLY semantic model from success story CSV using ALL SQL queries.
@@ -84,6 +85,9 @@ async def init_success_story_semantic_model_async(
             for the current project before regenerating. ``"incremental"``
             skips generation when all referenced tables already have semantic
             model rows; otherwise it generates and upserts missing coverage.
+        require_exact_osi_target: In OSI incremental mode, run the semantic
+            agent even when coverage exists so a metrics bootstrap caller can
+            capture the exact planned target.
     """
     # Load and validate CSV file
     csv_path = success_story
@@ -177,31 +181,38 @@ async def init_success_story_semantic_model_async(
             return False, error_msg
 
     elif build_mode == "incremental":
-        try:
-            from datus.storage.semantic_model.auto_create import (
-                extract_tables_from_sql_list,
-                find_missing_semantic_models,
-            )
+        from datus.agent.node.semantic_authoring import AUTHORING_FORMAT_OSI, resolve_authoring_format
 
-            referenced_tables = extract_tables_from_sql_list(
-                [str(sql) for sql in all_sqls if str(sql).strip()], agent_config
-            )
-            if referenced_tables:
-                missing_tables = find_missing_semantic_models(referenced_tables, agent_config)
-                if not missing_tables:
-                    logger.info(
-                        "[incremental] semantic models already exist for %d referenced table(s); generation skipped",
-                        len(referenced_tables),
-                    )
-                    return True, ""
-                logger.info(
-                    "[incremental] %d/%d referenced table(s) need semantic model refresh: %s",
-                    len(missing_tables),
-                    len(referenced_tables),
-                    missing_tables,
+        if resolve_authoring_format(agent_config) == AUTHORING_FORMAT_OSI and require_exact_osi_target:
+            logger.info("[incremental] OSI target selection requires running gen_semantic_model")
+        else:
+            try:
+                from datus.storage.semantic_model.auto_create import (
+                    extract_tables_from_sql_list,
+                    find_missing_semantic_models,
                 )
-        except Exception as exc:
-            logger.warning("Failed to compute incremental semantic-model coverage; generation will continue: %s", exc)
+
+                referenced_tables = extract_tables_from_sql_list(
+                    [str(sql) for sql in all_sqls if str(sql).strip()], agent_config
+                )
+                if referenced_tables:
+                    missing_tables = find_missing_semantic_models(referenced_tables, agent_config)
+                    if not missing_tables:
+                        logger.info(
+                            "[incremental] semantic models already exist for %d referenced table(s); generation skipped",
+                            len(referenced_tables),
+                        )
+                        return True, ""
+                    logger.info(
+                        "[incremental] %d/%d referenced table(s) need semantic model refresh: %s",
+                        len(missing_tables),
+                        len(referenced_tables),
+                        missing_tables,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to compute incremental semantic-model coverage; generation will continue: %s", exc
+                )
 
     # Build comprehensive context from all rows
     context_message = "Generate semantic models for the following SQL queries:\n\n"

--- a/datus/tools/func_tool/__init__.py
+++ b/datus/tools/func_tool/__init__.py
@@ -13,6 +13,7 @@ from datus.tools.func_tool.generation_tools import GenerationTools
 from datus.tools.func_tool.memory_filesystem_tools import MemoryFilesystemFuncTool
 from datus.tools.func_tool.memory_tools import MemoryFuncTool
 from datus.tools.func_tool.orchestrator_tools import OrchestratorIssueTools
+from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState, OsiSemanticModelTargetTools
 from datus.tools.func_tool.plan_tools import PlanTool, SessionTodoStorage
 from datus.tools.func_tool.platform_doc_search import PlatformDocSearchTool
 from datus.tools.func_tool.report_artifact_tools import ReportArtifactTools, ReportFilesystemFuncTool
@@ -46,6 +47,8 @@ __all__ = [
     "PlatformDocSearchTool",
     "SubAgentTaskTool",
     "OrchestratorIssueTools",
+    "OsiSemanticModelTargetState",
+    "OsiSemanticModelTargetTools",
     "WebTool",
 ]
 

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -5,7 +5,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Iterator, List, Optional
+from typing import Callable, Iterator, List, Optional
 
 from agents import Tool
 from wcmatch import glob as wc_glob
@@ -79,6 +79,8 @@ class FilesystemFuncTool(BaseTool):
         datus_home: Optional[str] = None,
         strict: bool = False,
         session_data_dir: Optional[str] = None,
+        mutation_callback: Optional[Callable[[], None]] = None,
+        mutation_guard: Optional[Callable[[Path], None]] = None,
         **kwargs,
     ):
         """
@@ -105,6 +107,21 @@ class FilesystemFuncTool(BaseTool):
         self._root_resolved = Path(self.root_path).expanduser().resolve(strict=False)
         self._strict = strict
         self._session_data_dir = Path(session_data_dir).expanduser().resolve(strict=False) if session_data_dir else None
+        self._mutation_callback = mutation_callback
+        self._mutation_guard = mutation_guard
+
+    def _notify_mutation(self) -> None:
+        if self._mutation_callback is not None:
+            self._mutation_callback()
+
+    def _mutation_guard_error(self, path: Path) -> Optional[FuncToolResult]:
+        if self._mutation_guard is None:
+            return None
+        try:
+            self._mutation_guard(path)
+        except Exception as exc:
+            return FuncToolResult(success=0, error=str(exc))
+        return None
 
     @property
     def strict(self) -> bool:
@@ -330,10 +347,14 @@ class FilesystemFuncTool(BaseTool):
             # must be able to emit any text artifact (shell/infra/scala/etc.).
             # Zone, read-only and strict-external gating above still apply.
             target_path = resolved.resolved
+            guard_error = self._mutation_guard_error(target_path)
+            if guard_error is not None:
+                return guard_error
 
             try:
                 target_path.parent.mkdir(parents=True, exist_ok=True)
                 target_path.write_text(content, encoding="utf-8")
+                self._notify_mutation()
                 return FuncToolResult(result=f"File written successfully: {resolved.display}")
             except PermissionError:
                 return FuncToolResult(success=0, error=f"Permission denied: {resolved.display}")
@@ -372,6 +393,9 @@ class FilesystemFuncTool(BaseTool):
                 return self._read_only_reject(resolved)
 
             target_path = resolved.resolved
+            guard_error = self._mutation_guard_error(target_path)
+            if guard_error is not None:
+                return guard_error
             if not target_path.exists():
                 return FuncToolResult(success=0, error=f"File not found: {resolved.display}")
             if target_path.is_dir():
@@ -390,6 +414,7 @@ class FilesystemFuncTool(BaseTool):
 
             try:
                 target_path.unlink()
+                self._notify_mutation()
                 return FuncToolResult(result=f"File deleted successfully: {resolved.display}")
             except PermissionError:
                 return FuncToolResult(success=0, error=f"Permission denied: {resolved.display}")
@@ -428,6 +453,9 @@ class FilesystemFuncTool(BaseTool):
                 return self._read_only_reject(resolved)
 
             target_path = resolved.resolved
+            guard_error = self._mutation_guard_error(target_path)
+            if guard_error is not None:
+                return guard_error
             if not target_path.exists():
                 return FuncToolResult(success=0, error=f"File not found: {resolved.display}")
 
@@ -444,6 +472,7 @@ class FilesystemFuncTool(BaseTool):
                     return FuncToolResult(success=0, error=error)
 
                 target_path.write_text(new_content, encoding="utf-8")
+                self._notify_mutation()
                 return FuncToolResult(result=f"File edited successfully: {resolved.display}")
             except UnicodeDecodeError:
                 return FuncToolResult(success=0, error=f"Cannot edit binary file: {resolved.display}")

--- a/datus/tools/func_tool/generation_evidence.py
+++ b/datus/tools/func_tool/generation_evidence.py
@@ -44,9 +44,9 @@ def _metadata_from_result(result: Any) -> Dict[str, Any]:
 class GenerationEvidence:
     """Minimal runtime state for generation publish gates.
 
-    The evidence is scoped to one node run and intentionally does not track
-    file hashes or dirty state. The generation flow assumes files are not edited
-    after successful validation / dry-run before publish.
+    Evidence is scoped to one node run. Exact semantic validation is tied to
+    artifact bytes, and every successful authoring mutation invalidates prior
+    validation, dry-run, and sync evidence.
     """
 
     validation_passed: bool = False
@@ -58,9 +58,28 @@ class GenerationEvidence:
     metric_aliases: Dict[str, str] = field(default_factory=dict)
     semantic_kb_sync_passed: bool = False
     metric_kb_sync_passed: bool = False
+    metric_kb_sync_metrics: Set[str] = field(default_factory=set)
     generic_kb_sync_passed: bool = False
-    storage_revision: int = 0
     validated_semantic_artifacts: Dict[str, Dict[str, str]] = field(default_factory=dict)
+
+    def reset(self) -> None:
+        """Clear evidence before reusing a node for another request."""
+        self.invalidate_artifact_evidence()
+        self.metric_queryability_contracts.clear()
+        self.metric_aliases.clear()
+
+    def invalidate_artifact_evidence(self) -> None:
+        """Discard validation, dry-run, and sync evidence after a file mutation."""
+        self.validation_passed = False
+        self.metric_dry_run_passed = False
+        self.metric_dry_run_metrics.clear()
+        self.metric_dry_run_queries.clear()
+        self.metric_sqls.clear()
+        self.semantic_kb_sync_passed = False
+        self.metric_kb_sync_passed = False
+        self.metric_kb_sync_metrics.clear()
+        self.generic_kb_sync_passed = False
+        self.validated_semantic_artifacts.clear()
 
     @property
     def kb_sync_passed(self) -> bool:
@@ -69,7 +88,10 @@ class GenerationEvidence:
     def record_validation_result(self, result: Any) -> None:
         payload = _result_payload(result)
         valid = isinstance(payload, dict) and payload.get("valid") is True
-        if _result_success(result) and valid:
+        # Explicit adapter checks are diagnostic subsets. Only the adapter's
+        # canonical default profile may satisfy a generation publish gate.
+        canonical_profile = isinstance(payload, dict) and payload.get("checks") is None
+        if _result_success(result) and valid and canonical_profile:
             self.validation_passed = True
             semantic_model_name = str(payload.get("semantic_model_name") or "").strip()
             semantic_model_file = str(payload.get("semantic_model_file") or "").strip()
@@ -270,14 +292,20 @@ class GenerationEvidence:
             return False
         return True
 
-    def mark_kb_sync(self, kind: str = "") -> None:
+    def has_metric_kb_sync(self, metric_names: Optional[Iterable[str]] = None) -> bool:
+        names = {str(name).strip() for name in (metric_names or []) if str(name).strip()}
+        if not names:
+            return False
+        return self.metric_kb_sync_passed and names.issubset(self.metric_kb_sync_metrics)
+
+    def mark_kb_sync(self, kind: str = "", metric_names: Optional[Iterable[str]] = None) -> None:
         if kind == "metric":
             self.metric_kb_sync_passed = True
+            self.metric_kb_sync_metrics.update(str(name).strip() for name in (metric_names or []) if str(name).strip())
         elif kind == "semantic":
             self.semantic_kb_sync_passed = True
         else:
             self.generic_kb_sync_passed = True
-        self.storage_revision += 1
 
 
 _GENERIC_DIMENSION_TOKENS = {"id", "key", "name", "dim", "dimension", "value"}

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -334,7 +334,7 @@ class GenerationTools:
         self._semantic_table_object_index = index
         return index
 
-    def _resolve_planned_osi_semantic_target(self) -> tuple[str, str, str]:
+    def resolve_planned_osi_semantic_target(self) -> tuple[str, str, str]:
         """Return the planned file, absolute path, and declared OSI model name."""
         planned = self.osi_target_state.planned if self.osi_target_state is not None else None
         if planned is None:
@@ -355,7 +355,7 @@ class GenerationTools:
         model_names = self.extract_osi_model_names(resolved)
         if len(model_names) != 1:
             raise ValueError(
-                f"Generated Ossie files must declare exactly one semantic model; found {model_names or '<none>'}."
+                f"Generated OSI files must declare exactly one semantic model; found {model_names or '<none>'}."
             )
 
         planned_name = str(planned.get("semantic_model_name") or "")
@@ -384,7 +384,7 @@ class GenerationTools:
         try:
             osi_target: Optional[tuple[str, str]] = None
             if self._is_osi_authoring():
-                semantic_model_file, resolved, model_name = self._resolve_planned_osi_semantic_target()
+                semantic_model_file, resolved, model_name = self.resolve_planned_osi_semantic_target()
                 semantic_model_files = [semantic_model_file]
                 osi_target = (resolved, model_name)
                 validation_passed = self.generation_evidence.semantic_artifact_validation_passed(model_name, resolved)

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -9,7 +9,7 @@ import tempfile
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import yaml
 from agents import Tool
@@ -32,6 +32,9 @@ from datus.utils.loggings import get_logger
 from datus.utils.path_manager import get_path_manager
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
 
 
 def _rows_to_dicts(rows: Any) -> List[Dict[str, Any]]:
@@ -90,6 +93,8 @@ class GenerationTools:
         agent_config: AgentConfig,
         generation_evidence: Optional[GenerationEvidence] = None,
         authoring_format: Optional[str] = None,
+        osi_target_state: Optional["OsiSemanticModelTargetState"] = None,
+        require_bound_osi_target: bool = False,
     ):
         self.agent_config = agent_config
         self.generation_evidence = generation_evidence or GenerationEvidence()
@@ -109,6 +114,8 @@ class GenerationTools:
                 logger.debug(f"Failed to initialize table semantic profile storage: {exc}")
         self._semantic_object_exists_cache: Dict[tuple[str, str, str], FuncToolResult] = {}
         self._semantic_table_object_index: Optional[Dict[str, Dict[str, object]]] = None
+        self.osi_target_state = osi_target_state
+        self.require_bound_osi_target = require_bound_osi_target
 
     def _is_osi_authoring(self) -> bool:
         return self.authoring_format == "osi"
@@ -157,6 +164,8 @@ class GenerationTools:
                 return FuncToolResult(success=0, error="name is required")
 
             normalized_kind = str(kind or "").strip().lower()
+            if self._is_osi_authoring() and self.require_bound_osi_target:
+                return self._check_bound_osi_object(object_name, normalized_kind)
             cache_key = (
                 normalized_kind,
                 object_name.lower(),
@@ -236,69 +245,55 @@ class GenerationTools:
             logger.error(f"Error checking semantic object existence: {e}")
             return FuncToolResult(success=0, error=f"Failed to check object: {str(e)}")
 
-    def resolve_osi_semantic_model_target(
-        self,
-        semantic_model_name: str = "",
-        business_domain: str = "",
-        fact_tables: Optional[List[str]] = None,
-        dimension_tables: Optional[List[str]] = None,
-        require_existing: bool = False,
-    ) -> FuncToolResult:
-        """Choose the stable Ossie semantic-model name and file for this task.
-
-        Call this after identifying fact and dimension tables, before any file
-        mutation. An explicit semantic_model_name wins. Otherwise an existing
-        model containing the core fact table is reused, then business_domain is
-        used, and finally the first/core fact table becomes the naming fallback.
-        Dimension tables never affect the name. Set require_existing for metric
-        authoring, which is not allowed to create a semantic model.
-
-        Args:
-            semantic_model_name: User-specified stable model name, when provided.
-            business_domain: Concise business-domain name inferred from the request.
-            fact_tables: Fact tables in priority order, with the core fact first.
-            dimension_tables: Related dimensions; excluded from naming.
-            require_existing: Fail when the resolved model file does not exist.
-        """
+    def _check_bound_osi_object(self, object_name: str, normalized_kind: str) -> FuncToolResult:
+        """Check the exact bound YAML instead of potentially stale vector storage."""
+        state = self.osi_target_state
+        if state is None or state.bound is None:
+            return FuncToolResult(
+                success=0,
+                error="Bind an OSI semantic model before checking semantic objects.",
+                result={"code": "semantic_model_required"},
+            )
+        path = str(state.bound["absolute_path"])
         try:
-            from datus.agent.node.semantic_authoring import (
-                is_osi_authoring,
-                resolve_osi_semantic_model_target,
-            )
+            state.require_current_revision(path)
+            document = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+            models = document.get("semantic_model") if isinstance(document, dict) else None
+            if not isinstance(models, list) or len(models) != 1 or not isinstance(models[0], dict):
+                raise ValueError("The bound YAML must contain exactly one semantic model.")
+            model = models[0]
+            exists = False
+            if normalized_kind == "metric":
+                target_name = normalize_metric_name(object_name)
+                exists = any(
+                    isinstance(metric, dict) and normalize_metric_name(metric.get("name")) == target_name
+                    for metric in model.get("metrics") or []
+                )
+            elif normalized_kind == "table":
+                from datus.agent.node.semantic_authoring import _model_covers_table
 
-            if not is_osi_authoring(self.agent_config):
-                return FuncToolResult(success=0, error="Ossie target resolution is only available in OSI mode.")
-            target = resolve_osi_semantic_model_target(
-                self.agent_config,
-                semantic_model_name=semantic_model_name,
-                business_domain=business_domain,
-                fact_tables=fact_tables,
-                dimension_tables=dimension_tables,
+                exists = _model_covers_table(state.bound, object_name)
+            else:
+                return FuncToolResult(
+                    success=0,
+                    error="Bound OSI YAML checks currently support kind='table' or kind='metric'.",
+                )
+            return FuncToolResult(
+                result={
+                    "exists": exists,
+                    "name": object_name if exists else None,
+                    "kind": normalized_kind,
+                    "semantic_model_name": state.bound["semantic_model_name"],
+                    "semantic_model_file": state.bound["semantic_model_file"],
+                    "message": (
+                        f"Object '{object_name}' ({normalized_kind}) exists in the bound OSI model."
+                        if exists
+                        else f"No {normalized_kind} found for '{object_name}' in the bound OSI model."
+                    ),
+                }
             )
-            if target.get("ambiguous"):
-                candidates = ", ".join(candidate["semantic_model_name"] for candidate in target.get("candidates") or [])
-                candidate_suffix = f" Candidates: {candidates}" if candidates else ""
-                return FuncToolResult(
-                    success=0,
-                    error=(
-                        f"Unable to resolve a safe Ossie semantic model target: {target.get('reason', 'ambiguous target')}"
-                        f" Specify semantic_model_name explicitly when needed.{candidate_suffix}"
-                    ),
-                    result=target,
-                )
-            if require_existing and not target.get("exists"):
-                return FuncToolResult(
-                    success=0,
-                    error=(
-                        "No existing Ossie semantic model matches this request. "
-                        "Run gen_semantic_model first or specify an existing semantic_model_name."
-                    ),
-                    result=target,
-                )
-            return FuncToolResult(result=target)
         except Exception as exc:
-            logger.error("Failed to resolve Ossie semantic-model target: %s", exc)
-            return FuncToolResult(success=0, error=f"Failed to resolve Ossie semantic-model target: {exc}")
+            return FuncToolResult(success=0, error=f"Failed to inspect the bound OSI semantic model: {exc}")
 
     # Backward compatibility wrapper
     def check_semantic_model_exists(
@@ -339,6 +334,35 @@ class GenerationTools:
         self._semantic_table_object_index = index
         return index
 
+    def _resolve_planned_osi_semantic_target(self) -> tuple[str, str, str]:
+        """Return the planned file, absolute path, and declared OSI model name."""
+        planned = self.osi_target_state.planned if self.osi_target_state is not None else None
+        if planned is None:
+            raise ValueError(
+                "Plan the OSI semantic-model name and file with plan_osi_semantic_model_target before publishing."
+            )
+        if self.osi_target_state.last_error_code:
+            raise ValueError(
+                "The OSI semantic-model plan is unresolved after a failed replan. "
+                "Plan the authored target again before publishing."
+            )
+
+        semantic_model_file = str(planned.get("semantic_model_file") or "")
+        resolved = self._resolve_generation_path(semantic_model_file, "semantic")
+        if not resolved:
+            raise ValueError(f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_file!r}")
+
+        model_names = self.extract_osi_model_names(resolved)
+        if len(model_names) != 1:
+            raise ValueError(
+                f"Generated Ossie files must declare exactly one semantic model; found {model_names or '<none>'}."
+            )
+
+        planned_name = str(planned.get("semantic_model_name") or "")
+        if model_names[0] != planned_name:
+            raise ValueError(f"The planned OSI target is {planned_name!r}, but the file declares {model_names[0]!r}.")
+        return semantic_model_file, resolved, model_names[0]
+
     def end_semantic_model_generation(self, semantic_model_files: List[str]) -> FuncToolResult:
         """
         Complete semantic model generation process.
@@ -360,33 +384,10 @@ class GenerationTools:
         try:
             osi_target: Optional[tuple[str, str]] = None
             if self._is_osi_authoring():
-                if len(semantic_model_files) != 1:
-                    return FuncToolResult(
-                        success=0,
-                        error=("Ossie semantic model generation must publish exactly one target file per run."),
-                        result={"semantic_model_files": semantic_model_files},
-                    )
-                resolved = self._resolve_generation_path(semantic_model_files[0], "semantic")
-                if not resolved:
-                    return FuncToolResult(
-                        success=0,
-                        error=f"semantic_model_file escapes Knowledge Base sandbox: {semantic_model_files[0]!r}",
-                        result={"semantic_model_files": semantic_model_files},
-                    )
-                model_names = self.extract_osi_model_names(resolved)
-                if len(model_names) != 1:
-                    return FuncToolResult(
-                        success=0,
-                        error=(
-                            "Generated Ossie files must declare exactly one semantic model; "
-                            f"found {model_names or '<none>'}."
-                        ),
-                        result={"semantic_model_files": semantic_model_files},
-                    )
-                osi_target = (resolved, model_names[0])
-                validation_passed = self.generation_evidence.semantic_artifact_validation_passed(
-                    model_names[0], resolved
-                )
+                semantic_model_file, resolved, model_name = self._resolve_planned_osi_semantic_target()
+                semantic_model_files = [semantic_model_file]
+                osi_target = (resolved, model_name)
+                validation_passed = self.generation_evidence.semantic_artifact_validation_passed(model_name, resolved)
             else:
                 validation_passed = self.generation_evidence.validation_passed
 
@@ -478,6 +479,90 @@ class GenerationTools:
                 semantic_model_files = [semantic_model_file]
             semantic_model_files = semantic_model_files or []
 
+            exact_osi_target_required = self._is_osi_authoring() and self.require_bound_osi_target
+            osi_metric_names_to_sync: Optional[set[str]] = None
+            if exact_osi_target_required:
+                state = self.osi_target_state
+                if state is None or state.bound is None:
+                    return FuncToolResult(
+                        success=0,
+                        error="Bind an existing OSI semantic model before publishing metrics.",
+                        result={"code": "semantic_model_required"},
+                    )
+                if state.last_error_code:
+                    return FuncToolResult(
+                        success=0,
+                        error=(
+                            "The OSI target selection is unresolved after a failed bind. "
+                            "Bind a valid target again before publishing."
+                        ),
+                        result={"code": state.last_error_code},
+                    )
+                abs_bound_metric = self._resolve_generation_path(metric_file, "metric")
+                try:
+                    state.require_current_revision(abs_bound_metric)
+                except ValueError as exc:
+                    return FuncToolResult(
+                        success=0,
+                        error=str(exc),
+                        result={"code": "semantic_model_target_invalid"},
+                    )
+                if self.extract_osi_model_names(abs_bound_metric) != [state.bound["semantic_model_name"]]:
+                    return FuncToolResult(
+                        success=0,
+                        error="The bound OSI artifact no longer declares the selected semantic model.",
+                        result={"code": "semantic_model_target_invalid"},
+                    )
+                if not state.authored_metric_names:
+                    return FuncToolResult(
+                        success=0,
+                        error="No metrics were authored in the bound OSI semantic model during this run.",
+                    )
+                osi_metric_names_to_sync = set(state.authored_metric_names)
+                current_metric_names = set(self.extract_osi_metric_names(abs_bound_metric))
+                missing_authored_metrics = [
+                    name for name in state.authored_metric_names if name not in current_metric_names
+                ]
+                if missing_authored_metrics:
+                    return FuncToolResult(
+                        success=0,
+                        error=(
+                            "The bound OSI artifact no longer contains every metric authored in this run: "
+                            f"{', '.join(missing_authored_metrics)}."
+                        ),
+                        result={"code": "semantic_model_target_invalid"},
+                    )
+                if not self.generation_evidence.semantic_artifact_validation_passed(
+                    state.bound["semantic_model_name"],
+                    abs_bound_metric,
+                ):
+                    return FuncToolResult(
+                        success=0,
+                        error="validate_semantic must pass for the exact bound OSI semantic-model artifact.",
+                    )
+                if not self.generation_evidence.has_metric_dry_run(state.authored_metric_names):
+                    return FuncToolResult(
+                        success=0,
+                        error=(
+                            "query_metrics(dry_run=True) must pass for every metric authored "
+                            "in the bound OSI semantic model."
+                        ),
+                    )
+                if not self.generation_evidence.has_required_queryability_dry_runs(state.authored_metric_names):
+                    missing_contracts = self.generation_evidence.missing_queryability_contracts(
+                        state.authored_metric_names
+                    )
+                    return FuncToolResult(
+                        success=0,
+                        error=(
+                            "query_metrics(dry_run=True) must pass with the source SQL group-by dimensions "
+                            "before publishing metrics. Run a dry-run query for the authored metric names "
+                            "with the matching dimensions/time grain, fix semantic model join or dimension "
+                            f"issues, and retry. Missing: {summarize_queryability_contracts(missing_contracts)}"
+                        ),
+                        result={"queryability_contracts": missing_contracts},
+                    )
+
             # Parse JSON string to dict
             metric_sqls: Dict[str, str] = {}
             if metric_sqls_json:
@@ -489,7 +574,7 @@ class GenerationTools:
                 except (json.JSONDecodeError, TypeError) as e:
                     logger.warning(f"Failed to parse metric_sqls_json: {e}")
 
-            if not self.generation_evidence.validation_passed:
+            if not exact_osi_target_required and not self.generation_evidence.validation_passed:
                 return FuncToolResult(
                     success=0,
                     error=(
@@ -503,7 +588,7 @@ class GenerationTools:
                     },
                 )
 
-            if not self.generation_evidence.metric_dry_run_passed:
+            if not exact_osi_target_required and not self.generation_evidence.metric_dry_run_passed:
                 return FuncToolResult(
                     success=0,
                     error=(
@@ -579,8 +664,13 @@ class GenerationTools:
                 )
 
             if self._is_osi_authoring():
+                if osi_metric_names_to_sync is None:
+                    osi_metric_names_to_sync = set(self.extract_osi_metric_names(abs_metric))
                 sync_result = self._sync_osi_metric_to_db(
-                    abs_metric, abs_semantic_files, metric_sqls, replace_metric_artifact=False
+                    abs_metric,
+                    abs_semantic_files,
+                    metric_sqls,
+                    metric_names_to_sync=osi_metric_names_to_sync,
                 )
                 if not sync_result.get("success"):
                     return FuncToolResult(
@@ -593,7 +683,7 @@ class GenerationTools:
                             "sync": sync_result,
                         },
                     )
-                self.generation_evidence.mark_kb_sync("metric")
+                self.generation_evidence.mark_kb_sync("metric", osi_metric_names_to_sync)
                 if sync_result.get("semantic_synced"):
                     self.generation_evidence.mark_kb_sync("semantic")
                 return FuncToolResult(
@@ -710,7 +800,7 @@ class GenerationTools:
                     },
                 )
 
-            self.generation_evidence.mark_kb_sync("metric")
+            self.generation_evidence.mark_kb_sync("metric", scoped_metric_names)
             if sync_result.get("semantic_synced"):
                 self.generation_evidence.mark_kb_sync("semantic")
             self._semantic_object_exists_cache.clear()
@@ -1794,18 +1884,34 @@ class GenerationTools:
         metric_file: str,
         semantic_model_file: Optional[str | List[str]] = None,
         metric_sqls: Optional[Dict[str, str]] = None,
-        replace_metric_artifact: bool = True,
+        metric_names_to_sync: Optional[set[str]] = None,
     ) -> dict:
-        """Sync OSI metrics into MetricRAG using the OSI document as source of truth."""
+        """Sync all OSI metrics, or incrementally upsert one explicit metric scope."""
         try:
             semantic_model_files = (
                 list(semantic_model_file)
                 if isinstance(semantic_model_file, list)
                 else ([semantic_model_file] if semantic_model_file else [])
             )
-            target_metric_names = set(self.extract_osi_metric_names(metric_file))
-            if not target_metric_names:
+            declared_metric_names = set(self.extract_osi_metric_names(metric_file))
+            if not declared_metric_names:
                 return {"success": False, "error": f"No OSI metrics found in metric file to sync: {metric_file}"}
+            target_metric_names = (
+                declared_metric_names
+                if metric_names_to_sync is None
+                else {str(name).strip() for name in metric_names_to_sync if str(name).strip()}
+            )
+            missing_metric_names = target_metric_names - declared_metric_names
+            if missing_metric_names:
+                return {
+                    "success": False,
+                    "error": (
+                        "OSI metric publish scope contains names not declared in the metric file: "
+                        f"{', '.join(sorted(missing_metric_names))}"
+                    ),
+                }
+            if not target_metric_names:
+                return {"success": False, "error": "OSI metric publish scope must not be empty"}
 
             doc = self._load_osi_document(
                 metric_file=metric_file,
@@ -1864,7 +1970,7 @@ class GenerationTools:
                 synced_semantic_files.append(current_semantic_file)
 
             metric_plan = (self.metric_rag, metric_file, metric_objects)
-            replacement_plans = [metric_plan] if replace_metric_artifact else []
+            replacement_plans = [metric_plan] if metric_names_to_sync is None else []
             snapshots = snapshot_artifact_replacements([metric_plan])
             try:
                 self.metric_rag.upsert_batch(metric_objects)

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -8,7 +8,7 @@ import stat
 import tempfile
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import yaml
 
@@ -21,6 +21,9 @@ from datus.tools.func_tool.fs_path_policy import PathZone, ResolvedPath
 _OSI_METRIC_PATH_LOCKS: Dict[str, threading.RLock] = {}
 _OSI_METRIC_PATH_LOCKS_GUARD = threading.Lock()
 
+if TYPE_CHECKING:
+    from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
+
 
 class MetricFilesystemFuncTool(FilesystemFuncTool):
     """Filesystem tool variant for MetricFlow YAML generation.
@@ -31,9 +34,16 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
     MetricFlow YAML files are merged structurally.
     """
 
-    def __init__(self, *args, authoring_format: str = "metricflow", **kwargs):
+    def __init__(
+        self,
+        *args,
+        authoring_format: str = "metricflow",
+        osi_target_state: Optional["OsiSemanticModelTargetState"] = None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.authoring_format = (authoring_format or "metricflow").strip().lower()
+        self.osi_target_state = osi_target_state
 
     def _is_metricflow_authoring(self) -> bool:
         return self.authoring_format == "metricflow"
@@ -70,9 +80,10 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
         """Create or update metrics in an existing OSI semantic-model file.
 
         The input is a JSON array of OSI metric objects. Existing metrics are
-        replaced by ``name`` and new metrics are appended. The tool reads the
-        live document and only assigns its ``metrics`` collection, so datasets,
-        fields, relationships, and model metadata remain unchanged.
+        replaced by ``name`` and new metrics are appended. Identical metrics
+        leave the file bytes unchanged but still enter this request's exact
+        publish scope. The tool only owns the ``metrics`` collection, so
+        datasets, fields, relationships, and model metadata remain unchanged.
 
         Args:
             path: Existing OSI semantic-model YAML file under the project workspace.
@@ -102,7 +113,31 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
             incoming_by_name[name] = metric
 
         target_path = resolved.resolved
+        if not self._is_metricflow_authoring():
+            if self.osi_target_state is None:
+                return FuncToolResult(
+                    success=0,
+                    error="Bind an existing OSI semantic model before authoring metrics.",
+                    result={"code": "semantic_model_required"},
+                )
+            try:
+                self.osi_target_state.require_bound_path(target_path)
+            except ValueError as exc:
+                return FuncToolResult(
+                    success=0,
+                    error=str(exc),
+                    result={"code": "semantic_model_target_invalid"},
+                )
         with self._osi_metric_path_lock(target_path):
+            if self.osi_target_state is not None:
+                try:
+                    self.osi_target_state.require_current_revision(target_path)
+                except ValueError as exc:
+                    return FuncToolResult(
+                        success=0,
+                        error=str(exc),
+                        result={"code": "semantic_model_target_invalid"},
+                    )
             if not target_path.exists() or not target_path.is_file():
                 return FuncToolResult(
                     success=0,
@@ -114,8 +149,9 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
                 )
 
             try:
-                document = yaml.safe_load(target_path.read_text(encoding="utf-8"))
-            except (OSError, yaml.YAMLError) as exc:
+                original_content = target_path.read_bytes()
+                document = yaml.safe_load(original_content.decode("utf-8"))
+            except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
                 return FuncToolResult(success=0, error=f"Cannot load OSI semantic model {resolved.display}: {exc}")
 
             if not isinstance(document, dict):
@@ -139,25 +175,41 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
 
             created: List[str] = []
             updated: List[str] = []
+            unchanged: List[str] = []
             for name, metric in incoming_by_name.items():
                 if name in metric_indexes:
-                    existing_metrics[metric_indexes[name]] = metric
-                    updated.append(name)
+                    index = metric_indexes[name]
+                    if existing_metrics[index] == metric:
+                        unchanged.append(name)
+                    else:
+                        existing_metrics[index] = metric
+                        updated.append(name)
                 else:
                     metric_indexes[name] = len(existing_metrics)
                     existing_metrics.append(metric)
                     created.append(name)
 
-            model["metrics"] = existing_metrics
-            validation_error = self._validate_osi_document(document)
-            if validation_error:
-                return FuncToolResult(success=0, error=f"Invalid OSI metric update: {validation_error}")
+            if created or updated:
+                model["metrics"] = existing_metrics
+                validation_error = self._validate_osi_document(document)
+                if validation_error:
+                    return FuncToolResult(success=0, error=f"Invalid OSI metric update: {validation_error}")
 
-            serialized = yaml.safe_dump(document, allow_unicode=True, sort_keys=False)
-            try:
-                self._atomic_write_text(target_path, serialized)
-            except OSError as exc:
-                return FuncToolResult(success=0, error=f"Cannot update {resolved.display}: {exc}")
+                serialized = yaml.safe_dump(document, allow_unicode=True, sort_keys=False)
+                try:
+                    self._atomic_write_text(target_path, serialized)
+                except OSError as exc:
+                    return FuncToolResult(success=0, error=f"Cannot update {resolved.display}: {exc}")
+                self._notify_mutation()
+                serialized_content = serialized.encode("utf-8")
+            else:
+                serialized_content = original_content
+            if self.osi_target_state is not None:
+                self.osi_target_state.record_metric_write(
+                    target_path,
+                    serialized_content,
+                    list(incoming_by_name),
+                )
 
         return FuncToolResult(
             result={
@@ -165,6 +217,7 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
                 "semantic_model_file": resolved.display,
                 "created": created,
                 "updated": updated,
+                "unchanged": unchanged,
             }
         )
 
@@ -176,17 +229,9 @@ class MetricFilesystemFuncTool(FilesystemFuncTool):
 
     @staticmethod
     def _validate_osi_document(document: Dict[str, Any]) -> Optional[str]:
-        try:
-            from datus_semantic_osi.errors import OSIValidationError
-            from datus_semantic_osi.profile import validate_osi_core_schema
-        except ImportError as exc:
-            return f"OSI schema validator is unavailable: {exc}"
+        from datus.agent.node.semantic_authoring import validate_osi_core_document
 
-        try:
-            validate_osi_core_schema(document)
-        except OSIValidationError as exc:
-            return str(exc)
-        return None
+        return validate_osi_core_document(document)
 
     @staticmethod
     def _atomic_write_text(target_path: Path, content: str) -> None:

--- a/datus/tools/func_tool/osi_target_tools.py
+++ b/datus/tools/func_tool/osi_target_tools.py
@@ -1,0 +1,408 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Filesystem-backed OSI semantic-model planning and metric target binding."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from datus.configuration.agent_config import AgentConfig
+from datus.tools.func_tool.base import FuncToolResult
+
+if TYPE_CHECKING:
+    from datus.tools.func_tool.generation_evidence import GenerationEvidence
+
+
+@dataclass
+class OsiSemanticModelTargetState:
+    """Request-local exact target shared by OSI tools."""
+
+    selected: Optional[Dict[str, Any]] = None
+    mode: str = ""
+    artifact_sha256: str = ""
+    authored_metric_names: List[str] = field(default_factory=list)
+    target_mutated: bool = False
+    last_error_code: str = ""
+
+    def clear_target(self) -> None:
+        self.selected = None
+        self.mode = ""
+        self.artifact_sha256 = ""
+        self.target_mutated = False
+
+    def reset(self) -> None:
+        self.clear_target()
+        self.authored_metric_names = []
+        self.last_error_code = ""
+
+    def _matches_selected_target(self, candidate: Dict[str, Any]) -> bool:
+        if self.selected is None:
+            return False
+        return (
+            str(candidate.get("absolute_path") or "") == str(self.selected.get("absolute_path") or "")
+            and str(candidate.get("semantic_model_name") or "") == str(self.selected.get("semantic_model_name") or "")
+            and str(candidate.get("artifact_sha256") or "") == self.artifact_sha256
+        )
+
+    def select(self, candidate: Dict[str, Any], *, mode: str) -> None:
+        if (self.target_mutated or self.authored_metric_names) and not self._matches_selected_target(candidate):
+            raise ValueError("The OSI target cannot change after authoring started.")
+        self.selected = dict(candidate)
+        self.mode = mode
+        self.artifact_sha256 = str(candidate.get("artifact_sha256") or "")
+        self.last_error_code = ""
+
+    @property
+    def bound(self) -> Optional[Dict[str, Any]]:
+        return self.selected if self.mode == "bound" else None
+
+    @property
+    def planned(self) -> Optional[Dict[str, Any]]:
+        return self.selected if self.mode == "planned" else None
+
+    def require_bound_path(self, path: str | Path) -> Dict[str, Any]:
+        bound = self.bound
+        if bound is None:
+            raise ValueError(
+                "Bind an existing OSI semantic model with bind_osi_semantic_model_target before authoring metrics."
+            )
+        requested = Path(path).expanduser().resolve(strict=False)
+        selected = Path(str(bound["absolute_path"])).expanduser().resolve(strict=False)
+        if requested != selected:
+            raise ValueError(f"Metric authoring is bound to {bound['semantic_model_file']}; refusing target {path!s}.")
+        return bound
+
+    def require_planned_path(self, path: str | Path) -> Dict[str, Any]:
+        planned = self.planned
+        if planned is None:
+            raise ValueError("Plan the OSI semantic-model target before writing or editing semantic YAML.")
+        requested = Path(path).expanduser().resolve(strict=False)
+        selected = Path(str(planned["absolute_path"])).expanduser().resolve(strict=False)
+        if requested != selected:
+            raise ValueError(
+                f"Semantic-model authoring is planned for {planned['semantic_model_file']}; refusing target {path!s}."
+            )
+        if self.artifact_sha256:
+            try:
+                current_sha256 = hashlib.sha256(requested.read_bytes()).hexdigest()
+            except OSError as exc:
+                raise ValueError(f"Cannot read the planned OSI semantic model: {exc}") from exc
+            if current_sha256 != self.artifact_sha256:
+                raise ValueError(
+                    "The planned OSI semantic model changed after planning. Plan the target again before writing."
+                )
+        elif requested.exists():
+            raise ValueError(
+                "The planned OSI semantic-model path was created after planning. Plan the target again before writing."
+            )
+        return planned
+
+    def require_current_revision(self, path: str | Path) -> None:
+        self.require_bound_path(path)
+        try:
+            current = hashlib.sha256(Path(path).read_bytes()).hexdigest()
+        except OSError as exc:
+            raise ValueError(f"Cannot read the bound OSI semantic model: {exc}") from exc
+        if current != self.artifact_sha256:
+            raise ValueError(
+                "The bound OSI semantic model changed after selection. "
+                "Inspect the live inventory and bind it again before writing."
+            )
+
+    def record_planned_write(self) -> None:
+        planned = self.planned
+        if planned is None:
+            raise ValueError("Cannot record an OSI semantic-model write without a planned target.")
+        path = Path(str(planned["absolute_path"]))
+        self.artifact_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+        self.target_mutated = True
+
+    def record_metric_write(self, path: str | Path, content: bytes, metric_names: List[str]) -> None:
+        self.require_bound_path(path)
+        self.artifact_sha256 = hashlib.sha256(content).hexdigest()
+        for name in metric_names:
+            if name not in self.authored_metric_names:
+                self.authored_metric_names.append(name)
+
+
+class OsiSemanticModelTargetTools:
+    """Expose one planner for model authoring and list/bind for metric authoring."""
+
+    permission_category = "semantic_tools"
+
+    def __init__(
+        self,
+        agent_config: AgentConfig,
+        *,
+        target_state: Optional[OsiSemanticModelTargetState] = None,
+        generation_evidence: Optional["GenerationEvidence"] = None,
+    ):
+        self.agent_config = agent_config
+        self.target_state = target_state or OsiSemanticModelTargetState()
+        self.generation_evidence = generation_evidence
+
+    def available_tools(self):
+        """Return the complete target-tool surface for permission registration."""
+        from datus.tools.func_tool import trans_to_function_tool
+
+        return [
+            trans_to_function_tool(self.plan_osi_semantic_model_target),
+            trans_to_function_tool(self.list_existing_osi_semantic_models),
+            trans_to_function_tool(self.bind_osi_semantic_model_target),
+        ]
+
+    def _plan_failure(self, error: str, result: Optional[Dict[str, Any]] = None) -> FuncToolResult:
+        if not self.target_state.target_mutated:
+            self.target_state.reset()
+        else:
+            self.target_state.last_error_code = "semantic_model_target_invalid"
+        return FuncToolResult(success=0, error=error, result=result)
+
+    def _model_dir(self) -> Path:
+        from datus.agent.node.semantic_authoring import osi_semantic_model_directory
+
+        model_dir = osi_semantic_model_directory(self.agent_config)
+        if model_dir is None:
+            raise ValueError("The active datasource semantic-model directory is unavailable.")
+        return model_dir.expanduser().resolve(strict=False)
+
+    def _canonical_selector(self, semantic_model_file: str) -> Path:
+        selector = str(semantic_model_file or "").strip()
+        if not selector:
+            raise ValueError("semantic_model_file is required")
+
+        datasource = str(getattr(self.agent_config, "current_datasource", "") or "default").strip() or "default"
+        model_dir = self._model_dir()
+        expanded = Path(selector).expanduser()
+        if expanded.is_absolute():
+            candidate = expanded
+        else:
+            parts = PurePosixPath(selector.replace("\\", "/")).parts
+            if parts[:2] == ("subject", "semantic_models"):
+                if len(parts) < 4 or parts[2] != datasource:
+                    raise ValueError(f"semantic_model_file must belong to active datasource {datasource!r}.")
+                parts = parts[3:]
+            candidate = model_dir.joinpath(*parts)
+
+        canonical = candidate.resolve(strict=False)
+        try:
+            canonical.relative_to(model_dir)
+        except ValueError as exc:
+            raise ValueError(f"semantic_model_file must resolve inside the active datasource {datasource!r}.") from exc
+        if canonical.suffix.lower() not in {".yml", ".yaml"}:
+            raise ValueError("semantic_model_file must be a .yml or .yaml file")
+        return canonical
+
+    @staticmethod
+    def _public_candidate(candidate: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            key: candidate[key]
+            for key in (
+                "semantic_model_name",
+                "semantic_model_file",
+                "description",
+                "datasets",
+                "table_references",
+                "repair_required",
+            )
+            if candidate.get(key)
+        }
+
+    @staticmethod
+    def _public_issue(issue: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            key: issue[key]
+            for key in (
+                "code",
+                "semantic_model_name",
+                "semantic_model_file",
+                "model_index",
+                "dataset_name",
+                "error",
+            )
+            if issue.get(key) is not None
+        }
+
+    def _inventory(self) -> Dict[str, Any]:
+        from datus.agent.node.semantic_authoring import inspect_osi_semantic_model_inventory
+
+        return inspect_osi_semantic_model_inventory(self.agent_config)
+
+    def plan_osi_semantic_model_target(
+        self,
+        semantic_model_name: str = "",
+        business_domain: str = "",
+        fact_tables: Optional[List[str]] = None,
+        dimension_tables: Optional[List[str]] = None,
+    ) -> FuncToolResult:
+        """Plan the stable name and file used by gen_semantic_model."""
+        if not self.target_state.target_mutated:
+            self.target_state.reset()
+        try:
+            from datus.agent.node.semantic_authoring import (
+                is_osi_authoring,
+                plan_osi_semantic_model_target,
+            )
+
+            if not is_osi_authoring(self.agent_config):
+                return self._plan_failure("OSI target planning is only available in OSI mode.")
+            target = plan_osi_semantic_model_target(
+                self.agent_config,
+                semantic_model_name=semantic_model_name,
+                business_domain=business_domain,
+                fact_tables=fact_tables,
+                dimension_tables=dimension_tables,
+            )
+            if target.get("ambiguous"):
+                return self._plan_failure(
+                    target.get("reason") or "The OSI semantic-model target is ambiguous.",
+                    target,
+                )
+
+            canonical = self._canonical_selector(str(target["semantic_model_file"]))
+            selected = {
+                **target,
+                "absolute_path": str(canonical),
+            }
+            selected.setdefault("artifact_sha256", "")
+            if target.get("exists"):
+                target_path = Path(str(target.get("absolute_path") or "")).resolve(strict=False)
+                if (
+                    target_path != canonical
+                    or not target.get("artifact_sha256")
+                    or not target.get("semantic_model_name")
+                ):
+                    return self._plan_failure(
+                        "The planned existing OSI target is not uniquely present in the live YAML inventory.",
+                        {"code": "semantic_model_target_invalid"},
+                    )
+            if self.generation_evidence is not None:
+                self.generation_evidence.invalidate_artifact_evidence()
+            self.target_state.select(selected, mode="planned")
+            return FuncToolResult(result=self._public_candidate(selected) | {"exists": bool(target.get("exists"))})
+        except Exception as exc:
+            return self._plan_failure(f"Failed to plan OSI semantic-model target: {exc}")
+
+    def list_existing_osi_semantic_models(self) -> FuncToolResult:
+        """Return the live YAML inventory for LLM semantic target selection."""
+        try:
+            inventory = self._inventory()
+            models = inventory["models"]
+            issues = inventory["issues"]
+            discovery_warnings = inventory["discovery_warnings"]
+            if models and issues:
+                status, code = "partial", None
+            elif models:
+                status, code = "found", None
+            elif issues:
+                status, code = "invalid", "semantic_model_target_invalid"
+            else:
+                status, code = "missing", "semantic_model_required"
+            return FuncToolResult(
+                result={
+                    "status": status,
+                    "code": code,
+                    "count": len(models),
+                    "files_scanned": inventory["files_scanned"],
+                    "semantic_models": [self._public_candidate(model) for model in models],
+                    "issues": [self._public_issue(issue) for issue in issues],
+                    "discovery_warnings": [self._public_issue(warning) for warning in discovery_warnings],
+                    "bound_target": (
+                        self._public_candidate(self.target_state.bound) if self.target_state.bound is not None else None
+                    ),
+                }
+            )
+        except Exception as exc:
+            return FuncToolResult(success=0, error=f"Failed to list OSI semantic models: {exc}")
+
+    def _bind_failure(self, code: str, error: str, **result: Any) -> FuncToolResult:
+        if not self.target_state.authored_metric_names:
+            self.target_state.clear_target()
+        self.target_state.last_error_code = code
+        return FuncToolResult(success=0, error=error, result={"code": code, **result})
+
+    def bind_osi_semantic_model_target(
+        self,
+        semantic_model_file: str = "",
+        semantic_model_name: str = "",
+    ) -> FuncToolResult:
+        """Validate and bind one exact existing semantic model selected by the LLM."""
+        try:
+            if not str(semantic_model_file or "").strip() and not str(semantic_model_name or "").strip():
+                return self._bind_failure(
+                    "semantic_model_selection_required",
+                    "Provide semantic_model_file or semantic_model_name from the live inventory.",
+                )
+
+            requested_path: Optional[Path] = None
+            if semantic_model_file:
+                try:
+                    requested_path = self._canonical_selector(semantic_model_file)
+                except ValueError as exc:
+                    return self._bind_failure("semantic_model_target_invalid", str(exc))
+
+            inventory = self._inventory()
+            matches = list(inventory["models"])
+            if requested_path is not None:
+                matches = [
+                    model for model in matches if Path(model["absolute_path"]).resolve(strict=False) == requested_path
+                ]
+                path_issues = [
+                    issue
+                    for issue in inventory["issues"]
+                    if Path(issue["absolute_path"]).resolve(strict=False) == requested_path
+                ]
+                if path_issues:
+                    return self._bind_failure(
+                        "semantic_model_target_invalid",
+                        "The requested YAML file is not safe for metric authoring.",
+                        issues=[self._public_issue(issue) for issue in path_issues],
+                    )
+            if semantic_model_name:
+                requested_name = str(semantic_model_name).strip()
+                matches = [model for model in matches if model["semantic_model_name"] == requested_name]
+
+            if not matches:
+                if requested_path is not None:
+                    return self._bind_failure(
+                        "semantic_model_target_invalid",
+                        "The requested OSI semantic-model file is not present in the live YAML inventory.",
+                    )
+                if not inventory["models"] and not inventory["issues"]:
+                    return self._bind_failure(
+                        "semantic_model_required",
+                        "No OSI semantic model exists for the active datasource.",
+                    )
+                return self._bind_failure(
+                    "semantic_model_target_invalid",
+                    "The requested OSI semantic model is not present in the live YAML inventory.",
+                )
+            if len(matches) != 1:
+                return self._bind_failure(
+                    "semantic_model_selection_required",
+                    "The selector matches multiple OSI semantic models; provide both exact file and model name.",
+                    candidates=[self._public_candidate(model) for model in matches],
+                )
+
+            selected = matches[0]
+            if self.generation_evidence is not None:
+                self.generation_evidence.invalidate_artifact_evidence()
+            self.target_state.select(selected, mode="bound")
+            return FuncToolResult(
+                result={
+                    "status": "bound",
+                    **self._public_candidate(selected),
+                }
+            )
+        except ValueError as exc:
+            return self._bind_failure("semantic_model_target_invalid", str(exc))
+        except Exception as exc:
+            return self._bind_failure(
+                "semantic_model_target_invalid",
+                f"Failed to bind OSI semantic-model target: {exc}",
+            )

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -75,15 +75,18 @@ class SemanticDiscoveryTools:
         """Get all available semantic discovery tools."""
         from datus.tools.func_tool import trans_to_function_tool
 
-        methods_to_convert = [self.analyze_metric_candidates_from_history]
+        methods_to_convert = []
         if self.db_tool is not None:
-            methods_to_convert[0:0] = [
-                self.analyze_table_relationships,
-                self.get_multiple_tables_ddl,
-                self.analyze_column_usage_patterns,
-            ]
-        if self.enable_semantic_model_profiler:
-            methods_to_convert.insert(3, self.profile_semantic_model_evidence)
+            methods_to_convert.extend(
+                [
+                    self.analyze_table_relationships,
+                    self.get_multiple_tables_ddl,
+                    self.analyze_column_usage_patterns,
+                ]
+            )
+            if self.enable_semantic_model_profiler:
+                methods_to_convert.append(self.profile_semantic_model_evidence)
+        methods_to_convert.append(self.analyze_metric_candidates_from_history)
 
         return [trans_to_function_tool(bound_method) for bound_method in methods_to_convert]
 

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -15,13 +15,16 @@ import time
 from collections import Counter, defaultdict
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from agents import Tool
 
 from datus.tools.func_tool.base import FuncToolResult
-from datus.tools.func_tool.database import DBFuncTool
 from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from datus.configuration.agent_config import AgentConfig
+    from datus.tools.func_tool.database import DBFuncTool
 
 logger = get_logger(__name__)
 
@@ -38,18 +41,25 @@ class SemanticDiscoveryTools:
 
     _AGGREGATE_CLASSES = ()
 
-    def __init__(self, db_tool: DBFuncTool, enable_semantic_model_profiler: bool = False):
+    def __init__(
+        self,
+        db_tool: Optional["DBFuncTool"] = None,
+        enable_semantic_model_profiler: bool = False,
+        *,
+        agent_config: Optional["AgentConfig"] = None,
+        sub_agent_name: Optional[str] = None,
+    ):
         """
         Initialize semantic discovery tools.
 
         Args:
-            db_tool: Database function tool instance for accessing database info
+            db_tool: Optional database tool. Direct SQL metric analysis does not require it.
             enable_semantic_model_profiler: Whether to expose the optional
                 semantic SQL history profiler tool.
         """
         self.db_tool = db_tool
-        self.agent_config = db_tool.agent_config
-        self.sub_agent_name = db_tool.sub_agent_name
+        self.agent_config = agent_config if agent_config is not None else getattr(db_tool, "agent_config", None)
+        self.sub_agent_name = sub_agent_name if sub_agent_name is not None else getattr(db_tool, "sub_agent_name", None)
         self.enable_semantic_model_profiler = enable_semantic_model_profiler
 
     @classmethod
@@ -65,19 +75,17 @@ class SemanticDiscoveryTools:
         """Get all available semantic discovery tools."""
         from datus.tools.func_tool import trans_to_function_tool
 
-        bound_tools = []
-        methods_to_convert = [
-            self.analyze_table_relationships,
-            self.get_multiple_tables_ddl,
-            self.analyze_column_usage_patterns,
-            self.analyze_metric_candidates_from_history,
-        ]
+        methods_to_convert = [self.analyze_metric_candidates_from_history]
+        if self.db_tool is not None:
+            methods_to_convert[0:0] = [
+                self.analyze_table_relationships,
+                self.get_multiple_tables_ddl,
+                self.analyze_column_usage_patterns,
+            ]
         if self.enable_semantic_model_profiler:
             methods_to_convert.insert(3, self.profile_semantic_model_evidence)
 
-        for bound_method in methods_to_convert:
-            bound_tools.append(trans_to_function_tool(bound_method))
-        return bound_tools
+        return [trans_to_function_tool(bound_method) for bound_method in methods_to_convert]
 
     def analyze_table_relationships(
         self,

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -351,96 +351,12 @@ class SubAgentTaskTool:
             return FuncToolResult(success=0, error="Missing required parameter: prompt")
 
         try:
-            normalized_type = type.strip().strip("\"'") if isinstance(type, str) else type
-            semantic_types = {"gen_semantic_model", "gen_metrics"}
-            if normalized_type in semantic_types and normalized_type in self._get_available_types():
-                from datus.agent.node.semantic_authoring import semantic_authoring_guard
-
-                async with semantic_authoring_guard(self.agent_config):
-                    if normalized_type == "gen_metrics":
-                        precondition = self._osi_metric_precondition(prompt)
-                        if precondition is not None:
-                            return precondition
-                    return await self._execute_node(
-                        normalized_type,
-                        prompt,
-                        description=description,
-                        call_id=call_id,
-                        session_id=session_id,
-                    )
-
             return await self._execute_node(
                 type, prompt, description=description, call_id=call_id, session_id=session_id
             )
         except Exception as e:
             logger.error(f"Task tool execution error (type={type}): {e}")
             return FuncToolResult(success=0, error=f"Task execution failed: {str(e)}")
-
-    def _osi_metric_precondition(self, prompt: str = "") -> Optional[FuncToolResult]:
-        """Require the OSI domain model before starting the metric subagent."""
-        from datus.agent.node.semantic_authoring import (
-            is_osi_authoring,
-            osi_semantic_model_directory,
-            resolve_existing_osi_semantic_model,
-        )
-
-        if not is_osi_authoring(self.agent_config):
-            return None
-
-        resolution = resolve_existing_osi_semantic_model(
-            self.agent_config,
-            user_input=getattr(self._parent_node, "input", None),
-            request_text=prompt,
-        )
-        if resolution["status"] == "found":
-            return None
-        if resolution["status"] == "ambiguous":
-            return FuncToolResult(
-                success=0,
-                error=(
-                    "Multiple OSI semantic models match this metric request. "
-                    "Specify semantic_model_name or reference a dataset from the intended model."
-                ),
-                result={
-                    "code": "semantic_model_selection_required",
-                    "candidates": [
-                        {
-                            "semantic_model_name": model["semantic_model_name"],
-                            "semantic_model_file": model["semantic_model_file"],
-                        }
-                        for model in resolution.get("candidates") or []
-                    ],
-                    "retry_subagent": "gen_metrics",
-                },
-            )
-        if resolution["status"] == "invalid":
-            parse_errors = resolution.get("parse_errors") or []
-            details = "; ".join(f"{item.get('source_sql_name')}: {item.get('error')}" for item in parse_errors)
-            return FuncToolResult(
-                success=0,
-                error=f"Invalid structured source SQL: {details or resolution.get('reason')}",
-                result={
-                    "code": "semantic_model_source_sql_invalid",
-                    "parse_errors": parse_errors,
-                    "retry_subagent": "gen_metrics",
-                },
-            )
-
-        target_dir = osi_semantic_model_directory(self.agent_config)
-
-        return FuncToolResult(
-            success=0,
-            error=(
-                "OSI semantic model is required before metric generation. "
-                "Run gen_semantic_model first, wait for it to finish, then retry gen_metrics."
-            ),
-            result={
-                "code": "semantic_model_required",
-                "required_subagent": "gen_semantic_model",
-                "semantic_model_directory": str(target_dir) if target_dir is not None else "",
-                "retry_subagent": "gen_metrics",
-            },
-        )
 
     # ── node creation ─────────────────────────────────────────────────
 
@@ -1284,19 +1200,28 @@ class SubAgentTaskTool:
         to a later task() call.
         """
 
-        def _failure(error_msg: str) -> FuncToolResult:
+        def _failure(error_msg: str, output_payload: Optional[Dict[str, Any]] = None) -> FuncToolResult:
             # Carry session_id under `result` so the parent can resume the
             # partial subagent session. ``result`` is None when no session
             # was created (e.g. errors raised before node construction).
-            result_payload = {"session_id": session_id} if session_id else None
-            return FuncToolResult(success=0, error=error_msg, result=result_payload)
+            result_payload = {
+                key: output_payload[key]
+                for key in ("status", "blocker_code", "skip_reason", "response", "semantic_models", "tokens_used")
+                if output_payload is not None and key in output_payload
+            }
+            if session_id:
+                result_payload["session_id"] = session_id
+            return FuncToolResult(success=0, error=error_msg, result=result_payload or None)
 
         if not output or not isinstance(output, dict):
             return _failure("No result from subagent")
 
         # Check for explicit failure from subagent
         if output.get("success") is False:
-            return _failure(output.get("error") or output.get("response") or output.get("content", "Subagent failed"))
+            return _failure(
+                output.get("error") or output.get("response") or output.get("content", "Subagent failed"),
+                output,
+            )
 
         response = output.get("response", "")
         tokens = output.get("tokens_used", 0)
@@ -1334,13 +1259,15 @@ class SubAgentTaskTool:
         # Semantic model result: has 'semantic_models' key
         semantic_models = output.get("semantic_models")
         if semantic_models is not None:
-            return _wrap(
-                {
-                    "response": response,
-                    "semantic_models": semantic_models,
-                    "tokens_used": tokens,
-                }
+            result_dict = {
+                "response": response,
+                "semantic_models": semantic_models,
+                "tokens_used": tokens,
+            }
+            result_dict.update(
+                {key: output[key] for key in ("status", "blocker_code", "skip_reason") if output.get(key) is not None}
             )
+            return _wrap(result_dict)
 
         # SQL summary result: has 'sql_summary_file' key
         sql_summary_file = output.get("sql_summary_file")

--- a/tests/unit_tests/agent/node/test_build_success_result_fallbacks.py
+++ b/tests/unit_tests/agent/node/test_build_success_result_fallbacks.py
@@ -353,7 +353,14 @@ class TestGenSemanticModelBuildSuccessResultFallback:
 class TestGenMetricsBuildSuccessResultFallback:
     def test_falls_back_to_raw_output_dict(self):
         node = _bare_node(GenMetricsAgenticNode, agent_config=None)
-        node._extract_metric_and_output_from_response = lambda payload: (None, None, None, None)  # type: ignore[assignment]
+        node._extract_metric_and_output_from_response = lambda payload: (  # type: ignore[assignment]
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
         node._finalize_metric_generation = lambda **_kw: None  # type: ignore[assignment]
         ctx = _ctx(last_successful_output={"raw_output": {"metric_file": "x.yml"}})
         result = node._build_success_result(ctx)
@@ -361,7 +368,14 @@ class TestGenMetricsBuildSuccessResultFallback:
 
     def test_falls_back_to_str_of_last_successful_output(self):
         node = _bare_node(GenMetricsAgenticNode, agent_config=None)
-        node._extract_metric_and_output_from_response = lambda payload: (None, None, None, None)  # type: ignore[assignment]
+        node._extract_metric_and_output_from_response = lambda payload: (  # type: ignore[assignment]
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
         node._finalize_metric_generation = lambda **_kw: None  # type: ignore[assignment]
         ctx = _ctx(last_successful_output={"raw_output": ""})
         result = node._build_success_result(ctx)

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -24,18 +24,23 @@ Design principle: NO mock except LLM.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from datus.agent.node import semantic_authoring
 from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
-from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
-from datus.tools.func_tool.base import FuncToolResult
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.generation_tools import GenerationTools
 from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
 from tests.unit_tests.mock_llm_model import MockToolCall, build_simple_response, build_tool_then_response
+
+
+@pytest.fixture(autouse=True)
+def _stub_osi_schema_validation(monkeypatch):
+    monkeypatch.setattr(semantic_authoring, "validate_osi_core_document", lambda document: None)
 
 
 def _set_global_semantic_adapter(agent_config, adapter: str) -> None:
@@ -102,23 +107,14 @@ class TestGenMetricsAgenticNodeInit:
             tool_names
         )
         assert "task" not in tool_names
-        assert node.sub_agent_task_tool is not None
-        assert node.sub_agent_task_tool._allowed_subagents == ["gen_semantic_model"]
-        assert "resolve_osi_semantic_model_target" in tool_names
-        assert "end_metric_generation" in tool_names
-
-    def test_osi_metrics_subagent_does_not_bootstrap_recursively(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(
-            agent_config=real_agent_config,
-            execution_mode="workflow",
-            is_subagent=True,
-        )
-
         assert node.sub_agent_task_tool is None
-        assert "task" not in {tool.name for tool in node.tools}
+        assert "list_existing_osi_semantic_models" in tool_names
+        assert "bind_osi_semantic_model_target" in tool_names
+        assert "plan_osi_semantic_model_target" not in tool_names
+        assert "end_metric_generation" in tool_names
+        node._populate_tool_registry()
+        assert node.tool_registry.get("list_existing_osi_semantic_models") == "semantic_tools"
+        assert node.tool_registry.get("bind_osi_semantic_model_target") == "semantic_tools"
 
     def test_metrics_max_turns(self, real_agent_config, mock_llm_create):
         """Test max_turns is read from agentic_nodes config."""
@@ -211,228 +207,38 @@ class TestGenMetricsAgenticNodeExecution:
         assert last_action.status == ActionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_direct_osi_metrics_bootstraps_missing_model_before_llm(self, real_agent_config, mock_llm_create):
+    async def test_before_stream_resets_all_request_scoped_authoring_state(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.agent.node.stream_run_context import StreamRunContext
 
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.input = SemanticNodeInput(user_message="Generate enrollment metrics from schools")
-        target = (
-            real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
-            / "school-domain.yaml"
+        node.input = SemanticNodeInput(
+            user_message="Create order metrics. The semantic model is at subject/semantic_models/warehouse/orders.yml."
         )
-
-        async def bootstrap(**kwargs):
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(
-                "version: 0.2.0.dev0\n"
-                "semantic_model:\n"
-                "  - name: school_operations\n"
-                "    datasets:\n"
-                "      - name: schools\n"
-                "        source: education.schools\n",
-                encoding="utf-8",
-            )
-            return FuncToolResult(result={"semantic_models": [str(target)]})
-
-        node.sub_agent_task_tool.task = AsyncMock(side_effect=bootstrap)
+        node.osi_target_state.select(
+            {
+                "semantic_model_name": "old_target",
+                "semantic_model_file": "subject/semantic_models/warehouse/old.yml",
+                "absolute_path": "/tmp/old.yml",
+            },
+            mode="bound",
+        )
+        node.osi_target_state.authored_metric_names = ["old_metric"]
+        node.generation_evidence.validation_passed = True
+        node.generation_evidence.metric_kb_sync_passed = True
+        evidence = node.generation_evidence
         ctx = StreamRunContext(user_input=node.input, action_history_manager=ActionHistoryManager())
 
         await node._before_stream(ctx)
 
-        node.sub_agent_task_tool.task.assert_awaited_once()
-        assert node.input.semantic_model_name == "school_operations"
-        context = node._prepare_template_context(node.input)
-        assert context["osi_target_resolved"] is False
-        enhanced = node._build_enhanced_message(node.input)
-        assert "school_operations" in enhanced
-        assert "school-domain.yaml" in enhanced
-        assert mock_llm_create.call_history == []
-
-    @pytest.mark.asyncio
-    async def test_direct_osi_metrics_reuses_arbitrarily_named_model_by_dataset(
-        self, real_agent_config, mock_llm_create
-    ):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.agent.node.stream_run_context import StreamRunContext
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        target = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource) / "ops.yml"
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(
-            "version: 0.2.0.dev0\n"
-            "semantic_model:\n"
-            "  - name: sales\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: commerce.orders\n",
-            encoding="utf-8",
-        )
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.input = SemanticNodeInput(
-            user_message=(
-                "Analyze the following SQL queries and extract core metrics:\n"
-                "Query 1:\nSQL:\nSELECT SUM(amount) FROM commerce.orders"
-            ),
-            source_queries=[
-                SourceQueryEvidence(
-                    source_sql_name="sql_1",
-                    sql="SELECT SUM(amount) FROM commerce.orders",
-                )
-            ],
-        )
-        node.sub_agent_task_tool.task = AsyncMock()
-        ctx = StreamRunContext(user_input=node.input, action_history_manager=ActionHistoryManager())
-
-        await node._before_stream(ctx)
-
-        node.sub_agent_task_tool.task.assert_not_awaited()
-        assert node.input.semantic_model_name == "sales"
-        context = node._prepare_template_context(node.input)
-        assert context["osi_target_resolved"] is False
-        enhanced = node._build_enhanced_message(node.input)
-        assert "sales" in enhanced
-        assert "ops.yml" in enhanced
-
-    @pytest.mark.asyncio
-    async def test_direct_osi_metrics_rejects_invalid_structured_source_before_bootstrap(
-        self, real_agent_config, mock_llm_create
-    ):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.input = SemanticNodeInput(
-            user_message="SQL:\nSELECT COUNT(*) FROM commerce.orders",
-            source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
-        )
-        node.sub_agent_task_tool.task = AsyncMock()
-
-        actions = [action async for action in node.execute_stream(ActionHistoryManager())]
-
-        node.sub_agent_task_tool.task.assert_not_awaited()
-        assert actions[-1].action_type == "error"
-        assert actions[-1].status == ActionStatus.FAILED
-        assert "invalid structured source SQL" in str(actions[-1].output)
-        assert "sql_9" in str(actions[-1].output)
-        assert mock_llm_create.call_history == []
-
-    @pytest.mark.asyncio
-    async def test_osi_target_is_request_scoped_when_session_switches_models(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.agent.node.stream_run_context import StreamRunContext
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
-        model_dir.mkdir(parents=True, exist_ok=True)
-        (model_dir / "alpha-target.yml").write_text(
-            "semantic_model:\n"
-            "  - name: alpha_orders_domain\n"
-            "    datasets:\n"
-            "      - name: orders\n"
-            "        source: commerce.orders\n",
-            encoding="utf-8",
-        )
-        (model_dir / "beta-target.yml").write_text(
-            "semantic_model:\n"
-            "  - name: beta_payments_domain\n"
-            "    datasets:\n"
-            "      - name: payments\n"
-            "        source: finance.payments\n",
-            encoding="utf-8",
-        )
-
-        session_id = "metrics_target_switch_session"
-        first = GenMetricsAgenticNode(
-            agent_config=real_agent_config,
-            execution_mode="workflow",
-            session_id=session_id,
-        )
-        first.input = SemanticNodeInput(user_message="Generate metrics from orders")
-        first_ctx = StreamRunContext(user_input=first.input, action_history_manager=ActionHistoryManager())
-        await first._before_stream(first_ctx)
-        first_system = first._get_session_system_prompt(
-            template_context=first._build_template_context(first_ctx),
-        )
-        first_message = first._build_enhanced_message(first.input)
-
-        second = GenMetricsAgenticNode(
-            agent_config=real_agent_config,
-            execution_mode="workflow",
-            session_id=session_id,
-        )
-        second.input = SemanticNodeInput(user_message="Generate metrics from payments")
-        second_ctx = StreamRunContext(user_input=second.input, action_history_manager=ActionHistoryManager())
-        await second._before_stream(second_ctx)
-        second_system = second._get_session_system_prompt(
-            template_context=second._build_template_context(second_ctx),
-        )
-        second_message = second._build_enhanced_message(second.input)
-
-        assert first_system == second_system
-        assert "alpha_orders_domain" not in first_system
-        assert "beta_payments_domain" not in second_system
-        assert "alpha_orders_domain" in first_message
-        assert "alpha-target.yml" in first_message
-        assert "beta_payments_domain" in second_message
-        assert "beta-target.yml" in second_message
-        assert "alpha_orders_domain" not in second_message
-
-    @pytest.mark.asyncio
-    async def test_direct_osi_metrics_rejects_bootstrap_result_without_full_dataset_coverage(
-        self, real_agent_config, mock_llm_create
-    ):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.input = SemanticNodeInput(
-            user_message="Generate enrollment metrics",
-            fact_tables=["education.schools", "education.students"],
-        )
-        target = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource) / "school.yml"
-
-        async def incomplete_bootstrap(**kwargs):
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(
-                "semantic_model:\n"
-                "  - name: school_operations\n"
-                "    datasets:\n"
-                "      - name: schools\n"
-                "        source: education.schools\n",
-                encoding="utf-8",
-            )
-            return FuncToolResult(result={"semantic_models": [str(target)]})
-
-        node.sub_agent_task_tool.task = AsyncMock(side_effect=incomplete_bootstrap)
-
-        actions = [action async for action in node.execute_stream(ActionHistoryManager())]
-
-        node.sub_agent_task_tool.task.assert_awaited_once()
-        assert actions[-1].action_type == "error"
-        assert actions[-1].status == ActionStatus.FAILED
-        assert "without creating a resolvable OSI semantic model" in str(actions[-1].output)
-        assert mock_llm_create.call_history == []
-
-    @pytest.mark.asyncio
-    async def test_direct_osi_metrics_bootstrap_failure_stops_before_metrics_llm(
-        self, real_agent_config, mock_llm_create
-    ):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.input = SemanticNodeInput(user_message="Generate revenue metrics")
-        node.sub_agent_task_tool.task = AsyncMock(
-            return_value=FuncToolResult(success=0, error="semantic validation failed")
-        )
-
-        actions = [action async for action in node.execute_stream(ActionHistoryManager())]
-
-        assert actions[-1].action_type == "error"
-        assert actions[-1].status == ActionStatus.FAILED
-        assert "semantic validation failed" in str(actions[-1].output)
+        assert node.osi_target_state.bound is None
+        assert node.osi_target_state.authored_metric_names == []
+        assert node.generation_evidence is evidence
+        assert node.generation_evidence == type(evidence)()
+        assert node.generation_tools.generation_evidence is evidence
+        assert node.semantic_tools.generation_evidence is evidence
+        assert node.input.semantic_model_name is None
         assert mock_llm_create.call_history == []
 
     @pytest.mark.asyncio
@@ -648,7 +454,7 @@ class TestGenMetricsAgenticNodeExecution:
         async def _raise_interrupted(*args, **kwargs):
             """Async generator that raises ExecutionInterrupted."""
             raise ExecutionInterrupted("User pressed ESC")
-            yield  # noqa: makes this an async generator
+            yield  # pragma: no cover - makes this an async generator
 
         node = GenMetricsAgenticNode(
             agent_config=real_agent_config,
@@ -752,8 +558,8 @@ class TestSetupSemanticDiscoveryTools:
         )
         assert isinstance(node.semantic_discovery_tools, SemanticDiscoveryTools)
 
-    def test_semantic_discovery_tools_skipped_when_no_db(self, real_agent_config, mock_llm_create):
-        """When DBFuncTool() constructor fails, semantic_discovery_tools is None but node still works."""
+    def test_sql_history_analyzer_remains_when_no_db(self, real_agent_config, mock_llm_create):
+        """SQL-history analysis is filesystem-backed and does not require a live DB tool."""
         from unittest.mock import patch as _patch
 
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
@@ -769,8 +575,10 @@ class TestSetupSemanticDiscoveryTools:
 
         tool_names = [tool.name for tool in node.tools]
         assert "analyze_table_relationships" not in tool_names
-        assert node.semantic_discovery_tools is None
-        # Other tools still present
+        assert "get_multiple_tables_ddl" not in tool_names
+        assert "analyze_column_usage_patterns" not in tool_names
+        assert "analyze_metric_candidates_from_history" in tool_names
+        assert isinstance(node.semantic_discovery_tools, SemanticDiscoveryTools)
         assert "read_file" in tool_names
         assert "check_semantic_object_exists" in tool_names
 
@@ -790,10 +598,14 @@ class TestExtractMetricAndOutputFromResponse:
                 "output": "Generated successfully",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert metric_file == "revenue_metrics.yml"
         assert sem_model == ["model.yml"]
         assert status is None
+        assert blocker_code is None
+        assert skip_reason is None
         assert out == "Generated successfully"
 
     def test_extracts_from_json_string(self, real_agent_config, mock_llm_create):
@@ -806,10 +618,14 @@ class TestExtractMetricAndOutputFromResponse:
             }
         )
         output = {"content": content}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert metric_file == "sales_metrics.yml"
         assert sem_model == ["model.yml"]
         assert status is None
+        assert blocker_code is None
+        assert skip_reason is None
         assert out == "Done"
 
     def test_extracts_status_from_dict_content(self, real_agent_config, mock_llm_create):
@@ -819,14 +635,19 @@ class TestExtractMetricAndOutputFromResponse:
                 "semantic_model_file": "model.yml",
                 "metric_file": None,
                 "status": "skipped",
-                "output": "All requested metrics already exist; skipped per Step 4.",
+                "skip_reason": "not_a_metric",
+                "output": "The request is not a metric.",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "skipped"
-        assert out.startswith("All requested metrics already exist")
+        assert blocker_code is None
+        assert skip_reason == "not_a_metric"
+        assert out == "The request is not a metric."
 
     def test_extracts_generated_status_without_metric_file(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
@@ -838,10 +659,14 @@ class TestExtractMetricAndOutputFromResponse:
                 "output": "Generated successfully.",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "generated"
+        assert blocker_code is None
+        assert skip_reason is None
         assert out == "Generated successfully."
 
     def test_extracts_explicit_status_without_metric_file(self, real_agent_config, mock_llm_create):
@@ -854,10 +679,14 @@ class TestExtractMetricAndOutputFromResponse:
                 "output": "Done.",
             }
         }
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "done"
+        assert blocker_code is None
+        assert skip_reason is None
         assert out == "Done."
 
     def test_extracts_status_from_json_string(self, real_agent_config, mock_llm_create):
@@ -867,38 +696,78 @@ class TestExtractMetricAndOutputFromResponse:
                 "semantic_model_file": "model.yml",
                 "metric_file": None,
                 "status": "skipped",
-                "output": "Skipped: metric already exists.",
+                "skip_reason": "not_a_metric",
+                "output": "Skipped: not a metric.",
             }
         )
         output = {"content": content}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert sem_model == ["model.yml"]
         assert metric_file is None
         assert status == "skipped"
-        assert out == "Skipped: metric already exists."
+        assert blocker_code is None
+        assert skip_reason == "not_a_metric"
+        assert out == "Skipped: not a metric."
 
-    def test_returns_none_quad_on_empty_content(self, real_agent_config, mock_llm_create):
+    def test_extracts_blocker_code(self, real_agent_config, mock_llm_create):
+        node = _make_node(real_agent_config, mock_llm_create)
+        output = {
+            "content": {
+                "semantic_model_files": [],
+                "metric_file": None,
+                "status": "blocked",
+                "blocker_code": "semantic_model_selection_required",
+                "output": "Multiple semantic models match.",
+            }
+        }
+
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
+
+        assert sem_model == []
+        assert metric_file is None
+        assert status == "blocked"
+        assert blocker_code == "semantic_model_selection_required"
+        assert skip_reason is None
+        assert out == "Multiple semantic models match."
+
+    def test_returns_none_tuple_on_empty_content(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": ""}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert metric_file is None
         assert sem_model is None
         assert status is None
+        assert blocker_code is None
+        assert skip_reason is None
         assert out is None
 
-    def test_returns_none_quad_on_dict_missing_metric_file(self, real_agent_config, mock_llm_create):
+    def test_returns_none_tuple_on_dict_missing_metric_file(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": {"some_key": "some_value"}}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert metric_file is None
         assert status is None
+        assert blocker_code is None
+        assert skip_reason is None
 
-    def test_returns_none_quad_on_invalid_json(self, real_agent_config, mock_llm_create):
+    def test_returns_none_tuple_on_invalid_json(self, real_agent_config, mock_llm_create):
         node = _make_node(real_agent_config, mock_llm_create)
         output = {"content": "not json at all !!!"}
-        sem_model, metric_file, status, out = node._extract_metric_and_output_from_response(output)
+        sem_model, metric_file, status, blocker_code, skip_reason, out = node._extract_metric_and_output_from_response(
+            output
+        )
         assert metric_file is None
         assert status is None
+        assert blocker_code is None
+        assert skip_reason is None
 
 
 # ---------------------------------------------------------------------------
@@ -949,6 +818,21 @@ class TestPrepareTemplateContext:
 
         assert "native_tools" in context
         assert "mcp_tools" in context
+
+    def test_osi_structured_target_is_an_unresolved_turn_hint(self, real_agent_config, mock_llm_create):
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = _make_node(real_agent_config, mock_llm_create)
+        user_input = SemanticNodeInput(
+            user_message="Generate order metrics",
+            semantic_model_name="orders_model",
+            semantic_model_file="subject/semantic_models/warehouse/orders.yml",
+        )
+
+        enhanced = node._build_enhanced_message(user_input)
+
+        assert "Requested semantic model name: `orders_model`" in enhanced
+        assert "Requested semantic model file: `subject/semantic_models/warehouse/orders.yml`" in enhanced
+        assert "bind_osi_semantic_model_target" in enhanced
 
 
 class TestGetSystemPrompt:
@@ -1234,324 +1118,350 @@ class TestExecuteStreamGenMetricsError:
             semantic_model_files=[str(real_agent_config.path_manager.semantic_model_path(datasource) / "orders.yml")],
         )
 
-    def test_osi_final_metric_publish_does_not_sync_semantic_model_files(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.func_tool.base import FuncToolResult
-
-        datasource = real_agent_config.current_datasource
-        semantic_dir = real_agent_config.path_manager.semantic_model_path(datasource)
-        metric_dir = semantic_dir / "metrics"
-        metric_dir.mkdir(parents=True, exist_ok=True)
-        metric_path = metric_dir / "orders_metrics.yml"
-        metric_path.write_text(
-            """
-version: 0.2.0.dev0
-semantic_model:
-  - name: shop
-    datasets:
-      - name: orders
-        source: orders
-    metrics:
-      - name: order_count
-        expression:
-          dialects:
-            - dialect: ANSI_SQL
-              expression: COUNT(DISTINCT order_id)
-""",
+    @staticmethod
+    def _bind_authored_osi_target(node, real_agent_config, metric_name="order_count"):
+        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        target = model_dir / "shop.yml"
+        target.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: shop\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: commerce.orders\n",
             encoding="utf-8",
         )
-        reported_semantic_path = f"subject/semantic_models/{datasource}/orders.yml"
-        reported_metric_path = f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml"
+        bind_result = node.osi_target_tools.bind_osi_semantic_model_target(
+            semantic_model_file=str(target),
+            semantic_model_name="shop",
+        )
+        assert bind_result.success == 1
+
+        authored = (
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: shop\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: commerce.orders\n"
+            "    metrics:\n"
+            f"      - name: {metric_name}\n"
+        )
+        target.write_text(authored, encoding="utf-8")
+        node.osi_target_state.record_metric_write(target, authored.encode("utf-8"), [metric_name])
+        return target
+
+    def test_osi_finalizer_publishes_only_the_bound_target(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
 
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         node.input = SemanticNodeInput(user_message="Generate OSI metrics")
+        target = self._bind_authored_osi_target(node, real_agent_config)
         node.semantic_tools = MagicMock()
         node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
         node.semantic_tools.query_metrics = MagicMock(
             return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
         )
+        node.generation_tools.extract_osi_model_names = MagicMock(return_value=["shop"])
         node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
 
-        node._finalize_metric_generation([reported_semantic_path], reported_metric_path, "generated")
+        node._finalize_metric_generation(
+            semantic_model_files=["subject/semantic_models/ignored.yml"],
+            metric_file="subject/semantic_models/ignored/metrics/wrong.yml",
+            status="generated",
+        )
 
+        node.semantic_tools.validate_semantic.assert_called_once_with(
+            semantic_model_name="shop",
+        )
         node.semantic_tools.query_metrics.assert_called_once_with(metrics=["order_count"], dry_run=True)
         node.generation_tools.end_metric_generation.assert_called_once_with(
-            metric_file=str(metric_path),
+            metric_file=str(target),
             semantic_model_files=[],
         )
 
-    def test_osi_final_metric_publish_ignores_legacy_string_semantic_model_file(
-        self, real_agent_config, mock_llm_create
+    def test_osi_retry_republishes_an_identical_existing_metric(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        metric = {
+            "name": "order_count",
+            "description": "Count orders",
+            "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "COUNT(*)"}]},
+        }
+        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        target = model_dir / "shop.yml"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": "0.2.0.dev0",
+                    "semantic_model": [
+                        {
+                            "name": "shop",
+                            "datasets": [{"name": "orders", "source": "commerce.orders"}],
+                            "metrics": [metric],
+                        }
+                    ],
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        original_content = target.read_bytes()
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate order_count")
+        bind_result = node.osi_target_tools.bind_osi_semantic_model_target(str(target), "shop")
+        assert bind_result.success == 1
+
+        upsert_result = node.filesystem_func_tool.upsert_osi_metrics(str(target), json.dumps([metric]))
+
+        assert upsert_result.success == 1
+        assert upsert_result.result["unchanged"] == ["order_count"]
+        assert target.read_bytes() == original_content
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
+        node.semantic_tools.query_metrics = MagicMock(
+            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT COUNT(*) FROM orders"}})
+        )
+        node.generation_tools.extract_osi_model_names = MagicMock(return_value=["shop"])
+        node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
+
+        node._finalize_metric_generation(None, None, "generated")
+
+        node.semantic_tools.query_metrics.assert_called_once_with(metrics=["order_count"], dry_run=True)
+        node.generation_tools.end_metric_generation.assert_called_once_with(
+            metric_file=str(target),
+            semantic_model_files=[],
+        )
+
+    def test_osi_publish_scope_expansion_does_not_reuse_partial_sync(
+        self,
+        real_agent_config,
+        mock_llm_create,
     ):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.tools.func_tool.base import FuncToolResult
 
-        datasource = real_agent_config.current_datasource
-        semantic_dir = real_agent_config.path_manager.semantic_model_path(datasource)
-        metric_dir = semantic_dir / "metrics"
-        metric_dir.mkdir(parents=True, exist_ok=True)
-        metric_path = metric_dir / "orders_metrics.yml"
-        metric_path.write_text(
-            """
-version: 0.2.0.dev0
-semantic_model:
-  - name: shop
-    metrics:
-      - name: order_count
-""",
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        metrics = [
+            {
+                "name": "order_count",
+                "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "COUNT(*)"}]},
+            },
+            {
+                "name": "revenue",
+                "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "SUM(amount)"}]},
+            },
+        ]
+        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        target = model_dir / "shop.yml"
+        target.write_text(
+            json.dumps(
+                {
+                    "version": "0.2.0.dev0",
+                    "semantic_model": [
+                        {
+                            "name": "shop",
+                            "datasets": [{"name": "orders", "source": "commerce.orders"}],
+                            "metrics": metrics,
+                        }
+                    ],
+                }
+            ),
             encoding="utf-8",
         )
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate order_count and revenue")
+        assert node.osi_target_tools.bind_osi_semantic_model_target(str(target), "shop").success == 1
+        assert node.filesystem_func_tool.upsert_osi_metrics(str(target), json.dumps([metrics[0]])).success == 1
+        node.generation_evidence.record_semantic_artifact_validation("shop", target)
+        node.generation_evidence.record_metric_dry_run(
+            ["order_count"],
+            FuncToolResult(result={"metadata": {"sql": "SELECT COUNT(*) FROM orders"}}),
+        )
+        node.generation_evidence.mark_kb_sync("metric", ["order_count"])
+
+        assert node.filesystem_func_tool.upsert_osi_metrics(str(target), json.dumps([metrics[1]])).success == 1
+        assert node.osi_target_state.authored_metric_names == ["order_count", "revenue"]
+        node.semantic_tools = MagicMock()
+        node.semantic_tools.query_metrics = MagicMock(
+            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
+        )
+        node.generation_tools.extract_osi_model_names = MagicMock(return_value=["shop"])
+        node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
+
+        node._finalize_metric_generation(None, None, "generated")
+
+        node.semantic_tools.validate_semantic.assert_not_called()
+        node.semantic_tools.query_metrics.assert_called_once_with(
+            metrics=["order_count", "revenue"],
+            dry_run=True,
+        )
+        node.generation_tools.end_metric_generation.assert_called_once_with(
+            metric_file=str(target),
+            semantic_model_files=[],
+        )
+
+    def test_osi_skipped_requires_non_metric_reason(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+
+        with pytest.raises(RuntimeError, match="skip_reason='not_a_metric'"):
+            node._finalize_metric_generation(None, None, "skipped")
+
+        node._finalize_metric_generation(None, None, "skipped", skip_reason="not_a_metric")
+
+    def test_osi_generated_result_requires_a_bound_target(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+
+        with pytest.raises(RuntimeError, match="must bind an existing semantic model"):
+            node._finalize_metric_generation(None, None, "generated")
+
+    def test_osi_implicit_generated_result_cannot_bypass_target_discovery(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+
+        with pytest.raises(RuntimeError, match="must bind an existing semantic model"):
+            node._finalize_metric_generation(None, None, None)
+
+    def test_osi_blocked_result_does_not_reintroduce_host_model_matching(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate metrics for another business domain")
+        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        (model_dir / "unrelated.yml").write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: unrelated\n"
+            "    datasets:\n"
+            "      - name: inventory\n"
+            "        source: warehouse.inventory\n",
+            encoding="utf-8",
+        )
+        ctx = StreamRunContext(
+            user_input=node.input,
+            action_history_manager=ActionHistoryManager(),
+        )
+        ctx.response_content = json.dumps(
+            {
+                "metric_file": None,
+                "status": "blocked",
+                "blocker_code": "semantic_model_required",
+                "output": "No existing model matches this metric domain.",
+            }
+        )
+
+        result = node._build_success_result(ctx)
+
+        assert result.success is False
+        assert result.status == "blocked"
+        assert result.blocker_code == "semantic_model_required"
+
+    def test_osi_bound_target_can_report_a_missing_semantic_prerequisite(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate a metric that requires a missing relationship")
+        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        target = model_dir / "commerce.yml"
+        target.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: commerce\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: warehouse.orders\n",
+            encoding="utf-8",
+        )
+        assert node.osi_target_tools.bind_osi_semantic_model_target(str(target), "commerce").success == 1
+        ctx = StreamRunContext(
+            user_input=node.input,
+            action_history_manager=ActionHistoryManager(),
+        )
+        ctx.response_content = json.dumps(
+            {
+                "metric_file": None,
+                "status": "blocked",
+                "blocker_code": "semantic_model_target_invalid",
+                "output": "The bound model is missing a required relationship.",
+            }
+        )
+
+        result = node._build_success_result(ctx)
+
+        assert result.success is False
+        assert result.status == "blocked"
+        assert result.blocker_code == "semantic_model_target_invalid"
+
+    def test_osi_generated_result_requires_an_authored_metric(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        model_dir = real_agent_config.path_manager.semantic_model_path(real_agent_config.current_datasource)
+        model_dir.mkdir(parents=True, exist_ok=True)
+        target = model_dir / "shop.yml"
+        target.write_text("semantic_model:\n  - name: shop\n", encoding="utf-8")
+        result = node.osi_target_tools.bind_osi_semantic_model_target(str(target), "shop")
+        assert result.success == 1
+
+        with pytest.raises(RuntimeError, match="No metrics were authored"):
+            node._finalize_metric_generation(None, None, "generated")
+
+    def test_osi_finalizer_rejects_a_stale_bound_revision(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        target = self._bind_authored_osi_target(node, real_agent_config)
+        target.write_text(target.read_text(encoding="utf-8") + "# external change\n", encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="changed after selection"):
+            node._finalize_metric_generation(None, None, "generated")
+
+    def test_osi_blocked_result_is_rejected_after_metric_authoring(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
 
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         node.input = SemanticNodeInput(user_message="Generate OSI metrics")
-        node.semantic_tools = MagicMock()
-        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
-        node.semantic_tools.query_metrics = MagicMock(
-            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
+        self._bind_authored_osi_target(node, real_agent_config)
+        ctx = StreamRunContext(
+            user_input=node.input,
+            action_history_manager=ActionHistoryManager(),
         )
-        node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
-
-        node._finalize_metric_generation(
-            f"subject/semantic_models/{datasource}/orders.yml",
-            f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml",
-            "generated",
-        )
-
-        node.generation_tools.end_metric_generation.assert_called_once_with(
-            metric_file=str(metric_path),
-            semantic_model_files=[],
+        ctx.response_content = json.dumps(
+            {
+                "metric_file": None,
+                "status": "blocked",
+                "blocker_code": "semantic_model_target_invalid",
+                "output": "Cannot select a model.",
+            }
         )
 
-    def test_osi_final_metric_publish_skips_when_already_synced(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.generation_evidence.mark_kb_sync("metric")
-        node.generation_tools.end_metric_generation = MagicMock()
-
-        node._finalize_metric_generation(None, "orders_metrics.yml", "generated")
-
-        node.generation_tools.end_metric_generation.assert_not_called()
-
-    def test_osi_skipped_status_without_metric_file_returns_cleanly(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.generation_tools.end_metric_generation = MagicMock()
-
-        node._finalize_metric_generation(None, None, "skipped")
-
-        node.generation_tools.end_metric_generation.assert_not_called()
-
-    def test_osi_skipped_status_with_metric_file_fails_closed(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-
-        with pytest.raises(RuntimeError, match="status='skipped' with a non-null metric_file"):
-            node._finalize_metric_generation(None, "orders_metrics.yml", "skipped")
-
-    def test_osi_generated_status_without_metric_file_fails_closed(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-
-        with pytest.raises(RuntimeError, match="status='generated' without a metric_file"):
-            node._finalize_metric_generation(None, None, "generated")
-
-    def test_osi_empty_final_response_without_metric_file_is_noop(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.generation_tools.end_metric_generation = MagicMock()
-
-        node._finalize_metric_generation(None, None, None)
-
-        node.generation_tools.end_metric_generation.assert_not_called()
-
-    def test_osi_final_metric_publish_requires_generation_tools(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.generation_tools = None
-
-        with pytest.raises(RuntimeError, match="generation tools are unavailable"):
-            node._finalize_metric_generation(None, "orders_metrics.yml", "generated")
-
-    def test_osi_final_metric_publish_requires_validation_tool(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.semantic_tools = None
-
-        with pytest.raises(RuntimeError, match="validate_semantic is unavailable"):
-            node._finalize_metric_generation(None, "orders_metrics.yml", "generated")
-
-    def test_osi_final_metric_publish_reports_validation_failure(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.func_tool.base import FuncToolResult
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.semantic_tools = MagicMock()
-        node.semantic_tools.validate_semantic = MagicMock(
-            return_value=FuncToolResult(success=0, error="invalid OSI", result={"valid": False})
-        )
-        node.generation_tools.extract_osi_model_names = MagicMock(return_value=["shop"])
-
-        with pytest.raises(RuntimeError, match="validate_semantic failed"):
-            node._finalize_metric_generation(None, "orders_metrics.yml", "generated")
-
-    def test_osi_final_metric_publish_uses_authoring_quality_check(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.func_tool.base import FuncToolResult
-
-        datasource = real_agent_config.current_datasource
-        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
-        metric_dir.mkdir(parents=True, exist_ok=True)
-        (metric_dir / "orders_metrics.yml").write_text(
-            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: order_count\n",
-            encoding="utf-8",
-        )
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.semantic_tools = MagicMock()
-        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
-        node.semantic_tools.query_metrics = MagicMock(
-            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
-        )
-        node.generation_tools.end_metric_generation = MagicMock(return_value=FuncToolResult(result={"message": "ok"}))
-
-        node._finalize_metric_generation(
-            None,
-            f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml",
-            "generated",
-        )
-
-        node.semantic_tools.validate_semantic.assert_called_once_with(
-            semantic_model_name="shop", checks=["authoring_quality"]
-        )
-
-    def test_osi_final_metric_publish_requires_query_metrics_tool(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.func_tool.base import FuncToolResult
-
-        datasource = real_agent_config.current_datasource
-        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
-        metric_dir.mkdir(parents=True, exist_ok=True)
-        (metric_dir / "orders_metrics.yml").write_text(
-            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: order_count\n",
-            encoding="utf-8",
-        )
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.semantic_tools = MagicMock()
-        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
-        delattr(node.semantic_tools, "query_metrics")
-
-        with pytest.raises(RuntimeError, match="query_metrics is unavailable"):
-            node._finalize_metric_generation(
-                None,
-                f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml",
-                "generated",
-            )
-
-    def test_osi_final_metric_publish_reports_dry_run_failure(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.func_tool.base import FuncToolResult
-
-        datasource = real_agent_config.current_datasource
-        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
-        metric_dir.mkdir(parents=True, exist_ok=True)
-        (metric_dir / "orders_metrics.yml").write_text(
-            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: order_count\n",
-            encoding="utf-8",
-        )
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.semantic_tools = MagicMock()
-        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
-        node.semantic_tools.query_metrics = MagicMock(return_value=FuncToolResult(success=0, error="compile failed"))
-
-        with pytest.raises(RuntimeError, match="query_metrics\\(dry_run=True\\) failed"):
-            node._finalize_metric_generation(
-                None, f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml", "generated"
-            )
-
-    def test_osi_final_metric_publish_requires_queryability_contracts(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.func_tool.base import FuncToolResult
-        from datus.utils.exceptions import DatusException
-
-        datasource = real_agent_config.current_datasource
-        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
-        metric_dir.mkdir(parents=True, exist_ok=True)
-        (metric_dir / "revenue_metrics.yml").write_text(
-            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: revenue_total\n",
-            encoding="utf-8",
-        )
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.input = SemanticNodeInput(
-            user_message="SELECT customer_segment, SUM(revenue) FROM orders GROUP BY customer_segment"
-        )
-        node.semantic_tools = MagicMock()
-        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
-        node.semantic_tools.query_metrics = MagicMock(
-            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
-        )
-        node.generation_tools.end_metric_generation = MagicMock()
-
-        with pytest.raises(DatusException, match="source SQL group-by dimensions"):
-            node._finalize_metric_generation(
-                None,
-                f"subject/semantic_models/{datasource}/metrics/revenue_metrics.yml",
-                "generated",
-            )
-
-        node.generation_tools.end_metric_generation.assert_not_called()
-
-    def test_osi_final_metric_publish_reports_sync_failure(self, real_agent_config, mock_llm_create):
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-        from datus.tools.func_tool.base import FuncToolResult
-
-        datasource = real_agent_config.current_datasource
-        metric_dir = real_agent_config.path_manager.semantic_model_path(datasource) / "metrics"
-        metric_dir.mkdir(parents=True, exist_ok=True)
-        (metric_dir / "orders_metrics.yml").write_text(
-            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: order_count\n",
-            encoding="utf-8",
-        )
-
-        _set_global_semantic_adapter(real_agent_config, "osi")
-        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
-        node.semantic_tools = MagicMock()
-        node.semantic_tools.validate_semantic = MagicMock(return_value=FuncToolResult(result={"valid": True}))
-        node.semantic_tools.query_metrics = MagicMock(
-            return_value=FuncToolResult(result={"metadata": {"sql": "SELECT 1"}})
-        )
-        node.generation_tools.end_metric_generation = MagicMock(
-            return_value=FuncToolResult(success=0, error="sync failed")
-        )
-
-        with pytest.raises(RuntimeError, match="OSI metric KB sync failed"):
-            node._finalize_metric_generation(
-                None,
-                f"subject/semantic_models/{datasource}/metrics/orders_metrics.yml",
-                "generated",
-            )
+        with pytest.raises(RuntimeError, match="only valid before metric authoring"):
+            node._build_success_result(ctx)
 
     @pytest.mark.asyncio
     async def test_final_metric_file_rejects_out_of_sandbox_absolute_path(
@@ -1723,43 +1633,6 @@ semantic_model:
         assert actions[-1].status == ActionStatus.FAILED
         assert actions[-1].action_type == "error"
         assert "status='generated' without a metric_file" in actions[-1].output["error"]
-
-    @pytest.mark.asyncio
-    async def test_explicit_non_skipped_status_without_metric_file_fails_closed(
-        self, real_agent_config, mock_llm_create
-    ):
-        """Any explicit non-skipped final status must not silently bypass publishing."""
-        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
-
-        mock_llm_create.reset(
-            responses=[
-                build_simple_response(
-                    json.dumps(
-                        {
-                            "semantic_model_file": "orders.yml",
-                            "metric_file": None,
-                            "status": "done",
-                            "output": "Done.",
-                        }
-                    )
-                ),
-            ]
-        )
-
-        node = GenMetricsAgenticNode(
-            agent_config=real_agent_config,
-            execution_mode="workflow",
-        )
-        node.input = SemanticNodeInput(user_message="Generate metrics")
-
-        action_manager = ActionHistoryManager()
-        actions = []
-        async for action in node.execute_stream(action_manager):
-            actions.append(action)
-
-        assert actions[-1].status == ActionStatus.FAILED
-        assert actions[-1].action_type == "error"
-        assert "status='done' without a metric_file" in actions[-1].output["error"]
 
 
 class TestGenMetricsFilesystemRootPath:

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -207,14 +207,17 @@ class TestGenMetricsAgenticNodeExecution:
         assert last_action.status == ActionStatus.SUCCESS
 
     @pytest.mark.asyncio
-    async def test_before_stream_resets_all_request_scoped_authoring_state(self, real_agent_config, mock_llm_create):
+    async def test_before_stream_resets_authoring_state_and_preserves_request_hints(
+        self, real_agent_config, mock_llm_create
+    ):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.agent.node.stream_run_context import StreamRunContext
 
         _set_global_semantic_adapter(real_agent_config, "osi")
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         node.input = SemanticNodeInput(
-            user_message="Create order metrics. The semantic model is at subject/semantic_models/warehouse/orders.yml."
+            user_message="Create order metrics. The semantic model is at subject/semantic_models/warehouse/orders.yml.",
+            semantic_model_name="requested_target",
         )
         node.osi_target_state.select(
             {
@@ -238,7 +241,7 @@ class TestGenMetricsAgenticNodeExecution:
         assert node.generation_evidence == type(evidence)()
         assert node.generation_tools.generation_evidence is evidence
         assert node.semantic_tools.generation_evidence is evidence
-        assert node.input.semantic_model_name is None
+        assert node.input.semantic_model_name == "requested_target"
         assert mock_llm_create.call_history == []
 
     @pytest.mark.asyncio
@@ -1363,7 +1366,7 @@ class TestExecuteStreamGenMetricsError:
             {
                 "metric_file": None,
                 "status": "blocked",
-                "blocker_code": "semantic_model_required",
+                "blocker_code": " Semantic_Model_Required ",
                 "output": "No existing model matches this metric domain.",
             }
         )
@@ -1373,6 +1376,31 @@ class TestExecuteStreamGenMetricsError:
         assert result.success is False
         assert result.status == "blocked"
         assert result.blocker_code == "semantic_model_required"
+
+    def test_osi_skipped_result_normalizes_skip_reason(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Explain the source data")
+        ctx = StreamRunContext(
+            user_input=node.input,
+            action_history_manager=ActionHistoryManager(),
+        )
+        ctx.response_content = json.dumps(
+            {
+                "metric_file": None,
+                "status": " SKIPPED ",
+                "skip_reason": " Not_A_Metric ",
+                "output": "The request does not define a metric.",
+            }
+        )
+
+        result = node._build_success_result(ctx)
+
+        assert result.status == "skipped"
+        assert result.skip_reason == "not_a_metric"
 
     def test_osi_bound_target_can_report_a_missing_semantic_prerequisite(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -125,10 +125,92 @@ class TestGenSemanticModelAgenticNodeInit:
             "edit_file",
             "glob",
             "grep",
-            "resolve_osi_semantic_model_target",
+            "plan_osi_semantic_model_target",
         }.issubset(tool_names)
         assert {"delete_file", "upsert_osi_metrics", "bash"}.isdisjoint(tool_names)
         assert "end_semantic_model_generation" in tool_names
+        node._populate_tool_registry()
+        assert node.tool_registry.get("plan_osi_semantic_model_target") == "semantic_tools"
+
+    @pytest.mark.asyncio
+    async def test_before_stream_resets_request_state_without_replacing_shared_evidence(
+        self, real_agent_config, mock_llm_create
+    ):
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+        from datus.agent.node.stream_run_context import StreamRunContext
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenSemanticModelAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.input = SemanticNodeInput(user_message="Generate an OSI semantic model")
+        node.osi_target_state.select(
+            {
+                "semantic_model_name": "old_model",
+                "semantic_model_file": "subject/semantic_models/warehouse/old.yml",
+                "absolute_path": "/tmp/old.yml",
+            },
+            mode="planned",
+        )
+        node.generation_evidence.validation_passed = True
+        node.generation_evidence.semantic_kb_sync_passed = True
+        evidence = node.generation_evidence
+        ctx = StreamRunContext(user_input=node.input, action_history_manager=ActionHistoryManager())
+
+        await node._before_stream(ctx)
+
+        assert node.osi_target_state.planned is None
+        assert node.generation_evidence is evidence
+        assert node.generation_evidence == type(evidence)()
+        assert node.generation_tools.generation_evidence is evidence
+        assert node.semantic_func_tool.generation_evidence is evidence
+
+    def test_osi_filesystem_mutations_require_and_preserve_the_planned_target(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+
+        _set_global_semantic_adapter(real_agent_config, "osi")
+        node = GenSemanticModelAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        datasource = real_agent_config.current_datasource
+        target = f"subject/semantic_models/{datasource}/orders.yml"
+        sibling = f"subject/semantic_models/{datasource}/customers.yml"
+        content = (
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: orders\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: orders\n"
+        )
+
+        unplanned = node.filesystem_func_tool.write_file(target, content)
+        assert not unplanned.success
+        assert "Plan the OSI semantic-model target" in unplanned.error
+
+        plan = node.osi_target_tools.plan_osi_semantic_model_target(semantic_model_name="orders")
+        assert plan.success
+        wrong_target = node.filesystem_func_tool.write_file(sibling, content.replace("orders", "customers"))
+        assert not wrong_target.success
+        assert "authoring is planned for" in wrong_target.error
+
+        node.generation_evidence.validation_passed = True
+        node.generation_evidence.semantic_kb_sync_passed = True
+        written = node.filesystem_func_tool.write_file(target, content)
+        edited = node.filesystem_func_tool.edit_file(
+            target,
+            "source: orders",
+            "source: analytics.orders",
+        )
+
+        assert written.success
+        assert edited.success
+        assert node.generation_evidence.validation_passed is False
+        assert node.generation_evidence.semantic_kb_sync_passed is False
+
+        replan = node.osi_target_tools.plan_osi_semantic_model_target(semantic_model_name="customers")
+        assert not replan.success
+        assert "cannot change after authoring started" in replan.error
+        assert node.osi_target_state.planned["semantic_model_name"] == "orders"
+        assert node.osi_target_state.last_error_code == "semantic_model_target_invalid"
+        with pytest.raises(ValueError, match="unresolved after a failed replan"):
+            node.generation_tools._resolve_planned_osi_semantic_target()
 
     def test_semantic_sql_history_profiler_tool_opt_out(self, real_agent_config, mock_llm_create):
         """An explicit empty skills entry removes the profiler tool."""
@@ -546,12 +628,12 @@ class TestPrepareTemplateContext:
 
         context = node._prepare_template_context(user_input)
 
-        assert context["osi_target_resolved"] is False
-        assert context["requested_semantic_model_name"] == ""
-        assert context["requested_dimension_tables"] == []
+        assert "osi_target_resolved" not in context
+        assert "requested_semantic_model_name" not in context
         enhanced = node._build_enhanced_message(user_input)
-        assert "executive_sales" in enhanced
-        assert "executive_sales.yml" in enhanced
+        assert "Requested semantic model name: `Executive Sales`" in enhanced
+        assert "executive_sales.yml" not in enhanced
+        assert "only the tool result binds the target" in enhanced
         assert "main.orders" in enhanced
         assert "main.customers" in enhanced
 
@@ -678,11 +760,16 @@ class TestExecuteStreamGenSemanticModelError:
         node.generation_evidence = GenerationEvidence(validation_passed=True)
         node.generation_evidence.record_semantic_artifact_validation("sales", sales_file)
         node.generation_tools = MagicMock()
-        node.generation_tools._resolve_generation_path.return_value = str(finance_file)
-        node.generation_tools.extract_osi_model_names.return_value = ["finance"]
+        node.generation_tools._resolve_planned_osi_semantic_target.return_value = (
+            "subject/semantic_models/warehouse/finance.yml",
+            str(finance_file),
+            "finance",
+        )
+        node.generation_tools.end_semantic_model_generation.return_value = FuncToolResult(
+            result={"semantic_model_files": ["subject/semantic_models/warehouse/finance.yml"]}
+        )
         node.semantic_func_tool = MagicMock()
         node.semantic_func_tool.validate_semantic.return_value = FuncToolResult(result={"valid": True, "issues": []})
-        node._save_to_db = MagicMock(return_value=True)
 
         node._finalize_semantic_model_generation(["finance.yml"])
 
@@ -690,13 +777,29 @@ class TestExecuteStreamGenSemanticModelError:
             scope="semantic_model",
             semantic_model_name="finance",
         )
-        node._save_to_db.assert_called_once_with(
-            "finance.yml",
-            catalog=None,
-            database=None,
-            db_schema=None,
+        node.generation_tools.end_semantic_model_generation.assert_called_once_with(
+            ["subject/semantic_models/warehouse/finance.yml"]
         )
         assert node.generation_evidence.semantic_artifact_validation_passed("finance", finance_file)
+
+    def test_osi_finalizer_rejects_unplanned_final_json_fallback(self):
+        from datus.agent.node.gen_semantic_model_agentic_node import GenSemanticModelAgenticNode
+        from datus.tools.func_tool.generation_evidence import GenerationEvidence
+
+        node = GenSemanticModelAgenticNode.__new__(GenSemanticModelAgenticNode)
+        node.agent_config = SimpleNamespace(resolve_semantic_adapter=lambda requested=None: "osi")
+        node.generation_evidence = GenerationEvidence()
+        node.generation_tools = MagicMock()
+        node.generation_tools._resolve_planned_osi_semantic_target.side_effect = ValueError(
+            "Plan the OSI semantic-model name and file before publishing."
+        )
+        node.semantic_func_tool = MagicMock()
+
+        with pytest.raises(RuntimeError, match="Plan the OSI semantic-model"):
+            node._finalize_semantic_model_generation(["subject/semantic_models/warehouse/rogue.yml"])
+
+        node.semantic_func_tool.validate_semantic.assert_not_called()
+        node.generation_tools.end_semantic_model_generation.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_execute_stream_error_yields_error_action(self, real_agent_config, mock_llm_create):

--- a/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_semantic_model_agentic_node.py
@@ -210,7 +210,7 @@ class TestGenSemanticModelAgenticNodeInit:
         assert node.osi_target_state.planned["semantic_model_name"] == "orders"
         assert node.osi_target_state.last_error_code == "semantic_model_target_invalid"
         with pytest.raises(ValueError, match="unresolved after a failed replan"):
-            node.generation_tools._resolve_planned_osi_semantic_target()
+            node.generation_tools.resolve_planned_osi_semantic_target()
 
     def test_semantic_sql_history_profiler_tool_opt_out(self, real_agent_config, mock_llm_create):
         """An explicit empty skills entry removes the profiler tool."""
@@ -760,7 +760,7 @@ class TestExecuteStreamGenSemanticModelError:
         node.generation_evidence = GenerationEvidence(validation_passed=True)
         node.generation_evidence.record_semantic_artifact_validation("sales", sales_file)
         node.generation_tools = MagicMock()
-        node.generation_tools._resolve_planned_osi_semantic_target.return_value = (
+        node.generation_tools.resolve_planned_osi_semantic_target.return_value = (
             "subject/semantic_models/warehouse/finance.yml",
             str(finance_file),
             "finance",
@@ -790,7 +790,7 @@ class TestExecuteStreamGenSemanticModelError:
         node.agent_config = SimpleNamespace(resolve_semantic_adapter=lambda requested=None: "osi")
         node.generation_evidence = GenerationEvidence()
         node.generation_tools = MagicMock()
-        node.generation_tools._resolve_planned_osi_semantic_target.side_effect = ValueError(
+        node.generation_tools.resolve_planned_osi_semantic_target.side_effect = ValueError(
             "Plan the OSI semantic-model name and file before publishing."
         )
         node.semantic_func_tool = MagicMock()

--- a/tests/unit_tests/agent/node/test_semantic_authoring.py
+++ b/tests/unit_tests/agent/node/test_semantic_authoring.py
@@ -1,37 +1,29 @@
 """Unit tests for semantic authoring format resolution."""
 
-from dataclasses import dataclass
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import yaml
 
+from datus.agent.node import semantic_authoring
 from datus.agent.node.semantic_authoring import (
     AUTHORING_FORMAT_METRICFLOW,
     AUTHORING_FORMAT_OSI,
-    _source_query_dialect,
     default_optional_skills,
-    default_osi_semantic_model_file,
-    default_osi_semantic_model_name,
     discover_osi_semantic_models,
-    osi_semantic_models_cover_tables,
+    plan_osi_semantic_model_target,
     required_authoring_skills,
     resolve_authoring_format,
-    resolve_existing_osi_semantic_model,
-    resolve_osi_semantic_model_target,
     resolve_semantic_adapter_type,
+    validate_osi_core_document,
 )
-from datus.configuration.agent_config import DbConfig
-from datus.schemas.node_models import ReferenceSql
-from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
 from datus.utils.exceptions import DatusException, ErrorCode
 
 
-@dataclass
-class _DbScope:
-    database: str = ""
-    schema: str = ""
-    catalog: str = ""
+@pytest.fixture(autouse=True)
+def _stub_osi_schema_validation(monkeypatch):
+    monkeypatch.setattr(semantic_authoring, "validate_osi_core_document", lambda document: None)
 
 
 def _agent_config(adapter):
@@ -63,6 +55,29 @@ def _write_osi_model(tmp_path, filename, model_name, datasets):
     return target
 
 
+def test_validate_osi_core_document_uses_canonical_validator(monkeypatch):
+    class FakeOSIValidationError(Exception):
+        pass
+
+    profile_module = ModuleType("datus_semantic_osi.profile")
+    errors_module = ModuleType("datus_semantic_osi.errors")
+    package_module = ModuleType("datus_semantic_osi")
+    package_module.__path__ = []
+    errors_module.OSIValidationError = FakeOSIValidationError
+    profile_module.validate_osi_core_schema = lambda document: None
+    monkeypatch.setitem(sys.modules, "datus_semantic_osi", package_module)
+    monkeypatch.setitem(sys.modules, "datus_semantic_osi.profile", profile_module)
+    monkeypatch.setitem(sys.modules, "datus_semantic_osi.errors", errors_module)
+
+    assert validate_osi_core_document({"version": "valid"}) is None
+
+    def reject(document):
+        raise FakeOSIValidationError("schema mismatch")
+
+    profile_module.validate_osi_core_schema = reject
+    assert validate_osi_core_document({"version": "invalid"}) == "schema mismatch"
+
+
 def test_legacy_node_config_fields_are_ignored():
     assert (
         resolve_authoring_format(_agent_config("metricflow"), {"authoring_format": "osi"})
@@ -83,66 +98,6 @@ def test_legacy_node_semantic_adapter_is_ignored():
     )
 
 
-def test_default_osi_semantic_model_name_uses_database_scope():
-    config = SimpleNamespace(
-        current_datasource="warehouse",
-        current_db_config=lambda: _DbScope(database="Sales Domain"),
-    )
-
-    assert default_osi_semantic_model_name(config) == "sales_domain"
-    assert default_osi_semantic_model_file(config) == "subject/semantic_models/warehouse/sales_domain.yml"
-
-
-def test_default_osi_semantic_model_name_prefers_runtime_database_scope():
-    config = SimpleNamespace(
-        current_datasource="starrocks",
-        current_db_config=lambda: _DbScope(),
-        runtime_db_context=lambda: {"database": "ac_manage"},
-    )
-
-    assert default_osi_semantic_model_name(config) == "ac_manage"
-    assert default_osi_semantic_model_file(config) == "subject/semantic_models/starrocks/ac_manage.yml"
-
-
-def test_default_osi_semantic_model_name_uses_declared_db_scope_fallbacks():
-    config = SimpleNamespace(
-        current_datasource="warehouse",
-        current_db_config=lambda: _DbScope(schema="Reporting Schema", catalog="Lake House"),
-    )
-
-    assert default_osi_semantic_model_name(config) == "reporting_schema"
-    assert default_osi_semantic_model_file(config) == "subject/semantic_models/warehouse/reporting_schema.yml"
-
-
-def test_default_osi_semantic_model_name_skips_undeclared_schema_method():
-    class DbScopeWithSchemaMethod:
-        __annotations__ = {"database": str, "catalog": str}
-
-        database = ""
-        catalog = "Lake House"
-
-        def schema(self):
-            return "method-value"
-
-    config = SimpleNamespace(
-        current_datasource="warehouse",
-        current_db_config=lambda: DbScopeWithSchemaMethod(),
-    )
-
-    assert default_osi_semantic_model_name(config) == "lake_house"
-
-
-def test_default_osi_semantic_model_name_uses_agent_scope_fallbacks():
-    config = SimpleNamespace(
-        current_datasource="",
-        project_name="Project Alpha",
-        current_db_config=lambda: _DbScope(),
-    )
-
-    assert default_osi_semantic_model_name(config) == "project_alpha"
-    assert default_osi_semantic_model_file(config) == "subject/semantic_models/default/project_alpha.yml"
-
-
 def test_osi_target_explicit_name_wins_over_domain_and_existing_fact(tmp_path):
     config = _osi_config(tmp_path)
     _write_osi_model(
@@ -152,7 +107,7 @@ def test_osi_target_explicit_name_wins_over_domain_and_existing_fact(tmp_path):
         [{"name": "orders", "source": "analytics.fact_orders"}],
     )
 
-    target = resolve_osi_semantic_model_target(
+    target = plan_osi_semantic_model_target(
         config,
         semantic_model_name="Executive Sales",
         business_domain="commerce",
@@ -166,7 +121,7 @@ def test_osi_target_explicit_name_wins_over_domain_and_existing_fact(tmp_path):
 
 
 def test_osi_target_uses_business_domain_for_a_new_model(tmp_path):
-    target = resolve_osi_semantic_model_target(
+    target = plan_osi_semantic_model_target(
         _osi_config(tmp_path),
         business_domain="Order Fulfillment",
         fact_tables=["analytics.fact_orders"],
@@ -179,12 +134,12 @@ def test_osi_target_uses_business_domain_for_a_new_model(tmp_path):
 
 def test_osi_target_fact_fallback_does_not_change_when_dimensions_change(tmp_path):
     config = _osi_config(tmp_path)
-    first = resolve_osi_semantic_model_target(
+    first = plan_osi_semantic_model_target(
         config,
         fact_tables=["analytics.fact_order_items"],
         dimension_tables=["analytics.dim_customer"],
     )
-    second = resolve_osi_semantic_model_target(
+    second = plan_osi_semantic_model_target(
         config,
         fact_tables=["analytics.fact_order_items"],
         dimension_tables=["analytics.dim_customer", "analytics.dim_product"],
@@ -204,7 +159,7 @@ def test_osi_target_reuses_existing_model_name_when_dimensions_are_added(tmp_pat
         [{"name": "orders", "source": "analytics.fact_orders"}],
     )
 
-    target = resolve_osi_semantic_model_target(
+    target = plan_osi_semantic_model_target(
         config,
         business_domain="new_domain_label",
         fact_tables=["analytics.fact_orders"],
@@ -226,7 +181,7 @@ def test_osi_target_identity_uses_only_the_core_fact_table(tmp_path):
         [{"name": "inventory", "source": "analytics.fact_inventory"}],
     )
 
-    target = resolve_osi_semantic_model_target(
+    target = plan_osi_semantic_model_target(
         config,
         business_domain="support",
         fact_tables=["support.fact_tickets", "analytics.fact_inventory"],
@@ -235,287 +190,6 @@ def test_osi_target_identity_uses_only_the_core_fact_table(tmp_path):
     assert target["semantic_model_name"] == "support"
     assert target["matched_by"] == "business_domain"
     assert target["exists"] is False
-
-
-def test_osi_model_coverage_requires_one_model_to_cover_the_table_group(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(
-        tmp_path,
-        "orders.yml",
-        "orders",
-        [{"name": "orders", "source": "analytics.fact_orders"}],
-    )
-    _write_osi_model(
-        tmp_path,
-        "payments.yml",
-        "payments",
-        [{"name": "payments", "source": "finance.fact_payments"}],
-    )
-
-    assert osi_semantic_models_cover_tables(config, ["analytics.fact_orders"])
-    assert osi_semantic_models_cover_tables(config, ["finance.fact_payments"])
-    assert not osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "finance.fact_payments"])
-    assert not osi_semantic_models_cover_tables(config, ["analytics.fact_orders", "support.fact_tickets"])
-
-
-def test_existing_osi_metric_target_uses_dataset_mentioned_in_request(tmp_path):
-    config = _osi_config(tmp_path)
-    school_file = _write_osi_model(
-        tmp_path,
-        "school-domain.yaml",
-        "school_operations",
-        [{"name": "schools", "source": "education.schools"}],
-    )
-    _write_osi_model(
-        tmp_path,
-        "sales.yml",
-        "sales",
-        [{"name": "orders", "source": "commerce.orders"}],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(
-        config,
-        request_text="Generate enrollment metrics from schools",
-    )
-
-    assert resolution["status"] == "found"
-    assert resolution["selected"]["semantic_model_name"] == "school_operations"
-    assert resolution["selected"]["absolute_path"] == str(school_file)
-
-
-def test_existing_osi_metric_target_is_ambiguous_without_dataset_hint(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(tmp_path, "schools.yml", "schools", [{"name": "schools", "source": "edu.schools"}])
-    _write_osi_model(tmp_path, "sales.yml", "sales", [{"name": "orders", "source": "sales.orders"}])
-
-    resolution = resolve_existing_osi_semantic_model(config, request_text="Generate metrics")
-
-    assert resolution["status"] == "ambiguous"
-    assert {model["semantic_model_name"] for model in resolution["candidates"]} == {"schools", "sales"}
-
-
-def test_existing_osi_metric_target_does_not_reuse_unrelated_single_model(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(tmp_path, "sales.yml", "sales", [{"name": "orders", "source": "sales.orders"}])
-
-    resolution = resolve_existing_osi_semantic_model(
-        config,
-        request_text="Generate total amount from payments",
-    )
-
-    assert resolution["status"] == "missing"
-    assert resolution["referenced_tables"] == ["payments"]
-
-
-def test_existing_osi_metric_target_rejects_tables_split_across_models(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(tmp_path, "schools.yml", "schools", [{"name": "schools", "source": "edu.schools"}])
-    _write_osi_model(tmp_path, "sales.yml", "sales", [{"name": "orders", "source": "sales.orders"}])
-
-    resolution = resolve_existing_osi_semantic_model(
-        config,
-        referenced_tables=["edu.schools", "sales.orders"],
-    )
-
-    assert resolution["status"] == "ambiguous"
-    assert resolution["reason"] == "referenced datasets are split across multiple semantic models"
-
-
-def test_existing_osi_metric_target_uses_structured_source_sql_instead_of_batch_prompt(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(
-        tmp_path,
-        "campaign.yml",
-        "campaign_management",
-        [{"name": "campaign", "source": "analytics.campaign"}],
-    )
-    user_input = SemanticNodeInput(
-        user_message=(
-            "Analyze the following SQL queries and extract core metrics:\n\n"
-            "Query 2:\nQuestion: campaign count\nSQL:\nSELECT COUNT(*) FROM analytics.campaign"
-        ),
-        source_queries=[
-            SourceQueryEvidence(
-                source_sql_name="sql_2",
-                question="campaign count",
-                sql="SELECT COUNT(*) FROM analytics.campaign",
-            )
-        ],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(
-        config,
-        user_input=user_input,
-        request_text=user_input.user_message,
-    )
-
-    assert resolution["status"] == "found"
-    assert resolution["selected"]["semantic_model_name"] == "campaign_management"
-    assert resolution["referenced_tables"] == ["analytics.campaign"]
-    assert resolution["evidence_source"] == "source_queries"
-    assert resolution["source_sql_names"] == ["sql_2"]
-
-
-def test_structured_source_sql_does_not_change_reference_sql_context(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(
-        tmp_path,
-        "orders.yml",
-        "orders",
-        [{"name": "orders", "source": "sales.orders"}],
-    )
-    _write_osi_model(
-        tmp_path,
-        "payments.yml",
-        "payments",
-        [{"name": "payments", "source": "finance.payments"}],
-    )
-    user_input = SemanticNodeInput(
-        user_message="Generate order metrics",
-        source_queries=[SourceQueryEvidence(source_sql_name="sql_1", sql="SELECT COUNT(*) FROM sales.orders")],
-        reference_sql=[ReferenceSql(name="payment_example", sql="SELECT SUM(amount) FROM finance.payments")],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
-
-    assert resolution["status"] == "found"
-    assert resolution["selected"]["semantic_model_name"] == "orders"
-    assert resolution["referenced_tables"] == ["sales.orders"]
-    assert user_input.reference_sql[0].name == "payment_example"
-
-
-def test_reference_sql_still_resolves_model_without_structured_sources(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(
-        tmp_path,
-        "payments.yml",
-        "payments",
-        [{"name": "payments", "source": "finance.payments"}],
-    )
-    user_input = SemanticNodeInput(
-        user_message="Generate payment metrics",
-        reference_sql=[ReferenceSql(name="payment_example", sql="SELECT SUM(amount) FROM finance.payments")],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
-
-    assert resolution["status"] == "found"
-    assert resolution["selected"]["semantic_model_name"] == "payments"
-    assert resolution["evidence_source"] == "legacy_request"
-
-
-def test_invalid_structured_source_sql_does_not_fallback_to_prompt(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(
-        tmp_path,
-        "orders.yml",
-        "orders",
-        [{"name": "orders", "source": "sales.orders"}],
-    )
-    user_input = SemanticNodeInput(
-        user_message="SQL:\nSELECT COUNT(*) FROM sales.orders",
-        source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(
-        config,
-        user_input=user_input,
-        request_text=user_input.user_message,
-    )
-
-    assert resolution["status"] == "invalid"
-    assert resolution["evidence_source"] == "source_queries"
-    assert resolution["parse_errors"][0]["source_sql_name"] == "sql_9"
-
-
-def test_invalid_structured_source_sql_is_rejected_before_explicit_model_selection(tmp_path):
-    config = _osi_config(tmp_path)
-    _write_osi_model(
-        tmp_path,
-        "orders.yml",
-        "orders",
-        [{"name": "orders", "source": "sales.orders"}],
-    )
-    user_input = SemanticNodeInput(
-        user_message="Generate order metrics",
-        semantic_model_name="orders",
-        source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
-
-    assert resolution["status"] == "invalid"
-    assert resolution["parse_errors"][0]["source_sql_name"] == "sql_9"
-
-
-def test_structured_source_sql_uses_mysql_fallback_for_starrocks_datetime_cast(tmp_path):
-    config = _osi_config(tmp_path)
-    config.current_db_config = lambda: DbConfig(type="starrocks")
-    _write_osi_model(
-        tmp_path,
-        "campaign.yml",
-        "campaign_management",
-        [{"name": "activities", "source": "v_udata_ac_info"}],
-    )
-    user_input = SemanticNodeInput(
-        user_message="Analyze the following SQL queries",
-        source_queries=[
-            SourceQueryEvidence(
-                source_sql_name="sql_13",
-                sql=(
-                    "SELECT CAST(start_time AS DATETIME) AS start_at, COUNT(*) "
-                    "FROM v_udata_ac_info GROUP BY CAST(start_time AS DATETIME)"
-                ),
-            )
-        ],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
-
-    assert _source_query_dialect(config) == "starrocks"
-    assert resolution["status"] == "found"
-    assert resolution["selected"]["semantic_model_name"] == "campaign_management"
-    assert resolution["referenced_tables"] == ["v_udata_ac_info"]
-
-
-def test_existing_osi_metric_target_indexes_query_backed_dataset_source_tables(tmp_path):
-    config = _osi_config(tmp_path)
-    config.current_db_config = lambda: DbConfig(type="starrocks")
-    query_source = (
-        "SELECT a.suserid, c.city_level "
-        "FROM ac_manage.dim_mgamejp_account_allinfo_nf AS a "
-        "JOIN ac_manage.dim_uf_player_gameinfo_mf AS c ON a.suserid = c.userid"
-    )
-    _write_osi_model(
-        tmp_path,
-        "account.yml",
-        "account_analytics",
-        [
-            {
-                "name": "account_player_gameinfo",
-                "source": query_source,
-                "custom_extensions": [
-                    {
-                        "vendor_name": "DATUS",
-                        "data": '{"source_type":"query"}',
-                    }
-                ],
-            }
-        ],
-    )
-    user_input = SemanticNodeInput(
-        user_message="Analyze the following SQL queries",
-        source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql=query_source)],
-    )
-
-    resolution = resolve_existing_osi_semantic_model(config, user_input=user_input)
-
-    assert resolution["status"] == "found"
-    assert resolution["selected"]["semantic_model_name"] == "account_analytics"
-    assert set(resolution["referenced_tables"]) == {
-        "ac_manage.dim_mgamejp_account_allinfo_nf",
-        "ac_manage.dim_uf_player_gameinfo_mf",
-    }
 
 
 def test_osi_target_creates_a_different_file_for_an_unrelated_fact(tmp_path):
@@ -527,7 +201,7 @@ def test_osi_target_creates_a_different_file_for_an_unrelated_fact(tmp_path):
         [{"name": "orders", "source": "analytics.fact_orders"}],
     )
 
-    target = resolve_osi_semantic_model_target(config, fact_tables=["finance.fact_payments"])
+    target = plan_osi_semantic_model_target(config, fact_tables=["finance.fact_payments"])
 
     assert target["semantic_model_name"] == "fact_payments_analytics"
     assert target["semantic_model_file"].endswith("/fact_payments_analytics.yml")
@@ -544,7 +218,7 @@ def test_osi_target_does_not_reuse_same_leaf_table_from_another_schema(tmp_path)
         [{"name": "orders", "source": "sales.fact_orders"}],
     )
 
-    target = resolve_osi_semantic_model_target(config, fact_tables=["finance.fact_orders"])
+    target = plan_osi_semantic_model_target(config, fact_tables=["finance.fact_orders"])
 
     assert target["semantic_model_name"] == "fact_orders_analytics"
     assert target["semantic_model_file"].endswith("/fact_orders_analytics.yml")
@@ -560,7 +234,7 @@ def test_osi_target_preserves_qualified_table_component_boundaries(tmp_path):
         [{"name": "orders", "source": "sales_fact.orders"}],
     )
 
-    target = resolve_osi_semantic_model_target(config, fact_tables=["sales.fact_orders"])
+    target = plan_osi_semantic_model_target(config, fact_tables=["sales.fact_orders"])
 
     assert target["semantic_model_name"] == "fact_orders_analytics"
     assert target["exists"] is False
@@ -575,7 +249,7 @@ def test_osi_target_allows_leaf_fallback_for_unqualified_fact_reference(tmp_path
         [{"name": "orders", "source": "sales.fact_orders"}],
     )
 
-    target = resolve_osi_semantic_model_target(config, fact_tables=["fact_orders"])
+    target = plan_osi_semantic_model_target(config, fact_tables=["fact_orders"])
 
     assert target["semantic_model_name"] == "sales_orders"
     assert target["matched_by"] == "existing_fact_table"
@@ -587,7 +261,7 @@ def test_osi_target_refuses_to_overwrite_an_unparseable_target_file(tmp_path):
     target_path.parent.mkdir(parents=True, exist_ok=True)
     target_path.write_text("semantic_model: [\n", encoding="utf-8")
 
-    target = resolve_osi_semantic_model_target(config, semantic_model_name="sales")
+    target = plan_osi_semantic_model_target(config, semantic_model_name="sales")
 
     assert target["ambiguous"] is True
     assert "already exists" in target["reason"]
@@ -595,7 +269,7 @@ def test_osi_target_refuses_to_overwrite_an_unparseable_target_file(tmp_path):
 
 
 def test_osi_target_refuses_an_unsafe_generic_fallback(tmp_path):
-    target = resolve_osi_semantic_model_target(
+    target = plan_osi_semantic_model_target(
         _osi_config(tmp_path),
         dimension_tables=["analytics.dim_customer"],
     )
@@ -614,7 +288,7 @@ def test_osi_target_refuses_to_reuse_an_occupied_filename_with_a_different_model
         [{"name": "orders", "source": "analytics.fact_orders"}],
     )
 
-    target = resolve_osi_semantic_model_target(
+    target = plan_osi_semantic_model_target(
         config,
         semantic_model_name="sales",
         fact_tables=["analytics.fact_payments"],

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -18,11 +18,6 @@ COMMON_VARS = {
     "knowledge_base_dir": "/kb",
     "semantic_model_dir": "/kb/semantic_models/duckdb",
     "kind_subdir": "subject/semantic_models/duckdb",
-    "default_osi_semantic_model_name": "sales_domain",
-    "default_osi_semantic_model_file": "subject/semantic_models/duckdb/sales_domain.yml",
-    "osi_target_resolved": True,
-    "requested_semantic_model_name": "",
-    "requested_business_domain": "",
 }
 
 
@@ -62,10 +57,11 @@ def test_semantic_model_template_osi_mode():
     text = _render("gen_semantic_model_system", "osi")
     assert "OSI (Open Semantic Interchange) core schema" in text
     assert "never write backend YAML" in text
-    assert "Resolved semantic model file: `subject/semantic_models/duckdb/sales_domain.yml`" in text
+    assert "Semantic model target is not planned yet" in text
     assert "create it with `write_file`" in text
     assert "use `edit_file` for targeted changes" in text
     assert "Dimension tables never participate in the name" in text
+    assert "without a custom `checks` subset" in text
     assert '"semantic_model_files"' in text  # same publish contract as metricflow
 
 
@@ -143,6 +139,13 @@ def test_metrics_template_osi_mode_contract():
     assert "subject_path" in text
     assert "locked_metadata.tags" not in text.split("Record the classification")[1].split("\n")[0]
     assert "Covered by an existing base metric" in text
+    assert "bind_osi_semantic_model_target" in text
+    assert "list_existing_osi_semantic_models" in text
+    assert "request SQL tables, dataset names/sources/descriptions, and business meaning" in text
+    assert "semantic_model_selection_required" in text
+    assert "resolve_osi_semantic_model_target" not in text
+    assert "non-metric request" not in text
+    assert "without a custom `checks` subset" in text
 
 
 def test_semantic_model_template_includes_profiler_gate_both_formats():

--- a/tests/unit_tests/storage/metric/test_metric_init.py
+++ b/tests/unit_tests/storage/metric/test_metric_init.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from datus.agent.node import semantic_authoring
+from datus.schemas.action_history import ActionStatus
 from datus.schemas.semantic_agentic_node_models import SourceQueryEvidence
 from datus.storage.metric.metric_init import (
     BIZ_NAME,
@@ -26,8 +28,23 @@ from datus.storage.metric.metric_init import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stub_osi_schema_validation(monkeypatch):
+    monkeypatch.setattr(semantic_authoring, "validate_osi_core_document", lambda document: None)
+
+
 def _source_query(sql: str, name: str = "sql_1", question: str = "") -> SourceQueryEvidence:
     return SourceQueryEvidence(source_sql_name=name, sql=sql, question=question)
+
+
+def _report_semantic_target(action_callback, semantic_model_file: str) -> None:
+    action_callback(
+        SimpleNamespace(
+            status=ActionStatus.SUCCESS,
+            action_type="gen_semantic_model_response",
+            output={"semantic_models": [semantic_model_file]},
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -627,6 +644,51 @@ class TestInitSuccessStoryMetricsAsyncOverwriteTruncate:
 @pytest.mark.ci
 class TestEnsureSemanticModelsForMetrics:
     @pytest.mark.asyncio
+    async def test_osi_lets_semantic_agent_reuse_the_only_live_model(self, tmp_path):
+        model_dir = tmp_path / "subject" / "semantic_models" / "warehouse"
+        model_dir.mkdir(parents=True)
+        (model_dir / "orders.yml").write_text(
+            "semantic_model:\n"
+            "  - name: order_operations\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: analytics.fact_orders\n",
+            encoding="utf-8",
+        )
+        config = SimpleNamespace(
+            project_root=str(tmp_path),
+            current_datasource="warehouse",
+            resolve_semantic_adapter=lambda requested=None: "osi",
+        )
+
+        async def fake_init(*args, action_callback=None, **kwargs):
+            _report_semantic_target(
+                action_callback,
+                "subject/semantic_models/warehouse/orders.yml",
+            )
+            return True, ""
+
+        with patch(
+            "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
+            side_effect=fake_init,
+        ) as init_mock:
+            result = await _ensure_semantic_models_for_metrics(
+                config,
+                "success_story.csv",
+                [_source_query("SELECT COUNT(*) FROM analytics.fact_orders")],
+            )
+
+        assert result == (
+            True,
+            "",
+            {
+                "semantic_model_name": "order_operations",
+                "semantic_model_file": "subject/semantic_models/warehouse/orders.yml",
+            },
+        )
+        init_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_osi_generates_domain_semantic_model_once(self, tmp_path):
         from unittest.mock import patch
 
@@ -640,7 +702,14 @@ class TestEnsureSemanticModelsForMetrics:
         action_callback = MagicMock()
         captured = {}
 
-        async def fake_init(agent_config, success_story, emit=None, build_mode="overwrite", action_callback=None):
+        async def fake_init(
+            agent_config,
+            success_story,
+            emit=None,
+            build_mode="overwrite",
+            action_callback=None,
+            require_exact_osi_target=False,
+        ):
             target_path.parent.mkdir(parents=True)
             target_path.write_text(
                 "version: 0.2.0.dev0\n"
@@ -652,7 +721,9 @@ class TestEnsureSemanticModelsForMetrics:
                 encoding="utf-8",
             )
             captured["build_mode"] = build_mode
+            captured["require_exact_osi_target"] = require_exact_osi_target
             captured["action_callback"] = action_callback
+            _report_semantic_target(action_callback, target_file)
             return True, ""
 
         with (
@@ -662,7 +733,7 @@ class TestEnsureSemanticModelsForMetrics:
             ) as init_mock,
             patch("datus.storage.metric.metric_init.ensure_semantic_models_exist") as ensure_mock,
         ):
-            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
+            ok, error, target = await _ensure_semantic_models_for_metrics(
                 config,
                 "success_story.csv",
                 [_source_query("SELECT COUNT(*) FROM orders", question="How many orders?")],
@@ -671,12 +742,16 @@ class TestEnsureSemanticModelsForMetrics:
 
         assert ok is True
         assert error == ""
-        assert created == [target_file]
-        assert model_name == "orders_analytics"
+        assert target == {
+            "semantic_model_name": "orders_analytics",
+            "semantic_model_file": target_file,
+        }
         init_mock.assert_called_once()
         ensure_mock.assert_not_called()
         assert captured["build_mode"] == "incremental"
-        assert captured["action_callback"] is action_callback
+        assert captured["require_exact_osi_target"] is True
+        assert captured["action_callback"] is not action_callback
+        action_callback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_osi_accepts_generated_query_backed_model_for_join_source(self, tmp_path):
@@ -696,7 +771,15 @@ class TestEnsureSemanticModelsForMetrics:
             resolve_semantic_adapter=lambda requested=None: "osi",
         )
 
-        async def fake_init(agent_config, success_story, emit=None, build_mode="overwrite", action_callback=None):
+        async def fake_init(
+            agent_config,
+            success_story,
+            emit=None,
+            build_mode="overwrite",
+            action_callback=None,
+            require_exact_osi_target=False,
+        ):
+            assert require_exact_osi_target is True
             target_path.parent.mkdir(parents=True)
             target_path.write_text(
                 "version: 0.2.0.dev0\n"
@@ -713,13 +796,14 @@ class TestEnsureSemanticModelsForMetrics:
                 '            data: \'{"source_type":"query"}\'\n',
                 encoding="utf-8",
             )
+            _report_semantic_target(action_callback, target_file)
             return True, ""
 
         with patch(
             "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
             side_effect=fake_init,
         ) as init_mock:
-            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
+            ok, error, target = await _ensure_semantic_models_for_metrics(
                 config,
                 "success_story.csv",
                 [_source_query(query_source, "sql_9")],
@@ -727,12 +811,14 @@ class TestEnsureSemanticModelsForMetrics:
 
         assert ok is True
         assert error == ""
-        assert created == [target_file]
-        assert model_name == "account_analytics"
+        assert target == {
+            "semantic_model_name": "account_analytics",
+            "semantic_model_file": target_file,
+        }
         init_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_osi_rejects_success_story_split_across_models(self, tmp_path):
+    async def test_osi_propagates_exact_unchanged_model_selected_by_semantic_agent(self, tmp_path):
         from unittest.mock import patch
 
         model_dir = tmp_path / "subject" / "semantic_models" / "warehouse"
@@ -765,22 +851,30 @@ class TestEnsureSemanticModelsForMetrics:
             _source_query("SELECT SUM(amount) FROM finance.fact_payments", "sql_2"),
         ]
 
-        with (
-            patch(
-                "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async"
-            ) as init_mock,
-        ):
-            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
+        async def fake_init(*args, action_callback=None, **kwargs):
+            _report_semantic_target(
+                action_callback,
+                "subject/semantic_models/warehouse/orders.yml",
+            )
+            return True, ""
+
+        with patch(
+            "datus.storage.semantic_model.semantic_model_init.init_success_story_semantic_model_async",
+            side_effect=fake_init,
+        ) as init_mock:
+            ok, error, target = await _ensure_semantic_models_for_metrics(
                 config,
                 "success_story.csv",
                 source_queries,
             )
 
-        assert ok is False
-        assert "exactly one semantic model" in error
-        assert created == []
-        assert model_name is None
-        init_mock.assert_not_called()
+        assert ok is True
+        assert error == ""
+        assert target == {
+            "semantic_model_name": "orders",
+            "semantic_model_file": "subject/semantic_models/warehouse/orders.yml",
+        }
+        init_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_metricflow_keeps_per_table_semantic_model_auto_create(self):
@@ -808,7 +902,7 @@ class TestEnsureSemanticModelsForMetrics:
             ),
             patch("datus.storage.metric.metric_init.ensure_semantic_models_exist", side_effect=fake_ensure),
         ):
-            ok, error, created, model_name = await _ensure_semantic_models_for_metrics(
+            ok, error, target = await _ensure_semantic_models_for_metrics(
                 config,
                 "success_story.csv",
                 [_source_query(sql_list[0], question=records[0]["question"])],
@@ -816,8 +910,7 @@ class TestEnsureSemanticModelsForMetrics:
 
         assert ok is True
         assert error == ""
-        assert created == ["customers", "orders"]
-        assert model_name is None
+        assert target is None
 
 
 # ---------------------------------------------------------------------------
@@ -994,13 +1087,17 @@ class TestGenerateMetricsBatch:
                 None,
                 BatchEventHelper("test", None),
                 None,
-                semantic_model_name="orders_analytics",
+                semantic_model_target={
+                    "semantic_model_name": "orders_analytics",
+                    "semantic_model_file": "subject/semantic_models/warehouse/orders.yml",
+                },
             )
 
         assert ok is True
         assert err == ""
         assert result == {"metrics": ["revenue"]}
         assert mock_node.input.semantic_model_name == "orders_analytics"
+        assert mock_node.input.semantic_model_file == "subject/semantic_models/warehouse/orders.yml"
         assert mock_node.input.source_queries[0].sql == "SELECT 1"
         assert "Analyze the following SQL queries" in mock_node.input.user_message
 
@@ -1283,7 +1380,16 @@ class TestBatchSplitting:
         mock_config.current_db_config.return_value = MagicMock(catalog="", database="db", schema="")
         mock_pm = MagicMock()
         mock_pm.get_latest_version.return_value = "1.0"
-        ensure = AsyncMock(return_value=(True, "", [], "orders_analytics"))
+        ensure = AsyncMock(
+            return_value=(
+                True,
+                "",
+                {
+                    "semantic_model_name": "orders_analytics",
+                    "semantic_model_file": "subject/semantic_models/warehouse/orders.yml",
+                },
+            )
+        )
         rows = [{"question": f"q{i}", "sql": f"SELECT SUM(amount) FROM orders WHERE id = {i}"} for i in range(3)]
 
         with (
@@ -1306,6 +1412,9 @@ class TestBatchSplitting:
         assert len(ensure.await_args.args[2]) == 3
         assert [len(node_input.source_queries) for node_input in captured_inputs] == [2, 1]
         assert {node_input.semantic_model_name for node_input in captured_inputs} == {"orders_analytics"}
+        assert {node_input.semantic_model_file for node_input in captured_inputs} == {
+            "subject/semantic_models/warehouse/orders.yml"
+        }
 
     @pytest.mark.asyncio
     async def test_partial_batch_failure_continues(self):

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -1588,3 +1588,74 @@ class TestInitSuccessStorySemanticModelAsyncOverwriteTruncate:
         assert success is True
         fake_rag_instance.truncate.assert_not_called()
         profile_rag_factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_osi_incremental_keeps_existing_coverage_fast_path(self, tmp_path):
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT COUNT(*) FROM orders,Q?\n")
+        mock_config = MagicMock()
+        mock_config.resolve_semantic_adapter.return_value = "osi"
+
+        with (
+            patch(
+                "datus.storage.semantic_model.auto_create.extract_tables_from_sql_list",
+                return_value=["orders"],
+            ),
+            patch(
+                "datus.storage.semantic_model.auto_create.find_missing_semantic_models",
+                return_value=[],
+            ),
+            patch("datus.storage.semantic_model.semantic_model_init.GenSemanticModelAgenticNode") as semantic_node,
+        ):
+            success, error = await init_success_story_semantic_model_async(
+                mock_config,
+                str(csv_path),
+                build_mode="incremental",
+            )
+
+        assert success is True
+        assert error == ""
+        semantic_node.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_osi_incremental_runs_agent_when_exact_target_is_required(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+
+        from datus.schemas.action_history import ActionStatus
+        from datus.storage.semantic_model.semantic_model_init import init_success_story_semantic_model_async
+
+        csv_path = tmp_path / "story.csv"
+        csv_path.write_text("sql,question\nSELECT COUNT(*) FROM orders,Q?\n")
+        mock_config = MagicMock()
+        mock_config.resolve_semantic_adapter.return_value = "osi"
+        mock_config.current_db_config.return_value = SimpleNamespace(catalog="", database="db", schema="")
+
+        class MockSemanticNode:
+            def __init__(self, *args, **kwargs):
+                self.input = None
+
+            async def execute_stream(self, action_history_manager):
+                yield SimpleNamespace(
+                    status=ActionStatus.SUCCESS,
+                    action_type="gen_semantic_model_response",
+                    output={"semantic_models": ["subject/semantic_models/warehouse/orders.yml"]},
+                    messages="ok",
+                )
+
+        monkeypatch.setattr(
+            "datus.storage.semantic_model.semantic_model_init.GenSemanticModelAgenticNode",
+            MockSemanticNode,
+        )
+        with patch("datus.storage.semantic_model.auto_create.find_missing_semantic_models") as coverage_probe:
+            success, error = await init_success_story_semantic_model_async(
+                mock_config,
+                str(csv_path),
+                build_mode="incremental",
+                require_exact_osi_target=True,
+            )
+
+        assert success is True
+        assert error == ""
+        coverage_probe.assert_not_called()

--- a/tests/unit_tests/tools/func_tool/test_generation_evidence.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_evidence.py
@@ -130,14 +130,18 @@ class TestGenerationEvidence:
         assert ev.validation_passed is False
         assert ev.metric_dry_run_passed is False
         assert ev.kb_sync_passed is False
-        assert ev.storage_revision == 0
 
     def test_kb_sync_passed_when_any_kind_set(self):
         ev = GenerationEvidence()
-        ev.mark_kb_sync("metric")
+        ev.mark_kb_sync("metric", ["revenue"])
         assert ev.kb_sync_passed is True
         assert ev.metric_kb_sync_passed is True
-        assert ev.storage_revision == 1
+        assert ev.has_metric_kb_sync(["revenue"])
+        assert not ev.has_metric_kb_sync(["revenue", "orders"])
+        assert not ev.has_metric_kb_sync()
+
+        ev.mark_kb_sync("metric", ["orders"])
+        assert ev.has_metric_kb_sync(["revenue", "orders"])
 
     def test_kb_sync_semantic(self):
         ev = GenerationEvidence()
@@ -148,6 +152,58 @@ class TestGenerationEvidence:
         ev = GenerationEvidence()
         ev.mark_kb_sync()
         assert ev.generic_kb_sync_passed is True
+
+    def test_reset_clears_all_request_evidence_without_replacing_object(self, tmp_path):
+        artifact = tmp_path / "sales.yml"
+        artifact.write_text("semantic_model: sales\n", encoding="utf-8")
+        ev = GenerationEvidence(
+            validation_passed=True,
+            metric_dry_run_passed=True,
+            metric_dry_run_metrics={"revenue"},
+            metric_dry_run_queries=[{"metrics": ["revenue"]}],
+            metric_sqls={"revenue": "select 1"},
+            metric_queryability_contracts=[{"dimension_hints": ["country"]}],
+            metric_aliases={"rev": "revenue"},
+            semantic_kb_sync_passed=True,
+            metric_kb_sync_passed=True,
+            metric_kb_sync_metrics={"revenue"},
+            generic_kb_sync_passed=True,
+        )
+        ev.record_semantic_artifact_validation("sales", artifact)
+
+        ev.reset()
+
+        assert ev == GenerationEvidence()
+
+    def test_artifact_mutation_invalidates_publish_evidence_but_keeps_request_contracts(self, tmp_path):
+        artifact = tmp_path / "sales.yml"
+        artifact.write_text("semantic_model: sales\n", encoding="utf-8")
+        ev = GenerationEvidence(
+            validation_passed=True,
+            metric_dry_run_passed=True,
+            metric_dry_run_metrics={"revenue"},
+            metric_dry_run_queries=[{"metrics": ["revenue"]}],
+            metric_sqls={"revenue": "select 1"},
+            metric_queryability_contracts=[{"dimension_hints": ["country"]}],
+            metric_aliases={"rev": "revenue"},
+            semantic_kb_sync_passed=True,
+            metric_kb_sync_passed=True,
+            metric_kb_sync_metrics={"revenue"},
+        )
+        ev.record_semantic_artifact_validation("sales", artifact)
+
+        ev.invalidate_artifact_evidence()
+
+        assert ev.validation_passed is False
+        assert ev.metric_dry_run_passed is False
+        assert ev.metric_dry_run_metrics == set()
+        assert ev.metric_dry_run_queries == []
+        assert ev.metric_sqls == {}
+        assert ev.validated_semantic_artifacts == {}
+        assert ev.kb_sync_passed is False
+        assert ev.metric_kb_sync_metrics == set()
+        assert ev.metric_queryability_contracts == [{"dimension_hints": ["country"]}]
+        assert ev.metric_aliases == {"rev": "revenue"}
 
     def test_record_validation_result_success(self):
         ev = GenerationEvidence()
@@ -184,6 +240,26 @@ class TestGenerationEvidence:
 
         artifact.write_text("semantic_model: changed\n", encoding="utf-8")
 
+        assert not ev.semantic_artifact_validation_passed("sales", artifact)
+
+    def test_explicit_validation_checks_do_not_satisfy_publish_gate(self, tmp_path):
+        artifact = tmp_path / "sales.yml"
+        artifact.write_text("semantic_model: sales\n", encoding="utf-8")
+        ev = GenerationEvidence()
+
+        ev.record_validation_result(
+            {
+                "success": 1,
+                "result": {
+                    "valid": True,
+                    "checks": ["authoring_quality"],
+                    "semantic_model_name": "sales",
+                    "semantic_model_file": str(artifact),
+                },
+            }
+        )
+
+        assert ev.validation_passed is False
         assert not ev.semantic_artifact_validation_passed("sales", artifact)
 
     def test_record_metric_dry_run_success(self):

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 """Unit tests for GenerationTools - CI level, zero external dependencies."""
 
+import hashlib
 import json
 import os
 import sys
@@ -11,6 +12,45 @@ from unittest.mock import Mock, patch
 import pytest
 
 from datus.tools.func_tool.base import FuncToolResult
+
+
+def _bind_osi_target(generation_tools, target, *, model_name="orders_model", metric_names=None):
+    from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
+
+    state = OsiSemanticModelTargetState()
+    state.select(
+        {
+            "semantic_model_name": model_name,
+            "semantic_model_file": f"subject/semantic_models/warehouse/{target.name}",
+            "absolute_path": str(target.resolve()),
+            "artifact_sha256": hashlib.sha256(target.read_bytes()).hexdigest(),
+            "table_references": ["analytics.orders"],
+        },
+        mode="bound",
+    )
+    state.authored_metric_names = list(metric_names or [])
+    generation_tools.authoring_format = "osi"
+    generation_tools.osi_target_state = state
+    generation_tools.require_bound_osi_target = True
+    return state
+
+
+def _plan_osi_target(generation_tools, target, *, model_name):
+    from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
+
+    state = OsiSemanticModelTargetState()
+    state.select(
+        {
+            "semantic_model_name": model_name,
+            "semantic_model_file": str(target),
+            "absolute_path": str(target.resolve()),
+            "artifact_sha256": hashlib.sha256(target.read_bytes()).hexdigest(),
+        },
+        mode="planned",
+    )
+    generation_tools.authoring_format = "osi"
+    generation_tools.osi_target_state = state
+    return state
 
 
 @pytest.fixture
@@ -46,6 +86,32 @@ class TestAvailableTools:
 
 
 class TestCheckSemanticObjectExists:
+    def test_osi_bound_yaml_takes_precedence_over_stale_rag(self, generation_tools, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "version: 0.2.0\n"
+            "semantic_model:\n"
+            "  - name: orders_model\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: analytics.orders\n"
+            "    metrics:\n"
+            "      - name: live_revenue\n",
+            encoding="utf-8",
+        )
+        _bind_osi_target(generation_tools, target)
+        generation_tools.metric_rag.storage.search_all.return_value = [{"name": "stale_revenue"}]
+
+        live_result = generation_tools.check_semantic_object_exists("live_revenue", kind="metric")
+        stale_result = generation_tools.check_semantic_object_exists("stale_revenue", kind="metric")
+
+        assert live_result.success == 1
+        assert live_result.result["exists"] is True
+        assert stale_result.success == 1
+        assert stale_result.result["exists"] is False
+        generation_tools.metric_rag.storage.search_all.assert_not_called()
+
     def test_table_found(self, generation_tools):
         mock_storage = Mock()
         generation_tools.semantic_rag.storage = mock_storage
@@ -219,7 +285,6 @@ class TestEndSemanticModelGeneration:
         assert "log failure" in result.error
 
     def test_osi_requires_validation_for_the_exact_target_artifact(self, generation_tools, tmp_path):
-        generation_tools.authoring_format = "osi"
         sales_file = tmp_path / "semantic_models" / "warehouse" / "sales.yml"
         finance_file = tmp_path / "semantic_models" / "warehouse" / "finance.yml"
         sales_file.parent.mkdir(parents=True)
@@ -233,6 +298,7 @@ class TestEndSemanticModelGeneration:
         )
         generation_tools.generation_evidence.validation_passed = True
         generation_tools.generation_evidence.record_semantic_artifact_validation("sales", sales_file)
+        _plan_osi_target(generation_tools, finance_file, model_name="finance")
         mock_pm = Mock(subject_dir=str(tmp_path))
 
         with (
@@ -246,13 +312,13 @@ class TestEndSemanticModelGeneration:
         sync_mock.assert_not_called()
 
     def test_osi_publishes_the_exact_validated_artifact(self, generation_tools, tmp_path):
-        generation_tools.authoring_format = "osi"
         model_file = tmp_path / "semantic_models" / "warehouse" / "finance.yml"
         model_file.parent.mkdir(parents=True)
         model_file.write_text(
             "version: 0.2.0.dev0\nsemantic_model:\n  - name: finance\n    datasets: []\n",
             encoding="utf-8",
         )
+        _plan_osi_target(generation_tools, model_file, model_name="finance")
         generation_tools.generation_evidence.record_semantic_artifact_validation("finance", model_file)
         mock_pm = Mock(subject_dir=str(tmp_path))
 
@@ -268,6 +334,24 @@ class TestEndSemanticModelGeneration:
 
         assert result.success == 1
         sync_mock.assert_called_once_with(str(model_file))
+
+    def test_osi_rejects_file_whose_model_name_differs_from_plan(self, generation_tools, tmp_path):
+        model_file = tmp_path / "semantic_models" / "warehouse" / "orders.yml"
+        model_file.parent.mkdir(parents=True)
+        model_file.write_text("semantic_model:\n  - name: finance\n    datasets: []\n", encoding="utf-8")
+        _plan_osi_target(generation_tools, model_file, model_name="orders")
+        generation_tools.generation_evidence.record_semantic_artifact_validation("finance", model_file)
+        mock_pm = Mock(subject_dir=str(tmp_path))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "sync_osi_semantic_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_semantic_model_generation([str(model_file)])
+
+        assert result.success == 0
+        assert "planned OSI target" in result.error
+        sync_mock.assert_not_called()
 
 
 class TestEndMetricGeneration:
@@ -300,6 +384,178 @@ class TestEndMetricGeneration:
         result = generation_tools.end_metric_generation(metric_file="/path/semantic_models/metric.yaml")
         assert result.success == 0
         assert "query_metrics(dry_run=True) must pass" in result.error
+
+    def test_osi_rejects_publish_without_bound_target(self, generation_tools):
+        from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
+
+        generation_tools.authoring_format = "osi"
+        generation_tools.osi_target_state = OsiSemanticModelTargetState()
+        generation_tools.require_bound_osi_target = True
+
+        result = generation_tools.end_metric_generation(metric_file="subject/semantic_models/warehouse/orders.yml")
+
+        assert result.success == 0
+        assert result.result["code"] == "semantic_model_required"
+
+    def test_osi_rejects_publish_path_other_than_bound_target(self, generation_tools, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "orders.yml"
+        wrong_target = target.with_name("customers.yml")
+        target.parent.mkdir(parents=True)
+        target.write_text("semantic_model:\n  - name: orders_model\n    metrics: []\n", encoding="utf-8")
+        wrong_target.write_text("semantic_model:\n  - name: customers_model\n    metrics: []\n", encoding="utf-8")
+        _bind_osi_target(generation_tools, target, metric_names=["order_count"])
+        mock_pm = Mock(subject_dir=str(tmp_path / "subject"))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_osi_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(wrong_target))
+
+        assert result.success == 0
+        assert result.result["code"] == "semantic_model_target_invalid"
+        sync_mock.assert_not_called()
+
+    def test_osi_publishes_exact_bound_target(self, generation_tools, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "semantic_model:\n"
+            "  - name: orders_model\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: analytics.orders\n"
+            "    metrics:\n"
+            "      - name: order_count\n",
+            encoding="utf-8",
+        )
+        _bind_osi_target(generation_tools, target, metric_names=["order_count"])
+        generation_tools.generation_evidence.record_semantic_artifact_validation("orders_model", target)
+        generation_tools.generation_evidence.record_metric_dry_run(
+            ["order_count"],
+            {"success": 1, "result": {"metadata": {}}},
+        )
+        mock_pm = Mock(subject_dir=str(tmp_path / "subject"))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(
+                generation_tools,
+                "_sync_osi_metric_to_db",
+                return_value={"success": True, "message": "synced"},
+            ) as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(target))
+
+        assert result.success == 1
+        sync_mock.assert_called_once_with(
+            str(target),
+            [],
+            {},
+            metric_names_to_sync={"order_count"},
+        )
+        assert result.result["metric_file"] == str(target)
+        assert generation_tools.generation_evidence.has_metric_kb_sync(["order_count"])
+
+    def test_osi_rejects_poisoned_target_after_failed_rebind(self, generation_tools, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("semantic_model:\n  - name: orders_model\n    metrics:\n      - name: order_count\n")
+        state = _bind_osi_target(generation_tools, target, metric_names=["order_count"])
+        state.last_error_code = "semantic_model_target_invalid"
+        generation_tools.generation_evidence.record_semantic_artifact_validation("orders_model", target)
+        generation_tools.generation_evidence.record_metric_dry_run(
+            ["order_count"],
+            {"success": 1, "result": {"metadata": {}}},
+        )
+        mock_pm = Mock(subject_dir=str(tmp_path / "subject"))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_osi_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(target))
+
+        assert result.success == 0
+        assert result.result["code"] == "semantic_model_target_invalid"
+        assert "failed bind" in result.error
+        sync_mock.assert_not_called()
+
+    def test_osi_rejects_missing_queryability_dry_run_for_exact_target(self, generation_tools, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("semantic_model:\n  - name: orders_model\n    metrics:\n      - name: order_count\n")
+        _bind_osi_target(generation_tools, target, metric_names=["order_count"])
+        generation_tools.generation_evidence.record_semantic_artifact_validation("orders_model", target)
+        generation_tools.generation_evidence.set_metric_queryability_contracts(
+            [
+                {
+                    "metric_hints": ["order_count"],
+                    "dimension_hints": ["customer_id"],
+                    "time_group_hints": [],
+                }
+            ]
+        )
+        generation_tools.generation_evidence.record_metric_dry_run(
+            ["order_count"],
+            {"success": 1, "result": {"metadata": {}}},
+        )
+        mock_pm = Mock(subject_dir=str(tmp_path / "subject"))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_osi_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(target))
+
+        assert result.success == 0
+        assert "group-by dimensions" in result.error
+        sync_mock.assert_not_called()
+
+    def test_osi_rejects_stale_authored_metric_names(self, generation_tools, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "orders.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("semantic_model:\n  - name: orders_model\n    metrics:\n      - name: replacement_metric\n")
+        _bind_osi_target(generation_tools, target, metric_names=["order_count"])
+        generation_tools.generation_evidence.record_semantic_artifact_validation("orders_model", target)
+        generation_tools.generation_evidence.record_metric_dry_run(
+            ["order_count"],
+            {"success": 1, "result": {"metadata": {}}},
+        )
+        mock_pm = Mock(subject_dir=str(tmp_path / "subject"))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_osi_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(target))
+
+        assert result.success == 0
+        assert "no longer contains" in result.error
+        sync_mock.assert_not_called()
+
+    def test_osi_rejects_unrelated_validation_and_dry_run_evidence(self, generation_tools, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "orders.yml"
+        unrelated = target.with_name("finance.yml")
+        target.parent.mkdir(parents=True)
+        target.write_text("semantic_model:\n  - name: orders_model\n    metrics:\n      - name: order_count\n")
+        unrelated.write_text("semantic_model:\n  - name: finance\n")
+        _bind_osi_target(generation_tools, target, metric_names=["order_count"])
+        generation_tools.generation_evidence.validation_passed = True
+        generation_tools.generation_evidence.metric_dry_run_passed = True
+        generation_tools.generation_evidence.metric_dry_run_metrics.add("finance_total")
+        generation_tools.generation_evidence.record_semantic_artifact_validation("finance", unrelated)
+        mock_pm = Mock(subject_dir=str(tmp_path / "subject"))
+
+        with (
+            patch("datus.tools.func_tool.generation_tools.get_path_manager", return_value=mock_pm),
+            patch.object(generation_tools, "_sync_osi_metric_to_db") as sync_mock,
+        ):
+            result = generation_tools.end_metric_generation(metric_file=str(target))
+
+        assert result.success == 0
+        assert "exact bound OSI" in result.error
+        sync_mock.assert_not_called()
 
     def test_success_basic(self, generation_tools):
         self._mark_ready_to_publish(generation_tools)
@@ -367,7 +623,12 @@ class TestEndMetricGeneration:
 
         assert result.success == 1
         preflight_mock.assert_not_called()
-        sync_mock.assert_called_once_with(str(metric_file), [], {}, replace_metric_artifact=False)
+        sync_mock.assert_called_once_with(
+            str(metric_file),
+            [],
+            {},
+            metric_names_to_sync={"order_count"},
+        )
 
     def test_osi_ignores_semantic_model_files_to_avoid_duplicate_sync(self, generation_tools, tmp_path):
         self._mark_ready_to_publish(generation_tools)
@@ -404,7 +665,7 @@ class TestEndMetricGeneration:
             str(metric_file),
             [],
             {},
-            replace_metric_artifact=False,
+            metric_names_to_sync={"order_count"},
         )
         assert result.result["semantic_model_files"] == []
         assert generation_tools.generation_evidence.semantic_kb_sync_passed is False
@@ -1015,7 +1276,7 @@ class TestOsiSync:
         assert metric_obj["yaml_path"] == str(metric_file)
         assert result["metric_names"] == ["order_count"]
 
-    def test_sync_osi_metric_to_db_can_upsert_without_replacing_artifact(self, generation_tools, tmp_path):
+    def test_sync_osi_metric_scope_does_not_overwrite_existing_metric_sql(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
             catalog="default_catalog", database="shop", schema=""
         )
@@ -1025,7 +1286,8 @@ class TestOsiSync:
             "semantic_model:\n"
             "  - name: shop\n"
             "    metrics:\n"
-            "      - name: order_count\n"
+            "      - name: existing_metric\n"
+            "      - name: new_metric\n"
             "        expression:\n"
             "          dialects:\n"
             "            - dialect: ANSI_SQL\n"
@@ -1038,24 +1300,38 @@ class TestOsiSync:
             time_dimension=None,
             dimensions=[],
         )
-        metric = SimpleNamespace(
-            name="order_count",
-            description="Number of orders",
+        existing_metric = SimpleNamespace(
+            name="existing_metric",
+            description="Existing metric",
+            expression="SUM(existing_value)",
+            dataset="orders",
+            subject_path=None,
+            kind=None,
+        )
+        new_metric = SimpleNamespace(
+            name="new_metric",
+            description="New metric",
             expression="COUNT(DISTINCT order_id)",
             dataset="orders",
             subject_path=None,
             kind=None,
         )
-        doc = SimpleNamespace(datasets=[dataset], metrics=[metric])
+        doc = SimpleNamespace(name="shop", datasets=[dataset], metrics=[existing_metric, new_metric])
 
         with patch.object(generation_tools, "_load_osi_document", return_value=doc):
-            result = generation_tools._sync_osi_metric_to_db(str(metric_file), replace_metric_artifact=False)
+            result = generation_tools._sync_osi_metric_to_db(
+                str(metric_file),
+                metric_sqls={"new_metric": "SELECT new_metric"},
+                metric_names_to_sync={"new_metric"},
+            )
 
         assert result["success"] is True
+        metric_objects = generation_tools.metric_rag.upsert_batch.call_args.args[0]
+        assert [metric["name"] for metric in metric_objects] == ["new_metric"]
+        assert metric_objects[0]["sql"] == "SELECT new_metric"
         generation_tools.metric_rag.delete_artifact_rows.assert_not_called()
         generation_tools.metric_rag.delete_artifact_rows_except.assert_not_called()
         generation_tools.metric_rag.list_artifact_rows.assert_called_once_with(str(metric_file))
-        generation_tools.metric_rag.upsert_batch.assert_called_once()
 
     def test_sync_osi_metric_partial_publish_restores_on_later_failure(self, generation_tools, tmp_path):
         generation_tools.agent_config.current_db_config.return_value = SimpleNamespace(
@@ -1093,7 +1369,10 @@ class TestOsiSync:
         generation_tools.metric_rag.create_indices.side_effect = RuntimeError("index failed")
 
         with patch.object(generation_tools, "_load_osi_document", return_value=doc):
-            result = generation_tools._sync_osi_metric_to_db(str(metric_file), replace_metric_artifact=False)
+            result = generation_tools._sync_osi_metric_to_db(
+                str(metric_file),
+                metric_names_to_sync={"order_count"},
+            )
 
         assert result["success"] is False
         assert "index failed" in result["error"]
@@ -1266,6 +1545,21 @@ class TestOsiSync:
 
         assert result["success"] is False
         assert "No OSI metrics found in metric file" in result["error"]
+        generation_tools.metric_rag.upsert_batch.assert_not_called()
+
+    def test_sync_osi_metric_to_db_rejects_missing_scoped_metric(self, generation_tools, tmp_path):
+        metric_file = tmp_path / "orders.yml"
+        metric_file.write_text(
+            "version: 0.2.0.dev0\nsemantic_model:\n  - name: shop\n    metrics:\n      - name: order_count\n"
+        )
+
+        result = generation_tools._sync_osi_metric_to_db(
+            str(metric_file),
+            metric_names_to_sync={"missing_metric"},
+        )
+
+        assert result["success"] is False
+        assert "missing_metric" in result["error"]
         generation_tools.metric_rag.upsert_batch.assert_not_called()
 
     def test_sync_osi_semantic_to_db_upserts_only_current_dataset_columns(self, generation_tools, tmp_path):

--- a/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_filesystem_tools.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import hashlib
 import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -10,7 +11,9 @@ from unittest.mock import Mock
 import pytest
 import yaml
 
+from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTool
+from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
 
 
 def _osi_metric(name, expression):
@@ -19,6 +22,20 @@ def _osi_metric(name, expression):
         "description": f"Definition for {name}",
         "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": expression}]},
     }
+
+
+def _bound_state(target, name="sales"):
+    state = OsiSemanticModelTargetState()
+    state.select(
+        {
+            "semantic_model_name": name,
+            "semantic_model_file": f"subject/semantic_models/warehouse/{target.name}",
+            "absolute_path": str(target.resolve()),
+            "artifact_sha256": hashlib.sha256(target.read_bytes()).hexdigest(),
+        },
+        mode="bound",
+    )
+    return state
 
 
 @pytest.fixture
@@ -82,6 +99,7 @@ semantic_model:
             root_path=str(project),
             current_node="gen_metrics",
             authoring_format="osi",
+            osi_target_state=_bound_state(target),
         )
 
         result = tool.upsert_osi_metrics(
@@ -111,6 +129,88 @@ semantic_model:
         assert after_model["metrics"][0]["description"] == "Corrected definition"
         osi_schema_validator.assert_called_once()
 
+    def test_upsert_invalidates_prior_validation_dry_run_and_sync_evidence(self, tmp_path, osi_schema_validator):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            "version: 0.2.0.dev0\n"
+            "semantic_model:\n"
+            "  - name: sales\n"
+            "    datasets:\n"
+            "      - name: orders\n"
+            "        source: orders\n",
+            encoding="utf-8",
+        )
+        evidence = GenerationEvidence(
+            validation_passed=True,
+            metric_dry_run_passed=True,
+            metric_dry_run_metrics={"revenue"},
+            semantic_kb_sync_passed=True,
+            metric_kb_sync_passed=True,
+        )
+        evidence.record_semantic_artifact_validation("sales", target)
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+            osi_target_state=_bound_state(target),
+            mutation_callback=evidence.invalidate_artifact_evidence,
+        )
+
+        result = tool.upsert_osi_metrics(
+            str(target.relative_to(tmp_path)),
+            json.dumps([_osi_metric("revenue", "SUM(amount)")]),
+        )
+
+        assert result.success == 1
+        assert evidence.validation_passed is False
+        assert evidence.metric_dry_run_passed is False
+        assert evidence.metric_dry_run_metrics == set()
+        assert evidence.validated_semantic_artifacts == {}
+        assert evidence.kb_sync_passed is False
+
+    def test_identical_upsert_preserves_bytes_and_registers_publish_scope(self, tmp_path, osi_schema_validator):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+        target.parent.mkdir(parents=True)
+        metric = _osi_metric("revenue", "SUM(amount)")
+        target.write_text(
+            yaml.safe_dump(
+                {
+                    "version": "0.2.0.dev0",
+                    "semantic_model": [
+                        {
+                            "name": "sales",
+                            "datasets": [{"name": "orders", "source": "orders"}],
+                            "metrics": [metric],
+                        }
+                    ],
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        original_content = target.read_bytes()
+        mutation_callback = Mock()
+        state = _bound_state(target)
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+            osi_target_state=state,
+            mutation_callback=mutation_callback,
+        )
+
+        result = tool.upsert_osi_metrics(str(target.relative_to(tmp_path)), json.dumps([metric]))
+
+        assert result.success == 1
+        assert result.result["created"] == []
+        assert result.result["updated"] == []
+        assert result.result["unchanged"] == ["revenue"]
+        assert target.read_bytes() == original_content
+        assert state.authored_metric_names == ["revenue"]
+        mutation_callback.assert_not_called()
+        osi_schema_validator.assert_not_called()
+
     @pytest.mark.parametrize("invalid_metrics", [{}, ""])
     def test_upsert_osi_metrics_rejects_present_invalid_metrics_collection(self, tmp_path, invalid_metrics):
         target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
@@ -122,7 +222,12 @@ semantic_model:
         document["semantic_model"][0]["metrics"] = invalid_metrics
         original = yaml.safe_dump(document, sort_keys=False)
         target.write_text(original, encoding="utf-8")
-        tool = MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi")
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+            osi_target_state=_bound_state(target),
+        )
 
         result = tool.upsert_osi_metrics(
             str(target.relative_to(tmp_path)), json.dumps([_osi_metric("revenue", "SUM(amount)")])
@@ -143,7 +248,12 @@ semantic_model:
         source: orders
 """
         target.write_text(original, encoding="utf-8")
-        tool = MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi")
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+            osi_target_state=_bound_state(target),
+        )
         osi_schema_validator.return_value = "metric expression is required"
 
         result = tool.upsert_osi_metrics(
@@ -168,9 +278,20 @@ semantic_model:
 """,
             encoding="utf-8",
         )
+        target_state = _bound_state(target)
         tools = [
-            MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi"),
-            MetricFilesystemFuncTool(root_path=str(tmp_path), current_node="gen_metrics", authoring_format="osi"),
+            MetricFilesystemFuncTool(
+                root_path=str(tmp_path),
+                current_node="gen_metrics",
+                authoring_format="osi",
+                osi_target_state=target_state,
+            ),
+            MetricFilesystemFuncTool(
+                root_path=str(tmp_path),
+                current_node="gen_metrics",
+                authoring_format="osi",
+                osi_target_state=target_state,
+            ),
         ]
         relative_path = str(target.relative_to(tmp_path))
         shared_lock = tools[0]._osi_metric_path_lock(target)
@@ -209,6 +330,51 @@ semantic_model:
 
         assert result.success == 0
         assert result.result["code"] == "semantic_model_required"
+
+    def test_upsert_osi_metrics_rejects_path_other_than_bound_target(self, tmp_path):
+        model_dir = tmp_path / "subject" / "semantic_models" / "warehouse"
+        selected = model_dir / "selected.yml"
+        other = model_dir / "other.yml"
+        for path, name in ((selected, "selected"), (other, "other")):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f"semantic_model:\n  - name: {name}\n    datasets: []\n", encoding="utf-8")
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+            osi_target_state=_bound_state(selected, "selected"),
+        )
+
+        result = tool.upsert_osi_metrics(
+            str(other.relative_to(tmp_path)),
+            json.dumps([_osi_metric("revenue", "SUM(amount)")]),
+        )
+
+        assert not result.success
+        assert result.result["code"] == "semantic_model_target_invalid"
+        assert "bound to" in result.error
+
+    def test_upsert_osi_metrics_rejects_target_changed_since_bind(self, tmp_path):
+        target = tmp_path / "subject" / "semantic_models" / "warehouse" / "sales.yml"
+        target.parent.mkdir(parents=True)
+        target.write_text("semantic_model:\n  - name: sales\n    datasets: []\n", encoding="utf-8")
+        state = _bound_state(target)
+        tool = MetricFilesystemFuncTool(
+            root_path=str(tmp_path),
+            current_node="gen_metrics",
+            authoring_format="osi",
+            osi_target_state=state,
+        )
+        target.write_text(target.read_text(encoding="utf-8") + "# external edit\n", encoding="utf-8")
+
+        result = tool.upsert_osi_metrics(
+            str(target.relative_to(tmp_path)),
+            json.dumps([_osi_metric("revenue", "SUM(amount)")]),
+        )
+
+        assert not result.success
+        assert result.result["code"] == "semantic_model_target_invalid"
+        assert "changed after selection" in result.error
 
     def test_write_file_merges_existing_semantic_model(self, tmp_path):
         project = tmp_path / "project"

--- a/tests/unit_tests/tools/func_tool/test_osi_target_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_osi_target_tools.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from datus.agent.node import semantic_authoring
+from datus.tools.func_tool.osi_target_tools import (
+    OsiSemanticModelTargetState,
+    OsiSemanticModelTargetTools,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_osi_schema_validation(monkeypatch):
+    monkeypatch.setattr(semantic_authoring, "validate_osi_core_document", lambda document: None)
+
+
+def _config(tmp_path: Path):
+    model_root = tmp_path / "subject" / "semantic_models"
+    model_dir = model_root / "warehouse"
+    return SimpleNamespace(
+        current_datasource="warehouse",
+        path_manager=SimpleNamespace(
+            project_root=tmp_path,
+            semantic_model_path=lambda datasource: model_root / datasource,
+        ),
+        project_root=tmp_path,
+        resolve_semantic_adapter=lambda _: "osi",
+    ), model_dir
+
+
+def _write_model(
+    path: Path,
+    *,
+    name: str,
+    dataset: str = "orders",
+    source: str = "analytics.orders",
+    description: str = "Order analytics",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "version: 0.2.0.dev0\n"
+        "semantic_model:\n"
+        f"  - name: {name}\n"
+        f"    description: {description}\n"
+        "    datasets:\n"
+        f"      - name: {dataset}\n"
+        f"        source: {source}\n"
+        f"        description: {description} dataset\n",
+        encoding="utf-8",
+    )
+
+
+def test_list_scans_live_yaml_inventory_without_mutating_binding(tmp_path):
+    config, model_dir = _config(tmp_path)
+    _write_model(model_dir / "orders.yml", name="orders_model")
+    _write_model(
+        model_dir / "domains" / "players.yaml",
+        name="players_model",
+        dataset="players",
+        source="games.players",
+        description="Player behavior",
+    )
+    (model_dir / "broken.yml").write_text("semantic_model: [\n", encoding="utf-8")
+    (model_dir / "metrics").mkdir(parents=True)
+    (model_dir / "metrics" / "legacy.yml").write_text("metric:\n  name: legacy\n", encoding="utf-8")
+    other_dir = tmp_path / "subject" / "semantic_models" / "other"
+    _write_model(other_dir / "ignored.yml", name="ignored")
+
+    state = OsiSemanticModelTargetState()
+    tools = OsiSemanticModelTargetTools(config, target_state=state)
+    result = tools.list_existing_osi_semantic_models()
+
+    assert result.success
+    assert result.result["status"] == "partial"
+    assert result.result["count"] == 2
+    assert {item["semantic_model_name"] for item in result.result["semantic_models"]} == {
+        "orders_model",
+        "players_model",
+    }
+    players = next(item for item in result.result["semantic_models"] if item["semantic_model_name"] == "players_model")
+    assert players["datasets"] == [
+        {
+            "name": "players",
+            "source": "games.players",
+            "description": "Player behavior dataset",
+        }
+    ]
+    assert result.result["issues"][0]["semantic_model_file"].endswith("/broken.yml")
+    assert state.selected is None
+    assert state.last_error_code == ""
+
+
+@pytest.mark.parametrize("selector_kind", ["name", "relative", "absolute"])
+def test_bind_exact_selector_records_canonical_target_and_revision(tmp_path, selector_kind):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "orders.yml"
+    _write_model(target, name="orders_model")
+    tools = OsiSemanticModelTargetTools(config)
+
+    kwargs = {
+        "name": {"semantic_model_name": "orders_model"},
+        "relative": {"semantic_model_file": "subject/semantic_models/warehouse/orders.yml"},
+        "absolute": {"semantic_model_file": str(target)},
+    }[selector_kind]
+    result = tools.bind_osi_semantic_model_target(**kwargs)
+
+    assert result.success
+    assert result.result["status"] == "bound"
+    assert tools.target_state.bound["absolute_path"] == str(target.resolve())
+    assert tools.target_state.artifact_sha256 == hashlib.sha256(target.read_bytes()).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        "../other/model.yml",
+        "subject/semantic_models/other/model.yml",
+        "subject/semantic_models/warehouse/missing.yml",
+    ],
+)
+def test_bind_rejects_invalid_selector(tmp_path, selector):
+    config, _ = _config(tmp_path)
+    tools = OsiSemanticModelTargetTools(config)
+
+    result = tools.bind_osi_semantic_model_target(semantic_model_file=selector)
+
+    assert not result.success
+    assert result.result["code"] == "semantic_model_target_invalid"
+
+
+def test_bind_rejects_malformed_and_multi_model_yaml(tmp_path):
+    config, model_dir = _config(tmp_path)
+    model_dir.mkdir(parents=True)
+    (model_dir / "broken.yml").write_text("semantic_model: [\n", encoding="utf-8")
+    (model_dir / "multi.yml").write_text(
+        "semantic_model:\n  - name: first\n    datasets: []\n  - name: second\n    datasets: []\n",
+        encoding="utf-8",
+    )
+    tools = OsiSemanticModelTargetTools(config)
+
+    broken = tools.bind_osi_semantic_model_target(semantic_model_file="broken.yml")
+    multi = tools.bind_osi_semantic_model_target(semantic_model_file="multi.yml")
+
+    assert not broken.success
+    assert broken.result["code"] == "semantic_model_target_invalid"
+    assert not multi.success
+    assert multi.result["code"] == "semantic_model_target_invalid"
+    assert semantic_authoring.inspect_osi_semantic_model_inventory(config)["recoverable_models"] == []
+
+
+def test_inventory_excludes_core_schema_invalid_yaml(tmp_path, monkeypatch):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "invalid.yml"
+    _write_model(target, name="invalid_model")
+    monkeypatch.setattr(
+        semantic_authoring,
+        "validate_osi_core_document",
+        lambda document: "version does not match the OSI core schema",
+    )
+    tools = OsiSemanticModelTargetTools(config)
+
+    raw_inventory = semantic_authoring.inspect_osi_semantic_model_inventory(config)
+    inventory = tools.list_existing_osi_semantic_models()
+    bound = tools.bind_osi_semantic_model_target(semantic_model_file=str(target))
+
+    assert raw_inventory["recoverable_models"][0]["semantic_model_name"] == "invalid_model"
+    assert inventory.result["status"] == "invalid"
+    assert inventory.result["semantic_models"] == []
+    assert inventory.result["issues"][0]["code"] == "invalid_osi_core_schema"
+    assert not bound.success
+    assert bound.result["code"] == "semantic_model_target_invalid"
+
+
+def test_semantic_plan_can_recover_unique_core_schema_invalid_model(tmp_path, monkeypatch):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "legacy.yml"
+    _write_model(target, name="orders_model")
+    monkeypatch.setattr(
+        semantic_authoring,
+        "validate_osi_core_document",
+        lambda document: "datasets do not match the OSI core schema",
+    )
+    inspect_inventory = semantic_authoring.inspect_osi_semantic_model_inventory
+    calls = 0
+
+    def inspect_once(agent_config):
+        nonlocal calls
+        calls += 1
+        return inspect_inventory(agent_config)
+
+    monkeypatch.setattr(semantic_authoring, "inspect_osi_semantic_model_inventory", inspect_once)
+    tools = OsiSemanticModelTargetTools(config)
+
+    result = tools.plan_osi_semantic_model_target(semantic_model_name="orders_model")
+
+    assert result.success
+    assert result.result["repair_required"] is True
+    assert tools.target_state.planned["absolute_path"] == str(target.resolve())
+    assert tools.target_state.artifact_sha256 == hashlib.sha256(target.read_bytes()).hexdigest()
+    assert calls == 1
+
+
+def test_planned_existing_target_rejects_external_revision_change(tmp_path):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "orders.yml"
+    _write_model(target, name="orders_model")
+    tools = OsiSemanticModelTargetTools(config)
+    assert tools.plan_osi_semantic_model_target(semantic_model_name="orders_model").success
+
+    target.write_text(target.read_text(encoding="utf-8") + "# external edit\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="changed after planning"):
+        tools.target_state.require_planned_path(target)
+
+
+def test_planned_new_target_rejects_path_created_after_planning(tmp_path):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "orders.yml"
+    tools = OsiSemanticModelTargetTools(config)
+    assert tools.plan_osi_semantic_model_target(semantic_model_name="orders").success
+
+    _write_model(target, name="orders")
+
+    with pytest.raises(ValueError, match="created after planning"):
+        tools.target_state.require_planned_path(target)
+
+
+def test_bind_name_requires_unique_live_match(tmp_path):
+    config, model_dir = _config(tmp_path)
+    _write_model(model_dir / "one.yml", name="shared")
+    _write_model(model_dir / "two.yaml", name="shared")
+    tools = OsiSemanticModelTargetTools(config)
+
+    inventory = tools.list_existing_osi_semantic_models()
+    assert inventory.result["status"] == "invalid"
+    assert inventory.result["semantic_models"] == []
+
+    result = tools.bind_osi_semantic_model_target(semantic_model_name="shared")
+
+    assert not result.success
+    assert result.result["code"] == "semantic_model_target_invalid"
+    assert {issue["semantic_model_file"] for issue in inventory.result["issues"]} == {
+        "subject/semantic_models/warehouse/one.yml",
+        "subject/semantic_models/warehouse/two.yaml",
+    }
+
+
+def test_bind_exact_path_rejects_duplicate_model_name(tmp_path):
+    config, model_dir = _config(tmp_path)
+    first = model_dir / "one.yml"
+    _write_model(first, name="shared")
+    _write_model(model_dir / "two.yaml", name="shared")
+    tools = OsiSemanticModelTargetTools(config)
+
+    result = tools.bind_osi_semantic_model_target(semantic_model_file=str(first))
+
+    assert not result.success
+    assert result.result["code"] == "semantic_model_target_invalid"
+    assert "not safe" in result.error
+
+
+def test_failed_rebind_clears_previous_unwritten_target(tmp_path):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "orders.yml"
+    _write_model(target, name="orders_model")
+    tools = OsiSemanticModelTargetTools(config)
+    assert tools.bind_osi_semantic_model_target(semantic_model_file=str(target)).success
+
+    result = tools.bind_osi_semantic_model_target(semantic_model_file="missing.yml")
+
+    assert not result.success
+    assert tools.target_state.bound is None
+    with pytest.raises(ValueError, match="Bind an existing OSI semantic model"):
+        tools.target_state.require_bound_path(target)
+
+
+def test_failed_rebind_after_write_keeps_authored_target_poisoned(tmp_path):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "orders.yml"
+    _write_model(target, name="orders_model")
+    tools = OsiSemanticModelTargetTools(config)
+    assert tools.bind_osi_semantic_model_target(semantic_model_file=str(target)).success
+    tools.target_state.authored_metric_names = ["order_count"]
+
+    result = tools.bind_osi_semantic_model_target(semantic_model_file="missing.yml")
+
+    assert not result.success
+    assert tools.target_state.bound is not None
+    assert tools.target_state.last_error_code == "semantic_model_target_invalid"
+
+
+def test_authored_target_cannot_rebind_to_a_different_revision_or_model(tmp_path):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "orders.yml"
+    _write_model(target, name="orders_model")
+    tools = OsiSemanticModelTargetTools(config)
+    assert tools.bind_osi_semantic_model_target(semantic_model_file=str(target)).success
+    tools.target_state.authored_metric_names = ["order_count"]
+
+    _write_model(target, name="replacement_model")
+    result = tools.bind_osi_semantic_model_target(semantic_model_file=str(target))
+
+    assert not result.success
+    assert "cannot change after authoring started" in result.error
+    assert tools.target_state.bound["semantic_model_name"] == "orders_model"
+    assert tools.target_state.last_error_code == "semantic_model_target_invalid"
+
+
+def test_failed_replan_clears_previous_plan(tmp_path):
+    config, _ = _config(tmp_path)
+    tools = OsiSemanticModelTargetTools(config)
+    assert tools.plan_osi_semantic_model_target(semantic_model_name="orders").success
+
+    result = tools.plan_osi_semantic_model_target()
+
+    assert not result.success
+    assert tools.target_state.planned is None
+
+
+def test_plan_only_blocks_duplicate_names_relevant_to_the_target(tmp_path):
+    config, model_dir = _config(tmp_path)
+    _write_model(model_dir / "one.yml", name="shared")
+    _write_model(model_dir / "two.yml", name="shared")
+    tools = OsiSemanticModelTargetTools(config)
+
+    unrelated = tools.plan_osi_semantic_model_target(semantic_model_name="new_model")
+    duplicate = tools.plan_osi_semantic_model_target(semantic_model_name="shared")
+
+    assert unrelated.success
+    assert not duplicate.success
+    assert len(duplicate.result["candidates"]) == 2
+    assert tools.target_state.planned is None
+
+
+@pytest.mark.parametrize("invalid_sources", [{"analytics.two"}, {"analytics.one", "analytics.two"}])
+def test_duplicate_names_span_valid_and_recoverable_models(tmp_path, monkeypatch, invalid_sources):
+    config, model_dir = _config(tmp_path)
+    _write_model(model_dir / "one.yml", name="shared", source="analytics.one")
+    _write_model(model_dir / "two.yml", name="shared", source="analytics.two")
+
+    def validate(document):
+        source = document["semantic_model"][0]["datasets"][0]["source"]
+        return "invalid core schema" if source in invalid_sources else None
+
+    monkeypatch.setattr(semantic_authoring, "validate_osi_core_document", validate)
+    inventory = semantic_authoring.inspect_osi_semantic_model_inventory(config)
+
+    assert inventory["models"] == []
+    assert inventory["recoverable_models"] == []
+    duplicate_paths = {
+        issue["semantic_model_file"]
+        for issue in inventory["issues"]
+        if issue["code"] == "duplicate_semantic_model_name"
+    }
+    assert duplicate_paths == {
+        "subject/semantic_models/warehouse/one.yml",
+        "subject/semantic_models/warehouse/two.yml",
+    }
+
+
+def test_query_backed_parse_warning_does_not_make_exact_target_unbindable(tmp_path):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "query.yml"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        "version: 0.2.0.dev0\n"
+        "semantic_model:\n"
+        "  - name: query_model\n"
+        "    datasets:\n"
+        "      - name: query_dataset\n"
+        "        source: SELECT * FROM\n"
+        "        custom_extensions:\n"
+        "          - vendor_name: DATUS\n"
+        '            data: \'{"source_type":"query"}\'\n',
+        encoding="utf-8",
+    )
+    tools = OsiSemanticModelTargetTools(config)
+
+    inventory = tools.list_existing_osi_semantic_models()
+    bound = tools.bind_osi_semantic_model_target(semantic_model_file=str(target))
+
+    assert inventory.result["status"] == "found"
+    assert inventory.result["issues"] == []
+    assert inventory.result["discovery_warnings"][0]["code"] == "query_backed_dataset_tables_unknown"
+    candidate = inventory.result["semantic_models"][0]
+    assert "table_references" not in candidate
+    assert "source" not in candidate["datasets"][0]
+    assert bound.success
+
+
+def test_bound_revision_must_match_live_file(tmp_path):
+    config, model_dir = _config(tmp_path)
+    target = model_dir / "orders.yml"
+    _write_model(target, name="orders_model")
+    tools = OsiSemanticModelTargetTools(config)
+    assert tools.bind_osi_semantic_model_target(semantic_model_file=str(target)).success
+
+    target.write_text(target.read_text(encoding="utf-8") + "\n# external edit\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="changed after selection"):
+        tools.target_state.require_current_revision(target)

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -693,6 +693,16 @@ class TestAnalyzeMetricCandidatesFromHistory:
 
         assert tool_names == {"analyze_metric_candidates_from_history"}
 
+    def test_available_tools_without_db_omits_enabled_profiler(self):
+        tools = SemanticDiscoveryTools(
+            db_tool=None,
+            enable_semantic_model_profiler=True,
+        )
+
+        tool_names = {tool.name for tool in tools.available_tools()}
+
+        assert tool_names == {"analyze_metric_candidates_from_history"}
+
     def test_history_analyzer_accepts_direct_sql_without_db(self):
         tools = SemanticDiscoveryTools(db_tool=None)
 

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -682,6 +682,25 @@ class TestProfileSemanticModelEvidence:
 
 
 class TestAnalyzeMetricCandidatesFromHistory:
+    def test_available_tools_without_db_exposes_only_history_analyzer(self):
+        tools = SemanticDiscoveryTools(
+            db_tool=None,
+            agent_config=MagicMock(),
+            sub_agent_name="gen_metrics",
+        )
+
+        tool_names = {tool.name for tool in tools.available_tools()}
+
+        assert tool_names == {"analyze_metric_candidates_from_history"}
+
+    def test_history_analyzer_accepts_direct_sql_without_db(self):
+        tools = SemanticDiscoveryTools(db_tool=None)
+
+        result = tools.analyze_metric_candidates_from_history(sql_queries=["SELECT SUM(amount) AS revenue FROM orders"])
+
+        assert result.success == 1
+        assert [candidate["name"] for candidate in result.result["metric_candidates"]] == ["revenue"]
+
     def test_available_tools_includes_metric_candidate_mining(self):
         tools = _make_tools()
         tool_names = {tool.name for tool in tools.available_tools()}
@@ -1578,12 +1597,12 @@ class TestAnalyzeMetricCandidatesFromHistory:
     def test_mysql_dialect_fallback_parses_backtick_aliases(self):
         tools = _make_tools()
         result = tools.analyze_metric_candidates_from_history(
-            sql_queries=["SELECT COUNT(DISTINCT `user_id`) AS `人数` FROM `orders`"]
+            sql_queries=["SELECT COUNT(DISTINCT `user_id`) AS `***` FROM `orders`"]
         )
 
         assert result.result["parse_errors"] == []
         candidate = result.result["metric_candidates"][0]
-        assert candidate["source_alias"] == "人数"
+        assert candidate["source_alias"] == "***"
         assert candidate["requires_name_translation"] is True
         assert candidate["name_source"] == "expression_fallback"
         assert candidate["name"] == "count_distinct_user_id"
@@ -1694,34 +1713,34 @@ class TestAnalyzeMetricCandidatesFromHistory:
         result = tools.analyze_metric_candidates_from_history(
             sql_queries=[
                 """
-                WITH user_total_playtime_per_mode AS (
-                    SELECT vplayerid, modename, SUM(roundtime) AS total_playtime
-                    FROM mode_roundrecord
-                    GROUP BY vplayerid, modename
+                WITH customer_total_amount_per_category AS (
+                    SELECT customer_id, category_name, SUM(amount) AS total_amount
+                    FROM transactions
+                    GROUP BY customer_id, category_name
                 ),
-                user_main_mode AS (
+                customer_preferred_category AS (
                     SELECT
-                        vplayerid,
-                        modename,
+                        customer_id,
+                        category_name,
                         ROW_NUMBER() OVER (
-                            PARTITION BY vplayerid
-                            ORDER BY total_playtime DESC
+                            PARTITION BY customer_id
+                            ORDER BY total_amount DESC
                         ) AS rn
-                    FROM user_total_playtime_per_mode
+                    FROM customer_total_amount_per_category
                 )
-                SELECT modename AS `主玩玩法`, COUNT(*) AS `人数`
-                FROM user_main_mode
+                SELECT category_name AS preferred_category, COUNT(*) AS `***`
+                FROM customer_preferred_category
                 WHERE rn = 1
-                GROUP BY modename
+                GROUP BY category_name
                 """
             ]
         )
 
         assert result.result["query_classification"] == "metric_plus_derived_datasource"
-        assert result.result["blocked_direct_metric_candidates"][0]["source_alias"] == "人数"
+        assert result.result["blocked_direct_metric_candidates"][0]["source_alias"] == "***"
         assert result.result["blocked_direct_metric_candidates"][0]["requires_name_translation"] is True
         recommendation = result.result["derived_datasource_recommendations"][0]
-        assert recommendation["source_cte"] == "user_main_mode"
+        assert recommendation["source_cte"] == "customer_preferred_category"
         assert recommendation["rank_alias"] == "rn"
         assert recommendation["window"]["function"] == "ROW_NUMBER"
         assert recommendation["rank_filters"] == ["rn = 1"]

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -4,7 +4,6 @@
 
 """CI-level tests for SubAgentTaskTool (AgenticNode-based execution)."""
 
-import asyncio
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
@@ -635,6 +634,33 @@ class TestConvertToFuncResult:
         assert result.success == 1
         assert result.result["response"] == "Some content"
 
+    def test_gen_metrics_failure_preserves_blocker_contract(self, task_tool):
+        output = {
+            "success": False,
+            "error": "Multiple semantic models remain plausible.",
+            "status": "blocked",
+            "blocker_code": "semantic_model_selection_required",
+            "response": "Choose the intended semantic model.",
+            "semantic_models": [],
+            "tokens_used": 73,
+        }
+
+        result = task_tool._convert_to_func_result(
+            output,
+            session_id="gen_metrics_session_blocked01",
+        )
+
+        assert result.success == 0
+        assert result.error == "Multiple semantic models remain plausible."
+        assert result.result == {
+            "status": "blocked",
+            "blocker_code": "semantic_model_selection_required",
+            "response": "Choose the intended semantic model.",
+            "semantic_models": [],
+            "tokens_used": 73,
+            "session_id": "gen_metrics_session_blocked01",
+        }
+
     def test_markdown_report_result(self, task_tool):
         output = {"response": "Metric answer", "markdown_report": "## Metric answer", "tokens_used": 25}
 
@@ -783,146 +809,24 @@ class TestSubAgentTaskAcceptance:
 @pytest.mark.ci
 class TestTaskExecution:
     @pytest.mark.asyncio
-    async def test_osi_gen_metrics_requires_existing_semantic_model(self, task_tool, tmp_path):
+    async def test_osi_gen_metrics_starts_without_host_target_precondition(self, task_tool, tmp_path):
         task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
         task_tool.agent_config.current_datasource = "test_db"
         task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
-
-        with patch.object(task_tool, "_execute_node") as execute_node:
-            result = await task_tool.task(type="gen_metrics", prompt="Generate revenue")
-
-        assert result.success == 0
-        assert result.result["code"] == "semantic_model_required"
-        assert result.result["required_subagent"] == "gen_semantic_model"
-        assert result.result["semantic_model_directory"].endswith("subject/semantic_models/test_db")
-        assert result.result["retry_subagent"] == "gen_metrics"
-        execute_node.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_osi_gen_metrics_selects_discovered_model_by_dataset(self, task_tool, tmp_path):
-        task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
-        task_tool.agent_config.current_datasource = "test_db"
-        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
-        model_dir = tmp_path / "subject" / "semantic_models" / "test_db"
-        model_dir.mkdir(parents=True)
-        for name, dataset in (("orders_analytics", "orders"), ("support", "tickets")):
-            (model_dir / f"{name}.yml").write_text(
-                "version: 0.2.0.dev0\n"
-                "semantic_model:\n"
-                f"  - name: {name}\n"
-                "    datasets:\n"
-                f"      - name: {dataset}\n"
-                f"        source: main.{dataset}\n",
-                encoding="utf-8",
-            )
-        expected = FuncToolResult(result={"response": "generated"})
+        prompt = "Create order metrics. The semantic model is at subject/semantic_models/test_db/orders.yml."
+        expected = FuncToolResult(result={"response": "gen_metrics started"})
 
         with patch.object(task_tool, "_execute_node", return_value=expected) as execute_node:
-            result = await task_tool.task(type="gen_metrics", prompt="Generate order count from orders")
+            result = await task_tool.task(type="gen_metrics", prompt=prompt)
 
         assert result is expected
-        execute_node.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_osi_gen_metrics_reports_ambiguous_model_candidates(self, task_tool, tmp_path):
-        task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
-        task_tool.agent_config.current_datasource = "test_db"
-        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
-        model_dir = tmp_path / "subject" / "semantic_models" / "test_db"
-        model_dir.mkdir(parents=True)
-        for name, dataset in (("orders", "orders"), ("support", "tickets")):
-            (model_dir / f"{name}.yml").write_text(
-                "semantic_model:\n"
-                f"  - name: {name}\n"
-                "    datasets:\n"
-                f"      - name: {dataset}\n"
-                f"        source: main.{dataset}\n",
-                encoding="utf-8",
-            )
-
-        with patch.object(task_tool, "_execute_node") as execute_node:
-            result = await task_tool.task(type="gen_metrics", prompt="Generate metrics")
-
-        assert result.success == 0
-        assert result.result["code"] == "semantic_model_selection_required"
-        assert {candidate["semantic_model_name"] for candidate in result.result["candidates"]} == {
-            "orders",
-            "support",
-        }
-        execute_node.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_osi_gen_metrics_rejects_invalid_structured_source_sql(self, task_tool, tmp_path):
-        from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
-
-        task_tool.agent_config.resolve_semantic_adapter.return_value = "osi"
-        task_tool.agent_config.current_datasource = "test_db"
-        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
-        parent = MagicMock()
-        parent.input = SemanticNodeInput(
-            user_message="SQL:\nSELECT COUNT(*) FROM main.orders",
-            source_queries=[SourceQueryEvidence(source_sql_name="sql_9", sql="SELECT * FROM")],
+        execute_node.assert_awaited_once_with(
+            "gen_metrics",
+            prompt,
+            description="",
+            call_id=None,
+            session_id=None,
         )
-        task_tool.set_parent_node(parent)
-
-        with patch.object(task_tool, "_execute_node") as execute_node:
-            result = await task_tool.task(type="gen_metrics", prompt="Generate order metrics")
-
-        assert result.success == 0
-        assert result.result["code"] == "semantic_model_source_sql_invalid"
-        assert result.result["parse_errors"][0]["source_sql_name"] == "sql_9"
-        execute_node.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_semantic_authoring_tasks_are_serialized_across_tool_instances(
-        self, task_tool, monkeypatch, tmp_path
-    ):
-        active = 0
-        max_active = 0
-        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
-        metrics_tool = SubAgentTaskTool(agent_config=task_tool.agent_config)
-
-        async def fake_execute(subagent_type, prompt, **kwargs):
-            nonlocal active, max_active
-            active += 1
-            max_active = max(max_active, active)
-            await asyncio.sleep(0.01)
-            active -= 1
-            return FuncToolResult(result={"subagent_type": subagent_type})
-
-        monkeypatch.setattr(task_tool, "_execute_node", fake_execute)
-        monkeypatch.setattr(task_tool, "_osi_metric_precondition", lambda *_args, **_kwargs: None)
-        monkeypatch.setattr(metrics_tool, "_execute_node", fake_execute)
-        monkeypatch.setattr(metrics_tool, "_osi_metric_precondition", lambda *_args, **_kwargs: None)
-
-        semantic_result, metrics_result = await asyncio.gather(
-            task_tool.task(type="gen_semantic_model", prompt="Generate the sales model"),
-            metrics_tool.task(type="gen_metrics", prompt="Generate revenue"),
-        )
-
-        assert semantic_result.success == 1
-        assert metrics_result.success == 1
-        assert max_active == 1
-
-    @pytest.mark.asyncio
-    async def test_semantic_authoring_guard_is_reentrant_for_nested_subagent(self, task_tool, monkeypatch, tmp_path):
-        from datus.agent.node.semantic_authoring import semantic_authoring_guard
-
-        task_tool.agent_config.path_manager = SimpleNamespace(project_root=tmp_path)
-
-        async def fake_execute(subagent_type, prompt, **kwargs):
-            return FuncToolResult(result={"subagent_type": subagent_type})
-
-        monkeypatch.setattr(task_tool, "_execute_node", fake_execute)
-
-        async with semantic_authoring_guard(task_tool.agent_config):
-            result = await asyncio.wait_for(
-                task_tool.task(type="gen_semantic_model", prompt="Generate the sales model"),
-                timeout=0.5,
-            )
-
-        assert result.success == 1
-        assert result.result["subagent_type"] == "gen_semantic_model"
 
     @pytest.mark.asyncio
     async def test_execute_gen_sql_success(self, task_tool):
@@ -1872,6 +1776,21 @@ class TestConvertToFuncResultBuiltIn:
         result = task_tool._convert_to_func_result(output)
         assert result.success == 1
         assert result.result["semantic_models"] == []
+
+    def test_gen_metrics_success_preserves_outcome(self, task_tool):
+        output = {
+            "response": "The request is not a metric.",
+            "semantic_models": [],
+            "tokens_used": 100,
+            "status": "skipped",
+            "skip_reason": "not_a_metric",
+        }
+
+        result = task_tool._convert_to_func_result(output)
+
+        assert result.success == 1
+        assert result.result["status"] == "skipped"
+        assert result.result["skip_reason"] == "not_a_metric"
 
     def test_sql_summary_file_result(self, task_tool):
         output = {

--- a/tests/unit_tests/utils/test_sql_utils.py
+++ b/tests/unit_tests/utils/test_sql_utils.py
@@ -723,7 +723,7 @@ def test_parse_sql_type_with():
                      vplayerid,
                      sum(roundcnt) roundcnt,
                      sum(roundtime) roundtime
-              from dws_jordass_mode_roundrecord_di
+              from sample_activity_daily
               where ((dtstatdate between '20240326' and '20240409')
                   or (dtstatdate between '20240528' and '20240611'))
                 and mode in (401,402,403,101,102,103,603)
@@ -753,7 +753,7 @@ def test_parse_sql_type_with():
                ) a
                    left join (
               select dtstatdate,vplayerid
-              from dws_jordass_login_di
+              from sample_login_daily
               where ((dtstatdate between '20240326' and '20240404')
                   or (dtstatdate between '20240528' and '20240606'))
                 and platid =255
@@ -762,7 +762,7 @@ def test_parse_sql_type_with():
                              on a.vplayerid = b1.vplayerid and date_add(a.dtstatdate,1) = b1.dtstatdate
                    left join (
               select dtstatdate,vplayerid
-              from dws_jordass_login_di
+              from sample_login_daily
               where ((dtstatdate between '20240326' and '20240409') or (dtstatdate between '20240528' and '20240611'))
                 and platid =255
               group by dtstatdate,vplayerid


### PR DESCRIPTION
## Why

`task(gen_metrics)` performed a host-side semantic-model precondition before starting the subagent. The precondition inferred selectors from free-form task text, so it could return `semantic_model_required` or ambiguous-selection errors even when the requested OSI YAML had already been generated and synced.

This also prevented CLI/agentic-loop usage from discovering semantic models autonomously.

## Solution

- Remove the host-side OSI metric target precondition and the superseded resolver path.
- Let `gen_metrics` inspect the current datasource inventory and explicitly bind an exact semantic-model target through agent tools.
- Keep inventory and validation scoped to `subject/semantic_models/<datasource>`.
- Add revision-aware write and publish guards so authoring cannot continue against a stale or rejected target.
- Preserve structured blocked results when discovery needs clarification.
- Keep semantic-model creation planning separate from metric target binding and simplify superseded authoring paths.

## Test Cases

- `1181 passed` across the affected agent nodes, target-binding tools, storage, prompts, and SQL utilities, including the latest generic `AgenticNode` tests.
- Ruff check passed.
- Ruff format check passed.
- `git diff --check` passed.
- Local end-to-end verification from an empty semantic-model directory using raw SQL/DDL data:
  - `gen_semantic_model` created and validated a fresh OSI YAML.
  - The main agent invoked the general `task(gen_metrics)` tool without a YAML path.
  - `gen_metrics` scanned inventory, bound the unique model, created the metric, validated it, generated a dry-run query, and synced it.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added explicit planning and binding for OSI semantic model targets, including live inventory and candidate selection.
  * Added structured metric-generation outcomes: generated, skipped, or blocked, with actionable blocker details.
  * Added support for passing and verifying semantic model file hints.
* **Bug Fixes**
  * Improved validation and publishing safeguards to prevent changes to the wrong or outdated semantic model.
  * Ensured artifact changes invalidate stale validation and synchronization results.
* **Documentation**
  * Updated OSI authoring guidance for target selection, metric publishing, and validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OSI semantic-model planning and exact binding with live inventory, safer candidate selection, and planned/selected target enforcement.
  * Introduced richer OSI metric workflow outcomes (`generated`, `skipped`, `blocked`) with `blocker_code` and `skip_reason`, plus optional semantic-model file hints.
* **Bug Fixes**
  * Strengthened validation/publishing to prevent publishing against the wrong or outdated semantic/model target.
  * Improved evidence invalidation so updated artifacts refresh validation and sync state.
* **Documentation**
  * Updated OSI authoring and metrics skill guidance to match the new planning/binding and validation contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->