### PR TITLE
[BugFix] Accept full shell command shapes for managed plugin commands

### DIFF
--- a/datus/plugins/registry.py
+++ b/datus/plugins/registry.py
@@ -365,7 +365,11 @@ def _plugin_config_preamble(config_mutable: bool = True) -> str:
             "agent configuration is read-only in this environment. Never suggest "
             "editing configuration files and never walk the user through plugin "
             "setup; if a plugin is not configured, tell the user to contact their "
-            "administrator. Configured `datus <plugin>` commands work normally."
+            "administrator. Configured `datus <plugin>` commands work normally.\n"
+            "Run at most one `datus <plugin>` command per bash call, with `datus` as "
+            "the command word: never wrap it in `$(...)`/backticks, and never behind "
+            "`timeout`, `env`, `xargs` or `sh -c`. Pipes, redirection, `&&`/`;` lists "
+            "and `--profile` are all fine; `--config` is rejected."
         )
     config_path = _agent_config_location()
     location = f"`{config_path}` " if config_path else "the agent config file (agent.yml) "

--- a/datus/plugins/runtime_context.py
+++ b/datus/plugins/runtime_context.py
@@ -48,7 +48,11 @@ _DATUS_COMMAND_WORD_RE = re.compile(r"(?<![A-Za-z0-9_.-])datus(?![A-Za-z0-9_.-])
 
 # Tokens that may legally precede a command word inside one simple command.
 _ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-_REDIRECT_OP_RE = re.compile(r"^\d*(?:>>|>&|<&|<>|>|<)(?:\d+-?)?$")
+# `2>&1`, `<&3`, `3>&-` name their target inside the operator, while a bare
+# `>`/`2>>`/`<>` takes the FOLLOWING word as its target. Tested in that order
+# because _REDIRECT_TARGET_RE would also match `2>&1`.
+_REDIRECT_DUP_RE = re.compile(r"^\d*[<>]&(?:\d+-?|-)$")
+_REDIRECT_OP_RE = re.compile(r"^\d*(?:>>|>&|<&|<>|>|<)$")
 _REDIRECT_TARGET_RE = re.compile(r"^\d*(?:>>|>|<)\S+$")
 _COMMAND_PREFIX_WORDS = frozenset({"!", "time", "if", "elif", "while", "until", "then", "do", "else"})
 
@@ -365,9 +369,9 @@ def _command_word_index(words: List[Tuple[int, str]]) -> Optional[int]:
     """Index of the command word among one simple command's raw words.
 
     Variable assignments (``FOO=1 datus ...``), redirections placed before the
-    command word (``> out.txt datus ...``) and shell keywords that introduce a
-    command (``do``, ``then``, ``!``, ``time``) are skipped. Returns ``None``
-    when the command consists of prefix words only.
+    command word (``> out.txt datus ...``, ``2>&1 datus ...``) and shell
+    keywords that introduce a command (``do``, ``then``, ``!``, ``time``) are
+    skipped. Returns ``None`` when the command consists of prefix words only.
     """
     i = 0
     while i < len(words):
@@ -375,11 +379,17 @@ def _command_word_index(words: List[Tuple[int, str]]) -> Optional[int]:
         if text in _COMMAND_PREFIX_WORDS or _ASSIGNMENT_RE.match(text):
             i += 1
             continue
+        if _REDIRECT_DUP_RE.match(text):
+            # Self-contained fd duplication: `2>&1`, `<&3`, `3>&-`.
+            i += 1
+            continue
         if _REDIRECT_OP_RE.match(text):
-            # A bare operator takes the next word as its target.
+            # A bare operator takes the next word as its target. Checked before
+            # _REDIRECT_TARGET_RE, whose `\S+` would swallow `>>` itself.
             i += 2
             continue
         if _REDIRECT_TARGET_RE.match(text):
+            # Target attached to the operator: `>out.txt`.
             i += 1
             continue
         return i
@@ -474,14 +484,18 @@ def _scan_word(
     substitutions: List[str],
     heredocs: List[Tuple[str, bool]],
 ) -> Tuple[int, Optional[str]]:
-    """Advance past one word, returning the offset after it."""
+    """Advance past one word, returning the offset after it.
+
+    Braces are literal here: ``--opt={a,b}`` is one word to Bash, and only a
+    brace at a word boundary (handled by :func:`_scan_command`) groups commands.
+    """
     n = len(command)
     while i < n:
         char = command[i]
         if char == "\\":
             i += 2
             continue
-        if char in " \t\r" or char in _SEPARATOR_CHARS or char in _GROUPING_CHARS:
+        if char in " \t\r" or char in _SEPARATOR_CHARS or char in "()":
             return i, None
         if char == "'":
             end = command.find("'", i + 1)
@@ -513,7 +527,13 @@ def _scan_word(
                 return n, error
             substitutions.append(inner)
             continue
-        if char == "<" and command.startswith("<<", i) and not command.startswith("<<<", i):
+        if char == "<" and command.startswith("<<<", i):
+            # A here-string takes its payload inline — consuming all three
+            # characters keeps the trailing `<<` from re-matching as a heredoc,
+            # whose body skip would swallow the rest of the command.
+            i += 3
+            continue
+        if char == "<" and command.startswith("<<", i):
             i, error = _consume_heredoc_delimiter(command, i + 2, heredocs)
             if error is not None:
                 return n, error

--- a/datus/plugins/runtime_context.py
+++ b/datus/plugins/runtime_context.py
@@ -14,6 +14,18 @@ The context is intentionally passed through one command-scoped environment
 variable.  It contains only the invoked plugin's resolved profile and, when
 needed, the exact plugin directory selected by the normal managed-store /
 ``agent.plugin_paths`` precedence.
+
+The Bash command itself is preserved verbatim: :func:`prepare_plugin_invocation`
+locates the single ``datus`` command word and inserts an inline environment
+assignment in front of it, so redirections, ``&&``/``;`` lists, groupings and
+expansions in the model-written command keep working.
+
+The bridge only recognizes ``datus`` when it appears as a real command word.  An
+invocation hidden inside a string a wrapper interprets later (``sh -c "datus
+..."``) is not rewritten, so that subprocess simply receives no runtime context
+and resolves configuration the ordinary way; such wrapper commands never
+auto-allow in the permission layer either (see
+:mod:`datus.tools.permission.bash_rules`).
 """
 
 from __future__ import annotations
@@ -24,17 +36,29 @@ import os
 import re
 import shlex
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-
-from datus.tools.permission.bash_rules import split_pipeline
 
 RUNTIME_CONTEXT_ENV = "DATUS_PLUGIN_RUNTIME_CONTEXT"
 RUNTIME_CONTEXT_VERSION = 1
 RUNTIME_CONTEXT_PREFIX = "v1."
 MAX_RUNTIME_CONTEXT_SIZE = 64 * 1024
 _DATUS_COMMAND_WORD_RE = re.compile(r"(?<![A-Za-z0-9_.-])datus(?![A-Za-z0-9_.-])")
+
+# Tokens that may legally precede a command word inside one simple command.
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_REDIRECT_OP_RE = re.compile(r"^\d*(?:>>|>&|<&|<>|>|<)(?:\d+-?)?$")
+_REDIRECT_TARGET_RE = re.compile(r"^\d*(?:>>|>|<)\S+$")
+_COMMAND_PREFIX_WORDS = frozenset({"!", "time", "if", "elif", "while", "until", "then", "do", "else"})
+
+# Characters that end a simple command at the top level of the command line.
+_SEPARATOR_CHARS = ";&|\n"
+_GROUPING_CHARS = "(){}"
+
+# Bounds recursion while matching nested substitutions so a pathological
+# command can never hang the scanner; deeper nesting fails closed.
+_MAX_NESTING = 16
 
 
 class PluginRuntimeContextError(ValueError):
@@ -181,41 +205,59 @@ def load_runtime_context_from_env(*, expected_plugin: Optional[str] = None) -> O
 
 
 def prepare_plugin_invocation(command: str, agent_config: Any) -> Optional[PreparedPluginInvocation]:
-    """Prepare a managed ``datus <plugin>`` command or pure pipeline.
+    """Prepare a managed ``datus <plugin>`` command.
+
+    Any shell command shape is accepted as long as the single plugin CLI
+    invocation sits at a top-level command position: pipelines, redirections,
+    ``;``/``&&``/``||``/newline lists, ``(...)``/``{...}`` groupings, heredocs
+    and expansions all keep their original text.
 
     Returns ``None`` for commands with no plugin CLI segment.  Commands that
     contain a plugin invocation but cannot be bridged safely fail closed rather
     than falling back to a local config file.
     """
-    segments = split_pipeline(command)
-    if segments is None or _has_unsupported_shell_controls(command):
-        if _contains_datus_command(command):
-            raise PluginRuntimeContextError(
-                "Managed plugin commands support a single command or a pure `|` pipeline only"
-            )
+    scan = _scan_command(command)
+    if scan.error is not None:
+        # The command word cannot be located, so be maximally conservative: any
+        # `datus` word at all fails the command rather than letting it run
+        # unbridged (which would fall back to local config resolution). Token
+        # position analysis is unreliable here precisely because the parse failed.
+        if _DATUS_COMMAND_WORD_RE.search(command):
+            raise PluginRuntimeContextError(f"Invalid managed plugin command syntax: {scan.error}")
         return None
+    for substitution in scan.substitutions:
+        if _contains_datus_command(substitution):
+            raise PluginRuntimeContextError(
+                "Managed plugin commands cannot invoke `datus` inside a command substitution "
+                "(`$(...)`, backticks); run the plugin command directly and pipe its output instead"
+            )
 
-    plugin_segments: List[Tuple[int, List[str]]] = []
-    for index, segment in enumerate(segments):
+    plugin_invocations: List[Tuple[int, List[str]]] = []
+    for span in scan.spans:
+        index = _command_word_index(span.words)
+        if index is None:
+            continue
+        word_offset = span.words[index][0]
         try:
-            argv = shlex.split(segment)
+            argv = shlex.split(command[word_offset : span.end])
         except ValueError as exc:
-            if "datus" in segment:
+            if "datus" in command[span.start : span.end]:
                 raise PluginRuntimeContextError(f"Invalid managed plugin command syntax: {exc}") from exc
-            return None
+            continue
         if argv and Path(argv[0]).name == "datus":
-            plugin_segments.append((index, argv))
+            plugin_invocations.append((word_offset, argv))
         elif any(Path(token).name == "datus" for token in argv):
             raise PluginRuntimeContextError(
-                "Managed plugin commands must invoke `datus` directly at the start of a pipeline segment"
+                "Managed plugin commands must invoke `datus` directly as the command word, "
+                "not through a wrapper such as `timeout`, `env`, `xargs` or `sh -c`"
             )
 
-    if not plugin_segments:
+    if not plugin_invocations:
         return None
-    if len(plugin_segments) != 1:
+    if len(plugin_invocations) != 1:
         raise PluginRuntimeContextError("A managed Bash command may invoke only one plugin CLI")
 
-    segment_index, argv = plugin_segments[0]
+    insert_at, argv = plugin_invocations[0]
     if len(argv) < 2 or argv[1].startswith("-"):
         return None
     plugin_name = argv[1]
@@ -249,16 +291,17 @@ def prepare_plugin_invocation(command: str, agent_config: Any) -> Optional[Prepa
 
     # The payload initially enters Bash through its environment.  The prologue
     # copies it into a randomly-named, non-exported shell variable and unsets
-    # the exported name before the pipeline is spawned.  The inline assignment
-    # then exposes it only to the datus segment; sibling pipeline commands do
-    # not inherit it.
+    # the exported name before any command in the line is spawned.  The inline
+    # assignment then exports it only for the datus command; sibling commands
+    # in the same line do not inherit it.
     internal_var = f"__datus_plugin_ctx_{uuid.uuid4().hex}"
     while internal_var in command:
         internal_var = f"__datus_plugin_ctx_{uuid.uuid4().hex}"
-    wrapped_segments = list(segments)
-    wrapped_segments[segment_index] = f'{RUNTIME_CONTEXT_ENV}="${{{internal_var}}}" {wrapped_segments[segment_index]}'
-    wrapped_command = f'{internal_var}="${{{RUNTIME_CONTEXT_ENV}}}"; unset {RUNTIME_CONTEXT_ENV}; ' + " | ".join(
-        wrapped_segments
+    wrapped_command = (
+        f'{internal_var}="${{{RUNTIME_CONTEXT_ENV}}}"; unset {RUNTIME_CONTEXT_ENV}; '
+        + command[:insert_at]
+        + f'{RUNTIME_CONTEXT_ENV}="${{{internal_var}}}" '
+        + command[insert_at:]
     )
     read_dirs = [str(plugin_path)] if plugin_path is not None else []
     return PreparedPluginInvocation(
@@ -318,39 +361,366 @@ def _contains_datus_command(command: str) -> bool:
     return False
 
 
-def _has_unsupported_shell_controls(command: str) -> bool:
-    """Detect top-level shell controls while allowing literals inside quotes.
+def _command_word_index(words: List[Tuple[int, str]]) -> Optional[int]:
+    """Index of the command word among one simple command's raw words.
 
-    A plugin argument such as ``python -c 'a=1; print(a)'`` is safe to retain
-    in a pure pipeline, while a top-level ``;``/``&&``/redirection or command
-    substitution would change which processes receive the runtime context.
+    Variable assignments (``FOO=1 datus ...``), redirections placed before the
+    command word (``> out.txt datus ...``) and shell keywords that introduce a
+    command (``do``, ``then``, ``!``, ``time``) are skipped. Returns ``None``
+    when the command consists of prefix words only.
     """
-    in_single = in_double = False
     i = 0
-    while i < len(command):
-        char = command[i]
-        if char == "\\" and not in_single:
+    while i < len(words):
+        text = words[i][1]
+        if text in _COMMAND_PREFIX_WORDS or _ASSIGNMENT_RE.match(text):
+            i += 1
+            continue
+        if _REDIRECT_OP_RE.match(text):
+            # A bare operator takes the next word as its target.
             i += 2
             continue
-        if char == "'" and not in_double:
-            in_single = not in_single
+        if _REDIRECT_TARGET_RE.match(text):
             i += 1
             continue
-        if char == '"' and not in_single:
-            in_double = not in_double
+        return i
+    return None
+
+
+@dataclass(frozen=True)
+class _CommandSpan:
+    """One top-level simple command: its offsets and its raw words."""
+
+    start: int
+    end: int
+    words: List[Tuple[int, str]]
+
+
+@dataclass(frozen=True)
+class _ShellScan:
+    """Structure of one Bash command line, as far as this bridge needs it.
+
+    ``spans`` describes the top-level simple commands; ``substitutions`` holds
+    the raw text of every command substitution and ``${...}`` expansion found,
+    so a ``datus`` word hiding in one can be rejected; ``error`` is set when the
+    line cannot be parsed at all.
+    """
+
+    spans: List[_CommandSpan] = field(default_factory=list)
+    substitutions: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def _scan_command(command: str) -> _ShellScan:
+    """Split a command line into its top-level simple-command spans.
+
+    Only enough Bash syntax is modelled to know *where* a command word may
+    start: quoting, expansions, command substitutions, heredoc bodies and
+    comments are skipped, and separators (``;``, ``&``, ``|``, newline) plus
+    groupings (``(``, ``)``, ``{``, ``}``) end the current span. Redirections
+    stay inside the span they belong to.
+    """
+    spans: List[_CommandSpan] = []
+    substitutions: List[str] = []
+    heredocs: List[Tuple[str, bool]] = []
+    span_start: Optional[int] = None
+    words: List[Tuple[int, str]] = []
+    i = 0
+    n = len(command)
+
+    def close_span(end: int) -> None:
+        nonlocal span_start, words
+        if span_start is not None:
+            if words:
+                spans.append(_CommandSpan(span_start, end, words))
+            span_start = None
+            words = []
+
+    while i < n:
+        char = command[i]
+        if char in " \t\r":
             i += 1
             continue
-        if in_single:
+        if char == "\n":
+            close_span(i)
             i += 1
+            if heredocs:
+                i = _skip_heredoc_bodies(command, i, heredocs)
+                heredocs = []
+            continue
+        if char in _SEPARATOR_CHARS or char in _GROUPING_CHARS:
+            close_span(i)
+            i += 1
+            continue
+        if char == "#":
+            # An unquoted `#` starting a word begins a comment.
+            close_span(i)
+            newline = command.find("\n", i)
+            i = n if newline == -1 else newline
+            continue
+        if span_start is None:
+            span_start = i
+        word_start = i
+        i, error = _scan_word(command, i, substitutions, heredocs)
+        if error is not None:
+            return _ShellScan(spans, substitutions, error)
+        words.append((word_start, command[word_start:i]))
+    close_span(n)
+    return _ShellScan(spans, substitutions, None)
+
+
+def _scan_word(
+    command: str,
+    i: int,
+    substitutions: List[str],
+    heredocs: List[Tuple[str, bool]],
+) -> Tuple[int, Optional[str]]:
+    """Advance past one word, returning the offset after it."""
+    n = len(command)
+    while i < n:
+        char = command[i]
+        if char == "\\":
+            i += 2
+            continue
+        if char in " \t\r" or char in _SEPARATOR_CHARS or char in _GROUPING_CHARS:
+            return i, None
+        if char == "'":
+            end = command.find("'", i + 1)
+            if end == -1:
+                return n, "unbalanced single quote"
+            i = end + 1
+            continue
+        if char == '"':
+            i, error = _skip_double_quoted(command, i, substitutions=substitutions)
+            if error is not None:
+                return n, error
             continue
         if char == "`":
-            return True
-        if char == "$" and i + 1 < len(command) and command[i + 1] in "({":
-            return True
-        if not in_double and (char in ";&<>()\n"):
-            return True
+            end = _find_backtick_end(command, i + 1)
+            if end is None:
+                return n, "unbalanced backtick"
+            substitutions.append(command[i + 1 : end])
+            i = end + 1
+            continue
+        if char == "$" and i + 1 < n and command[i + 1] == "(":
+            i, inner, error = _scan_substitution(command, i + 2)
+            if error is not None:
+                return n, error
+            substitutions.append(inner)
+            continue
+        if char == "$" and i + 1 < n and command[i + 1] == "{":
+            i, inner, error = _skip_brace_expansion(command, i + 2)
+            if error is not None:
+                return n, error
+            substitutions.append(inner)
+            continue
+        if char == "<" and command.startswith("<<", i) and not command.startswith("<<<", i):
+            i, error = _consume_heredoc_delimiter(command, i + 2, heredocs)
+            if error is not None:
+                return n, error
+            continue
+        if char in "<>" and command.startswith(f"{char}&", i):
+            # `2>&1` / `<&3` keep the `&` out of separator handling.
+            i += 2
+            continue
         i += 1
-    return False
+    return n, None
+
+
+def _skip_double_quoted(
+    command: str,
+    i: int,
+    nesting: int = 0,
+    substitutions: Optional[List[str]] = None,
+) -> Tuple[int, Optional[str]]:
+    """Advance past a double-quoted string starting at ``i``."""
+    n = len(command)
+    j = i + 1
+    while j < n:
+        char = command[j]
+        if char == "\\":
+            j += 2
+            continue
+        if char == '"':
+            return j + 1, None
+        if char == "`":
+            end = _find_backtick_end(command, j + 1)
+            if end is None:
+                return n, "unbalanced backtick"
+            if substitutions is not None:
+                substitutions.append(command[j + 1 : end])
+            j = end + 1
+            continue
+        if char == "$" and j + 1 < n and command[j + 1] == "(":
+            j, inner, error = _scan_substitution(command, j + 2, nesting + 1)
+            if error is not None:
+                return n, error
+            if substitutions is not None:
+                substitutions.append(inner)
+            continue
+        if char == "$" and j + 1 < n and command[j + 1] == "{":
+            j, inner, error = _skip_brace_expansion(command, j + 2)
+            if error is not None:
+                return n, error
+            if substitutions is not None:
+                substitutions.append(inner)
+            continue
+        j += 1
+    return n, "unbalanced double quote"
+
+
+def _scan_substitution(command: str, i: int, nesting: int = 0) -> Tuple[int, str, Optional[str]]:
+    """Match a ``$(...)`` substitution whose body starts at ``i``.
+
+    Returns the offset after the closing paren and the raw body text.
+    """
+    if nesting > _MAX_NESTING:
+        return len(command), command[i:], "command substitution nested too deeply"
+    n = len(command)
+    start = i
+    parens = 0
+    j = i
+    while j < n:
+        char = command[j]
+        if char == "\\":
+            j += 2
+            continue
+        if char == "'":
+            end = command.find("'", j + 1)
+            if end == -1:
+                return n, command[start:], "unbalanced single quote"
+            j = end + 1
+            continue
+        if char == '"':
+            j, error = _skip_double_quoted(command, j, nesting + 1)
+            if error is not None:
+                return n, command[start:], error
+            continue
+        if char == "`":
+            end = _find_backtick_end(command, j + 1)
+            if end is None:
+                return n, command[start:], "unbalanced backtick"
+            j = end + 1
+            continue
+        if char == "$" and j + 1 < n and command[j + 1] == "(":
+            j, _inner, error = _scan_substitution(command, j + 2, nesting + 1)
+            if error is not None:
+                return n, command[start:], error
+            continue
+        if char == "(":
+            parens += 1
+            j += 1
+            continue
+        if char == ")":
+            if parens:
+                parens -= 1
+                j += 1
+                continue
+            return j + 1, command[start:j], None
+        j += 1
+    return n, command[start:], "unterminated command substitution"
+
+
+def _skip_brace_expansion(command: str, i: int) -> Tuple[int, str, Optional[str]]:
+    """Match a ``${...}`` expansion whose body starts at ``i``.
+
+    The body is returned so a command substitution smuggled into a default
+    value (``${x:-$(datus ...)}``) is still inspected.
+    """
+    n = len(command)
+    start = i
+    depth = 1
+    j = i
+    while j < n:
+        char = command[j]
+        if char == "\\":
+            j += 2
+            continue
+        if char == "$" and j + 1 < n and command[j + 1] == "{":
+            # Only a nested expansion opens a level — a bare `{` in a default
+            # value (``${A:-{x\}}``) is literal text to Bash.
+            depth += 1
+            j += 2
+            continue
+        if char == "}":
+            depth -= 1
+            j += 1
+            if depth == 0:
+                return j, command[start : j - 1], None
+            continue
+        j += 1
+    return n, command[start:], "unbalanced ${...} expansion"
+
+
+def _find_backtick_end(command: str, i: int) -> Optional[int]:
+    """Offset of the backtick closing a substitution opened before ``i``."""
+    n = len(command)
+    while i < n:
+        if command[i] == "\\":
+            i += 2
+            continue
+        if command[i] == "`":
+            return i
+        i += 1
+    return None
+
+
+def _consume_heredoc_delimiter(
+    command: str,
+    i: int,
+    heredocs: List[Tuple[str, bool]],
+) -> Tuple[int, Optional[str]]:
+    """Read the delimiter word of a ``<<``/``<<-`` heredoc starting at ``i``."""
+    n = len(command)
+    strip_tabs = False
+    if i < n and command[i] == "-":
+        strip_tabs = True
+        i += 1
+    while i < n and command[i] in " \t":
+        i += 1
+    parts: List[str] = []
+    while i < n:
+        char = command[i]
+        if char == "'":
+            end = command.find("'", i + 1)
+            if end == -1:
+                return n, "unbalanced single quote"
+            parts.append(command[i + 1 : end])
+            i = end + 1
+            continue
+        if char == '"':
+            end = command.find('"', i + 1)
+            if end == -1:
+                return n, "unbalanced double quote"
+            parts.append(command[i + 1 : end])
+            i = end + 1
+            continue
+        if char in " \t\r\n<>" or char in _SEPARATOR_CHARS or char in _GROUPING_CHARS:
+            break
+        parts.append(char)
+        i += 1
+    delimiter = "".join(parts)
+    if delimiter:
+        heredocs.append((delimiter, strip_tabs))
+    return i, None
+
+
+def _skip_heredoc_bodies(command: str, i: int, heredocs: List[Tuple[str, bool]]) -> int:
+    """Advance past the bodies of the heredocs opened on the previous line.
+
+    Body text is never a command position, so a ``datus`` word inside a payload
+    must not be mistaken for a second plugin invocation. An unterminated body
+    consumes the remainder of the line, which is what Bash does too.
+    """
+    n = len(command)
+    for delimiter, strip_tabs in heredocs:
+        while i < n:
+            line_end = command.find("\n", i)
+            line = command[i:] if line_end == -1 else command[i:line_end]
+            i = n if line_end == -1 else line_end + 1
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate.rstrip("\r") == delimiter:
+                break
+    return i
 
 
 __all__ = [

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -151,14 +151,18 @@ that request's `AgentConfig`. It does not fall back to another tenant's loaded
 configuration or to `./.datus/config.yml`. Standalone CLI skill commands that
 do not hold an `AgentConfig` keep the local project-file behavior.
 
-This bridge accepts one direct plugin invocation, optionally as one stage of a
-plain `|` pipeline. It deliberately fails closed for multiple `datus`
-invocations and for shell control forms such as `&&`, `;`, redirection, command
-substitution, and `|&`. `--profile` remains supported and is resolved against
-the request's `AgentConfig`; `--config` is rejected because the AuthProvider
-configuration is authoritative. The encoded runtime snapshot is capped at
-64 KiB. Sibling pipeline stages do not inherit it, and the parent process
-environment is never modified.
+This bridge accepts one plugin invocation per Bash command, in any shell shape
+that puts `datus` at a command position: pipelines, redirections (`>`, `2>&1`),
+`;`/`&&`/`||`/newline lists, `(...)`/`{...}` groupings, loops, heredocs and
+expansions all keep their original text — the runtime value is injected as an
+inline assignment in front of the `datus` command word only. It deliberately
+fails closed for multiple `datus` invocations in one command, for `datus` inside
+a command substitution (`$(...)`, backticks), and for `datus` behind a wrapper
+such as `timeout`, `env`, `xargs` or `sh -c`. `--profile` remains supported and
+is resolved against the request's `AgentConfig`; `--config` is rejected because
+the AuthProvider configuration is authoritative. The encoded runtime snapshot is
+capped at 64 KiB. Sibling commands in the same Bash invocation do not inherit
+it, and the parent process environment is never modified.
 
 ### Which profile runs
 

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -130,11 +130,14 @@ plugin skill 发现遵循相同规则:`plugins_enabled`、激活 plugin 白名�
 租户已加载的配置或 `./.datus/config.yml`。只有拿不到 `AgentConfig` 的独立 CLI
 skill 命令才保留本地项目配置文件行为。
 
-此桥接允许一次直接的 plugin 调用,也允许它作为普通 `|` 管道中的一个 stage。
-若命令包含多个 `datus` 调用,或使用 `&&`、`;`、重定向、命令替换、`|&` 等 shell
-控制形式,则会 fail closed。`--profile` 仍受支持,并针对当前请求的 `AgentConfig`
-解析;`--config` 会被拒绝,因为 AuthProvider 提供的配置是权威来源。编码后的运行时
-快照上限为 64 KiB。管道中的其他 stage 不会继承它,父进程环境也不会被修改。
+每条 Bash 命令允许一次 plugin 调用,只要 `datus` 位于命令位即可,shell 形态不限:
+管道、重定向(`>`、`2>&1`)、`;`/`&&`/`||`/换行 序列、`(...)`/`{...}` 分组、循环、
+heredoc 与各类展开都会原样保留——运行时快照只以内联赋值的形式插在 `datus` 命令词
+之前。以下情形仍会 fail closed:同一条命令里出现多个 `datus` 调用;`datus` 位于命令
+替换(`$(...)`、反引号)内部;`datus` 被 `timeout`、`env`、`xargs`、`sh -c` 等包裹。
+`--profile` 仍受支持,并针对当前请求的 `AgentConfig` 解析;`--config` 会被拒绝,
+因为 AuthProvider 提供的配置是权威来源。编码后的运行时快照上限为 64 KiB。同一条 Bash
+命令中的其他命令不会继承它,父进程环境也不会被修改。
 
 ### 哪个 profile 生效 {#which-profile-runs}
 

--- a/tests/unit_tests/plugins/test_registry.py
+++ b/tests/unit_tests/plugins/test_registry.py
@@ -326,6 +326,9 @@ def test_preamble_immutable_omits_config_path_and_edit_guidance(plugin_env, monk
     assert "agent.plugins.<plugin>.<profile>" not in sections[0]
     assert "administrator" in sections[0]
     assert "read-only" in sections[0]
+    # The managed bridge accepts one plugin invocation per bash call; telling
+    # the model up front avoids rejected commands it has to retry.
+    assert "one `datus <plugin>` command per bash call" in sections[0]
 
 
 def test_sections_pass_config_mutable_to_template(plugin_env):

--- a/tests/unit_tests/plugins/test_runtime_context.py
+++ b/tests/unit_tests/plugins/test_runtime_context.py
@@ -119,6 +119,22 @@ def test_prepare_pipeline_injects_only_datus_segment(monkeypatch, tmp_path):
         ("datus hello run > out.txt", f'{_CTX}="${{V}}" datus hello run > out.txt'),
         ("datus hello run >> log 2>&1", f'{_CTX}="${{V}}" datus hello run >> log 2>&1'),
         ("> out.txt datus hello run", f'> out.txt {_CTX}="${{V}}" datus hello run'),
+        (">out.txt datus hello run", f'>out.txt {_CTX}="${{V}}" datus hello run'),
+        # An fd duplication names its target inside the operator, so it consumes
+        # one word — skipping two would make `hello` look like the command word
+        # and leave the invocation unbridged.
+        ("2>&1 datus hello run", f'2>&1 {_CTX}="${{V}}" datus hello run'),
+        ("<&3 datus hello run", f'<&3 {_CTX}="${{V}}" datus hello run'),
+        ("3<&4- datus hello run", f'3<&4- {_CTX}="${{V}}" datus hello run'),
+        # A here-string is inline: its `<<` must not re-match as a heredoc, whose
+        # body skip would swallow the rest of the command.
+        ("datus hello run <<< 'x'", f"{_CTX}=\"${{V}}\" datus hello run <<< 'x'"),
+        ("echo a <<< 'x'\ndatus hello run", f"echo a <<< 'x'\n{_CTX}=\"${{V}}\" datus hello run"),
+        # Braces inside a word are brace expansion, not a command grouping.
+        (
+            "datus hello run --opt={a,b} --x 1",
+            f'{_CTX}="${{V}}" datus hello run --opt={{a,b}} --x 1',
+        ),
         # Lists: the assignment goes in front of the plugin command only.
         ("cd /tmp && datus hello run", f'cd /tmp && {_CTX}="${{V}}" datus hello run'),
         ("echo before; datus hello run", f'echo before; {_CTX}="${{V}}" datus hello run'),
@@ -172,6 +188,7 @@ def test_prepare_supports_full_shell_command_shapes(monkeypatch, command, expect
         "datus hello run \\\n  --limit 5 \\\n  --format json",
         "datus hello post <<-'EOF'\n\t{\"a\": 1}\n\tEOF",
         'datus hello run --path "a b/c(d)"',
+        "datus hello run --opt={a,b} --nested={x,{y,z}}",
         "while true; do datus hello run; break; done",
         "case x in x) datus hello run;; esac",
     ],

--- a/tests/unit_tests/plugins/test_runtime_context.py
+++ b/tests/unit_tests/plugins/test_runtime_context.py
@@ -5,12 +5,25 @@
 """Tests for managed plugin CLI runtime-context bridging."""
 
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
 from datus.plugins import runtime_context
 from datus.tools.func_tool.bash_tool import BashExecutionContext, BashTool
+
+_CTX = runtime_context.RUNTIME_CONTEXT_ENV
+
+
+def _normalized_command(prepared):
+    """Rewritten command with the random shell variable name replaced by ``V``."""
+    return re.sub(r"__datus_plugin_ctx_[0-9a-f]{32}", "V", prepared.command)
+
+
+def _expected(body: str) -> str:
+    """The prologue every rewritten command carries, followed by ``body``."""
+    return f'V="${{{_CTX}}}"; unset {_CTX}; ' + body
 
 
 class _Config:
@@ -100,22 +113,188 @@ def test_prepare_pipeline_injects_only_datus_segment(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "command",
+    "command,expected_body",
     [
-        "datus hello run && echo done",
-        "echo before; datus hello run",
-        "datus hello run > out.txt",
-        "datus hello run |& grep ok",
-        "datus hello run | datus hello inspect",
-        "(datus hello run)",
-        "echo $(datus hello run)",
-        'echo "$(datus hello run)"',
-        "echo `datus hello run`",
+        # Redirections stay attached to the command they belong to.
+        ("datus hello run > out.txt", f'{_CTX}="${{V}}" datus hello run > out.txt'),
+        ("datus hello run >> log 2>&1", f'{_CTX}="${{V}}" datus hello run >> log 2>&1'),
+        ("> out.txt datus hello run", f'> out.txt {_CTX}="${{V}}" datus hello run'),
+        # Lists: the assignment goes in front of the plugin command only.
+        ("cd /tmp && datus hello run", f'cd /tmp && {_CTX}="${{V}}" datus hello run'),
+        ("echo before; datus hello run", f'echo before; {_CTX}="${{V}}" datus hello run'),
+        ("datus hello run || echo failed", f'{_CTX}="${{V}}" datus hello run || echo failed'),
+        ("datus hello run |& grep ok", f'{_CTX}="${{V}}" datus hello run |& grep ok'),
+        ("echo a\ndatus hello run\necho b", f'echo a\n{_CTX}="${{V}}" datus hello run\necho b'),
+        # Groupings and compound commands keep their structure; the assignment
+        # must land on the command word, never on `(`, `{` or the `do` keyword.
+        ("(datus hello run)", f'({_CTX}="${{V}}" datus hello run)'),
+        ("{ datus hello run; }", f'{{ {_CTX}="${{V}}" datus hello run; }}'),
+        ("for i in 1 2; do datus hello run; done", f'for i in 1 2; do {_CTX}="${{V}}" datus hello run; done'),
+        ("if datus hello run; then echo ok; fi", f'if {_CTX}="${{V}}" datus hello run; then echo ok; fi'),
+        ("time datus hello run", f'time {_CTX}="${{V}}" datus hello run'),
+        # Leading assignments precede the command word too.
+        ("FOO=1 datus hello run", f'FOO=1 {_CTX}="${{V}}" datus hello run'),
+        # Expansions and substitutions that do not invoke datus are preserved.
+        (
+            "datus hello run --date $(date +%F)",
+            f'{_CTX}="${{V}}" datus hello run --date $(date +%F)',
+        ),
+        (
+            'datus hello run --token "${HELLO_TOKEN}"',
+            f'{_CTX}="${{V}}" datus hello run --token "${{HELLO_TOKEN}}"',
+        ),
+        # A heredoc body is payload, not a command position.
+        (
+            'datus hello post <<EOF\n{"note": "datus hello run"}\nEOF',
+            f'{_CTX}="${{V}}" datus hello post <<EOF\n{{"note": "datus hello run"}}\nEOF',
+        ),
     ],
 )
-def test_prepare_rejects_unsupported_managed_shell_forms(command):
-    with pytest.raises(runtime_context.PluginRuntimeContextError):
+def test_prepare_supports_full_shell_command_shapes(monkeypatch, command, expected_body):
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+
+    prepared = runtime_context.prepare_plugin_invocation(command, _Config())
+
+    assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
+    assert _normalized_command(prepared) == _expected(expected_body)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'datus hello run --sql "select a from t where b > 1 and c < 2"',
+        "datus hello run --sql 'select * from t; drop table x'",
+        'datus hello run --note "it\'s fine" --re "a|b" | grep -E "x|y"',
+        "datus hello run 2> err.log 1>&2",
+        "datus hello run &",
+        'datus hello --profile prod run --dir "$HOME/x" > "$HOME/o.json"',
+        'echo "$(ls)" && datus hello run',
+        "datus hello run \\\n  --limit 5 \\\n  --format json",
+        "datus hello post <<-'EOF'\n\t{\"a\": 1}\n\tEOF",
+        'datus hello run --path "a b/c(d)"',
+        "while true; do datus hello run; break; done",
+        "case x in x) datus hello run;; esac",
+    ],
+)
+def test_prepare_preserves_the_original_command_text(monkeypatch, command):
+    """Removing the injected assignment must restore the command byte for byte.
+
+    The rewrite only ever inserts a prologue and one inline assignment, so
+    quoting, line continuations, redirections and heredoc bodies written by the
+    model reach Bash unchanged.
+    """
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+
+    prepared = runtime_context.prepare_plugin_invocation(command, _Config())
+
+    assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
+    body = _normalized_command(prepared).replace(_expected(""), "", 1)
+    assert body.replace(f'{_CTX}="${{V}}" ', "", 1) == command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Substitutions that do not invoke datus are scanned through, not rejected.
+        "echo $(grep 'a b' f) && datus hello run",
+        'echo $(grep "a b" f); datus hello run',
+        "echo $(echo `date`); datus hello run",
+        "echo $(echo $(date +%F)); datus hello run",
+        "echo $( (cd /tmp && ls) ); datus hello run",
+        # Quoting inside one word: escapes, backticks and expansions.
+        'datus hello run --x "`date`"',
+        'datus hello run --x "a\\"b"',
+        'datus hello run --x "${A:-{brace\\}}"',
+        "datus hello run --x \"$(printf '%s' ok)\"",
+        # Heredoc delimiter spellings.
+        "datus hello post << EOF\npayload\nEOF",
+        'datus hello post <<"EOF"\npayload\nEOF',
+        "datus hello post <<-EOF\n\tpayload\n\tEOF",
+        "datus hello post <<EOF\nunterminated body",
+        "datus hello run <&3",
+    ],
+)
+def test_prepare_scans_nested_shell_syntax_without_rejecting(monkeypatch, command):
+    """Nested quoting/substitution must be traversed, not treated as a control.
+
+    Each of these carries syntax the scanner has to walk through to find the
+    command word; a mis-parse would either reject a valid command or move the
+    injected assignment.
+    """
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+
+    prepared = runtime_context.prepare_plugin_invocation(command, _Config())
+
+    assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
+    body = _normalized_command(prepared).replace(_expected(""), "", 1)
+    assert body.replace(f'{_CTX}="${{V}}" ', "", 1) == command
+
+
+@pytest.mark.parametrize(
+    "command,message",
+    [
+        ('datus hello run --x "unterminated', "unbalanced double quote"),
+        ("datus hello run --x `oops", "unbalanced backtick"),
+        ("datus hello run --x $(oops", "unterminated command substitution"),
+        ("datus hello run --x ${oops", r"unbalanced \$\{\.\.\.\} expansion"),
+        ("datus hello post <<'EOF", "unbalanced single quote"),
+        ('datus hello post <<"EOF', "unbalanced double quote"),
+        ("echo $(grep 'a && datus hello run", "unbalanced single quote"),
+        ('echo $(grep "a && datus hello run', "unbalanced double quote"),
+        ("echo `datus hello run", "unbalanced backtick"),
+        (
+            "echo " + "$(" * 20 + "date" + ")" * 20 + "; datus hello run",
+            "command substitution nested too deeply",
+        ),
+    ],
+)
+def test_prepare_reports_malformed_shell_syntax(monkeypatch, command, message):
+    """Unparsable commands fail closed with the reason, never silently unbridged.
+
+    Returning ``None`` here would run the plugin CLI with no runtime context,
+    which falls back to local config resolution the managed path forbids.
+    """
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match=f"syntax: {message}"):
         runtime_context.prepare_plugin_invocation(command, _Config())
+
+
+@pytest.mark.parametrize(
+    "command,message",
+    [
+        ("datus hello run | datus hello inspect", "only one plugin CLI"),
+        ("datus hello run; datus hello inspect", "only one plugin CLI"),
+        ("echo $(datus hello run)", "command substitution"),
+        ('echo "$(datus hello run)"', "command substitution"),
+        ("echo `datus hello run`", "command substitution"),
+        ('datus hello run --token "${x:-$(datus hello token)}"', "command substitution"),
+        ("timeout 30 datus hello run", "directly as the command word"),
+        ("echo a | xargs datus hello run", "directly as the command word"),
+        ("datus hello run 'unbalanced", "syntax"),
+    ],
+)
+def test_prepare_rejects_unsupported_managed_shell_forms(monkeypatch, command, message):
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match=message):
+        runtime_context.prepare_plugin_invocation(command, _Config())
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls -la > out.txt && echo ok",
+        "echo $(date +%F)",
+        "echo hi # datus hello run",
+        "datus --help",
+        "datus",
+    ],
+)
+def test_prepare_ignores_commands_without_a_plugin_invocation(monkeypatch, command):
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+
+    assert runtime_context.prepare_plugin_invocation(command, _Config()) is None
 
 
 def test_prepare_rejects_managed_config_override(monkeypatch):
@@ -169,6 +348,48 @@ def test_bash_pipeline_scopes_context_to_plugin_segment(monkeypatch, tmp_path):
         "print(sys.stdin.read().strip()); "
         'print("sibling=" + str(bool(os.environ.get("DATUS_PLUGIN_RUNTIME_CONTEXT"))))\''
     )
+
+    assert result.success == 1
+    assert "plugin=True" in result.result
+    assert "sibling=False" in result.result
+
+
+def test_bash_command_list_scopes_context_to_plugin_command(monkeypatch, tmp_path):
+    """A `&&` list with a redirection still isolates the context to datus."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    plugin_dir = tmp_path / "hello"
+    plugin_dir.mkdir()
+    fake_datus = workspace / "datus"
+    fake_datus.write_text(
+        "#!/bin/bash\n"
+        "python -c 'import os; "
+        'print("plugin=" + str(bool(os.environ.get("DATUS_PLUGIN_RUNTIME_CONTEXT"))))\'\n',
+        encoding="utf-8",
+    )
+    fake_datus.chmod(0o755)
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dir)
+
+    config = _Config()
+
+    def provider(command):
+        prepared = runtime_context.prepare_plugin_invocation(command, config)
+        if prepared is None:
+            return None
+        return BashExecutionContext(
+            command=prepared.command,
+            env=prepared.env,
+            sandbox_read_dirs=prepared.sandbox_read_dirs,
+        )
+
+    tool = BashTool(
+        workspace_root=str(workspace),
+        allowed_patterns=["*"],
+        extra_env={"PATH": f"{workspace}{os.pathsep}{os.environ.get('PATH', '')}"},
+        execution_context_provider=provider,
+    )
+    sibling = 'python -c \'import os; print("sibling=" + str(bool(os.environ.get("DATUS_PLUGIN_RUNTIME_CONTEXT"))))\''
+    result = tool.bash(f"datus hello run > plugin.txt && {sibling} && cat plugin.txt")
 
     assert result.success == 1
     assert "plugin=True" in result.result


### PR DESCRIPTION
## Why

In a managed multi-tenant deployment (`config_mutable=False`, `AgentConfig`
supplied by an AuthProvider), almost every model-written `datus <plugin>`
command failed with:

```
Error: Managed plugin commands support a single command or a pure `|` pipeline only
```

The guard in `prepare_plugin_invocation` was a raw character blacklist
(`;&<>()\n`, `$(`, `${`), so all of these were rejected even though they are
ordinary, safe shell:

| Command | Before |
|---|---|
| `datus tushare daily \| head -20` | OK |
| `datus tushare daily > /tmp/out.json` | rejected |
| `datus tushare daily 2>&1 \| tail -5` | rejected |
| `cd /tmp && datus tushare daily` | rejected |
| `datus tushare daily --date $(date +%F)` | rejected |
| `datus tushare daily --token "${TOKEN}"` | rejected |
| multi-line command | rejected |

The restriction existed because the rewrite reconstructed the command by
re-joining `split_pipeline` segments with `" | "` — only a pure pipeline
round-trips through that. Nothing told the model about the constraint either,
so it kept producing rejected commands and retrying.

## Solution

Replace the blacklist with a small Bash scanner (`_scan_command`) that models
just enough syntax to know **where a command word may start**: quoting,
`${...}`, `$(...)`, backticks, heredoc bodies and comments are traversed;
separators (`;`, `&`, `|`, newline) and groupings (`(`, `)`, `{`, `}`) end a
simple command; redirections stay inside the command they belong to.
`_command_word_index` then skips assignments, leading redirections and
keywords (`do`, `then`, `time`, `!`) to find the real command word, and the
runtime-context assignment is inserted **at that offset**:

```
for i in 1 2; do datus hello run; done
→ V="${CTX}"; unset CTX; for i in 1 2; do CTX="${V}" datus hello run; done
```

The original command text is preserved byte for byte (locked by a test), so
quoting, line continuations, redirections and heredoc payloads reach Bash
unchanged. The prologue still unsets the exported name before any child is
spawned, so the #1192 isolation guarantee holds in every new shape — verified
by real execution, not just structurally.

Still fails closed, now with actionable messages: multiple plugin invocations
in one command, `datus` inside `$(...)`/backticks, `datus` behind a wrapper
(`timeout`, `env`, `xargs`, `sh -c`), unbalanced quoting.

Two defects found while covering the scanner:

- `${A:-{x\}}` counted a literal `{` as a nesting level and rejected a valid
  command; only `${` opens a level now, matching Bash.
- On a parse failure the old `_contains_datus_command` fallback was unreliable
  (shlex merges runs of punctuation, hiding the `;` that precedes a `datus`
  word), so such a command ran **unbridged** — i.e. the plugin subprocess fell
  back to local config resolution. Any `datus` word now fails the command.

Model-facing guidance added so the constraint is known up front: the read-only
prompt preamble states "one `datus <plugin>` command per bash call, `datus` as
the command word", and `docs/plugin/introduction{,.zh}.md` are updated.

Two upstream gates are deliberately **unchanged** and still apply to the newly
accepted shapes: the execution-layer whitelist (`bash_allowed_patterns`, e.g.
`["datus*"]`, rejects segments containing `;&<>`) and the permission safety
ceiling (`contains_shell_metachars` forces ASK, never auto-allow). Relaxing
those is a separate tradeoff about per-segment rule matching.

## Test Cases

All in `tests/unit_tests/plugins/test_runtime_context.py`; the rejection test
that previously passed for the wrong reason (`_resolve_plugin_path` was
unpatched, so every case raised "no installed plugin") is now split and
patched properly.

- `test_prepare_supports_full_shell_command_shapes` — 18 shapes with exact
  expected rewrites, asserting the assignment lands on the command word and
  never on `(`, `{` or the `do` keyword.
- `test_prepare_preserves_the_original_command_text` — stripping the injected
  assignment must restore the input byte for byte (quotes containing `;`/`>`,
  line continuations, `<<-'EOF'`, `case`, background `&`).
- `test_prepare_scans_nested_shell_syntax_without_rejecting` — nested
  substitutions, subshells inside `$( )`, backticks and expansions inside
  double quotes, four heredoc delimiter spellings, `<&3`.
- `test_prepare_reports_malformed_shell_syntax` — adversarial inputs: every
  unbalanced-quote/backtick/`$(`/`${` variant, unterminated heredoc delimiter,
  and 20-level substitution nesting, each asserting the specific reason.
- `test_prepare_rejects_unsupported_managed_shell_forms` — the fail-closed set,
  each matched against its own message.
- `test_bash_command_list_scopes_context_to_plugin_command` — real bash:
  `datus hello run > f && python -c ...` yields `plugin=True` / `sibling=False`.
- `test_registry.py::test_preamble_immutable_...` — asserts the added prompt
  constraint.

Gates: `ruff format`/`check` clean, `audit_tests --diff-only` P0=0/P1=0, diff
coverage 92% (was 75%). Manually verified all accepted shapes pass `bash -n`
and execute with the context reaching only the datus process. Unrelated
pre-existing failures in `tests/unit_tests/api/services/test_explorer_service.py`
(17) and the data-dependent `tests/integration/**` suites reproduce on
`datus/main` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Managed plugin commands now support runtime configuration across more Bash command formats, including pipelines, redirections, grouped commands, loops, and heredocs.
  * Runtime configuration remains scoped to the intended plugin command and does not affect sibling commands.

* **Bug Fixes**
  * Unsafe or ambiguous command patterns now fail safely, including multiple plugin calls, command substitutions, and wrapper commands.

* **Documentation**
  * Updated English and Chinese documentation with supported syntax and runtime configuration limits.

* **Tests**
  * Expanded coverage for command parsing, scoping, malformed syntax, and read-only configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed plugin commands now support injecting runtime configuration across a broader set of Bash command forms (for example: pipelines, redirections, grouped commands, loops, and heredocs).
  * Runtime configuration is scoped to the single intended `datus <plugin>` invocation within a Bash command and does not leak to sibling segments.

* **Bug Fixes**
  * More shell patterns are now safely rejected when the `datus` invocation is ambiguous, appears inside command substitution, or is wrapped by common execution wrappers.

* **Documentation**
  * Updated English and Chinese guidance to clearly document the stricter bridging rules, one-invocation-per-command constraint, and configuration limits (including the encoded snapshot cap).

* **Tests**
  * Expanded unit and integration tests to validate injection/scoping behavior, parsing failures, and read-only prompt guidance text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->