### PR TITLE
[BugFix] Recover malformed tool call arguments

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -8,6 +8,7 @@ import inspect
 import json
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
+import json_repair
 from agents import FunctionTool, function_tool
 from pydantic import BaseModel, Field
 
@@ -27,6 +28,96 @@ def normalize_null(value):
     if isinstance(value, str) and value.strip().lower() in ("null", "none", ""):
         return None
     return value
+
+
+def parse_tool_args(
+    args_str: Any,
+    *,
+    tool_name: str = "unknown",
+) -> tuple[dict, str, Optional[str]]:
+    """Parse tool arguments, repairing malformed JSON objects when possible.
+
+    Returns ``(arguments, canonical_json, error)``. ``canonical_json`` is always
+    a valid JSON object so it can safely replace the raw tool-call arguments
+    before the Agents SDK replays or persists the call. A repaired call returns
+    an error so the model retries with valid arguments instead of executing
+    parameters that permission hooks did not inspect.
+    """
+    if not args_str:
+        return {}, "{}", None
+
+    original_error: Optional[Exception] = None
+
+    if isinstance(args_str, str):
+        stripped = args_str.strip()
+        if not stripped:
+            return {}, "{}", None
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError) as exc:
+            original_error = exc
+            parsed = None
+            # Function-tool arguments must be a JSON object. Limiting repair to
+            # object-shaped input avoids turning arbitrary text into an empty
+            # object and treating it as a successful repair.
+            if stripped.startswith("{"):
+                try:
+                    parsed = json_repair.loads(stripped)
+                except Exception:  # noqa: BLE001 - json-repair is best effort
+                    parsed = None
+                if isinstance(parsed, dict):
+                    canonical_json = json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
+                    logger.warning(
+                        "Repaired malformed JSON arguments for tool '%s': %s",
+                        tool_name,
+                        original_error,
+                    )
+                    error = (
+                        f"Malformed JSON arguments for tool '{tool_name}' were repaired for replay. "
+                        "The tool was not executed. Retry the tool with one complete JSON object."
+                    )
+                    return parsed, canonical_json, error
+    else:
+        try:
+            parsed = dict(args_str)
+        except (TypeError, ValueError) as exc:
+            original_error = exc
+            parsed = None
+
+    if not isinstance(parsed, dict):
+        if original_error is None:
+            original_error = TypeError(f"expected a JSON object, got {type(parsed).__name__}")
+        args_len = len(args_str) if isinstance(args_str, str) else 0
+        truncated_hint = ""
+        if isinstance(args_str, str):
+            stripped = args_str.rstrip()
+            if stripped and not stripped.endswith("}"):
+                truncated_hint = " Output appears truncated — likely hit model max_output_tokens limit."
+        error = (
+            f"Invalid JSON arguments for tool '{tool_name}' ({original_error}). "
+            f"Args length: {args_len} chars.{truncated_hint}"
+        )
+        return {}, "{}", error
+
+    canonical_json = (
+        args_str if isinstance(args_str, str) else json.dumps(parsed, ensure_ascii=False, separators=(",", ":"))
+    )
+    return parsed, canonical_json, None
+
+
+def write_back_tool_args(tool_ctx: Any, canonical_json: str) -> None:
+    """Update the current SDK tool call so replay and session persistence use valid JSON."""
+    if tool_ctx is None:
+        return
+
+    tool_ctx.tool_arguments = canonical_json
+    tool_call = getattr(tool_ctx, "tool_call", None)
+    if tool_call is None:
+        return
+    if isinstance(tool_call, dict):
+        tool_call["arguments"] = canonical_json
+    else:
+        tool_call.arguments = canonical_json
 
 
 class FuncToolResult(BaseModel):
@@ -131,25 +222,13 @@ def trans_to_function_tool(
             This is an async wrapper for tool methods.
             The agent framework will 'await' this coroutine.
             """
-            # The actual work (JSON parsing, method call)
-            try:
-                if args_str:
-                    args_dict = json.loads(args_str) if isinstance(args_str, str) else dict(args_str or {})
-                else:
-                    args_dict = {}
-            except (TypeError, json.JSONDecodeError) as e:
-                args_len = len(args_str) if isinstance(args_str, str) else 0
-                truncated_hint = ""
-                if isinstance(args_str, str) and args_len > 0:
-                    # Check if it looks like truncated output (no closing brace)
-                    stripped = args_str.rstrip()
-                    if not stripped.endswith("}") and not stripped.endswith("]"):
-                        truncated_hint = " Output appears truncated — likely hit model max_output_tokens limit."
-                return {
-                    "success": 0,
-                    "error": f"Invalid JSON arguments ({e}). Args length: {args_len} chars.{truncated_hint}",
-                    "result": None,
-                }
+            args_dict, canonical_json, error = parse_tool_args(
+                args_str,
+                tool_name=method_to_call.__name__,
+            )
+            write_back_tool_args(tool_ctx, canonical_json)
+            if error:
+                return {"success": 0, "error": error, "result": None}
 
             # Call sync or async bound methods transparently
             if inspect.ismethod(method_to_call):

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -13,7 +13,6 @@ tools, template rendering, and action history.
 
 from __future__ import annotations
 
-import json
 import uuid
 from contextlib import nullcontext
 from datetime import datetime
@@ -34,7 +33,7 @@ from datus.schemas.action_history import (
 )
 from datus.schemas.agent_models import ScopedContext, SubAgentConfig
 from datus.schemas.at_context import apply_at_context
-from datus.tools.func_tool.base import FuncToolResult
+from datus.tools.func_tool.base import FuncToolResult, parse_tool_args, write_back_tool_args
 from datus.utils.constants import SYS_SUB_AGENTS
 from datus.utils.loggings import get_logger
 from datus.utils.memory_loader import resolve_memory_node
@@ -313,10 +312,13 @@ class SubAgentTaskTool:
         }
 
         async def _invoke(_tool_ctx, args_str) -> dict:
-            try:
-                args = json.loads(args_str) if isinstance(args_str, str) else dict(args_str or {})
-            except (TypeError, json.JSONDecodeError):
-                return FuncToolResult(success=0, error="Invalid JSON arguments for task tool").model_dump()
+            args, canonical_json, error = parse_tool_args(
+                args_str,
+                tool_name="task",
+            )
+            write_back_tool_args(_tool_ctx, canonical_json)
+            if error:
+                return FuncToolResult(success=0, error=error).model_dump()
             # Resolve parent call_id from SDK ToolContext for action linking
             call_id = getattr(_tool_ctx, "tool_call_id", None) if _tool_ctx else None
             result = await self.task(call_id=call_id, **args)

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -787,6 +787,21 @@ class PermissionHooks(AgentHooks):
         """
         from datus.utils.sql_utils import looks_like_sql_file_ref, parse_sql_statement_kind, read_workspace_sql_file
 
+        raw_args = getattr(context, "tool_arguments", "{}")
+        if isinstance(raw_args, str):
+            try:
+                json.loads(raw_args)
+            except (json.JSONDecodeError, TypeError):
+                # DBFuncTool.execute_sql is always wrapped by
+                # trans_to_function_tool, whose malformed-JSON path repairs
+                # the history and returns a retry error without executing SQL.
+                # Let that no-execute path run instead of classifying an empty
+                # fallback as UNKNOWN and prompting (or denying workflows).
+                # The model's valid retry comes through this gate again and is
+                # classified from the actual SQL before it can execute.
+                logger.debug("Deferring malformed execute_sql arguments to tool recovery")
+                return True
+
         args = self._parse_tool_args(context)
         if not isinstance(args, dict):
             return False

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -145,8 +145,10 @@ class TestTransToFunctionTool:
         assert "not executed" in result["error"]
         assert "Retry" in result["error"]
         assert fake.received is None
-        assert json.loads(tool_ctx.tool_arguments)["min_rows"] == ""
-        assert json.loads(raw_tool_call.arguments)["max_rows"] == ""
+        written_args = json.loads(tool_ctx.tool_arguments)
+        assert written_args["sql"] == "SELECT 1"
+        assert {"min_rows", "max_rows"} <= written_args.keys()
+        assert json.loads(raw_tool_call.arguments) == written_args
 
         replayed = ToolCallItem(agent=Agent(name="test"), raw_item=raw_tool_call).to_input_item()
         assert json.loads(replayed["arguments"])["sql"] == "SELECT 1"

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -6,10 +6,27 @@ Focuses on trans_to_function_tool parameter filtering for LLM-hallucinated argum
 import asyncio
 import json
 import threading
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import MagicMock
 
 import pytest
+from agents import Agent, Runner, SQLiteSession
+from agents.items import ToolCallItem
+from agents.models.interface import Model
+from agents.run import RunConfig
+from agents.usage import Usage
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
 
 from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
+from datus.tools.permission.permission_hooks import PermissionHooks
+from datus.tools.permission.permission_manager import PermissionManager
+from datus.tools.permission.profiles import get_profile
+from datus.tools.registry.tool_registry import ToolRegistry
 
 
 class TestTransToFunctionTool:
@@ -85,6 +102,246 @@ class TestTransToFunctionTool:
         result = await tool.on_invoke_tool(None, "not-valid-json{")
         assert result["success"] == 0
         assert "Invalid JSON" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_repairs_arguments_for_replay_without_executing(self):
+        """Repair malformed arguments for replay, then execute only a valid retry."""
+
+        class FakeTool:
+            def __init__(self):
+                self.received = None
+
+            def execute_sql(
+                self,
+                sql: str,
+                datasource: str = "",
+                database: str = "",
+                min_rows: Optional[int] = None,
+                max_rows: Optional[int] = None,
+            ) -> FuncToolResult:
+                self.received = {
+                    "sql": sql,
+                    "datasource": datasource,
+                    "database": database,
+                    "min_rows": min_rows,
+                    "max_rows": max_rows,
+                }
+                return FuncToolResult(result="ok")
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.execute_sql)
+        raw_args = '{"sql":"SELECT 1","datasource":"njtest","database":"njyh","min_rows":,"max_rows":}'
+        raw_tool_call = ResponseFunctionToolCall(
+            arguments=raw_args,
+            call_id="call_repaired",
+            name="execute_sql",
+            type="function_call",
+        )
+        tool_ctx = SimpleNamespace(tool_arguments=raw_args, tool_call=raw_tool_call)
+
+        result = await tool.on_invoke_tool(tool_ctx, raw_args)
+
+        assert result["success"] == 0
+        assert "not executed" in result["error"]
+        assert "Retry" in result["error"]
+        assert fake.received is None
+        assert json.loads(tool_ctx.tool_arguments)["min_rows"] == ""
+        assert json.loads(raw_tool_call.arguments)["max_rows"] == ""
+
+        replayed = ToolCallItem(agent=Agent(name="test"), raw_item=raw_tool_call).to_input_item()
+        assert json.loads(replayed["arguments"])["sql"] == "SELECT 1"
+
+        retry_args = json.dumps(
+            {
+                "sql": "SELECT 1",
+                "datasource": "njtest",
+                "database": "njyh",
+                "min_rows": None,
+                "max_rows": None,
+            }
+        )
+        retry_tool_call = ResponseFunctionToolCall(
+            arguments=retry_args,
+            call_id="call_retry",
+            name="execute_sql",
+            type="function_call",
+        )
+        retry_ctx = SimpleNamespace(tool_arguments=retry_args, tool_call=retry_tool_call)
+
+        retry_result = await tool.on_invoke_tool(retry_ctx, retry_args)
+
+        assert retry_result["success"] == 1
+        assert fake.received == {
+            "sql": "SELECT 1",
+            "datasource": "njtest",
+            "database": "njyh",
+            "min_rows": None,
+            "max_rows": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_valid_json_preserves_original_arguments_string(self):
+        """A valid call should not be rewritten merely to canonicalize formatting."""
+
+        class FakeTool:
+            def some_method(self, x: str) -> FuncToolResult:
+                return FuncToolResult(result=x)
+
+        tool = self._make_tool_from_method(FakeTool().some_method)
+        raw_args = '{\n  "x": "value"\n}'
+        raw_tool_call = ResponseFunctionToolCall(
+            arguments=raw_args,
+            call_id="call_valid",
+            name="some_method",
+            type="function_call",
+        )
+        tool_ctx = SimpleNamespace(tool_arguments=raw_args, tool_call=raw_tool_call)
+
+        result = await tool.on_invoke_tool(tool_ctx, raw_args)
+
+        assert result["success"] == 1
+        assert tool_ctx.tool_arguments == raw_args
+        assert raw_tool_call.arguments == raw_args
+
+    @pytest.mark.asyncio
+    async def test_runner_replays_repaired_args_and_executes_only_valid_retry(self):
+        """Exercise the real Runner turn and session persistence path."""
+
+        class FakeTool:
+            def __init__(self):
+                self.calls = []
+
+            def execute_sql(
+                self,
+                sql: str,
+                min_rows: Optional[int] = None,
+                max_rows: Optional[int] = None,
+            ) -> FuncToolResult:
+                self.calls.append((sql, min_rows, max_rows))
+                return FuncToolResult(result="ok")
+
+        class SequenceModel(Model):
+            def __init__(self):
+                self.inputs = []
+
+            async def get_response(self, system_instructions, input, *_args, **_kwargs):
+                from agents.items import ModelResponse
+
+                del system_instructions
+                self.inputs.append(input)
+                if len(self.inputs) == 1:
+                    output = [
+                        ResponseFunctionToolCall(
+                            arguments='{"sql":"SELECT 1","min_rows":,"max_rows":}',
+                            call_id="call_malformed",
+                            name="execute_sql",
+                            type="function_call",
+                        )
+                    ]
+                elif len(self.inputs) == 2:
+                    replayed_call = next(
+                        item for item in input if isinstance(item, dict) and item.get("call_id") == "call_malformed"
+                    )
+                    assert json.loads(replayed_call["arguments"])["sql"] == "SELECT 1"
+                    output = [
+                        ResponseFunctionToolCall(
+                            arguments='{"sql":"SELECT 1","min_rows":null,"max_rows":null}',
+                            call_id="call_retry",
+                            name="execute_sql",
+                            type="function_call",
+                        )
+                    ]
+                else:
+                    output = [
+                        ResponseOutputMessage(
+                            id="message_done",
+                            content=[
+                                ResponseOutputText(
+                                    annotations=[],
+                                    text="done",
+                                    type="output_text",
+                                )
+                            ],
+                            role="assistant",
+                            status="completed",
+                            type="message",
+                        )
+                    ]
+                return ModelResponse(output=output, usage=Usage(), response_id=None)
+
+            async def stream_response(self, *_args, **_kwargs):
+                if False:
+                    yield None
+
+        fake = FakeTool()
+        model = SequenceModel()
+        session = SQLiteSession("tool-args-repair", ":memory:")
+        tool = self._make_tool_from_method(fake.execute_sql)
+        registry = ToolRegistry()
+        registry.register_tools("db_tools", [tool])
+        broker = MagicMock()
+        permission_hooks = PermissionHooks(
+            broker=broker,
+            permission_manager=PermissionManager(
+                global_config=get_profile("normal"),
+                active_profile="normal",
+            ),
+            node_name="chat",
+            tool_registry=registry,
+        )
+        agent = Agent(
+            name="test",
+            model=model,
+            tools=[tool],
+            hooks=permission_hooks,
+        )
+
+        result = await Runner.run(
+            agent,
+            input="run a query",
+            max_turns=5,
+            session=session,
+            run_config=RunConfig(tracing_disabled=True),
+        )
+
+        assert result.final_output == "done"
+        assert fake.calls == [("SELECT 1", None, None)]
+        broker.request.assert_not_called()
+        saved_calls = [
+            item for item in await session.get_items() if isinstance(item, dict) and item.get("type") == "function_call"
+        ]
+        assert len(saved_calls) == 2
+        assert all(isinstance(json.loads(item["arguments"]), dict) for item in saved_calls)
+
+    @pytest.mark.asyncio
+    async def test_unrepairable_json_is_not_executed_and_writes_back_empty_object(self):
+        """An unrecoverable call must leave valid JSON for the Runner's next turn."""
+
+        class FakeTool:
+            def __init__(self):
+                self.called = False
+
+            def some_method(self, x: str) -> FuncToolResult:
+                self.called = True
+                return FuncToolResult(result=x)
+
+        fake = FakeTool()
+        tool = self._make_tool_from_method(fake.some_method)
+        raw_tool_call = ResponseFunctionToolCall(
+            arguments="not-valid-json{",
+            call_id="call_invalid",
+            name="some_method",
+            type="function_call",
+        )
+        tool_ctx = SimpleNamespace(tool_arguments=raw_tool_call.arguments, tool_call=raw_tool_call)
+
+        result = await tool.on_invoke_tool(tool_ctx, raw_tool_call.arguments)
+
+        assert result["success"] == 0
+        assert "Invalid JSON" in result["error"]
+        assert fake.called is False
+        assert tool_ctx.tool_arguments == "{}"
+        assert raw_tool_call.arguments == "{}"
 
     @pytest.mark.asyncio
     async def test_multiple_extra_params_all_filtered(self):

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -4,10 +4,12 @@
 
 """CI-level tests for SubAgentTaskTool (AgenticNode-based execution)."""
 
+import json
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from openai.types.responses import ResponseFunctionToolCall
 
 from datus.configuration.agent_config import AgentConfig
 from datus.configuration.node_type import NodeType
@@ -77,6 +79,60 @@ class TestAvailableTools:
         assert "type" in schema["properties"]
         assert "prompt" in schema["properties"]
         assert set(schema["required"]) == {"type", "prompt", "description"}
+
+    @pytest.mark.asyncio
+    async def test_repairs_arguments_for_replay_without_executing(self, task_tool):
+        tool = task_tool.available_tools()[0]
+        task_tool.task = AsyncMock(return_value=FuncToolResult(result={"session_id": "child-1"}))
+        raw_args = '{"type":"gen_sql","prompt":"show sales","description":"sales query",}'
+        raw_tool_call = ResponseFunctionToolCall(
+            arguments=raw_args,
+            call_id="call_task",
+            name="task",
+            type="function_call",
+        )
+        tool_ctx = SimpleNamespace(
+            tool_call_id="call_task",
+            tool_arguments=raw_args,
+            tool_call=raw_tool_call,
+        )
+
+        result = await tool.on_invoke_tool(tool_ctx, raw_args)
+
+        assert result["success"] == 0
+        assert "not executed" in result["error"]
+        task_tool.task.assert_not_awaited()
+        assert json.loads(tool_ctx.tool_arguments)["prompt"] == "show sales"
+        assert json.loads(raw_tool_call.arguments)["description"] == "sales query"
+
+        retry_args = json.dumps(
+            {
+                "type": "gen_sql",
+                "prompt": "show sales",
+                "description": "sales query",
+            }
+        )
+        retry_tool_call = ResponseFunctionToolCall(
+            arguments=retry_args,
+            call_id="call_task_retry",
+            name="task",
+            type="function_call",
+        )
+        retry_ctx = SimpleNamespace(
+            tool_call_id="call_task_retry",
+            tool_arguments=retry_args,
+            tool_call=retry_tool_call,
+        )
+
+        retry_result = await tool.on_invoke_tool(retry_ctx, retry_args)
+
+        assert retry_result["success"] == 1
+        task_tool.task.assert_awaited_once_with(
+            call_id="call_task_retry",
+            type="gen_sql",
+            prompt="show sales",
+            description="sales query",
+        )
 
 
 # ── _get_available_types ───────────────────────────────────────────

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -24,6 +24,7 @@ from datus.tools.permission.permission_hooks import (
     PermissionHooks,
 )
 from datus.tools.permission.permission_manager import PermissionManager
+from datus.tools.permission.profiles import get_profile
 from datus.tools.registry.tool_registry import ToolRegistry
 
 
@@ -1621,6 +1622,28 @@ class TestExecuteSqlPermission:
         t = MagicMock()
         t.name = "execute_sql"
         return t
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("profile", ["normal", "auto"])
+    @pytest.mark.parametrize("non_interactive", [False, True])
+    async def test_malformed_arguments_defer_to_tool_recovery_without_prompt(
+        self,
+        mock_broker,
+        profile,
+        non_interactive,
+    ):
+        """Malformed calls reach the no-execute recovery path in every default mode."""
+        hooks = self._make_hooks(
+            mock_broker,
+            get_profile(profile),
+            non_interactive=non_interactive,
+        )
+        context = MagicMock()
+        context.tool_arguments = '{"sql":"SELECT 1","min_rows":,"max_rows":}'
+
+        await hooks.on_tool_start(context, MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_read_auto_allows_under_normal_default_ask(self, mock_broker):


### PR DESCRIPTION
## Summary

- Repair malformed JSON object arguments before the Agents SDK replays or persists a tool call.
- Return a retryable tool error without executing repaired arguments, so the model must issue a valid follow-up call.
- Apply the same recovery behavior to regular function tools and the sub-agent `task` tool.
- Let malformed `execute_sql` calls reach the non-executing recovery path before SQL permission classification; valid retries still pass through the normal SQL permission gate.

## Root cause

When a model emitted arguments such as `"min_rows":,"max_rows":`, the tool returned an invalid-JSON error but the malformed assistant tool call remained in conversation history. On the next model request, Anthropic/LiteLLM failed while parsing that historical tool call, so the model never received a chance to recover.

## Behavior

- Valid JSON arguments execute normally and retain their original representation.
- Repairable malformed JSON is canonicalized and written back to the current tool call, but the tool is not executed.
- Unrepairable arguments are replaced with an empty JSON object for safe replay and return an error.
- A later valid `execute_sql` retry is classified and authorized from its actual SQL before execution.

## Validation

- `uv run pytest -q tests/unit_tests/tools/func_tool/test_base.py tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py tests/unit_tests/tools/permission/test_permission_hooks.py` — 392 passed
- Ruff check and format check passed
- `git diff --check` passed

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed tool-call arguments through automatic repair and standardized recovery responses.
  - Preserved valid argument formatting while stabilizing repaired arguments for retries and session replay.
  - Prevented tools from executing when arguments cannot be recovered.
  - SQL permission checks now defer malformed requests to tool recovery without unnecessary permission prompts.
  - Improved retry behavior for subagent tasks with corrected arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed tool-call arguments with best-effort repair, canonicalized formatting for reliable retries, and standardized “recoverable” error responses.
  - Valid argument payloads are retained as-is, while repaired payloads are stabilized for session replay.
  - Tools no longer execute when arguments can’t be recovered; instead, the stored replay arguments are cleared and an “Invalid JSON” error is returned.
  - SQL permission checks now defer malformed requests to the tool recovery path without unnecessary prompting.
  - Nested task execution now correctly retries with corrected arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->