### PR TITLE
[Enhancement] Allow configured filesystem roots outside the project root

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -178,6 +178,25 @@ agent:
   #     allow_write: []       # extra writable dirs
   #     deny_network: false   # true blocks all network inside the sandbox
 
+  # ---------------------------------------------------------------------------
+  # Filesystem tools (read_file / write_file / edit_file / delete_file / glob /
+  # grep) and the scheduler tools' SQL-file lookup.
+  #   strict      — fail-closed on paths outside the project root instead of
+  #                 asking the user (API / gateway surfaces set this; the CLI
+  #                 leaves it false and prompts instead).
+  #   allow_read  — extra absolute dirs readable outside the project root
+  #   allow_write — extra absolute dirs readable AND writable outside it
+  # allow_read/allow_write are the escape hatch for directories a deployment
+  # mounts next to the workspace — e.g. an Airflow DAGs folder the agent must
+  # write DAG files into — without giving up ``strict``. Relative entries are
+  # ignored (they would resolve against the process CWD).
+  # ---------------------------------------------------------------------------
+  # filesystem:
+  #   strict: false
+  #   allow_read: []
+  #   allow_write:
+  #     - /data/airflow/dags
+
   nodes:
     schema_linking:
       matching_rate: fast

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -3567,6 +3567,16 @@ class AgenticNode(Node):
             return False
         return bool(self.agent_config.filesystem_strict)
 
+    def _resolve_filesystem_allowlist(self):
+        """Resolve the configured extra fs roots for this node's tools.
+
+        Reads ``agent_config.filesystem_allowlist`` (``agent.filesystem
+        .allow_read`` / ``allow_write``). Returns ``None`` when unset or empty
+        so the tool / policy layers keep their default project-only view.
+        """
+        allowlist = getattr(self.agent_config, "filesystem_allowlist", None) if self.agent_config else None
+        return allowlist or None
+
     def _resolve_config_mutable(self) -> bool:
         """Whether the agent may edit the agent config file (agent.yml).
 
@@ -3606,12 +3616,14 @@ class AgenticNode(Node):
             strict = self._resolve_filesystem_strict()
         current_node = kwargs.pop("current_node", None) or self.get_node_name()
         session_data_dir = kwargs.pop("session_data_dir", None) or self._resolve_session_data_dir()
+        path_allowlist = kwargs.pop("path_allowlist", None) or self._resolve_filesystem_allowlist()
         return FilesystemFuncTool(
             root_path=root_path,
             current_node=current_node,
             datus_home=datus_home,
             strict=strict,
             session_data_dir=session_data_dir,
+            path_allowlist=path_allowlist,
             **kwargs,
         )
 
@@ -3696,6 +3708,7 @@ class AgenticNode(Node):
                 datus_home=_Path(path_manager.datus_home),
                 strict=self._resolve_filesystem_strict(),
                 session_data_dir=session_data_dir,
+                allowlist=self._resolve_filesystem_allowlist(),
             )
         except Exception as e:
             logger.debug(f"Failed to build FilesystemPolicy: {e}")

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from datus.agent.node.stream_run_context import StreamRunContext
     from datus.agent.workflow import Workflow
     from datus.schemas.token_usage import TokenUsage
+    from datus.tools.func_tool.fs_path_policy import PathAllowlist
     from datus.tools.permission.permission_manager import PermissionManager
     from datus.tools.skill_tools.skill_manager import SkillManager
 
@@ -3567,7 +3568,7 @@ class AgenticNode(Node):
             return False
         return bool(self.agent_config.filesystem_strict)
 
-    def _resolve_filesystem_allowlist(self):
+    def _resolve_filesystem_allowlist(self) -> Optional["PathAllowlist"]:
         """Resolve the configured extra fs roots for this node's tools.
 
         Reads ``agent_config.filesystem_allowlist`` (``agent.filesystem

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -909,6 +909,15 @@ class AgentConfig:
         # CLI, or direct assignment from API/gateway bootstraps.
         filesystem_raw = kwargs.get("filesystem") or {}
         self._filesystem_strict = bool(filesystem_raw.get("strict", False))
+        # ``filesystem.allow_read`` / ``allow_write`` widen the fs tools beyond
+        # the project root with explicitly configured absolute directories (the
+        # filesystem counterpart of ``bash.sandbox.allow_*``). Needed whenever a
+        # deployment mounts a shared dir next to the workspace that the agent
+        # must still write — e.g. an Airflow DAGs folder. Lazy import for the
+        # same cycle reason as ``SandboxSettings`` below.
+        from datus.tools.func_tool.fs_path_policy import PathAllowlist
+
+        self._filesystem_allowlist = PathAllowlist.from_dict(filesystem_raw)
         # ``config_mutable`` gates whether the agent may be guided to edit the
         # loaded agent config file (e.g. ``agent.plugins`` profiles). Default
         # ``True`` (CLI). The chat API and gateway force it to ``False`` on
@@ -1199,6 +1208,29 @@ class AgentConfig:
     @filesystem_strict.setter
     def filesystem_strict(self, value: bool) -> None:
         self._filesystem_strict = bool(value)
+
+    @property
+    def filesystem_allowlist(self):
+        """Extra fs roots outside the project root (``PathAllowlist``).
+
+        Populated from ``agent.filesystem.allow_read`` / ``allow_write``. Empty
+        by default, in which case only the project root and the built-in
+        whitelist are reachable. Nodes forward it to ``FilesystemFuncTool`` and
+        ``FilesystemPolicy`` so tool and permission layers agree.
+        """
+        return self._filesystem_allowlist
+
+    @filesystem_allowlist.setter
+    def filesystem_allowlist(self, value) -> None:
+        """Accepts a ``PathAllowlist``, an ``agent.filesystem``-shaped dict, or ``None``."""
+        from datus.tools.func_tool.fs_path_policy import PathAllowlist
+
+        if value is None:
+            self._filesystem_allowlist = PathAllowlist()
+        elif isinstance(value, PathAllowlist):
+            self._filesystem_allowlist = value
+        else:
+            self._filesystem_allowlist = PathAllowlist.from_dict(value)
 
     @property
     def config_mutable(self) -> bool:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -23,6 +23,7 @@ from datus.utils.path_utils import get_files_from_glob_pattern
 
 if TYPE_CHECKING:
     from datus.prompts.prompt_manager import PromptManager
+    from datus.tools.func_tool.fs_path_policy import PathAllowlist
     from datus.utils.path_manager import DatusPathManager
 
 # Regex for validating platform/identifier names (no special chars that break paths)
@@ -917,7 +918,7 @@ class AgentConfig:
         # same cycle reason as ``SandboxSettings`` below.
         from datus.tools.func_tool.fs_path_policy import PathAllowlist
 
-        self._filesystem_allowlist = PathAllowlist.from_dict(filesystem_raw)
+        self._filesystem_allowlist: "PathAllowlist" = PathAllowlist.from_dict(filesystem_raw)
         # ``config_mutable`` gates whether the agent may be guided to edit the
         # loaded agent config file (e.g. ``agent.plugins`` profiles). Default
         # ``True`` (CLI). The chat API and gateway force it to ``False`` on
@@ -1210,7 +1211,7 @@ class AgentConfig:
         self._filesystem_strict = bool(value)
 
     @property
-    def filesystem_allowlist(self):
+    def filesystem_allowlist(self) -> "PathAllowlist":
         """Extra fs roots outside the project root (``PathAllowlist``).
 
         Populated from ``agent.filesystem.allow_read`` / ``allow_write``. Empty
@@ -1221,7 +1222,7 @@ class AgentConfig:
         return self._filesystem_allowlist
 
     @filesystem_allowlist.setter
-    def filesystem_allowlist(self, value) -> None:
+    def filesystem_allowlist(self, value: Union["PathAllowlist", dict, None]) -> None:
         """Accepts a ``PathAllowlist``, an ``agent.filesystem``-shaped dict, or ``None``."""
         from datus.tools.func_tool.fs_path_policy import PathAllowlist
 

--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -13,6 +13,7 @@ from wcmatch import glob as wc_glob
 from datus.tools import BaseTool
 from datus.tools.func_tool import FuncToolResult
 from datus.tools.func_tool.fs_path_policy import (
+    PathAllowlist,
     PathZone,
     ResolvedPath,
     classify_path,
@@ -79,6 +80,7 @@ class FilesystemFuncTool(BaseTool):
         datus_home: Optional[str] = None,
         strict: bool = False,
         session_data_dir: Optional[str] = None,
+        path_allowlist: Optional[PathAllowlist] = None,
         mutation_callback: Optional[Callable[[], None]] = None,
         mutation_guard: Optional[Callable[[Path], None]] = None,
         **kwargs,
@@ -98,6 +100,12 @@ class FilesystemFuncTool(BaseTool):
                 qualifies as a read-only WHITELIST anchor so the LLM can
                 ``read_file`` archived tool I/O without triggering a permission
                 prompt. Other sessions' archive directories stay EXTERNAL.
+            path_allowlist: Operator-configured roots outside the project root
+                (``agent.filesystem.allow_read`` / ``allow_write``) that count
+                as WHITELIST rather than EXTERNAL. This is how a deployment
+                grants access to a shared directory mounted next to the
+                workspace — e.g. an Airflow DAGs folder — without turning
+                ``strict`` off.
         """
         super().__init__(**kwargs)
         self.root_path = root_path or os.getcwd()
@@ -107,6 +115,7 @@ class FilesystemFuncTool(BaseTool):
         self._root_resolved = Path(self.root_path).expanduser().resolve(strict=False)
         self._strict = strict
         self._session_data_dir = Path(session_data_dir).expanduser().resolve(strict=False) if session_data_dir else None
+        self._path_allowlist = path_allowlist
         self._mutation_callback = mutation_callback
         self._mutation_guard = mutation_guard
 
@@ -177,6 +186,7 @@ class FilesystemFuncTool(BaseTool):
             current_node=self._current_node,
             datus_home=self._datus_home,
             session_data_dir=self._session_data_dir,
+            allowlist=self._path_allowlist,
         )
 
     def _read_only_reject(self, resolved: ResolvedPath) -> FuncToolResult:
@@ -563,6 +573,7 @@ class FilesystemFuncTool(BaseTool):
             current_node=self._current_node,
             datus_home=self._datus_home,
             session_data_dir=self._session_data_dir,
+            allowlist=self._path_allowlist,
         )
 
         def has_whitelisted_descendant(directory: Path) -> bool:
@@ -629,6 +640,7 @@ class FilesystemFuncTool(BaseTool):
                                 current_node=self._current_node,
                                 datus_home=self._datus_home,
                                 session_data_dir=self._session_data_dir,
+                                allowlist=self._path_allowlist,
                             ).zone
                             if item_zone == PathZone.EXTERNAL:
                                 # Symlink escape from project tree; skip.
@@ -889,6 +901,7 @@ def filesystem_function_tools(
     current_node: Optional[str] = None,
     strict: bool = False,
     session_data_dir: Optional[str] = None,
+    path_allowlist: Optional[PathAllowlist] = None,
 ) -> List[Tool]:
     """Get filesystem function tools"""
     return FilesystemFuncTool(
@@ -896,4 +909,5 @@ def filesystem_function_tools(
         current_node=current_node,
         strict=strict,
         session_data_dir=session_data_dir,
+        path_allowlist=path_allowlist,
     ).available_tools()

--- a/datus/tools/func_tool/fs_path_policy.py
+++ b/datus/tools/func_tool/fs_path_policy.py
@@ -26,6 +26,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Iterable, List, Optional, Tuple
 
+from pydantic import BaseModel, ConfigDict
+
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -99,8 +101,7 @@ def _normalize_allow_roots(raw: Any) -> Tuple[Path, ...]:
     return tuple(roots)
 
 
-@dataclass(frozen=True)
-class PathAllowlist:
+class PathAllowlist(BaseModel):
     """Extra roots outside the project root that stay reachable to fs tools.
 
     Parsed from ``agent.filesystem.allow_read`` / ``allow_write``: a path under
@@ -113,7 +114,15 @@ class PathAllowlist:
     Anchors only ever *upgrade* an otherwise ``EXTERNAL`` path: project-side
     zones (``INTERNAL``, the built-in whitelist, ``HIDDEN``) are decided first,
     so an allowlist entry can never expose ``.datus/`` internals.
+
+    Frozen: the tool, the permission hook and the scheduler tools all read the
+    same instance off ``AgentConfig``, so it must never be mutated underneath
+    one of them. Build via :meth:`from_dict` — direct construction skips the
+    absolute-path normalization that keeps a relative entry from resolving
+    against the process CWD.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     read: Tuple[Path, ...] = ()
     write: Tuple[Path, ...] = ()

--- a/datus/tools/func_tool/fs_path_policy.py
+++ b/datus/tools/func_tool/fs_path_policy.py
@@ -24,7 +24,11 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Any, Iterable, List, Optional, Tuple
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
 
 
 class PathZone(str, Enum):
@@ -60,6 +64,78 @@ class ResolvedPath:
     read_only: bool = False
 
 
+def _normalize_allow_roots(raw: Any) -> Tuple[Path, ...]:
+    """Coerce an ``allow_read``/``allow_write`` config value into anchor paths.
+
+    Accepts a single string or a list of strings; non-absolute entries (after
+    ``~`` expansion) are dropped because resolving them against the process CWD
+    would silently grant an unrelated directory. Existence is NOT required —
+    the anchor may be created later (e.g. a DAGs folder the scheduler pod
+    provisions on first submit).
+    """
+    if raw is None:
+        return ()
+    candidates: Iterable[Any] = [raw] if isinstance(raw, (str, Path)) else raw
+    try:
+        candidates = list(candidates)
+    except TypeError:
+        logger.warning("filesystem allowlist must be a path or list of paths; ignoring %r.", raw)
+        return ()
+
+    roots: List[Path] = []
+    for candidate in candidates:
+        if not isinstance(candidate, (str, Path)):
+            continue
+        text = str(candidate).strip()
+        if not text:
+            continue
+        expanded = Path(os.path.expanduser(text))
+        if not expanded.is_absolute():
+            logger.warning("Ignoring relative filesystem allowlist entry %r — absolute paths only.", text)
+            continue
+        resolved = expanded.resolve(strict=False)
+        if resolved not in roots:
+            roots.append(resolved)
+    return tuple(roots)
+
+
+@dataclass(frozen=True)
+class PathAllowlist:
+    """Extra roots outside the project root that stay reachable to fs tools.
+
+    Parsed from ``agent.filesystem.allow_read`` / ``allow_write``: a path under
+    a ``write`` anchor classifies as a writable ``WHITELIST``, one under a
+    ``read`` anchor as a read-only ``WHITELIST``. Intentionally generic — the
+    first consumer is the Airflow DAGs folder mounted next to (not inside) the
+    project workspace, but any deployment-specific shared directory plugs in
+    through the same config keys with no code change.
+
+    Anchors only ever *upgrade* an otherwise ``EXTERNAL`` path: project-side
+    zones (``INTERNAL``, the built-in whitelist, ``HIDDEN``) are decided first,
+    so an allowlist entry can never expose ``.datus/`` internals.
+    """
+
+    read: Tuple[Path, ...] = ()
+    write: Tuple[Path, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: Optional[dict]) -> "PathAllowlist":
+        """Build from the ``agent.filesystem`` config section (``None`` → empty)."""
+        if not isinstance(raw, dict):
+            return cls()
+        return cls(
+            read=_normalize_allow_roots(raw.get("allow_read")),
+            write=_normalize_allow_roots(raw.get("allow_write")),
+        )
+
+    def anchors(self) -> List[Path]:
+        """All anchors, write-first (mirrors ``classify_path`` precedence)."""
+        return [*self.write, *self.read]
+
+    def __bool__(self) -> bool:
+        return bool(self.read or self.write)
+
+
 def _is_relative_to(candidate: Path, anchor: Path) -> bool:
     """Python 3.12 has ``Path.is_relative_to`` but guarded with a try/except for
     non-Path comparisons. Kept as a small helper for readability and so tests
@@ -86,6 +162,7 @@ def classify_path(
     current_node: Optional[str] = None,
     datus_home: Optional[Path] = None,
     session_data_dir: Optional[Path] = None,
+    allowlist: Optional[PathAllowlist] = None,
 ) -> ResolvedPath:
     """Classify ``path`` into a ``PathZone`` relative to ``root_path``.
 
@@ -111,6 +188,11 @@ def classify_path(
             compact pass owns the directory contents. Other session_ids'
             directories stay ``EXTERNAL`` even though they live under the
             same ``sessions/`` root.
+        allowlist: Operator-configured extra roots (``agent.filesystem
+            .allow_read`` / ``allow_write``). Matching paths become
+            ``WHITELIST`` (read-only for ``read``-only anchors) instead of
+            ``EXTERNAL``, which is what lets strict-mode deployments reach
+            shared directories mounted outside the project workspace.
 
     Returns:
         A ``ResolvedPath`` with the computed zone and display form. Never
@@ -193,6 +275,15 @@ def classify_path(
     elif _is_relative_to(resolved, root_resolved):
         zone = PathZone.INTERNAL
         display = resolved.relative_to(root_resolved).as_posix() or "."
+    elif allowlist is not None and any(_is_relative_to(resolved, anchor) for anchor in allowlist.write):
+        # Configured shared root outside the project — absolute display, since
+        # nothing project-relative would round-trip back to the same file.
+        zone = PathZone.WHITELIST
+        display = str(resolved)
+    elif allowlist is not None and any(_is_relative_to(resolved, anchor) for anchor in allowlist.read):
+        zone = PathZone.WHITELIST
+        read_only = True
+        display = str(resolved)
     else:
         zone = PathZone.EXTERNAL
         display = str(resolved)
@@ -206,6 +297,7 @@ def whitelist_anchors(
     current_node: Optional[str] = None,
     datus_home: Optional[Path] = None,
     session_data_dir: Optional[Path] = None,
+    allowlist: Optional[PathAllowlist] = None,
 ) -> list[Path]:
     """Return the resolved whitelist anchor directories for a given node.
 
@@ -214,7 +306,9 @@ def whitelist_anchors(
     for every descendant. The order mirrors ``classify_path`` (project-side
     first) so longer prefixes win. ``current_node`` is accepted for call-site
     compatibility but no longer contributes a memory anchor — the
-    ``.datus/memory/**`` subtree is HIDDEN to filesystem tools.
+    ``.datus/memory/**`` subtree is HIDDEN to filesystem tools. Configured
+    ``allowlist`` roots are appended last (they live outside the project, so
+    they never shadow a project-side anchor).
     """
     del current_node
     root_resolved = Path(root_path).expanduser().resolve(strict=False)
@@ -227,6 +321,8 @@ def whitelist_anchors(
     ]
     if session_data_dir is not None:
         anchors.append(Path(session_data_dir).expanduser().resolve(strict=False))
+    if allowlist is not None:
+        anchors.extend(allowlist.anchors())
     return anchors
 
 

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -67,7 +67,9 @@ class SchedulerTools(BaseTool):
         produced by ``write_file`` is read back from the same location regardless
         of process CWD. HIDDEN paths get the same "not found" response
         ``FilesystemFuncTool`` uses (so ``.datus/sessions/...`` stays invisible).
-        EXTERNAL paths are rejected only in ``strict`` mode.
+        EXTERNAL paths are rejected only in ``strict`` mode — configured
+        ``agent.filesystem.allow_read``/``allow_write`` roots (e.g. a mounted
+        DAGs folder holding generated SQL) classify as WHITELIST, not EXTERNAL.
 
         Returns:
             ``(sql_content, None)`` on success, or ``(None, error_result)`` on failure.
@@ -78,6 +80,7 @@ class SchedulerTools(BaseTool):
                 root_path=Path(self.agent_config.project_root),
                 current_node=None,
                 datus_home=None,
+                allowlist=getattr(self.agent_config, "filesystem_allowlist", None),
             )
         except Exception as exc:
             return None, FuncToolResult(success=0, error=f"Failed to resolve SQL file path '{sql_file_path}': {exc}")

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -28,7 +28,7 @@ from agents.lifecycle import AgentHooks
 
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
 from datus.schemas.interaction_event import InteractionEvent
-from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
+from datus.tools.func_tool.fs_path_policy import PathAllowlist, PathZone, classify_path
 from datus.tools.permission.bash_classifier import BashClassifierContext
 from datus.tools.permission.bash_rules import (
     BashDecisionSource,
@@ -186,6 +186,11 @@ class FilesystemPolicy:
     # without prompting. Stays ``None`` outside of agentic sessions (e.g. SaaS
     # request-scoped tools) — those paths then remain EXTERNAL.
     session_data_dir: Optional[Path] = None
+    # Operator-configured roots outside the project root (``agent.filesystem
+    # .allow_read`` / ``allow_write``). Must mirror what the tool was built
+    # with, otherwise the hook would prompt (or fail) on a path the tool is
+    # perfectly willing to write.
+    allowlist: Optional[PathAllowlist] = None
 
 
 class CompositeHooks(AgentHooks):
@@ -569,6 +574,7 @@ class PermissionHooks(AgentHooks):
                 current_node=policy.current_node,
                 datus_home=policy.datus_home,
                 session_data_dir=policy.session_data_dir,
+                allowlist=policy.allowlist,
             )
         except Exception as e:
             logger.debug(f"classify_path failed for {tool_name} path={path_arg!r}: {e}")

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -1778,6 +1778,52 @@ class TestAgentConfigFilesystemStrict:
         cfg.override_by_args(filesystem_strict=None)
         assert cfg.filesystem_strict is True
 
+
+class TestAgentConfigFilesystemAllowlist:
+    """``agent.filesystem.allow_read``/``allow_write`` → ``filesystem_allowlist``.
+
+    The allowlist is what lets a strict deployment reach directories mounted
+    outside the project root (e.g. the Airflow DAGs folder) — it must survive
+    alongside ``strict`` in the same config section.
+    """
+
+    _make = TestAgentConfigFilesystemStrict._make
+
+    def test_default_is_empty(self, tmp_path):
+        cfg = self._make(tmp_path)
+        assert bool(cfg.filesystem_allowlist) is False
+        assert cfg.filesystem_allowlist.read == ()
+        assert cfg.filesystem_allowlist.write == ()
+
+    def test_parsed_alongside_strict(self, tmp_path):
+        dags = tmp_path / "dags"
+        cfg = self._make(tmp_path, filesystem={"strict": True, "allow_write": [str(dags)]})
+        assert cfg.filesystem_strict is True
+        assert cfg.filesystem_allowlist.write == (dags.resolve(),)
+
+    def test_read_and_write_kept_separate(self, tmp_path):
+        cfg = self._make(
+            tmp_path,
+            filesystem={"allow_read": [str(tmp_path / "ro")], "allow_write": [str(tmp_path / "rw")]},
+        )
+        assert cfg.filesystem_allowlist.read == ((tmp_path / "ro").resolve(),)
+        assert cfg.filesystem_allowlist.write == ((tmp_path / "rw").resolve(),)
+
+    def test_setter_accepts_dict_and_none(self, tmp_path):
+        cfg = self._make(tmp_path)
+        cfg.filesystem_allowlist = {"allow_write": [str(tmp_path / "dags")]}
+        assert cfg.filesystem_allowlist.write == ((tmp_path / "dags").resolve(),)
+        cfg.filesystem_allowlist = None
+        assert bool(cfg.filesystem_allowlist) is False
+
+    def test_setter_accepts_allowlist_instance(self, tmp_path):
+        from datus.tools.func_tool.fs_path_policy import PathAllowlist
+
+        cfg = self._make(tmp_path)
+        allowlist = PathAllowlist.from_dict({"allow_read": [str(tmp_path / "shared")]})
+        cfg.filesystem_allowlist = allowlist
+        assert cfg.filesystem_allowlist is allowlist
+
     def test_override_by_args_missing_preserves_yaml(self, tmp_path):
         # override_by_args is also called without a filesystem_strict key
         # (e.g. in non-CLI code paths). That must not reset the flag.

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 
 from datus.tools.func_tool.filesystem_tools import FilesystemConfig, FilesystemFuncTool
-from datus.tools.func_tool.fs_path_policy import PathZone
+from datus.tools.func_tool.fs_path_policy import PathAllowlist, PathZone
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -746,6 +746,86 @@ class TestPathZones:
         tool = FilesystemFuncTool(root_path=str(project), current_node="chat", strict=True)
         assert tool.read_file("hello.md").result == "hi"
         assert tool.write_file(".datus/skills/x/SKILL.md", "# skill\n").success == 1
+
+    def test_strict_allows_write_into_allowlisted_root(self, tmp_path):
+        """The DAGs-folder case: strict mode + a configured ``allow_write`` root.
+
+        A deployment mounts a shared directory (Airflow DAGs folder) next to the
+        project workspace; the agent must be able to author files there without
+        the whole surface losing its fail-closed default.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        dags = tmp_path / "services" / "airflow" / "dags" / "ws1" / "proj1"
+        dags.mkdir(parents=True)
+        tool = FilesystemFuncTool(
+            root_path=str(project),
+            current_node="chat",
+            strict=True,
+            path_allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        target = dags / "daily_job.py"
+        assert tool.write_file(str(target), "print('dag')\n").success == 1
+        assert target.read_text() == "print('dag')\n"
+        # Round-trip through the other mutating/reading ops on the same root.
+        assert tool.read_file(str(target)).result == "print('dag')\n"
+        assert tool.edit_file(str(target), "dag", "dag2").success == 1
+        assert tool.delete_file(str(target)).success == 1
+
+    def test_strict_allowlisted_read_root_rejects_write(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "ref.sql").write_text("select 1")
+        tool = FilesystemFuncTool(
+            root_path=str(project),
+            current_node="chat",
+            strict=True,
+            path_allowlist=PathAllowlist.from_dict({"allow_read": [str(shared)]}),
+        )
+        assert tool.read_file(str(shared / "ref.sql")).result == "select 1"
+        result = tool.write_file(str(shared / "ref.sql"), "select 2")
+        assert result.success == 0
+        assert "read-only" in (result.error or "").lower()
+        assert (shared / "ref.sql").read_text() == "select 1"
+
+    def test_strict_still_rejects_paths_outside_allowlist(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        dags = tmp_path / "dags"
+        dags.mkdir()
+        tool = FilesystemFuncTool(
+            root_path=str(project),
+            current_node="chat",
+            strict=True,
+            path_allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        target = tmp_path / "elsewhere.md"
+        result = tool.write_file(str(target), "payload")
+        assert result.success == 0
+        assert "not allowed in strict mode" in (result.error or "").lower()
+        assert not target.exists()
+
+    def test_glob_seeded_at_allowlisted_root_lists_files(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        dags = tmp_path / "dags"
+        dags.mkdir()
+        (dags / "a_dag.py").write_text("a")
+        (dags / "b_dag.py").write_text("b")
+        tool = FilesystemFuncTool(
+            root_path=str(project),
+            current_node="chat",
+            strict=True,
+            path_allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        result = tool.glob("*_dag.py", str(dags))
+        assert result.success == 1
+        # Seed is WHITELIST (not EXTERNAL), and reported paths stay absolute
+        # because they cannot be expressed relative to the project root.
+        assert result.result.get("external") is None
+        assert {Path(p).name for p in result.result["files"]} == {"a_dag.py", "b_dag.py"}
 
     def test_glob_external_seed_returns_absolute_paths(self, tmp_path):
         other = tmp_path / "other"

--- a/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
+++ b/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from datus.tools.func_tool.fs_path_policy import (
+    PathAllowlist,
     PathZone,
     build_walk_patterns,
     classify_path,
@@ -268,3 +269,143 @@ class TestSessionDataAnchor:
         # project-side anchors + the global ``skills`` dir.
         for anchor in anchors:
             assert "sessions" not in anchor.parts
+
+
+class TestPathAllowlistParsing:
+    """``agent.filesystem.allow_read``/``allow_write`` → anchors."""
+
+    def test_from_dict_parses_both_lists(self, tmp_path):
+        allowlist = PathAllowlist.from_dict(
+            {"allow_read": [str(tmp_path / "ro")], "allow_write": [str(tmp_path / "rw")]}
+        )
+        assert allowlist.read == ((tmp_path / "ro").resolve(),)
+        assert allowlist.write == ((tmp_path / "rw").resolve(),)
+        assert bool(allowlist) is True
+        # write-first ordering mirrors classify_path precedence
+        assert allowlist.anchors() == [(tmp_path / "rw").resolve(), (tmp_path / "ro").resolve()]
+
+    def test_missing_section_is_empty(self):
+        for raw in (None, {}, {"strict": True}, "not-a-dict", []):
+            allowlist = PathAllowlist.from_dict(raw)
+            assert allowlist.read == ()
+            assert allowlist.write == ()
+            assert bool(allowlist) is False
+
+    def test_single_string_accepted(self, tmp_path):
+        allowlist = PathAllowlist.from_dict({"allow_write": str(tmp_path / "dags")})
+        assert allowlist.write == ((tmp_path / "dags").resolve(),)
+
+    def test_relative_and_blank_entries_dropped(self, tmp_path):
+        # A relative entry would resolve against the process CWD — silently
+        # granting an unrelated directory. Must be ignored, not resolved.
+        allowlist = PathAllowlist.from_dict(
+            {"allow_write": ["relative/dags", "  ", None, 42, str(tmp_path / "ok")]},
+        )
+        assert allowlist.write == ((tmp_path / "ok").resolve(),)
+
+    def test_duplicates_collapsed(self, tmp_path):
+        target = str(tmp_path / "dags")
+        allowlist = PathAllowlist.from_dict({"allow_write": [target, target + "/", target]})
+        assert allowlist.write == ((tmp_path / "dags").resolve(),)
+
+    def test_nonexistent_root_still_anchored(self, tmp_path):
+        # The DAGs folder may be created later by the scheduler pod; anchoring
+        # must not depend on it existing at config-load time.
+        missing = tmp_path / "not-created-yet"
+        allowlist = PathAllowlist.from_dict({"allow_write": [str(missing)]})
+        assert allowlist.write == (missing.resolve(),)
+
+
+class TestClassifyWithAllowlist:
+    """Configured roots outside the project turn EXTERNAL into WHITELIST.
+
+    This is what lets a strict-mode deployment (no interactive broker) write
+    generated DAG files into a folder mounted next to the workspace.
+    """
+
+    @pytest.fixture
+    def dags(self, tmp_path):
+        folder = tmp_path / "services" / "airflow" / "dags" / "ws1" / "proj1"
+        folder.mkdir(parents=True)
+        return folder
+
+    def test_allow_write_root_is_writable_whitelist(self, project, dags):
+        r = classify_path(
+            str(dags / "daily_job.py"),
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.read_only is False
+        # Absolute display: nothing project-relative would round-trip here.
+        assert r.display == str(dags / "daily_job.py")
+
+    def test_allow_read_root_is_read_only_whitelist(self, project, dags):
+        r = classify_path(
+            str(dags / "daily_job.py"),
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_read": [str(dags)]}),
+        )
+        assert r.zone == PathZone.WHITELIST
+        assert r.read_only is True
+
+    def test_write_anchor_wins_over_read_anchor(self, project, dags):
+        r = classify_path(
+            str(dags / "daily_job.py"),
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_read": [str(dags)], "allow_write": [str(dags)]}),
+        )
+        assert r.read_only is False
+
+    def test_sibling_of_allowed_root_stays_external(self, project, dags):
+        # Prefix-only match must not leak: ``.../proj1_backup`` is a sibling,
+        # not a descendant, of the allowed ``.../proj1``.
+        sibling = dags.parent / "proj1_backup" / "x.py"
+        r = classify_path(
+            str(sibling),
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        assert r.zone == PathZone.EXTERNAL
+
+    def test_traversal_out_of_allowed_root_stays_external(self, project, dags):
+        r = classify_path(
+            str(dags / ".." / ".." / "secrets.env"),
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        assert r.zone == PathZone.EXTERNAL
+
+    def test_allowlist_never_unhides_project_internals(self, project):
+        # Allowlisting an ancestor of the project must not expose ``.datus``:
+        # project-side zones are decided before the allowlist is consulted.
+        r = classify_path(
+            ".datus/sessions/foo.db",
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(project.parent)]}),
+        )
+        assert r.zone == PathZone.HIDDEN
+
+    def test_project_paths_stay_internal_under_allowlisted_ancestor(self, project):
+        r = classify_path(
+            "src/main.py",
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(project.parent)]}),
+        )
+        assert r.zone == PathZone.INTERNAL
+        assert r.display == "src/main.py"
+
+    def test_without_allowlist_dags_path_is_external(self, project, dags):
+        r = classify_path(str(dags / "daily_job.py"), root_path=project)
+        assert r.zone == PathZone.EXTERNAL
+
+    def test_whitelist_anchors_include_allowlist_roots(self, project, fake_home, dags):
+        anchors = whitelist_anchors(
+            root_path=project,
+            current_node="chat",
+            datus_home=fake_home,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        assert dags.resolve() in anchors
+        # Project-side anchors are still first so longer prefixes keep winning.
+        assert anchors[0] == (project / ".datus" / "skills").resolve(strict=False)

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -63,6 +63,9 @@ def _make_agent_config(scheduler_config=None, project_root="/tmp/datus_test_proj
     # Without this an auto-attribute MagicMock would be truthy, flipping
     # SchedulerTools into strict mode and breaking existing EXTERNAL-path tests.
     cfg.filesystem_strict = False
+    # Same reason: an auto-attribute MagicMock here would be a truthy
+    # "allowlist" whose anchors cannot be iterated meaningfully.
+    cfg.filesystem_allowlist = None
 
     def _get_scheduler_config(service_name=None):
         if service_name:
@@ -774,6 +777,81 @@ class TestSubmitSqlJob:
 
         assert result.success == 0
         assert "Connection failed" in (result.error or "")
+
+
+# ── SchedulerTools SQL-path resolution in strict mode ────────────────────
+
+
+class TestStrictSqlPathResolution:
+    """``_load_sql_content`` shares ``classify_path`` with the filesystem tool.
+
+    Strict mode (API / gateway) must reject SQL outside the project root, but
+    accept the deployment's configured ``agent.filesystem.allow_*`` roots —
+    otherwise a DAG whose SQL lives in the mounted DAGs folder can never be
+    submitted.
+    """
+
+    def _strict_config(self, project_root, allowlist=None):
+        cfg = _make_agent_config(project_root=str(project_root))
+        cfg.filesystem_strict = True
+        cfg.filesystem_allowlist = allowlist
+        return cfg
+
+    def test_external_sql_rejected_in_strict_mode(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        sql_file = tmp_path / "outside.sql"
+        sql_file.write_text("SELECT 1")
+
+        tools = SchedulerTools(self._strict_config(project))
+        result = tools.submit_sql_job(job_name="j", sql_file_path=str(sql_file), conn_id="c")
+        assert result.success == 0
+        assert "not allowed in strict mode" in (result.error or "").lower()
+
+    def test_allowlisted_sql_accepted_in_strict_mode(self, tmp_path):
+        from datus.tools.func_tool.fs_path_policy import PathAllowlist
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        dags = tmp_path / "dags" / "ws1" / "proj1"
+        dags.mkdir(parents=True)
+        sql_file = dags / "daily.sql"
+        sql_file.write_text("SELECT 1")
+
+        mock_adapter = MagicMock()
+        mock_adapter.submit_job.return_value = _make_scheduled_job("daily")
+        mock_adapter.close.return_value = None
+
+        cfg = self._strict_config(project, PathAllowlist.from_dict({"allow_write": [str(dags)]}))
+        tools = SchedulerTools(cfg)
+        with patch.object(tools, "_get_adapter", return_value=mock_adapter):
+            result = tools.submit_sql_job(job_name="daily", sql_file_path=str(sql_file), conn_id="c")
+
+        assert result.success == 1
+        payload = mock_adapter.submit_job.call_args[0][0]
+        assert payload.sql == "SELECT 1"
+
+    def test_read_only_allowlist_still_loads_sql(self, tmp_path):
+        from datus.tools.func_tool.fs_path_policy import PathAllowlist
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        sql_file = shared / "ref.sql"
+        sql_file.write_text("SELECT 2")
+
+        mock_adapter = MagicMock()
+        mock_adapter.submit_job.return_value = _make_scheduled_job("ref")
+        mock_adapter.close.return_value = None
+
+        cfg = self._strict_config(project, PathAllowlist.from_dict({"allow_read": [str(shared)]}))
+        tools = SchedulerTools(cfg)
+        with patch.object(tools, "_get_adapter", return_value=mock_adapter):
+            result = tools.submit_sql_job(job_name="ref", sql_file_path=str(sql_file), conn_id="c")
+
+        assert result.success == 1
+        assert mock_adapter.submit_job.call_args[0][0].sql == "SELECT 2"
 
 
 # ── SchedulerTools.submit_sparksql_job ───────────────────────────────────

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -626,7 +626,7 @@ class TestFilesystemZoneBranch:
     path so approval never leaks across targets.
     """
 
-    def _build(self, broker, tmp_path, rules=None, *, strict=False):
+    def _build(self, broker, tmp_path, rules=None, *, strict=False, allowlist=None):
         registry = ToolRegistry()
         fs_tool = MagicMock()
         fs_tool.name = "read_file"
@@ -644,9 +644,65 @@ class TestFilesystemZoneBranch:
             permission_manager=manager,
             node_name="chat",
             tool_registry=registry,
-            fs_policy=FilesystemPolicy(root_path=project, current_node="chat", strict=strict),
+            fs_policy=FilesystemPolicy(
+                root_path=project,
+                current_node="chat",
+                strict=strict,
+                allowlist=allowlist,
+            ),
         )
         return hooks, manager, project
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_root_bypasses_ask(self, mock_broker, tmp_path):
+        """A configured ``allow_write`` root must not prompt.
+
+        The tool classifies it as WHITELIST and writes happily; if the hook
+        still treated it as EXTERNAL, an interactive deployment would prompt on
+        every DAG file and a non-interactive one would raise.
+        """
+        from datus.tools.func_tool.fs_path_policy import PathAllowlist
+
+        dags = tmp_path / "dags"
+        dags.mkdir()
+        (dags / "job.py").write_text("x")
+        hooks, _, _ = self._build(
+            mock_broker,
+            tmp_path,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        mock_broker.request = AsyncMock(return_value="n")
+
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{dags / "job.py"}"}}'
+        tool = MagicMock()
+        tool.name = "read_file"
+
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
+        mock_broker.request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_path_outside_allowlist_still_asks(self, mock_broker, tmp_path):
+        from datus.tools.func_tool.fs_path_policy import PathAllowlist
+
+        dags = tmp_path / "dags"
+        dags.mkdir()
+        hooks, _, _ = self._build(
+            mock_broker,
+            tmp_path,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        mock_broker.request = AsyncMock(return_value="a")
+
+        target = tmp_path / "elsewhere.md"
+        target.write_text("x")
+        ctx = MagicMock()
+        ctx.tool_arguments = f'{{"path": "{target}"}}'
+        tool = MagicMock()
+        tool.name = "read_file"
+
+        await hooks.on_tool_start(ctx, MagicMock(), tool)
+        assert mock_broker.request.await_count == 1
 
     @pytest.mark.asyncio
     async def test_internal_bypasses_ask_rule(self, mock_broker, tmp_path):


### PR DESCRIPTION
## Why

Filesystem tools classify every path outside the project root as `EXTERNAL`, and
strict deployments (API / gateway — no interactive broker) fail those closed:

```
Path outside workspace is not allowed in strict mode:
/data/tenants/datus-default/services/airflow/dags/<ws>/<project>/daily_stg_requisition_enhanced.py
```

A deployment that mounts a shared directory *next to* the project workspace has
no way to grant access to it short of turning `strict` off for the whole
surface. The concrete case is the Airflow DAGs folder: the agent generates a DAG
file, but the folder lives outside the workspace, so `write_file` (and the
scheduler tools' SQL-file lookup, which shares `classify_path`) is rejected.

## Solution

New config keys `agent.filesystem.allow_read` / `allow_write` — the filesystem
counterpart of the existing `bash.sandbox.allow_read` / `allow_write`:

- `fs_path_policy.PathAllowlist` parses them into anchor paths (absolute only;
  relative entries are ignored rather than resolved against the process CWD,
  and existence is not required since the folder may be provisioned later).
- `classify_path(..., allowlist=...)`: a path under a `write` anchor becomes a
  writable `WHITELIST`, under a `read` anchor a read-only `WHITELIST`.
  Deliberately generic — DAGs folder is just the first consumer.
- `AgentConfig.filesystem_allowlist` (property + setter for runtime injection
  by API/gateway bootstraps) carries it; `AgenticNode` threads it into both
  `FilesystemFuncTool` and `FilesystemPolicy` so the tool layer and the
  permission hook agree, and `SchedulerTools` reads it for SQL-file resolution.
- `whitelist_anchors()` includes the configured roots so directory walks treat
  them consistently.

Key invariant: anchors only ever **upgrade** an otherwise `EXTERNAL` path.
Project-side zones (`INTERNAL`, the built-in whitelist, `HIDDEN`) are decided
first, so allowlisting an ancestor of the project cannot expose `.datus/`
internals, and sibling/traversal paths outside an anchor stay `EXTERNAL`.

Default behaviour is unchanged: no keys configured → empty allowlist → today's
project-only view.

## Test Cases

Unit tests (CI tier, no external deps):

- `tests/unit_tests/tools/func_tool/test_fs_path_policy.py` — parsing (list /
  single string / blank / relative / duplicate / non-existent entries), zone
  outcomes (write anchor → writable whitelist, read anchor → read-only,
  write beats read), and the containment guards: sibling prefix, `..`
  traversal, allowlisted ancestor must not un-hide `.datus/`, project paths
  stay `INTERNAL`, anchors appear in `whitelist_anchors`.
- `tests/unit_tests/tools/func_tool/test_filesystem_tools.py` — strict mode
  writes/reads/edits/deletes inside an allowed root, read-only root rejects
  writes, paths outside the allowlist still fail closed, glob seeded at an
  allowed root.
- `tests/unit_tests/tools/func_tool/test_scheduler_tools.py` — `submit_sql_job`
  with SQL in an allowed root succeeds under `filesystem_strict`, external SQL
  still rejected, read-only root still loads SQL.
- `tests/unit_tests/tools/permission/test_permission_hooks.py` — allowlisted
  path bypasses the ASK prompt; a path outside it still prompts.
- `tests/unit_tests/configuration/test_agent_config.py` — config parsing,
  read/write separation, setter accepting dict / instance / `None`.

No integration/nightly test added: the behaviour is pure path classification
with no external service involved, and the acceptance harness has no
multi-tenant mount to exercise.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added configurable filesystem read and write allowlists.
  * Allowlisted external directories can be accessed in strict mode, with separate read-only and writable permissions.
  * Filesystem tools, SQL file loading, and permission checks now consistently honor configured allowlists.
  * Added safeguards to prevent traversal outside approved directories and exposure of protected project files.
* **Documentation**
  * Updated the example agent configuration with filesystem allowlist settings and usage guidance.
* **Tests**
  * Added coverage for allowlist parsing, access permissions, strict mode, traversal protection, SQL loading, and permission prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable filesystem read/write allowlists (including strict-mode behavior with read-only vs writable roots).
  * Filesystem operations now consistently treat allowlisted targets as permitted, while preventing traversal outside approved directories.
  * Scheduler SQL-file resolution and permission checks now honor the same allowlist rules.
* **Documentation**
  * Updated the example agent configuration to include filesystem allowlist settings.
* **Tests**
  * Added unit tests covering allowlist parsing, strict access behavior, traversal protection, SQL loading, and permission prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->