### PR TITLE
[Enhancement] Give an unknown custom model its own error code

### DIFF
--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -2593,11 +2593,18 @@ class AgentConfig:
         Mirrors :meth:`set_active_provider_model` but drops into the
         legacy custom-model dispatch path. Persists as
         ``target: {custom: name}`` so the intent is explicit on reload.
+
+        Raises ``MODEL_NOT_CONFIGURED`` rather than a generic validation
+        error: remote front-ends pass a user-picked model into
+        ``stream_chat``, and that selection can name a connection the
+        project no longer has. They need a stable ``error_type`` to
+        recognise "your model is gone, refresh and pick another" instead of
+        matching on the message text.
         """
         if not name or name not in self.models:
             raise DatusException(
-                code=ErrorCode.COMMON_FIELD_INVALID,
-                message=f"Unknown custom model `{name}`. Available: {sorted(self.models.keys())}",
+                code=ErrorCode.MODEL_NOT_CONFIGURED,
+                message_args={"model_name": name, "available_models": sorted(self.models.keys())},
             )
         self._target_provider = None
         self._target_model = None

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -63,6 +63,10 @@ class ErrorCode(Enum):
         "SSL_CERT_FILE=<path-to-ca.pem>). Avoid `ssl_verify: false`, which disables verification. "
         "See docs/configuration/agent.md (Private or self-signed certificates).",
     )
+    MODEL_NOT_CONFIGURED = (
+        "300025",
+        "Unknown custom model `{model_name}`. Available: {available_models}",
+    )
 
     # OAuth authentication errors
     OAUTH_NOT_AUTHENTICATED = ("300030", "Not authenticated. Please run OAuth login first.")

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -8,6 +8,7 @@ import pytest
 from datus.api.services.chat_service import ChatService
 from datus.api.services.chat_task_manager import ChatTaskManager
 from datus.models.session_manager import SessionManager
+from datus.utils.exceptions import ErrorCode
 
 
 @pytest.fixture
@@ -366,6 +367,30 @@ class TestChatServiceStreamChat:
                 break
         assert len(events) >= 1
         assert events[0].event == "session"
+
+    async def test_stream_chat_unknown_model_yields_model_not_configured(self, real_agent_config, mock_llm_create):
+        """A model param naming a connection this project no longer has is
+        reported under its own error_type, which is what remote front-ends
+        match on to refresh their model list instead of parsing the message."""
+        from datus.api.models.cli_models import StreamChatInput
+
+        svc = ChatService(
+            agent_config=real_agent_config,
+            task_manager=ChatTaskManager(),
+            project_id="test-proj",
+        )
+        request = StreamChatInput(
+            message="hello",
+            session_id="unknown-model",
+            model="custom/detached-connection",
+        )
+
+        events = [event async for event in svc.stream_chat(request)]
+
+        assert len(events) == 1
+        assert events[0].event == "error"
+        assert events[0].data.error_type == ErrorCode.MODEL_NOT_CONFIGURED.name
+        assert "detached-connection" in events[0].data.error
 
     async def test_stream_chat_duplicate_session_yields_error(self, real_agent_config, mock_llm_create):
         """stream_chat for duplicate session_id yields error event."""

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -36,7 +36,7 @@ from datus.configuration.agent_config import (
     load_model_config,
     resolve_env,
 )
-from datus.utils.exceptions import DatusException
+from datus.utils.exceptions import DatusException, ErrorCode
 
 pytestmark = pytest.mark.ci
 
@@ -2271,8 +2271,14 @@ class TestProviderConfigurationDispatch:
 
     def test_set_active_custom_rejects_unknown_name(self, tmp_path):
         cfg = self._make(tmp_path)
-        with pytest.raises(DatusException):
+        with pytest.raises(DatusException) as excinfo:
             cfg.set_active_custom("not-registered")
+
+        # Remote front-ends match on this error_type to recover a stale
+        # model selection, so keep both the code and the listing stable.
+        assert excinfo.value.code is ErrorCode.MODEL_NOT_CONFIGURED
+        assert "Unknown custom model `not-registered`" in str(excinfo.value)
+        assert "legacy" in str(excinfo.value)
 
     def test_set_provider_config_mutates_in_memory(self, tmp_path):
         cfg = self._make(tmp_path)


### PR DESCRIPTION
## Problem

`AgentConfig.set_active_custom` rejects an unregistered name with the generic `COMMON_FIELD_INVALID` (100001). `ChatService.stream_chat` surfaces `code.name` as the SSE `error_type`, so a remote front-end that wants to recover this specific case — "the model you picked is no longer configured for this project" — has nothing to key off but the message text:

```
error_code=100001, error_message=Unknown custom model `Datus Free Token Credits`. Available: ['oracle-test']
```

Datus-saas hit exactly this: a user's free-credit connection was detached, the web client kept sending it, and every turn failed. The client-side recovery (refetch the project's models, offer another one) had to match `/unknown custom model/i` — which breaks silently if the wording ever changes, with no test on either side to catch it.

## Change

- New `ErrorCode.MODEL_NOT_CONFIGURED` (`300025`, model range) whose description is the message this path already produced: ``Unknown custom model `{model_name}`. Available: {available_models}``.
- `set_active_custom` raises it via `message_args`, so the wording now lives in the code definition instead of an f-string at the raise site.

The rendered message is byte-identical to before, so CLI output and logs don't change; only `error_code` / `error_type` do. `set_active_provider_model` is untouched — it validates only emptiness (`COMMON_FIELD_REQUIRED`).

## Test

- `tests/unit_tests/configuration/test_agent_config.py::test_set_active_custom_rejects_unknown_name` now asserts the code plus the name and the available-models listing.
- New `tests/unit_tests/api/services/test_chat_service.py::test_stream_chat_unknown_model_yields_model_not_configured` pins the contract clients actually consume: a `model="custom/<gone>"` request yields a single `error` event with `error_type == "MODEL_NOT_CONFIGURED"`.

`uv run pytest tests/unit_tests/configuration/test_agent_config.py` 298 passed; `tests/unit_tests/api/services/test_chat_service.py` + `tests/unit_tests/cli/test_model_commands.py` 41 passed; `ruff format` / `ruff check` clean.

## Follow-up

Datus-saas PR #695 matches the message text today; it will switch to `error_type == "MODEL_NOT_CONFIGURED"` and keep the regex only as a fallback for agents older than this change.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when an unknown or unavailable custom model is selected.
  * Chat requests now return a clear model-configuration error instead of a generic validation error.
  * Error messages identify the requested model and list available models for easier troubleshooting.

* **Tests**
  * Added coverage for unknown model selections in configuration and chat streaming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->