### PR TITLE
[BugFix] Name the reachable roots when strict mode rejects a path

### DIFF
--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -17,6 +17,7 @@ from datus.tools.func_tool.fs_path_policy import (
     PathZone,
     ResolvedPath,
     classify_path,
+    strict_mode_rejection_message,
     whitelist_anchors,
 )
 from datus.utils.loggings import get_logger
@@ -210,13 +211,18 @@ class FilesystemFuncTool(BaseTool):
 
         Unlike ``_not_found``, this is explicit: the caller **asked** for a
         path outside the workspace, so hiding the rejection would be
-        confusing. The error message names the path so the LLM can fix it
-        on the next turn. Used by the API / gateway surfaces that have no
-        interactive broker to prompt the user.
+        confusing. The error message names both the path and the roots that
+        *are* reachable so the LLM can retarget on the next turn. Used by the
+        API / gateway surfaces that have no interactive broker to prompt the
+        user.
         """
         return FuncToolResult(
             success=0,
-            error=f"Path outside workspace is not allowed in strict mode: {resolved.display}",
+            error=strict_mode_rejection_message(
+                resolved.display,
+                root_path=self._root_resolved,
+                allowlist=self._path_allowlist,
+            ),
         )
 
     def _get_safe_path(self, path: str) -> Optional[Path]:

--- a/datus/tools/func_tool/fs_path_policy.py
+++ b/datus/tools/func_tool/fs_path_policy.py
@@ -157,6 +157,52 @@ def _is_relative_to(candidate: Path, anchor: Path) -> bool:
         return False
 
 
+# Keeps a pathological allowlist from bloating a tool-result the LLM has to read.
+_MAX_LISTED_ROOTS = 8
+
+
+def _join_roots(roots: List[Path]) -> str:
+    shown = [str(root) for root in roots[:_MAX_LISTED_ROOTS]]
+    if len(roots) > _MAX_LISTED_ROOTS:
+        shown.append(f"... (+{len(roots) - _MAX_LISTED_ROOTS} more)")
+    return ", ".join(shown)
+
+
+def strict_mode_rejection_message(
+    display: str,
+    *,
+    root_path: Path,
+    allowlist: Optional[PathAllowlist] = None,
+) -> str:
+    """Error text for an ``EXTERNAL`` path rejected by strict mode.
+
+    Naming the reachable roots is what keeps the model from probing: with a bare
+    rejection it walks parent directories and shell-outs looking for a file it
+    wrote through a proxied (differently anchored) fs op, and every probe is
+    another rejected turn.
+
+    The text up to and including ``display`` is a tool-result contract matched by
+    the permission hooks' tests and by the LLM — only ever append to it.
+    """
+    root_resolved = Path(root_path).expanduser().resolve(strict=False)
+    allowed = [root_resolved]
+    read_only: List[Path] = []
+    if allowlist is not None:
+        # Anchors under the project root add nothing — the root already covers them.
+        for anchor in allowlist.write:
+            if not _is_relative_to(anchor, root_resolved) and anchor not in allowed:
+                allowed.append(anchor)
+        for anchor in allowlist.read:
+            if _is_relative_to(anchor, root_resolved) or anchor in allowed or anchor in read_only:
+                continue
+            read_only.append(anchor)
+
+    hints = [f"allowed roots: {_join_roots(allowed)}"]
+    if read_only:
+        hints.append(f"read-only roots: {_join_roots(read_only)}")
+    return f"Path outside workspace is not allowed in strict mode: {display} ({'; '.join(hints)})"
+
+
 def _resolve_home(datus_home: Optional[Path]) -> Path:
     """Resolve the effective ``~/.datus`` root for whitelist anchors."""
     if datus_home is not None:

--- a/datus/tools/func_tool/scheduler_tools.py
+++ b/datus/tools/func_tool/scheduler_tools.py
@@ -14,7 +14,7 @@ from datus_scheduler_core.registry import SchedulerAdapterRegistry
 from datus.configuration.agent_config import AgentConfig
 from datus.tools import BaseTool
 from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
-from datus.tools.func_tool.fs_path_policy import PathZone, classify_path
+from datus.tools.func_tool.fs_path_policy import PathZone, classify_path, strict_mode_rejection_message
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 
@@ -90,7 +90,11 @@ class SchedulerTools(BaseTool):
         if self._strict and resolved.zone == PathZone.EXTERNAL:
             return None, FuncToolResult(
                 success=0,
-                error=f"Path outside workspace is not allowed in strict mode: {resolved.display}",
+                error=strict_mode_rejection_message(
+                    resolved.display,
+                    root_path=Path(self.agent_config.project_root),
+                    allowlist=getattr(self.agent_config, "filesystem_allowlist", None),
+                ),
             )
 
         sql_path = resolved.resolved

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -737,6 +737,31 @@ class TestPathZones:
         assert result.success == 0
         assert "not allowed in strict mode" in (result.error or "").lower()
 
+    def test_strict_rejection_names_the_reachable_roots(self, tmp_path):
+        """Seeding a walk at the *parent* of the project root and the DAGs folder.
+
+        Observed in a SaaS session: the model wrote a DAG through the proxied
+        (workspace-anchored) fs path, then globbed the workspace root looking for
+        it and got a bare rejection, so it kept probing. Naming both roots is what
+        lets it retarget instead.
+        """
+        workspace = tmp_path / "ws"
+        project = workspace / "proj" / "files"
+        project.mkdir(parents=True)
+        dags = workspace / "proj" / "dags"
+        dags.mkdir()
+        tool = FilesystemFuncTool(
+            root_path=str(project),
+            current_node="chat",
+            strict=True,
+            path_allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        result = tool.glob("**/*.py", str(workspace))
+        assert result.success == 0
+        assert str(workspace.resolve()) in (result.error or "")
+        assert str(project.resolve()) in (result.error or "")
+        assert str(dags.resolve()) in (result.error or "")
+
     def test_strict_allows_internal_and_whitelist(self, tmp_path):
         """Strict mode must NOT break project-internal / whitelist access —
         otherwise the API surface could not read its own files."""

--- a/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
+++ b/tests/unit_tests/tools/func_tool/test_fs_path_policy.py
@@ -12,6 +12,7 @@ from datus.tools.func_tool.fs_path_policy import (
     PathZone,
     build_walk_patterns,
     classify_path,
+    strict_mode_rejection_message,
     whitelist_anchors,
 )
 
@@ -409,3 +410,60 @@ class TestClassifyWithAllowlist:
         assert dags.resolve() in anchors
         # Project-side anchors are still first so longer prefixes keep winning.
         assert anchors[0] == (project / ".datus" / "skills").resolve(strict=False)
+
+
+class TestStrictModeRejectionMessage:
+    """The rejection text is read by the LLM, so its shape is a contract."""
+
+    @pytest.fixture
+    def dags(self, tmp_path):
+        folder = tmp_path / "services" / "airflow" / "dags" / "ws1" / "proj1"
+        folder.mkdir(parents=True)
+        return folder
+
+    def test_prefix_and_path_are_preserved(self, project):
+        msg = strict_mode_rejection_message("/outside/x.py", root_path=project)
+        assert msg.startswith("Path outside workspace is not allowed in strict mode: /outside/x.py")
+        assert str(project.resolve()) in msg
+
+    def test_lists_allowlisted_write_roots(self, project, dags):
+        msg = strict_mode_rejection_message(
+            "/outside/x.py",
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(dags)]}),
+        )
+        assert f"allowed roots: {project.resolve()}, {dags.resolve()}" in msg
+        assert "read-only" not in msg
+
+    def test_read_roots_are_reported_separately(self, project, tmp_path):
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        msg = strict_mode_rejection_message(
+            "/outside/x.py",
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_read": [str(shared)]}),
+        )
+        assert f"allowed roots: {project.resolve()}" in msg
+        assert f"read-only roots: {shared.resolve()}" in msg
+
+    def test_anchors_under_project_root_are_not_repeated(self, project):
+        inside = project / "dags"
+        msg = strict_mode_rejection_message(
+            "/outside/x.py",
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(inside)], "allow_read": [str(inside)]}),
+        )
+        assert msg.count(str(project.resolve())) == 1
+        assert "read-only" not in msg
+
+    def test_long_allowlist_is_truncated(self, project, tmp_path):
+        roots = [tmp_path / f"root{i}" for i in range(12)]
+        msg = strict_mode_rejection_message(
+            "/outside/x.py",
+            root_path=project,
+            allowlist=PathAllowlist.from_dict({"allow_write": [str(r) for r in roots]}),
+        )
+        # project root + 7 anchors listed, the rest collapsed into a counter.
+        assert str(roots[6].resolve()) in msg
+        assert str(roots[7].resolve()) not in msg
+        assert "... (+5 more)" in msg

--- a/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_scheduler_tools.py
@@ -1581,6 +1581,8 @@ class TestSqlPathPolicy:
         )
         assert result.success == 0
         assert "outside workspace" in (result.error or "").lower()
+        # The reachable root is named so the model can retarget the SQL path.
+        assert str(project_root.resolve()) in (result.error or "")
 
     def test_non_strict_allows_external_path(self, tmp_path):
         """Default (non-strict) mode lets absolute paths through, matching


### PR DESCRIPTION
## Why

A SaaS chat session (DeepSeek-V4, strict mode, sandbox runtime) wrote a generated Airflow DAG through the IDE-proxied `write_file` — which is anchored at the workspace root — and then tried to locate it with `glob(pattern="**/*.py", path="/data/tenants/.../workspaces/<ws>")`. It got:

```
Path outside workspace is not allowed in strict mode: /data/tenants/.../workspaces/<ws>
```

The rejection itself is correct and should stay: the workspace root is the **parent** of both reachable roots (`<ws>/<pj>/files` as the project root, `<ws>/<pj>/dags` as a configured `allow_write` anchor), so allowing it would expose every project in the workspace.

The problem is that the message named only the path that failed, never the ones that would have worked. The model had no way to converge, so it kept probing — `find /data/tenants/.../workspaces -name ...`, `pwd && find . -name ...`, another `glob` — and eventually rewrote the same DAG at a second location, leaving two copies whose `deploy` targets disagreed. Every one of those turns is a wasted round-trip against a gate that already knew the answer.

## Solution

Append the reachable roots to the rejection so the model can retarget in a single turn:

```
Path outside workspace is not allowed in strict mode: <path>
  (allowed roots: <project_root>, <allow_write anchors>; read-only roots: <allow_read anchors>)
```

- `strict_mode_rejection_message()` in `fs_path_policy.py` is now the single source of the text. Both gates call it instead of formatting their own copy of the same literal — `FilesystemFuncTool._strict_reject` (covering `read_file` / `write_file` / `edit_file` / `delete_file` / `glob` / `grep`, and inherited by `MetricFilesystemFuncTool`) and `SchedulerTools._load_sql_content`.
- `allow_read` anchors are reported separately as `read-only roots`, matching how `classify_path` treats them — otherwise the model would try to write there and hit a second rejection.
- Anchors that live under the project root are dropped (the root already covers them), and the list collapses to `... (+N more)` past 8 entries, so a large deployment allowlist can't bloat a tool result the LLM has to read.
- **The text up to and including the offending path is unchanged.** The permission hooks' tests and the LLM both match on that prefix, so this only ever appends.

Deliberately *not* changed: the zone policy. The `<pj>/dags` folder has to stay outside the project root — Airflow only scans the shared per-project DAGs dir — so the asymmetry between the proxied (workspace-anchored) fs ops and the in-process (project-anchored) ones is a deployment fact the message now surfaces rather than something to paper over here.

## Test Cases

Unit tests only — the change is pure message construction on an existing rejection path, and both call sites already had strict-mode coverage.

- `tests/unit_tests/tools/func_tool/test_fs_path_policy.py::TestStrictModeRejectionMessage` — 5 cases pinning the contract: prefix + path preserved, `allow_write` anchors listed, `allow_read` reported as a separate read-only group, anchors under the project root not repeated, long allowlist truncated with an accurate remainder count.
- `tests/unit_tests/tools/func_tool/test_filesystem_tools.py::test_strict_rejection_names_the_reachable_roots` — end-to-end replay of the session above: a `glob` seeded at the common parent of the project root and the DAGs allowlist must still fail closed *and* name both roots.
- `tests/unit_tests/tools/func_tool/test_scheduler_tools.py::test_strict_rejects_external_path` — extended to assert the reachable root reaches the caller on the scheduler path too.

`ci/run-pr-tests.py upstream/main`: impacted unit suite green, diff coverage 100%. The 1 failure + 3 errors in the acceptance run are pre-existing locally (missing `~/benchmark/bird` sqlite fixtures — identical failures with the change stashed). `ci/audit_tests.py --diff-only`: P0=0, P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strict-mode filesystem error messages by identifying the workspace, project, and permitted paths involved.
  * Clarified handling of writable and read-only allowed locations.
  * Prevented overly long path lists by summarizing additional entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->