### PR TITLE
[Doc] Simplify plugin documentation

### DIFF
--- a/docs/cli/execution_command.md
+++ b/docs/cli/execution_command.md
@@ -40,25 +40,9 @@ Type `!` on its own to list the available tools and plugins.
 ```
 
 - `!<plugin> <args...>` runs `datus <plugin> <args...>` as a subprocess. The command is permission-gated like any bash command, and the plugin's own CLI permissions apply inside the child process. Its output is fed to the model as an execution turn (same as `!<tool>`), so it enters the conversation and triggers a reply.
-- A plugin can declare its commands and arguments in its `datus-plugin.yml` manifest under `commands:` (see the plugin manifest reference). When present, the `!<plugin>` completer lists them and hints their argument names. Command groups nest via `subcommands:`, so the completer drills in one level at a time (`!airflow dags ` → `list`, `trigger`, …).
-
-```yaml
-# datus-plugin.yml (excerpt)
-commands:
-  - name: ls                        # a flat command with arguments
-    description: List objects under a prefix
-    args:
-      - {name: uri, required: true, description: s3://bucket/prefix}
-      - {name: --recursive, description: recurse into sub-prefixes}
-  - name: dags                      # a command group with nested subcommands
-    description: DAG operations
-    subcommands:
-      - name: trigger
-        args:
-          - {name: dag_id, required: true}
-          - {name: --conf, description: run configuration JSON}
-      - name: list
-```
+- When a plugin provides command metadata, the `!<plugin>` completer lists its
+  commands and hints their arguments. Completion follows nested command groups,
+  so typing `!airflow dags ` can offer commands such as `list` and `trigger`.
 
 ## 4. Notes
 

--- a/docs/cli/execution_command.zh.md
+++ b/docs/cli/execution_command.zh.md
@@ -40,25 +40,9 @@
 ```
 
 - `!<plugin> <args...>` 会以子进程方式运行 `datus <plugin> <args...>`。该命令像普通 bash 命令一样受权限门控，并且插件自身的 CLI 权限在子进程内同样生效。其输出会作为执行 turn 喂给模型（与 `!<tool>` 一致），进入对话并触发一次回复。
-- 插件可以在其 `datus-plugin.yml` manifest 的 `commands:` 下声明命令与参数（见插件 manifest 参考）。声明后，`!<plugin>` 补全器会列出它们并提示其参数名。命令分组通过 `subcommands:` 嵌套，补全器会逐级下钻（`!airflow dags ` → `list`、`trigger` …）。
-
-```yaml
-# datus-plugin.yml（节选）
-commands:
-  - name: ls                        # 带参数的扁平命令
-    description: List objects under a prefix
-    args:
-      - {name: uri, required: true, description: s3://bucket/prefix}
-      - {name: --recursive, description: recurse into sub-prefixes}
-  - name: dags                      # 带嵌套子命令的命令分组
-    description: DAG operations
-    subcommands:
-      - name: trigger
-        args:
-          - {name: dag_id, required: true}
-          - {name: --conf, description: run configuration JSON}
-      - name: list
-```
+- 如果插件提供了命令信息，`!<plugin>` 补全器会列出可用命令并提示参数。补全也会
+  沿命令层级逐步展开，例如输入 `!airflow dags ` 后，可以继续选择 `list` 或
+  `trigger`。
 
 ## 4. 说明
 

--- a/docs/plugin/development.md
+++ b/docs/plugin/development.md
@@ -1,873 +1,119 @@
-# Plugin Development
+# Develop a Plugin
 
-This guide shows how to build a Datus plugin, from a minimal working `hello`
-command to the full contract. For what plugins are, how users install and
-configure them, and how profiles are resolved, start with the
-[introduction](introduction.md).
+The recommended way to build a Datus plugin is with the
+[`datus-plugin-development`](https://github.com/Datus-ai/Datus-Plugins/blob/main/skills/datus-plugin-development/SKILL.md)
+skill from the
+[`Datus-Plugins`](https://github.com/Datus-ai/Datus-Plugins) repository.
 
-A plugin is an installable Python package discovered through the
-`datus.plugins` entry-point group. The defining constraints:
+Give the skill the SDK, API specification, or product documentation you want
+to wrap. It will help you choose a useful command surface, generate the plugin,
+and verify the result. The skill contains the current plugin contract, so this
+page focuses on the workflow instead of repeating implementation details that
+can drift out of date.
 
-- **A plugin never imports `datus.*`** and depends on no shared SDK.
-- **The whole contract is one declarative file** — `datus-plugin.yml`, shipped
-  inside your package. It names your CLI entry function, your tool
-  transformers, your skills directory, your system-prompt template, your bash
-  permission rules, and your config schema. The only Python you write are
-  plain functions.
+## Before you start
 
-Datus is the *config broker* — it reads `agent.yml`, expands `${VAR}`
-references, resolves the active profile, and calls your declared `cli`
-function with a plain `dict`. Reading the manifest never executes your code:
-skills, permissions, prompt sections and config schemas are collected without
-importing your package. Only your `cli` function (on `datus <name> ...`) and
-your declared tool transformers are imported, lazily.
+Prepare:
 
-## Prerequisites
+- The SDK, REST API, OpenAPI specification, CLI documentation, or README you
+  want to expose through Datus. A local path or public URL both work.
+- A short command name. For example, an Airflow plugin uses `datus airflow`.
+- Any scope preferences, such as which operations matter most or which
+  administrative actions should be excluded.
 
-- A Python package you can install into the same environment as `datus`.
-- `datus` installed (`pip install datus-agent` or a source checkout).
-- Python 3.12+ — a plugin runs inside datus' own interpreter
-  (`datus-agent` declares `requires-python >= 3.12`), so your code and
-  dependencies must be compatible with it.
+You only need to provide the source material and describe what you want the
+plugin to do. The development skill handles the implementation.
 
-## Quickstart: a minimal plugin
+## Install the development skill
 
-**1. Package layout**
+### Codex
 
-```text
-datus-plugin-hello/
-├── pyproject.toml
-└── datus_plugin_hello/
-    ├── __init__.py
-    ├── datus-plugin.yml      # the manifest — the whole plugin contract
-    └── cli.py
-```
-
-**2. The manifest** (`datus_plugin_hello/datus-plugin.yml`)
-
-```yaml
-manifest_version: 1
-description: "Say hello to someone."
-cli: datus_plugin_hello.cli:main
-```
-
-**3. The CLI function** (`datus_plugin_hello/cli.py`)
-
-```python
-from __future__ import annotations
-
-
-def main(argv: list[str], profile: dict) -> int:
-    # `profile` is the resolved agent.plugins.hello.<profile> dict
-    # (already ${VAR}-expanded by datus). Empty dict is fine.
-    greeting = profile.get("greeting", "Hello")
-    name = argv[0] if argv else "world"
-    print(f"{greeting}, {name}!")
-    return 0
-```
-
-**4. Register the entry point** (`pyproject.toml`)
-
-```toml
-[project]
-name = "datus-plugin-hello"
-version = "0.1.0"
-dependencies = []                      # note: NOT datus
-
-[project.entry-points."datus.plugins"]
-hello = "datus_plugin_hello"           # the PACKAGE name — not a class
-
-[tool.setuptools.package-data]
-datus_plugin_hello = ["datus-plugin.yml"]
-```
-
-The entry-point value is your **package name** — a pure name → package
-mapping, no code reference. The entry-point name (`hello`) alone determines
-the CLI command (`datus hello`) and the config key (`agent.plugins.hello`) —
-the package name is free. Three names are **reserved** and never dispatched to
-plugins: `upgrade`, `skill`, and `plugin`. A plugin registered under any of
-them is unreachable (and `datus plugin install` refuses it), and names
-starting with `-` cannot be dispatched at all.
-
-The manifest is package data, not Python — make sure it ships in the wheel.
-Hatchling packages every file under the package directory by default; with
-setuptools use the `[tool.setuptools.package-data]` stanza above. Verify with
-`unzip -l dist/*.whl | grep datus-plugin.yml` (both `datus plugin install` and
-`datus plugin pack` refuse a package whose manifest is missing).
-
-**5. Install and run**
+Add the Datus plugin marketplace:
 
 ```bash
-datus plugin install src:./datus-plugin-hello   # installs into ~/.datus/plugins/hello/
-datus hello Ada          # -> Hello, Ada!
+codex plugin marketplace add Datus-ai/Datus-Plugins
 ```
 
-For a tight edit-run loop while developing, `pip install -e datus-plugin-hello`
-into datus' own environment also works — such plugins are still discovered as a
-fallback, without a `~/.datus/plugins/` directory.
+Open `/plugins`, install **datus-plugin-development**, and start a new session
+so the skill is available.
 
-That is a complete plugin. Everything below is optional surface area.
+### Claude Code
 
-## The manifest reference
-
-`datus-plugin.yml` lives at your package root. Only `manifest_version` is
-required; every other key is optional:
-
-| Key | Type | Purpose |
-|---|---|---|
-| `manifest_version` | int, **required** | Must be `1`. A newer version than datus understands rejects the manifest with a "requires newer datus" warning. |
-| `description` | string | One-line summary shown by `datus plugin info`. |
-| `cli` | code ref | `module.path:function` called as `main(argv, profile)` on `datus <name> ...`. See [Implementing the CLI entry](#implementing-the-cli-entry). Without it, `datus <name>` exits 2. |
-| `tool_transformers` | mapping | Tool pattern → code ref (or list of refs) that rewrite or deny the agent's tool calls. See [Tool argument transformers](#tool-argument-transformers). |
-| `permissions` | mapping | Bash-permission rules for your own CLI namespace, per permission profile — pure YAML, no code. See [CLI bash permissions](#cli-bash-permissions). |
-| `system_prompt` | path | Package-relative path of a Jinja2 template rendered into the agent's system prompt. See [System-prompt template](#system-prompt-template). |
-| `skills` | path | Package-relative path of a bundled skill directory. See [Bundling skills](#bundling-skills). |
-| `config_schema` | JSON Schema | Inline object schema describing one profile — drives the `/plugins` TUI form and validates profiles before saving. See [Config schema and validation](#config-schema-and-validation). |
-
-A **code ref** is a dotted `module.path:function` string. Paths are relative
-to the package directory and may not escape it. Manifest parsing is defensive:
-a malformed section is warned about and dropped while the rest of the manifest
-stays usable; only a missing/unsupported `manifest_version` (or unreadable
-YAML) rejects the manifest as a whole.
-
-The machine-readable contract lives in `datus/plugins/base.py`; this table and
-that docstring are kept in sync.
-
-## Configuration: what Datus hands you
-
-Users configure your plugin under `agent.plugins.<name>`, where each key below
-`<name>` is a **profile** (an environment):
-
-```yaml
-agent:
-  plugins:
-    hello:
-      prod:
-        default: true
-        greeting: Hi
-        token: ${HELLO_TOKEN}      # prefer ${ENV_VAR} for secrets
-      staging:
-        greeting: Yo
-```
-
-Datus parses this into `agent.plugins.<name>.<profile> -> dict`, **expands
-`${VAR}` per profile**, and injects a `name` key equal to the profile name.
-Which profile dict reaches your `cli` function is decided by Datus — explicit
-`--profile`, project pin, `default: true`, sole profile, or an empty dict
-when nothing is configured. The full resolution order is documented in the
-[introduction](introduction.md#which-profile-runs); you never write any of
-that logic. Your function simply receives the resolved `dict`.
-
-When testing locally, put your profile in whichever config file your datus
-session actually loads (explicit `--config` → `./conf/agent.yml` →
-`~/.datus/conf/agent.yml`).
-
-## Config schema and validation
-
-Declare a `config_schema` — an inline JSON Schema for **one profile** — and
-the `/plugins` TUI renders a proper form instead of free-form key/value
-editing, and Datus validates a candidate profile against it before saving:
-
-```yaml
-config_schema:
-  type: object
-  required: [token, s3]
-  properties:                    # property order == TUI field order
-    token:
-      type: string
-      description: "API token"
-      x-secret: true             # masked in the TUI, stripped from the prompt
-    greeting:
-      type: string
-      description: "Greeting word"
-      default: "Hi"
-    s3:                          # nested objects expand into dotted form fields
-      type: object
-      required: [secret_access_key]
-      properties:
-        region: {type: string, default: us-east-1}
-        secret_access_key: {type: string, x-secret: true}
-```
-
-Semantics:
-
-- **`x-secret: true`** marks a secret field: the TUI masks it and prompts the
-  user to enter a `${ENV_VAR}` reference, and the system-prompt renderer
-  strips it (see [System-prompt template](#system-prompt-template)). It is a
-  property-level extension keyword — JSON Schema validators ignore it.
-- **`required`** membership marks a form field as required; **`default`** is
-  pre-filled as the field's initial value. A field left empty (no default,
-  nothing typed yet) shows its `description` as a dim placeholder instead.
-- **Nested objects** — a `type: object` property with its own `properties`
-  expands in the TUI into one field per leaf, named by its dotted path
-  (`s3.region`, `s3.secret_access_key`); submitted values are re-assembled
-  into the nested profile shape before saving. `x-secret: true` on the object
-  marks every leaf secret, and a leaf is form-required only when its whole
-  ancestor path is required too. The system-prompt whitelist filters declared
-  nested objects recursively under the same rules.
-- **Free-form objects pass through wholesale.** A `type: object` property
-  **without** its own `properties` (a free-form dict) is *not* filtered per
-  key: the TUI keeps it as a single field, and the system-prompt renderer
-  passes its entire stored value into the prompt. Only per-key stripping is
-  skipped — the field itself still has to be declared — so a secret nested
-  inside such a field would reach the LLM. Either declare its sub-`properties`
-  (to get recursive filtering) or mark the whole object `x-secret: true`.
-- **Validation** runs `jsonschema` on the raw candidate dict (the values the
-  user just entered, **before** `${VAR}` expansion). Values containing
-  `${ENV_VAR}` placeholders are treated as opaque — pattern/enum/format
-  violations on them are suppressed, while a missing `required` field still
-  fails. Keep the real runtime validation in your `cli` function.
-- **TUI-entered values are strings**, so prefer `type: string` with `pattern`
-  / `enum` constraints; reserve other types for hand-written `agent.yml`
-  profiles.
-- A schema that is itself invalid (rejected by the JSON Schema meta-schema) is
-  warned about and treated as absent — the TUI falls back to free-form
-  editing.
-
-## Implementing the CLI entry
-
-The manifest's `cli` names a function called as `main(argv, profile)`:
+Add the marketplace and install the development plugin:
 
 ```text
-datus hello --profile staging greet Ada
-                └── stripped ──┘ └── argv = ["greet", "Ada"] ──┘
+/plugin marketplace add Datus-ai/Datus-Plugins
+/plugin install datus-plugin-development@datus-plugin
 ```
 
-Only `--profile` / `--config` appearing **before the first non-option token**
-are consumed as Datus globals; from the first command token onward everything
-belongs to the plugin. `datus hello greet --profile staging` therefore passes
-`["greet", "--profile", "staging"]` through untouched — your subcommands are
-free to define their own `--profile` option.
+## Start a plugin project
 
-In a read-only multi-tenant API session, Datus may obtain the profile from the
-request's in-memory `AgentConfig` and bridge it through a subprocess-scoped
-environment value. This transport is host-owned: your plugin should continue
-to use the supplied `profile` argument and may read its own values from that
-dict. Do not depend on the internal environment value. In this mode
-`--profile` works, while `--config` and compound shell forms other than a plain
-`|` pipeline are rejected.
+Invoke the skill with the documentation source and the command name you want.
 
-Return an integer exit code (`None` means `0`). Suggested conventions:
-
-| Code | Meaning |
-|---|---|
-| `0` | success |
-| `1` | runtime error |
-| `2` | usage error |
-| `3` | config error |
-| `8` | missing optional dependency |
-
-Raising is also fine — Datus catches exceptions from your `cli` function and
-maps them to exit code `1` rather than crashing the CLI — but returning an
-explicit code gives users clearer signals.
-
-## Recipes: wrapping functions and APIs into a CLI
-
-Your `cli` function receives a raw `argv` list, so you are free to route it
-however you like. Here are four common patterns, from quickest to richest.
-
-### A. Dict dispatch — a few functions, zero dependencies
-
-```python
-def main(argv, profile):
-    if not argv:
-        print("usage: datus toolbox <add|upper> ...")
-        return 2
-    cmd, rest = argv[0], argv[1:]
-    handlers = {"add": _add, "upper": _upper}
-    handler = handlers.get(cmd)
-    if handler is None:
-        print(f"unknown command: {cmd}")
-        return 2
-    return handler(rest)
-
-
-def _add(args):          # datus toolbox add 1 2 3
-    print(sum(float(a) for a in args))
-    return 0
-
-
-def _upper(args):        # datus toolbox upper hello
-    print(" ".join(args).upper())
-    return 0
-```
-
-### B. argparse — typed args, flags, auto usage/`-h`
-
-Stdlib, no extra dependency. `argparse` prints usage and raises `SystemExit`
-on `-h` or a bad invocation; Datus surfaces that as the exit code (0 for `-h`,
-2 for usage errors), which is the conventional CLI behavior.
-
-```python
-import argparse
-
-
-def main(argv, profile):
-    parser = argparse.ArgumentParser(prog="datus toolbox")
-    sub = parser.add_subparsers(dest="cmd", required=True)
-
-    p_add = sub.add_parser("add", help="sum numbers")
-    p_add.add_argument("nums", nargs="+", type=float)
-
-    p_grep = sub.add_parser("grep", help="filter lines in a file")
-    p_grep.add_argument("pattern")
-    p_grep.add_argument("path")
-    p_grep.add_argument("-i", "--ignore-case", action="store_true")
-
-    ns = parser.parse_args(argv)      # SystemExit on -h / bad usage
-    if ns.cmd == "add":
-        print(sum(ns.nums))
-        return 0
-    if ns.cmd == "grep":
-        return _grep(ns.pattern, ns.path, ns.ignore_case)
-
-
-def _grep(pattern, path, ignore_case):
-    needle = pattern.lower() if ignore_case else pattern
-    with open(path, encoding="utf-8") as fh:
-        for line in fh:
-            hay = line.lower() if ignore_case else line
-            if needle in hay:
-                print(line.rstrip())
-    return 0
-```
-
-### C. Wrapping a REST API
-
-Read the endpoint and credentials from the profile (Datus already expanded
-`${VAR}`), then map subcommands to requests. Keep credentials in the profile —
-never hard-code them, and never echo them.
-
-```python
-import argparse
-import json
-
-
-def main(argv, profile):
-    import requests  # a plugin may depend on its own libraries
-
-    base = profile.get("api_base_url")
-    if not base:
-        print("no api_base_url configured for the profile")
-        return 3
-    headers = {}
-    if profile.get("token"):
-        headers["Authorization"] = f"Bearer {profile['token']}"
-
-    parser = argparse.ArgumentParser(prog="datus petstore")
-    sub = parser.add_subparsers(dest="cmd", required=True)
-    sub.add_parser("list-pets")
-    p_get = sub.add_parser("get-pet")
-    p_get.add_argument("id")
-    ns = parser.parse_args(argv)
-
-    base = base.rstrip("/")
-    if ns.cmd == "list-pets":
-        resp = requests.get(f"{base}/pets", headers=headers, timeout=30)
-    else:
-        resp = requests.get(f"{base}/pets/{ns.id}", headers=headers, timeout=30)
-
-    if resp.status_code >= 400:
-        print(f"error {resp.status_code}: {resp.text}")
-        return 1
-    print(json.dumps(resp.json(), indent=2))
-    return 0
-```
-
-Corresponding config:
-
-```yaml
-agent:
-  plugins:
-    petstore:
-      prod:
-        default: true
-        api_base_url: https://api.example.com/v1
-        token: ${PETSTORE_TOKEN}
-```
-
-### D. Typer / Click — richest UX, one extra dependency
-
-For a large command surface, a framework like [Typer](https://typer.tiangolo.com/)
-gives you help text, type coercion, and completion. Because Datus calls your
-entry function per-invocation but the Typer app is a module-level object,
-expose the active profile through a module global that commands read.
-
-```python
-import typer
-
-app = typer.Typer(add_completion=False)
-_ACTIVE_PROFILE: dict = {}
-
-
-@app.command("greet")
-def greet(name: str, loud: bool = False):
-    greeting = _ACTIVE_PROFILE.get("greeting", "Hello")
-    msg = f"{greeting}, {name}!"
-    print(msg.upper() if loud else msg)
-
-
-def main(argv, profile):
-    global _ACTIVE_PROFILE
-    _ACTIVE_PROFILE = profile
-    try:
-        # standalone_mode=False stops Click from calling sys.exit itself,
-        # so we can return a code and always clear the profile.
-        app(args=argv, standalone_mode=False)
-        return 0
-    except SystemExit as exc:      # -h / usage
-        return int(exc.code or 0)
-    except typer.Exit as exc:
-        return exc.exit_code
-    finally:
-        _ACTIVE_PROFILE = {}
-```
-
-Add `typer` to your package's `dependencies` (your plugin's deps are its own —
-just not `datus`).
-
-## Bundling skills
-
-Declare a package-relative skills directory in the manifest and Datus
-discovers the skills at startup (they show up in `/skill list`, alongside
-project and user skills) — no code involved:
-
-```yaml
-skills: skills
-```
-
-Layout and packaging:
+In Codex:
 
 ```text
-datus_plugin_hello/
-├── datus-plugin.yml
-└── skills/
-    └── hello/
-        └── SKILL.md
+$datus-plugin-development ./docs/openapi.yaml, command name: acme
 ```
 
-A minimal `SKILL.md` is YAML frontmatter plus markdown instructions (the
-frontmatter follows the [agentskills.io](https://agentskills.io) spec used by
-the Skills system):
-
-```markdown
----
-name: hello
-description: Say hello to someone via the `datus hello` CLI
----
-
-# Hello
-
-Run `datus hello <name>` to greet someone. ...
-```
-
-See the [Skills](../skills/introduction.md) docs for the full frontmatter
-field reference.
-
-In a multi-tenant API deployment, discovery is scoped by the request's
-`AgentConfig` (`plugins_enabled`, active plugins, `plugin_paths`, and
-`skills`); plugin skills do not depend on a local `./.datus/config.yml`.
-
-Make sure the skill files are included in the wheel (they are data, not
-Python). Hatchling packages every file under the package directory by default,
-so nothing extra is needed unless the files are VCS-ignored (then list them
-under `[tool.hatch.build.targets.wheel] artifacts`). With setuptools you must
-opt in explicitly:
-
-```toml
-[tool.setuptools.package-data]
-datus_plugin_hello = ["datus-plugin.yml", "skills/**/*", "prompts/*"]
-```
-
-After building, verify with `unzip -l dist/*.whl | grep SKILL.md`.
-
-## System-prompt template
-
-A plugin can tell the agent, up front, what it is and which environments are
-configured — so the model chooses it proactively instead of guessing. Declare
-a Jinja2 template in the manifest:
-
-```yaml
-system_prompt: prompts/system.md.j2
-```
-
-```jinja
-## Hello
-Say hello via `datus hello <name>`.
-
-{% if profiles %}
-Environments ({{ profiles | length }}):
-{% for name, cfg in profiles.items() %}
-- {{ name }}: {{ cfg.get("greeting", "?") }}
-{% endfor %}
-{% else %}
-Installed but not configured.
-{% if config_mutable %}
-Run the `hello-setup` skill to configure an environment.
-{% else %}
-Configuration is managed by the deployment administrator — tell the user to
-contact them.
-{% endif %}
-{% endif %}
-```
-
-The render context:
-
-| Variable | Value |
-|---|---|
-| `plugin_name` | your entry-point name |
-| `profiles` | `dict[str, dict]` — the plugin's profile mapping, **narrowed to the profiles the project activated** (`plugins.<name>.active_profile` in `./.datus/config.yml`) and **secret-stripped** (see below) |
-| `config_path` | the loaded agent config file path, or `None` (always `None` when the config is read-only) |
-| `config_mutable` | `True` when the agent may edit the config file; `False` in managed deployments (multi-tenant chat API / gateway). Requires datus-agent ≥ the release introducing it — on older versions a template referencing it fails to render (strict mode) and the section is skipped |
-
-An installed-but-unconfigured plugin (or one whose pin matches nothing)
-renders with `profiles == {}` — use `{% if profiles %}` to emit a short
-"installed, not configured" note instead of disappearing from the prompt, and
-inside that branch check `config_mutable`: point at your bundled setup skill
-only when it is `True`, otherwise defer to the administrator.
-
-When at least one plugin contributes a section, Datus prepends its own
-`## Plugins` preamble naming the loaded config file and the
-`agent.plugins.<plugin>.<profile>` shape — your template never needs to
-hard-code config paths. In read-only mode the preamble switches to wording
-that forbids config-edit suggestions and defers to the administrator.
-
-!!! note "Secrets are stripped structurally"
-    The rendered text enters the LLM context, and profile values are already
-    `${VAR}`-expanded (real secrets) at prompt time — so Datus filters the
-    profiles **before** your template sees them: only fields declared in your
-    `config_schema` and **not** marked `x-secret: true` pass through;
-    undeclared fields are dropped too, and declared nested objects (a
-    `type: object` with its own `properties`) are filtered recursively under
-    the same rules. The one exception is a **free-form** object field
-    (declared `type: object` with no `properties`): its whole value passes
-    through unfiltered, so mark it `x-secret: true` if it can hold anything
-    sensitive. Without a `config_schema`, templates
-    receive profile names with empty dicts. A template referencing a stripped
-    field fails to render (strict mode) and the section is skipped — it can
-    never leak.
-
-Template errors (missing file, syntax error, undefined variable) are logged
-and the section is skipped — they never break prompt construction. The
-template renders in strict mode (`StrictUndefined`), so a typo shows up in the
-log instead of as silently wrong prompt text.
-
-## CLI bash permissions
-
-When the **agent** (not a human) runs your CLI through its bash tool — e.g. the
-model decides to execute `datus hello greet Ada` — the command goes through
-Datus' permission layer. Without a declaration, every such command prompts the
-user for confirmation. The manifest's `permissions` key declares, per
-permission profile, which of your subcommands are safe to auto-run (`allow`),
-which must be confirmed (`ask`), and which are blocked (`deny`) — pure YAML,
-no code:
-
-```yaml
-permissions:
-  normal:
-    allow: ["greet:*"]
-    ask: ["config set:*"]
-  auto:
-    allow: ["greet:*", "config set:*"]
-```
-
-Semantics:
-
-- **Patterns are relative to your namespace.** Datus prefixes each pattern
-  with `datus <name> `, so `greet:*` becomes `datus hello greet:*`. A plugin
-  can never affect commands outside `datus <name>` — not `rm`, not another
-  plugin.
-- **Pattern syntax** matches `permissions.bash_commands` in `agent.yml`:
-  `cmd` is an exact match, `cmd:*` a prefix match, `cmd:glob` a prefix match
-  whose first argument must satisfy the glob (e.g. `greet:A*`). A bare `:*`
-  covers the whole namespace.
-- **Profile keys**: only `normal` and `auto` are accepted. The `dangerous`
-  profile ignores all command-level bash rules by design; a `dangerous` key is
-  warned about and dropped.
-- **Users always win.** A user `deny` rule in `agent.yml` overrides a plugin
-  `allow` (deny > ask > allow, regardless of declaration order), and plugin
-  declarations can never change a profile's default posture.
-- **`ask` rules can be relaxed per project.** When the agent hits one of your
-  `ask` subcommands, the confirmation prompt offers "allow (project)" —
-  choosing it persists the exact matched pattern (e.g.
-  `datus hello config set:*`) to the project's `.datus/config.yml`
-  `bash_allow` list, and that subcommand auto-runs from then on. The grant is
-  exact-match only: it never widens to the rest of your namespace, and your
-  `deny` rules are unaffected. (User-authored `ask` rules from `agent.yml` do
-  not get this option — relaxing those belongs in the user's own config.)
-- **Scope**: only the agent's bash tool is gated. A human typing
-  `datus hello ...` in a terminal is never affected. `plugins_enabled: false`
-  disables collection along with the rest of the plugin system (see the
-  [introduction](introduction.md#disabling-the-plugin-system)).
-- **`--profile` is transparent to matching.** `datus hello --profile prod
-  config set x` matches the same rules (and the same project grants) as the
-  unqualified form — the leading datus-global flag is normalized away before
-  evaluation. `--config <path>` is deliberately *not* normalized: pointing
-  datus at a different config file rebinds credentials, so those invocations
-  always fall back to a confirmation.
-- Malformed declarations (wrong types, unknown keys, empty patterns) are
-  logged and skipped — they never break Datus startup.
-
-Declare read-only subcommands as `allow` and state-changing ones as `ask`
-under `normal`; promote routine state changes to `allow` under `auto` only
-when re-running them is harmless.
-
-## Tool argument transformers
-
-The manifest's `tool_transformers` key lets your plugin intercept the
-**agent's tool calls** — inspect and rewrite the arguments before the tool
-executes, or deny the call outright. The canonical use case is SQL policy
-enforcement: append a tenant-scope predicate to every `execute_sql` query,
-using the request principal the deployment injects.
-
-```yaml
-tool_transformers:
-  "db_tools.execute_sql": datus_plugin_scoped_sql.transformers:enforce_tenant_scope
-```
-
-```python
-# datus_plugin_scoped_sql/transformers.py
-def enforce_tenant_scope(tool_name, args, context):
-    tenant_id = (context.get("principal") or {}).get("tenant", {}).get("id")
-    if not tenant_id:
-        raise PermissionError("missing principal.tenant.id; cannot scope query")
-    args["sql"] = add_where_predicate(args["sql"], f"tenant_id = '{tenant_id}'")
-    return args
-```
-
-Semantics:
-
-- **Declaration shape**: a mapping of tool patterns to a code ref or a list of
-  code refs. Patterns use the proxy syntax — a bare tool name
-  (`execute_sql`), or `category.method` with fnmatch globs (`db_tools.*`).
-- **Transformer signature**: `transformer(tool_name, args, context) -> dict`,
-  sync or async. Return the (possibly modified) argument dict to continue.
-  **Raise to deny**: the tool never runs and the model receives your
-  exception message as a normal tool failure. Returning anything that is not
-  a dict also denies, fail closed.
-- **`context`** is a plain dict with `node_name`, `principal` (request-scoped
-  caller attributes, empty when the deployment sets none), `project_root`,
-  and `agent_config` (the live agent configuration object — read your own
-  profile via `context["agent_config"].get_plugin_profile("<name>")`; access
-  it duck-typed, never import `datus.*` for it). It is rebuilt on every call,
-  so per-request values are always fresh.
-- **Loading is lazy**: the referenced module is imported when transformers are
-  first collected for an agent node, not at manifest load. A ref that fails to
-  import (or is not callable) is warned about and skipped — the plugin's
-  remaining transformers still apply.
-- **Coverage**: transformers wrap the agent's `FunctionTool` layer, which
-  both execution paths (SDK Runner and the native loop) go through. They do
-  **not** cover direct Python invocations of tool methods (e.g.
-  reference-template execution) or tools proxied to an external client —
-  server-side enforcement that must survive those paths belongs in the tool
-  layer itself (see `agent.sql_policy`).
-- **Trust model**: transformers run in-process with full access to every
-  matched tool call's arguments. They are trusted code, gated by the same
-  `plugins_enabled` master switch as the rest of the plugin surface.
-- Use a SQL parser or a database-safe query builder when rewriting SQL —
-  never string concatenation for policy predicates.
-- A declaration that collects successfully but fails to apply aborts the
-  agent node instead of silently running without enforcement.
-
-## Bundling a setup skill
-
-Editing YAML by hand is the main friction after `pip install`. Ship a
-`<name>-setup` skill next to your main skill so the agent can collect the
-values and write the profile itself:
+In Claude Code:
 
 ```text
-datus_plugin_hello/
-└── skills/
-    ├── hello/
-    │   └── SKILL.md
-    └── hello-setup/
-        └── SKILL.md
+/datus-plugin-development ./docs/openapi.yaml, command name: acme
 ```
 
-The setup `SKILL.md` should cover, in order:
+A URL or a directory containing several related documents can be used in place
+of the file path. Add any scope or compatibility requirements to the same
+request.
 
-1. **When to use** — the plugin is unconfigured, or the user wants another
-   environment.
-2. **Config structure** — a complete YAML template for
-   `agent.plugins.<name>.<profile>`, with comments marking required / optional
-   / secret fields.
-3. **Ask the user** — list the fields that must come from the user (endpoint,
-   auth choice, ...). For secrets, instruct the agent to have the user export
-   an environment variable and reference it as `${VAR}` in the YAML — never
-   write literal secrets to the file.
-4. **Write the config** — into the file named by the `## Plugins` prompt
-   preamble, marking the first profile `default: true`.
-5. **Verify** — a cheap read-only command (e.g. `datus hello version`).
-   `datus <plugin>` reloads the config on every invocation, so the profile
-   works immediately; the prompt's environment list refreshes next session.
+## What happens next
 
-Declare `requires_mutable_config: true` in the setup skill's frontmatter.
-Datus then hides the skill from `<available_skills>` and refuses `load_skill`
-in deployments where the agent config is read-only (multi-tenant chat API /
-gateway) — the agent defers to the administrator instead of walking the user
-through an edit it cannot make. Keep an in-body guard note as a fallback for
-older datus-agent versions that ignore the frontmatter field: if the current
-environment cannot edit the config file, the agent should tell the user to
-edit `agent.yml` on the server instead.
+The skill follows a design-first workflow:
 
-A complete minimal `hello-setup/SKILL.md`:
+1. **Review the source documentation.** It inventories the available
+   operations, authentication requirements, configuration, and dependencies.
+2. **Propose a design.** You receive a draft covering the proposed commands,
+   configuration fields, permission behavior, bundled skills, and anything
+   intentionally left out.
+3. **Review the scope.** The skill stops before writing code. Confirm the
+   proposal, request changes, or bring excluded operations back into scope.
+4. **Build the plugin.** After you approve the design, the skill creates the
+   working plugin, supporting skills, and tests.
+5. **Verify the result.** It runs the relevant tests and checks installation,
+   CLI dispatch, bundled skills, and packaging.
 
-````markdown
----
-name: hello-setup
-description: Configure an environment profile for the `datus hello` plugin
-requires_mutable_config: true
----
+This confirmation step is important: it keeps a large vendor API from becoming
+an equally large CLI by accident, while leaving the final scope in your hands.
 
-# Hello Setup
+## Try the generated plugin
 
-Use this skill when `datus hello` is installed but has no configured
-environment, or when the user wants to add another one.
-
-## Config structure
-
-Profiles live under `agent.plugins.hello.<profile>` in the config file named
-by the `## Plugins` section of the system prompt:
-
-```yaml
-agent:
-  plugins:
-    hello:
-      prod:
-        default: true            # mark the first profile as default
-        greeting: Hi             # required
-        token: ${HELLO_TOKEN}    # secret — reference an env var, never a literal
-```
-
-## Steps
-
-1. Ask the user for `greeting` and which environment variable holds the
-   token. Have the user export the variable; write `${VAR}` into the YAML —
-   never a literal secret.
-2. Write the profile into the config file above; mark the first profile
-   `default: true`.
-3. Verify with a cheap read-only call: `datus hello Ada`.
-
-If this environment cannot edit the config file (API / web deployment), tell
-the user to edit `agent.yml` on the server instead.
-````
-
-## Verifying your plugin end-to-end
-
-After `pip install -e`, each surface can be checked without restarting
-anything (plugins are discovered per invocation):
-
-- **CLI dispatch** — run `datus <name> ...` from any directory. If it falls
-  through to the REPL instead, the entry point is missing or misnamed, or the
-  manifest was rejected (check the log); `datus <name>` printing "declares no
-  CLI command" means the manifest loaded but has no `cli` key. Check
-  `pip show -f your-package` for the `entry_points.txt` and the bundled
-  `datus-plugin.yml`.
-- **Skills** — start `datus` and run `/skill list`; plugin-bundled skills
-  appear alongside project and user skills.
-- **Prompt injection** — render the template in a unit test (next section).
-  To confirm it lands in a live session, start `datus` and ask the agent
-  "which plugins are configured?" — the answer comes from the injected
-  section. Note that config edits take effect on the next `datus <plugin>`
-  invocation immediately, but the prompt section refreshes only on the next
-  session.
-
-## Testing your plugin
-
-Because Datus is the broker, unit tests call your functions with a plain dict
-— no `agent.yml`, no Datus imports. Validate the manifest and template with
-plain YAML/Jinja2 tooling:
-
-```python
-from pathlib import Path
-
-import yaml
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
-
-from datus_plugin_hello.cli import main
-
-PKG = Path(__file__).parent.parent / "datus_plugin_hello"
-
-
-def test_cli_uses_profile_greeting(capsys):
-    rc = main(["Ada"], {"name": "prod", "greeting": "Hi"})
-    assert rc == 0
-    assert "Hi, Ada!" in capsys.readouterr().out
-
-
-def test_manifest_is_valid():
-    manifest = yaml.safe_load((PKG / "datus-plugin.yml").read_text())
-    assert manifest["manifest_version"] == 1
-    assert manifest["cli"] == "datus_plugin_hello.cli:main"
-    # every declared path exists in the package
-    assert (PKG / manifest["skills"]).is_dir()
-    assert (PKG / manifest["system_prompt"]).is_file()
-
-
-def test_prompt_template_renders_without_secrets():
-    env = Environment(loader=FileSystemLoader(PKG), undefined=StrictUndefined)
-    template = env.get_template("prompts/system.md.j2")
-    # datus strips undeclared / x-secret fields before rendering; emulate that.
-    ctx = {"plugin_name": "hello", "config_path": None, "config_mutable": True}
-    text = template.render(profiles={"prod": {"greeting": "Hi"}}, **ctx)
-    assert "## Hello" in text
-    text = template.render(profiles={}, **ctx)
-    assert "hello-setup" in text
-    # read-only deployments must not be pointed at the setup skill
-    text = template.render(profiles={}, plugin_name="hello", config_path=None, config_mutable=False)
-    assert "hello-setup" not in text
-```
-
-## Distributing for offline install
-
-Bundle your plugin into a wheelhouse `.zip` with `datus plugin pack`, run from
-the plugin's project directory where you have network:
+After implementation, install the local project and inspect its CLI:
 
 ```bash
-datus plugin pack -o ./dist               # plugin wheel only (default)
-# → ./dist/datus-plugin-hello-1.0.0.zip
-
-datus plugin pack --with-deps -o ./dist   # plugin wheel + every dependency wheel
+datus plugin install src:./datus-acme-plugin
+datus acme --help
 ```
 
-The bundle is a zip of a `datus-bundle.json` manifest plus a `wheels/`
-wheelhouse. `pack` verifies the wheel declares a module-ref `datus.plugins`
-entry point **and** bundles its `datus-plugin.yml` — a wheel missing either is
-refused before any dependency download. Users install it via `datus plugin
-install zip:./….zip` (see
-[Offline install](introduction.md#offline-install-air-gapped)). Choose the
-flavor:
+To build a distributable bundle:
 
-- **Default (plugin wheel only)** — a small bundle; the target machine resolves
-  dependencies from a package index at install time (needs network).
-- **`--with-deps`** — every transitive dependency wheel is bundled so the install
-  is fully offline (`pip install --no-index --find-links`). `pack` uses
-  `pip download --only-binary=:all:`, so every dependency must publish a wheel
-  (no sdist-only packages). A pure-Python dependency set is portable; a
-  dependency with a native extension makes the bundle a **same-platform
-  snapshot** — build it on a machine matching the target's OS/Python.
-- **A declared `Requires-Python`.** Set it in `pyproject.toml`; `pack` copies it
-  into the manifest so install can reject a mismatched interpreter early (with a
-  clear message, overridable via `--force`).
+```bash
+datus plugin pack ./datus-acme-plugin -o ./dist
+```
 
-## Constraints checklist
+Use `--with-deps` when the target environment must install the bundle without
+access to a package index. See
+[Offline installation](introduction.md#offline-install) for the difference
+between the two bundle types.
 
-Before publishing, verify:
+## Source of truth
 
-- [ ] The package does **not** `import datus` anywhere (`grep -rn "import datus" your_pkg/`).
-- [ ] The package does **not** depend on `datus` or a shared plugin SDK in `pyproject.toml`.
-- [ ] The `datus.plugins` entry-point value is the **package name** (no `:Class` part).
-- [ ] The entry-point name is not a reserved name (`upgrade`, `skill`, `plugin`) and does not start with `-`.
-- [ ] `datus-plugin.yml` sits at the package root, declares `manifest_version: 1`, and ships in the wheel (`unzip -l dist/*.whl`).
-- [ ] The `cli` function signature is `main(argv: list[str], profile: dict) -> int | None` and does not call `sys.exit()` on the success path.
-- [ ] Secret config fields are marked `x-secret: true` in `config_schema`.
-- [ ] The system-prompt template handles `profiles == {}` via `{% if profiles %}`.
-- [ ] `permissions` patterns are namespace-relative (no `datus <name>` prefix — Datus adds it), and state-changing subcommands are `ask` under `normal`.
-- [ ] Skill files and the prompt template are packaged into the wheel.
-- [ ] The entry-point name matches the intended `datus <name>` command and the `agent.plugins.<name>` config key.
+Use these resources when you need more detail:
 
-## Reference
-
-- **Entry-point group**: `datus.plugins` — one entry per plugin, whose value is the plugin **package name**.
-- **Contract source of truth**: `datus/plugins/base.py` (the `datus-plugin.yml` manifest spec).
-- **Related**: [Plugin Introduction](introduction.md), [Skills](../skills/introduction.md).
+- [Development skill source](https://github.com/Datus-ai/Datus-Plugins/blob/main/skills/datus-plugin-development/SKILL.md) —
+  the current development workflow and plugin contract.
+- [Datus-Plugins README](https://github.com/Datus-ai/Datus-Plugins#develop-your-own-plugin) —
+  marketplace installation and repository examples.
+- [Contributing to Datus Plugins](https://github.com/Datus-ai/Datus-Plugins/blob/main/CONTRIBUTING.md) —
+  workspace setup, tests, pull requests, and releases.
+- [Plugin introduction](introduction.md) — installing, configuring, and
+  managing plugins as a user.

--- a/docs/plugin/development.zh.md
+++ b/docs/plugin/development.zh.md
@@ -1,792 +1,105 @@
-# Plugin 开发
+# 开发插件
 
-本指南讲解如何开发一个 Datus plugin:从一个最小可用的 `hello` 命令出发,逐步覆盖
-完整契约。关于 plugin 是什么、用户如何安装配置、profile 如何解析,请先阅读
-[介绍](introduction.zh.md)。
+推荐使用
+[`datus-plugin-development`](https://github.com/Datus-ai/Datus-Plugins/blob/main/skills/datus-plugin-development/SKILL.md)
+skill 开发 Datus 插件。这个 skill 来自
+[`Datus-Plugins`](https://github.com/Datus-ai/Datus-Plugins) 项目。
 
-plugin 是一个可安装的 Python 包,通过 `datus.plugins` entry-point 组被发现。
-最关键的约束:
+你只需要提供想要封装的 SDK、API 规范或产品文档。skill 会帮助你确定命令范围、
+生成插件，并验证最终结果。插件契约已经包含在 skill 中，因此本文只介绍开发流程，
+不再重复容易过时的实现细节。
 
-- **plugin 绝不 `import datus.*`**,也不依赖任何共享 SDK。
-- **整个契约就是一个声明式文件**——随包分发的 `datus-plugin.yml`。它声明你的 CLI
-  入口函数、tool transformer、skills 目录、系统提示词模板、bash 权限规则和配置
-  schema。你唯一要写的 Python 只是普通函数。
+## 开始前的准备
 
-Datus 是 *配置 broker*——它负责读 `agent.yml`、展开 `${VAR}`、解析激活 profile,
-然后用一个普通 `dict` 调用你声明的 `cli` 函数。读取 manifest 不会执行你的任何
-代码:skills、权限、提示词、配置 schema 的收集全程不 import 你的包;只有 `cli`
-函数(在 `datus <name> ...` 分发时)和声明的 tool transformer 才会被惰性导入。
+请准备以下信息：
 
-## 前置条件
+- 想要接入 Datus 的 SDK、REST API、OpenAPI 规范、CLI 文档或 README。可以提供
+  本地路径，也可以提供公开 URL。
+- 一个简短的命令名。例如，Airflow 插件对应 `datus airflow`。
+- 对功能范围的要求，例如优先支持哪些操作，或明确排除哪些管理类功能。
 
-- 一个能安装到与 `datus` 同一环境的 Python 包。
-- 已安装 `datus`(`pip install datus-agent` 或源码 checkout)。
-- Python 3.12+——plugin 运行在 datus 自己的解释器里(`datus-agent` 声明
-  `requires-python >= 3.12`),你的代码和依赖必须与之兼容。
+你只需要提供原始资料，并说明希望插件完成什么。具体实现由开发 skill 处理。
 
-## 快速开始:最小 plugin
+## 安装开发 skill
 
-**1. 包结构**
+### Codex
 
-```text
-datus-plugin-hello/
-├── pyproject.toml
-└── datus_plugin_hello/
-    ├── __init__.py
-    ├── datus-plugin.yml      # manifest——整个 plugin 契约
-    └── cli.py
-```
-
-**2. manifest**(`datus_plugin_hello/datus-plugin.yml`)
-
-```yaml
-manifest_version: 1
-description: "Say hello to someone."
-cli: datus_plugin_hello.cli:main
-```
-
-**3. CLI 函数**(`datus_plugin_hello/cli.py`)
-
-```python
-from __future__ import annotations
-
-
-def main(argv: list[str], profile: dict) -> int:
-    # `profile` 是解析好的 agent.plugins.hello.<profile> 字典
-    # (已由 datus 完成 ${VAR} 展开)。空字典也没问题。
-    greeting = profile.get("greeting", "Hello")
-    name = argv[0] if argv else "world"
-    print(f"{greeting}, {name}!")
-    return 0
-```
-
-**4. 注册 entry-point**(`pyproject.toml`)
-
-```toml
-[project]
-name = "datus-plugin-hello"
-version = "0.1.0"
-dependencies = []                      # 注意:不要依赖 datus
-
-[project.entry-points."datus.plugins"]
-hello = "datus_plugin_hello"           # 包名——不是类
-
-[tool.setuptools.package-data]
-datus_plugin_hello = ["datus-plugin.yml"]
-```
-
-entry-point 的值是你的**包名**——一条纯粹的"名字 → 包"映射,不是代码引用。
-entry-point 的名字(`hello`)唯一决定 CLI 命令(`datus hello`)和配置键
-(`agent.plugins.hello`)——包名可以随意取。三个名字是**保留字**,永远不会分发给
-plugin:`upgrade`、`skill`、`plugin`。注册在这些名字下的 plugin 不可达
-(`datus plugin install` 也会拒绝),以 `-` 开头的名字则完全无法分发。
-
-manifest 是包数据而非 Python 代码——务必确保它进入 wheel。Hatchling 默认打包包
-目录下所有文件;setuptools 需要上面的 `[tool.setuptools.package-data]` 配置。
-用 `unzip -l dist/*.whl | grep datus-plugin.yml` 验证(`datus plugin install`
-和 `datus plugin pack` 都会拒绝缺失 manifest 的包)。
-
-**5. 安装并运行**
+先添加 Datus 插件市场：
 
 ```bash
-datus plugin install src:./datus-plugin-hello   # 安装到 ~/.datus/plugins/hello/
-datus hello Ada          # -> Hello, Ada!
+codex plugin marketplace add Datus-ai/Datus-Plugins
 ```
 
-开发期想要快速的改-跑循环,也可以直接 `pip install -e datus-plugin-hello` 到
-datus 自己的环境——这类 plugin 作为回退同样会被发现,只是没有
-`~/.datus/plugins/` 目录。
+然后打开 `/plugins`，安装 **datus-plugin-development**，并新建一个会话。
 
-以上就是一个完整的 plugin。下面的内容全部是可选扩展面。
+### Claude Code
 
-## manifest 参考
-
-`datus-plugin.yml` 位于包根。只有 `manifest_version` 必填,其余键全部可选:
-
-| 键 | 类型 | 用途 |
-|---|---|---|
-| `manifest_version` | int,**必填** | 必须是 `1`。比 datus 能理解的更新的版本会被拒绝并警告"requires newer datus"。 |
-| `description` | 字符串 | 一行摘要,`datus plugin info` 展示。 |
-| `cli` | 代码引用 | `module.path:function`,在 `datus <name> ...` 时以 `main(argv, profile)` 调用。见[实现 CLI 入口](#实现-cli-入口)。没有它时 `datus <name>` 以退出码 2 结束。 |
-| `tool_transformers` | 映射 | 工具 pattern → 代码引用(或引用列表),改写或拒绝 agent 的工具调用。见[工具参数 transformer](#工具参数-transformer)。 |
-| `permissions` | 映射 | 你自己 CLI 命名空间的 bash 权限规则,按权限 profile 分组——纯 YAML,零代码。见[CLI bash 权限](#cli-bash-权限)。 |
-| `system_prompt` | 路径 | 包内相对路径,指向渲染进 agent 系统提示词的 Jinja2 模板。见[系统提示词模板](#系统提示词模板)。 |
-| `skills` | 路径 | 包内相对路径,指向捆绑的 skill 目录。见[捆绑 skills](#捆绑-skills)。 |
-| `config_schema` | JSON Schema | 内联 object schema,描述一个 profile——驱动 `/plugins` TUI 表单并在保存前校验。见[配置 schema 与校验](#配置-schema-与校验)。 |
-
-**代码引用**是形如 `module.path:function` 的点分字符串。路径均相对包目录,且不
-允许逃逸出去。manifest 解析是防御式的:某一段格式错误只会被警告并丢弃,其余部分
-照常可用;只有 `manifest_version` 缺失/不支持(或 YAML 不可读)才会整体拒绝。
-
-机器可读的契约在 `datus/plugins/base.py`;本表与该 docstring 保持同步。
-
-## 配置:Datus 交给你什么
-
-用户在 `agent.plugins.<name>` 下配置你的 plugin,`<name>` 下的每个键都是一个
-**profile**(一个环境):
-
-```yaml
-agent:
-  plugins:
-    hello:
-      prod:
-        default: true
-        greeting: Hi
-        token: ${HELLO_TOKEN}      # secret 建议用 ${ENV_VAR}
-      staging:
-        greeting: Yo
-```
-
-Datus 把它解析成 `agent.plugins.<name>.<profile> -> dict`,**按 profile 展开
-`${VAR}`**,并注入一个等于 profile 名的 `name` 键。哪个 profile 字典进入你的
-`cli` 函数由 Datus 决定——显式 `--profile`、项目 pin、`default: true`、唯一
-profile,或在完全未配置时给一个空字典。完整解析顺序见
-[介绍](introduction.zh.md#which-profile-runs);这些逻辑你一行都不用写,你的函数
-只管接收解析好的 `dict`。
-
-本地测试时,把 profile 写进你的 datus 会话实际加载的那个配置文件(显式
-`--config` → `./conf/agent.yml` → `~/.datus/conf/agent.yml`)。
-
-## 配置 schema 与校验
-
-声明一个 `config_schema`——描述**单个 profile** 的内联 JSON Schema——之后
-`/plugins` TUI 会渲染出真正的表单(而非自由键值编辑),Datus 也会在保存前用它
-校验候选 profile:
-
-```yaml
-config_schema:
-  type: object
-  required: [token, s3]
-  properties:                    # 属性顺序 == TUI 字段顺序
-    token:
-      type: string
-      description: "API token"
-      x-secret: true             # TUI 中掩码显示,提示词渲染时被剥离
-    greeting:
-      type: string
-      description: "Greeting word"
-      default: "Hi"
-    s3:                          # 嵌套 object 会展开为点分表单字段
-      type: object
-      required: [secret_access_key]
-      properties:
-        region: {type: string, default: us-east-1}
-        secret_access_key: {type: string, x-secret: true}
-```
-
-语义:
-
-- **`x-secret: true`** 标记 secret 字段:TUI 掩码显示并提示用户输入
-  `${ENV_VAR}` 引用,系统提示词渲染器会剥离它(见
-  [系统提示词模板](#系统提示词模板))。它是属性级扩展关键字——JSON Schema
-  校验器会忽略它。
-- **`required`** 成员标记表单必填字段;**`default`** 会直接预填为字段初始值。
-  留空的字段(无 default 且尚未输入)会以浅色占位符显示其 `description`。
-- **嵌套 object** —— 带自身 `properties` 的 `type: object` 属性在 TUI 中展开
-  为每个叶子一个字段,字段名为点分路径(`s3.region`、`s3.secret_access_key`);
-  提交时按嵌套结构重新组装后再保存。object 上的 `x-secret: true` 会把所有叶子
-  标记为 secret;叶子只有在整条祖先路径都必填时才是表单必填。系统提示词的
-  白名单剥离也按同样规则递归过滤已声明的嵌套 object。
-- **自由 object 会整体透传。** **没有**自身 `properties` 的 `type: object`
-  属性(自由字典)*不会*逐键过滤:TUI 把它当作单个字段,系统提示词渲染器会把
-  它存储的整个值原样送进提示词。被跳过的只是逐键剥离——字段本身仍须先声明——
-  因此这种字段里嵌套的任何 secret 都会到达 LLM。要么声明其子 `properties`
-  (以获得递归过滤),要么把整个 object 标记为 `x-secret: true`。
-- **校验**在原始候选字典上运行 `jsonschema`(用户刚输入、**尚未** `${VAR}` 展开
-  的值)。含 `${ENV_VAR}` 占位符的值被视为不透明——针对它们的
-  pattern/enum/format 违规会被抑制,但缺失 `required` 字段仍会报错。真正的运行
-  时校验放在你的 `cli` 函数里。
-- **TUI 输入的值都是字符串**,所以优先用 `type: string` 配合 `pattern` /
-  `enum` 约束;其他类型留给手写 `agent.yml` 的场景。
-- schema 本身非法(被 JSON Schema 元 schema 拒绝)时只会警告并视为不存在——TUI
-  回退到自由编辑。
-
-## 实现 CLI 入口
-
-manifest 的 `cli` 指向一个以 `main(argv, profile)` 调用的函数:
+添加插件市场并安装插件：
 
 ```text
-datus hello --profile staging greet Ada
-                └── 被剥离 ──┘ └── argv = ["greet", "Ada"] ──┘
+/plugin marketplace add Datus-ai/Datus-Plugins
+/plugin install datus-plugin-development@datus-plugin
 ```
 
-只有出现在**第一个非选项 token 之前**的 `--profile` / `--config` 会被当作
-Datus 全局参数消费;从第一个命令 token 起的一切都属于 plugin。因此
-`datus hello greet --profile staging` 会原样传入
-`["greet", "--profile", "staging"]`——你的子命令可以自由定义自己的 `--profile`。
+## 创建插件
 
-在只读的多租户 API 会话中,Datus 可能从当前请求的内存 `AgentConfig` 取得
-profile,并通过仅对子进程生效的环境变量完成桥接。该传输由宿主管理:plugin 应继续
-使用传入的 `profile` 参数,也允许从这个字典读取自己的配置;不要依赖内部环境变量。
-此模式支持 `--profile`,但会拒绝 `--config`,也会拒绝普通 `|` 管道以外的复合
-shell 形式。
+调用 skill 时，传入文档位置和期望的命令名。
 
-返回整数退出码(`None` 视为 `0`)。建议的约定:
-
-| 退出码 | 含义 |
-|---|---|
-| `0` | 成功 |
-| `1` | 运行时错误 |
-| `2` | 用法错误 |
-| `3` | 配置错误 |
-| `8` | 缺少可选依赖 |
-
-直接抛异常也可以——Datus 会捕获 `cli` 函数的异常并映射为退出码 `1`,不会让 CLI
-崩溃——但显式返回退出码能给用户更清晰的信号。
-
-## 配方:把函数和 API 包装成 CLI
-
-`cli` 函数收到的是原始 `argv` 列表,路由方式完全自由。以下是四种常见模式,从最
-快到最丰富。
-
-### A. 字典分发——几个函数,零依赖
-
-```python
-def main(argv, profile):
-    if not argv:
-        print("usage: datus toolbox <add|upper> ...")
-        return 2
-    cmd, rest = argv[0], argv[1:]
-    handlers = {"add": _add, "upper": _upper}
-    handler = handlers.get(cmd)
-    if handler is None:
-        print(f"unknown command: {cmd}")
-        return 2
-    return handler(rest)
-
-
-def _add(args):          # datus toolbox add 1 2 3
-    print(sum(float(a) for a in args))
-    return 0
-
-
-def _upper(args):        # datus toolbox upper hello
-    print(" ".join(args).upper())
-    return 0
-```
-
-### B. argparse——带类型的参数、flag、自动 usage/`-h`
-
-标准库,零额外依赖。`argparse` 在 `-h` 或错误用法时打印 usage 并抛
-`SystemExit`;Datus 将其转成对应退出码(`-h` 为 0,用法错误为 2),这正是常规
-CLI 行为。
-
-```python
-import argparse
-
-
-def main(argv, profile):
-    parser = argparse.ArgumentParser(prog="datus toolbox")
-    sub = parser.add_subparsers(dest="cmd", required=True)
-
-    p_add = sub.add_parser("add", help="sum numbers")
-    p_add.add_argument("nums", nargs="+", type=float)
-
-    p_grep = sub.add_parser("grep", help="filter lines in a file")
-    p_grep.add_argument("pattern")
-    p_grep.add_argument("path")
-    p_grep.add_argument("-i", "--ignore-case", action="store_true")
-
-    ns = parser.parse_args(argv)      # -h / 错误用法时抛 SystemExit
-    if ns.cmd == "add":
-        print(sum(ns.nums))
-        return 0
-    if ns.cmd == "grep":
-        return _grep(ns.pattern, ns.path, ns.ignore_case)
-
-
-def _grep(pattern, path, ignore_case):
-    needle = pattern.lower() if ignore_case else pattern
-    with open(path, encoding="utf-8") as fh:
-        for line in fh:
-            hay = line.lower() if ignore_case else line
-            if needle in hay:
-                print(line.rstrip())
-    return 0
-```
-
-### C. 包装 REST API
-
-从 profile 读取端点和凭证(Datus 已展开 `${VAR}`),把子命令映射为请求。凭证
-只放在 profile 里——绝不硬编码,也绝不回显。
-
-```python
-import argparse
-import json
-
-
-def main(argv, profile):
-    import requests  # plugin 可以有自己的依赖
-
-    base = profile.get("api_base_url")
-    if not base:
-        print("no api_base_url configured for the profile")
-        return 3
-    headers = {}
-    if profile.get("token"):
-        headers["Authorization"] = f"Bearer {profile['token']}"
-
-    parser = argparse.ArgumentParser(prog="datus petstore")
-    sub = parser.add_subparsers(dest="cmd", required=True)
-    sub.add_parser("list-pets")
-    p_get = sub.add_parser("get-pet")
-    p_get.add_argument("id")
-    ns = parser.parse_args(argv)
-
-    base = base.rstrip("/")
-    if ns.cmd == "list-pets":
-        resp = requests.get(f"{base}/pets", headers=headers, timeout=30)
-    else:
-        resp = requests.get(f"{base}/pets/{ns.id}", headers=headers, timeout=30)
-
-    if resp.status_code >= 400:
-        print(f"error {resp.status_code}: {resp.text}")
-        return 1
-    print(json.dumps(resp.json(), indent=2))
-    return 0
-```
-
-对应配置:
-
-```yaml
-agent:
-  plugins:
-    petstore:
-      prod:
-        default: true
-        api_base_url: https://api.example.com/v1
-        token: ${PETSTORE_TOKEN}
-```
-
-### D. Typer / Click——最丰富的体验,一个额外依赖
-
-命令面很大时,[Typer](https://typer.tiangolo.com/) 这类框架能提供帮助文本、类型
-转换和补全。由于 Datus 每次调用你的入口函数,而 Typer app 是模块级对象,可通过
-模块全局变量把当前 profile 暴露给命令读取。
-
-```python
-import typer
-
-app = typer.Typer(add_completion=False)
-_ACTIVE_PROFILE: dict = {}
-
-
-@app.command("greet")
-def greet(name: str, loud: bool = False):
-    greeting = _ACTIVE_PROFILE.get("greeting", "Hello")
-    msg = f"{greeting}, {name}!"
-    print(msg.upper() if loud else msg)
-
-
-def main(argv, profile):
-    global _ACTIVE_PROFILE
-    _ACTIVE_PROFILE = profile
-    try:
-        # standalone_mode=False 阻止 Click 自己调用 sys.exit,
-        # 这样我们能返回退出码并保证清理 profile。
-        app(args=argv, standalone_mode=False)
-        return 0
-    except SystemExit as exc:      # -h / 用法错误
-        return int(exc.code or 0)
-    except typer.Exit as exc:
-        return exc.exit_code
-    finally:
-        _ACTIVE_PROFILE = {}
-```
-
-把 `typer` 加进你自己包的 `dependencies`(plugin 的依赖归它自己——只是不能有
-`datus`)。
-
-## 捆绑 skills
-
-在 manifest 里声明一个包内相对路径的 skills 目录,Datus 启动时即发现这些 skill
-(出现在 `/skill list`,与项目和用户 skill 并列)——零代码:
-
-```yaml
-skills: skills
-```
-
-目录与打包:
+在 Codex 中：
 
 ```text
-datus_plugin_hello/
-├── datus-plugin.yml
-└── skills/
-    └── hello/
-        └── SKILL.md
+$datus-plugin-development ./docs/openapi.yaml，命令名使用 acme
 ```
 
-最小的 `SKILL.md` 是 YAML frontmatter 加 markdown 说明(frontmatter 遵循
-Skills 系统使用的 [agentskills.io](https://agentskills.io) 规范):
-
-```markdown
----
-name: hello
-description: Say hello to someone via the `datus hello` CLI
----
-
-# Hello
-
-Run `datus hello <name>` to greet someone. ...
-```
-
-完整 frontmatter 字段参考见 [Skills](../skills/introduction.zh.md) 文档。
-
-在多租户 API 部署中,skill 发现由当前请求的 `AgentConfig` 限定
-(`plugins_enabled`、激活 plugin、`plugin_paths` 和 `skills`),plugin skill 不依赖
-本地 `./.datus/config.yml`。
-
-确保 skill 文件被打进 wheel(它们是数据,不是 Python 代码)。Hatchling 默认打包
-包目录下所有文件,除非文件被 VCS 忽略(那样需要在
-`[tool.hatch.build.targets.wheel] artifacts` 列出);setuptools 必须显式声明:
-
-```toml
-[tool.setuptools.package-data]
-datus_plugin_hello = ["datus-plugin.yml", "skills/**/*", "prompts/*"]
-```
-
-构建后用 `unzip -l dist/*.whl | grep SKILL.md` 验证。
-
-## 系统提示词模板
-
-plugin 可以预先告诉 agent 它是什么、配置了哪些环境——让模型主动选择它而不是靠
-猜。在 manifest 里声明一个 Jinja2 模板:
-
-```yaml
-system_prompt: prompts/system.md.j2
-```
-
-```jinja
-## Hello
-Say hello via `datus hello <name>`.
-
-{% if profiles %}
-Environments ({{ profiles | length }}):
-{% for name, cfg in profiles.items() %}
-- {{ name }}: {{ cfg.get("greeting", "?") }}
-{% endfor %}
-{% else %}
-Installed but not configured.
-{% if config_mutable %}
-Run the `hello-setup` skill to configure an environment.
-{% else %}
-Configuration is managed by the deployment administrator — tell the user to
-contact them.
-{% endif %}
-{% endif %}
-```
-
-渲染上下文:
-
-| 变量 | 值 |
-|---|---|
-| `plugin_name` | 你的 entry-point 名 |
-| `profiles` | `dict[str, dict]`——plugin 的 profile 映射,**已收窄到项目激活的 profile**(`./.datus/config.yml` 的 `plugins.<name>.active_profile`)且**已剥离 secret**(见下) |
-| `config_path` | 已加载的 agent 配置文件路径,或 `None`(配置只读时恒为 `None`) |
-| `config_mutable` | agent 可编辑配置文件时为 `True`;托管部署(多租户 chat API / gateway)下为 `False`。需要引入该变量的 datus-agent 版本及以上——旧版本中引用它的模板会渲染失败(严格模式)并跳过该 section |
-
-已安装但未配置的 plugin(或 pin 无匹配)渲染时 `profiles == {}`——用
-`{% if profiles %}` 输出一段"已安装未配置"提示而不是从提示词中消失,并在该
-分支内检查 `config_mutable`:仅当它为 `True` 时指向捆绑的 setup skill,否则
-提示用户联系管理员。
-
-只要有任一 plugin 贡献了 section,Datus 会前置自己的 `## Plugins` 导语,写明已
-加载的配置文件和 `agent.plugins.<plugin>.<profile>` 结构——你的模板永远不需要
-硬编码配置路径。只读模式下导语会换成禁止建议修改配置、请联系管理员的措辞。
-
-!!! note "secret 是结构性剥离的"
-    渲染出的文本会进入 LLM 上下文,而 profile 的值在提示词构建时已完成
-    `${VAR}` 展开(是真实明文 secret)——所以 Datus 在模板看到 profiles
-    **之前**就做了过滤:只有在你的 `config_schema` 中声明且**未**标记
-    `x-secret: true` 的字段才会通过;未声明的字段同样被丢弃,已声明的嵌套
-    object(带自身 `properties` 的 `type: object`)也按同样规则递归过滤。
-    唯一例外是**自由** object 字段(声明为 `type: object` 但没有 `properties`):
-    它的整个值会原样透传,若可能存放敏感内容,请把它标记为 `x-secret: true`。
-    没有 `config_schema` 时,模板只能拿到 profile 名和空字典。模板若引用被剥离的
-    字段会渲染失败(严格模式)并跳过该 section——永远不可能泄漏。
-
-模板错误(文件缺失、语法错误、未定义变量)只会记录日志并跳过该 section——绝不
-影响提示词构建。模板以严格模式(`StrictUndefined`)渲染,笔误会出现在日志里,
-而不是变成悄悄错误的提示词文本。
-
-## CLI bash 权限
-
-当 **agent**(而非人)通过它的 bash 工具运行你的 CLI——例如模型决定执行
-`datus hello greet Ada`——命令会经过 Datus 的权限层。没有声明时,agent 发出的
-每条 plugin 命令都会请求用户确认。manifest 的 `permissions` 键按权限 profile 声
-明你的哪些子命令可以自动运行(`allow`)、哪些必须确认(`ask`)、哪些被阻止
-(`deny`)——纯 YAML,零代码:
-
-```yaml
-permissions:
-  normal:
-    allow: ["greet:*"]
-    ask: ["config set:*"]
-  auto:
-    allow: ["greet:*", "config set:*"]
-```
-
-语义:
-
-- **模式相对于你的命名空间。**Datus 给每个模式加 `datus <name> ` 前缀,
-  `greet:*` 变成 `datus hello greet:*`。plugin 永远影响不到 `datus <name>` 之外
-  的命令——不能碰 `rm`,也不能碰别的 plugin。
-- **模式语法**与 `agent.yml` 的 `permissions.bash_commands` 一致:`cmd` 精确
-  匹配,`cmd:*` 前缀匹配,`cmd:glob` 前缀匹配且第一个参数需满足 glob(如
-  `greet:A*`)。裸 `:*` 覆盖整个命名空间。
-- **profile 键**:只接受 `normal` 和 `auto`。`dangerous` profile 按设计忽略所有
-  命令级 bash 规则;`dangerous` 键会被警告并丢弃。
-- **用户永远优先。**用户在 `agent.yml` 写的 `deny` 覆盖 plugin 的 `allow`
-  (deny > ask > allow,与声明顺序无关),plugin 声明也永远改不了 profile 的默认
-  姿态。
-- **`ask` 规则可以按项目放宽。**agent 撞上你声明的 `ask` 子命令时,确认提示会
-  提供"allow (project)"选项——选择后把精确匹配到的模式(如
-  `datus hello config set:*`)持久化到项目 `.datus/config.yml` 的 `bash_allow`
-  列表,此后该子命令自动运行。授权只精确匹配:永远不会扩大到命名空间的其余部
-  分,你的 `deny` 规则也不受影响。(用户自己在 `agent.yml` 写的 `ask` 规则没有
-  这个选项——放宽它们应该改用户自己的配置。)
-- **范围**:只有 agent 的 bash 工具被管控。人在终端里敲 `datus hello ...` 永远
-  不受影响。`plugins_enabled: false` 会连同插件系统的其余部分一起禁用收集(见
-  [介绍](introduction.zh.md#disabling-the-plugin-system))。
-- **`--profile` 对匹配透明。**`datus hello --profile prod config set x` 匹配的
-  规则(和项目授权)与不带该参数的形式相同——前导的 datus 全局 flag 在求值前被
-  归一化掉。`--config <path>` 刻意**不**归一化:把 datus 指向另一个配置文件会重
-  绑凭证,这类调用总是回退到确认。
-- 畸形声明(类型错误、未知键、空模式)只会记录日志并跳过——绝不影响 Datus 启动。
-
-只读子命令声明为 `normal` 下的 `allow`,变更状态的声明为 `ask`;只有重复执行无
-害的常规变更才在 `auto` 下提升为 `allow`。
-
-## 工具参数 transformer
-
-manifest 的 `tool_transformers` 键让 plugin 拦截 **agent 的工具调用**——在工具
-执行前检查并改写参数,或直接拒绝调用。典型用例是 SQL 策略强制:给每条
-`execute_sql` 查询追加租户范围谓词,使用部署注入的请求 principal。
-
-```yaml
-tool_transformers:
-  "db_tools.execute_sql": datus_plugin_scoped_sql.transformers:enforce_tenant_scope
-```
-
-```python
-# datus_plugin_scoped_sql/transformers.py
-def enforce_tenant_scope(tool_name, args, context):
-    tenant_id = (context.get("principal") or {}).get("tenant", {}).get("id")
-    if not tenant_id:
-        raise PermissionError("missing principal.tenant.id; cannot scope query")
-    args["sql"] = add_where_predicate(args["sql"], f"tenant_id = '{tenant_id}'")
-    return args
-```
-
-语义:
-
-- **声明形状**:工具 pattern 到代码引用(或引用列表)的映射。pattern 使用 proxy
-  语法——裸工具名(`execute_sql`),或带 fnmatch glob 的 `category.method`
-  (`db_tools.*`)。
-- **transformer 签名**:`transformer(tool_name, args, context) -> dict`,同步或
-  异步均可。返回(可能已修改的)参数字典则继续执行。**抛异常即拒绝**:工具不会
-  运行,模型把你的异常消息当作普通工具失败收到。返回非 dict 同样拒绝,fail
-  closed。
-- **`context`** 是普通字典,含 `node_name`、`principal`(请求级调用方属性,部署
-  未设置时为空)、`project_root` 和 `agent_config`(存活的 agent 配置对象——用
-  `context["agent_config"].get_plugin_profile("<name>")` 读取你自己的 profile;
-  鸭子类型访问,绝不为此 `import datus.*`)。它在每次调用时重建,请求级的值总是
-  新鲜的。
-- **加载是惰性的**:被引用的模块在为 agent 节点首次收集 transformer 时才导入,
-  而不是在 manifest 加载时。导入失败(或不可调用)的引用会被警告并跳过——plugin
-  其余的 transformer 仍然生效。
-- **覆盖范围**:transformer 包装 agent 的 `FunctionTool` 层,两条执行路径
-  (SDK Runner 与原生 loop)都经过它。它**不**覆盖对工具方法的直接 Python 调用
-  (如 reference-template 执行)或代理给外部 client 的工具——必须在这些路径上
-  存活的服务端强制应放进工具层本身(见 `agent.sql_policy`)。
-- **信任模型**:transformer 在进程内运行,能完整访问每个被匹配工具调用的参数。
-  它们是受信代码,与插件面的其余部分一样受 `plugins_enabled` 总开关管控。
-- 改写 SQL 时用 SQL parser 或数据库安全的查询构造器——策略谓词绝不用字符串拼接。
-- 收集成功但应用失败的声明会中止 agent 节点,而不是在没有强制的情况下静默运行。
-
-## 捆绑 setup skill
-
-`pip install` 之后手工编辑 YAML 是最大的摩擦。把 `<name>-setup` skill 与主
-skill 一起分发,让 agent 自己收集值并写好 profile:
+在 Claude Code 中：
 
 ```text
-datus_plugin_hello/
-└── skills/
-    ├── hello/
-    │   └── SKILL.md
-    └── hello-setup/
-        └── SKILL.md
+/datus-plugin-development ./docs/openapi.yaml，命令名使用 acme
 ```
 
-setup `SKILL.md` 应按顺序覆盖:
+文档参数也可以是 URL，或一个包含多份相关文档的目录。如果你对功能范围、兼容性
+或权限有额外要求，可以在同一条请求中说明。
 
-1. **何时使用**——plugin 未配置,或用户想加一个环境。
-2. **配置结构**——`agent.plugins.<name>.<profile>` 的完整 YAML 模板,用注释标出
-   必填/可选/secret 字段。
-3. **询问用户**——列出必须来自用户的字段(端点、认证方式……)。secret 字段要求
-   agent 让用户导出环境变量,YAML 里写 `${VAR}` 引用——绝不写字面 secret。
-4. **写入配置**——写进 `## Plugins` 提示词导语指出的文件,第一个 profile 标
-   `default: true`。
-5. **验证**——一条便宜的只读命令(如 `datus hello version`)。
-   `datus <plugin>` 每次调用都重新加载配置,profile 立即生效;提示词里的环境列
-   表下个会话刷新。
+## 开发流程
 
-在 setup skill 的 frontmatter 里声明 `requires_mutable_config: true`。配置只读
-的部署(多租户 chat API / gateway)中,Datus 会把该 skill 从
-`<available_skills>` 中隐藏并拒绝 `load_skill`——agent 会引导用户联系管理员,
-而不是走一遍它做不到的配置编辑。同时在正文保留一条保护性说明,作为旧版
-datus-agent(会忽略该 frontmatter 字段)的兜底:若当前环境无法编辑配置文件,
-agent 应告知用户去服务器上改 `agent.yml`。
+这个 skill 会按以下流程工作：
 
-一个完整的最小 `hello-setup/SKILL.md`:
+1. **阅读原始文档。** 梳理可用操作、认证方式、配置项和依赖。
+2. **给出设计草案。** 草案会列出建议的命令、配置字段、权限行为、随插件提供的
+   skills，以及暂不纳入的功能。
+3. **等待你确认范围。** 这一步不会写代码。你可以确认方案、提出修改，或将被排除的
+   功能重新加入范围。
+4. **实现插件。** 方案确认后，skill 才会生成可运行的插件、配套 skills 和测试。
+5. **验证结果。** skill 会运行相关测试，并检查本地安装、CLI 分发、skill 加载和
+   打包是否正常。
 
-````markdown
----
-name: hello-setup
-description: Configure an environment profile for the `datus hello` plugin
-requires_mutable_config: true
----
+先确认设计、再开始实现，可以避免把一个庞大的厂商 API 原样复制成同样庞大的 CLI，
+同时确保最终范围仍由你决定。
 
-# Hello Setup
+## 试用生成的插件
 
-Use this skill when `datus hello` is installed but has no configured
-environment, or when the user wants to add another one.
-
-## Config structure
-
-Profiles live under `agent.plugins.hello.<profile>` in the config file named
-by the `## Plugins` section of the system prompt:
-
-```yaml
-agent:
-  plugins:
-    hello:
-      prod:
-        default: true            # mark the first profile as default
-        greeting: Hi             # required
-        token: ${HELLO_TOKEN}    # secret — reference an env var, never a literal
-```
-
-## Steps
-
-1. Ask the user for `greeting` and which environment variable holds the
-   token. Have the user export the variable; write `${VAR}` into the YAML —
-   never a literal secret.
-2. Write the profile into the config file above; mark the first profile
-   `default: true`.
-3. Verify with a cheap read-only call: `datus hello Ada`.
-
-If this environment cannot edit the config file (API / web deployment), tell
-the user to edit `agent.yml` on the server instead.
-````
-
-## 端到端验证你的 plugin
-
-`pip install -e` 之后,每个扩展面都可以在不重启任何东西的情况下验证(plugin 每
-次调用都会被发现):
-
-- **CLI 分发**——在任意目录运行 `datus <name> ...`。如果落进了 REPL,说明
-  entry point 缺失/拼错,或 manifest 被拒绝(看日志);`datus <name>` 打印
-  "declares no CLI command" 说明 manifest 加载了但没有 `cli` 键。用
-  `pip show -f your-package` 检查 `entry_points.txt` 和随包的
-  `datus-plugin.yml`。
-- **Skills**——启动 `datus` 执行 `/skill list`;plugin 捆绑的 skill 与项目、
-  用户 skill 并列出现。
-- **提示词注入**——在单测里直接渲染模板(见下节)。要确认真实会话里生效,启动
-  `datus` 问 agent"配置了哪些 plugin?"——答案来自注入的 section。注意配置修改
-  对下一次 `datus <plugin>` 调用立即生效,但提示词 section 只在下个会话刷新。
-
-## 测试你的 plugin
-
-因为 Datus 是 broker,单测直接用普通 dict 调用你的函数——不需要 `agent.yml`,
-不需要 import Datus。manifest 和模板用普通的 YAML/Jinja2 工具验证:
-
-```python
-from pathlib import Path
-
-import yaml
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
-
-from datus_plugin_hello.cli import main
-
-PKG = Path(__file__).parent.parent / "datus_plugin_hello"
-
-
-def test_cli_uses_profile_greeting(capsys):
-    rc = main(["Ada"], {"name": "prod", "greeting": "Hi"})
-    assert rc == 0
-    assert "Hi, Ada!" in capsys.readouterr().out
-
-
-def test_manifest_is_valid():
-    manifest = yaml.safe_load((PKG / "datus-plugin.yml").read_text())
-    assert manifest["manifest_version"] == 1
-    assert manifest["cli"] == "datus_plugin_hello.cli:main"
-    # 所有声明的路径都存在于包内
-    assert (PKG / manifest["skills"]).is_dir()
-    assert (PKG / manifest["system_prompt"]).is_file()
-
-
-def test_prompt_template_renders_without_secrets():
-    env = Environment(loader=FileSystemLoader(PKG), undefined=StrictUndefined)
-    template = env.get_template("prompts/system.md.j2")
-    # datus 渲染前会剥离未声明 / x-secret 字段;此处模拟同样的输入。
-    ctx = {"plugin_name": "hello", "config_path": None, "config_mutable": True}
-    text = template.render(profiles={"prod": {"greeting": "Hi"}}, **ctx)
-    assert "## Hello" in text
-    text = template.render(profiles={}, **ctx)
-    assert "hello-setup" in text
-    # 只读部署下绝不能把 agent 指向 setup skill
-    text = template.render(profiles={}, plugin_name="hello", config_path=None, config_mutable=False)
-    assert "hello-setup" not in text
-```
-
-## 分发离线安装包
-
-在有网络的机器上、从 plugin 项目目录用 `datus plugin pack` 打出 wheelhouse
-`.zip`:
+实现完成后，可以安装本地项目并查看 CLI：
 
 ```bash
-datus plugin pack -o ./dist               # 只含 plugin wheel(默认)
-# → ./dist/datus-plugin-hello-1.0.0.zip
-
-datus plugin pack --with-deps -o ./dist   # plugin wheel + 全部依赖 wheel
+datus plugin install src:./datus-acme-plugin
+datus acme --help
 ```
 
-bundle 是一个 zip,内含 `datus-bundle.json` 清单和 `wheels/` wheelhouse。
-`pack` 会验证 wheel 声明了模块引用式的 `datus.plugins` entry point **并且**捆绑
-了它的 `datus-plugin.yml`——缺少任一项的 wheel 在任何依赖下载之前就被拒绝。用户
-通过 `datus plugin install zip:./….zip` 安装(见
-[离线安装](introduction.zh.md#offline-install))。选择哪种口味:
+需要分发时，可以生成安装包：
 
-- **默认(只含 plugin wheel)**——bundle 很小;目标机器在安装时从 package index
-  解析依赖(需要网络)。
-- **`--with-deps`**——捆绑所有传递依赖 wheel,安装完全离线
-  (`pip install --no-index --find-links`)。`pack` 使用
-  `pip download --only-binary=:all:`,因此每个依赖都必须发布 wheel(不接受只有
-  sdist 的包)。纯 Python 依赖集可跨平台;含原生扩展的依赖会让 bundle 变成
-  **同平台快照**——在与目标 OS/Python 匹配的机器上构建。
-- **声明 `Requires-Python`。**在 `pyproject.toml` 里设置;`pack` 会把它拷进清
-  单,安装时可以尽早拒绝不匹配的解释器(报错清晰,可用 `--force` 覆盖)。
+```bash
+datus plugin pack ./datus-acme-plugin -o ./dist
+```
 
-## 约束检查清单
+如果目标环境无法访问 package index，可以添加 `--with-deps`。两种安装包的区别见
+[离线安装](introduction.zh.md#offline-install)。
 
-发布前逐项确认:
+## 延伸阅读
 
-- [ ] 包内任何地方都**没有** `import datus`(`grep -rn "import datus" your_pkg/`)。
-- [ ] `pyproject.toml` **不**依赖 `datus` 或共享 plugin SDK。
-- [ ] `datus.plugins` entry-point 的值是**包名**(没有 `:Class` 部分)。
-- [ ] entry-point 名不是保留名(`upgrade`、`skill`、`plugin`)且不以 `-` 开头。
-- [ ] `datus-plugin.yml` 位于包根,声明 `manifest_version: 1`,并进入 wheel(`unzip -l dist/*.whl`)。
-- [ ] `cli` 函数签名为 `main(argv: list[str], profile: dict) -> int | None`,成功路径不调用 `sys.exit()`。
-- [ ] secret 配置字段在 `config_schema` 中标记了 `x-secret: true`。
-- [ ] 系统提示词模板用 `{% if profiles %}` 处理 `profiles == {}` 的情况。
-- [ ] `permissions` 模式是命名空间相对的(不带 `datus <name>` 前缀——Datus 会加),`normal` 下变更状态的子命令是 `ask`。
-- [ ] skill 文件和提示词模板都打进了 wheel。
-- [ ] entry-point 名与期望的 `datus <name>` 命令和 `agent.plugins.<name>` 配置键一致。
-
-## 参考
-
-- **entry-point 组**:`datus.plugins`——每个 plugin 一条,值为 plugin 的**包名**。
-- **契约的唯一权威**:`datus/plugins/base.py`(`datus-plugin.yml` manifest 规格)。
-- **相关**:[Plugin 介绍](introduction.zh.md)、[Skills](../skills/introduction.zh.md)。
+- [Development skill 源文件](https://github.com/Datus-ai/Datus-Plugins/blob/main/skills/datus-plugin-development/SKILL.md)：
+  最新的开发流程和插件契约。
+- [Datus-Plugins README](https://github.com/Datus-ai/Datus-Plugins#develop-your-own-plugin)：
+  插件市场安装方式和项目示例。
+- [Datus Plugins 贡献指南](https://github.com/Datus-ai/Datus-Plugins/blob/main/CONTRIBUTING.md)：
+  工作区配置、测试、Pull Request 和发布流程。
+- [插件介绍](introduction.zh.md)：面向使用者的安装、配置和管理说明。

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -1,321 +1,282 @@
-# Plugin Introduction
+# Plugins
 
-A **plugin** is an installable Python package that extends Datus without
-modifying it. `datus plugin install` puts each plugin in its own directory under
-`~/.datus/plugins/{name}/` (with its dependencies vendored in), and — depending
-on what the plugin ships — you get:
+A plugin connects Datus to an external service or adds a focused command-line
+capability without changing Datus itself. Depending on the plugin, it may add:
 
-| Surface | What it adds |
+| Capability | What you get |
 |---|---|
-| CLI subcommand | `datus <plugin> ...` runs the plugin's own command-line interface |
-| Skills | plugin-bundled skills appear in `/skill list`, alongside project and user skills |
-| Agent awareness | the plugin describes itself and its configured environments in the agent's system prompt, so the model chooses it proactively |
-| Bash permissions | the plugin pre-declares which of its subcommands the agent may auto-run and which need confirmation |
-| Tool transformers | the plugin can rewrite or deny the agent's tool calls before execution (e.g. enforce SQL scoping policies) |
+| CLI commands | Run the service through `datus <plugin> ...` |
+| Skills | Use plugin-provided skills alongside project and user skills |
+| Agent context | Let the agent discover the plugin and its configured environments |
+| Permission rules | Require confirmation before the agent runs sensitive commands |
+| Tool safeguards | Check, rewrite, or reject selected agent tool calls |
 
-Each enabled plugin's directory is appended to `sys.path` at startup, so its
-`datus.plugins` entry point is discovered on every invocation — no restart and
-no registration step. (A plugin installed the old way, straight into the same
-Python environment with plain `pip install`, is still discovered as a fallback.)
+Plugins are isolated Python packages. Datus discovers them automatically after
+installation, so there is no separate registration step.
 
-Want to build one? See the [development guide](development.md).
+Want to build one? Follow [Develop a plugin](development.md).
 
-## Installing a plugin
+## Install a plugin
 
-`datus plugin install` takes a `{type}:{src}` source and installs the plugin
-into `~/.datus/plugins/{name}/`. The type prefix is optional and defaults to
-`pip`, so a bare requirement is treated as `pip:`:
+For a published plugin, pass its package name:
 
 ```bash
-datus plugin install datus-plugin-hello                           # defaults to pip: (a PyPI requirement)
-datus plugin install pip:datus-plugin-hello                       # the same, spelled out
-datus plugin install src:./datus-plugin-hello                     # a local project directory
-datus plugin install whl:./dist/hello-1.0-py3-none-any.whl        # a local wheel file
-datus plugin install git:https://github.com/acme/datus-plugin-hello   # a git repository
-datus plugin install zip:./dist/datus-plugin-hello-1.0.0.zip      # an offline bundle (see below)
-
-datus hello Ada          # the subcommand is available immediately
+datus plugin install datus-airflow-plugin
+datus airflow --help
 ```
 
-`pip`, `src`, `whl`, and `git` resolve dependencies from a package index (they
-need network); the plugin and its dependencies are vendored into the plugin's
-directory via `pip install --target`. `datus plugin install` records how the
-plugin was installed in `~/.datus/plugins/{name}/datus-plugin.json`, so
-`datus plugin upgrade <name>` can later re-fetch it the same way. If the plugin
-is already installed, pass `--force` to replace it.
-
-If `datus <name>` falls through to the REPL instead of running the plugin, it is
-not installed, or it is not active for this project (see
-[Activating plugins](#activating-plugins)).
-
-### Offline install (air-gapped)
-
-An offline **bundle** is an ordinary `.zip` holding a wheelhouse (the plugin
-wheel and, optionally, every dependency wheel). Build one where you *do* have
-network with `datus plugin pack`, copy the file across, and install it with
-`zip:`:
+You can also make the source type explicit:
 
 ```bash
-# on a networked machine, from the plugin's project directory
-datus plugin pack --with-deps -o ./dist     # plugin wheel + all dependency wheels
-datus plugin pack -o ./dist                 # plugin wheel only (default)
-
-# on the target machine
-datus plugin install zip:./dist/datus-plugin-hello-1.0.0.zip
+datus plugin install pip:datus-airflow-plugin
+datus plugin install src:./datus-airflow-plugin
+datus plugin install whl:./dist/datus_airflow_plugin-0.3.0-py3-none-any.whl
+datus plugin install git:https://github.com/acme/datus-airflow-plugin
+datus plugin install zip:./dist/datus-airflow-plugin-0.3.0.zip
 ```
 
-`pack` defaults to **plugin wheel only** — small, but the target machine
-resolves dependencies from an index at install time (needs network). Add
-`--with-deps` to bundle every dependency wheel so the install is **fully
-offline** (`pip install --no-index --find-links`). Every wheel's checksum is
-verified against the bundle manifest before anything is installed; if the bundle
-was built for a different Python version or platform, install refuses with a
-clear message unless you pass `--force` (checksums are still enforced). Because a
-with-deps bundle is a same-platform snapshot, build it on a machine matching the
-target's OS/Python.
+The supported source types are:
 
-### Exporting an installed plugin
+| Source | Use it for |
+|---|---|
+| `pip:` | A package requirement from a package index. This is the default when the prefix is omitted. |
+| `src:` | A local plugin project. |
+| `whl:` | A wheel already built on disk. |
+| `git:` | A Git repository URL. |
+| `zip:` | A bundle created by `datus plugin pack` or `datus plugin export`. |
 
-`datus plugin export <name>` reproduces a distributable `.zip` from an already
-installed plugin — a `zip:` install returns its retained original bundle
-verbatim, while a `pip`/`src`/`whl`/`git` install is re-packed from its recorded
-source (needs network).
+Datus installs the plugin and its dependencies under
+`~/.datus/plugins/<name>/`. If the same plugin is already present, add
+`--force` to replace it.
 
-## Mounting plugins from other paths
+If `datus <name>` opens the chat REPL instead of the plugin, check that the
+plugin is installed and [active for the current project](#activating-plugins).
 
-Besides the managed store, `agent.plugin_paths` in `agent.yml` mounts plugin
-directories living anywhere on disk. Each entry is already **one plugin's
-directory** — the same layout a single `~/.datus/plugins/{name}/` subdirectory
-has (a `pip install --target` tree with the package, its vendored dependencies
-and a `*.dist-info`), not a root containing several plugins:
+## Configure a plugin
 
-```yaml
-agent:
-  plugin_paths:
-    - /opt/shared/datus-plugins/airflow          # one path = one plugin
-    - $DATUS_PLUGIN_HOME/hello                   # ~ and $ENV_VAR are expanded
-```
-
-Mounted directories are unioned with `~/.datus/plugins/` at startup and behave
-like installed plugins on every surface: `datus <name>` dispatch, skills,
-prompt sections, bash permissions, and per-project
-[activation](#activating-plugins). On a name clash the managed install under
-`~/.datus/plugins/` wins. `datus plugin list` shows mounted plugins with source
-`path`. This suits plugin trees deployed centrally (one copy shared by several
-machines or projects) that you do not want to copy into every user's home
-store.
-
-## Configuration
-
-Plugins are configured under `agent.plugins.<name>` in `agent.yml`, where each
-key below `<name>` is a **profile** — one named environment (endpoint,
-credentials, options). A plugin can have any number of profiles:
+Plugin settings live under `agent.plugins.<name>` in `agent.yml`. Each child is
+a named **profile**, usually representing an environment such as production or
+staging:
 
 ```yaml
 agent:
   plugins:
-    hello:
+    airflow:
       prod:
-        default: true              # picked when --profile is omitted (see below)
-        greeting: Hi
-        token: ${HELLO_TOKEN}      # prefer ${ENV_VAR} for secrets
+        default: true
+        base_url: https://airflow.example.com
+        token: ${AIRFLOW_TOKEN}
       staging:
-        greeting: Yo
+        base_url: https://airflow-staging.example.com
+        token: ${AIRFLOW_STAGING_TOKEN}
 ```
 
-Datus resolves the config file in this order: explicit `--config` →
-`./conf/agent.yml` (project) → `~/.datus/conf/agent.yml` (user default). Put
-the profile in whichever file your datus session actually loads.
+Use `${ENV_VAR}` references for credentials instead of writing secrets directly
+in the file. Datus expands those references before it runs the plugin.
 
-`${VAR}` references are expanded from environment variables per profile —
-always use them for secrets instead of literal values. Config edits take
-effect on the next `datus <plugin>` invocation; no restart is needed.
+Datus looks for the configuration in this order:
 
-Some plugins ship a `<name>-setup` skill that writes this configuration for
-you — see [Using a plugin with the agent](#using-a-plugin-with-the-agent).
+1. The file passed with `--config`.
+2. `./conf/agent.yml` in the current project.
+3. `~/.datus/conf/agent.yml`.
 
-### Managed API runtime configuration
+Configuration changes apply the next time you run the plugin; no restart is
+needed.
 
-In a multi-tenant `datus-api` deployment, an `AuthProvider` can supply a
-request-scoped `AgentConfig` without writing `agent.yml`. When that config is
-read-only (`config_mutable: false`) and the agent runs `datus <name> ...`
-through Bash, Datus resolves the selected plugin path and profile in the API
-process and passes that snapshot to only the plugin subprocess through a
-versioned environment value. The plugin still receives the resolved dict as
-the normal `profile` argument to `main(argv, profile)`; plugin code does not
-need to read the environment variable.
+### Managed API deployments
 
-Plugin skill discovery follows the same rule: `plugins_enabled`, the active
-plugin whitelist, `plugin_paths`, and `skills` directories are resolved from
-that request's `AgentConfig`. It does not fall back to another tenant's loaded
-configuration or to `./.datus/config.yml`. Standalone CLI skill commands that
-do not hold an `AgentConfig` keep the local project-file behavior.
+In a multi-tenant `datus-api` deployment, an `AuthProvider` can supply plugin
+settings for each request without writing `agent.yml`. Plugin and skill
+discovery stays within that request, so one tenant never falls back to another
+tenant's settings or to the server's local project configuration.
 
-This bridge accepts one plugin invocation per Bash command, in any shell shape
-that puts `datus` at a command position: pipelines, redirections (`>`, `2>&1`),
-`;`/`&&`/`||`/newline lists, `(...)`/`{...}` groupings, loops, heredocs and
-expansions all keep their original text — the runtime value is injected as an
-inline assignment in front of the `datus` command word only. It deliberately
-fails closed for multiple `datus` invocations in one command, for `datus` inside
-a command substitution (`$(...)`, backticks), and for `datus` behind a wrapper
-such as `timeout`, `env`, `xargs` or `sh -c`. `--profile` remains supported and
-is resolved against the request's `AgentConfig`; `--config` is rejected because
-the AuthProvider configuration is authoritative. The encoded runtime snapshot is
-capped at 64 KiB. Sibling commands in the same Bash invocation do not inherit
-it, and the parent process environment is never modified.
+`--profile` remains available, while `--config` is rejected because the
+provider's configuration is authoritative. When the agent runs a plugin
+through Bash, keep the command to one direct `datus <name>` invocation.
+Pipelines and redirections are supported, but command substitutions and
+wrappers such as `timeout`, `env`, `xargs`, or `sh -c` are rejected.
 
-### Which profile runs
+Many plugins also provide a `<name>-setup` skill. Ask the agent to configure
+the plugin and it can collect the required values and create the profile for
+you.
 
-When you run `datus <name> ...`, the active profile is resolved in this order:
+### Choose a profile
 
-1. Explicit `--profile <p>` on the command line
-   (`datus hello --profile staging ...`).
-2. Project pin in `./.datus/config.yml` (see below).
-3. The profile flagged `default: true` (more than one is an error).
-4. The sole profile, if only one is configured.
-5. No `agent.plugins.<name>` section at all → the plugin runs with an empty
-   configuration (config-free plugins still work).
-6. Multiple profiles with no way to disambiguate → Datus errors and asks you
-   to pass `--profile`.
+When a plugin has more than one profile, Datus chooses one in this order:
 
-### Pinning a profile per project
+1. `--profile <name>` on the command line.
+2. The profile selected for the current project in `./.datus/config.yml`.
+3. A profile marked `default: true`.
+4. The only configured profile, when there is just one.
 
-To make one project always use a specific profile without typing `--profile`,
-pin it in the project's `./.datus/config.yml` under `plugins.<name>
-.active_profile`. When exactly one profile is active it becomes the
-`datus <plugin>` default:
+A plugin that needs no configuration can run with an empty profile. If several
+profiles remain and none can be selected, Datus asks you to pass `--profile`.
+
+For example:
+
+```bash
+datus airflow --profile staging dags list
+```
+
+To make a profile the default for one project, select it in
+`./.datus/config.yml`:
 
 ```yaml
 plugins:
-  hello:
+  airflow:
     enabled: true
-    active_profile:
-      - staging
+    active_profile: [staging]
 ```
+
+## Manage plugins
+
+Use `datus plugin` from the terminal:
+
+| Command | Purpose |
+|---|---|
+| `datus plugin install <source>` | Install a plugin. Add `--force` to replace an existing installation. |
+| `datus plugin list` | Show installed plugins, versions, sources, profiles, and project status. |
+| `datus plugin info <name>` | Show details for one plugin. |
+| `datus plugin upgrade <name>` | Reinstall a plugin from its recorded `pip:`, `git:`, or `src:` source. |
+| `datus plugin uninstall <name>` | Remove an installed plugin. |
+| `datus plugin enable <name>` | Enable a plugin for the current project. |
+| `datus plugin disable <name>` | Disable a plugin for the current project. |
+| `datus plugin pack [directory]` | Build a distributable `.zip` from a plugin project. |
+| `datus plugin export <name>` | Export an installed plugin as a `.zip`. |
+
+Inside the chat REPL, `/plugins` opens an interactive manager. Use it to browse
+plugins, edit profiles, enter secrets as environment-variable references, and
+choose which plugins and profiles are active for the current project.
 
 ## Activating plugins
 
-The `plugins:` section of `./.datus/config.yml` also decides **which installed
-plugins are active for the project**. It is optional but authoritative:
-
-- **Omit it entirely** and every installed plugin — and all of its profiles —
-  is active. This is the default.
-- **Write it** and it becomes a whitelist. Each entry is
-  `{enabled: bool, active_profile: [<profile>, ...]}`. A plugin the section
-  does not list (or lists with `enabled: false`) is **not loaded** for the
-  project: its `datus <plugin>` subcommand is refused, and its bundled skills,
-  system-prompt section, tool transformers, and bash rules are all skipped.
-  `active_profile` narrows which configured profiles are active (omit it for
-  "all profiles").
+Plugins are available to every project by default. Add a `plugins:` section to
+`./.datus/config.yml` when a project should use only a selected set:
 
 ```yaml
 plugins:
-  hello:
+  airflow:
     enabled: true
-    active_profile: [staging]   # only 'staging' is active
-  noisy-plugin:
-    enabled: false              # installed but off for this project
+    active_profile: [staging]
+  internal-admin:
+    enabled: false
 ```
 
-Toggle activation without hand-editing the file:
+Once this section exists, it acts as the project's plugin list. Plugins omitted
+from the list, or marked `enabled: false`, are not loaded in that project. Their
+CLI commands, skills, prompt context, permission rules, and tool safeguards are
+all disabled.
+
+The CLI can update the same setting:
 
 ```bash
-datus plugin enable hello                    # activate (all profiles)
-datus plugin enable hello --profile staging  # activate, pinned to 'staging'
-datus plugin disable noisy-plugin            # deactivate for this project
+datus plugin enable airflow
+datus plugin enable airflow --profile staging
+datus plugin disable internal-admin
 ```
 
-The first `enable`/`disable` in a project seeds the whitelist with every
-installed plugin (all enabled) before applying your change, so turning one
-plugin off never silently deactivates the others.
+This setting belongs to the current project. It is separate from the
+[global plugin switch](#disabling-the-plugin-system).
 
-This is per-project activation, distinct from the global master switch
-[`agent.plugins_enabled`](#disabling-the-plugin-system) which turns the whole
-system off everywhere.
+## Use a plugin with the agent
 
-## Managing plugins
+You can run a plugin directly in a terminal, or let the agent use it as part of
+a task:
 
-`datus plugin` is the management entry point (it always works, even for a
-deactivated plugin):
+- Plugin-provided skills appear in `/skill list`.
+- A configured plugin can describe its available environments to the agent, so
+  the agent knows when the plugin is relevant.
+- A setup skill can guide you through creating a profile without exposing
+  literal credentials.
+- In the chat REPL, `!<plugin> ...` runs a plugin command directly and returns
+  the output to the conversation. See [Tool and plugin commands](../cli/execution_command.md).
 
-| Command | What it does |
-|---|---|
-| `datus plugin install '[{type}:]{src}'` | Install from `pip:` (default) / `src:` / `whl:` / `git:` / `zip:` into `~/.datus/plugins/` (`--force` replaces an existing install). |
-| `datus plugin pack [dir]` | Build a distributable wheelhouse `.zip` from a plugin project directory (default `./`); `--with-deps` bundles dependencies, `-o` sets the output dir. |
-| `datus plugin export <name>` | Export an installed plugin as a `.zip` (`-o` sets the output dir). |
-| `datus plugin upgrade <name>` | Re-install from the recorded source (`pip`/`git`/`src`). A `whl`/`zip` install is a pinned artifact and cannot be upgraded in place — reinstall a newer bundle instead. |
-| `datus plugin uninstall <name>` | Remove the plugin's `~/.datus/plugins/{name}/` directory. |
-| `datus plugin list` | List installed plugins: package, version, source, configured profiles, project activation. |
-| `datus plugin info <name>` | Show one plugin's description, profiles, config schema, and activation. |
-| `datus plugin enable/disable <name>` | Toggle per-project activation. |
+Plugin context is prepared when a session starts. If you change a profile
+during a session, start a new session before expecting the agent to see the
+updated environment information.
 
-Inside the REPL, `/plugins` opens an interactive manager for the same tasks:
-browse installed plugins, create / edit / delete global profiles (the form is
-driven by the plugin's config schema — nested schema objects expand into
-dotted fields like `s3.secret_access_key`, defaults are pre-filled, empty
-fields show their description as a dim placeholder, and secrets are entered
-as `${ENV_VAR}` references), and toggle which plugins and profiles are active
-for the project.
+In managed deployments where the agent cannot edit `agent.yml`, setup skills
+are hidden. An administrator must configure the plugin instead.
 
-## Using a plugin with the agent
+## Permissions
 
-Beyond running `datus <name> ...` yourself, plugins integrate with the agent:
+Commands that the agent runs go through Datus's permission system. A plugin can
+mark its own commands as:
 
-- **Skills** — plugin-bundled skills show up in `/skill list` and can be
-  invoked like any other skill.
-- **Prompt awareness** — a configured plugin lists its environments in the
-  agent's system prompt, so the model knows the plugin exists and picks it
-  proactively. Ask the agent "which plugins are configured?" to see what it
-  knows. The prompt section refreshes at session start; config edits made
-  mid-session appear in the next session.
-- **Guided setup** — an installed-but-unconfigured plugin typically announces
-  itself in the prompt and points the agent at its bundled `<name>-setup`
-  skill. Ask the agent to set the plugin up, and it collects the required
-  values and writes the profile for you (secrets are referenced as `${VAR}`,
-  never written literally). In managed deployments where the agent config is
-  read-only (the multi-tenant chat API / gateway), setup skills are hidden and
-  the agent directs users to their administrator instead.
+- `allow`: the agent may run the command without asking.
+- `ask`: the user must confirm first.
+- `deny`: the agent may not run the command.
 
-## Agent bash permissions
+These rules apply only when the agent runs the plugin. Commands you type
+directly in a terminal are unaffected.
 
-When the **agent** (not you) runs a plugin's CLI through its bash tool, the
-command goes through Datus' permission layer. Plugins can pre-declare, per
-permission profile (`normal` / `auto`), which of their subcommands are safe to
-auto-run (`allow`), which require confirmation (`ask`), and which are blocked
-(`deny`). Without a declaration, every agent-issued plugin command prompts for
-confirmation.
+A plugin can define rules only for its own `datus <name> ...` command. It
+cannot grant access to another plugin or to unrelated shell commands. Rules in
+your `agent.yml` remain authoritative, and a plugin can never override a user
+`deny`.
 
-What this means in practice:
+When an `ask` command is approved with **allow (project)**, Datus remembers that
+exact command pattern in the current project's `.datus/config.yml`.
 
-- **Plugin declarations are namespace-scoped.** A plugin can only shape rules
-  for `datus <its-own-name> ...` — never for `rm`, other plugins, or anything
-  else.
-- **Your rules always win.** A `deny` rule you write under
-  `permissions.bash_commands` in `agent.yml` overrides any plugin `allow`
-  (precedence is deny > ask > allow), and plugin declarations never change a
-  profile's default posture.
-- **`ask` can be relaxed per project.** When the agent hits a plugin-declared
-  `ask` subcommand, the confirmation prompt offers **allow (project)** —
-  choosing it persists the exact matched pattern to the project's
-  `.datus/config.yml` `bash_allow` list, and that subcommand auto-runs from
-  then on. The grant never widens beyond the exact pattern, and plugin `deny`
-  rules are unaffected.
-- **Only the agent is gated.** Typing `datus <name> ...` in a terminal
-  yourself is never affected.
-- The `dangerous` permission profile ignores all command-level bash rules by
-  design, including plugin declarations.
+## Offline installation {#offline-install}
 
-## Disabling the plugin system
+Create a bundle on a machine that has network access:
 
-`agent.plugins_enabled: false` in `agent.yml` is a master switch that turns
-off **all** plugin functionality — `datus <plugin>` dispatch, plugin-bundled
-skills, prompt injection (including setup guidance), permission declarations,
-and tool transformers. Recommended for API/web deployments where the agent
-must not be guided to edit configuration files. The default is `true`.
+```bash
+# From the plugin project directory
+datus plugin pack -o ./dist
+datus plugin pack --with-deps -o ./dist
+```
+
+The default bundle contains the plugin wheel only. The target machine still
+needs access to a package index to resolve dependencies.
+
+Use `--with-deps` for a fully offline bundle. It includes the plugin and all
+dependency wheels, so build it on the same operating system and Python version
+as the target when any dependency contains native code.
+
+Install the resulting file with:
+
+```bash
+datus plugin install zip:./dist/datus-airflow-plugin-0.3.0.zip
+```
+
+You can also export an installed plugin:
+
+```bash
+datus plugin export airflow -o ./dist
+```
+
+## Mount plugins from another directory {#plugin-paths}
+
+`agent.plugin_paths` can load a plugin from a directory managed outside
+`~/.datus/plugins/`:
+
+```yaml
+agent:
+  plugin_paths:
+    - /opt/shared/datus-plugins/airflow
+    - $DATUS_PLUGIN_HOME/internal
+```
+
+Each entry must point to one installed plugin directory, not to a parent
+directory containing several plugins. This is useful when several projects or
+machines share centrally deployed plugins. If a mounted plugin has the same
+name as a managed installation, the copy under `~/.datus/plugins/` wins.
+
+## Disable the plugin system {#disabling-the-plugin-system}
+
+Set the global switch in `agent.yml`:
+
+```yaml
+agent:
+  plugins_enabled: false
+```
+
+This disables plugin commands, bundled skills, agent context, permission rules,
+and tool safeguards. The default is `true`.
 
 ## Next steps
 
-- [Plugin Development](development.md) — build your own plugin, from a minimal
-  `hello` command to the full contract.
-- [Skills](../skills/introduction.md) — how skills work, including
-  plugin-bundled ones.
+- [Develop a plugin](development.md) with the `datus-plugin-development` skill.
+- Learn how [skills](../skills/introduction.md) are discovered and used.

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -1,271 +1,259 @@
-# Plugin 介绍
+# 插件
 
-**plugin**(插件)是一个可安装的 Python 包,在不修改 Datus 本身的前提下对其进行扩展。
-`datus plugin install` 会把每个插件装到独立目录 `~/.datus/plugins/{name}/`(依赖一并
-vendored 进目录内),根据插件打包的内容,你可以获得:
+插件可以在不修改 Datus 本身的情况下，接入外部服务或增加一组专用命令。根据插件
+提供的内容，你可以获得：
 
-| 功能面 | 提供什么 |
+| 能力 | 作用 |
 |---|---|
-| CLI 子命令 | `datus <plugin> ...` 运行插件自己的命令行界面 |
-| Skills | 插件自带的 skill 出现在 `/skill list` 中,与项目、用户 skill 并列 |
-| Agent 感知 | 插件在 agent 的 system prompt 中描述自己和已配置的环境,模型会主动选用它 |
-| Bash 权限 | 插件预先声明哪些子命令 agent 可以直接执行、哪些需要确认 |
-| 工具 transformer | 插件可以在 agent 的工具调用执行前改写参数或拒绝调用(如强制 SQL 作用域策略) |
+| CLI 命令 | 通过 `datus <plugin> ...` 操作外部服务 |
+| Skills | 像使用项目和用户 skills 一样使用插件自带的 skills |
+| Agent 上下文 | 让 agent 知道插件及其已配置的环境 |
+| 权限规则 | Agent 执行敏感命令前先征得你的确认 |
+| 工具保护 | 在指定的 agent 工具执行前检查、修改或拒绝调用 |
 
-每个已启用插件的目录会在启动时追加到 `sys.path`,其 `datus.plugins` entry-point 因此
-在每次调用时被发现——无需重启,也没有任何注册步骤。(用旧方式直接 `pip install` 装进
-同一 Python 环境的插件仍会作为兜底被发现。)
+每个插件都是独立安装的 Python 包。安装完成后，Datus 会自动发现它，不需要额外注册。
 
-想开发自己的插件?见[开发指南](development.zh.md)。
+如果你想开发自己的插件，请阅读[开发插件](development.zh.md)。
 
 ## 安装插件
 
-`datus plugin install` 接收 `{type}:{src}` 形式的安装源,把插件装到
-`~/.datus/plugins/{name}/`。类型前缀**可选,默认为 `pip`**——不写前缀时整段当作 `pip:` 处理:
+安装已发布的插件时，直接传入包名即可：
 
 ```bash
-datus plugin install datus-plugin-hello                           # 默认走 pip:(PyPI 包名)
-datus plugin install pip:datus-plugin-hello                       # 同上,显式写出
-datus plugin install src:./datus-plugin-hello                     # 本地项目目录
-datus plugin install whl:./dist/hello-1.0-py3-none-any.whl        # 本地 wheel 文件
-datus plugin install git:https://github.com/acme/datus-plugin-hello   # git 仓库
-datus plugin install zip:./dist/datus-plugin-hello-1.0.0.zip      # 离线 bundle(见下)
-
-datus hello Ada          # 子命令立即可用
+datus plugin install datus-airflow-plugin
+datus airflow --help
 ```
 
-`pip`、`src`、`whl`、`git` 会从 package index 解析依赖(需要网络);插件及其依赖通过
-`pip install --target` 一并 vendored 进插件目录。`datus plugin install` 会把安装方式
-记录到 `~/.datus/plugins/{name}/datus-plugin.json`,以便之后
-`datus plugin upgrade <name>` 用同样的方式重新拉取。若插件已安装,传 `--force` 可替换。
-
-如果 `datus <name>` 落进了 REPL 而不是运行插件,说明它未安装,或未在本项目激活
-(见[激活插件](#activating-plugins))。
-
-### 离线安装(内网/气隙环境) {#offline-install}
-
-离线 **bundle** 就是一个普通 `.zip`,内含一个 wheelhouse(插件 wheel,以及可选的每个
-依赖 wheel)。在**有网**的机器上用 `datus plugin pack` 打好包,把文件拷过去,再用
-`zip:` 安装:
+也可以明确指定安装来源：
 
 ```bash
-# 有网机器,在插件的项目目录下
-datus plugin pack --with-deps -o ./dist     # 插件 wheel + 全部依赖 wheel
-datus plugin pack -o ./dist                 # 仅插件 wheel(默认)
-
-# 目标机器
-datus plugin install zip:./dist/datus-plugin-hello-1.0.0.zip
+datus plugin install pip:datus-airflow-plugin
+datus plugin install src:./datus-airflow-plugin
+datus plugin install whl:./dist/datus_airflow_plugin-0.3.0-py3-none-any.whl
+datus plugin install git:https://github.com/acme/datus-airflow-plugin
+datus plugin install zip:./dist/datus-airflow-plugin-0.3.0.zip
 ```
 
-`pack` 默认**仅打插件 wheel**——包体小,但目标机器在安装时要从 index 解析依赖(需要
-网络)。加 `--with-deps` 会把每个依赖 wheel 都打进去,从而**完全离线**安装
-(`pip install --no-index --find-links`)。安装前会对照 bundle manifest 逐一校验每个
-wheel 的 checksum;若 bundle 是为不同的 Python 版本或平台构建的,安装会带明确提示拒绝,
-除非传 `--force`(checksum 仍强制校验)。含依赖 bundle 是同平台快照,请在与目标机
-OS/Python 匹配的机器上构建。
+支持的来源包括：
 
-### 导出已安装插件
+| 来源 | 适用场景 |
+|---|---|
+| `pip:` | 从 Python 包索引安装。省略前缀时默认使用这种方式。 |
+| `src:` | 安装本地插件项目。 |
+| `whl:` | 安装已经构建好的 wheel 文件。 |
+| `git:` | 从 Git 仓库安装。 |
+| `zip:` | 安装由 `datus plugin pack` 或 `datus plugin export` 生成的包。 |
 
-`datus plugin export <name>` 能把一个已安装插件重新导出成可分发的 `.zip`——`zip:`
-来源的安装会字节级返回其保留的原始 bundle,而 `pip`/`src`/`whl`/`git` 来源则按记录的
-安装源重新打包(需要网络)。
+Datus 会把插件及其依赖安装到 `~/.datus/plugins/<name>/`。如果同名插件已经存在，
+可以添加 `--force` 进行替换。
 
-## 挂载其他路径下的插件 {#plugin-paths}
+如果执行 `datus <name>` 后进入了聊天 REPL，而不是插件 CLI，请检查插件是否已经安装，
+以及它是否在[当前项目中启用](#activating-plugins)。
 
-除受管目录外,`agent.yml` 中的 `agent.plugin_paths` 可以挂载位于磁盘任意位置的插件
-目录。每个条目本身就是**一个插件的目录**——与单个 `~/.datus/plugins/{name}/` 子目录
-的布局相同(即一棵 `pip install --target` 树:插件包、其内嵌依赖和 `*.dist-info`),
-而不是包含多个插件的根目录:
+## 配置插件
 
-```yaml
-agent:
-  plugin_paths:
-    - /opt/shared/datus-plugins/airflow          # 一个路径 = 一个插件
-    - $DATUS_PLUGIN_HOME/hello                   # 支持 ~ 与 $ENV_VAR 展开
-```
-
-启动时挂载目录与 `~/.datus/plugins/` 取并集,在所有能力面上与已安装插件行为一致:
-`datus <name>` 分发、skills、系统提示词、bash 权限,以及按项目的
-[激活开关](#activating-plugins)。同名冲突时,`~/.datus/plugins/` 下的受管安装优先。
-`datus plugin list` 会以 `path` 来源展示挂载插件。适合集中部署的插件树
-(多台机器或多个项目共享同一份拷贝),无需复制到每个用户的 home 目录。
-
-## 配置
-
-插件在 `agent.yml` 的 `agent.plugins.<name>` 下配置,`<name>` 之下的每个键是一个
-**profile**——一套命名环境(endpoint、凭据、选项)。一个插件可以有任意多个 profile:
+插件配置位于 `agent.yml` 的 `agent.plugins.<name>` 下。每个子项都是一个命名的
+**配置环境（profile）**，通常对应生产、测试等不同环境：
 
 ```yaml
 agent:
   plugins:
-    hello:
+    airflow:
       prod:
-        default: true              # 省略 --profile 时选它(见下)
-        greeting: Hi
-        token: ${HELLO_TOKEN}      # 密钥优先用 ${ENV_VAR}
+        default: true
+        base_url: https://airflow.example.com
+        token: ${AIRFLOW_TOKEN}
       staging:
-        greeting: Yo
+        base_url: https://airflow-staging.example.com
+        token: ${AIRFLOW_STAGING_TOKEN}
 ```
 
-Datus 按以下顺序解析 config 文件:显式 `--config` → `./conf/agent.yml`(项目级)→
-`~/.datus/conf/agent.yml`(用户默认)。把 profile 写进你的 datus 会话实际加载的那个文件。
+凭据应使用 `${ENV_VAR}` 引用，不要直接写入配置文件。运行插件前，Datus 会读取对应的
+环境变量。
 
-`${VAR}` 引用会按 profile 从环境变量展开——密钥请一律使用它,不要写明文。配置修改对
-下一次 `datus <plugin>` 调用即刻生效,无需重启。
+Datus 按以下顺序查找配置文件：
 
-有些插件自带 `<name>-setup` skill,可以替你写好这段配置——见
-[与 agent 配合使用](#agent)。
+1. 通过 `--config` 显式指定的文件。
+2. 当前项目下的 `./conf/agent.yml`。
+3. 用户目录下的 `~/.datus/conf/agent.yml`。
 
-### 托管 API 的运行时配置
+配置修改会在下次运行插件时生效，不需要重启。
 
-在多租户 `datus-api` 部署中,`AuthProvider` 可以为每个请求直接提供内存中的
-`AgentConfig`,无需写入 `agent.yml`。当该配置只读(`config_mutable: false`),且
-agent 通过 Bash 执行 `datus <name> ...` 时,Datus 会在 API 进程内解析选中的
-plugin 路径与 profile,再通过带版本的环境变量把这份快照只传给目标 plugin
-子进程。plugin 仍通过常规的 `main(argv, profile)` 的 `profile` 参数取得解析后的
-字典,无需自行读取该环境变量。
+### 托管 API 部署
 
-plugin skill 发现遵循相同规则:`plugins_enabled`、激活 plugin 白名单、
-`plugin_paths` 和 `skills` 目录均以当前请求的 `AgentConfig` 为准,不会回退到其他
-租户已加载的配置或 `./.datus/config.yml`。只有拿不到 `AgentConfig` 的独立 CLI
-skill 命令才保留本地项目配置文件行为。
+在多租户 `datus-api` 部署中，`AuthProvider` 可以为每个请求提供插件配置，而不必
+写入 `agent.yml`。插件和 skill 只使用当前请求的配置，不会读取其他租户的设置，也
+不会回退到服务器上的本地项目配置。
 
-每条 Bash 命令允许一次 plugin 调用,只要 `datus` 位于命令位即可,shell 形态不限:
-管道、重定向(`>`、`2>&1`)、`;`/`&&`/`||`/换行 序列、`(...)`/`{...}` 分组、循环、
-heredoc 与各类展开都会原样保留——运行时快照只以内联赋值的形式插在 `datus` 命令词
-之前。以下情形仍会 fail closed:同一条命令里出现多个 `datus` 调用;`datus` 位于命令
-替换(`$(...)`、反引号)内部;`datus` 被 `timeout`、`env`、`xargs`、`sh -c` 等包裹。
-`--profile` 仍受支持,并针对当前请求的 `AgentConfig` 解析;`--config` 会被拒绝,
-因为 AuthProvider 提供的配置是权威来源。编码后的运行时快照上限为 64 KiB。同一条 Bash
-命令中的其他命令不会继承它,父进程环境也不会被修改。
+这种模式仍支持 `--profile`，但会拒绝 `--config`，因为 `AuthProvider` 提供的配置
+才是权威来源。当 agent 通过 Bash 运行插件时，每条命令应只包含一次直接的
+`datus <name>` 调用。管道和重定向可以正常使用，但命令替换以及 `timeout`、`env`、
+`xargs`、`sh -c` 等包装方式会被拒绝。
 
-### 哪个 profile 生效 {#which-profile-runs}
+许多插件还会提供 `<name>-setup` skill。你可以让 agent 帮忙配置插件，它会收集必要
+信息并创建 profile。
 
-执行 `datus <name> ...` 时,激活 profile 按以下顺序解析:
+### 选择 profile
 
-1. 命令行显式 `--profile <p>`(`datus hello --profile staging ...`)。
-2. 项目 pin —— `./.datus/config.yml`(见下)。
-3. 标了 `default: true` 的 profile(超过一个 → 报错)。
-4. 唯一 profile(只配了一个时直接用)。
-5. 完全没有 `agent.plugins.<name>` 配置段 → 插件以空配置运行(config-free
-   插件仍可工作)。
-6. 多个 profile 且无法判定 → Datus 报错,提示传 `--profile`。
+当插件配置了多个 profile 时，Datus 按以下顺序选择：
 
-### 按项目固定 profile
+1. 命令行中的 `--profile <name>`。
+2. 当前项目在 `./.datus/config.yml` 中选定的 profile。
+3. 标记了 `default: true` 的 profile。
+4. 仅有的一个 profile。
 
-想让某个项目始终使用特定 profile 而不必每次敲 `--profile`,在项目的
-`./.datus/config.yml` 里用 `plugins.<name>.active_profile` pin 住它。当只有
-一个 profile 激活时,它就成为 `datus <plugin>` 的默认:
+不需要配置的插件可以直接以空 profile 运行。如果存在多个 profile，但无法确定使用
+哪一个，Datus 会提示你传入 `--profile`。
 
-```yaml
-plugins:
-  hello:
-    enabled: true
-    active_profile:
-      - staging
-```
-
-## 激活插件 {#activating-plugins}
-
-`./.datus/config.yml` 的 `plugins:` 段还决定**本项目激活哪些已安装插件**。
-它可选,但一旦写了即为权威:
-
-- **整段省略** —— 全部已安装插件及其所有 profile 都激活。这是默认。
-- **写了它** —— 即成为白名单。每项为
-  `{enabled: bool, active_profile: [<profile>, ...]}`。段里未列出(或列出但
-  `enabled: false`)的插件在本项目**不加载**:其 `datus <plugin>` 子命令被拒绝,
-  自带 skill、system-prompt 段、工具 transformer、bash 规则一律跳过。
-  `active_profile` 用于收窄激活的 profile(省略即"全部 profile")。
-
-```yaml
-plugins:
-  hello:
-    enabled: true
-    active_profile: [staging]   # 只激活 'staging'
-  noisy-plugin:
-    enabled: false              # 已安装但本项目关闭
-```
-
-不必手改文件也能切换激活:
+例如：
 
 ```bash
-datus plugin enable hello                    # 激活(全部 profile)
-datus plugin enable hello --profile staging  # 激活并固定到 'staging'
-datus plugin disable noisy-plugin            # 本项目停用
+datus airflow --profile staging dags list
 ```
 
-项目里第一次 `enable`/`disable` 会先用全部已安装插件(均 enabled)播种白名单,
-再应用你的改动,这样关掉一个插件绝不会悄悄停用其余插件。
+如果希望某个项目默认使用指定 profile，可以在 `./.datus/config.yml` 中设置：
 
-这是**按项目**激活,与全局总开关
-[`agent.plugins_enabled`](#disabling-the-plugin-system)(在任何地方关掉整个系统)
-是两回事。
+```yaml
+plugins:
+  airflow:
+    enabled: true
+    active_profile: [staging]
+```
 
 ## 管理插件
 
-`datus plugin` 是管理入口(即使插件已停用它也始终可用):
+在终端中使用 `datus plugin`：
 
 | 命令 | 作用 |
 |---|---|
-| `datus plugin install '[{type}:]{src}'` | 从 `pip:`(默认)/ `src:` / `whl:` / `git:` / `zip:` 安装到 `~/.datus/plugins/`(`--force` 替换已有安装)。 |
-| `datus plugin pack [dir]` | 从插件项目目录(默认 `./`)构建可分发的 wheelhouse `.zip`;`--with-deps` 打入依赖,`-o` 指定输出目录。 |
-| `datus plugin export <name>` | 把已安装插件导出成 `.zip`(`-o` 指定输出目录)。 |
-| `datus plugin upgrade <name>` | 按记录的安装源重装(`pip`/`git`/`src`)。`whl`/`zip` 是固定制品,不能就地升级——请重新安装更新版本的 bundle。 |
-| `datus plugin uninstall <name>` | 删除插件目录 `~/.datus/plugins/{name}/`。 |
-| `datus plugin list` | 列出已安装插件:包、版本、来源、已配置 profile、本项目激活状态。 |
-| `datus plugin info <name>` | 查看单个插件的描述、profile、配置 schema 与激活状态。 |
-| `datus plugin enable/disable <name>` | 切换本项目激活状态。 |
+| `datus plugin install <source>` | 安装插件。添加 `--force` 可替换已有安装。 |
+| `datus plugin list` | 查看已安装插件、版本、来源、profile 和项目启用状态。 |
+| `datus plugin info <name>` | 查看一个插件的详细信息。 |
+| `datus plugin upgrade <name>` | 按记录的 `pip:`、`git:` 或 `src:` 来源重新安装插件。 |
+| `datus plugin uninstall <name>` | 卸载插件。 |
+| `datus plugin enable <name>` | 在当前项目中启用插件。 |
+| `datus plugin disable <name>` | 在当前项目中停用插件。 |
+| `datus plugin pack [directory]` | 从插件项目生成可分发的 `.zip`。 |
+| `datus plugin export <name>` | 将已安装插件导出为 `.zip`。 |
 
-在 REPL 内,`/plugins` 打开交互式管理器完成同样的事:浏览已安装插件,增删改
-全局 profile(表单由插件的配置 schema 驱动——嵌套 schema object 展开为
-`s3.secret_access_key` 这样的点分字段,默认值直接预填,留空字段以浅色占位符
-显示 description,密钥以 `${ENV_VAR}` 引用形式输入),并切换本项目激活哪些
-插件与 profile。
+在聊天 REPL 中，`/plugins` 会打开交互式管理界面。你可以浏览插件、编辑 profile、
+以环境变量引用的形式填写凭据，以及选择当前项目启用的插件和 profile。
 
-## 与 agent 配合使用 {#agent}
+## 在项目中启用插件 {#activating-plugins}
 
-除了自己在终端执行 `datus <name> ...`,插件还与 agent 深度集成:
+默认情况下，所有项目都可以使用已安装的插件。如果某个项目只应启用一部分插件，
+可以在 `./.datus/config.yml` 中添加 `plugins:`：
 
-- **Skills** —— 插件自带的 skill 出现在 `/skill list`,可以像其他 skill 一样调用。
-- **Prompt 感知** —— 已配置的插件会把自己的环境列表写进 agent 的 system prompt,
-  模型因此知道插件的存在并主动选用。可以问 agent"配置了哪些 plugin?"来查看它
-  掌握的信息。prompt 段落在会话启动时刷新;会话中途的配置修改要到下一个会话才可见。
-- **引导式配置** —— 已安装但未配置的插件通常会在 prompt 中声明自己,并指向自带的
-  `<name>-setup` skill。让 agent 帮你配置,它会收集必填项并替你写入 profile
-  (密钥以 `${VAR}` 形式引用,绝不写明文)。在 agent 配置只读的托管部署
-  (多租户 chat API / gateway)中,setup skill 会被隐藏,agent 会引导用户联系
-  管理员。
+```yaml
+plugins:
+  airflow:
+    enabled: true
+    active_profile: [staging]
+  internal-admin:
+    enabled: false
+```
 
-## Agent bash 权限
+一旦添加这个配置段，它就会成为当前项目的插件列表。没有列出的插件，以及标记为
+`enabled: false` 的插件，都不会在该项目中加载。对应的 CLI 命令、skills、agent
+上下文、权限规则和工具保护也会一并停用。
 
-当 **agent**(而非你本人)通过它的 bash 工具执行插件 CLI 时,命令会经过 Datus 的
-权限层。插件可以按权限 profile(`normal` / `auto`)预先声明:哪些子命令可以直接
-放行(`allow`)、哪些必须确认(`ask`)、哪些直接拦截(`deny`)。若无任何声明,
-agent 发起的每条插件命令都会弹出确认。
+也可以通过命令修改同一设置：
 
-实际含义:
+```bash
+datus plugin enable airflow
+datus plugin enable airflow --profile staging
+datus plugin disable internal-admin
+```
 
-- **插件声明只作用于自己的命名空间。** 插件只能为 `datus <自己的名字> ...` 声明
-  规则——碰不到 `rm`、其他插件或任何别的命令。
-- **你的规则永远优先。** 你写在 `agent.yml` `permissions.bash_commands` 下的
-  `deny` 规则压过插件的任何 `allow`(判定固定为 deny > ask > allow),且插件声明
-  永远改不了 profile 的默认姿态。
-- **`ask` 可按项目放宽。** agent 命中插件声明的 `ask` 子命令时,确认框会提供
-  **allow (project)** 选项——选择后把命中的 pattern 原样持久化到项目
-  `.datus/config.yml` 的 `bash_allow` 列表,此后该子命令直接放行。授权绝不会
-  扩大到 pattern 之外,插件的 `deny` 规则也不受影响。
-- **只有 agent 受门控。** 你自己在终端敲 `datus <name> ...` 不受任何影响。
-- `dangerous` 权限 profile 设计上忽略一切命令级 bash 规则,包括插件声明。
+这是项目级设置，与[全局插件开关](#disabling-the-plugin-system)相互独立。
 
-## 关闭 plugin 系统 {#disabling-the-plugin-system}
+## 与 agent 配合使用
 
-`agent.yml` 中的 `agent.plugins_enabled: false` 是总开关,关闭**全部** plugin
-功能——`datus <plugin>` 分发、插件自带 skill、prompt 注入(含 setup 引导)、
-权限声明与工具 transformer 一律失效。建议在 API/web 部署中关闭,避免 agent
-被引导去修改配置文件。默认值为 `true`。
+你既可以在终端中直接运行插件，也可以让 agent 在任务中使用它：
+
+- 插件自带的 skills 会出现在 `/skill list` 中。
+- 配置完成后，插件可以把可用环境告诉 agent，让 agent 判断何时应该使用它。
+- Setup skill 可以引导你创建 profile，同时避免在配置中写入明文凭据。
+- 在聊天 REPL 中，`!<plugin> ...` 可以直接运行插件命令，并把结果带回当前对话。
+  详见[工具和插件命令](../cli/execution_command.zh.md)。
+
+插件上下文会在会话开始时生成。如果你在会话中修改了 profile，请新建会话，让 agent
+读取更新后的环境信息。
+
+在不允许 agent 修改 `agent.yml` 的托管环境中，对应的 setup skill 不会显示。此时需要由
+管理员完成配置。
+
+## 权限
+
+Agent 运行的插件命令会经过 Datus 权限系统。插件可以将自己的命令标记为：
+
+- `allow`：agent 可以直接运行。
+- `ask`：运行前需要用户确认。
+- `deny`：agent 不得运行。
+
+这些规则只约束 agent。你在终端中直接输入的命令不受影响。
+
+插件只能为自己的 `datus <name> ...` 命令声明规则，不能控制其他插件或无关的 shell
+命令。你在 `agent.yml` 中设置的规则始终优先，插件不能覆盖用户设置的 `deny`。
+
+如果在确认 `ask` 命令时选择 **allow (project)**，Datus 会把本次匹配到的命令规则
+保存到当前项目的 `.datus/config.yml`。
+
+## 离线安装 {#offline-install}
+
+先在能够访问网络的机器上生成安装包：
+
+```bash
+# 在插件项目目录中执行
+datus plugin pack -o ./dist
+datus plugin pack --with-deps -o ./dist
+```
+
+默认生成的安装包只包含插件 wheel，目标机器仍需访问 Python 包索引才能安装依赖。
+
+添加 `--with-deps` 后，安装包会包含插件和全部依赖 wheel，可用于完全离线安装。如果
+依赖中包含原生代码，请使用与目标环境相同的操作系统和 Python 版本构建。
+
+安装生成的文件：
+
+```bash
+datus plugin install zip:./dist/datus-airflow-plugin-0.3.0.zip
+```
+
+也可以导出已经安装的插件：
+
+```bash
+datus plugin export airflow -o ./dist
+```
+
+## 从其他目录加载插件 {#plugin-paths}
+
+通过 `agent.plugin_paths`，可以加载不在 `~/.datus/plugins/` 中管理的插件：
+
+```yaml
+agent:
+  plugin_paths:
+    - /opt/shared/datus-plugins/airflow
+    - $DATUS_PLUGIN_HOME/internal
+```
+
+每一项都必须指向一个已经安装好的插件目录，而不是包含多个插件的父目录。这种方式
+适合多个项目或机器共享集中部署的插件。如果外部目录与 `~/.datus/plugins/` 中存在
+同名插件，Datus 会优先使用后者。
+
+## 关闭插件系统 {#disabling-the-plugin-system}
+
+在 `agent.yml` 中设置全局开关：
+
+```yaml
+agent:
+  plugins_enabled: false
+```
+
+关闭后，插件命令、自带 skills、agent 上下文、权限规则和工具保护都会停用。默认值为
+`true`。
 
 ## 下一步
 
-- [Plugin 开发](development.zh.md) —— 从一个最小的 `hello` 命令到完整契约,开发你
-  自己的插件。
-- [Skills](../skills/introduction.zh.md) —— skill 的工作机制,包括插件自带的 skill。
+- 使用 `datus-plugin-development` skill [开发插件](development.zh.md)。
+- 了解 [skills](../skills/introduction.zh.md) 的发现和使用方式。


### PR DESCRIPTION
## Why

The plugin documentation duplicated implementation details already maintained by the `datus-plugin-development` skill. The duplicated contract had started to drift, and the Chinese pages used dense, translated wording that was difficult to read.

## Solution

- Rewrite the English and Chinese plugin development pages around the recommended development-skill workflow.
- Link to the Datus-Plugins development skill as the source of truth instead of repeating plugin implementation details.
- Reorganize the plugin introduction pages around installation, configuration, management, activation, permissions, and advanced usage.
- Remove manifest details from user-facing plugin and `!<plugin>` documentation.
- Preserve the new managed multi-tenant runtime behavior as a concise deployment-facing note.
- Normalize Chinese terminology and punctuation and keep the English and Chinese structures aligned.

## Test Cases

Documentation-only change; no integration or nightly tests were added.

- `git diff --check datus/main...HEAD`
- Static validation of Markdown code fences and local link targets
- Verified that user-facing plugin docs contain no manifest references

`mkdocs build --strict` was not run because `mkdocs` is not installed in the current development environment.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated plugin CLI guidance to explain command completion, including nested command groups.
  - Reworked plugin development guides with streamlined workflows for generating, testing, and packaging plugins.
  - Expanded plugin documentation covering supported installation sources, project activation, configuration profiles, permissions, offline installation, and plugin management.
  - Clarified configuration precedence, profile selection, managed API behavior, Bash invocation restrictions, and project-level plugin controls.
  - Updated English and Chinese documentation consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->