### PR TITLE
[BugFix] Run the finalize narrative stage when no prior output exists

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -37,7 +37,11 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, ClassVar, Dict, Generic, 
 from pydantic import BaseModel
 
 from datus.agent.node.agentic_node import AgenticNode
-from datus.agent.node.visual_artifact._visual_artifact_finalize import FINALIZE_STAGE_TEXT, run_finalize_analysis
+from datus.agent.node.visual_artifact._visual_artifact_finalize import (
+    FINALIZE_STAGE_TEXT,
+    narrative_outputs_present,
+    run_finalize_analysis,
+)
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 
@@ -427,6 +431,10 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
 
     # ── Finalize stage ────────────────────────────────────────────────────
 
+    def _artifact_dir(self, artifact_slug: str) -> Path:
+        """Absolute on-disk directory for ``artifact_slug``."""
+        return Path(self.agent_config.project_root).resolve() / self.ARTIFACT_ROOT_DIR_NAME / artifact_slug
+
     def _run_finalize(
         self,
         artifact_slug: str,
@@ -450,8 +458,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         the data is unchanged; the deterministic aggregations still run.
         """
         try:
-            project_root = Path(self.agent_config.project_root).resolve()
-            artifact_dir = project_root / self.ARTIFACT_ROOT_DIR_NAME / artifact_slug
+            artifact_dir = self._artifact_dir(artifact_slug)
             queries_dir = artifact_dir / "queries"
             analysis_dir = artifact_dir / "analysis"
             return run_finalize_analysis(
@@ -783,7 +790,12 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         # Render-only edit (no query saved this run): skip the finalize LLM
         # stage and its per-stage progress bubbles — the only work left is the
         # deterministic schema/key_tables refresh, which needs no narration.
-        skip_narrative = not ctx.extras.get("artifact_data_changed", True)
+        # Only legitimate when a prior finalize left narrative files to reuse;
+        # otherwise (first generation whose queries landed in an earlier turn)
+        # skipping would strand the artifact without chips.
+        skip_narrative = not ctx.extras.get("artifact_data_changed", True) and narrative_outputs_present(
+            self._artifact_dir(slug) / "analysis", artifact_kind=self.ARTIFACT_KIND
+        )
 
         progress_queue: asyncio.Queue = asyncio.Queue()
         loop = asyncio.get_running_loop()

--- a/datus/agent/node/visual_artifact/_visual_artifact_finalize.py
+++ b/datus/agent/node/visual_artifact/_visual_artifact_finalize.py
@@ -397,6 +397,22 @@ def load_existing_finalize_output(
     return _load("insights.json"), _load("suggested_questions.json")
 
 
+def narrative_outputs_present(analysis_dir: Path, *, artifact_kind: str) -> bool:
+    """True when a prior finalize's LLM-authored files are on disk.
+
+    ``skip_narrative`` means "reuse what's already there". With nothing to
+    reuse — a first generation split across turns (queries saved in an
+    earlier run, ``validate_render`` landing in a later render-only one), or
+    a prior finalize whose LLM call failed and cleaned up after itself — the
+    skip would strand the artifact without chips permanently, so callers
+    upgrade to a full finalize instead.
+    """
+    if not (analysis_dir / "suggested_questions.json").is_file():
+        return False
+    # Dashboards never write insights.json — insights are report-only.
+    return artifact_kind != "report" or (analysis_dir / "insights.json").is_file()
+
+
 def parse_finalize_output(raw: Any, *, artifact_kind: str) -> FinalizeAnalysisOutput:
     """Validate the LLM's response against :class:`FinalizeAnalysisOutput`.
 
@@ -1237,11 +1253,23 @@ def run_finalize_analysis(
     ``suggested_questions.json`` are left in place (NOT deleted — they're
     still valid), and the deterministic aggregations below still run so the
     ask_* consultant's indices stay fresh. The result carries
-    ``skipped_narrative: True`` and ``ok: True``.
+    ``skipped_narrative: True`` and ``ok: True``. The skip is ignored when
+    there is nothing on disk to reuse (see
+    :func:`narrative_outputs_present`) — a full finalize runs instead.
     """
     warnings: List[str] = []
     output: Optional[FinalizeAnalysisOutput] = None
     llm_error: Optional[str] = None
+
+    if skip_narrative and not narrative_outputs_present(analysis_dir, artifact_kind=artifact_kind):
+        # Nothing on disk to preserve — honouring the skip would leave this
+        # artifact without insights / suggested questions for good. Callers
+        # pre-check the same way (so the progress bubbles are wired up); this
+        # is the belt-and-suspenders side for direct callers.
+        logger.info(
+            "Narrative skip requested for %s but prior outputs are missing; running the LLM stage.", analysis_dir
+        )
+        skip_narrative = False
 
     if not skip_narrative:
         intent_md = load_intent_md(analysis_dir)

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -2025,6 +2025,7 @@ class TestRunFinalizeSkipNarrative:
         artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(
             tmp_path, sql_body="SELECT region FROM finbench.main.Account"
         )
+        self._seed_existing_narrative(analysis_dir)
 
         result = run_finalize_analysis(
             model=Mock(spec=["generate_with_json_output", "generate"]),
@@ -2044,12 +2045,21 @@ class TestRunFinalizeSkipNarrative:
         manifest = json.loads((artifact_dir / "manifest.json").read_text(encoding="utf-8"))
         assert "finbench.main.Account" in manifest["key_tables"]
 
-    def test_does_not_create_narrative_files_when_absent(self, tmp_path: Path):
-        # No prior insights/suggested_questions on disk: skip must not mint them.
+    def test_runs_llm_anyway_when_no_prior_narrative_on_disk(self, tmp_path: Path):
+        """Skip requested with nothing to reuse → full finalize instead.
+
+        A first generation whose queries landed in an earlier turn reaches
+        finalize with ``artifact_data_changed=False``; honouring the skip
+        would leave the artifact without chips permanently.
+        """
         artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
 
+        model = Mock(spec=["generate_with_json_output", "generate"])
+        model.generate_with_json_output.return_value = _full_finalize_response()
+        model.generate.return_value = _ORIGINAL_INTENT
+
         result = run_finalize_analysis(
-            model=Mock(spec=["generate_with_json_output", "generate"]),
+            model=model,
             artifact_kind="report",
             artifact_dir=artifact_dir,
             queries_dir=queries_dir,
@@ -2059,5 +2069,56 @@ class TestRunFinalizeSkipNarrative:
         )
 
         assert result["ok"] is True
-        assert not (analysis_dir / "insights.json").exists()
-        assert not (analysis_dir / "suggested_questions.json").exists()
+        assert result.get("skipped_narrative") is None
+        assert model.generate_with_json_output.call_count == 1
+        assert (analysis_dir / "insights.json").is_file()
+        assert (analysis_dir / "suggested_questions.json").is_file()
+
+    def test_dashboard_skip_needs_only_suggested_questions(self, tmp_path: Path):
+        """Dashboards never write insights.json, so its absence must not
+        force a needless LLM re-run on a render-only edit."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+        sq = json.dumps([{"question": "q?", "kind": "quick"}]) + "\n"
+        (analysis_dir / "suggested_questions.json").write_text(sq, encoding="utf-8")
+
+        model = Mock(spec=["generate_with_json_output", "generate"])
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="dashboard",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            skip_narrative=True,
+        )
+
+        assert result["skipped_narrative"] is True
+        assert model.generate_with_json_output.call_count == 0
+        assert (analysis_dir / "suggested_questions.json").read_text(encoding="utf-8") == sq
+
+    def test_report_skip_reruns_when_only_insights_missing(self, tmp_path: Path):
+        """Half-present narrative (suggested_questions but no insights) is not
+        reusable for a report — the chips reference insight ids."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+        (analysis_dir / "suggested_questions.json").write_text(
+            json.dumps([{"question": "q?", "kind": "quick"}]) + "\n", encoding="utf-8"
+        )
+
+        model = Mock(spec=["generate_with_json_output", "generate"])
+        model.generate_with_json_output.return_value = _full_finalize_response()
+        model.generate.return_value = _ORIGINAL_INTENT
+
+        result = run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            skip_narrative=True,
+        )
+
+        assert result["ok"] is True
+        assert model.generate_with_json_output.call_count == 1
+        assert (analysis_dir / "insights.json").is_file()


### PR DESCRIPTION
## Why

`gen_visual_report` / `gen_visual_dashboard` runs can finish without ever producing `analysis/suggested_questions.json` (and, for reports, `analysis/insights.json`).

`_stream_post_build` skips the finalize LLM stage when no query was saved during the run (`artifact_data_changed == False`) — correct for a render-only edit, where the previous narrative is still valid and must not be regenerated. But the skip branch only *preserves* files; it never mints them. Two paths reach it with nothing on disk to preserve:

1. A first generation split across turns — queries saved in an earlier subagent dispatch, `validate_render` landing in a later render-only one. The artifact then has no follow-up chips at all, and no later run will ever create them (every subsequent render edit takes the same skip).
2. A prior finalize whose LLM call failed: that path deliberately unlinks the stale narrative files, so the next render-only run skips against an empty `analysis/`.

The `ask_*` consultant inlines these files, so the loss is permanent for that artifact.

## Solution

Gate the skip on the files actually being present, via a new `narrative_outputs_present(analysis_dir, artifact_kind=...)`:

- Report mode requires **both** `insights.json` and `suggested_questions.json` — quick chips reference insight ids, so a half-present pair is not reusable.
- Dashboards never write `insights.json` (insights are report-only for runtime-parameterized templates), so only `suggested_questions.json` is required — otherwise every dashboard edit would needlessly re-run the LLM.

The check runs in two places, one judgement:

- `_stream_post_build` computes `skip_narrative` with it, so `progress_cb` is wired up and the user sees the three finalize progress bubbles instead of waiting silently.
- `run_finalize_analysis` re-checks as a belt-and-suspenders boundary for direct callers.

Also extracted `_artifact_dir()` on the node so `_run_finalize` and the new check share the path construction.

## Test Cases

`tests/unit_tests/agent/node/test_visual_artifact_finalize.py`:

- `test_runs_llm_anyway_when_no_prior_narrative_on_disk` — skip requested, nothing on disk → full finalize runs, both files written, no `skipped_narrative` flag. This replaces `test_does_not_create_narrative_files_when_absent`, which pinned the old (buggy) behaviour.
- `test_dashboard_skip_needs_only_suggested_questions` — dashboard with `suggested_questions.json` and no `insights.json` still skips the LLM (no needless re-run).
- `test_report_skip_reruns_when_only_insights_missing` — half-present report narrative re-runs.
- `test_still_refreshes_subject_refs_and_key_tables` — seeded with prior narrative; it previously passed `skip_narrative=True` with an empty `analysis/`, a premise the new gate rejects.

Full file: 98 passed. `tests/unit_tests/agent/node/`: 1749 passed, 14 skipped. `ci/audit_tests.py --diff-only upstream/main`: P0=0, P1=0.

Local `ci/run-pr-tests.py` acceptance targets error out in my environment (`.datus/config.yml` has `default_datasource: finbench`, which the integration fixtures reject) — unrelated to this diff; the unit tiers above are the relevant gate.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved finalize processing to ensure required narrative outputs are available before skipping analysis.
  * Prevented incomplete artifacts when narrative files are missing.
  * Preserved deterministic subject references and key table updates during finalization.
  * Added artifact-specific handling for dashboards and reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->