### PR TITLE
[BugFix] Pin the finalize stage output language

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, ClassVar, Dict, Generic, 
 
 from pydantic import BaseModel
 
-from datus.agent.node.agentic_node import AgenticNode
+from datus.agent.node.agentic_node import AgenticNode, _resolve_language_name
 from datus.agent.node.visual_artifact._visual_artifact_finalize import (
     FINALIZE_STAGE_TEXT,
     narrative_outputs_present,
@@ -435,6 +435,30 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         """Absolute on-disk directory for ``artifact_slug``."""
         return Path(self.agent_config.project_root).resolve() / self.ARTIFACT_ROOT_DIR_NAME / artifact_slug
 
+    def _finalize_language_directive(self) -> Optional[str]:
+        """The configured response-language section, or ``None`` when unpinned.
+
+        finalize is an independent LLM call with no system prompt, so the
+        directive every agentic node gets injected has to travel into the
+        finalize prompt explicitly. Reuses the same rendered template rather
+        than a second copy of the wording.
+
+        ``_inject_response_language`` swallows a template-render failure and
+        returns the prompt untouched, which here would read as "no language
+        pinned" and hand finalize the infer-from-the-user's-prompts branch —
+        wrong whenever the operator pinned a language the user does not write
+        in. Fall back to a minimal directive built from the same code/name pair
+        so a pinned language always survives.
+        """
+        language_raw = getattr(self.agent_config, "language", None)
+        if not language_raw or not str(language_raw).strip():
+            return None
+        directive = self._inject_response_language("").strip()
+        if directive:
+            return directive
+        language_code = str(language_raw).strip()
+        return f"# Response Language\n- Use: {_resolve_language_name(language_code)} ({language_code})"
+
     def _run_finalize(
         self,
         artifact_slug: str,
@@ -469,6 +493,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
                 analysis_dir=analysis_dir,
                 actions=actions,
                 skip_narrative=skip_narrative,
+                language_directive=self._finalize_language_directive(),
                 # ``db_func_tool`` is wired by ``setup_tools`` early in
                 # the run. Passing it through enables the finalize-time
                 # ``key_tables_schema.json`` bake (describe_table snapshot

--- a/datus/agent/node/visual_artifact/_visual_artifact_finalize.py
+++ b/datus/agent/node/visual_artifact/_visual_artifact_finalize.py
@@ -107,6 +107,7 @@ def build_finalize_prompt(
     action_history_hints: List[Dict[str, Any]],
     existing_insights: Optional[List[Dict[str, Any]]],
     existing_suggested_questions: Optional[List[Dict[str, Any]]],
+    language_directive: Optional[str] = None,
 ) -> str:
     """Compose the single-shot finalize prompt.
 
@@ -114,6 +115,13 @@ def build_finalize_prompt(
     chatty: the LLM has to emit one strict JSON object matching
     :class:`FinalizeAnalysisOutput`, so we want every constraint visible
     in one place.
+
+    ``language_directive`` is the rendered ``response_language`` section
+    when ``agent_config.language`` pins one. finalize is an independent
+    LLM call with no system prompt, so the directive every agentic node
+    gets injected has to be restated here or the model answers an
+    English prompt in English — regardless of the language the user (and
+    therefore the artifact) actually uses.
     """
     is_dashboard = artifact_kind == "dashboard"
     sections: List[str] = []
@@ -194,6 +202,26 @@ def build_finalize_prompt(
         "output. The schema rejects quick questions with no grounding, and a "
         "post-validation check warns when the distribution drifts off-target."
     )
+
+    sections.append("## OUTPUT LANGUAGE")
+    audience_note = (
+        "This applies to `insights[].title`, `insights[].summary` and "
+        "`suggested_questions[].question` — they are shown to the user verbatim "
+        "(the questions become clickable chips beside the artifact). Everything "
+        "machine-read stays exactly as specified above: `insights[].id` and the "
+        "query slugs in `evidence_queries` / `related_queries`, the `kind` "
+        "values, and every JSON key."
+    )
+    if language_directive:
+        sections.append(f"{language_directive}\n\n{audience_note}")
+    else:
+        sections.append(
+            "Write the user-facing strings in the SAME language the user wrote "
+            "the prompts in RAW USER PROMPTS below — Chinese prompts get Chinese "
+            "questions, Japanese prompts get Japanese questions. Do NOT switch "
+            "to English just because these instructions are in English; the "
+            f"artifact itself is authored in the user's language.\n\n{audience_note}"
+        )
 
     sections.append("## RAW USER PROMPTS (intent.md)")
     sections.append(intent_md.strip() or "(empty)")
@@ -1204,6 +1232,7 @@ def run_finalize_analysis(
     db_func_tool: Optional[Any] = None,
     on_progress: Optional[Callable[[int], None]] = None,
     skip_narrative: bool = False,
+    language_directive: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Top-level orchestrator. Returns a result dict::
 
@@ -1286,6 +1315,7 @@ def run_finalize_analysis(
             action_history_hints=action_hints,
             existing_insights=existing_insights,
             existing_suggested_questions=existing_sq,
+            language_directive=language_directive,
         )
 
         if on_progress is not None:

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -742,19 +742,38 @@ class TestFinalizeLanguageDirective:
         real_agent_config.language = "zh-CN"
         node = _make_node(real_agent_config)
         project_root = Path(real_agent_config.project_root)
+        dashboard_dir = project_root / "dashboards" / "lang_probe"
         _seed_dashboard_on_disk(project_root, "lang_probe")
+        # The response below grounds its quick chips in this slug; without the
+        # template on disk ``consistency_check`` rightly reports them as
+        # unresolvable, and the fixture would not be something finalize could
+        # legally emit.
+        (dashboard_dir / "queries" / "kpi_summary.sql.j2").write_text("SELECT 1 AS v\n", encoding="utf-8")
 
         model = MagicMock(spec=["generate_with_json_output", "generate"])
         model.generate_with_json_output.return_value = {
+            # Dashboards carry no insights, so every chip grounds on a query
+            # slug; the contract is 5 entries split 3 quick + 2 deep_dive.
             "insights": [],
             "suggested_questions": [
                 {
-                    "question": "这个看板默认的时间范围是什么？",
+                    "question": f"这个看板的{topic}是什么？",
                     "kind": "quick",
                     "related_queries": ["kpi_summary"],
                     "related_insight": None,
                     "priority": 0.9,
                 }
+                for topic in ("默认时间范围", "可用筛选维度", "指标口径")
+            ]
+            + [
+                {
+                    "question": f"{topic}的原因是什么？",
+                    "kind": "deep_dive",
+                    "related_queries": ["kpi_summary"],
+                    "related_insight": None,
+                    "priority": 0.6,
+                }
+                for topic in ("环比下降", "分组差异")
             ],
         }
         node.model = model
@@ -762,7 +781,9 @@ class TestFinalizeLanguageDirective:
         result = node._run_finalize("lang_probe", [])
 
         assert result["ok"] is True
+        # A contract-valid response on a well-formed artifact warns about nothing.
+        assert result["warnings"] == []
         prompt = model.generate_with_json_output.call_args.args[0]
         assert "Chinese (zh-CN)" in prompt
-        analysis_dir = project_root / "dashboards" / "lang_probe" / "analysis"
+        analysis_dir = dashboard_dir / "analysis"
         assert (analysis_dir / "suggested_questions.json").is_file()

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -694,3 +695,74 @@ async def test_execute_stream_fails_when_validate_render_not_called(real_agent_c
     # ``_active_dashboard_slug`` got captured even though validate_render didn't run.
     assert result["dashboard_slug"] == "incomplete"
     assert "validate_render" in (result.get("error") or "")
+
+
+class TestFinalizeLanguageDirective:
+    """The finalize stage is an independent LLM call with no system prompt, so
+    the node has to hand it the response-language directive explicitly —
+    otherwise an English instruction block yields English insights /
+    suggested questions for an artifact the user asked for in Chinese.
+    """
+
+    def test_pinned_language_is_resolved_into_a_directive(self, real_agent_config, mock_llm_create):
+        real_agent_config.language = "zh"
+        node = _make_node(real_agent_config)
+
+        directive = node._finalize_language_directive() or ""
+
+        assert "- Use: Chinese (zh)" in directive
+        # No leading blank lines — it is spliced into a prompt section.
+        assert directive == directive.strip()
+
+    def test_unpinned_language_yields_none(self, real_agent_config, mock_llm_create):
+        real_agent_config.language = None
+        node = _make_node(real_agent_config)
+
+        # None lets the finalize prompt fall back to "follow the language of
+        # the user's prompts in intent.md" instead of pinning a wrong one.
+        assert node._finalize_language_directive() is None
+
+    def test_template_failure_still_pins_the_language(self, real_agent_config, mock_llm_create, monkeypatch):
+        """``_inject_response_language`` swallows a render failure and returns
+        the prompt untouched. Reading that as "unpinned" would silently hand
+        finalize the infer-from-user-prompts branch, which contradicts an
+        operator who pinned a language the user doesn't write in."""
+        real_agent_config.language = "ja"
+        node = _make_node(real_agent_config)
+        monkeypatch.setattr(type(node), "_inject_response_language", lambda self, base: base)
+
+        directive = node._finalize_language_directive()
+
+        assert directive == "# Response Language\n- Use: Japanese (ja)"
+
+    def test_run_finalize_forwards_the_directive_to_the_llm(self, real_agent_config, mock_llm_create, tmp_path):
+        """End-to-end through ``_run_finalize`` → ``run_finalize_analysis``:
+        the resolved directive must reach the prompt of the independent
+        finalize LLM call, which is the only place it can take effect."""
+        real_agent_config.language = "zh-CN"
+        node = _make_node(real_agent_config)
+        project_root = Path(real_agent_config.project_root)
+        _seed_dashboard_on_disk(project_root, "lang_probe")
+
+        model = MagicMock(spec=["generate_with_json_output", "generate"])
+        model.generate_with_json_output.return_value = {
+            "insights": [],
+            "suggested_questions": [
+                {
+                    "question": "这个看板默认的时间范围是什么？",
+                    "kind": "quick",
+                    "related_queries": ["kpi_summary"],
+                    "related_insight": None,
+                    "priority": 0.9,
+                }
+            ],
+        }
+        node.model = model
+
+        result = node._run_finalize("lang_probe", [])
+
+        assert result["ok"] is True
+        prompt = model.generate_with_json_output.call_args.args[0]
+        assert "Chinese (zh-CN)" in prompt
+        analysis_dir = project_root / "dashboards" / "lang_probe" / "analysis"
+        assert (analysis_dir / "suggested_questions.json").is_file()

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -530,6 +530,36 @@ class TestBuildFinalizePrompt:
             existing_suggested_questions=None,
         )
 
+    def test_unpinned_language_follows_the_user_prompts(self, report_prompt: str):
+        """finalize has no system prompt, so the language rule must live in the
+        prompt itself — otherwise an English instruction block gets English
+        chips for a Chinese artifact."""
+        assert "## OUTPUT LANGUAGE" in report_prompt
+        assert "SAME language" in report_prompt
+        # The rule has to name the user-visible fields, since slugs / kinds in
+        # the same object must stay machine-readable.
+        assert "`suggested_questions[].question`" in report_prompt
+        assert "`insights[].title`" in report_prompt
+
+    def test_pinned_language_directive_is_inlined(self):
+        directive = "# Response Language\n- Use: Chinese (zh)"
+        prompt = build_finalize_prompt(
+            artifact_kind="dashboard",
+            intent_md="请做一个示例看板",
+            query_briefs=[],
+            query_previews=[],
+            action_history_hints=[],
+            existing_insights=None,
+            existing_suggested_questions=None,
+            language_directive=directive,
+        )
+
+        assert directive in prompt
+        # The pinned branch still carries the field-scope note.
+        assert "`suggested_questions[].question`" in prompt
+        # ...and drops the "infer it from the prompts" fallback.
+        assert "SAME language" not in prompt
+
     def test_prompt_announces_kind_field_in_schema(self, report_prompt: str):
         # Schema section must mention the kind field by name so the LLM
         # actually emits it.
@@ -1444,6 +1474,28 @@ class TestRunFinalizeAnalysis:
         refs = json.loads((analysis_dir / "subject_refs.json").read_text(encoding="utf-8"))
         assert any(m["path"] == ["Revenue"] and m["name"] == "revenue_by_region" for m in refs["metrics"])
         assert result["subject_refs_count"]["metrics"] == 1
+
+    def test_language_directive_reaches_the_llm_prompt(self, tmp_path: Path):
+        """The node resolves ``agent_config.language`` into a directive; it has
+        to land in the finalize prompt, since this LLM call carries no system
+        prompt of its own."""
+        artifact_dir, queries_dir, analysis_dir = _make_artifact_layout(tmp_path)
+
+        model = Mock(spec=["generate_with_json_output", "generate"])
+        model.generate_with_json_output.return_value = _full_finalize_response()
+
+        run_finalize_analysis(
+            model=model,
+            artifact_kind="report",
+            artifact_dir=artifact_dir,
+            queries_dir=queries_dir,
+            analysis_dir=analysis_dir,
+            actions=[],
+            language_directive="# Response Language\n- Use: Chinese (zh)",
+        )
+
+        prompt = model.generate_with_json_output.call_args.args[0]
+        assert "- Use: Chinese (zh)" in prompt
 
     def test_end_to_end_curates_intent_md_when_present(self, tmp_path: Path):
         """When intent.md exists, finalize triggers run_intent_curation


### PR DESCRIPTION
## Why

A user working in Chinese asked for a dashboard. The agent authored it in Chinese throughout — name, description, chart labels, insight cards — and the follow-up question chips beside it came out in English.

`insights[].title` / `.summary` and `suggested_questions[].question` are produced by the finalize stage, which is an **independent LLM call** (`model.generate_with_json_output`) with no system prompt attached. Every AgenticNode gets the `response_language` directive appended in `_finalize_system_prompt`, and the visual prompts even reference it explicitly ("Follow the Response Language directive at the bottom of this prompt") — but the finalize call bypasses all of it. The model saw an all-English instruction block and answered in English, both when `agent.language` is pinned and when it is unset (the main loop follows the user's language, finalize follows the prompt's).

The chips are the most visible surface of the whole artifact (rendered as clickable buttons beside it), so the mismatch is glaring.

## Solution

Restate the directive inside the finalize prompt — a new `## OUTPUT LANGUAGE` section built from `language_directive`, resolved on the node side by `_finalize_language_directive()`:

- **`agent_config.language` pinned** → reuse the rendered `response_language` template verbatim (`_inject_response_language("")`), so there is one copy of that wording, not two.
- **unset** → explicitly instruct the model to follow the language of the user's own prompts, which are already inlined further down as `## RAW USER PROMPTS (intent.md)`. This is the case that bit here, and a pinned-language-only fix would have missed it.

Either branch carries the same field-scope note: the rule covers insight title/summary and question text; `insights[].id`, the query slugs in `evidence_queries` / `related_queries`, the `kind` values and all JSON keys stay machine-readable.

Not changed, for the record:

- `run_intent_curation` (the second finalize LLM call) already carries a CROSS-LANGUAGE NOTE and makes a binary keep/delete decision per section, so it never mints new prose or translates.
- `FINALIZE_STAGE_TEXT` (the three progress bubbles: "Generating insights and follow-up questions…") and `_final_summary_message` are hardcoded English shown in the chat panel. Same class of problem, but fixing them means an i18n mechanism for Python-side user-facing strings that this repo doesn't have yet — worth a separate discussion rather than a silent one-off table here.

## Test Cases

`tests/unit_tests/agent/node/test_visual_artifact_finalize.py`:

- `test_unpinned_language_follows_the_user_prompts` — the OUTPUT LANGUAGE section exists, names the user-visible fields, and instructs the model to follow the prompts' language.
- `test_pinned_language_directive_is_inlined` — a supplied directive is inlined verbatim, keeps the field-scope note, and drops the infer-from-prompts fallback.
- `test_language_directive_reaches_the_llm_prompt` — end-to-end through `run_finalize_analysis`: the directive shows up in the actual prompt handed to `generate_with_json_output`.

`tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py` — `TestFinalizeLanguageDirective`: `language: "zh"` resolves to a `Chinese (zh)` directive with no leading blank lines; unset resolves to `None` (so the prompt takes the fallback branch instead of pinning a wrong language).

`tests/unit_tests/agent/node/` → 1754 passed, 14 skipped. `ruff format` / `ruff check` clean. `ci/audit_tests.py --diff-only upstream/main`: P0=0 (2 pre-existing P1 weak-assert hits in the intent-curation tests, untouched by this diff).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Finalized visual artifact insights and suggested questions now follow the configured response language.
  * When no language is configured, user-facing text follows the language of the original prompts.
  * JSON structure and machine-readable fields remain unchanged.

* **Tests**
  * Added coverage for configured-language behavior and language fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up (review)

A pinned language could still be dropped: `_inject_response_language` swallows a template-render failure and returns the prompt untouched, which the helper read as "unpinned" and answered with the inference branch. It now resolves the configured code first and falls back to a minimal directive built from the same code/name pair, so a pinned language always reaches the finalize call. Covered by `test_template_failure_still_pins_the_language` (exact-match on the fallback text) and `test_run_finalize_forwards_the_directive_to_the_llm` (full path through `_run_finalize` → `run_finalize_analysis`, asserting the directive lands in the prompt handed to the LLM).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization for visual artifact finalization by honoring the configured response language.
  * Added robust fallback behavior to avoid defaulting to English when language injection fails.
  * Updated finalize output instructions to keep machine-readable JSON valid while localizing user-facing text (insights titles/summaries and suggested questions).

* **Tests**
  * Expanded unit coverage for language pinning, missing/injected language fallback, and end-to-end verification that the finalize LLM receives the resolved language directive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->