### PR TITLE
[Enhancement] Integrate Doris and Hologres adapters

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -154,6 +154,8 @@ jobs:
             --reinstall-package datus-semantic-core \
             --reinstall-package datus-semantic-metricflow \
             --reinstall-package datus-snowflake \
+            --reinstall-package datus-doris \
+            --reinstall-package datus-hologres \
             --reinstall-package datus-storage-base \
             --reinstall-package datus-storage-postgresql \
             pytest-playwright \
@@ -168,6 +170,8 @@ jobs:
             ./external/datus-db-adapters/datus-mysql \
             ./external/datus-db-adapters/datus-clickhouse \
             ./external/datus-db-adapters/datus-starrocks \
+            ./external/datus-db-adapters/datus-doris \
+            ./external/datus-db-adapters/datus-hologres \
             ./external/datus-db-adapters/datus-trino \
             ./external/datus-db-adapters/datus-greenplum \
             ./external/datus-db-adapters/datus-hive \
@@ -299,6 +303,7 @@ jobs:
           echo "ADAPTERS_MYSQL=1" >> $GITHUB_ENV
           echo "ADAPTERS_CH=1" >> $GITHUB_ENV
           echo "ADAPTERS_SR=1" >> $GITHUB_ENV
+          echo "ADAPTERS_DORIS=1" >> $GITHUB_ENV
           echo "ADAPTERS_TRINO=1" >> $GITHUB_ENV
           echo "ADAPTERS_GP=1" >> $GITHUB_ENV
           echo "ADAPTERS_HIVE=1" >> $GITHUB_ENV
@@ -321,6 +326,8 @@ jobs:
           echo "CLICKHOUSE_NATIVE_HOST_PORT=29000" >> $GITHUB_ENV
           echo "STARROCKS_QUERY_HOST_PORT=29030" >> $GITHUB_ENV
           echo "STARROCKS_HTTP_HOST_PORT=28030" >> $GITHUB_ENV
+          echo "DORIS_QUERY_HOST_PORT=29031" >> $GITHUB_ENV
+          echo "DORIS_HTTP_HOST_PORT=28031" >> $GITHUB_ENV
           echo "TRINO_HOST_PORT=28080" >> $GITHUB_ENV
           echo "GREENPLUM_HOST_PORT=15434" >> $GITHUB_ENV
           echo "HIVE_METASTORE_HOST_PORT=29083" >> $GITHUB_ENV

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -348,6 +348,7 @@ flow_groups:
               - tests/integration/adapters/test_mysql.py
               - tests/integration/adapters/test_clickhouse.py
               - tests/integration/adapters/test_starrocks.py
+              - tests/integration/adapters/test_doris.py
               - tests/integration/adapters/test_trino.py
               - tests/integration/adapters/test_greenplum.py
               - tests/integration/adapters/test_hive.py
@@ -439,6 +440,7 @@ flow_groups:
               - tests/integration/tools/test_bi_grafana.py
               - tests/integration/agent/test_scheduler_agentic.py
               - tests/integration/adapters/test_starrocks.py
+              - tests/integration/adapters/test_doris.py
           weekly_benchmark:
             status: covered
             notes: Weekly benchmark uses datus-agent with released/source adapter packages for the selected scenario.

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -32,6 +32,8 @@ PACKAGE_NAMES = (
     "datus-mysql",
     "datus-clickhouse",
     "datus-starrocks",
+    "datus-doris",
+    "datus-hologres",
     "datus-trino",
     "datus-greenplum",
     "datus-hive",

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -68,6 +68,7 @@ POSTGRES_COMPOSE="${POSTGRES_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-postgresql/docke
 MYSQL_COMPOSE="${MYSQL_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-mysql/docker-compose.yml}"
 CLICKHOUSE_COMPOSE="${CLICKHOUSE_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-clickhouse/docker-compose.yml}"
 STARROCKS_COMPOSE="${STARROCKS_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-starrocks/docker-compose.yml}"
+DORIS_COMPOSE="${DORIS_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-doris/docker-compose.yml}"
 TRINO_COMPOSE="${TRINO_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-trino/docker-compose.yml}"
 GREENPLUM_COMPOSE="${GREENPLUM_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-greenplum/docker-compose.yml}"
 HIVE_COMPOSE="${HIVE_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-hive/docker-compose.yml}"
@@ -81,6 +82,7 @@ COMPOSE_FILES=(
   "$MYSQL_COMPOSE"
   "$CLICKHOUSE_COMPOSE"
   "$STARROCKS_COMPOSE"
+  "$DORIS_COMPOSE"
   "$TRINO_COMPOSE"
   "$GREENPLUM_COMPOSE"
   "$HIVE_COMPOSE"
@@ -98,6 +100,7 @@ COMPOSE_GROUPS=(
   "MySQL Adapter Tests"
   "ClickHouse Adapter Tests"
   "StarRocks Adapter Tests"
+  "Doris Adapter Tests"
   "Trino Adapter Tests"
   "Greenplum Adapter Tests"
   "Hive Adapter Tests"
@@ -481,6 +484,7 @@ compose_project_slug() {
     "MySQL Adapter Tests") echo "mysql" ;;
     "ClickHouse Adapter Tests") echo "clickhouse" ;;
     "StarRocks Adapter Tests") echo "starrocks" ;;
+    "Doris Adapter Tests") echo "doris" ;;
     "Trino Adapter Tests") echo "trino" ;;
     "Greenplum Adapter Tests") echo "greenplum" ;;
     "Hive Adapter Tests") echo "hive" ;;
@@ -536,6 +540,7 @@ cleanup_all_compose() {
       "MySQL Adapter Tests") compose_file="$MYSQL_COMPOSE" ;;
       "ClickHouse Adapter Tests") compose_file="$CLICKHOUSE_COMPOSE" ;;
       "StarRocks Adapter Tests") compose_file="$STARROCKS_COMPOSE" ;;
+      "Doris Adapter Tests") compose_file="$DORIS_COMPOSE" ;;
       "Trino Adapter Tests") compose_file="$TRINO_COMPOSE" ;;
       "Greenplum Adapter Tests") compose_file="$GREENPLUM_COMPOSE" ;;
       "Hive Adapter Tests") compose_file="$HIVE_COMPOSE" ;;
@@ -821,6 +826,7 @@ export ADAPTERS_PG="${ADAPTERS_PG:-1}"
 export ADAPTERS_MYSQL="${ADAPTERS_MYSQL:-1}"
 export ADAPTERS_CH="${ADAPTERS_CH:-1}"
 export ADAPTERS_SR="${ADAPTERS_SR:-1}"
+export ADAPTERS_DORIS="${ADAPTERS_DORIS:-1}"
 export ADAPTERS_TRINO="${ADAPTERS_TRINO:-1}"
 export ADAPTERS_GP="${ADAPTERS_GP:-1}"
 export ADAPTERS_HIVE="${ADAPTERS_HIVE:-1}"
@@ -878,6 +884,15 @@ if [ "${NIGHTLY_FORCE_ADAPTER_ENV:-1}" = "1" ]; then
   export STARROCKS_PASSWORD=
   export STARROCKS_CATALOG=default_catalog
   export STARROCKS_DATABASE=test
+
+  export DORIS_QUERY_HOST_PORT="${DORIS_QUERY_HOST_PORT:-29031}"
+  export DORIS_HTTP_HOST_PORT="${DORIS_HTTP_HOST_PORT:-28031}"
+  export DORIS_HOST=127.0.0.1
+  export DORIS_PORT="$DORIS_QUERY_HOST_PORT"
+  export DORIS_USER=root
+  export DORIS_PASSWORD=
+  export DORIS_CATALOG=internal
+  export DORIS_DATABASE=test
 
   export TRINO_HOST_PORT="${TRINO_HOST_PORT:-28080}"
   export TRINO_HOST=127.0.0.1
@@ -1134,6 +1149,9 @@ compose_host_port_specs() {
       ;;
     "StarRocks Adapter Tests")
       printf 'StarRocks query:%s\nStarRocks HTTP:%s\n' "${STARROCKS_QUERY_HOST_PORT:-29030}" "${STARROCKS_HTTP_HOST_PORT:-28030}"
+      ;;
+    "Doris Adapter Tests")
+      printf 'Doris query:%s\nDoris HTTP:%s\n' "${DORIS_QUERY_HOST_PORT:-29031}" "${DORIS_HTTP_HOST_PORT:-28031}"
       ;;
     "Trino Adapter Tests")
       printf 'Trino HTTP:%s\n' "${TRINO_HOST_PORT:-28080}"
@@ -1417,6 +1435,9 @@ wait_for_compose_client_readiness() {
     "StarRocks Adapter Tests")
       wait_for_starrocks_client_readiness 300
       ;;
+    "Doris Adapter Tests")
+      wait_for_tcp_readiness "Doris" "${DORIS_HOST:-127.0.0.1}" "${DORIS_PORT:-9030}" 600
+      ;;
     "Trino Adapter Tests")
       wait_for_http_readiness "Trino" "http://${TRINO_HOST:-127.0.0.1}:${TRINO_PORT:-8080}/v1/info" 300
       ;;
@@ -1548,6 +1569,7 @@ log "POSTGRESQL_HOST=${POSTGRESQL_HOST:-} POSTGRESQL_PORT=${POSTGRESQL_PORT:-} P
 log "MYSQL_HOST=${MYSQL_HOST:-} MYSQL_PORT=${MYSQL_PORT:-} MYSQL_HOST_PORT=${MYSQL_HOST_PORT:-}"
 log "CLICKHOUSE_HOST=${CLICKHOUSE_HOST:-} CLICKHOUSE_PORT=${CLICKHOUSE_PORT:-} CLICKHOUSE_HTTP_HOST_PORT=${CLICKHOUSE_HTTP_HOST_PORT:-} CLICKHOUSE_NATIVE_HOST_PORT=${CLICKHOUSE_NATIVE_HOST_PORT:-}"
 log "STARROCKS_HOST=${STARROCKS_HOST:-} STARROCKS_PORT=${STARROCKS_PORT:-} STARROCKS_QUERY_HOST_PORT=${STARROCKS_QUERY_HOST_PORT:-} STARROCKS_HTTP_HOST_PORT=${STARROCKS_HTTP_HOST_PORT:-}"
+log "DORIS_HOST=${DORIS_HOST:-} DORIS_PORT=${DORIS_PORT:-} DORIS_QUERY_HOST_PORT=${DORIS_QUERY_HOST_PORT:-} DORIS_HTTP_HOST_PORT=${DORIS_HTTP_HOST_PORT:-}"
 log "TRINO_HOST=${TRINO_HOST:-} TRINO_PORT=${TRINO_PORT:-}"
 log "GREENPLUM_HOST=${GREENPLUM_HOST:-} GREENPLUM_PORT=${GREENPLUM_PORT:-} GREENPLUM_HOST_PORT=${GREENPLUM_HOST_PORT:-}"
 log "HIVE_HOST=${HIVE_HOST:-} HIVE_PORT=${HIVE_PORT:-} HIVE_METASTORE_HOST_PORT=${HIVE_METASTORE_HOST_PORT:-} HIVE_THRIFT_HOST_PORT=${HIVE_THRIFT_HOST_PORT:-} HIVE_WEBUI_HOST_PORT=${HIVE_WEBUI_HOST_PORT:-}"
@@ -1603,6 +1625,7 @@ NIGHTLY_DEDICATED_SUITE_DESELECTS=(
   --deselect tests/integration/adapters/test_mysql.py
   --deselect tests/integration/adapters/test_clickhouse.py
   --deselect tests/integration/adapters/test_starrocks.py
+  --deselect tests/integration/adapters/test_doris.py
   --deselect tests/integration/adapters/test_trino.py
   --deselect tests/integration/adapters/test_greenplum.py
   --deselect tests/integration/adapters/test_hive.py
@@ -1628,6 +1651,7 @@ run_compose_suite "PostgreSQL Adapter Tests" "$POSTGRES_COMPOSE" "postgres:300" 
 run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_mysql.py tests/integration/adapters/test_semantic_metricflow_mysql.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "ClickHouse Adapter Tests" "$CLICKHOUSE_COMPOSE" "clickhouse:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_clickhouse.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "StarRocks Adapter Tests" "$STARROCKS_COMPOSE" "starrocks:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_starrocks.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_compose_suite "Doris Adapter Tests" "$DORIS_COMPOSE" "doris-fe:600" "doris-be:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_doris.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_trino.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300 --timeout-method=thread

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -19,6 +19,8 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-mysql": "datus-db-adapters/datus-mysql",
     "datus-clickhouse": "datus-db-adapters/datus-clickhouse",
     "datus-starrocks": "datus-db-adapters/datus-starrocks",
+    "datus-doris": "datus-db-adapters/datus-doris",
+    "datus-hologres": "datus-db-adapters/datus-hologres",
     "datus-trino": "datus-db-adapters/datus-trino",
     "datus-greenplum": "datus-db-adapters/datus-greenplum",
     "datus-hive": "datus-db-adapters/datus-hive",
@@ -32,6 +34,17 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-semantic-metricflow": "datus-semantic-adapter/datus-semantic-metricflow",
     "datus-storage-base": "datus-storage-adapters/datus-storage-base",
     "datus-storage-postgresql": "datus-storage-adapters/datus-storage-postgresql",
+}
+
+DATABASE_ADAPTER_CONTRACTS = {
+    "datus_doris": {
+        "db_type": "doris",
+    },
+    "datus_hologres": {
+        "db_type": "hologres",
+        "parser_dialect": "postgres",
+        "required_hooks": ("get_identifier_parser", "get_sql_generation_notes"),
+    },
 }
 
 
@@ -94,6 +107,41 @@ def verify_semantic_adapter_imports() -> list[str]:
     return errors
 
 
+def verify_database_adapter_imports() -> list[str]:
+    """Verify new database adapters can register their Agent-facing hooks."""
+    errors: list[str] = []
+    try:
+        core = importlib.import_module("datus_db_core")
+        registry = core.connector_registry
+    except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
+        return [f"datus-db-core registry import failed: {exc}"]
+
+    for module_name, contract in DATABASE_ADAPTER_CONTRACTS.items():
+        try:
+            module = importlib.import_module(module_name)
+            module.register()
+        except Exception as exc:  # noqa: BLE001 - report the actual nightly import failure.
+            errors.append(f"{module_name} registration failed: {exc}")
+            continue
+
+        db_type = contract["db_type"]
+        metadata_obj = registry.get_metadata(db_type)
+        if metadata_obj is None:
+            errors.append(f"{module_name} did not register connector metadata for {db_type}")
+            continue
+
+        expected_parser = contract.get("parser_dialect")
+        if expected_parser and registry.get_parser_dialect(db_type) != expected_parser:
+            errors.append(f"{module_name} parser dialect is not {expected_parser}")
+
+        for hook_name in contract.get("required_hooks", ()):
+            getter = getattr(registry, hook_name, None)
+            if not callable(getter) or not getter(db_type):
+                errors.append(f"{module_name} did not register {hook_name}")
+
+    return errors
+
+
 def verify_storage_adapter_imports() -> list[str]:
     errors: list[str] = []
     required_names = ("FtsField", "FtsIndexStatus", "FtsSpec", "normalize_fts_spec")
@@ -149,6 +197,7 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     errors = verify_local_sources(args.external_repos_root)
+    errors.extend(verify_database_adapter_imports())
     errors.extend(verify_semantic_adapter_imports())
     errors.extend(verify_storage_adapter_imports())
     if errors:

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
+from pydantic import BaseModel, ConfigDict
+
 EXPECTED_LOCAL_PACKAGES = {
     "datus-db-core": "datus-db-adapters/datus-db-core",
     "datus-sqlalchemy": "datus-db-adapters/datus-sqlalchemy",
@@ -36,15 +38,24 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-storage-postgresql": "datus-storage-adapters/datus-storage-postgresql",
 }
 
-DATABASE_ADAPTER_CONTRACTS = {
-    "datus_doris": {
-        "db_type": "doris",
-    },
-    "datus_hologres": {
-        "db_type": "hologres",
-        "parser_dialect": "postgres",
-        "required_hooks": ("get_identifier_parser", "get_sql_generation_notes"),
-    },
+
+class DatabaseAdapterContract(BaseModel):
+    """Agent-facing registration contract required from a database adapter."""
+
+    model_config = ConfigDict(frozen=True)
+
+    db_type: str
+    parser_dialect: str | None = None
+    required_hooks: tuple[str, ...] = ()
+
+
+DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
+    "datus_doris": DatabaseAdapterContract(db_type="doris"),
+    "datus_hologres": DatabaseAdapterContract(
+        db_type="hologres",
+        parser_dialect="postgres",
+        required_hooks=("get_identifier_parser", "get_sql_generation_notes"),
+    ),
 }
 
 
@@ -124,17 +135,17 @@ def verify_database_adapter_imports() -> list[str]:
             errors.append(f"{module_name} registration failed: {exc}")
             continue
 
-        db_type = contract["db_type"]
+        db_type = contract.db_type
         metadata_obj = registry.get_metadata(db_type)
         if metadata_obj is None:
             errors.append(f"{module_name} did not register connector metadata for {db_type}")
             continue
 
-        expected_parser = contract.get("parser_dialect")
+        expected_parser = contract.parser_dialect
         if expected_parser and registry.get_parser_dialect(db_type) != expected_parser:
             errors.append(f"{module_name} parser dialect is not {expected_parser}")
 
-        for hook_name in contract.get("required_hooks", ()):
+        for hook_name in contract.required_hooks:
             getter = getattr(registry, hook_name, None)
             if not callable(getter) or not getter(db_type):
                 errors.append(f"{module_name} did not register {hook_name}")

--- a/datus/cli/datasource_app.py
+++ b/datus/cli/datasource_app.py
@@ -44,8 +44,10 @@ logger = get_logger(__name__)
 INSTALLABLE_TYPES = (
     "clickhouse",
     "clickzetta",
+    "doris",
     "greenplum",
     "hive",
+    "hologres",
     "mysql",
     "postgresql",
     "redshift",

--- a/datus/storage/reference_template/template_file_processor.py
+++ b/datus/storage/reference_template/template_file_processor.py
@@ -14,6 +14,7 @@ import jinja2.meta
 
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
+from datus.utils.sql_utils import parse_dialect
 
 logger = get_logger(__name__)
 
@@ -164,8 +165,10 @@ def _resolve_dimension_columns(template_content: str, quoted_params: set, dialec
     # Replace remaining {{param}} with ASC (safe for ORDER BY / LIMIT)
     sql = re.sub(r"\{\{\s*\w+\s*\}\}", "ASC", sql)
 
-    # Try specified dialect, then fallback chain for backtick support
-    dialects_to_try = [dialect] if dialect else [dialect, "sqlite", "mysql"]
+    # Resolve adapter-defined parser aliases before handing the dialect to
+    # sqlglot (for example, Hologres -> PostgreSQL).
+    parser_dialect = parse_dialect(dialect) if dialect else None
+    dialects_to_try = [parser_dialect] if parser_dialect else [None, "sqlite", "mysql"]
     parsed = None
     for d in dialects_to_try:
         try:

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -32,7 +32,7 @@ from datus.utils.constants import DBType, SQLType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.mcp_decorators import mcp_tool, mcp_tool_class
-from datus.utils.sql_utils import parse_table_name_parts
+from datus.utils.sql_utils import parse_dialect, parse_table_name_parts
 
 logger = get_logger(__name__)
 
@@ -2028,7 +2028,7 @@ class DBFuncTool:
 
     @staticmethod
     def _identifier_quote_char(dialect: str) -> str:
-        backtick_dialects = ("mysql", "starrocks", "hive", "spark", "bigquery", "clickhouse")
+        backtick_dialects = ("mysql", "starrocks", "doris", "hive", "spark", "bigquery", "clickhouse")
         return "`" if dialect in backtick_dialects else '"'
 
     @classmethod
@@ -2062,7 +2062,7 @@ class DBFuncTool:
 
         from pandas.api import types as pd_types
 
-        dialect = str(dialect or "").lower()
+        dialect = parse_dialect(str(dialect or "")).lower()
 
         def choose(default: str, *, sqlite: str = "", postgres: str = "", duckdb: str = "") -> str:
             if dialect == DBType.SQLITE:

--- a/datus/tools/func_tool/metric_queryability.py
+++ b/datus/tools/func_tool/metric_queryability.py
@@ -13,7 +13,9 @@ from typing import Any, Dict, Iterable, List, Optional
 
 _SQL_FENCE_LANGS = {
     "bigquery",
+    "doris",
     "duckdb",
+    "hologres",
     "mysql",
     "postgres",
     "postgresql",

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 
 from datus.tools.func_tool.base import FuncToolResult
 from datus.utils.loggings import get_logger
+from datus.utils.sql_utils import parse_dialect
 
 if TYPE_CHECKING:
     from datus.configuration.agent_config import AgentConfig
@@ -4739,10 +4740,7 @@ class SemanticDiscoveryTools:
                 configured_dialect = str(getattr(dialect_value, "value", dialect_value) or "").strip().lower()
             except Exception:
                 configured_dialect = ""
-        configured_dialect = {"postgresql": "postgres"}.get(
-            configured_dialect,
-            configured_dialect,
-        )
+        configured_dialect = parse_dialect(configured_dialect) if configured_dialect else ""
         dialects = [
             configured_dialect or None,
             None,

--- a/datus/tools/sql_guard.py
+++ b/datus/tools/sql_guard.py
@@ -115,7 +115,12 @@ def estimate_rows_from_explain(dialect: str, explain_rows: List[Any]) -> Optiona
     """
     if not explain_rows:
         return None
-    normalized = (dialect or "").lower()
+    # Adapter names are not always sqlglot/engine-family names. Resolve the
+    # adapter-provided parser dialect so PostgreSQL-compatible engines such as
+    # Hologres retain the same pre-execution safety guard as PostgreSQL.
+    from datus.utils.sql_utils import parse_dialect
+
+    normalized = parse_dialect(dialect or "").lower()
     if normalized in ("starrocks", "doris"):
         return _max_match(_STARROCKS_CARDINALITY_RE, _flatten_text(explain_rows))
     if normalized == "duckdb":

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -26,6 +26,8 @@ This design keeps the core package lightweight while allowing you to add support
 | Spark | datus-spark | `pip install datus-spark` | Ready |
 | ClickHouse | datus-clickhouse | `pip install datus-clickhouse` | Ready |
 | Trino | datus-trino | `pip install datus-trino` | Ready |
+| Apache Doris | datus-doris | `pip install datus-doris` | Ready |
+| Hologres | datus-hologres | `pip install datus-hologres` | Ready |
 
 ## Installation
 
@@ -64,6 +66,12 @@ pip install datus-clickhouse
 
 # Trino
 pip install datus-trino
+
+# Apache Doris
+pip install datus-doris
+
+# Hologres
+pip install datus-hologres
 ```
 
 Once installed, Datus Agent will automatically detect and load the adapter.
@@ -227,6 +235,42 @@ trino_data:
   http_scheme: http  # optional: http or https
 ```
 
+### Apache Doris
+
+```yaml
+doris_data:
+  type: doris
+  host: localhost
+  port: 9030
+  username: root
+  password: your_password
+  database: your_database
+  catalog: internal  # optional, default is internal
+```
+
+Doris speaks the MySQL protocol; `port` is the FE query port (default 9030). The built-in catalog is
+`internal`; external catalogs (for example, Hive Metastore catalogs) can be selected through the same
+`catalog` field.
+
+### Hologres
+
+```yaml
+hologres_data:
+  type: hologres
+  host: your-instance-cn-hangzhou.hologres.aliyuncs.com  # console endpoint, may embed ":80"
+  port: 80
+  username: ${HOLOGRES_ACCESS_KEY_ID}
+  password: ${HOLOGRES_ACCESS_KEY_SECRET}
+  database: your_database
+  schema: public   # optional, default is public
+  sslmode: prefer  # optional, default is prefer
+```
+
+Hologres (Alibaba Cloud) uses the PostgreSQL wire protocol with AccessKey credentials.
+`access_key_id`/`access_key_secret` are also accepted as aliases for `username`/`password`. The `host`
+accepts either a plain hostname or a `hostname:port` console endpoint; an explicit `port` must match an
+embedded one.
+
 ### Multiple Database Entries
 
 ```yaml
@@ -314,6 +358,19 @@ All adapters support:
 - Built-in TPC-H connector for benchmarking
 - HTTP/HTTPS connection with SSL support
 
+#### Apache Doris
+- MySQL protocol compatibility
+- Multi-catalog discovery and context switching (`catalog.database.table`)
+- Materialized view discovery and DDL retrieval
+- Catalog-aware metadata and sample-row retrieval
+
+#### Hologres
+- PostgreSQL wire protocol (PostgreSQL-compatible SQL dialect)
+- Alibaba Cloud AccessKey authentication
+- Multi-schema datasource support
+- Console endpoint normalization (`hostname` or `hostname:port`)
+- SSL connection modes (disable, allow, prefer, require, verify-ca, verify-full)
+
 ## Troubleshooting
 
 ### Adapter Not Found
@@ -344,6 +401,8 @@ Some adapters require additional system dependencies:
 - **Spark**: Requires `pyhive`, `thrift`, `thrift-sasl`, `pure-sasl` (installed automatically)
 - **ClickHouse**: Requires `clickhouse-sqlalchemy` (installed automatically)
 - **Trino**: Requires `trino` (installed automatically)
+- **Apache Doris**: Requires `datus-mysql` and `pymysql` (installed automatically)
+- **Hologres**: Requires `datus-postgresql` and `psycopg2-binary` (installed automatically)
 
 ## Architecture
 
@@ -356,8 +415,10 @@ datus-agent (Core)
 └── Plugin System (Entry Points)
     ├── datus-sqlalchemy (Base layer)
     │   ├── datus-mysql
+    │   │   ├── datus-starrocks
+    │   │   └── datus-doris
     │   ├── datus-postgresql
-    │   ├── datus-starrocks
+    │   │   └── datus-hologres
     │   ├── datus-hive
     │   ├── datus-spark
     │   ├── datus-clickhouse

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -18,6 +18,7 @@ Datus 使用模块化适配器架构，允许连接不同的数据库：
 | SQLite | 内置 | 已包含 | 可用 |
 | DuckDB | 内置 | 已包含 | 可用 |
 | MySQL | datus-mysql | `pip install datus-mysql` | 可用 |
+| PostgreSQL | datus-postgresql | `pip install datus-postgresql` | 可用 |
 | StarRocks | datus-starrocks | `pip install datus-starrocks` | 可用 |
 | Snowflake | datus-snowflake | `pip install datus-snowflake` | 可用 |
 | ClickZetta | datus-clickzetta | `pip install datus-clickzetta` | 可用 |
@@ -25,6 +26,8 @@ Datus 使用模块化适配器架构，允许连接不同的数据库：
 | Spark | datus-spark | `pip install datus-spark` | 可用 |
 | ClickHouse | datus-clickhouse | `pip install datus-clickhouse` | 可用 |
 | Trino | datus-trino | `pip install datus-trino` | 可用 |
+| Apache Doris | datus-doris | `pip install datus-doris` | 可用 |
+| Hologres | datus-hologres | `pip install datus-hologres` | 可用 |
 
 ## 安装
 
@@ -60,6 +63,12 @@ pip install datus-clickhouse
 
 # Trino
 pip install datus-trino
+
+# Apache Doris
+pip install datus-doris
+
+# Hologres
+pip install datus-hologres
 ```
 
 安装后，Datus Agent 会自动检测并加载适配器。
@@ -220,6 +229,40 @@ trino_data:
   http_scheme: http  # 可选：http 或 https
 ```
 
+### Apache Doris
+
+```yaml
+doris_data:
+  type: doris
+  host: localhost
+  port: 9030
+  username: root
+  password: your_password
+  database: your_database
+  catalog: internal  # 可选，默认为 internal
+```
+
+Doris 使用 MySQL 协议，`port` 为 FE 查询端口（默认 9030）。内置 catalog 为 `internal`，外部
+catalog（例如 Hive Metastore catalog）可通过同一个 `catalog` 字段选择。
+
+### Hologres
+
+```yaml
+hologres_data:
+  type: hologres
+  host: your-instance-cn-hangzhou.hologres.aliyuncs.com  # 控制台 endpoint，可内嵌 ":80"
+  port: 80
+  username: ${HOLOGRES_ACCESS_KEY_ID}
+  password: ${HOLOGRES_ACCESS_KEY_SECRET}
+  database: your_database
+  schema: public   # 可选，默认为 public
+  sslmode: prefer  # 可选，默认为 prefer
+```
+
+Hologres（阿里云）使用 PostgreSQL wire 协议和 AccessKey 凭证。`access_key_id`/`access_key_secret`
+也可作为 `username`/`password` 的别名。`host` 支持纯 hostname 或 `hostname:port` 形式的控制台
+endpoint；显式配置的 `port` 必须与 endpoint 中内嵌的端口一致。
+
 ## 多数据库连接
 
 可以在 `agent.services.datasources` 下配置多个独立数据源连接：
@@ -302,6 +345,19 @@ agent:
 - 内置 TPC-H 连接器用于基准测试
 - HTTP/HTTPS 连接及 SSL 支持
 
+#### Apache Doris
+- MySQL 协议兼容
+- 多 Catalog 发现与上下文切换（`catalog.database.table`）
+- 物化视图发现与 DDL 获取
+- Catalog 感知的元数据和样本数据获取
+
+#### Hologres
+- PostgreSQL wire 协议（PostgreSQL 兼容 SQL 方言）
+- 阿里云 AccessKey 认证
+- 多 schema 数据源支持
+- 控制台 endpoint 归一化（`hostname` 或 `hostname:port`）
+- SSL 连接模式（disable、allow、prefer、require、verify-ca、verify-full）
+
 ## 故障排除
 
 ### 适配器未找到
@@ -331,6 +387,8 @@ pip install datus-mysql
 - **Spark**：需要 `pyhive`、`thrift`、`thrift-sasl`、`pure-sasl`（自动安装）
 - **ClickHouse**：需要 `clickhouse-sqlalchemy`（自动安装）
 - **Trino**：需要 `trino`（自动安装）
+- **Apache Doris**：需要 `datus-mysql` 和 `pymysql`（自动安装）
+- **Hologres**：需要 `datus-postgresql` 和 `psycopg2-binary`（自动安装）
 
 ## 架构
 
@@ -343,7 +401,10 @@ datus-agent (核心)
 └── 插件系统 (Entry Points)
     ├── datus-sqlalchemy (基础层)
     │   ├── datus-mysql
-    │   ├── datus-starrocks
+    │   │   ├── datus-starrocks
+    │   │   └── datus-doris
+    │   ├── datus-postgresql
+    │   │   └── datus-hologres
     │   ├── datus-hive
     │   ├── datus-spark
     │   ├── datus-clickhouse

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -146,6 +146,33 @@ my_postgresql:
   database: analytics
 ```
 
+### Apache Doris
+
+```yaml
+my_doris:
+  type: doris
+  host: ${DORIS_HOST}
+  port: 9030                    # FE query port (MySQL protocol)
+  username: ${DORIS_USER}
+  password: ${DORIS_PASSWORD}
+  database: ${DORIS_DATABASE}
+  catalog: internal             # Optional, default is internal
+```
+
+### Hologres
+
+```yaml
+my_hologres:
+  type: hologres
+  host: ${HOLOGRES_ENDPOINT}    # Console endpoint, hostname or hostname:port
+  port: 80
+  username: ${HOLOGRES_ACCESS_KEY_ID}
+  password: ${HOLOGRES_ACCESS_KEY_SECRET}
+  database: ${HOLOGRES_DATABASE}
+  schema: public                # Optional
+  sslmode: prefer               # Optional
+```
+
 ### Path Pattern (Multiple Files)
 
 Use glob patterns to auto-discover database files:
@@ -164,7 +191,7 @@ Supported patterns: `*.sqlite`, `**/*.sqlite`, `data/2024/*.db`
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `type` | Yes | Database type: `sqlite`, `duckdb`, `snowflake`, `starrocks`, `mysql`, `postgresql` |
+| `type` | Yes | Database type: `sqlite`, `duckdb`, `snowflake`, `starrocks`, `mysql`, `postgresql`, `doris`, `hologres`, ... |
 | `default` | No | Set to `true` to mark as default database |
 | `uri` | For file DBs | Connection URI for SQLite/DuckDB |
 | `host` | For server DBs | Database server hostname |
@@ -179,6 +206,8 @@ Supported patterns: `*.sqlite`, `**/*.sqlite`, `data/2024/*.db`
 - **StarRocks**: `catalog`
 - **SQLite/DuckDB**: `path_pattern` for glob-based discovery
 - **MySQL/PostgreSQL**: `host`, `port`, `username`, `password`, `database`
+- **Apache Doris**: `catalog` (default `internal`)
+- **Hologres**: `schema`, `sslmode`; `access_key_id`/`access_key_secret` are accepted as aliases for `username`/`password`
 
 ## Managing Databases
 

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -151,6 +151,33 @@ my_postgresql:
   database: analytics
 ```
 
+### Apache Doris
+
+```yaml
+my_doris:
+  type: doris
+  host: ${DORIS_HOST}
+  port: 9030                    # FE 查询端口（MySQL 协议）
+  username: ${DORIS_USER}
+  password: ${DORIS_PASSWORD}
+  database: ${DORIS_DATABASE}
+  catalog: internal             # 可选，默认为 internal
+```
+
+### Hologres
+
+```yaml
+my_hologres:
+  type: hologres
+  host: ${HOLOGRES_ENDPOINT}    # 控制台 endpoint，hostname 或 hostname:port
+  port: 80
+  username: ${HOLOGRES_ACCESS_KEY_ID}
+  password: ${HOLOGRES_ACCESS_KEY_SECRET}
+  database: ${HOLOGRES_DATABASE}
+  schema: public                # 可选
+  sslmode: prefer               # 可选
+```
+
 ### 路径模式（批量发现多个文件）
 
 使用 glob 模式自动发现数据库文件：
@@ -169,7 +196,7 @@ bird_benchmark:
 
 | 参数 | 是否必填 | 说明 |
 |------|----------|------|
-| `type` | 是 | 数据库类型，例如 `sqlite`、`duckdb`、`snowflake`、`starrocks`、`mysql`、`postgresql` |
+| `type` | 是 | 数据库类型，例如 `sqlite`、`duckdb`、`snowflake`、`starrocks`、`mysql`、`postgresql`、`doris`、`hologres` 等 |
 | `default` | 否 | 设为 `true` 后作为默认数据库 |
 | `uri` | 文件型数据库必填 | SQLite / DuckDB 的连接 URI |
 | `host` | 服务型数据库必填 | 数据库主机地址 |
@@ -184,6 +211,8 @@ bird_benchmark:
 - **StarRocks**：`catalog`
 - **SQLite/DuckDB**：`path_pattern` 用于批量发现数据库文件
 - **MySQL/PostgreSQL**：`host`、`port`、`username`、`password`、`database`
+- **Apache Doris**：`catalog`（默认为 `internal`）
+- **Hologres**：`schema`、`sslmode`；`access_key_id`/`access_key_secret` 可作为 `username`/`password` 的别名
 
 ## 管理数据库
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "datus-db-core>=0.1.4",
+    "datus-db-core>=0.1.5",
     "datus-storage-base>=0.1.5,<0.2.0",
     "python-dotenv==1.0.0",
     "pandas==2.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ lxml>=5.0.0
 markdown-it-py>=3.0.0
 tabulate>=0.9.0
 datus-storage-base==0.1.5
-datus-db-core>=0.1.4
+datus-db-core>=0.1.5
 datus-semantic-core>=0.2.2
 datus-bi-core>=0.1.2
 datus-scheduler-core>=0.1.1

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -36,6 +36,23 @@ cd /path/to/datus-db-adapters/datus-postgresql
 docker compose down -v
 ```
 
+### Apache Doris
+
+```bash
+# Install the adapter and start its canonical FE/BE compose stack.
+uv pip install datus-doris
+cd /path/to/datus-db-adapters/datus-doris
+docker compose up -d
+
+# Run the Agent-facing DBFuncTool contract.
+cd /path/to/Datus-agent
+ADAPTERS_DORIS=1 uv run pytest tests/integration/adapters/test_doris.py -v
+
+# Tear down.
+cd /path/to/datus-db-adapters/datus-doris
+docker compose down -v
+```
+
 ## Env vars
 
 | Adapter | Opt-in flag | Connection env | Default (matches adapter's docker-compose.yml) |
@@ -44,6 +61,7 @@ docker compose down -v
 | mysql | `ADAPTERS_MYSQL=1` | `MYSQL_HOST/PORT/USER/PASSWORD/DATABASE` | `localhost:3306 test_user/test_password/test` |
 | clickhouse | `ADAPTERS_CH=1` | `CLICKHOUSE_HOST/PORT/USER/PASSWORD/DATABASE` | `localhost:8123 default_user/default_test/default_test` |
 | starrocks | `ADAPTERS_SR=1` | `STARROCKS_HOST/PORT/USER/PASSWORD/CATALOG/DATABASE` | `127.0.0.1:9030 root//default_catalog/test` |
+| doris | `ADAPTERS_DORIS=1` | `DORIS_HOST/PORT/USER/PASSWORD/CATALOG/DATABASE` | `127.0.0.1:9030 root//internal/test` |
 | trino | `ADAPTERS_TRINO=1` | `TRINO_HOST/PORT/USER` | `localhost:8080 trino` (uses built-in `tpch.tiny`, no seeding) |
 | greenplum | `ADAPTERS_GP=1` | `GREENPLUM_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA` | `localhost:15432 gpadmin/pivotal/postgres/public` |
 | hive | `ADAPTERS_HIVE=1` | `HIVE_HOST/PORT/USERNAME/PASSWORD/DATABASE` | `localhost:10000 hive//default` |
@@ -55,6 +73,7 @@ Several adapters use default ports that are commonly occupied:
 - postgresql (5432) — conflicts with any local Postgres / superset-db
 - trino (8080) — conflicts with Airflow / many web dev servers
 - starrocks (9030) — conflicts with existing StarRocks instances
+- doris (9030) — conflicts with StarRocks and existing Doris instances
 - hive / spark (10000) — both default to the HiveServer2/Spark Thrift port; run one suite at a time or remap one service
 
 For the Trino adapter, the compose file already supports a `TRINO_HOST_PORT`

--- a/tests/integration/adapters/test_doris.py
+++ b/tests/integration/adapters/test_doris.py
@@ -1,0 +1,148 @@
+"""
+Contract tests: Doris adapter via DBFuncTool.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-doris`
+  * start:      `cd datus-db-adapters/datus-doris && docker compose up -d`
+  * set env:    ADAPTERS_DORIS=1
+
+Defaults match the adapter's docker-compose.yml:
+  DORIS_HOST=127.0.0.1  DORIS_PORT=9030
+  DORIS_USER=root  DORIS_PASSWORD=
+  DORIS_CATALOG=internal  DORIS_DATABASE=test
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+from tests.nightly_requirements import import_required, require_opt_in_env
+
+require_opt_in_env("ADAPTERS_DORIS", "tests/integration/adapters/README.md")
+
+datus_doris = import_required(
+    "datus_doris",
+    reason="datus-doris not installed; run `uv pip install datus-doris`",
+)
+
+DorisConfig = datus_doris.DorisConfig
+DorisConnector = datus_doris.DorisConnector
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+
+REGION_TABLE = "datus_agent_doris_region"
+NATION_TABLE = "datus_agent_doris_nation"
+
+
+def _config(database: str | None = None):
+    return DorisConfig(
+        host=os.getenv("DORIS_HOST", "127.0.0.1"),
+        port=int(os.getenv("DORIS_PORT", "9030")),
+        username=os.getenv("DORIS_USER", "root"),
+        password=os.getenv("DORIS_PASSWORD", ""),
+        catalog=os.getenv("DORIS_CATALOG", "internal"),
+        database=database if database is not None else os.getenv("DORIS_DATABASE", "test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def doris_connector() -> Generator:
+    database = os.getenv("DORIS_DATABASE", "test")
+    init_conn = DorisConnector(_config(database="information_schema"))
+    try:
+        if not init_conn.test_connection():
+            pytest.fail(
+                "Doris container unreachable despite ADAPTERS_DORIS=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-doris?"
+            )
+        created = init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{database}`")
+        assert created.success, created.error
+    finally:
+        init_conn.close()
+
+    conn = DorisConnector(_config(database=database))
+    try:
+        for table in (NATION_TABLE, REGION_TABLE):
+            conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")
+        region = conn.execute_ddl(
+            f"""
+            CREATE TABLE `{REGION_TABLE}` (
+                `r_regionkey` INT NOT NULL,
+                `r_name` VARCHAR(25) NOT NULL,
+                `r_comment` VARCHAR(152)
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`r_regionkey`)
+            DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+            """
+        )
+        assert region.success, region.error
+        nation = conn.execute_ddl(
+            f"""
+            CREATE TABLE `{NATION_TABLE}` (
+                `n_nationkey` INT NOT NULL,
+                `n_name` VARCHAR(25) NOT NULL,
+                `n_regionkey` INT NOT NULL,
+                `n_comment` VARCHAR(152)
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`n_nationkey`)
+            DISTRIBUTED BY HASH(`n_nationkey`) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+            """
+        )
+        assert nation.success, nation.error
+        inserted = conn.execute_insert(
+            f"INSERT INTO `{REGION_TABLE}` VALUES "
+            "(0, 'AFRICA', 'lar deposits.'), "
+            "(1, 'AMERICA', 'hs use ironic requests.'), "
+            "(2, 'ASIA', 'ges. pinto beans.')"
+        )
+        assert inserted.success, inserted.error
+        yield conn
+    finally:
+        for table in (NATION_TABLE, REGION_TABLE):
+            conn.execute_ddl(f"DROP TABLE IF EXISTS `{table}`")
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def db_tool(doris_connector) -> DBFuncTool:
+    return DBFuncTool(doris_connector)
+
+
+def test_list_tables_returns_seeded_table(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, result.error
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
+    assert REGION_TABLE in names
+    assert NATION_TABLE in names
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, result.error
+    assert [column["name"] for column in result.result["columns"]] == [
+        "r_regionkey",
+        "r_name",
+        "r_comment",
+    ]
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM `{REGION_TABLE}`")
+    assert result.success == 1, result.error
+    assert result.result["original_rows"] == 1
+    assert "3" in result.result["compressed_data"]
+
+
+def test_read_query_rejects_writes(db_tool: DBFuncTool) -> None:
+    dml = db_tool.read_query(f"INSERT INTO `{REGION_TABLE}` VALUES (99, 'X', '')")
+    assert dml.success == 0
+    assert "read-only" in (dml.error or "").lower()
+
+    multi = db_tool.read_query(f"SELECT 1; DELETE FROM `{REGION_TABLE}`")
+    assert multi.success == 0
+    assert "multi-statement" in (multi.error or "").lower()

--- a/tests/integration/adapters/test_doris.py
+++ b/tests/integration/adapters/test_doris.py
@@ -13,7 +13,7 @@ Defaults match the adapter's docker-compose.yml:
 """
 
 import os
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 
@@ -37,7 +37,7 @@ REGION_TABLE = "datus_agent_doris_region"
 NATION_TABLE = "datus_agent_doris_nation"
 
 
-def _config(database: str | None = None):
+def _config(database: str | None = None) -> DorisConfig:
     return DorisConfig(
         host=os.getenv("DORIS_HOST", "127.0.0.1"),
         port=int(os.getenv("DORIS_PORT", "9030")),
@@ -49,7 +49,7 @@ def _config(database: str | None = None):
 
 
 @pytest.fixture(scope="module")
-def doris_connector() -> Generator:
+def doris_connector() -> Generator[DorisConnector, None, None]:
     database = os.getenv("DORIS_DATABASE", "test")
     init_conn = DorisConnector(_config(database="information_schema"))
     try:
@@ -59,7 +59,7 @@ def doris_connector() -> Generator:
                 "Did you run `docker compose up -d` in datus-db-adapters/datus-doris?"
             )
         created = init_conn.execute_ddl(f"CREATE DATABASE IF NOT EXISTS `{database}`")
-        assert created.success, created.error
+        assert created.success == 1, created.error
     finally:
         init_conn.close()
 
@@ -79,7 +79,7 @@ def doris_connector() -> Generator:
             PROPERTIES ("replication_num" = "1")
             """
         )
-        assert region.success, region.error
+        assert region.success == 1, region.error
         nation = conn.execute_ddl(
             f"""
             CREATE TABLE `{NATION_TABLE}` (
@@ -93,14 +93,14 @@ def doris_connector() -> Generator:
             PROPERTIES ("replication_num" = "1")
             """
         )
-        assert nation.success, nation.error
+        assert nation.success == 1, nation.error
         inserted = conn.execute_insert(
             f"INSERT INTO `{REGION_TABLE}` VALUES "
             "(0, 'AFRICA', 'lar deposits.'), "
             "(1, 'AMERICA', 'hs use ironic requests.'), "
             "(2, 'ASIA', 'ges. pinto beans.')"
         )
-        assert inserted.success, inserted.error
+        assert inserted.success == 1, inserted.error
         yield conn
     finally:
         for table in (NATION_TABLE, REGION_TABLE):

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -44,6 +44,14 @@ def test_nightly_installs_storage_packages_from_latest_checkout():
         assert package_path in workflow
 
 
+def test_nightly_installs_new_database_adapters_from_latest_checkout():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for package_name in ("datus-doris", "datus-hologres"):
+        assert f"--reinstall-package {package_name}" in workflow
+        assert f"./external/datus-db-adapters/{package_name}" in workflow
+
+
 def test_nightly_runs_postgresql_storage_adapter_tests_from_checkout():
     script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
 
@@ -51,3 +59,15 @@ def test_nightly_runs_postgresql_storage_adapter_tests_from_checkout():
     assert 'run_logged "PostgreSQL Storage Adapter Tests"' in script
     assert 'uv run --no-sync pytest "$STORAGE_ADAPTERS_ROOT/datus-storage-postgresql/tests"' in script
     assert '"PostgreSQL Storage Adapter Tests"' in script.split("DOCKER_GROUPS=(", maxsplit=1)[1]
+
+
+def test_nightly_runs_doris_agent_contract_from_checkout():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'echo "ADAPTERS_DORIS=1" >> $GITHUB_ENV' in workflow
+    assert 'echo "DORIS_QUERY_HOST_PORT=29031" >> $GITHUB_ENV' in workflow
+    assert 'echo "DORIS_HTTP_HOST_PORT=28031" >> $GITHUB_ENV' in workflow
+    assert 'DORIS_COMPOSE="${DORIS_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-doris/docker-compose.yml}"' in script
+    assert 'run_compose_suite "Doris Adapter Tests"' in script
+    assert "tests/integration/adapters/test_doris.py" in script

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -45,6 +45,7 @@ def test_nightly_pytest_commands_set_explicit_test_layer():
     ]
 
     assert len(pytest_command_lines) == 21
+    assert any("tests/integration/adapters/test_doris.py" in line for line in pytest_command_lines)
     for line in pytest_command_lines:
         expected_layer = "unit" if "Full Unit Tests" in line else "nightly"
         assert f"env DATUS_TEST_LAYER={expected_layer} uv run pytest" in line

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -44,7 +44,7 @@ def test_nightly_pytest_commands_set_explicit_test_layer():
         if " uv run pytest " in line and ("run_logged" in line or "run_compose_suite" in line)
     ]
 
-    assert len(pytest_command_lines) == 20
+    assert len(pytest_command_lines) == 21
     for line in pytest_command_lines:
         expected_layer = "unit" if "Full Unit Tests" in line else "nightly"
         assert f"env DATUS_TEST_LAYER={expected_layer} uv run pytest" in line

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -44,6 +44,45 @@ def test_expected_sources_include_storage_packages():
     )
 
 
+def test_expected_sources_include_new_database_adapters():
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-doris"] == "datus-db-adapters/datus-doris"
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-hologres"] == "datus-db-adapters/datus-hologres"
+
+
+def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
+    registry = SimpleNamespace(
+        get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
+        get_parser_dialect=lambda db_type: "postgres" if db_type == "hologres" else None,
+        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type == "hologres" else None,
+    )
+    modules = {
+        "datus_db_core": SimpleNamespace(connector_registry=registry),
+        "datus_doris": SimpleNamespace(register=lambda: None),
+        "datus_hologres": SimpleNamespace(register=lambda: None),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_database_adapter_imports() == []
+
+
+def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypatch):
+    registry = SimpleNamespace(
+        get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
+        get_parser_dialect=lambda _db_type: None,
+        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type == "hologres" else None,
+    )
+    modules = {
+        "datus_db_core": SimpleNamespace(connector_registry=registry),
+        "datus_doris": SimpleNamespace(register=lambda: None),
+        "datus_hologres": SimpleNamespace(register=lambda: None),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_database_adapter_imports() == ["datus_hologres parser dialect is not postgres"]
+
+
 def test_verify_local_sources_rejects_registry_package(monkeypatch, tmp_path):
     external_root = tmp_path / "external"
     distributions = {

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "verify_nightly_adapter_sources.py"
 MODULE_SPEC = importlib.util.spec_from_file_location("verify_nightly_adapter_sources", MODULE_PATH)
 if MODULE_SPEC is None or MODULE_SPEC.loader is None:
@@ -81,6 +83,36 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
     assert verify_sources.verify_database_adapter_imports() == ["datus_hologres parser dialect is not postgres"]
+
+
+@pytest.mark.parametrize(
+    ("missing_hook", "expected_error"),
+    [
+        (
+            "get_identifier_parser",
+            "datus_hologres did not register get_identifier_parser",
+        ),
+        (
+            "get_sql_generation_notes",
+            "datus_hologres did not register get_sql_generation_notes",
+        ),
+    ],
+)
+def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, missing_hook, expected_error):
+    registry = SimpleNamespace(
+        get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
+        get_parser_dialect=lambda db_type: "postgres" if db_type == "hologres" else None,
+        get_identifier_parser=lambda _db_type: None if missing_hook == "get_identifier_parser" else object(),
+        get_sql_generation_notes=lambda _db_type: None if missing_hook == "get_sql_generation_notes" else "notes",
+    )
+    modules = {
+        "datus_db_core": SimpleNamespace(connector_registry=registry),
+        "datus_doris": SimpleNamespace(register=lambda: None),
+        "datus_hologres": SimpleNamespace(register=lambda: None),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_database_adapter_imports() == [expected_error]
 
 
 def test_verify_local_sources_rejects_registry_package(monkeypatch, tmp_path):

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -98,7 +98,7 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
         ),
     ],
 )
-def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, missing_hook, expected_error):
+def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, missing_hook: str, expected_error: str):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
         get_parser_dialect=lambda db_type: "postgres" if db_type == "hologres" else None,

--- a/tests/unit_tests/cli/test_datasource_commands.py
+++ b/tests/unit_tests/cli/test_datasource_commands.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
-from datus.cli.datasource_app import DatasourceApp, DatasourceSelection, _View
+from datus.cli.datasource_app import INSTALLABLE_TYPES, DatasourceApp, DatasourceSelection, _View
 from datus.cli.datasource_commands import DatasourceCommands
 
 # ── Helpers ───────────────────────────────────────────────────
@@ -441,6 +441,9 @@ class TestDatasourceAppViews:
             assert app._view == _View.TYPE_SELECT
             assert ("duckdb", "duckdb", True) in app._db_types
             assert ("sqlite", "sqlite", True) in app._db_types
+
+    def test_new_database_adapters_are_installable(self):
+        assert {"doris", "hologres"} <= set(INSTALLABLE_TYPES)
 
     def test_enter_config_form(self):
         cli = _make_cli()

--- a/tests/unit_tests/storage/reference_template/test_template_file_processor.py
+++ b/tests/unit_tests/storage/reference_template/test_template_file_processor.py
@@ -586,6 +586,22 @@ class TestAnalyzeTemplateParameters:
         assert len(result) == 1
         assert result[0]["type"] == "dimension"
 
+    def test_adapter_parser_dialect_is_used(self, monkeypatch):
+        from datus.storage.reference_template.template_file_processor import analyze_template_parameters
+        from datus.tools.db_tools import connector_registry
+
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "postgres" if dialect == "hologres" else None,
+            raising=False,
+        )
+
+        sql = "SELECT * FROM orders WHERE region = '{{region}}'"
+        result = analyze_template_parameters(sql, dialect="hologres")
+
+        assert result[0]["column_ref"] == "orders.region"
+
 
 class TestResolveDimensionColumns:
     """Tests for _resolve_dimension_columns — the sqlglot AST resolution function."""

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -1195,6 +1195,21 @@ class TestTransferQueryResult:
         connector.execute_insert.return_value = insert_result
         return connector, connector.execute_insert
 
+    def test_transfer_helpers_honor_new_adapter_dialects(self, monkeypatch):
+        import pandas as pd
+
+        from datus.tools.db_tools import connector_registry
+
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "postgres" if dialect == "hologres" else None,
+            raising=False,
+        )
+
+        assert DBFuncTool._identifier_quote_char("doris") == "`"
+        assert DBFuncTool._infer_transfer_column_type(pd.Series([1.5]), "hologres") == "DOUBLE PRECISION"
+
     def test_transfer_replace_mode_success(self):
         import pandas as pd
 

--- a/tests/unit_tests/tools/func_tool/test_metric_queryability.py
+++ b/tests/unit_tests/tools/func_tool/test_metric_queryability.py
@@ -15,6 +15,14 @@ from datus.tools.func_tool.metric_queryability import (
 
 
 class TestExtractSqlSnippets:
+    def test_accepts_new_adapter_fence_labels(self):
+        prompt = "```doris\nSELECT 1 AS doris_value\n```\n```hologres\nSELECT 2 AS hologres_value\n```"
+
+        assert extract_sql_snippets(prompt) == [
+            "SELECT 1 AS doris_value",
+            "SELECT 2 AS hologres_value",
+        ]
+
     def test_trims_natural_language_after_unfenced_sql(self):
         prompt = (
             "Generate a metric from the following SQL:\n"

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -1094,6 +1094,36 @@ class TestMetricCandidateAnalyzer:
 
         assert calls == ["mysql"]
 
+    def test_parser_uses_adapter_registered_parser_dialect(self, monkeypatch):
+        import sqlglot
+
+        from datus.tools.db_tools import connector_registry
+
+        calls = []
+        original_parse = sqlglot.parse
+
+        def record_parse(sql, read=None):
+            calls.append(read)
+            return original_parse(sql)
+
+        monkeypatch.setattr(sqlglot, "parse", record_parse)
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "postgres" if dialect == "hologres" else None,
+            raising=False,
+        )
+        tools = SemanticDiscoveryTools(
+            agent_config=SimpleNamespace(
+                current_datasource="analytics",
+                current_db_config=lambda _name: SimpleNamespace(type="hologres"),
+            )
+        )
+
+        tools._parse_sql("SELECT 1")
+
+        assert calls == ["postgres"]
+
     def test_available_tools_without_db_is_empty(self):
         tools = SemanticDiscoveryTools(
             db_tool=None,

--- a/tests/unit_tests/tools/test_sql_guard.py
+++ b/tests/unit_tests/tools/test_sql_guard.py
@@ -1,5 +1,6 @@
 """Tests for the EXPLAIN-based row-count guard (datus/tools/sql_guard.py)."""
 
+from datus.tools.db_tools import connector_registry
 from datus.tools.sql_guard import (
     MAX_ESTIMATED_ROWS,
     build_oversize_message,
@@ -47,6 +48,16 @@ class TestEstimateRowsFromExplain:
             {"QUERY PLAN": "        ->  Nested Loop  (cost=0.00..1.00 rows=9000000000 width=8)"},
         ]
         assert estimate_rows_from_explain("postgres", rows) == 9_000_000_000
+
+    def test_adapter_parser_dialect_keeps_postgres_guard(self, monkeypatch):
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "postgres" if dialect == "hologres" else None,
+            raising=False,
+        )
+        rows = [{"QUERY PLAN": "Nested Loop  (cost=0.00..1.00 rows=9000000000 width=8)"}]
+        assert estimate_rows_from_explain("hologres", rows) == 9_000_000_000
 
     def test_mysql_multiplies_per_table_rows(self):
         rows = [{"id": 1, "table": "a", "rows": 96478}, {"id": 1, "table": "b", "rows": 93358}]

--- a/uv.lock
+++ b/uv.lock
@@ -775,7 +775,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "charset-normalizer", specifier = ">=3.4.2" },
     { name = "datus-bi-core", specifier = ">=0.1.2" },
-    { name = "datus-db-core", specifier = ">=0.1.4" },
+    { name = "datus-db-core", specifier = ">=0.1.5" },
     { name = "datus-scheduler-core", specifier = ">=0.1.1" },
     { name = "datus-semantic-core", specifier = ">=0.2.2" },
     { name = "datus-storage-base", specifier = ">=0.1.5,<0.2.0" },
@@ -865,15 +865,15 @@ wheels = [
 
 [[package]]
 name = "datus-db-core"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "sqlglot" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/47/edbf32ce34e180c98bb6b18bf7f6a1f022f9baaabe0dcaa5a7783a1641de/datus_db_core-0.1.4.tar.gz", hash = "sha256:02d2629592511639adf9ac85118895f3692b439cdd22ecd691902b11b34b80ac", size = 32089, upload-time = "2026-05-19T15:18:36.054Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/7e/3d7c569b0ec3b46978ebd3aa846d83874a903203aadc1c0033883c836b04/datus_db_core-0.1.5.tar.gz", hash = "sha256:bfd44618432e88718998e38b5122de470bdab06b27ba919ee51084cb10df2faa", size = 33739, upload-time = "2026-07-30T07:26:31.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/0e/a1c3436417bb7528b372d6d033f30b4590220b8b38c39582dcaef21a7323/datus_db_core-0.1.4-py3-none-any.whl", hash = "sha256:2c6a9872c82e2c02d74f27df4249ea92748cb2dbc0a96515d2854ce5adfec8fc", size = 25327, upload-time = "2026-05-19T15:18:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/6b/94d4c676d99a61deda25aa18f19bac5db722a1ff0849618b552f0c199297/datus_db_core-0.1.5-py3-none-any.whl", hash = "sha256:209ef6d0188bcba722ec040ad42d277a516242c1b7daaa0f787668cae96e01e1", size = 26174, upload-time = "2026-07-30T07:26:30.684Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- integrate the released `datus-doris` and `datus-hologres` adapters into the Agent datasource UI, documentation, and nightly source-validation flow
- require `datus-db-core>=0.1.5` and consistently consume adapter-registered parser dialects in SQL guards, semantic discovery, reference-template parsing, and transfer type inference
- add a Docker-backed Doris Agent contract suite while keeping Hologres validation package- and registry-based because it requires a cloud service

## Why

The adapters already register themselves through `datus.adapters`, so the core connector discovery and auto-install path did not need database-specific branches. The remaining Agent gaps were:

- the datasource TUI did not offer Doris or Hologres
- several SQL parsing paths bypassed the registry's `parser_dialect`, causing Hologres to be treated as an unknown SQLGlot dialect
- nightly did not install or verify either adapter from the checked-out adapter repository
- Doris had no Agent-facing live integration contract

## User impact

Users can configure `type: doris` or `type: hologres`, install the adapters through the datasource UI, and use the adapters across the Agent's generic SQL parsing and transfer paths. Nightly now verifies checkout provenance and registration hooks for both packages and runs the Doris connector contract against its canonical FE/BE stack.

## Validation

- pure-PyPI install and registration smoke:
  - `datus-doris==0.1.0`
  - `datus-hologres==0.1.0`
  - `datus-mysql==0.1.8`
  - `datus-postgresql==0.1.8`
  - `datus-sqlalchemy==0.1.7`
  - `datus-db-core==0.1.5`
- `602 passed` across the affected SQL, datasource, nightly, prompt, and template unit suites
- `4 passed` against a real Doris 4.0.7 FE/BE Docker stack
- Ruff check and format, Actionlint, coverage-map validation, `uv lock --check`, `uv pip check`, `bash -n`, and `git diff --check`

Live Hologres cloud tests remain in the database adapter repository.

## Follow-up

The OSI semantic adapter maintains a separate datasource-to-SQLGlot mapping and still falls back from Hologres to MySQL. That cross-repository follow-up is tracked in:

- https://github.com/Datus-ai/datus-semantic-adapter/issues/65

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added Apache Doris and Hologres as supported database adapters.
  * Added Doris integration coverage for metadata discovery, query execution, and read-only safeguards.
  * Added adapter-aware SQL parsing, quoting, and query validation.

* **Documentation**
  * Added installation, configuration, capabilities, and troubleshooting guidance for Doris and Hologres.

* **Bug Fixes**
  * Improved dialect handling for PostgreSQL-compatible adapters.

* **Tests**
  * Expanded unit, integration, and nightly coverage for the new adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apache Doris and Hologres as supported database adapters.
  * Enabled Doris/Hologres adapter support in nightly adapter test runs with dedicated connection/port handling.
* **Documentation**
  * Updated adapter installation, configuration examples, capabilities, troubleshooting, and architecture/plugin listings for Doris and Hologres.
* **Bug Fixes**
  * Improved adapter-aware dialect normalization across SQL parsing and EXPLAIN handling, including quoting and fenced-SQL language support.
* **Tests**
  * Expanded Doris/Hologres integration and nightly coverage, tightened Doris contract assertions, and added verification for nightly adapter setup.
* **Maintenance**
  * Bumped the `datus-db-core` dependency constraint and updated nightly manifest/package collection for Doris/Hologres.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->