### PR TITLE
[Enhancement] Catch hooks-below-return in validate_render, share the insert queue with sub-agents

### DIFF
--- a/datus/tools/func_tool/_jsx_hooks_lint.py
+++ b/datus/tools/func_tool/_jsx_hooks_lint.py
@@ -25,6 +25,19 @@ Scope is deliberately narrow: *early return before a hook call, in the same
 function*. Conditional hooks (``if (x) useMemo(...)``) and the missing/incorrect
 import families are NOT checked here.
 
+Known misses, all deliberate — every one of them trades recall for the
+guarantee that correct code is never rejected:
+
+* ``if (x) foo(); else return null;`` — a ``return`` is only anchored when the
+  previous significant character is one of ``{};):``, which is what stops JSX
+  text from being read as code. ``else`` does not qualify.
+* A guard with neither a semicolon nor braces (``if (!x) return null`` on its
+  own line) leaves the return statement open to the end of the function, so
+  later hooks are not reported. Closing it at the newline instead would
+  misjudge multi-line unparenthesised JSX returns, which is the worse trade.
+* Hooks inside the returned expression itself are legal and skipped; see
+  ``_Frame.return_open``.
+
 Design constraints
 ------------------
 
@@ -117,6 +130,12 @@ class _Frame:
 
     return_line: int = 0
     return_pos: int = -1
+    # True between the anchoring ``return`` and the end of that statement.
+    # Hooks *inside* the returned expression run unconditionally on the paths
+    # that reach the return, so they are not violations — see ``_scan``.
+    return_open: bool = False
+    # ``len(braces)`` when the return was anchored, used to find its end.
+    return_depth: int = 0
 
 
 @dataclass
@@ -274,9 +293,14 @@ def _scan(source: str) -> List[HookOrderIssue]:  # noqa: C901 — one tokenizer 
                     if frame.return_pos < 0:
                         frame.return_pos = start
                         frame.return_line = line
+                        frame.return_open = True
+                        frame.return_depth = len(braces)
             elif _HOOK_NAME_RE.match(token) and _next_significant_char(source, i) == "(":
                 frame = frames[-1]
-                if frame.return_pos >= 0:
+                # ``return_open`` skips hooks written *into* the returned
+                # expression — ``return <div ref={useRef(null)} />`` calls the
+                # hook on every render that reaches the return, so it is legal.
+                if frame.return_pos >= 0 and not frame.return_open:
                     issues.append(
                         HookOrderIssue(
                             hook_name=token,
@@ -324,7 +348,21 @@ def _scan(source: str) -> List[HookOrderIssue]:  # noqa: C901 — one tokenizer 
                 frames.pop()
             if brace.restore_template:
                 in_template = True
+            # The block holding the return just closed, so the statement is
+            # over even without a semicolon (``if (x) { return null }``).
+            frame = frames[-1]
+            if frame.return_open and len(braces) < frame.return_depth:
+                frame.return_open = False
             prev_char = "}"
+            prev_token = ""
+            i += 1
+            continue
+
+        if ch == ";":
+            frame = frames[-1]
+            if frame.return_open and len(braces) == frame.return_depth:
+                frame.return_open = False
+            prev_char = ";"
             prev_token = ""
             i += 1
             continue

--- a/datus/tools/func_tool/_jsx_hooks_lint.py
+++ b/datus/tools/func_tool/_jsx_hooks_lint.py
@@ -1,0 +1,423 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Static detection of the "early return before hooks" Rules-of-Hooks violation.
+
+``validate_render`` used to check only paths (entry point, import targets,
+``useQuerySql`` slugs), so a render tree that parses fine but throws the moment
+React mounts it still passed. The single most common such failure — by a wide
+margin on smaller models — is a guard clause placed above the hook calls::
+
+    export default function App() {
+        const { data, loading } = useQuerySql('queries/sales');
+        if (loading) return <Spinner />;          // ← early return
+        const totals = useMemo(() => sum(data), [data]);   // ← never reached
+                                                          //   on the 1st render
+        ...
+    }
+
+React throws "Rendered fewer hooks than expected" on the second render and the
+whole artifact goes blank. Catching it here turns a user-visible blank iframe
+into a tool-result the subagent can fix before it ever delivers.
+
+Scope is deliberately narrow: *early return before a hook call, in the same
+function*. Conditional hooks (``if (x) useMemo(...)``) and the missing/incorrect
+import families are NOT checked here.
+
+Design constraints
+------------------
+
+A false positive is far worse than a miss: it blocks a correct artifact and
+sends the subagent editing code that was already fine. So the scanner is
+conservative everywhere it is unsure, and bails out entirely (returning no
+issues) on anything it cannot confidently tokenize.
+
+The core of the analysis is *function-frame* tracking rather than brace depth.
+A ``return`` belongs to the nearest enclosing **function body**, not the nearest
+enclosing brace, which is what makes both of these correct::
+
+    const f = () => { if (xx) return; };   // f's return, not the component's
+    useThing();                            // → NOT a violation
+
+    useEffect(() => { if (!x) return; }, [x]);   // the arrow's return
+    const y = useMemo(...);                      // → NOT a violation
+
+    if (loading) { return null; }   // the *component's* return (a block `{`
+    const y = useMemo(...);         //  does not open a new function frame)
+                                    // → violation
+"""
+
+from __future__ import annotations
+
+import re
+import string
+from dataclasses import dataclass
+from typing import List, Optional
+
+# Anything larger is almost certainly not hand-authored render code; skip it
+# rather than spend time (and risk) scanning a bundled blob.
+_MAX_SOURCE_CHARS = 512 * 1024
+
+_IDENT_START = frozenset(string.ascii_letters + "_$")
+_IDENT_PART = frozenset(string.ascii_letters + string.digits + "_$")
+
+# `useFoo` / `useFOO` — the React convention. `use` alone, `used`, `useful`
+# etc. deliberately do not match.
+_HOOK_NAME_RE = re.compile(r"^use[A-Z][A-Za-z0-9_$]*$")
+
+# `{` preceded by `)` opens a function body — unless the `(` belonged to one of
+# these, in which case it is a plain block sharing the enclosing function frame.
+_BLOCK_PAREN_HEADS = frozenset({"if", "for", "while", "switch", "catch", "with", "await"})
+
+# A `return` is only treated as a statement when the previous significant
+# character is one of these. This is what keeps JSX *text* from being mistaken
+# for code: in `<div>return</div>` the previous character is `>`, which is not
+# in the set. `)` covers the dominant `if (x) return ...` guard clause, `:`
+# covers `case 'a': return ...`.
+_RETURN_PREV_CHARS = frozenset("{};):")
+
+# Characters after which a `/` starts a regex literal rather than a division.
+# `{`, `}` and `>` are intentionally excluded: they precede the `/` of a
+# self-closing JSX tag (`<Foo bar={x} />`), and treating that as a regex would
+# swallow the rest of the line — including braces, which would corrupt the
+# frame stack.
+_REGEX_PREV_CHARS = frozenset("(,=:[!&|?;+-*%~^")
+_REGEX_PREV_TOKENS = frozenset(
+    {
+        "return",
+        "typeof",
+        "case",
+        "in",
+        "of",
+        "new",
+        "delete",
+        "void",
+        "instanceof",
+        "yield",
+        "await",
+        "do",
+        "else",
+    }
+)
+
+
+@dataclass(frozen=True)
+class HookOrderIssue:
+    """One hook call that is unreachable on some render because of a return."""
+
+    hook_name: str
+    hook_line: int
+    return_line: int
+
+
+@dataclass
+class _Frame:
+    """One function body. ``return_line``/``return_pos`` are the first found."""
+
+    return_line: int = 0
+    return_pos: int = -1
+
+
+@dataclass
+class _Brace:
+    """One open ``{``. ``opens_frame`` braces also pushed a :class:`_Frame`."""
+
+    opens_frame: bool
+    restore_template: bool = False
+
+
+class _Bail(Exception):
+    """Raised when the source cannot be tokenized with confidence."""
+
+
+def find_hook_order_issues(source: str) -> List[HookOrderIssue]:
+    """Return every hook call that sits after an early return in its function.
+
+    Returns an empty list — never a partial result — when the source cannot be
+    scanned confidently (unbalanced braces, unterminated string/comment, or an
+    implausibly large file).
+    """
+    if not source or len(source) > _MAX_SOURCE_CHARS:
+        return []
+
+    try:
+        return _scan(source)
+    except _Bail:
+        return []
+
+
+def format_hook_order_issues(rel: str, source: str) -> List[str]:
+    """Render :func:`find_hook_order_issues` output as ``validate_render`` issues."""
+    return [
+        f"render/{rel}: {issue.hook_name}() on line {issue.hook_line} is called below the "
+        f"`return` on line {issue.return_line}, so it is skipped whenever that branch is taken "
+        'and React throws "Rendered fewer hooks than expected". Move every hook call above the '
+        "first return, and gate the *rendered output* instead of the hook calls."
+        for issue in find_hook_order_issues(source)
+    ]
+
+
+def _scan(source: str) -> List[HookOrderIssue]:  # noqa: C901 — one tokenizer loop
+    issues: List[HookOrderIssue] = []
+    frames: List[_Frame] = [_Frame()]
+    braces: List[_Brace] = []
+    # Head token of each currently-open `(`, so a `)` can tell `if (...)` from
+    # `foo(...)` when the following `{` is classified.
+    paren_heads: List[str] = []
+    last_paren_head = ""
+
+    n = len(source)
+    i = 0
+    line = 1
+    in_template = False
+    prev_char = ""  # last significant character
+    prev_token = ""  # last significant identifier / `=>`
+
+    while i < n:
+        ch = source[i]
+
+        if ch == "\n":
+            line += 1
+            i += 1
+            continue
+
+        if ch in " \t\r\f\v":
+            i += 1
+            continue
+
+        # ---- comments
+        if ch == "/" and i + 1 < n and source[i + 1] == "/":
+            i = source.find("\n", i)
+            if i == -1:
+                break
+            continue
+
+        if ch == "/" and i + 1 < n and source[i + 1] == "*":
+            end = source.find("*/", i + 2)
+            if end == -1:
+                raise _Bail("unterminated block comment")
+            line += source.count("\n", i, end)
+            i = end + 2
+            continue
+
+        # ---- template literal bodies (outside `${ }`)
+        if in_template:
+            if ch == "`":
+                in_template = False
+                prev_char = "`"
+                prev_token = ""
+                i += 1
+                continue
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == "$" and i + 1 < n and source[i + 1] == "{":
+                braces.append(_Brace(opens_frame=False, restore_template=True))
+                in_template = False
+                prev_char = "{"
+                prev_token = ""
+                i += 2
+                continue
+            i += 1
+            continue
+
+        # ---- strings
+        if ch in "'\"":
+            end = _skip_quoted(source, i, ch)
+            if end is None:
+                # Not a string after all — an apostrophe in JSX text
+                # (``<p>Don't forget</p>``) is the common case. A real string
+                # literal cannot contain a raw newline, so skipping just this
+                # character and carrying on is the correct reading.
+                prev_char = ch
+                prev_token = ""
+                i += 1
+                continue
+            i = end
+            prev_char = ch
+            prev_token = ""
+            continue
+
+        if ch == "`":
+            in_template = True
+            i += 1
+            continue
+
+        # ---- regex literal vs division
+        if ch == "/":
+            if _starts_regex(prev_char, prev_token):
+                end = _skip_regex(source, i)
+                if end is not None:
+                    i = end
+                    prev_char = "/"
+                    prev_token = ""
+                    continue
+            # Division (or a JSX `/>`): fall through as a plain operator.
+            prev_char = "/"
+            prev_token = ""
+            i += 1
+            continue
+
+        # ---- identifiers / keywords
+        if ch in _IDENT_START:
+            start = i
+            i += 1
+            while i < n and source[i] in _IDENT_PART:
+                i += 1
+            token = source[start:i]
+
+            if token == "return" and prev_char in _RETURN_PREV_CHARS:
+                # `{ return: 1 }` — a property key, not a statement.
+                if _next_significant_char(source, i) != ":":
+                    frame = frames[-1]
+                    if frame.return_pos < 0:
+                        frame.return_pos = start
+                        frame.return_line = line
+            elif _HOOK_NAME_RE.match(token) and _next_significant_char(source, i) == "(":
+                frame = frames[-1]
+                if frame.return_pos >= 0:
+                    issues.append(
+                        HookOrderIssue(
+                            hook_name=token,
+                            hook_line=line,
+                            return_line=frame.return_line,
+                        )
+                    )
+
+            prev_char = token[-1]
+            prev_token = token
+            continue
+
+        # ---- structural punctuation
+        if ch == "(":
+            paren_heads.append(prev_token)
+            prev_char = "("
+            prev_token = ""
+            i += 1
+            continue
+
+        if ch == ")":
+            last_paren_head = paren_heads.pop() if paren_heads else ""
+            prev_char = ")"
+            prev_token = ""
+            i += 1
+            continue
+
+        if ch == "{":
+            opens_frame = prev_token == "=>" or (prev_char == ")" and last_paren_head not in _BLOCK_PAREN_HEADS)
+            braces.append(_Brace(opens_frame=opens_frame))
+            if opens_frame:
+                frames.append(_Frame())
+            prev_char = "{"
+            prev_token = ""
+            i += 1
+            continue
+
+        if ch == "}":
+            if not braces:
+                raise _Bail("unbalanced closing brace")
+            brace = braces.pop()
+            if brace.opens_frame:
+                if len(frames) == 1:
+                    raise _Bail("frame stack underflow")
+                frames.pop()
+            if brace.restore_template:
+                in_template = True
+            prev_char = "}"
+            prev_token = ""
+            i += 1
+            continue
+
+        if ch == "=" and i + 1 < n and source[i + 1] == ">":
+            prev_char = ">"
+            prev_token = "=>"
+            i += 2
+            continue
+
+        prev_char = ch
+        prev_token = ""
+        i += 1
+
+    if braces or in_template:
+        raise _Bail("unbalanced braces or unterminated template literal")
+
+    return issues
+
+
+def _skip_quoted(source: str, i: int, quote: str) -> Optional[int]:
+    """Return the index just past a ``'``/``"`` string, or ``None`` if it isn't one."""
+    n = len(source)
+    j = i + 1
+    while j < n:
+        c = source[j]
+        if c == "\\":
+            j += 2
+            continue
+        if c == quote:
+            return j + 1
+        if c == "\n":
+            return None
+        j += 1
+    return None
+
+
+def _starts_regex(prev_char: str, prev_token: str) -> bool:
+    if prev_token:
+        return prev_token in _REGEX_PREV_TOKENS
+    return prev_char == "" or prev_char in _REGEX_PREV_CHARS
+
+
+def _skip_regex(source: str, i: int) -> Optional[int]:
+    """Return the index just past a regex literal, or ``None`` if it isn't one.
+
+    Regex literals cannot span lines, so hitting a newline first means the `/`
+    was really a division (or a JSX `/>`), and the caller falls back to that.
+    """
+    n = len(source)
+    j = i + 1
+    in_class = False
+    while j < n:
+        c = source[j]
+        if c == "\\":
+            j += 2
+            continue
+        if c == "\n":
+            return None
+        if c == "[":
+            in_class = True
+        elif c == "]":
+            in_class = False
+        elif c == "/" and not in_class:
+            j += 1
+            # Trailing flags.
+            while j < n and source[j] in _IDENT_PART:
+                j += 1
+            return j
+        j += 1
+    return None
+
+
+def _next_significant_char(source: str, i: int) -> str:
+    """Peek at the next character, skipping whitespace and comments."""
+    n = len(source)
+    while i < n:
+        c = source[i]
+        if c in " \t\r\n\f\v":
+            i += 1
+            continue
+        if c == "/" and i + 1 < n:
+            if source[i + 1] == "/":
+                nl = source.find("\n", i)
+                if nl == -1:
+                    return ""
+                i = nl + 1
+                continue
+            if source[i + 1] == "*":
+                end = source.find("*/", i + 2)
+                if end == -1:
+                    return ""
+                i = end + 2
+                continue
+        return c
+    return ""

--- a/datus/tools/func_tool/_jsx_hooks_lint.py
+++ b/datus/tools/func_tool/_jsx_hooks_lint.py
@@ -205,22 +205,11 @@ def _scan(source: str) -> List[HookOrderIssue]:  # noqa: C901 — one tokenizer 
             i += 1
             continue
 
-        # ---- comments
-        if ch == "/" and i + 1 < n and source[i + 1] == "/":
-            i = source.find("\n", i)
-            if i == -1:
-                break
-            continue
-
-        if ch == "/" and i + 1 < n and source[i + 1] == "*":
-            end = source.find("*/", i + 2)
-            if end == -1:
-                raise _Bail("unterminated block comment")
-            line += source.count("\n", i, end)
-            i = end + 2
-            continue
-
         # ---- template literal bodies (outside `${ }`)
+        # Must precede the comment branches: a template is raw text, so the
+        # `//` in an interpolated URL (`` `https://api/${id}` ``) is not a
+        # comment. Reading it as one swallowed the closing backtick and bailed
+        # the whole file, silently disabling the check for it.
         if in_template:
             if ch == "`":
                 in_template = False
@@ -239,6 +228,21 @@ def _scan(source: str) -> List[HookOrderIssue]:  # noqa: C901 — one tokenizer 
                 i += 2
                 continue
             i += 1
+            continue
+
+        # ---- comments
+        if ch == "/" and i + 1 < n and source[i + 1] == "/":
+            i = source.find("\n", i)
+            if i == -1:
+                break
+            continue
+
+        if ch == "/" and i + 1 < n and source[i + 1] == "*":
+            end = source.find("*/", i + 2)
+            if end == -1:
+                raise _Bail("unterminated block comment")
+            line += source.count("\n", i, end)
+            i = end + 2
             continue
 
         # ---- strings

--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -44,6 +44,7 @@ from datus.schemas.gen_visual_dashboard_models import (
     parse_datus_params_header,
 )
 from datus.tools.func_tool._artifact_filesystem_base import ArtifactFilesystemFuncTool
+from datus.tools.func_tool._jsx_hooks_lint import format_hook_order_issues
 from datus.tools.func_tool._visual_artifact_helpers import (
     append_intent_section,
     coerce_uses_arg,
@@ -1035,6 +1036,8 @@ class DashboardArtifactTools:
         * Every ``import`` / ``export ... from`` path is either a bare
           specifier in the allowed list or a relative path that resolves
           to a file under ``render/``.
+        * No ``use*()`` hook call sits below a ``return`` in the same function
+          — the Rules-of-Hooks violation that renders as a blank artifact.
 
         Returns:
             FuncToolResult.result on success::
@@ -1293,6 +1296,9 @@ class DashboardArtifactTools:
                     f"render/{mod['rel']}: import {spec!r} is not allowed. Only bare specifiers "
                     f"{sorted(ALLOWED_BARE_MODULES)} or relative paths under render/ are allowed."
                 )
+
+            # ---- Rules of Hooks: no hook call below an early return
+            issues.extend(format_hook_order_issues(mod["rel"], source))
 
         if not _DEFAULT_EXPORT_RE.search(modules["app"]["source"]):
             issues.append(

--- a/datus/tools/func_tool/report_artifact_tools.py
+++ b/datus/tools/func_tool/report_artifact_tools.py
@@ -44,6 +44,7 @@ from datus.schemas.gen_visual_report_models import (
     extract_query_slug,
 )
 from datus.tools.func_tool._artifact_filesystem_base import ArtifactFilesystemFuncTool
+from datus.tools.func_tool._jsx_hooks_lint import format_hook_order_issues
 from datus.tools.func_tool._visual_artifact_helpers import (
     append_intent_section,
     coerce_uses_arg,
@@ -826,6 +827,8 @@ class ReportArtifactTools:
             ``@datus/web-artifact``), OR
           - a relative path that resolves to a file under ``render/``.
         * No file escapes ``render/`` via ``../`` import.
+        * No ``use*()`` hook call sits below a ``return`` in the same function
+          — the Rules-of-Hooks violation that renders as a blank artifact.
 
         Returns:
             FuncToolResult.result on success::
@@ -962,6 +965,9 @@ class ReportArtifactTools:
                     f"render/{mod['rel']}: import {spec!r} is not allowed. Only bare specifiers "
                     f"{sorted(ALLOWED_BARE_MODULES)} or relative paths under render/ are allowed."
                 )
+
+            # ---- Rules of Hooks: no hook call below an early return
+            issues.extend(format_hook_order_issues(mod["rel"], source))
 
         if not _DEFAULT_EXPORT_RE.search(modules["app"]["source"]):
             issues.append(

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -681,7 +681,7 @@ class SubAgentTaskTool:
                     if hasattr(h, "broker"):
                         h.broker = broker
 
-    def _inherit_pending_input_queue(self, node) -> None:
+    def _inherit_pending_input_queue(self, node: "AgenticNode") -> None:
         """Share the parent's pending-input queue with a sub-agent node.
 
         ``call_model_input_filter`` drains the queue on the node that owns it,

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -694,6 +694,17 @@ class SubAgentTaskTool:
         so parent and sub-agent holding one shared reference can never
         double-deliver an item; whichever loop reaches its next turn first
         consumes it.
+
+        Two consequences of that "first turn wins" rule, both accepted:
+
+        * Sharing is not scoped to artifact fixes. Any mid-run insert — even one
+          aimed at the parent ("stop, try another angle") — is consumed by a
+          sub-agent that happens to be holding the floor. Steering the loop that
+          is actually running is the intended reading of a mid-run message, and
+          the parent still sees the text on its own next turn via the session.
+        * With several sub-agents started in one parent turn, which of them
+          picks the item up is not deterministic. Still strictly better than the
+          old behaviour, where the item always waited out the full round trip.
         """
         parent_queue = getattr(self._parent_node, "pending_input_queue", None)
         if parent_queue is not None:

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -681,6 +681,24 @@ class SubAgentTaskTool:
                     if hasattr(h, "broker"):
                         h.broker = broker
 
+    def _inherit_pending_input_queue(self, node) -> None:
+        """Share the parent's pending-input queue with a sub-agent node.
+
+        ``call_model_input_filter`` drains the queue on the node that owns it,
+        once per LLM turn. Without this the queue stays with the parent while a
+        sub-agent holds the floor, so a mid-run insert — "the chart you just
+        wrote throws on render, fix it" — only reaches the model after the
+        sub-agent has already returned and delivered its broken artifact.
+
+        The queue is thread-safe and :meth:`PendingInputQueue.drain` empties it,
+        so parent and sub-agent holding one shared reference can never
+        double-deliver an item; whichever loop reaches its next turn first
+        consumes it.
+        """
+        parent_queue = getattr(self._parent_node, "pending_input_queue", None)
+        if parent_queue is not None:
+            node.pending_input_queue = parent_queue
+
     # ── execution via execute_stream ───────────────────────────────────
 
     async def _execute_node(
@@ -793,6 +811,8 @@ class SubAgentTaskTool:
             # avoid dual-consuming the same broker.fetch() stream.
             if self._interaction_broker is not None:
                 self._inject_broker(node, self._interaction_broker)
+
+            self._inherit_pending_input_queue(node)
 
             # Propagate proxy tool config from parent node so sub-agent tools are
             # also proxied.  Uses the parent's tool_channel so stdin dispatch can

--- a/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
@@ -767,6 +767,25 @@ class TestValidateRender:
         assert result.result["artifact_kind"] == "dashboard"
         assert result.result["artifact_slug"] == dashboard_tools.dashboard_slug
 
+    def test_rejects_hook_below_an_early_return(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        _seed_template(dashboard_tools)
+        early_return = (
+            "import React from 'react';\n"
+            "import { useDatusArtifact } from '@datus/web-artifact';\n"
+            "export default function App() {\n"
+            "  const { useQuerySql } = useDatusArtifact();\n"
+            "  const { data, loading } = useQuerySql('queries/revenue_by_region', { month_floor: '2026-01' });\n"
+            "  if (loading) return null;\n"
+            "  const rows = React.useMemo(() => data?.rows ?? [], [data]);\n"
+            "  return React.createElement('div', null, rows.length);\n"
+            "}\n"
+        )
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": early_return})
+        result = dashboard_tools.validate_render()
+        assert result.success == 0
+        assert "useMemo() on line 7" in (result.error or "")
+        assert "line 6" in (result.error or "")
+
     def test_rejects_useQuerySql_without_params_arg(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
         _seed_template(dashboard_tools)
         app_no_params = (

--- a/tests/unit_tests/tools/func_tool/test_jsx_hooks_lint.py
+++ b/tests/unit_tests/tools/func_tool/test_jsx_hooks_lint.py
@@ -360,6 +360,42 @@ export default function App({ xs }) {
 """
         assert find_hook_order_issues(source) == []
 
+    def test_template_url_does_not_swallow_the_rest_of_the_file(self):
+        # `//` inside a template body is text, not a comment. Reading it as one
+        # ate the closing backtick and bailed the whole scan, so the real
+        # violation below went unreported.
+        source = """
+export default function App({ id }) {
+  const url = `https://api.example.com/items/${id}`;
+  if (!id) return null;
+  const y = useMemo(() => fetch(url), [url]);
+  return <div>{y}</div>;
+}
+"""
+        assert names(source) == ["useMemo"]
+
+    def test_block_comment_opener_in_a_template_is_text(self):
+        source = """
+export default function App({ id }) {
+  const label = `rate /* per unit ${id}`;
+  if (!id) return null;
+  const y = useMemo(() => 1, []);
+  return <div>{y}{label}</div>;
+}
+"""
+        assert names(source) == ["useMemo"]
+
+    def test_comments_still_work_inside_a_template_expression(self):
+        # Inside `${ }` we are back in JS, where a comment is a comment.
+        source = """
+export default function App({ id }) {
+  const label = `id: ${/* keep */ id}`;
+  const [a] = useState();
+  return <div>{label}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
     def test_return_inside_line_and_block_comments(self):
         source = """
 export default function App() {

--- a/tests/unit_tests/tools/func_tool/test_jsx_hooks_lint.py
+++ b/tests/unit_tests/tools/func_tool/test_jsx_hooks_lint.py
@@ -1,0 +1,544 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the "early return before hooks" scanner.
+
+The scanner runs inside ``validate_render`` and *fails* the subagent's terminal
+action, so a false positive blocks a perfectly good artifact and sends the model
+editing correct code. The bulk of this file is therefore negative cases — code
+that must never be flagged — grouped by the tokenizer hazard they exercise:
+nested function frames, JSX text, strings/templates/regex, comments, and
+property keys named ``return``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from datus.tools.func_tool._jsx_hooks_lint import find_hook_order_issues
+
+
+def names(source: str) -> list[str]:
+    return [issue.hook_name for issue in find_hook_order_issues(source)]
+
+
+# --------------------------------------------------------------------------- #
+# Nested function frames — a `return` belongs to its own function              #
+# --------------------------------------------------------------------------- #
+
+
+class TestNestedFunctionFrames:
+    def test_inner_arrow_early_return_does_not_leak_to_the_component(self):
+        # The exact shape that must never be misjudged: an inner arrow returns
+        # early, then the *component* goes on to call its hooks.
+        source = """
+export default function App() {
+  const f = () => { if (xx) return; };
+
+  useXXHooks();
+  const [a, setA] = useState();
+
+  return <View />;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_use_effect_callback_early_return(self):
+        source = """
+export default function App() {
+  const { data } = useQuerySql('queries/sales');
+
+  useEffect(() => {
+    if (!data) return;
+    track(data);
+  }, [data]);
+
+  const totals = useMemo(() => sum(data), [data]);
+  return <div>{totals}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_use_callback_with_guard_then_more_hooks(self):
+        source = """
+export default function App() {
+  const onPick = useCallback((row) => {
+    if (!row) {
+      return null;
+    }
+    return row.id;
+  }, []);
+
+  const [sel, setSel] = useState(null);
+  return <Table onPick={onPick} sel={sel} />;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_map_callback_before_hooks(self):
+        source = """
+export default function App({ data }) {
+  const rows = data.map((d) => {
+    if (!d) return null;
+    return d.value;
+  });
+
+  const [page, setPage] = useState(0);
+  return <List rows={rows} page={page} />;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_helper_function_declared_above_the_component(self):
+        source = """
+function formatValue(v) {
+  if (v == null) return '-';
+  return String(v);
+}
+
+export default function App() {
+  const [a] = useState();
+  return <div>{formatValue(a)}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_nested_component_defined_after_the_outer_return(self):
+        source = """
+export default function App() {
+  const [a] = useState();
+  if (!a) return null;
+
+  function Inner() {
+    const [b] = useState();
+    return <div>{b}</div>;
+  }
+
+  return <Inner />;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_arrow_inside_jsx_attribute_before_a_later_hook(self):
+        source = """
+export default function App() {
+  const el = <button onClick={() => { if (!ready) return; go(); }}>Go</button>;
+  const [ready, setReady] = useState(false);
+  return el;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_object_method_shorthand_with_early_return(self):
+        source = """
+export default function App() {
+  const api = {
+    load(x) {
+      if (!x) return null;
+      return fetchIt(x);
+    },
+  };
+
+  const [a] = useState();
+  return <div>{api.load(a)}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_iife_with_early_return(self):
+        source = """
+export default function App() {
+  const cfg = (function () {
+    if (!window.cfg) return {};
+    return window.cfg;
+  })();
+
+  const [a] = useState(cfg);
+  return <div>{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_async_arrow_with_early_return(self):
+        source = """
+export default function App() {
+  const load = async () => {
+    if (!id) return;
+    await go(id);
+  };
+
+  const [a] = useState();
+  return <div onClick={load}>{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+
+# --------------------------------------------------------------------------- #
+# Blocks share the enclosing function frame                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestBlocksAreNotFrames:
+    @pytest.mark.parametrize(
+        "guard",
+        [
+            "if (loading) return <Spinner />;",
+            "if (loading) {\n    return <Spinner />;\n  }",
+            "if (a) {\n    if (b) {\n      return null;\n    }\n  }",
+            "for (const x of xs) {\n    if (x.bad) return null;\n  }",
+            "while (n--) {\n    if (n < 0) return null;\n  }",
+            "try {\n    return risky();\n  } catch (e) {\n    log(e);\n  }",
+            "switch (mode) {\n    case 'a':\n      return <A />;\n  }",
+        ],
+    )
+    def test_guard_in_a_block_still_belongs_to_the_component(self, guard: str):
+        source = f"""
+export default function App() {{
+  {guard}
+  const totals = useMemo(() => 1, []);
+  return <div>{{totals}}</div>;
+}}
+"""
+        assert names(source) == ["useMemo"]
+
+    def test_block_without_return_is_fine(self):
+        source = """
+export default function App() {
+  if (debug) {
+    console.log('mounting');
+  }
+  const [a] = useState();
+  return <div>{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_loop_with_continue_is_fine(self):
+        source = """
+export default function App({ xs }) {
+  const out = [];
+  for (const x of xs) {
+    if (!x) continue;
+    out.push(x);
+  }
+  const [a] = useState();
+  return <div>{a}{out.length}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+
+# --------------------------------------------------------------------------- #
+# JSX text, strings, templates, regex, comments                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestTokenizerHazards:
+    def test_return_as_jsx_text_before_hooks(self):
+        source = """
+export default function App() {
+  const hint = <p>press return to continue</p>;
+  const [a] = useState();
+  return <div>{hint}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_apostrophe_in_jsx_text_before_hooks(self):
+        source = """
+export default function App() {
+  const hint = <p>Don't return home yet</p>;
+  const [a] = useState();
+  return <div>{hint}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_return_inside_a_string_literal(self):
+        source = """
+export default function App() {
+  const msg = 'if empty return null';
+  const other = "return early";
+  const [a] = useState();
+  return <div>{msg}{other}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_return_inside_a_template_literal(self):
+        source = """
+export default function App({ n }) {
+  const msg = `return ${n} rows`;
+  const [a] = useState();
+  return <div>{msg}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_template_literal_with_nested_arrow_returning_early(self):
+        source = """
+export default function App({ xs }) {
+  const msg = `total ${xs.map((x) => { if (!x) return 0; return x.v; }).length}`;
+  const [a] = useState();
+  return <div>{msg}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_return_inside_line_and_block_comments(self):
+        source = """
+export default function App() {
+  // if (loading) return <Spinner />;
+  /* legacy:
+     if (!data) return null;
+  */
+  const [a] = useState();
+  return <div>{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_regex_literal_containing_return(self):
+        source = """
+export default function App() {
+  const re = /return\\s+null/g;
+  const [a] = useState();
+  return <div>{re.source}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_self_closing_jsx_with_expression_attribute_before_hooks(self):
+        source = """
+export default function App({ x }) {
+  const el = <Foo bar={x} baz={{ a: 1 }} />;
+  const [a] = useState();
+  return <div>{el}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_division_is_not_read_as_a_regex(self):
+        source = """
+export default function App({ total, count }) {
+  const avg = total / count / 2;
+  const [a] = useState();
+  return <div>{avg}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_property_key_named_return(self):
+        source = """
+export default function App() {
+  const codes = { return: 1, exit: 2 };
+  const [a] = useState();
+  return <div>{codes.return}{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_member_access_named_return(self):
+        source = """
+export default function App({ gen }) {
+  gen.return(undefined);
+  const [a] = useState();
+  return <div>{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+
+# --------------------------------------------------------------------------- #
+# Real violations                                                              #
+# --------------------------------------------------------------------------- #
+
+
+class TestViolations:
+    def test_classic_loading_guard_above_a_hook(self):
+        source = """
+export default function App() {
+  const { data, loading } = useQuerySql('queries/sales');
+  if (loading) return <Spinner />;
+  const totals = useMemo(() => sum(data), [data]);
+  return <div>{totals}</div>;
+}
+"""
+        issues = find_hook_order_issues(source)
+        assert [i.hook_name for i in issues] == ["useMemo"]
+        assert issues[0].return_line == 4
+        assert issues[0].hook_line == 5
+
+    def test_braced_guard_above_a_hook(self):
+        source = """
+export default function App({ data }) {
+  if (!data) {
+    return null;
+  }
+  const [sel, setSel] = useState(null);
+  return <div>{sel}</div>;
+}
+"""
+        assert names(source) == ["useState"]
+
+    def test_namespaced_hook_after_a_return(self):
+        source = """
+export default function App({ data }) {
+  if (!data) return null;
+  const [sel] = React.useState(null);
+  return <div>{sel}</div>;
+}
+"""
+        assert names(source) == ["useState"]
+
+    def test_every_hook_after_the_return_is_reported(self):
+        source = """
+export default function App({ data }) {
+  if (!data) return null;
+  const [a] = useState();
+  const b = useMemo(() => 1, []);
+  const c = useRef(null);
+  return <div>{a}{b}{c}</div>;
+}
+"""
+        assert names(source) == ["useState", "useMemo", "useRef"]
+
+    def test_only_the_first_return_is_used_as_the_anchor(self):
+        source = """
+export default function App({ data }) {
+  if (!data) return null;
+  if (data.empty) return <Empty />;
+  const [a] = useState();
+  return <div>{a}</div>;
+}
+"""
+        issues = find_hook_order_issues(source)
+        assert len(issues) == 1
+        assert issues[0].return_line == 3
+
+    def test_violation_inside_a_custom_hook(self):
+        source = """
+export function useRows(data) {
+  if (!data) return [];
+  const [rows, setRows] = useState([]);
+  return rows;
+}
+"""
+        assert names(source) == ["useState"]
+
+    def test_violation_in_a_nested_component_only(self):
+        source = """
+export default function App() {
+  const [a] = useState();
+
+  function Inner({ data }) {
+    if (!data) return null;
+    const [b] = useState();
+    return <div>{b}</div>;
+  }
+
+  return <Inner data={a} />;
+}
+"""
+        assert names(source) == ["useState"]
+
+    def test_hook_called_inline_inside_jsx_after_a_guard(self):
+        # Taken from a real generated report: the guard sits ~60 lines above a
+        # `ref={useRef(null)}` buried in the returned JSX, so nothing about the
+        # two lines looks related when read in isolation.
+        source = """
+export default function Trend({ rows }) {
+  const data = useMemo(() => rows.map(N), [rows]);
+  if (rows.length === 0) return null;
+
+  return (
+    <Section title="Trend">
+      <div ref={useRef(null)} style={{ marginTop: 32 }}>
+        <Chart data={data} />
+      </div>
+    </Section>
+  );
+}
+"""
+        assert names(source) == ["useRef"]
+
+    def test_two_components_each_reported(self):
+        source = """
+export function A({ x }) {
+  if (!x) return null;
+  const [a] = useState();
+  return <div>{a}</div>;
+}
+
+export default function B({ y }) {
+  if (!y) return null;
+  const [b] = useMemo(() => [1], []);
+  return <div>{b}</div>;
+}
+"""
+        assert names(source) == ["useState", "useMemo"]
+
+
+# --------------------------------------------------------------------------- #
+# Bail-out behaviour — never guess                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestBailOut:
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "",
+            "const a = 1;\n",
+            "export default function App() { return <div />; }\n",
+        ],
+    )
+    def test_benign_sources_report_nothing(self, source: str):
+        assert find_hook_order_issues(source) == []
+
+    def test_unbalanced_braces_bail_out(self):
+        source = """
+export default function App({ data }) {
+  if (!data) return null;
+  const [a] = useState();
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_stray_closing_brace_bails_out(self):
+        source = """
+}
+export default function App({ data }) {
+  if (!data) return null;
+  const [a] = useState();
+  return <div>{a}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_unterminated_block_comment_bails_out(self):
+        source = """
+export default function App({ data }) {
+  if (!data) return null;
+  const [a] = useState();
+  /* trailing
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_oversized_source_is_skipped(self):
+        source = "export default function App(){ if(!x) return null; const [a]=useState(); }\n"
+        padding = "// " + ("x" * 600 * 1024) + "\n"
+        assert find_hook_order_issues(padding + source) == []
+
+    def test_use_prefixed_non_hook_identifiers_are_ignored(self):
+        source = """
+export default function App({ data }) {
+  if (!data) return null;
+  const u = user(data);
+  const v = used(data);
+  const w = useful;
+  return <div>{u}{v}{w}</div>;
+}
+"""
+        assert find_hook_order_issues(source) == []

--- a/tests/unit_tests/tools/func_tool/test_jsx_hooks_lint.py
+++ b/tests/unit_tests/tools/func_tool/test_jsx_hooks_lint.py
@@ -235,6 +235,79 @@ export default function App({ xs }) {
 # --------------------------------------------------------------------------- #
 
 
+class TestHooksInsideTheReturnedExpression:
+    """A hook written into the returned JSX runs on every render that reaches
+    the return, so it is legal — the anchor must not swallow its own statement.
+    """
+
+    def test_hook_in_the_only_return(self):
+        source = """
+export default function App() {
+  return <div ref={useRef(null)}><Child /></div>;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_context_provider_value(self):
+        source = """
+export default function App({ a, x }) {
+  return (
+    <Ctx.Provider value={useMemo(() => a * x, [a, x])}>
+      <Child />
+    </Ctx.Provider>
+  );
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_hook_in_a_guards_own_returned_expression(self):
+        # A conditional hook, which is a different violation family and out of
+        # this scanner's declared scope — but it must not be misreported as an
+        # ordering problem either.
+        source = """
+export default function App({ x }) {
+  if (x) return <A data={useMemo(() => 1, [])} />;
+  return <B />;
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+    def test_hook_after_the_return_statement_is_still_caught(self):
+        source = """
+export default function App({ x }) {
+  if (!x) return <Empty />;
+  const y = useMemo(() => 1, []);
+  return <div>{y}</div>;
+}
+"""
+        assert names(source) == ["useMemo"]
+
+    def test_braced_guard_without_a_semicolon_closes_at_the_block(self):
+        source = """
+export default function App({ x }) {
+  if (!x) {
+    return null
+  }
+  const y = useMemo(() => 1, []);
+  return <div>{y}</div>;
+}
+"""
+        assert names(source) == ["useMemo"]
+
+    def test_arrow_inside_the_returned_jsx_does_not_end_the_statement(self):
+        source = """
+export default function App({ items }) {
+  return (
+    <List
+      onPick={(i) => { track(i); }}
+      footer={<Foot ref={useRef(null)} />}
+    />
+  );
+}
+"""
+        assert find_hook_order_issues(source) == []
+
+
 class TestTokenizerHazards:
     def test_return_as_jsx_text_before_hooks(self):
         source = """
@@ -530,6 +603,29 @@ export default function App({ data }) {
         source = "export default function App(){ if(!x) return null; const [a]=useState(); }\n"
         padding = "// " + ("x" * 600 * 1024) + "\n"
         assert find_hook_order_issues(padding + source) == []
+
+    @pytest.mark.parametrize(
+        "guard",
+        [
+            # `else` is not in the statement-start character set that keeps JSX
+            # text from being read as code.
+            "if (x) foo(); else return null;",
+            # No semicolon and no braces: the return statement never closes, so
+            # later hooks are not attributed to it.
+            "if (!x) return null",
+        ],
+    )
+    def test_documented_misses_stay_silent(self, guard: str):
+        source = f"""
+export default function App({{ x }}) {{
+  {guard}
+  const y = useMemo(() => 1, []);
+  return <div>{{y}}</div>;
+}}
+"""
+        # Recall traded away on purpose — see the module docstring. Pinned so a
+        # future change to either rule is a deliberate decision, not a surprise.
+        assert find_hook_order_issues(source) == []
 
     def test_use_prefixed_non_hook_identifiers_are_ignored(self):
         source = """

--- a/tests/unit_tests/tools/func_tool/test_report_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_report_artifact_tools.py
@@ -503,6 +503,55 @@ class TestValidateRender:
         assert result.success == 0
         assert "export default" in (result.error or "")
 
+    def test_rejects_hook_below_an_early_return(self, report_tools: ReportArtifactTools, project_root: Path):
+        report_tools.save_query(
+            name="sales_by_store",
+            sql="SELECT store_name FROM sales",
+            goal="list store names",
+            hypothesis="store names are stable identifiers within the dataset",
+        )
+        early_return = """\
+import React from 'react';
+import { useDatusArtifact } from '@datus/web-artifact';
+
+export default function App() {
+  const { useQuerySql } = useDatusArtifact();
+  const { data, loading } = useQuerySql('queries/sales_by_store');
+  if (loading) return null;
+  const rows = React.useMemo(() => data?.rows ?? [], [data]);
+  return React.createElement('div', null, rows.length);
+}
+"""
+        _write_render(project_root, report_tools.report_slug, {"app.jsx": early_return})
+        result = report_tools.validate_render()
+        assert result.success == 0
+        assert "useMemo() on line 8" in (result.error or "")
+        assert "line 7" in (result.error or "")
+
+    def test_accepts_a_guard_that_sits_below_every_hook(self, report_tools: ReportArtifactTools, project_root: Path):
+        report_tools.save_query(
+            name="sales_by_store",
+            sql="SELECT store_name FROM sales",
+            goal="list store names",
+            hypothesis="store names are stable identifiers within the dataset",
+        )
+        correct = """\
+import React from 'react';
+import { useDatusArtifact } from '@datus/web-artifact';
+
+export default function App() {
+  const { useQuerySql } = useDatusArtifact();
+  const { data, loading } = useQuerySql('queries/sales_by_store');
+  const rows = React.useMemo(() => data?.rows ?? [], [data]);
+  const fmt = (v) => { if (v == null) return '-'; return String(v); };
+  if (loading) return null;
+  return React.createElement('div', null, fmt(rows.length));
+}
+"""
+        _write_render(project_root, report_tools.report_slug, {"app.jsx": correct})
+        result = report_tools.validate_render()
+        assert result.success == 1, result.error
+
     def test_rejects_dangling_sqlid(self, report_tools: ReportArtifactTools, project_root: Path):
         _write_render(
             project_root,

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -252,8 +252,44 @@ class TestGetAvailableTypes:
 # ── _inherit_pending_input_queue ───────────────────────────────────
 
 
-@pytest.mark.ci
 class TestInheritPendingInputQueue:
+    @pytest.mark.asyncio
+    async def test_execute_node_wires_the_queue_into_the_sub_agent(self, task_tool, tmp_path):
+        """The call site, against a real node rather than a stand-in.
+
+        The unit tests below pin the helper's own logic; this one pins that
+        ``_execute_node`` actually calls it, and that ``pending_input_queue`` is
+        the attribute a real ``AgenticNode`` exposes — a stub object would agree
+        with any name we happened to pick.
+        """
+        from datus.cli.execution_state import PendingInputQueue
+
+        # ``_resolve_workspace_root`` reads ``project_root``; without a real
+        # path the node's filesystem tools fail to set up and log a traceback.
+        task_tool.agent_config.project_root = str(tmp_path)
+        task_tool.agent_config.workspace_root = str(tmp_path)
+        queue = PendingInputQueue()
+        task_tool.set_parent_node(SimpleNamespace(pending_input_queue=queue, proxy_tool_patterns=None, session_id=None))
+
+        created = {}
+
+        def _create_and_mute(subagent_type, session_id=None):
+            node = task_tool._create_builtin_node(subagent_type, session_id=session_id)
+
+            async def _no_actions(*_args, **_kwargs):
+                return
+                yield  # pragma: no cover — makes this an async generator
+
+            node.execute_stream_with_interactions = _no_actions
+            created["node"] = node
+            return node
+
+        task_tool._create_node = _create_and_mute
+
+        await task_tool._execute_node("gen_visual_report", "build a revenue report")
+
+        assert created["node"].pending_input_queue is queue
+
     def test_shares_the_parents_queue_by_reference(self, task_tool):
         from datus.cli.execution_state import PendingInputQueue
 

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -249,6 +249,56 @@ class TestGetAvailableTypes:
         assert "explore" in types
 
 
+# ── _inherit_pending_input_queue ───────────────────────────────────
+
+
+@pytest.mark.ci
+class TestInheritPendingInputQueue:
+    def test_shares_the_parents_queue_by_reference(self, task_tool):
+        from datus.cli.execution_state import PendingInputQueue
+
+        queue = PendingInputQueue()
+        task_tool.set_parent_node(SimpleNamespace(pending_input_queue=queue))
+        node = SimpleNamespace(pending_input_queue=None)
+
+        task_tool._inherit_pending_input_queue(node)
+
+        # Reference, not a copy — an insert pushed after the sub-agent started
+        # must be visible to the loop that is actually running.
+        assert node.pending_input_queue is queue
+        queue.push("the chart throws on render")
+        assert node.pending_input_queue.drain() == ["the chart throws on render"]
+
+    def test_drain_by_the_subagent_leaves_nothing_for_the_parent(self, task_tool):
+        from datus.cli.execution_state import PendingInputQueue
+
+        queue = PendingInputQueue()
+        task_tool.set_parent_node(SimpleNamespace(pending_input_queue=queue))
+        node = SimpleNamespace(pending_input_queue=None)
+        task_tool._inherit_pending_input_queue(node)
+
+        queue.push("fix it")
+        assert node.pending_input_queue.drain() == ["fix it"]
+        assert queue.drain() == []
+
+    def test_no_parent_leaves_the_node_untouched(self, task_tool):
+        node = SimpleNamespace(pending_input_queue=None)
+        task_tool._inherit_pending_input_queue(node)
+        assert node.pending_input_queue is None
+
+    def test_parent_without_a_queue_leaves_the_node_untouched(self, task_tool):
+        task_tool.set_parent_node(SimpleNamespace(pending_input_queue=None))
+        node = SimpleNamespace(pending_input_queue=None)
+        task_tool._inherit_pending_input_queue(node)
+        assert node.pending_input_queue is None
+
+    def test_parent_missing_the_attribute_is_tolerated(self, task_tool):
+        task_tool.set_parent_node(SimpleNamespace())
+        node = SimpleNamespace(pending_input_queue=None)
+        task_tool._inherit_pending_input_queue(node)
+        assert node.pending_input_queue is None
+
+
 # ── _resolve_node_type ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Why

Users on smaller models report spending most of their dashboard time re-rounding on render errors: the subagent delivers the artifact, the iframe is blank or throws, and the user has to copy the stack trace back into chat by hand.

`validate_render` — the terminal action of both `gen_visual_report` and `gen_visual_dashboard` — only validated *paths*: entry point exists, `useQuerySql` slugs resolve, imports point at allowed modules or real files. A render tree that parses fine but throws the moment React mounts it passed cleanly.

By far the most common such failure is a Rules-of-Hooks violation — a guard clause placed above the hook calls:

```jsx
export default function App() {
  const { data, loading } = useQuerySql('queries/sales');
  if (loading) return <Spinner />;                    // early return
  const totals = useMemo(() => sum(data), [data]);    // skipped on 1st render
  ...
}
```

React throws "Rendered fewer hooks than expected" on the second render and the whole artifact goes blank. The frontend error panel already hardcodes this diagnosis in its hint text, which is a good indication of how dominant it is.

Separately, mid-run insert (`/api/v1/chat/insert`) could not reach a running sub-agent. `call_model_input_filter` drains the queue on the node that owns it, and `SubAgentTaskTool` propagated the parent's `InteractionBroker` but not its `pending_input_queue`. Steering a long `gen_visual_*` run therefore only took effect after the sub-agent had already returned — a whole round trip too late to stop a broken artifact from being delivered.

## Solution

**1. Hooks-below-return detection in `validate_render`** (`datus/tools/func_tool/_jsx_hooks_lint.py`, wired into both artifact tools)

A false positive here is much worse than a miss — it blocks a correct artifact and sends the model editing code that was already fine — so the design is conservative throughout.

The analysis tracks **function frames**, not brace depth. A `return` belongs to the nearest enclosing *function body*, which is what makes all of these correct:

```jsx
const f = () => { if (xx) return; };        // f's return, not the component's
useThing();                                 // → not a violation

useEffect(() => { if (!x) return; }, [x]);  // the callback's return
const y = useMemo(...);                     // → not a violation

if (loading) { return null; }               // the component's return — a block
const y = useMemo(...);                     //   `{` opens no new frame
                                            // → violation
```

A `{` opens a function body iff it follows `=>`, or follows a `)` whose `(` was not headed by `if`/`for`/`while`/`switch`/`catch`/`with`/`await`. The scanner handles strings, template literals (including `${}` re-entry), comments, and regex-vs-division; a `return` is only counted when the previous significant character is one of `{};):`, which is what keeps JSX *text* (`<div>return</div>`) from being read as code. Anything it cannot tokenize confidently — unbalanced braces, unterminated block comment, implausible file size — bails out and reports nothing.

Scope is deliberately narrow: only *hook call below a return in the same function*. Conditional hooks and the missing/incorrect-import families are **not** checked here.

**2. Sub-agents inherit the parent's pending-input queue** (`sub_agent_task_tool.py`)

`_inherit_pending_input_queue` shares the reference next to the existing broker injection. `PendingInputQueue` is thread-safe and `drain()` empties it, so parent and sub-agent holding one reference can never double-deliver; whichever loop reaches its next LLM turn first consumes the item.

## Test Cases

`tests/unit_tests/tools/func_tool/test_jsx_hooks_lint.py` — 47 cases, weighted towards negatives since those are the risk:

- **Nested frames** (must not flag): inner arrow with early return before the component's hooks, `useEffect`/`useCallback` callbacks with guards, `.map` callbacks, helper functions declared above the component, nested components, arrows inside JSX attributes, object-method shorthand, IIFEs, async arrows.
- **Blocks are not frames** (must flag): guards inside `if` / nested `if` / `for` / `while` / `try` / `switch`.
- **Tokenizer hazards** (must not flag): `return` as JSX text, apostrophes in JSX text, `return` inside strings / template literals / line and block comments / regex literals, `{ return: 1 }` property keys, `gen.return()` member access, self-closing JSX with expression attributes, division not misread as a regex.
- **Violations**: classic loading guard, braced guard, `React.useState` after a return, every hook after the return reported, first return used as the anchor, violation inside a custom hook, violation only in a nested component, two components each reported, and a hook called inline inside returned JSX (`ref={useRef(null)}`) far below the guard.
- **Bail-out**: unbalanced braces, stray closing brace, unterminated block comment, oversized source, `use`-prefixed non-hooks (`user`, `used`, `useful`).

`test_sub_agent_task_tool.py::TestInheritPendingInputQueue` — 5 cases: shared by reference (not copied), a drain by the sub-agent leaves nothing for the parent, and the no-parent / no-queue / missing-attribute paths leave the node untouched.

Wiring tests in `test_report_artifact_tools.py` and `test_dashboard_artifact_tools.py` confirm `validate_render` actually fails on a hook below a guard and still passes when the guard sits below every hook.

**Real-corpus check:** ran the scanner over all 81 `.jsx` files produced by the subagent across local workspaces — 80 clean, 0 bail-outs, 1 flagged. The single flag is a genuine bug: a report with `if (rows.length === 0) return null;` on line 61 and `<div ref={useRef(null)}>` on line 128. That shape is now a regression test.

Full `tests/unit_tests/tools/func_tool/` suite: 1928 passed. `ci/audit_tests.py --diff-only`: P0=0, P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added render validation that detects React hooks placed after an early return and reports the affected hook and return locations.
* **Bug Fixes**
  * Improved sub-agent input handling so queued parent inputs remain available during sub-agent execution.
* **Tests**
  * Added coverage for hook-order validation, safe handling of complex or invalid source code, valid guard placement, and shared input-queue behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added render validation to detect React `use*()` hook calls that occur after an early `return`, reporting both the hook and return line numbers.
  * Applied the same “early return before hooks” rule across render artifact validation workflows.
* **Bug Fixes**
  * Reduced incorrect hook-order failures caused by tricky parsing cases (including sequences inside interpolated template text).
* **Documentation**
  * Clarified the shared pending-input queue “first-turn wins” semantics and updated validator behavior notes.
* **Tests**
  * Added/extended unit coverage for the new validation rules and for pending-input queue wiring in subagent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->