### PR TITLE
[BugFix] Paginate chat/sessions list before per-session sqlite reads

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -337,7 +337,9 @@ async def compact_chat_session(
     description=(
         "List chat sessions. Pass subagent_id to filter by agent "
         "(use 'chat' for the default chat agent, or any builtin/custom subagent id). "
-        "Omit to return every session for the user."
+        "Omit to return every session for the user. Use offset/limit to paginate — "
+        "only the requested page is read from disk, so cost doesn't scale with the "
+        "user's total session count."
     ),
 )
 async def list_sessions(
@@ -347,10 +349,18 @@ async def list_sessions(
         default=None,
         description="Filter by subagent id; 'chat' selects the default chat agent",
     ),
+    offset: int = Query(default=0, ge=0, description="Number of sessions to skip"),
+    limit: Optional[int] = Query(default=None, ge=1, description="Maximum number of sessions to return"),
 ) -> Result[ChatSessionData]:
     try:
         return await asyncio.wait_for(
-            asyncio.to_thread(svc.chat.list_sessions, user_id=ctx.user_id, subagent_id=subagent_id),
+            asyncio.to_thread(
+                svc.chat.list_sessions,
+                user_id=ctx.user_id,
+                subagent_id=subagent_id,
+                offset=offset,
+                limit=limit,
+            ),
             timeout=_FUSE_IO_TIMEOUT,
         )
     except TimeoutError:

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -336,12 +336,14 @@ async def compact_chat_session(
     summary="List Chat Sessions",
     description=(
         "List chat sessions. Pass subagent_id to filter by agent "
-        "(use 'chat' for the default chat agent, or any builtin/custom subagent id). "
+        "(use 'chat' for the default chat agent, or any built-in/custom subagent id). "
         "Omit to return sessions for every agent. Use offset/limit to paginate — "
-        "only the requested page is read from disk, so cost doesn't scale with the "
-        "user's total session count. Omitting limit yields the server default page "
-        "size (api.default_session_page_size); larger requested limits are clamped "
-        "to api.max_session_page_size. total_count reports the unpaginated total."
+        "only the requested page is opened as sqlite, so the dominant per-session "
+        "cost doesn't scale with the user's total session count (the mtime sort "
+        "still stats every session file, far more cheaply). Omitting limit yields "
+        "the server default page size (api.default_session_page_size); larger "
+        "requested limits are clamped to api.max_session_page_size. total_count "
+        "reports the unpaginated total."
     ),
 )
 async def list_sessions(

--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -337,9 +337,11 @@ async def compact_chat_session(
     description=(
         "List chat sessions. Pass subagent_id to filter by agent "
         "(use 'chat' for the default chat agent, or any builtin/custom subagent id). "
-        "Omit to return every session for the user. Use offset/limit to paginate — "
+        "Omit to return sessions for every agent. Use offset/limit to paginate — "
         "only the requested page is read from disk, so cost doesn't scale with the "
-        "user's total session count."
+        "user's total session count. Omitting limit yields the server default page "
+        "size (api.default_session_page_size); larger requested limits are clamped "
+        "to api.max_session_page_size. total_count reports the unpaginated total."
     ),
 )
 async def list_sessions(
@@ -350,7 +352,11 @@ async def list_sessions(
         description="Filter by subagent id; 'chat' selects the default chat agent",
     ),
     offset: int = Query(default=0, ge=0, description="Number of sessions to skip"),
-    limit: Optional[int] = Query(default=None, ge=1, description="Maximum number of sessions to return"),
+    limit: Optional[int] = Query(
+        default=None,
+        ge=1,
+        description="Maximum number of sessions to return; omit for the server default page size",
+    ),
 ) -> Result[ChatSessionData]:
     try:
         return await asyncio.wait_for(

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -40,6 +40,27 @@ from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
 
+# Session-list pagination bounds. Overridable via the ``api`` section of
+# agent.yml (``api.default_session_page_size`` / ``api.max_session_page_size``),
+# mirroring ``api.max_prefetch_tables``. Both are finite so that the default
+# request path — clients that omit ``limit`` entirely — stays bounded.
+_DEFAULT_SESSION_PAGE_SIZE = 50
+_DEFAULT_MAX_SESSION_PAGE_SIZE = 200
+
+
+def _positive_int(raw: Any, fallback: int) -> int:
+    """Coerce an ``api`` config value to a positive int, falling back on junk.
+
+    Operator-supplied YAML is untrusted here: a missing key, ``null``, a
+    non-numeric string, or a non-positive number all fall back to *fallback*
+    rather than producing an empty or reversed page.
+    """
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return fallback
+    return value if value > 0 else fallback
+
 
 class ChatService:
     """Thin service that delegates chat execution to ChatTaskManager.
@@ -118,15 +139,35 @@ class ChatService:
         final ``last_updated``-based sort applied to the enriched page below;
         the two can disagree at page boundaries in rare cases, which is an
         accepted tradeoff for avoiding an eager full-directory sqlite scan.
+
+        The page size is always finite. ``limit=None`` (the caller omitted it)
+        means "server default", not "unbounded" — otherwise the default request
+        path would still open every session file and re-trigger the very
+        timeouts pagination was added to prevent. An explicitly requested
+        ``limit`` is clamped down to ``api.max_session_page_size`` rather than
+        rejected, so an over-large page still returns a valid first page;
+        ``total_count`` reports the unpaginated total for callers to page
+        through. Both bounds come from the ``api`` section of agent.yml.
         """
         try:
+            api_config = getattr(self.agent_config, "api_config", {}) or {}
+            max_page_size = _positive_int(api_config.get("max_session_page_size"), _DEFAULT_MAX_SESSION_PAGE_SIZE)
+            default_page_size = min(
+                _positive_int(api_config.get("default_session_page_size"), _DEFAULT_SESSION_PAGE_SIZE),
+                max_page_size,
+            )
+            page_size = default_page_size if limit is None else min(limit, max_page_size)
+            # The route pins ``ge=0``; clamp again for non-HTTP callers, since a
+            # negative offset would silently slice from the tail of the list.
+            offset = max(offset, 0)
+
             session_mgr = SessionManager(session_dir=self._session_dir, scope=user_id)
             all_ids = session_mgr.list_sessions(sort_by_modified=True)
             if subagent_id is not None:
                 all_ids = [sid for sid in all_ids if session_matches_agent(sid, subagent_id)]
 
             total_count = len(all_ids)
-            page_ids = all_ids[offset:] if limit is None else all_ids[offset : offset + limit]
+            page_ids = all_ids[offset : offset + page_size]
 
             sessions = []
             for sid in page_ids:

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -100,6 +100,8 @@ class ChatService:
         self,
         user_id: Optional[str] = None,
         subagent_id: Optional[str] = None,
+        offset: int = 0,
+        limit: Optional[int] = None,
     ) -> Result[ChatSessionData]:
         """List chat sessions from disk, optionally filtered by agent.
 
@@ -107,15 +109,27 @@ class ChatService:
         returned. When set, only sessions whose id prefix encodes that agent
         are returned; the sentinel ``"chat"`` selects the default chat agent
         (including legacy prefix-less sessions).
+
+        ``offset``/``limit`` are applied *before* the per-session enrichment
+        below: only the requested page pays the per-file ``get_session_info``
+        cost (an individual sqlite open), so cost no longer scales with the
+        user's total lifetime session count. Ordering ids by file mtime here
+        (via ``sort_by_modified``, a cheap ``stat`` pass) is a proxy for the
+        final ``last_updated``-based sort applied to the enriched page below;
+        the two can disagree at page boundaries in rare cases, which is an
+        accepted tradeoff for avoiding an eager full-directory sqlite scan.
         """
         try:
             session_mgr = SessionManager(session_dir=self._session_dir, scope=user_id)
-            all_ids = session_mgr.list_sessions()
+            all_ids = session_mgr.list_sessions(sort_by_modified=True)
             if subagent_id is not None:
                 all_ids = [sid for sid in all_ids if session_matches_agent(sid, subagent_id)]
-            sessions = []
 
-            for sid in all_ids:
+            total_count = len(all_ids)
+            page_ids = all_ids[offset:] if limit is None else all_ids[offset : offset + limit]
+
+            sessions = []
+            for sid in page_ids:
                 try:
                     info = session_mgr.get_session_info(sid)
                     if not info.get("exists", False):
@@ -142,7 +156,7 @@ class ChatService:
                 success=True,
                 data=ChatSessionData(
                     sessions=sessions,
-                    total_count=len(sessions),
+                    total_count=total_count,
                 ),
             )
 

--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -49,15 +49,17 @@ _DEFAULT_MAX_SESSION_PAGE_SIZE = 200
 
 
 def _positive_int(raw: Any, fallback: int) -> int:
-    """Coerce an ``api`` config value to a positive int, falling back on junk.
+    """Coerce a config value or caller-supplied page size to a positive int.
 
-    Operator-supplied YAML is untrusted here: a missing key, ``null``, a
-    non-numeric string, or a non-positive number all fall back to *fallback*
-    rather than producing an empty or reversed page.
+    Both operator YAML and direct (non-HTTP) callers are untrusted here: a
+    missing key, ``null``, a non-numeric string, or a non-positive number all
+    fall back to *fallback* rather than producing an empty or reversed page.
+    ``OverflowError`` is caught alongside the usual pair because YAML ``.inf``
+    parses to float infinity, which ``int()`` refuses to convert.
     """
     try:
         value = int(raw)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return fallback
     return value if value > 0 else fallback
 
@@ -145,9 +147,15 @@ class ChatService:
         path would still open every session file and re-trigger the very
         timeouts pagination was added to prevent. An explicitly requested
         ``limit`` is clamped down to ``api.max_session_page_size`` rather than
-        rejected, so an over-large page still returns a valid first page;
-        ``total_count`` reports the unpaginated total for callers to page
-        through. Both bounds come from the ``api`` section of agent.yml.
+        rejected, so an over-large page still returns a valid first page, and a
+        non-positive one falls back to the default; ``total_count`` reports the
+        unpaginated total for callers to page through. Both bounds come from
+        the ``api`` section of agent.yml.
+
+        Note that only the *sqlite enrichment* is page-bounded. Listing the
+        directory and stat-ing each file for the mtime sort still costs one
+        ``stat`` per session, so that pass scales with the total; it is orders
+        of magnitude cheaper than the per-file sqlite open it replaces.
         """
         try:
             api_config = getattr(self.agent_config, "api_config", {}) or {}
@@ -156,9 +164,13 @@ class ChatService:
                 _positive_int(api_config.get("default_session_page_size"), _DEFAULT_SESSION_PAGE_SIZE),
                 max_page_size,
             )
-            page_size = default_page_size if limit is None else min(limit, max_page_size)
-            # The route pins ``ge=0``; clamp again for non-HTTP callers, since a
-            # negative offset would silently slice from the tail of the list.
+            # A non-positive ``limit`` is treated as unspecified rather than
+            # passed through: the route pins ``ge=1``, but a direct caller
+            # passing -1 would otherwise slice ``all_ids[offset:-1]`` and
+            # enrich nearly every session — the exact cost this bounds.
+            page_size = min(_positive_int(limit, default_page_size), max_page_size)
+            # Likewise the route pins ``ge=0``; clamp again for non-HTTP callers,
+            # since a negative offset would silently slice from the tail.
             offset = max(offset, 0)
 
             session_mgr = SessionManager(session_dir=self._session_dir, scope=user_id)

--- a/docs/API/chat.md
+++ b/docs/API/chat.md
@@ -67,13 +67,14 @@ List chat sessions for the current user.
 
 | Param | Type | Notes |
 |-------|------|-------|
-| `subagent_id` | string? | Filter by subagent. Pass `chat` for the default chat agent, or any builtin/custom subagent id. Omit to return sessions for every agent. |
+| `subagent_id` | string? | Filter by subagent. Pass `chat` for the default chat agent, or any built-in/custom subagent id. Omit to return sessions for every agent. |
 | `offset` | int | Number of sessions to skip. Defaults to `0`; must be `>= 0`. |
 | `limit` | int? | Page size; must be `>= 1`. Omit to use the server default (`api.default_session_page_size`, default `50`). Values above `api.max_session_page_size` (default `200`) are clamped down rather than rejected. |
 
 The response is always paginated — omitting `limit` yields the default page, not the full list. Only the
-requested page is read from disk, so response time doesn't scale with the user's total session count. Use
-`total_count` (the unpaginated total) with `offset` to page through the rest.
+requested page is opened as SQLite, so the dominant per-session cost no longer scales with the user's total
+session count; enumerating the session directory and stat-ing each file for the mtime sort still does, at a
+far lower cost per session. Use `total_count` (the unpaginated total) with `offset` to page through the rest.
 
 **Response**: `Result[ChatSessionData]` with `total_count` and an array of `{ session_id, user_query,
 created_at, last_updated, total_turns, token_count, last_sql_queries, is_active }`.

--- a/docs/API/chat.md
+++ b/docs/API/chat.md
@@ -67,10 +67,16 @@ List chat sessions for the current user.
 
 | Param | Type | Notes |
 |-------|------|-------|
-| `subagent_id` | string? | Filter by subagent. Pass `chat` for the default chat agent, or any builtin/custom subagent id. Omit to return every session for the user. |
+| `subagent_id` | string? | Filter by subagent. Pass `chat` for the default chat agent, or any builtin/custom subagent id. Omit to return sessions for every agent. |
+| `offset` | int | Number of sessions to skip. Defaults to `0`; must be `>= 0`. |
+| `limit` | int? | Page size; must be `>= 1`. Omit to use the server default (`api.default_session_page_size`, default `50`). Values above `api.max_session_page_size` (default `200`) are clamped down rather than rejected. |
 
-**Response**: `Result[ChatSessionData]` with an array of `{ session_id, user_query, created_at, last_updated,
-total_turns, token_count, last_sql_queries, is_active }`.
+The response is always paginated — omitting `limit` yields the default page, not the full list. Only the
+requested page is read from disk, so response time doesn't scale with the user's total session count. Use
+`total_count` (the unpaginated total) with `offset` to page through the rest.
+
+**Response**: `Result[ChatSessionData]` with `total_count` and an array of `{ session_id, user_query,
+created_at, last_updated, total_turns, token_count, last_sql_queries, is_active }`.
 
 ### `DELETE /api/v1/chat/sessions/{session_id}`
 

--- a/docs/API/chat.zh.md
+++ b/docs/API/chat.zh.md
@@ -66,10 +66,15 @@ Chat 相关接口驱动 Agent 的对话循环。流式接口以 Server-Sent Even
 
 | 参数 | 类型 | 说明 |
 |------|------|------|
-| `subagent_id` | string? | 按 subagent 过滤。传 `chat` 表示默认 chat agent,或传任意内置/自定义 subagent id;省略则返回该用户全部会话。 |
+| `subagent_id` | string? | 按 subagent 过滤。传 `chat` 表示默认 chat agent,或传任意内置/自定义 subagent id;省略则返回该用户所有 agent 的会话。 |
+| `offset` | int | 跳过的会话数,默认 `0`,必须 `>= 0`。 |
+| `limit` | int? | 每页数量,必须 `>= 1`。省略时使用服务端默认值(`api.default_session_page_size`,默认 `50`)。超过 `api.max_session_page_size`(默认 `200`)的取值会被截断到上限,而非报错。 |
 
-**响应**:`Result[ChatSessionData]`,数组元素为 `{ session_id, user_query, created_at, last_updated,
-total_turns, token_count, last_sql_queries, is_active }`。
+该接口始终分页:省略 `limit` 返回的是默认页,而非全部会话。每次只从磁盘读取所请求的那一页,因此响应耗时不会随
+用户的历史会话总数增长。可结合 `total_count`(未分页的总数)与 `offset` 翻页获取其余会话。
+
+**响应**:`Result[ChatSessionData]`,含 `total_count`,数组元素为 `{ session_id, user_query, created_at,
+last_updated, total_turns, token_count, last_sql_queries, is_active }`。
 
 ### `DELETE /api/v1/chat/sessions/{session_id}`
 

--- a/docs/API/chat.zh.md
+++ b/docs/API/chat.zh.md
@@ -70,8 +70,9 @@ Chat 相关接口驱动 Agent 的对话循环。流式接口以 Server-Sent Even
 | `offset` | int | 跳过的会话数,默认 `0`,必须 `>= 0`。 |
 | `limit` | int? | 每页数量,必须 `>= 1`。省略时使用服务端默认值(`api.default_session_page_size`,默认 `50`)。超过 `api.max_session_page_size`(默认 `200`)的取值会被截断到上限,而非报错。 |
 
-该接口始终分页:省略 `limit` 返回的是默认页,而非全部会话。每次只从磁盘读取所请求的那一页,因此响应耗时不会随
-用户的历史会话总数增长。可结合 `total_count`(未分页的总数)与 `offset` 翻页获取其余会话。
+该接口始终分页:省略 `limit` 返回的是默认页,而非全部会话。只有所请求的那一页会被以 SQLite 打开,因此占主导的
+单会话开销不再随用户的历史会话总数增长;但枚举会话目录、以及为按 mtime 排序而对每个文件执行 stat,其耗时仍与
+会话总数相关,只是单会话成本远低于前者。可结合 `total_count`(未分页的总数)与 `offset` 翻页获取其余会话。
 
 **响应**:`Result[ChatSessionData]`,含 `total_count`,数组元素为 `{ session_id, user_query, created_at,
 last_updated, total_turns, token_count, last_sql_queries, is_active }`。

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -591,11 +591,11 @@ class TestListSessions:
         expected = Result[ChatSessionData](success=True, data=ChatSessionData(sessions=[], total_count=0))
         svc.chat.list_sessions.return_value = expected
 
-        result = await list_sessions(svc, ctx, subagent_id=None)
+        result = await list_sessions(svc, ctx, subagent_id=None, offset=0, limit=None)
 
         assert result.success is True
         assert result is expected
-        svc.chat.list_sessions.assert_called_once_with(user_id="user1", subagent_id=None)
+        svc.chat.list_sessions.assert_called_once_with(user_id="user1", subagent_id=None, offset=0, limit=None)
 
     @pytest.mark.asyncio
     async def test_timeout_returns_request_timeout_error(self):
@@ -620,9 +620,22 @@ class TestListSessions:
             success=True, data=ChatSessionData(sessions=[], total_count=0)
         )
 
-        await list_sessions(svc, ctx, subagent_id="gen_sql")
+        await list_sessions(svc, ctx, subagent_id="gen_sql", offset=0, limit=None)
 
-        svc.chat.list_sessions.assert_called_once_with(user_id="user2", subagent_id="gen_sql")
+        svc.chat.list_sessions.assert_called_once_with(user_id="user2", subagent_id="gen_sql", offset=0, limit=None)
+
+    @pytest.mark.asyncio
+    async def test_forwards_offset_and_limit(self):
+        svc = MagicMock()
+        ctx = MagicMock()
+        ctx.user_id = "user3"
+        svc.chat.list_sessions.return_value = Result[ChatSessionData](
+            success=True, data=ChatSessionData(sessions=[], total_count=0)
+        )
+
+        await list_sessions(svc, ctx, subagent_id=None, offset=20, limit=10)
+
+        svc.chat.list_sessions.assert_called_once_with(user_id="user3", subagent_id=None, offset=20, limit=10)
 
     @pytest.mark.asyncio
     async def test_timeout_result_type_is_result(self):

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from datus.api.services.chat_service import ChatService
+from datus.api.services.chat_service import (
+    _DEFAULT_MAX_SESSION_PAGE_SIZE,
+    _DEFAULT_SESSION_PAGE_SIZE,
+    ChatService,
+)
 from datus.api.services.chat_task_manager import ChatTaskManager
 from datus.models.session_manager import SessionManager
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
@@ -230,7 +234,8 @@ class TestChatServiceListSessionsPagination:
 
         assert fake.get_session_info.call_count == 20
 
-    def test_no_limit_enriches_everything_from_offset(self, chat_svc):
+    def test_omitted_limit_still_honours_offset(self, chat_svc):
+        """A page smaller than the default page size is returned whole."""
         ids = [f"session-{i}" for i in range(5)]
         fake = self._fake_session_manager(ids)
         with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
@@ -238,6 +243,103 @@ class TestChatServiceListSessionsPagination:
 
         assert [s.session_id for s in result.data.sessions] == ids[2:]
         assert result.data.total_count == 5
+
+    def test_omitted_limit_falls_back_to_finite_default_page_size(self, chat_svc):
+        """Clients that omit ``limit`` are the ones that timed out in #1222, so
+        the default path must be bounded too — not just the opt-in one."""
+        ids = [f"session-{i}" for i in range(300)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions()
+
+        assert len(result.data.sessions) == _DEFAULT_SESSION_PAGE_SIZE
+        assert fake.get_session_info.call_count == _DEFAULT_SESSION_PAGE_SIZE
+        assert result.data.total_count == 300
+
+    def test_default_page_size_reads_from_api_config(self, chat_svc):
+        chat_svc.agent_config.api_config = {"default_session_page_size": 7}
+        ids = [f"session-{i}" for i in range(50)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions()
+
+        assert [s.session_id for s in result.data.sessions] == ids[:7]
+        assert fake.get_session_info.call_count == 7
+
+    def test_explicit_limit_above_max_is_clamped(self, chat_svc):
+        """An over-large explicit limit must not re-open the unbounded path."""
+        ids = [f"session-{i}" for i in range(500)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(limit=10_000)
+
+        assert len(result.data.sessions) == _DEFAULT_MAX_SESSION_PAGE_SIZE
+        assert fake.get_session_info.call_count == _DEFAULT_MAX_SESSION_PAGE_SIZE
+        assert result.data.total_count == 500
+
+    def test_max_page_size_reads_from_api_config(self, chat_svc):
+        chat_svc.agent_config.api_config = {"max_session_page_size": 3}
+        ids = [f"session-{i}" for i in range(50)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(offset=1, limit=100)
+
+        assert [s.session_id for s in result.data.sessions] == ids[1:4]
+
+    def test_explicit_limit_below_max_is_honoured_verbatim(self, chat_svc):
+        chat_svc.agent_config.api_config = {"max_session_page_size": 100}
+        ids = [f"session-{i}" for i in range(50)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(limit=4)
+
+        assert len(result.data.sessions) == 4
+
+    def test_configured_default_cannot_exceed_configured_max(self, chat_svc):
+        """A misconfigured default larger than the max must not defeat the cap."""
+        chat_svc.agent_config.api_config = {
+            "default_session_page_size": 100,
+            "max_session_page_size": 10,
+        }
+        ids = [f"session-{i}" for i in range(50)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions()
+
+        assert len(result.data.sessions) == 10
+
+    @pytest.mark.parametrize("bad_value", [0, -1, None, "abc", "", []])
+    def test_junk_page_size_config_falls_back_to_shipped_defaults(self, chat_svc, bad_value):
+        """Operator YAML is untrusted: junk must not yield an empty or reversed page."""
+        chat_svc.agent_config.api_config = {
+            "default_session_page_size": bad_value,
+            "max_session_page_size": bad_value,
+        }
+        ids = [f"session-{i}" for i in range(300)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions()
+
+        assert len(result.data.sessions) == _DEFAULT_SESSION_PAGE_SIZE
+
+    def test_fractional_page_size_config_truncates_to_a_bounded_int(self, chat_svc):
+        """A float still coerces to a positive int, so it bounds rather than falls back."""
+        chat_svc.agent_config.api_config = {"default_session_page_size": 3.5}
+        ids = [f"session-{i}" for i in range(50)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions()
+
+        assert [s.session_id for s in result.data.sessions] == ids[:3]
+
+    def test_negative_offset_is_clamped_to_the_first_page(self, chat_svc):
+        """The route pins ge=0; a direct caller must not slice from the tail."""
+        ids = [f"session-{i}" for i in range(10)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(offset=-5, limit=3)
+
+        assert [s.session_id for s in result.data.sessions] == ids[:3]
 
     def test_subagent_filter_applied_before_pagination(self, chat_svc):
         ids = ["chat_session_a", "gen_metrics_session_a", "chat_session_b", "gen_metrics_session_b", "chat_session_c"]

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -332,6 +332,33 @@ class TestChatServiceListSessionsPagination:
 
         assert [s.session_id for s in result.data.sessions] == ids[:3]
 
+    @pytest.mark.parametrize("bad_limit", [0, -1, -3])
+    def test_non_positive_limit_falls_back_to_the_default_page(self, chat_svc, bad_limit):
+        """A negative limit would slice all_ids[offset:-n] and enrich nearly every
+        session — the exact sqlite cost this pagination exists to bound."""
+        ids = [f"session-{i}" for i in range(300)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(limit=bad_limit)
+
+        assert len(result.data.sessions) == _DEFAULT_SESSION_PAGE_SIZE
+        assert fake.get_session_info.call_count == _DEFAULT_SESSION_PAGE_SIZE
+
+    def test_infinite_page_size_config_does_not_break_the_endpoint(self, chat_svc):
+        """YAML ``.inf`` parses to float infinity, which int() refuses to convert;
+        an uncaught OverflowError would fail every session-list request."""
+        chat_svc.agent_config.api_config = {
+            "default_session_page_size": float("inf"),
+            "max_session_page_size": float("inf"),
+        }
+        ids = [f"session-{i}" for i in range(300)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions()
+
+        assert result.success is True
+        assert len(result.data.sessions) == _DEFAULT_SESSION_PAGE_SIZE
+
     def test_negative_offset_is_clamped_to_the_first_page(self, chat_svc):
         """The route pins ge=0; a direct caller must not slice from the tail."""
         ids = [f"session-{i}" for i in range(10)]

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -175,6 +175,80 @@ class TestChatServiceListSessions:
         assert parsed == datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
 
 
+class TestChatServiceListSessionsPagination:
+    """offset/limit must slice *before* the expensive per-session get_session_info()
+    call, so cost stops scaling with a user's total lifetime session count
+    (regression test for the timeout reported in Datus-ai/Datus-agent#1222)."""
+
+    @staticmethod
+    def _fake_session_manager(ids):
+        fake = MagicMock()
+        fake.list_sessions.return_value = list(ids)
+        fake.get_session_info.side_effect = lambda sid: {
+            "exists": True,
+            "created_at": "2026-01-01 00:00:00",
+            "updated_at": "2026-01-01 00:00:00",
+            "first_user_message": None,
+            "message_count": 0,
+            "total_tokens": 0,
+        }
+        return fake
+
+    def test_uses_cheap_mtime_sort_instead_of_full_scan(self, chat_svc):
+        """Ordering comes from the stat-based sort, not an eager per-file open."""
+        fake = self._fake_session_manager([])
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            chat_svc.list_sessions()
+
+        fake.list_sessions.assert_called_once_with(sort_by_modified=True)
+
+    def test_total_count_reflects_all_matching_sessions_not_just_the_page(self, chat_svc):
+        ids = [f"session-{i}" for i in range(50)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(offset=0, limit=5)
+
+        assert result.success is True
+        assert result.data.total_count == 50
+        assert len(result.data.sessions) == 5
+
+    def test_offset_and_limit_select_the_requested_page(self, chat_svc):
+        ids = [f"session-{i}" for i in range(10)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(offset=4, limit=3)
+
+        assert [s.session_id for s in result.data.sessions] == ids[4:7]
+
+    def test_only_the_requested_page_is_enriched(self, chat_svc):
+        """The actual performance fix: get_session_info must not be called for
+        sessions outside the page, however many the user has accumulated."""
+        ids = [f"session-{i}" for i in range(300)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            chat_svc.list_sessions(offset=0, limit=20)
+
+        assert fake.get_session_info.call_count == 20
+
+    def test_no_limit_enriches_everything_from_offset(self, chat_svc):
+        ids = [f"session-{i}" for i in range(5)]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(offset=2)
+
+        assert [s.session_id for s in result.data.sessions] == ids[2:]
+        assert result.data.total_count == 5
+
+    def test_subagent_filter_applied_before_pagination(self, chat_svc):
+        ids = ["chat_session_a", "gen_metrics_session_a", "chat_session_b", "gen_metrics_session_b", "chat_session_c"]
+        fake = self._fake_session_manager(ids)
+        with patch("datus.api.services.chat_service.SessionManager", return_value=fake):
+            result = chat_svc.list_sessions(subagent_id="chat", offset=1, limit=1)
+
+        assert [s.session_id for s in result.data.sessions] == ["chat_session_b"]
+        assert result.data.total_count == 3
+
+
 class TestChatServiceDeleteSession:
     """Tests for delete_session."""
 


### PR DESCRIPTION
## Why

Fixes #1222.

`GET /api/v1/chat/sessions` never applied `offset`/`limit` before enriching every session — `ChatService.list_sessions()` calls `get_session_info()` (an individual sqlite open) once per session id for the *entire* user, regardless of the page size requested. Once a user/tenant accumulates enough historical sessions (confirmed live: 356 `.db` files for one tenant on a network-backed mount), this routinely exceeds the endpoint's own 15s `_FUSE_IO_TIMEOUT` guard and returns a disguised-200 `REQUEST_TIMEOUT` instead of the caller's data — indefinitely, since the cost only grows as more sessions accumulate.

## Solution

- `datus/api/services/chat_service.py`: `list_sessions()` now takes `offset`/`limit`. It lists session ids via `SessionManager.list_sessions(sort_by_modified=True)` — a cheap `stat`-based pass that was already implemented but unused here — filters by `subagent_id`, then slices to the requested page **before** calling `get_session_info()`. `total_count` is computed from the full (filtered) id list so callers still see the true total for pagination UI, even though only the page gets enriched.
- `datus/api/routes/chat_routes.py`: declares `offset`/`limit` as query parameters on the `/sessions` route (previously undeclared and silently ignored) and threads them through to the service call.
- Tradeoff: the pre-sort uses file mtime (cheap `stat`), while the final in-page sort uses each session's `last_updated`/`created_at` (from inside its sqlite file). These can disagree at page boundaries in rare cases. Accepted for this fix since it avoids an eager full-directory sqlite scan; noted in a docstring comment.

## Test Cases

- `tests/unit_tests/api/services/test_chat_service.py` — new `TestChatServiceListSessionsPagination` class:
  - `total_count` reflects all matching sessions, not just the page
  - `offset`/`limit` select the correct slice
  - `get_session_info` is called **only** for the requested page (the actual perf fix — verified against 300 mocked sessions)
  - no `limit` still enriches everything from `offset`
  - `subagent_id` filtering is applied before pagination
  - ordering comes from `sort_by_modified=True`, not a full scan
- `tests/unit_tests/api/routes/test_chat_routes.py` — updated existing `TestListSessions` assertions to include the new `offset`/`limit` kwargs, plus a new test asserting the route forwards them to the service unchanged.
- Ran `ruff format`/`ruff check`, `ci/audit_tests.py --diff-only upstream/main` (P0=0, P1=0), and the full `tests/unit_tests/api/routes/test_chat_routes.py` + `tests/unit_tests/api/services/test_chat_service.py` + `tests/unit_tests/models/test_session_manager.py` suites (233 passed).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added pagination support for chat session listings with `offset` and `limit` parameters.
  * Session results now include the total number of matching sessions, independent of the current page.
  * Preserved filtering and modified-date ordering while loading only sessions in the requested page.

* **Tests**
  * Added coverage for pagination, filtering, ordering, total counts, and efficient page loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination for chat session listings with `offset` and `limit`.
  * Session results now include the total number of matching sessions.
  * Preserved filtering and modified-date ordering while loading only the requested page.
  * Added configurable default and maximum page sizes with validation and limit handling.

* **Documentation**
  * Updated chat API documentation with pagination, filtering, and response details.

* **Tests**
  * Added coverage for pagination, filtering, ordering, total counts, and page loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->