### PR TITLE
[Enhancement] Attach an edit entry point to every non-chart dashboard block

### DIFF
--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -47,7 +47,7 @@ The optional `/** @datus-title ... */` annotation at the top is used by the stan
 | Module | Version | Notes |
 |---|---|---|
 | `react` | `^18.2.0` | `useState`, `useEffect`, `useRef`, `useMemo`, `useCallback`, `useContext`, `createContext`, plus the default `React` namespace |
-| `@datus/web-artifact` | runtime-provided | `useDatusArtifact`, `AnimateOnVisible` (see "Motion & animation"), `ChartCard` (see "Canonical component shape" + "Card props"), `ChartEntryMore` (escape hatch — `ChartCard` already embeds it), `Skeleton`, `ErrorBlock` (see "Loading & error placeholders") |
+| `@datus/web-artifact` | runtime-provided | `useDatusArtifact`, `AnimateOnVisible` (see "Motion & animation"), `ChartCard` (see "Canonical component shape" + "Card props"), `EditHandle` (see "Edit handles for non-chart blocks"), `ChartEntryMore` (escape hatch — `ChartCard` already embeds it), `Skeleton`, `ErrorBlock` (see "Loading & error placeholders") |
 | `recharts` | `^3.8.1` | any named export (`AreaChart`, `LineChart`, `BarChart`, `RadarChart`, `PieChart`, `ResponsiveContainer`, `Tooltip`, `XAxis`, `YAxis`, `CartesianGrid`, `Area`, `Line`, `Bar`, `Radar`, `Pie`, `Cell`, etc.). **v3, not v2** — see the v3 notes below. |
 | `lucide-react` | `^0.563.0` | any icon component (`User`, `TrendingUp`, `Banknote`, `Globe`, `Landmark`, …). **Use these instead of emoji** — see the "Iconography & emoji" section below. |
 | `d3-format` | `^3.1.2` | `format` — build numeric / currency / percent / SI-prefix formatters |
@@ -72,7 +72,9 @@ Before saving a file, scan its body and JSX for every capitalized component (Rec
 
 ### Canonical component shape
 
-Every chart / table / KPI component in `render/` is one `<ChartCard>` from `@datus/web-artifact` wrapping the chart body. **Copy this skeleton when you author a new component.** ChartCard owns the card chrome (white surface, 12-radius, asymmetric padding, flex-column stretch) and the chart-actions menu (View SQL / Export CSV / JSON / PNG / etc.). You only author the data layer and the chart body inside.
+Every chart / table component in `render/` is one `<ChartCard>` from `@datus/web-artifact` wrapping the chart body. **Copy this skeleton when you author a new component.** ChartCard owns the card chrome (white surface, 12-radius, asymmetric padding, flex-column stretch) and the chart-actions menu (View SQL / Export CSV / JSON / PNG / etc.). You only author the data layer and the chart body inside.
+
+(A KPI strip is the one exception: N small tiles fed by ONE query is not N ChartCards — see "Edit handles for non-chart blocks" below.)
 
 ```jsx
 import { useMemo } from 'react';
@@ -132,7 +134,7 @@ The four sections are not optional ordering — they are the only ordering React
 
 ### Card props
 
-`<ChartCard>` requires three declarative props on every chart card. They are read at render time by the chart-actions menu and also act as the stable identifier the runtime uses if a follow-up turn pins an edit to this specific chart (see "Targeted single-card edits" in the dashboard prompt).
+`<ChartCard>` requires three declarative props on every chart card. They are read at render time by the chart-actions menu and also act as the stable identifier the runtime uses if a follow-up turn pins an edit to this specific chart (see "Targeted single-block edits" in the dashboard prompt).
 
 | Prop | Required | Notes |
 |---|---|---|
@@ -147,6 +149,97 @@ The four sections are not optional ordering — they are the only ordering React
 | `style` / `className` | optional | Standard passthroughs. |
 
 **Do not pass `__sourcePath`.** It is auto-injected by the artifact runtime at module-load time; any value you set is overwritten.
+
+### Edit handles for non-chart blocks
+
+While an artifact is being authored, its creator needs a way to point at any block and say "change *this* one". `<ChartCard>` has that built in — a small Edit button in its title strip. The blocks that aren't ChartCards (KPI tiles, insight / callout panels, the filter strip) have no title strip to host it, and giving them a card header purely to carry a button would wreck the layout. Wrap those in `<EditHandle>` instead: it contributes **no visual surface of its own** and floats a small hover-revealed button in one corner of the block.
+
+`EditHandle` is an *entry point, not an editor*. Clicking it pins that block into the chat as a context chip; the change itself happens on the next turn, in the same shape as "Targeted single-block edits". The handle exists only while the artifact is being authored — the runtime hides it on published artifacts and in standalone HTML exports, exactly like ChartCard's Edit button. So attaching handles costs the viewer nothing.
+
+**Wrap each of these in its own `EditHandle`:**
+
+- **Every KPI tile, individually.** A KPI strip is 4–6 tiles fed by ONE query — it is *not* 4–6 ChartCards (that would stack six card headers and six action menus into a row meant to read as one line of numbers). One handle per tile, because the user wants to change one number, not the whole row.
+- **Every insight / key-finding / callout panel** — the highlight boxes summarising what the data says.
+- **The filter strip** — one handle for the strip as a whole.
+
+The runtime does **not** ship a KPI-card component: own that visual in `render/shared/kpi-card.jsx` so it stays yours to restyle. Put the `EditHandle` inside that shared component and every tile gets a handle for free.
+
+| Prop | Required | Notes |
+|---|---|---|
+| `handleId` | yes | Stable id, **globally unique across the whole render tree and sharing one namespace with `chartId`** (both land in the same field of the edit payload). Must match `^[a-z0-9_]{1,64}$`. Prefix by role so it reads as its own label: `kpi_total_revenue`, `insight_panel`, `filter_strip`. |
+| `name` | yes | Human-readable label shown verbatim on the chat chip. Write what the user calls the thing ("Total revenue", "总营收") — never the id. |
+| `kind` | recommended | `'kpi'` for single-value tiles, `'note'` for insight / callout copy, `'filter'` for filter chrome. Defaults to `'note'`. |
+| `sqlId` | when query-backed | `'queries/<slug>'`, same literal you passed to `useQuerySql`. Omit entirely for a static block (a hand-written callout, the filter strip) — the follow-up turn then edits from the JSX alone. |
+| `params` | dashboard mode, when query-backed | Same params object as the query; snapshotted into the payload so the follow-up turn sees the filter state the user was looking at. |
+| `placement` | optional | `'top-right'` (default) or `'top-left'`. Switch to `'top-left'` when the block's top-right corner already holds something (a period badge, a status pill). |
+| `style` / `className` | optional | Passthrough on the wrapper. The wrapper is a stretching flex column, so a wrapped tile keeps filling its grid cell and stays equal-height with its siblings. |
+
+**Do not pass `__sourcePath`** here either — same auto-injection rule as ChartCard.
+
+```jsx
+// render/shared/kpi-card.jsx — the KPI visual is yours, the handle comes
+// from the runtime. Every tile rendered through this component gets an
+// edit entry point without the caller having to remember one.
+import { EditHandle } from '@datus/web-artifact';
+import { COLORS } from './colors';
+
+export function KpiCard({ handleId, label, value, badge, icon: Icon, sqlId, params }) {
+  return (
+    <EditHandle handleId={handleId} name={label} kind="kpi" sqlId={sqlId} params={params}>
+      <div style={{ height: '100%', boxSizing: 'border-box', backgroundColor: COLORS.card, borderRadius: 12, padding: '16px 18px', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, fontWeight: 600, color: COLORS.muted, marginBottom: 6 }}>
+          <Icon size={16} strokeWidth={2} color={COLORS.muted} />
+          {label}
+        </div>
+        <div style={{ fontSize: 24, fontWeight: 700, color: COLORS.navy }}>{value}</div>
+        {badge}
+      </div>
+    </EditHandle>
+  );
+}
+```
+
+```jsx
+// render/kpi-strip.jsx — one query, N tiles, one handle each.
+import { useDatusArtifact, Skeleton, ErrorBlock } from '@datus/web-artifact';
+import { Banknote, Receipt, Users, Landmark } from 'lucide-react';
+import { KpiCard } from './shared/kpi-card';
+import { formatCurrency, formatInt } from './shared/formatters';
+
+export function KpiStrip({ params }) {
+  const { useQuerySql } = useDatusArtifact();
+  const { isLoading, errorMessage, data, refetch } = useQuerySql('queries/kpi_summary', params);
+
+  if (isLoading) return <Skeleton minHeight={90} />;
+  if (errorMessage) return <ErrorBlock msg={errorMessage} onRetry={refetch} />;
+
+  const r = data?.rows?.[0] ?? {};
+  const tiles = [
+    { handleId: 'kpi_total_revenue', label: 'Total revenue', value: formatCurrency(r.total_revenue), icon: Banknote },
+    { handleId: 'kpi_total_orders', label: 'Orders', value: formatInt(r.total_orders), icon: Receipt },
+    { handleId: 'kpi_customers', label: 'Customers', value: formatInt(r.unique_customers), icon: Users },
+    { handleId: 'kpi_avg_order_value', label: 'Avg order value', value: formatCurrency(r.avg_order_value), icon: Landmark },
+  ];
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12, marginBottom: 24 }}>
+      {tiles.map(t => (
+        <KpiCard key={t.handleId} {...t} sqlId="queries/kpi_summary" params={params} />
+      ))}
+    </div>
+  );
+}
+```
+
+A static insight panel needs no `sqlId` at all, and its top-right corner is usually taken by a period badge:
+
+```jsx
+<EditHandle handleId="insight_panel" name="Auto insights" kind="note" placement="top-left">
+  <div style={{ backgroundColor: '#FFFBEB', border: '1px solid #FDE68A', borderRadius: 12, padding: '16px 18px' }}>
+    {/* heading + findings grid */}
+  </div>
+</EditHandle>
+```
 
 ### Data layer — `useDatusArtifact`
 
@@ -411,9 +504,9 @@ ChartCard embeds the chart-actions menu (View SQL / Export SQL / CSV / JSON / PN
 
 **One ChartCard per card.** When a card visualizes more than one sub-view (e.g. two side-by-side pies sharing one query), wrap them in a single `<ChartCard>` whose body is a 2-column grid — not two adjacent ChartCards.
 
-**Attach a ChartCard to every `useQuerySql`-backed visualization** — charts, KPI cards, custom SVG, **and data tables** (the table goes inside the ChartCard body, including the header strip; the chart-actions menu lives in the ChartCard's title strip above it).
+**Attach a ChartCard to every `useQuerySql`-backed visualization** — charts, custom SVG, **and data tables** (the table goes inside the ChartCard body, including the header strip; the chart-actions menu lives in the ChartCard's title strip above it). The exception is a KPI strip, where N tiles share one query and a per-tile card header would destroy the row: those get `<EditHandle>` instead of `<ChartCard>` (see "Edit handles for non-chart blocks").
 
-If you genuinely need to render a card without the chart-actions menu (filter strip, decorative banner, etc.), set `hideMenu` on the ChartCard. Direct use of the standalone `ChartEntryMore` import is reserved for the rare custom case where ChartCard's chrome doesn't fit — almost never required.
+If you genuinely need to render a card without the chart-actions menu (decorative banner, a single hero number that still deserves card chrome), set `hideMenu` on the ChartCard. Direct use of the standalone `ChartEntryMore` import is reserved for the rare custom case where ChartCard's chrome doesn't fit — almost never required.
 
 ### Formatting helpers
 

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -176,6 +176,10 @@ The runtime does **not** ship a KPI-card component: own that visual in `render/s
 
 **Do not pass `__sourcePath`** here either — same auto-injection rule as ChartCard.
 
+**`EditHandle` carries no View SQL / Export menu, on purpose.** A viewer of a *published* dashboard should still be able to ask "where does this number come from" — but the handle is authoring-only, so folding the menu into it would hide a permanent, read-only affordance behind an authoring gate. The two also work at different granularities: a KPI strip is N tiles over ONE query, so edits are per-tile while the SQL is per-strip — N menus would all open the same statement.
+
+So when a wrapped block is query-backed, render a standalone `<ChartEntryMore sqlId={...} data={data} />` yourself, **at the granularity the query actually has** — once per strip, not once per tile — and mark that container with `data-datus-chart-card` so the menu's PNG export can find its capture root. Without a menu somewhere, a KPI strip's query is unreachable from the UI entirely: dashboards render their queries live, so the `.sql.j2` files are never shipped to the viewer.
+
 ```jsx
 // render/shared/kpi-card.jsx — the KPI visual is yours, the handle comes
 // from the runtime. Every tile rendered through this component gets an
@@ -200,8 +204,8 @@ export function KpiCard({ handleId, label, value, badge, icon: Icon, sqlId, para
 ```
 
 ```jsx
-// render/kpi-strip.jsx — one query, N tiles, one handle each.
-import { useDatusArtifact, Skeleton, ErrorBlock } from '@datus/web-artifact';
+// render/kpi-strip.jsx — one query, N tiles, one handle each, ONE menu.
+import { useDatusArtifact, ChartEntryMore, Skeleton, ErrorBlock } from '@datus/web-artifact';
 import { Banknote, Receipt, Users, Landmark } from 'lucide-react';
 import { KpiCard } from './shared/kpi-card';
 import { formatCurrency, formatInt } from './shared/formatters';
@@ -222,24 +226,35 @@ export function KpiStrip({ params }) {
   ];
 
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12, marginBottom: 24 }}>
-      {tiles.map(t => (
-        <KpiCard key={t.handleId} {...t} sqlId="queries/kpi_summary" params={params} />
-      ))}
+    // data-datus-chart-card marks the screenshot root for the strip's menu.
+    <div data-datus-chart-card style={{ marginBottom: 24 }}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 6 }}>
+        <ChartEntryMore sqlId="queries/kpi_summary" data={data} />
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12 }}>
+        {tiles.map(t => (
+          <KpiCard key={t.handleId} {...t} sqlId="queries/kpi_summary" params={params} />
+        ))}
+      </div>
     </div>
   );
 }
 ```
 
-A static insight panel needs no `sqlId` at all, and its top-right corner is usually taken by a period badge:
+An insight panel that a query drives gets the same treatment — a handle for the copy, a menu for the numbers behind it. Its top-right corner is usually taken by a period badge, so move the handle to the left:
 
 ```jsx
-<EditHandle handleId="insight_panel" name="Auto insights" kind="note" placement="top-left">
-  <div style={{ backgroundColor: '#FFFBEB', border: '1px solid #FDE68A', borderRadius: 12, padding: '16px 18px' }}>
+<EditHandle handleId="insight_panel" name="Auto insights" kind="note" placement="top-left" sqlId="queries/regional_gaps" params={params}>
+  <div data-datus-chart-card style={{ position: 'relative', backgroundColor: '#FFFBEB', border: '1px solid #FDE68A', borderRadius: 12, padding: '16px 18px' }}>
+    <div style={{ position: 'absolute', top: 12, right: 12 }}>
+      <ChartEntryMore sqlId="queries/regional_gaps" data={data} />
+    </div>
     {/* heading + findings grid */}
   </div>
 </EditHandle>
 ```
+
+Drop both `sqlId` and the menu when the block is genuinely static (hand-written copy, the filter strip) — and drop just the menu when the block's claims are derived from **several** queries, since "View SQL" then has no single honest answer. Say where the numbers came from in the copy instead.
 
 ### Data layer — `useDatusArtifact`
 
@@ -506,7 +521,9 @@ ChartCard embeds the chart-actions menu (View SQL / Export SQL / CSV / JSON / PN
 
 **Attach a ChartCard to every `useQuerySql`-backed visualization** — charts, custom SVG, **and data tables** (the table goes inside the ChartCard body, including the header strip; the chart-actions menu lives in the ChartCard's title strip above it). The exception is a KPI strip, where N tiles share one query and a per-tile card header would destroy the row: those get `<EditHandle>` instead of `<ChartCard>` (see "Edit handles for non-chart blocks").
 
-If you genuinely need to render a card without the chart-actions menu (decorative banner, a single hero number that still deserves card chrome), set `hideMenu` on the ChartCard. Direct use of the standalone `ChartEntryMore` import is reserved for the rare custom case where ChartCard's chrome doesn't fit — almost never required.
+If you genuinely need to render a card without the chart-actions menu (decorative banner, a single hero number that still deserves card chrome), set `hideMenu` on the ChartCard.
+
+**Standalone `<ChartEntryMore>`** is for the blocks that carry a query but no ChartCard — the two recurring cases are the KPI strip (one menu for the strip, since all its tiles share one query) and a query-driven insight panel. Pass `sqlId` + `data`, and mark the container it should screenshot with `data-datus-chart-card`. Never wire it up inside a `<ChartCard>` — that card already embeds one.
 
 ### Formatting helpers
 

--- a/datus/prompts/prompt_templates/_visual_artifact_common.j2
+++ b/datus/prompts/prompt_templates/_visual_artifact_common.j2
@@ -282,6 +282,10 @@ interface ISqlQueryResult {
   row_count: number;
   columns: IQueryColumnMeta[];
   rows: Array<Record<string, unknown>>;
+  // Fully rendered SQL (after Jinja2 + bind substitution), attached by the
+  // backend. This is what a <ChartEntryMore> shows under "View SQL" — which
+  // is why that menu needs the whole `data`, not just the rows.
+  sql?: string | null;
 }
 ```
 

--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -293,7 +293,7 @@ A dashboard reads top-to-bottom in a single screen. Adapt section counts to the 
 Two independent rules, and both must hold for every block on the screen:
 
 - **The creator can edit it** — charts and tables through `<ChartCard>`, everything else through `<EditHandle>`. A block with neither is a block the creator cannot ask you to change.
-- **The viewer can audit it** — any block showing numbers exposes the query behind them, via the ChartCard's built-in menu or a standalone `<ChartEntryMore>`. A number a viewer cannot trace is a number they cannot trust, and a dashboard's `.sql.j2` files never reach the viewer (queries run live), so the in-card menu is the only path.
+- **The viewer can audit it** — every block whose numbers come from a **single** query exposes that query, via the ChartCard's built-in menu or a standalone `<ChartEntryMore>`. A number a viewer cannot trace is a number they cannot trust, and a dashboard's `.sql.j2` files never reach the viewer (queries run live), so that menu is the only path. Two blocks are exempt, and neither is a loophole for skipping the menu on a query-backed one: chrome that shows no numbers of its own (the filter strip, a header), and a panel whose claims are derived from **several** queries — "View SQL" has no single honest answer there, so name the sources in the copy instead.
 
 If your dataset is sparse (one or two queries), collapse to **header + filters + KPI strip + one hero card**. Don't pad with filler.
 
@@ -331,15 +331,15 @@ When the user message contains this tag (typically introduced by a `修改下面
 
 1. `bind_existing_dashboard(<dashboard-slug>)`.
 2. `read_file(<jsx-path>)`, plus `read_file('queries/<sql-id basename>.sql.j2')` only if `sql-id` is present AND the change touches the SQL.
-3. Make the change strictly inside that JSX file (and its companion `.sql.j2` / `.params.json` when the SQL changed). Do **not** modify any other `render/*.jsx` or any unrelated query template.
+3. Keep the change inside the scope `target-kind` defines (below). Absent a wider scope, that means the pinned JSX file plus its companion `.sql.j2` / `.params.json` when the SQL changed — and never an unrelated block or query template.
 4. `validate_render()` once.
 
-`target-kind` tells you the granularity of what was pinned, which matters because several blocks usually share one file:
+`target-kind` tells you what was pinned and how far the edit may reach, which matters because several blocks usually share one file:
 
-- `kpi` — **one tile**, even though `jsx-path` points at the whole strip (or at `shared/kpi-card.jsx`, which every tile renders through). Change that tile only; do not restyle the row, reorder the other tiles, or add new ones. `chart-name` is the tile's label, and `chart-id` is its `handleId` — use both to find the right entry in the file.
-- `note` — one insight / callout block. Usually a copy or scope change; leave the surrounding charts alone.
-- `filter` — the filter strip. Adding or removing an option here almost always means the query templates' `-- @datus-params` and every `useQuerySql` call site must move with it; that is the one case where the edit legitimately spans files.
-- `chart` (or absent) — a whole ChartCard, as before.
+- `chart` (or absent) — a whole ChartCard. Scope: that JSX file.
+- `note` — one insight / callout block. Usually a copy or scope change; leave the surrounding charts alone. Scope: that JSX file.
+- `kpi` — **one tile**. Mind where `jsx-path` points: tiles normally render through `shared/kpi-card.jsx`, so that is the file the envelope names for *every* tile — and editing it changes all of them at once. What distinguishes one tile is its **call site**: the entry in the strip's tile list (or the `<KpiCard …>` element) whose id matches `chart-id`, labelled `chart-name`. Edit that call site, in the strip file, even though the envelope names the shared component. Touch `shared/kpi-card.jsx` itself **only** when the user asked for something that genuinely applies to every tile ("make all the KPI numbers bigger") — and say so in your reply, since the blast radius is larger than what they clicked.
+- `filter` — the filter strip, the one kind whose scope is deliberately wide. Adding, removing or renaming a filter option changes a parameter, and a parameter is a contract: update **every** dependent file in the same turn — each affected template's `-- @datus-params` declaration and body (re-save via `save_query_template`, with fresh `sample_params`), every `useQuerySql(…, params)` call site whose keys must match, and the filter JSX itself. A partial edit here fails `validate_render`'s params-key check, which is exactly the point: finish the contract, then validate once.
 
 When `sql-id` is absent the block is not query-backed (a hand-written callout, the filter strip). Do not invent a template for it — edit the JSX.
 
@@ -371,7 +371,7 @@ Before you stop, confirm — `validate_render` covers manifest / entry-point / s
 - [ ] Numeric columns are coerced with `Number(...)` before arithmetic / Recharts.
 - [ ] Loading / error states are rendered for every `useQuerySql` call (filter changes re-trigger loading).
 - [ ] **Every block is editable.** Walk the rendered screen top to bottom: each chart / table sits in a `<ChartCard>`, and each KPI tile, insight panel, and the filter strip sits in its own `<EditHandle>` with a unique `handleId` and a human-readable `name`. Anything with neither is a block the creator cannot ask you to change.
-- [ ] **Every number is traceable.** Same walk, asking a different question: can the viewer see the SQL behind each figure on screen? ChartCards answer this themselves; the KPI strip and any query-driven insight panel need a standalone `<ChartEntryMore sqlId data>` (one per query, not per tile) on a container marked `data-datus-chart-card`.
+- [ ] **Every single-query number is traceable.** Same walk, asking a different question: for each figure on screen that comes from one query, can the viewer see that query? ChartCards answer this themselves; the KPI strip and any single-query insight panel need a standalone `<ChartEntryMore sqlId data>` (one per query, not per tile) on a container marked `data-datus-chart-card`. Blocks with no numbers, and panels derived from several queries, are exempt — the latter cite their sources in the copy.
 - [ ] All hooks (`useRef` / `useMemo` / `useState` / `useCallback` / `useEffect` / `useQuerySql` / custom hooks) are declared as named `const`s at the top of every component — never called inline from JSX (e.g. `<div ref={useRef(null)}>`), all before any `if (...) return …`. Violations crash the artifact with React error #310.
 - [ ] **Cross-chart reconciliation.** Charts that decompose the **same** metric along different dimensions MUST agree on the total. Before stopping, verify (a quick `execute_sql` against the rendered SQL is enough): KPI strip's `total_<metric>` ≈ `SUM(time_series_chart.<metric>)` ≈ `SUM(per_<dimension>_chart.<metric>)` for the same date range, for every breakdown chart of the same metric. A spread >0.5% means one of those queries has a fan-out bug, a date-filter mismatch, or an inconsistent unit conversion — find which one and fix it before finalizing. Independent metrics (e.g. customer count vs supply cost) don't need to reconcile; this rule applies only across charts that share a common total.
 - [ ] `validate_render()` returned `success: 1`.

--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -284,13 +284,16 @@ A dashboard reads top-to-bottom in a single screen. Adapt section counts to the 
 
 1. **Header**: H1 title, sub-caption (period covered, scope), generation timestamp on the right.
 2. **Filter strip**: horizontal row of selectors (period / region / segment …). A plain styled `<div>` (see "Filter UI → Style" above), `flex` layout, gap 16. NOT a `<ChartCard>` — wrap it in one `<EditHandle handleId="filter_strip" kind="filter">` so its options stay editable.
-3. **KPI strip**: 4–6 small KPI cards in a single grid row, each with title / current value / sparkline / prior-period comparison badge. Each tile is an `<EditHandle kind="kpi">`, not a `<ChartCard>` — render them through `shared/kpi-card.jsx`.
+3. **KPI strip**: 4–6 small KPI cards in a single grid row, each with title / current value / sparkline / prior-period comparison badge. Each tile is an `<EditHandle kind="kpi">`, not a `<ChartCard>` — render them through `shared/kpi-card.jsx` — plus **one** `<ChartEntryMore>` for the strip so a viewer can see the query behind the numbers.
 4. **Hero section**: 2–3 medium cards with the most important charts (revenue trend, top-N table, distribution).
 5. **Distribution / segmentation section**: stacked bars, chord diagrams, radar charts, score breakdowns.
 6. **Detail section**: per-category KPI cards next to a faded multi-line trend chart, or a paginated detail table.
-7. **Insight / callout panels** (wherever they sit): every key-finding or auto-insight box gets its own `<EditHandle kind="note">`, so the creator can reword or re-scope the narrative without touching the charts.
+7. **Insight / callout panels** (wherever they sit): every key-finding or auto-insight box gets its own `<EditHandle kind="note">`, so the creator can reword or re-scope the narrative without touching the charts. Add a `<ChartEntryMore>` too when a single query drives its claims.
 
-Every block on the screen should be reachable by the creator's edit affordance: charts and tables through `<ChartCard>`, everything else through `<EditHandle>`. A block with neither is a block the creator cannot ask you to change.
+Two independent rules, and both must hold for every block on the screen:
+
+- **The creator can edit it** — charts and tables through `<ChartCard>`, everything else through `<EditHandle>`. A block with neither is a block the creator cannot ask you to change.
+- **The viewer can audit it** — any block showing numbers exposes the query behind them, via the ChartCard's built-in menu or a standalone `<ChartEntryMore>`. A number a viewer cannot trace is a number they cannot trust, and a dashboard's `.sql.j2` files never reach the viewer (queries run live), so the in-card menu is the only path.
 
 If your dataset is sparse (one or two queries), collapse to **header + filters + KPI strip + one hero card**. Don't pad with filler.
 
@@ -368,6 +371,7 @@ Before you stop, confirm — `validate_render` covers manifest / entry-point / s
 - [ ] Numeric columns are coerced with `Number(...)` before arithmetic / Recharts.
 - [ ] Loading / error states are rendered for every `useQuerySql` call (filter changes re-trigger loading).
 - [ ] **Every block is editable.** Walk the rendered screen top to bottom: each chart / table sits in a `<ChartCard>`, and each KPI tile, insight panel, and the filter strip sits in its own `<EditHandle>` with a unique `handleId` and a human-readable `name`. Anything with neither is a block the creator cannot ask you to change.
+- [ ] **Every number is traceable.** Same walk, asking a different question: can the viewer see the SQL behind each figure on screen? ChartCards answer this themselves; the KPI strip and any query-driven insight panel need a standalone `<ChartEntryMore sqlId data>` (one per query, not per tile) on a container marked `data-datus-chart-card`.
 - [ ] All hooks (`useRef` / `useMemo` / `useState` / `useCallback` / `useEffect` / `useQuerySql` / custom hooks) are declared as named `const`s at the top of every component — never called inline from JSX (e.g. `<div ref={useRef(null)}>`), all before any `if (...) return …`. Violations crash the artifact with React error #310.
 - [ ] **Cross-chart reconciliation.** Charts that decompose the **same** metric along different dimensions MUST agree on the total. Before stopping, verify (a quick `execute_sql` against the rendered SQL is enough): KPI strip's `total_<metric>` ≈ `SUM(time_series_chart.<metric>)` ≈ `SUM(per_<dimension>_chart.<metric>)` for the same date range, for every breakdown chart of the same metric. A spread >0.5% means one of those queries has a fan-out bug, a date-filter mismatch, or an inconsistent unit conversion — find which one and fix it before finalizing. Independent metrics (e.g. customer count vs supply cost) don't need to reconcile; this rule applies only across charts that share a common total.
 - [ ] `validate_render()` returned `success: 1`.

--- a/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_dashboard_system_1.0.j2
@@ -164,6 +164,7 @@ If the user is asking for an executive briefing, a narrative analysis, or anythi
    └── shared/
        ├── colors.js        # COLORS, palettes
        ├── formatters.js    # d3-format / dayjs wrappers
+       ├── kpi-card.jsx     # KPI tile visual, wrapping <EditHandle> (see the render tree contract)
        ├── table.jsx        # paginated <DataTable> primitive (sticky headers, row striping, fixed 15 rows/page — no page-size selector)
        └── filter-context.js  # React context for filter values
    ```
@@ -282,11 +283,14 @@ const { start, end } = useMemo(() => resolvePeriod(period), [period]);
 A dashboard reads top-to-bottom in a single screen. Adapt section counts to the dataset, but keep the order:
 
 1. **Header**: H1 title, sub-caption (period covered, scope), generation timestamp on the right.
-2. **Filter strip**: horizontal row of selectors (period / region / segment …). A plain styled `<div>` (see "Filter UI → Style" above), `flex` layout, gap 16. NOT a `<ChartCard>`.
-3. **KPI strip**: 4–6 small KPI cards in a single grid row, each with title / current value / sparkline / prior-period comparison badge.
+2. **Filter strip**: horizontal row of selectors (period / region / segment …). A plain styled `<div>` (see "Filter UI → Style" above), `flex` layout, gap 16. NOT a `<ChartCard>` — wrap it in one `<EditHandle handleId="filter_strip" kind="filter">` so its options stay editable.
+3. **KPI strip**: 4–6 small KPI cards in a single grid row, each with title / current value / sparkline / prior-period comparison badge. Each tile is an `<EditHandle kind="kpi">`, not a `<ChartCard>` — render them through `shared/kpi-card.jsx`.
 4. **Hero section**: 2–3 medium cards with the most important charts (revenue trend, top-N table, distribution).
 5. **Distribution / segmentation section**: stacked bars, chord diagrams, radar charts, score breakdowns.
 6. **Detail section**: per-category KPI cards next to a faded multi-line trend chart, or a paginated detail table.
+7. **Insight / callout panels** (wherever they sit): every key-finding or auto-insight box gets its own `<EditHandle kind="note">`, so the creator can reword or re-scope the narrative without touching the charts.
+
+Every block on the screen should be reachable by the creator's edit affordance: charts and tables through `<ChartCard>`, everything else through `<EditHandle>`. A block with neither is a block the creator cannot ask you to change.
 
 If your dataset is sparse (one or two queries), collapse to **header + filters + KPI strip + one hero card**. Don't pad with filler.
 
@@ -304,17 +308,18 @@ If the user asks for a follow-up change ("swap revenue for unit sales", "add a Y
 
 You do NOT need to rewrite `app.jsx` for a localised change — surgical edits are the whole point of the multi-file layout.
 
-### Targeted single-card edits
+### Targeted single-block edits
 
-A user turn may carry a self-closing `<artifact-chart-card />` XML tag that pins the edit to one specific chart. Shape:
+A user turn may carry a self-closing `<artifact-chart-card />` XML tag that pins the edit to one specific block — a chart, a single KPI tile, an insight panel, or the filter strip. Shape:
 
 ```
 <artifact-chart-card
   dashboard-slug="<dashboard_slug>"
   chart-id="<id>"
-  sql-id="queries/<slug>"
+  sql-id="queries/<slug>"                   <!-- optional: absent for a non-query-backed block -->
   jsx-path="render/<file>.jsx"
-  chart-name="<human-readable chart label>"
+  chart-name="<human-readable block label>"
+  target-kind="chart|kpi|note|filter"        <!-- optional: absent on older envelopes, which are charts -->
   params="<JSON-encoded filter snapshot>"   <!-- optional -->
 />
 ```
@@ -322,9 +327,18 @@ A user turn may carry a self-closing `<artifact-chart-card />` XML tag that pins
 When the user message contains this tag (typically introduced by a `修改下面这个 Chart：` prefix line above it):
 
 1. `bind_existing_dashboard(<dashboard-slug>)`.
-2. `read_file(<jsx-path>)`, plus `read_file('queries/<sql-id basename>.sql.j2')` only if the change touches the SQL.
+2. `read_file(<jsx-path>)`, plus `read_file('queries/<sql-id basename>.sql.j2')` only if `sql-id` is present AND the change touches the SQL.
 3. Make the change strictly inside that JSX file (and its companion `.sql.j2` / `.params.json` when the SQL changed). Do **not** modify any other `render/*.jsx` or any unrelated query template.
 4. `validate_render()` once.
+
+`target-kind` tells you the granularity of what was pinned, which matters because several blocks usually share one file:
+
+- `kpi` — **one tile**, even though `jsx-path` points at the whole strip (or at `shared/kpi-card.jsx`, which every tile renders through). Change that tile only; do not restyle the row, reorder the other tiles, or add new ones. `chart-name` is the tile's label, and `chart-id` is its `handleId` — use both to find the right entry in the file.
+- `note` — one insight / callout block. Usually a copy or scope change; leave the surrounding charts alone.
+- `filter` — the filter strip. Adding or removing an option here almost always means the query templates' `-- @datus-params` and every `useQuerySql` call site must move with it; that is the one case where the edit legitimately spans files.
+- `chart` (or absent) — a whole ChartCard, as before.
+
+When `sql-id` is absent the block is not query-backed (a hand-written callout, the filter strip). Do not invent a template for it — edit the JSX.
 
 The artifact kind is encoded in the slug attribute name — `dashboard-slug` ⇒ this is a dashboard edit; `report-slug` ⇒ it's a report edit (and you'll see this tag in the report subagent's prompt instead). If you ever see both slug variants on the same tag, treat the envelope as malformed and ask the user to confirm.
 
@@ -353,6 +367,7 @@ Before you stop, confirm — `validate_render` covers manifest / entry-point / s
 - [ ] Filter state lives in `app.jsx` and is threaded down; no duplicated filter state across components.
 - [ ] Numeric columns are coerced with `Number(...)` before arithmetic / Recharts.
 - [ ] Loading / error states are rendered for every `useQuerySql` call (filter changes re-trigger loading).
+- [ ] **Every block is editable.** Walk the rendered screen top to bottom: each chart / table sits in a `<ChartCard>`, and each KPI tile, insight panel, and the filter strip sits in its own `<EditHandle>` with a unique `handleId` and a human-readable `name`. Anything with neither is a block the creator cannot ask you to change.
 - [ ] All hooks (`useRef` / `useMemo` / `useState` / `useCallback` / `useEffect` / `useQuerySql` / custom hooks) are declared as named `const`s at the top of every component — never called inline from JSX (e.g. `<div ref={useRef(null)}>`), all before any `if (...) return …`. Violations crash the artifact with React error #310.
 - [ ] **Cross-chart reconciliation.** Charts that decompose the **same** metric along different dimensions MUST agree on the total. Before stopping, verify (a quick `execute_sql` against the rendered SQL is enough): KPI strip's `total_<metric>` ≈ `SUM(time_series_chart.<metric>)` ≈ `SUM(per_<dimension>_chart.<metric>)` for the same date range, for every breakdown chart of the same metric. A spread >0.5% means one of those queries has a fan-out bug, a date-filter mismatch, or an inconsistent unit conversion — find which one and fix it before finalizing. Independent metrics (e.g. customer count vs supply cost) don't need to reconcile; this rule applies only across charts that share a common total.
 - [ ] `validate_render()` returned `success: 1`.

--- a/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
@@ -223,7 +223,7 @@ When the user message contains this tag (typically introduced by a `修改下面
 3. Make the change strictly inside that JSX file (and the relevant query bundle when the data shape changed). Do **not** modify any other `render/*.jsx` or any unrelated query.
 4. `validate_render()` once.
 
-`target-kind` tells you the granularity: `kpi` pins **one tile** even though `jsx-path` covers the whole strip (change that tile only — `chart-name` is its label, `chart-id` its `handleId`); `note` pins one key-finding / callout block, usually a copy or scope change; `chart` (or absent) pins a whole ChartCard. When `sql-id` is absent the block isn't query-backed — edit the JSX, don't invent a query for it.
+`target-kind` tells you the granularity: `kpi` pins **one tile**, but tiles normally render through `shared/kpi-card.jsx`, so that shared file is what `jsx-path` names for *every* tile — editing it changes all of them. Edit the tile's **call site** instead: the entry whose id matches `chart-id`, labelled `chart-name`. Only touch the shared component when the request genuinely applies to every tile, and say so in your reply. `note` pins one key-finding / callout block, usually a copy or scope change; `chart` (or absent) pins a whole ChartCard. When `sql-id` is absent the block isn't query-backed — edit the JSX, don't invent a query for it.
 
 The artifact kind is encoded in the slug attribute name — `report-slug` ⇒ this is a report edit; `dashboard-slug` ⇒ it's a dashboard edit (and you'll see this tag in the dashboard subagent's prompt instead).
 

--- a/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
+++ b/datus/prompts/prompt_templates/gen_visual_report_system_1.0.j2
@@ -201,17 +201,18 @@ If the user asks for a follow-up change ("swap revenue for unit sales", "add a Y
 
 You do NOT need to rewrite `app.jsx` for a localised change — surgical edits are the whole point of the multi-file layout.
 
-### Targeted single-card edits
+### Targeted single-block edits
 
-A user turn may carry a self-closing `<artifact-chart-card />` XML tag that pins the edit to one specific chart. Shape:
+A user turn may carry a self-closing `<artifact-chart-card />` XML tag that pins the edit to one specific block — a chart, a KPI tile, or a key-finding / callout panel. Shape:
 
 ```
 <artifact-chart-card
   report-slug="<report_slug>"
   chart-id="<id>"
-  sql-id="queries/<slug>"
+  sql-id="queries/<slug>"                   <!-- optional: absent for a non-query-backed block -->
   jsx-path="render/<file>.jsx"
-  chart-name="<human-readable chart label>"
+  chart-name="<human-readable block label>"
+  target-kind="chart|kpi|note"               <!-- optional: absent on older envelopes, which are charts -->
 />
 ```
 
@@ -221,6 +222,8 @@ When the user message contains this tag (typically introduced by a `修改下面
 2. `read_file(<jsx-path>)`. If the SQL needs to change, `read_file('queries/<sql-id basename>.json')` to see what was already executed and use `save_query` to overwrite with the new shape.
 3. Make the change strictly inside that JSX file (and the relevant query bundle when the data shape changed). Do **not** modify any other `render/*.jsx` or any unrelated query.
 4. `validate_render()` once.
+
+`target-kind` tells you the granularity: `kpi` pins **one tile** even though `jsx-path` covers the whole strip (change that tile only — `chart-name` is its label, `chart-id` its `handleId`); `note` pins one key-finding / callout block, usually a copy or scope change; `chart` (or absent) pins a whole ChartCard. When `sql-id` is absent the block isn't query-backed — edit the JSX, don't invent a query for it.
 
 The artifact kind is encoded in the slug attribute name — `report-slug` ⇒ this is a report edit; `dashboard-slug` ⇒ it's a dashboard edit (and you'll see this tag in the dashboard subagent's prompt instead).
 

--- a/datus/tools/func_tool/dashboard_artifact_tools.py
+++ b/datus/tools/func_tool/dashboard_artifact_tools.py
@@ -197,6 +197,45 @@ _VALID_CHART_TYPES: Set[str] = {
 }
 
 
+# ``<EditHandle ... >`` opening tag — the edit entry point authors wrap
+# around blocks that aren't ChartCards (KPI tiles, insight panels, the
+# filter strip). Same atom-based attribute matching as ChartCard so
+# ``name={<span>a > b</span>}`` doesn't truncate the prop block.
+_EDIT_HANDLE_OPEN_RE = re.compile(
+    r"""
+    <EditHandle\b
+    (
+      (?:
+        [^'"{}<>]                                          # plain char
+        | '[^'\\]*(?:\\.[^'\\]*)*'                         # 'single-quoted'
+        | "[^"\\]*(?:\\.[^"\\]*)*"                         # "double-quoted"
+        | \{ (?: [^{}] | \{ (?: [^{}] | \{[^{}]*\} )* \} )* \}   # {balanced braces, depth ≤ 3}
+      )*
+    )
+    /?\s*>
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+# String-literal props audited on ``<EditHandle>``.
+_EDIT_HANDLE_STR_ATTR_RE = re.compile(
+    r"""\b(handleId|name|kind|sqlId)\s*=\s*['"]([^'"]+)['"]""",
+)
+
+
+# Presence of a prop regardless of whether its value is a literal. Used to
+# tell "the author forgot ``handleId``" (an issue) apart from "``handleId``
+# is forwarded from a wrapper component" (legitimate — see below).
+_EDIT_HANDLE_ANY_ATTR_RE = re.compile(r"\b(handleId|name)\s*=")
+
+
+# ``EditHandle``'s kind enum. ``'chart'`` is deliberately absent: that kind
+# belongs to ChartCard, and a chart wrapped in a bare EditHandle would lose
+# the chart-actions menu.
+_VALID_EDIT_HANDLE_KINDS: Set[str] = {"kpi", "note", "filter"}
+
+
 # --------------------------------------------------------------------------- #
 # Jinja2 sandbox + bind-value resolution                                      #
 # --------------------------------------------------------------------------- #
@@ -1148,11 +1187,15 @@ class DashboardArtifactTools:
         issues: List[str] = []
         warnings: List[str] = []
         query_refs: Set[str] = set()
-        # chartId → render-file rel-path of its first declaration. Used to
-        # detect duplicates across the whole render/ tree; the validate_render
-        # result also exposes this as the cards-registry for downstream
-        # consumers, and both require global uniqueness.
+        # chartId / handleId → render-file rel-path of its first declaration.
+        # One namespace for both because they land in the same field of the
+        # edit-intent payload. Used to detect duplicates across the whole
+        # render/ tree; the validate_render result also exposes this as the
+        # cards-registry for downstream consumers.
         chart_ids_seen: Dict[str, str] = {}
+        # Same keys → what the block is ("chart" for ChartCard, the EditHandle
+        # kind otherwise), so the registry can tell a KPI tile from a chart.
+        card_kinds: Dict[str, str] = {}
 
         for key, mod in modules.items():
             source = mod["source"]
@@ -1216,6 +1259,83 @@ class DashboardArtifactTools:
                         f"render/{mod['rel']}: <ChartCard chartType={chart_type!r}> is not one of "
                         f"{sorted(_VALID_CHART_TYPES)}."
                     )
+
+                card_kinds[chart_id] = "chart"
+
+            # ---- <EditHandle ... > opening tags — the non-chart edit entry
+            # point. Checks are deliberately looser than ChartCard's: a KPI
+            # tile is normally rendered through a shared wrapper
+            # (``shared/kpi-card.jsx``) that forwards ``handleId`` / ``name``
+            # from its own props, so those values are expressions rather than
+            # string literals at this call site. Literals get the full shape +
+            # uniqueness treatment; forwarded props are deferred to runtime.
+            for eh_match in _EDIT_HANDLE_OPEN_RE.finditer(source):
+                attrs = eh_match.group(1) or ""
+                attr_values = {name: value for name, value in _EDIT_HANDLE_STR_ATTR_RE.findall(attrs)}
+                present = {name for name in _EDIT_HANDLE_ANY_ATTR_RE.findall(attrs)}
+
+                if _CHART_CARD_SPREAD_RE.search(attrs):
+                    warnings.append(
+                        f"render/{mod['rel']}: <EditHandle> uses spread props — static "
+                        "validation of handleId / name / kind is deferred to runtime."
+                    )
+                    continue
+
+                missing = [k for k in ("handleId", "name") if k not in present]
+                if missing:
+                    issues.append(
+                        f"render/{mod['rel']}: <EditHandle> is missing required props: {missing}. "
+                        "Every EditHandle needs a globally-unique handleId and a human-readable "
+                        "name (the label the user sees on the chat chip)."
+                    )
+                    continue
+
+                kind = attr_values.get("kind")
+                if kind is not None and kind not in _VALID_EDIT_HANDLE_KINDS:
+                    issues.append(
+                        f"render/{mod['rel']}: <EditHandle kind={kind!r}> is not one of "
+                        f"{sorted(_VALID_EDIT_HANDLE_KINDS)}. Charts belong in <ChartCard>, "
+                        "which carries its own edit entry point."
+                    )
+
+                handle_sql_id = attr_values.get("sqlId")
+                if handle_sql_id is not None:
+                    slug = extract_query_slug(handle_sql_id)
+                    if slug is None:
+                        issues.append(
+                            f"render/{mod['rel']}: <EditHandle sqlId={handle_sql_id!r}> is not a valid "
+                            "queries/<slug> reference. Omit sqlId entirely for a block with no query "
+                            "behind it."
+                        )
+                    else:
+                        query_refs.add(f"queries/{slug}")
+                        if slug not in templates:
+                            issues.append(
+                                f"render/{mod['rel']}: <EditHandle sqlId='queries/{slug}'> points to a "
+                                "template not produced via save_query_template."
+                            )
+
+                handle_id = attr_values.get("handleId")
+                if handle_id is None:
+                    # Forwarded from a wrapper component's props — the id only
+                    # exists at runtime, so shape and uniqueness can't be
+                    # checked here.
+                    continue
+
+                if not _CHART_ID_RE.fullmatch(handle_id):
+                    issues.append(
+                        f"render/{mod['rel']}: <EditHandle handleId={handle_id!r}> must match {_CHART_ID_RE.pattern}."
+                    )
+                elif handle_id in chart_ids_seen:
+                    issues.append(
+                        f"render/{mod['rel']}: <EditHandle handleId={handle_id!r}> duplicates the id "
+                        f"already declared in render/{chart_ids_seen[handle_id]}. handleId shares one "
+                        "namespace with ChartCard's chartId and must be globally unique across the "
+                        "dashboard."
+                    )
+                else:
+                    chart_ids_seen[handle_id] = mod["rel"]
+                    card_kinds[handle_id] = kind or "note"
 
             # ---- 1-arg useQuerySql calls (no params) — always rejected.
             for match in _USE_QUERY_SQL_NO_PARAMS_RE.finditer(source):
@@ -1329,11 +1449,16 @@ class DashboardArtifactTools:
             for k in unreferenced
         )
 
-        # Cards registry derived from the validated <ChartCard> instances.
-        # Sorted by chartId for stable wire output. Downstream consumers
+        # Cards registry derived from the validated <ChartCard> / <EditHandle>
+        # instances. Sorted by id for stable wire output. Downstream consumers
         # (publish wire payload, future static-edit APIs) read this off the
-        # validate_render result rather than re-walking the AST.
-        cards_registry = [{"chart_id": cid, "jsx_path": f"render/{rel}"} for cid, rel in sorted(chart_ids_seen.items())]
+        # validate_render result rather than re-walking the AST. EditHandles
+        # whose handleId is forwarded from a wrapper component's props are
+        # absent — their ids only exist at runtime.
+        cards_registry = [
+            {"chart_id": cid, "jsx_path": f"render/{rel}", "kind": card_kinds.get(cid, "chart")}
+            for cid, rel in sorted(chart_ids_seen.items())
+        ]
 
         return FuncToolResult(
             result={

--- a/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_dashboard_artifact_tools.py
@@ -998,7 +998,9 @@ class TestValidateRenderChartCard:
         _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": _CHART_CARD_APP_JSX})
         result = dashboard_tools.validate_render()
         assert result.success == 1, result.error
-        assert result.result["cards"] == [{"chart_id": "revenue_by_region", "jsx_path": "render/app.jsx"}]
+        assert result.result["cards"] == [
+            {"chart_id": "revenue_by_region", "jsx_path": "render/app.jsx", "kind": "chart"}
+        ]
         # ChartCard's sqlId joins the query-ref set even when the validator
         # has already seen the same slug from useQuerySql.
         assert "queries/revenue_by_region" in result.result["query_refs"]
@@ -1205,6 +1207,168 @@ class TestValidateRenderChartCard:
         assert result.success == 1, result.error
         warnings = result.result.get("warnings", [])
         assert any("spread props" in w for w in warnings)
+
+
+# ----------------------------------------------------------------------------- #
+# validate_render — <EditHandle> static checks                                   #
+# ----------------------------------------------------------------------------- #
+
+
+def _edit_handle_app(handle_attrs: str) -> str:
+    """App whose KPI tile is wrapped in an ``<EditHandle>`` with ``handle_attrs``."""
+    return (
+        "import React from 'react';\n"
+        "import { useDatusArtifact, EditHandle } from '@datus/web-artifact';\n"
+        "export default function App() {\n"
+        "  const { useQuerySql } = useDatusArtifact();\n"
+        "  const { data } = useQuerySql('queries/revenue_by_region', { month_floor: '2026-01' });\n"
+        "  return (\n"
+        f"    <EditHandle {handle_attrs}>\n"
+        "      <div>{data?.rows?.length}</div>\n"
+        "    </EditHandle>\n"
+        "  );\n"
+        "}\n"
+    )
+
+
+class TestValidateRenderEditHandle:
+    """Static validation around the runtime-provided ``<EditHandle>``."""
+
+    def test_edit_handle_happy_path_lands_in_cards_registry(
+        self, dashboard_tools: DashboardArtifactTools, project_root: Path
+    ):
+        _seed_template(dashboard_tools)
+        app = _edit_handle_app(
+            'handleId="kpi_total_revenue" name="Total revenue" kind="kpi" sqlId="queries/revenue_by_region"'
+        )
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app})
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+        assert result.result["cards"] == [
+            {"chart_id": "kpi_total_revenue", "jsx_path": "render/app.jsx", "kind": "kpi"}
+        ]
+
+    def test_edit_handle_without_sql_id_is_accepted(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        """A static callout has no query behind it — sqlId is optional."""
+        _seed_template(dashboard_tools)
+        app = _edit_handle_app('handleId="insight_panel" name="Auto insights" kind="note"')
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app})
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+        assert result.result["cards"] == [{"chart_id": "insight_panel", "jsx_path": "render/app.jsx", "kind": "note"}]
+
+    def test_edit_handle_defaults_to_note_kind(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        _seed_template(dashboard_tools)
+        app = _edit_handle_app('handleId="filter_strip" name="Filters"')
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app})
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+        assert result.result["cards"][0]["kind"] == "note"
+
+    def test_edit_handle_missing_name_rejected(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        _seed_template(dashboard_tools)
+        app = _edit_handle_app('handleId="kpi_total_revenue" kind="kpi"')
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app})
+        result = dashboard_tools.validate_render()
+        assert result.success == 0
+        assert "missing required" in (result.error or "")
+        assert "name" in (result.error or "")
+
+    def test_edit_handle_invalid_handle_id_rejected(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        _seed_template(dashboard_tools)
+        app = _edit_handle_app('handleId="KPI-Total" name="Total revenue" kind="kpi"')
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app})
+        result = dashboard_tools.validate_render()
+        assert result.success == 0
+        assert "KPI-Total" in (result.error or "")
+
+    def test_edit_handle_chart_kind_rejected(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        """``kind="chart"`` belongs to ChartCard, which owns the actions menu."""
+        _seed_template(dashboard_tools)
+        app = _edit_handle_app('handleId="revenue_block" name="Revenue" kind="chart"')
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app})
+        result = dashboard_tools.validate_render()
+        assert result.success == 0
+        assert "'chart'" in (result.error or "")
+        assert "ChartCard" in (result.error or "")
+
+    def test_edit_handle_dangling_sql_id_rejected(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        _seed_template(dashboard_tools)
+        app = _edit_handle_app('handleId="kpi_total_revenue" name="Total revenue" sqlId="queries/orphaned_slug"')
+        _write_render(project_root, dashboard_tools.dashboard_slug, {"app.jsx": app})
+        result = dashboard_tools.validate_render()
+        assert result.success == 0
+        assert "orphaned_slug" in (result.error or "")
+        assert "save_query_template" in (result.error or "")
+
+    def test_edit_handle_id_collides_with_chart_id(self, dashboard_tools: DashboardArtifactTools, project_root: Path):
+        """handleId and chartId share one namespace — a collision is an error."""
+        _seed_template(dashboard_tools)
+        second = (
+            "import React from 'react';\n"
+            "import { EditHandle } from '@datus/web-artifact';\n"
+            "export function Tile() {\n"
+            "  return (\n"
+            '    <EditHandle handleId="revenue_by_region" name="Total revenue" kind="kpi">\n'
+            "      <div />\n"
+            "    </EditHandle>\n"
+            "  );\n"
+            "}\n"
+        )
+        _write_render(
+            project_root,
+            dashboard_tools.dashboard_slug,
+            {"app.jsx": _CHART_CARD_APP_JSX, "tile.jsx": second},
+        )
+        result = dashboard_tools.validate_render()
+        assert result.success == 0
+        assert "duplicates" in (result.error or "")
+        assert "revenue_by_region" in (result.error or "")
+
+    def test_edit_handle_forwarded_props_deferred_to_runtime(
+        self, dashboard_tools: DashboardArtifactTools, project_root: Path
+    ):
+        """A shared KPI-card wrapper forwards handleId / name from its props.
+
+        Those values only exist at runtime, so the shape + uniqueness checks
+        can't run — but the handle itself is well-formed and must not be
+        reported as missing required props.
+        """
+        _seed_template(dashboard_tools)
+        shared = (
+            "import React from 'react';\n"
+            "import { EditHandle } from '@datus/web-artifact';\n"
+            "export function KpiCard({ handleId, label, value, sqlId, params }) {\n"
+            "  return (\n"
+            '    <EditHandle handleId={handleId} name={label} kind="kpi" sqlId={sqlId} params={params}>\n'
+            "      <div>{value}</div>\n"
+            "    </EditHandle>\n"
+            "  );\n"
+            "}\n"
+        )
+        app = (
+            "import React from 'react';\n"
+            "import { useDatusArtifact } from '@datus/web-artifact';\n"
+            "import { KpiCard } from './shared/kpi-card';\n"
+            "export default function App() {\n"
+            "  const { useQuerySql } = useDatusArtifact();\n"
+            "  const { data } = useQuerySql('queries/revenue_by_region', { month_floor: '2026-01' });\n"
+            "  const r = data?.rows?.[0] ?? {};\n"
+            "  return (\n"
+            '    <KpiCard handleId="kpi_total_revenue" label="Total revenue" value={r.revenue} '
+            "sqlId=\"queries/revenue_by_region\" params={{ month_floor: '2026-01' }} />\n"
+            "  );\n"
+            "}\n"
+        )
+        _write_render(
+            project_root,
+            dashboard_tools.dashboard_slug,
+            {"app.jsx": app, "shared/kpi-card.jsx": shared},
+        )
+        result = dashboard_tools.validate_render()
+        assert result.success == 1, result.error
+        # Nothing statically knowable → no registry entry for the tile.
+        assert result.result["cards"] == []
 
 
 # ----------------------------------------------------------------------------- #


### PR DESCRIPTION
## Why

The creator could only pin **charts** for a follow-up edit. KPI tiles, insight / callout panels and the filter strip had no affordance at all.

The cause is structural: `ChartCard` hosts its Edit button in a title strip, and those blocks have none. Giving a KPI tile a card header purely to carry a button would stack six headers and six action menus into a row meant to read as one line of numbers — so the prompt let them be authored as bare `div`s, which the runtime cannot attribute to a source file and therefore cannot edit.

The saas runtime now ships `<EditHandle>` — zero visual chrome, a hover-revealed wand, hidden on published artifacts by the same gate as ChartCard's Edit button. This PR teaches the prompts to use it and the validator to check it.

## Prompt changes

- **`_visual_artifact_common.j2`** — `EditHandle` in the allowed-imports table, a full props contract, and a **complete KPI-strip demo**: `render/shared/kpi-card.jsx` (the tile visual, which stays userland — the runtime deliberately ships no KPI card, same principle as `shared/table.jsx`) wrapping the handle, plus `kpi-strip.jsx` mapping one query onto N tiles. The handle lives *inside* the shared wrapper so no call site can forget one. A second example covers a static callout with no `sqlId` and `placement="top-left"` (the observed collision: insight panels already put a period badge in their top-right corner).
- **Layout + checklist** — the dashboard layout section now requires a handle on the filter strip, each KPI tile, and every insight panel; a new finalize-checklist item makes the model walk the screen and confirm nothing is unreachable. The "attach a ChartCard to every `useQuerySql`-backed visualization" rule now carves out the KPI strip explicitly, since that rule is what pushed the model toward the wrong shape.
- **Targeted-edit envelope** — renamed to "Targeted single-block edits"; gains `target-kind` and an optional `sql-id`, with per-kind granularity guidance. The one that matters: `kpi` pins **one tile** even though `jsx-path` covers the whole strip (or `shared/kpi-card.jsx`), so the model must not restyle the row or reorder siblings. Mirrored into the report prompt, which shares the include and will emit handles on key-finding panels too.

## Validator

`validate_render` learns `<EditHandle>`:

- `handleId` shares **one global namespace** with `chartId` — both land in the same field of the edit payload, so a collision between a tile and a chart is an error.
- `kind` is enum-checked, with `'chart'` rejected: a chart wrapped in a bare handle would lose the chart-actions menu.
- `sqlId` is optional, but must resolve to a `save_query_template` output when present, and joins `query_refs`.
- The cards registry now records `kind` per entry (`"chart"` for ChartCard, the handle's kind otherwise). No downstream consumer reads this field yet — checked both repos.

Checks are **looser than ChartCard's on purpose**: a shared KPI wrapper forwards `handleId` / `name` from its own props, so at that call site they're expressions, not string literals. Those are deferred to runtime rather than reported as missing — otherwise the recommended structure would fail its own validator. Literal ids still get the full shape + uniqueness treatment.

## Companion PR

Datus-saas #707 — the `EditHandle` primitive plus the payload/envelope widening. Both must ship together: without saas nothing renders the handle, and without this PR nothing emits one.

## Test

- `pytest tests/unit_tests/tools/func_tool/ tests/unit_tests/agent/node/test_gen_visual_{dashboard,report}_agentic_node.py` → **1988 passed, 6 skipped**.
- 9 new `TestValidateRenderEditHandle` cases: happy path → registry, SQL-less accepted, kind defaulting, missing `name`, bad `handleId` shape, `kind="chart"` rejected, dangling `sqlId`, collision with a `chartId` in another file, and the forwarded-props case asserting a clean pass with no registry entry.
- Both prompt templates render through Jinja with the JSX examples intact (the `{{ ... }}` style objects and `{...spread}` survive the `raw` block).
- `ruff format` + `ruff check` clean on both touched Python files.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added support for targeted editing of individual KPI tiles, filters, insight panels, and other non-chart dashboard blocks.
  * Improved dashboard generation guidance for consistent edit controls and unique, readable block identifiers.
  * Expanded targeted editing to distinguish charts, KPI tiles, and notes.

* **Bug Fixes**
  * Improved validation for editable dashboard blocks, including required properties, supported block types, query references, and identifier conflicts.
  * Clarified when chart containers and edit controls should be used for KPI strips and static panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded dashboard and report editing guidance to support targeted single-block edits for KPI tiles, notes/callouts, and other non-chart blocks.
  * Strengthened viewer auditability rules: single-query numbers must expose query traceability via chart actions or standalone query-backed entries.

* **Bug Fixes**
  * Improved static validation for non-chart edit handles, including correct required fields, allowed edit kinds, conflict detection, and tighter query-reference handling.

* **Tests**
  * Added/updated unit tests to cover edit-handle validation and card registry metadata (including kind defaults and rejection scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->