### PR TITLE
[Enhancement] Add where filter and runtime guardrails to attribution_analyze

### DIFF
--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -1581,7 +1581,11 @@ def _build_attribution_analyze(action: ActionHistory, verbose: bool) -> ToolCall
             if isinstance(result, dict):
                 dims = result.get("selected_dimensions") or result.get("dimension_ranking", [])
                 count = len(dims) if isinstance(dims, list) else 0
-                tc.compact_result = f"{count} dimensions analyzed"
+                warnings = result.get("warnings") or []
+                warning_count = len(warnings) if isinstance(warnings, list) else 0
+                tc.compact_result = f"{count} {'dimension' if count == 1 else 'dimensions'} analyzed"
+                if warning_count:
+                    tc.compact_result += f", {warning_count} {'warning' if warning_count == 1 else 'warnings'}"
     return tc
 
 

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -57,6 +57,7 @@ Use the narrow metric workflow below:
 ## Attribution Playbook
 
 - Before attribution, use `query_metrics` at an appropriate time grain to confirm the comparison windows, observed change, and data coverage.
+- Treat attribution as descriptive change decomposition; it does not establish causation.
 - Use `get_dimensions` to choose 3-5 low-cardinality categorical candidates. Exclude time dimensions and numeric measures, IDs, or high-cardinality fields unless the user explicitly needs one.
 - Use equal-length baseline and current windows. If the result contains `UNEQUAL_WINDOWS`, disclose that values were not normalized before comparing them.
 - Read contribution details only from `per_dimension`. Never compare or add contribution percentages across different dimensions. `top_dimension_values` is a legacy compatibility field and must not be used for analysis.

--- a/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
+++ b/datus/prompts/prompt_templates/ask_metrics_system_1.0.j2
@@ -17,7 +17,7 @@ Use the narrow metric workflow below:
    `extra.time_granularities`; grains are ordered finest to coarsest, and the
    first grain is the default.
 6. Call `query_metrics` to retrieve metric values.
-7. For change explanation, root-cause, or contribution questions, call `attribution_analyze` after selecting candidate dimensions.
+7. For change explanation, root-cause, or contribution questions, follow the Attribution Playbook below.
 8. If no suitable existing metric can answer the question, say so directly and do not fall back to raw SQL.
 
 ## Tool Rules
@@ -53,6 +53,22 @@ Use the narrow metric workflow below:
 - When you have the query result that should be used as the final structured answer, call `select_final_metric_result` with the `result_id` from that successful `query_metrics` result. This selection is required; do not select diagnostic or exploratory queries as final.
 - Before selecting the final result, verify that its columns include every grouping dimension explicitly requested by the user and every requested metric value that is exposed as a metric. If another successful `query_metrics` result better matches those requested dimensions and metrics, select that result instead.
 {% endif %}
+
+## Attribution Playbook
+
+- Before attribution, use `query_metrics` at an appropriate time grain to confirm the comparison windows, observed change, and data coverage.
+- Use `get_dimensions` to choose 3-5 low-cardinality categorical candidates. Exclude time dimensions and numeric measures, IDs, or high-cardinality fields unless the user explicitly needs one.
+- Use equal-length baseline and current windows. If the result contains `UNEQUAL_WINDOWS`, disclose that values were not normalized before comparing them.
+- Read contribution details only from `per_dimension`. Never compare or add contribution percentages across different dimensions. `top_dimension_values` is a legacy compatibility field and must not be used for analysis.
+- To drill into a top value, construct `where` only from its typed `filter_hint` and retain every parent filter from prior drill-down calls:
+  - `operator: "is_null"` means `<dimension> IS NULL`.
+  - Numeric values are not quoted.
+  - String values are quoted with embedded quotes escaped for the datasource dialect.
+- Always disclose attribution `warnings`:
+  - With `NON_ADDITIVE_DIMENSION`, do not interpret that dimension's percentages as an additive decomposition.
+  - With `NO_DATA_*`, `NULL_TOTAL_*`, or `ZERO_OR_NO_DATA_*`, do not give an attribution conclusion; first confirm coverage with `query_metrics`.
+  - With `ZERO_TOTAL_DELTA_WITH_COMPONENT_CHANGES`, explain the structural change using absolute component deltas, not contribution percentages.
+  - With `HIGH_CARDINALITY_DIMENSION`, attribute a coarser dimension first and use `where` to narrow the follow-up query.
 
 ## Period-Over-Period Metric Queries
 

--- a/datus/schemas/tool_summary.py
+++ b/datus/schemas/tool_summary.py
@@ -16,9 +16,9 @@ Both call sites must produce identical wording, so the per-tool formatters
 live in one place. Only the ``success`` path is per-tool; failure
 summaries are produced uniformly by :func:`format_failure`.
 
-All non-filesystem summaries are clipped to ``SUMMARY_TEXT_MAX_CHARS``
-characters at the registry exit; filesystem tools (``read_file``,
-``write_file``, ``edit_file``, ``glob``, ``grep``) bypass the clip.
+Most summaries are clipped to ``SUMMARY_TEXT_MAX_CHARS`` characters at the
+registry exit. Tools whose compact contract requires complete identifiers,
+including filesystem tools and ``attribution_analyze``, bypass the clip.
 """
 
 from __future__ import annotations
@@ -40,6 +40,7 @@ SUMMARY_ERROR_MAX_CHARS = 19
 FS_TOOLS_NO_CLIP = frozenset(
     {"read_file", "write_file", "edit_file", "delete_file", "glob", "grep", "web_search", "web_fetch"}
 )
+SUMMARY_TOOLS_NO_CLIP = FS_TOOLS_NO_CLIP | frozenset({"attribution_analyze"})
 
 
 # ── Generic helpers (public API) ────────────────────────────────────────
@@ -174,13 +175,12 @@ def _list_count(value: Any, singular: str, plural: str) -> str:
 def _clip_short(text: str, tool_name: str = "", limit: int = SUMMARY_TEXT_MAX_CHARS) -> str:
     """Final-stage clip applied at registry exit.
 
-    Filesystem tools (``read_file``, ``write_file``, ``edit_file``,
-    ``delete_file``, ``glob``, ``grep``) are exempt — their summaries are
-    returned verbatim because users want full path / count visibility there.
+    Tools in ``SUMMARY_TOOLS_NO_CLIP`` are exempt because their summaries carry
+    identifiers that must remain complete.
     """
     if not isinstance(text, str):
         return text
-    if tool_name in FS_TOOLS_NO_CLIP:
+    if tool_name in SUMMARY_TOOLS_NO_CLIP:
         return text
     if len(text) <= limit:
         return text
@@ -540,16 +540,11 @@ def _fmt_validate_semantic(result: Any) -> str:
 
 def _fmt_attribution_analyze(result: Any) -> str:
     if isinstance(result, dict):
-        ranking = result.get("dimension_ranking") or []
         selected = result.get("selected_dimensions") or []
         warnings = result.get("warnings") or []
-        n_sel = len(selected) if isinstance(selected, list) else 0
-        n_rank = len(ranking) if isinstance(ranking, list) else 0
-        summary = ""
-        if n_sel and n_rank:
-            summary = f"sel {n_sel}/{n_rank} dims"
-        elif n_sel:
-            summary = f"sel {n_sel} dim" if n_sel == 1 else f"sel {n_sel} dims"
+        summary_parts = []
+        if isinstance(selected, list) and selected:
+            summary_parts.append(f"selected {','.join(str(dimension) for dimension in selected)}")
         warning_codes = []
         if isinstance(warnings, list):
             for warning in warnings:
@@ -557,9 +552,8 @@ def _fmt_attribution_analyze(result: Any) -> str:
                 if isinstance(code, str) and code and code not in warning_codes:
                     warning_codes.append(code)
         if warning_codes:
-            warning_summary = f"warn {','.join(warning_codes)}"
-            return f"{summary}; {warning_summary}" if summary else warning_summary
-        return summary
+            summary_parts.append(f"warnings {','.join(warning_codes)}")
+        return "; ".join(summary_parts)
     return ""
 
 
@@ -1134,8 +1128,8 @@ class ToolSummaryRegistry:
     per-tool formatters are invoked only when the payload indicates
     success and the unwrapped ``result`` is non-empty.
 
-    The registry exit applies :func:`_clip_short` so every non-filesystem
-    summary is bounded to ``SUMMARY_TEXT_MAX_CHARS`` characters.
+    The registry exit applies :func:`_clip_short`; tools outside
+    ``SUMMARY_TOOLS_NO_CLIP`` are bounded to ``SUMMARY_TEXT_MAX_CHARS``.
     """
 
     def __init__(self) -> None:

--- a/datus/schemas/tool_summary.py
+++ b/datus/schemas/tool_summary.py
@@ -542,12 +542,24 @@ def _fmt_attribution_analyze(result: Any) -> str:
     if isinstance(result, dict):
         ranking = result.get("dimension_ranking") or []
         selected = result.get("selected_dimensions") or []
+        warnings = result.get("warnings") or []
         n_sel = len(selected) if isinstance(selected, list) else 0
         n_rank = len(ranking) if isinstance(ranking, list) else 0
+        summary = ""
         if n_sel and n_rank:
-            return f"sel {n_sel}/{n_rank} dims"
-        if n_sel:
-            return f"sel {n_sel} dim" if n_sel == 1 else f"sel {n_sel} dims"
+            summary = f"sel {n_sel}/{n_rank} dims"
+        elif n_sel:
+            summary = f"sel {n_sel} dim" if n_sel == 1 else f"sel {n_sel} dims"
+        warning_codes = []
+        if isinstance(warnings, list):
+            for warning in warnings:
+                code = warning.get("code") if isinstance(warning, dict) else None
+                if isinstance(code, str) and code and code not in warning_codes:
+                    warning_codes.append(code)
+        if warning_codes:
+            warning_summary = f"warn {','.join(warning_codes)}"
+            return f"{summary}; {warning_summary}" if summary else warning_summary
+        return summary
     return ""
 
 

--- a/datus/tools/func_tool/attribution_utils.py
+++ b/datus/tools/func_tool/attribution_utils.py
@@ -2,21 +2,29 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""
-Dimension Attribution Analysis Tool
+"""Adapter-agnostic dimension attribution analysis."""
 
-Provides adapter-agnostic dimension attribution analysis capabilities.
-Only depends on BaseSemanticAdapter abstract interface.
-"""
+from __future__ import annotations
 
-from typing import Dict, List, Optional
+import json
+import math
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
 from datus.tools.semantic_tools.base import BaseSemanticAdapter
+from datus.tools.semantic_tools.models import QueryResult
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+JsonScalar = Union[str, int, float, bool]
+_MAX_DIMENSION_VALUES = 1000
+_ADDITIVITY_TOLERANCE = 0.02
+_ZERO_DELTA_EPSILON = 1e-6
+
 
 # ==================== Data Models ====================
 
@@ -30,14 +38,72 @@ class DimensionRanking(BaseModel):
     )
 
 
+class FilterHint(BaseModel):
+    """Typed filter information for a follow-up attribution query."""
+
+    dimension: str
+    operator: Literal["eq", "is_null"]
+    value: Optional[JsonScalar] = None
+
+
 class DimensionValueContribution(BaseModel):
     """Delta contribution of a dimension value."""
 
-    dimension_values: Dict[str, str] = Field(..., description="Dimension value(s)")
+    dimension_values: Dict[str, str] = Field(..., description="Legacy human-readable dimension value(s)")
     baseline: float = Field(..., description="Baseline period metric value")
     current: float = Field(..., description="Current period metric value")
     delta: float = Field(..., description="Absolute change (current - baseline)")
     contribution_pct_of_total_delta: float = Field(..., description="Percentage contribution to total delta")
+    filter_hint: Optional[FilterHint] = None
+
+
+class AdditivityCheck(BaseModel):
+    """Whether grouped values reconcile to the corresponding period totals."""
+
+    status: Literal["passed", "failed", "skipped", "unknown"] = "unknown"
+    baseline_residual: Optional[float] = None
+    current_residual: Optional[float] = None
+    baseline_residual_pct: Optional[float] = None
+    current_residual_pct: Optional[float] = None
+    delta_residual_pct: Optional[float] = None
+
+
+class DimensionAttribution(BaseModel):
+    """Attribution details and guardrail state for one dimension."""
+
+    dimension: str
+    score: Optional[float] = None
+    additivity_check: AdditivityCheck = Field(default_factory=AdditivityCheck)
+    truncated: bool = False
+    contributions: List[DimensionValueContribution] = Field(default_factory=list)
+
+
+class AttributionWarning(BaseModel):
+    """A non-fatal limitation that must be disclosed when interpreting results."""
+
+    code: str
+    dimension: Optional[str] = None
+    message: str
+
+
+class AttributionValidationErrorPayload(BaseModel):
+    """Structured fatal validation failure returned by the public tool wrapper."""
+
+    error_type: Literal["attribution_validation_error"] = "attribution_validation_error"
+    code: str
+    message: str
+    period: Optional[str] = None
+    dimension: Optional[str] = None
+    columns: List[str] = Field(default_factory=list)
+    row_count: Optional[int] = None
+
+
+class AttributionValidationException(Exception):
+    """Raised when an adapter result cannot be safely used for attribution."""
+
+    def __init__(self, payload: AttributionValidationErrorPayload):
+        self.payload = payload
+        super().__init__(payload.message)
 
 
 class AttributionAnalysisResult(BaseModel):
@@ -48,25 +114,19 @@ class AttributionAnalysisResult(BaseModel):
     dimension_ranking: List[DimensionRanking] = Field(..., description="Dimensions ranked by importance")
     selected_dimensions: List[str] = Field(..., description="Dimensions selected for analysis")
     top_dimension_values: List[DimensionValueContribution] = Field(
-        ..., description="Top contributors by dimension values"
+        ..., description="Legacy cross-dimension list of top contributors"
     )
     anomaly_context: Optional[Dict] = Field(None, description="Anomaly detection context")
     comparison_metadata: Dict = Field(..., description="Comparison period metadata")
+    per_dimension: Dict[str, DimensionAttribution] = Field(default_factory=dict)
+    warnings: List[AttributionWarning] = Field(default_factory=list)
 
 
 # ==================== Attribution Util ====================
 
 
 class DimensionAttributionUtil:
-    """
-    Adapter-agnostic dimension attribution analysis utility.
-
-    Only depends on BaseSemanticAdapter abstract interface:
-    - get_dimensions()
-    - query_metrics()
-
-    Works with any semantic layer backend (MetricFlow, dbt, Cube, etc.)
-    """
+    """Dimension attribution utility that only depends on BaseSemanticAdapter."""
 
     def __init__(self, adapter: BaseSemanticAdapter):
         self.adapter = adapter
@@ -83,41 +143,22 @@ class DimensionAttributionUtil:
         anomaly_context: Optional[Dict] = None,
         max_selected_dimensions: int = 3,
         top_n_values: int = 10,
+        where: Optional[str] = None,
+        max_dimension_values: int = 500,
     ) -> AttributionAnalysisResult:
-        """
-        Unified attribution analysis: ranks dimensions and calculates delta contributions.
+        """Rank candidate dimensions and calculate guarded delta contributions."""
+        requested_max_dimension_values = max_dimension_values
+        effective_max_dimension_values = max(1, min(max_dimension_values, _MAX_DIMENSION_VALUES))
+        grouped_query_limit = effective_max_dimension_values + 1
+        warnings: List[AttributionWarning] = []
 
-        This method:
-        1. Queries total metric values for baseline and current periods
-        2. Evaluates all candidate dimensions (single query per dimension)
-        3. Calculates both dimension scores and value contributions in one pass
-        4. Selects top dimensions and returns top contributing values
-
-        Args:
-            metric_name: Metric to analyze
-            candidate_dimensions: List of dimensions to evaluate (1-N dimensions)
-            baseline_start: Baseline period start date (e.g., "2026-01-01")
-            baseline_end: Baseline period end date (e.g., "2026-01-07")
-            current_start: Current period start date (e.g., "2026-01-08")
-            current_end: Current period end date (e.g., "2026-01-14")
-            path: Metric path for scoping
-            anomaly_context: Optional anomaly detection context (rule, observed_change, etc.)
-            max_selected_dimensions: Maximum number of dimensions to select (default: 3)
-            top_n_values: Number of top dimension values to return
-
-        Returns:
-            AttributionAnalysisResult with:
-            - dimension_ranking: All dimensions ranked by importance score
-            - selected_dimensions: Top dimensions selected for analysis
-            - top_dimension_values: Delta contributions of top dimension values
-        """
-        # Step 1: Query total metric values (no dimension breakdown)
         baseline_total_result = await self.adapter.query_metrics(
             metrics=[metric_name],
             dimensions=[],
             path=path,
             time_start=baseline_start,
             time_end=baseline_end,
+            where=where,
         )
         current_total_result = await self.adapter.query_metrics(
             metrics=[metric_name],
@@ -125,136 +166,567 @@ class DimensionAttributionUtil:
             path=path,
             time_start=current_start,
             time_end=current_end,
+            where=where,
         )
 
-        baseline_total = (
-            self._extract_metric_value(baseline_total_result.data[0], metric_name)
-            if baseline_total_result.data
-            else 0.0
+        baseline_total = self._parse_total(
+            baseline_total_result,
+            metric_name=metric_name,
+            period="baseline",
+            warnings=warnings,
         )
-        current_total = (
-            self._extract_metric_value(current_total_result.data[0], metric_name) if current_total_result.data else 0.0
+        current_total = self._parse_total(
+            current_total_result,
+            metric_name=metric_name,
+            period="current",
+            warnings=warnings,
         )
         total_delta = current_total - baseline_total
 
-        # Step 2: Analyze each dimension (one query per dimension, calculate both score and contributions)
+        baseline_days = self._window_days(baseline_start, baseline_end)
+        current_days = self._window_days(current_start, current_end)
+        if baseline_days is not None and current_days is not None and baseline_days != current_days:
+            warnings.append(
+                AttributionWarning(
+                    code="UNEQUAL_WINDOWS",
+                    message=(
+                        f"Baseline and current windows contain {baseline_days} and {current_days} days; "
+                        "values were not normalized."
+                    ),
+                )
+            )
+
+        total_delta_is_zero = self._is_effectively_zero_delta(
+            total_delta,
+            baseline_total=baseline_total,
+            current_total=current_total,
+        )
         dimension_rankings: List[DimensionRanking] = []
         all_contributions: Dict[str, List[DimensionValueContribution]] = {}
+        per_dimension: Dict[str, DimensionAttribution] = {}
 
         for dimension in candidate_dimensions:
-            # Query both periods for this dimension
             baseline_result = await self.adapter.query_metrics(
                 metrics=[metric_name],
                 dimensions=[dimension],
                 path=path,
                 time_start=baseline_start,
                 time_end=baseline_end,
+                where=where,
+                limit=grouped_query_limit,
             )
-
             current_result = await self.adapter.query_metrics(
                 metrics=[metric_name],
                 dimensions=[dimension],
                 path=path,
                 time_start=current_start,
                 time_end=current_end,
+                where=where,
+                limit=grouped_query_limit,
             )
 
             logger.debug(
-                f"Analyzing dimension '{dimension}': baseline={len(baseline_result.data)} rows, "
-                f"current={len(current_result.data)} rows"
+                "Analyzing dimension '%s': baseline=%d rows, current=%d rows",
+                dimension,
+                len(baseline_result.data),
+                len(current_result.data),
             )
 
-            # Build lookup for baseline values
-            baseline_lookup = {}
-            for row in baseline_result.data:
-                dim_val = self._extract_dimension_value(row, dimension)
-                metric_val = self._extract_metric_value(row, metric_name)
-                baseline_lookup[dim_val] = metric_val
+            baseline_lookup = self._parse_grouped_result(
+                baseline_result,
+                metric_name=metric_name,
+                dimension=dimension,
+                period="baseline",
+            )
+            current_lookup = self._parse_grouped_result(
+                current_result,
+                metric_name=metric_name,
+                dimension=dimension,
+                period="current",
+            )
+            union_keys = list(dict.fromkeys([*baseline_lookup, *current_lookup]))
+            truncated = (
+                len(baseline_result.data) >= grouped_query_limit
+                or len(current_result.data) >= grouped_query_limit
+                or len(union_keys) > effective_max_dimension_values
+            )
+            if truncated:
+                per_dimension[dimension] = DimensionAttribution(
+                    dimension=dimension,
+                    truncated=True,
+                    additivity_check=AdditivityCheck(status="skipped"),
+                )
+                warnings.append(
+                    AttributionWarning(
+                        code="HIGH_CARDINALITY_DIMENSION",
+                        dimension=dimension,
+                        message=(
+                            f"Dimension '{dimension}' exceeded the {effective_max_dimension_values}-value limit. "
+                            "Attribute a coarser dimension first, then use where to narrow this dimension."
+                        ),
+                    )
+                )
+                continue
 
-            # Calculate contributions for current values
-            contributions = []
-            deltas = []
-
-            for row in current_result.data:
-                dim_val = self._extract_dimension_value(row, dimension)
-                current_val = self._extract_metric_value(row, metric_name)
-                baseline_val = baseline_lookup.get(dim_val, 0.0)
-                delta = current_val - baseline_val
-                deltas.append(delta)
-
-                contribution_pct = (delta / total_delta * 100) if total_delta != 0 else 0.0
-                contributions.append(
-                    DimensionValueContribution(
-                        dimension_values={dimension: dim_val},
-                        baseline=baseline_val,
-                        current=current_val,
-                        delta=delta,
-                        contribution_pct_of_total_delta=contribution_pct,
+            contributions = self._build_contributions(
+                dimension=dimension,
+                union_keys=union_keys,
+                baseline_lookup=baseline_lookup,
+                current_lookup=current_lookup,
+                total_delta=total_delta,
+                total_delta_is_zero=total_delta_is_zero,
+            )
+            deltas = [contribution.delta for contribution in contributions]
+            score = (
+                max(abs(delta) for delta in deltas) / abs(total_delta) if deltas and not total_delta_is_zero else 0.0
+            )
+            additivity_check = self._check_additivity(
+                baseline_total=baseline_total,
+                current_total=current_total,
+                baseline_values=[item[1] for item in baseline_lookup.values()],
+                current_values=[item[1] for item in current_lookup.values()],
+            )
+            if additivity_check.status == "failed":
+                warnings.append(
+                    AttributionWarning(
+                        code="NON_ADDITIVE_DIMENSION",
+                        dimension=dimension,
+                        message=(
+                            f"Grouped values for '{dimension}' do not reconcile to the period totals; "
+                            "do not interpret its contribution percentages as an additive decomposition."
+                        ),
                     )
                 )
 
-            # Also include values that disappeared (exist in baseline but not in current)
-            current_dim_vals = {self._extract_dimension_value(row, dimension) for row in current_result.data}
-            for dim_val, baseline_val in baseline_lookup.items():
-                if dim_val not in current_dim_vals:
-                    delta = 0.0 - baseline_val
-                    deltas.append(delta)
-
-                    contribution_pct = (delta / total_delta * 100) if total_delta != 0 else 0.0
-                    contributions.append(
-                        DimensionValueContribution(
-                            dimension_values={dimension: dim_val},
-                            baseline=baseline_val,
-                            current=0.0,
-                            delta=delta,
-                            contribution_pct_of_total_delta=contribution_pct,
-                        )
+            if total_delta_is_zero and self._has_material_component_change(
+                deltas,
+                baseline_total=baseline_total,
+                current_total=current_total,
+            ):
+                warnings.append(
+                    AttributionWarning(
+                        code="ZERO_TOTAL_DELTA_WITH_COMPONENT_CHANGES",
+                        dimension=dimension,
+                        message=(
+                            f"Dimension '{dimension}' has offsetting component changes while the total change is "
+                            "effectively zero; interpret absolute deltas, not contribution percentages."
+                        ),
                     )
-
-            # Calculate dimension score (max contribution ratio)
-            if len(deltas) > 0 and abs(total_delta) > 0:
-                max_abs_delta = max(abs(d) for d in deltas)
-                score = max_abs_delta / abs(total_delta)
-            else:
-                score = 0.0
+                )
 
             dimension_rankings.append(DimensionRanking(dimension=dimension, score=score))
             all_contributions[dimension] = contributions
+            per_dimension[dimension] = DimensionAttribution(
+                dimension=dimension,
+                score=score,
+                additivity_check=additivity_check,
+                contributions=sorted(contributions, key=lambda item: abs(item.delta), reverse=True)[
+                    : max(0, top_n_values)
+                ],
+            )
 
-        # Step 3: Sort dimensions by score and select top N
-        dimension_rankings.sort(key=lambda r: r.score, reverse=True)
-        selected_dimensions = [ranking.dimension for ranking in dimension_rankings[:max_selected_dimensions]]
-
-        # Step 4: Collect contributions from selected dimensions and sort by contribution percentage
-        selected_contributions = []
-        for dim in selected_dimensions:
-            selected_contributions.extend(all_contributions[dim])
-
-        selected_contributions.sort(key=lambda c: c.contribution_pct_of_total_delta, reverse=True)
-        top_dimension_values = selected_contributions[:top_n_values]
+        dimension_rankings.sort(key=lambda ranking: ranking.score, reverse=True)
+        selected_dimensions = [ranking.dimension for ranking in dimension_rankings[: max(0, max_selected_dimensions)]]
+        selected_contributions = [
+            contribution for dimension in selected_dimensions for contribution in all_contributions[dimension]
+        ]
+        selected_contributions.sort(
+            key=lambda contribution: contribution.contribution_pct_of_total_delta,
+            reverse=True,
+        )
 
         return AttributionAnalysisResult(
             metric_name=metric_name,
             candidate_dimensions=candidate_dimensions,
             dimension_ranking=dimension_rankings,
             selected_dimensions=selected_dimensions,
-            top_dimension_values=top_dimension_values,
+            top_dimension_values=selected_contributions[: max(0, top_n_values)],
             anomaly_context=anomaly_context,
             comparison_metadata={
-                "baseline": {"start": baseline_start, "end": baseline_end},
-                "current": {"start": current_start, "end": current_end},
+                "baseline": {
+                    "start": baseline_start,
+                    "end": baseline_end,
+                    "days": baseline_days,
+                    "total": baseline_total,
+                },
+                "current": {
+                    "start": current_start,
+                    "end": current_end,
+                    "days": current_days,
+                    "total": current_total,
+                },
+                "total_delta": total_delta,
+                "where": where,
+                "path": path,
+                "requested_max_dimension_values": requested_max_dimension_values,
+                "effective_max_dimension_values": effective_max_dimension_values,
             },
+            per_dimension=per_dimension,
+            warnings=warnings,
         )
 
-    def _extract_metric_value(self, row: Dict, metric_name: str) -> float:
-        """Extract metric value from query result row."""
-        value = row.get(metric_name, 0)
-        try:
-            return float(value)
-        except (ValueError, TypeError):
+    def _parse_total(
+        self,
+        result: QueryResult,
+        *,
+        metric_name: str,
+        period: Literal["baseline", "current"],
+        warnings: List[AttributionWarning],
+    ) -> float:
+        row_count = len(result.data)
+        if row_count > 1:
+            self._raise_validation_error(
+                code="MULTI_ROW_TOTAL",
+                message=f"{period.title()} total query returned {row_count} rows; expected at most one.",
+                period=period,
+                columns=result.columns,
+                row_count=row_count,
+            )
+        if row_count == 0:
+            warnings.append(
+                AttributionWarning(
+                    code=f"NO_DATA_{period.upper()}",
+                    message=f"The {period} total query returned no rows; the total is treated as 0.",
+                )
+            )
+            return 0.0
+        metric_column = self._resolve_column(
+            requested=metric_name,
+            columns=result.columns,
+            missing_code="MISSING_METRIC_COLUMN",
+            period=period,
+            row_count=row_count,
+        )
+
+        row = result.data[0]
+        if metric_column not in row:
+            self._raise_validation_error(
+                code="MISSING_METRIC_COLUMN",
+                message=f"Resolved metric column '{metric_column}' is absent from the {period} result row.",
+                period=period,
+                columns=result.columns,
+                row_count=row_count,
+            )
+        value = row[metric_column]
+        if value is None:
+            warnings.append(
+                AttributionWarning(
+                    code=f"NULL_TOTAL_{period.upper()}",
+                    message=f"The {period} total is NULL and is treated as 0; confirm data coverage.",
+                )
+            )
             return 0.0
 
-    def _extract_dimension_value(self, row: Dict, dimension: str) -> str:
-        """Extract dimension value from query result row."""
-        value = row.get(dimension, "Unknown")
+        numeric_value = self._coerce_finite_metric(
+            value,
+            period=period,
+            columns=result.columns,
+            row_count=row_count,
+        )
+        if numeric_value == 0:
+            warnings.append(
+                AttributionWarning(
+                    code=f"ZERO_OR_NO_DATA_{period.upper()}",
+                    message=(
+                        f"The {period} total is 0, which cannot distinguish a real zero from empty aggregate "
+                        "input; confirm coverage with query_metrics at an appropriate time grain."
+                    ),
+                )
+            )
+        return numeric_value
+
+    def _parse_grouped_result(
+        self,
+        result: QueryResult,
+        *,
+        metric_name: str,
+        dimension: str,
+        period: Literal["baseline", "current"],
+    ) -> Dict[str, tuple[Optional[JsonScalar], float]]:
+        row_count = len(result.data)
+        if row_count == 0:
+            return {}
+        metric_column = self._resolve_column(
+            requested=metric_name,
+            columns=result.columns,
+            missing_code="MISSING_METRIC_COLUMN",
+            period=period,
+            dimension=dimension,
+            row_count=row_count,
+        )
+        dimension_column = self._resolve_column(
+            requested=dimension,
+            columns=result.columns,
+            missing_code="MISSING_DIMENSION_COLUMN",
+            period=period,
+            dimension=dimension,
+            row_count=row_count,
+        )
+
+        values: Dict[str, tuple[Optional[JsonScalar], float]] = {}
+        for row in result.data:
+            if metric_column not in row:
+                self._raise_validation_error(
+                    code="MISSING_METRIC_COLUMN",
+                    message=f"Resolved metric column '{metric_column}' is absent from a {period} grouped row.",
+                    period=period,
+                    dimension=dimension,
+                    columns=result.columns,
+                    row_count=row_count,
+                )
+            if dimension_column not in row:
+                self._raise_validation_error(
+                    code="MISSING_DIMENSION_COLUMN",
+                    message=f"Resolved dimension column '{dimension_column}' is absent from a {period} grouped row.",
+                    period=period,
+                    dimension=dimension,
+                    columns=result.columns,
+                    row_count=row_count,
+                )
+
+            raw_dimension_value = row[dimension_column]
+            normalized_dimension_value = self._normalize_dimension_value(raw_dimension_value)
+            key = self._dimension_key(normalized_dimension_value)
+            if key in values:
+                self._raise_validation_error(
+                    code="DUPLICATE_DIMENSION_KEY",
+                    message=(
+                        f"Dimension '{dimension}' returned duplicate value "
+                        f"'{self._display_dimension_value(normalized_dimension_value)}' in the {period} period; "
+                        "check for an implicit time grain or extra grouping columns."
+                    ),
+                    period=period,
+                    dimension=dimension,
+                    columns=result.columns,
+                    row_count=row_count,
+                )
+            metric_value = self._coerce_finite_metric(
+                row[metric_column],
+                period=period,
+                dimension=dimension,
+                columns=result.columns,
+                row_count=row_count,
+            )
+            values[key] = (normalized_dimension_value, metric_value)
+        return values
+
+    def _build_contributions(
+        self,
+        *,
+        dimension: str,
+        union_keys: List[str],
+        baseline_lookup: Dict[str, tuple[Optional[JsonScalar], float]],
+        current_lookup: Dict[str, tuple[Optional[JsonScalar], float]],
+        total_delta: float,
+        total_delta_is_zero: bool,
+    ) -> List[DimensionValueContribution]:
+        contributions: List[DimensionValueContribution] = []
+        for key in union_keys:
+            dimension_value = (current_lookup.get(key) or baseline_lookup[key])[0]
+            baseline_value = baseline_lookup.get(key, (dimension_value, 0.0))[1]
+            current_value = current_lookup.get(key, (dimension_value, 0.0))[1]
+            delta = current_value - baseline_value
+            contribution_pct = 0.0 if total_delta_is_zero else delta / total_delta * 100
+            is_null = dimension_value is None
+            contributions.append(
+                DimensionValueContribution(
+                    dimension_values={dimension: self._display_dimension_value(dimension_value)},
+                    baseline=baseline_value,
+                    current=current_value,
+                    delta=delta,
+                    contribution_pct_of_total_delta=contribution_pct,
+                    filter_hint=FilterHint(
+                        dimension=dimension,
+                        operator="is_null" if is_null else "eq",
+                        value=None if is_null else dimension_value,
+                    ),
+                )
+            )
+        return contributions
+
+    @staticmethod
+    def _check_additivity(
+        *,
+        baseline_total: float,
+        current_total: float,
+        baseline_values: List[float],
+        current_values: List[float],
+    ) -> AdditivityCheck:
+        baseline_sum = sum(baseline_values)
+        current_sum = sum(current_values)
+        baseline_residual = baseline_sum - baseline_total
+        current_residual = current_sum - current_total
+        baseline_tolerance = _ADDITIVITY_TOLERANCE * max(
+            abs(baseline_total),
+            sum(abs(value) for value in baseline_values),
+        )
+        current_tolerance = _ADDITIVITY_TOLERANCE * max(
+            abs(current_total),
+            sum(abs(value) for value in current_values),
+        )
+        status = (
+            "passed"
+            if abs(baseline_residual) <= baseline_tolerance and abs(current_residual) <= current_tolerance
+            else "failed"
+        )
+        total_delta = current_total - baseline_total
+        grouped_delta = current_sum - baseline_sum
+        return AdditivityCheck(
+            status=status,
+            baseline_residual=baseline_residual,
+            current_residual=current_residual,
+            baseline_residual_pct=(baseline_residual / abs(baseline_total) * 100 if baseline_total != 0 else None),
+            current_residual_pct=(current_residual / abs(current_total) * 100 if current_total != 0 else None),
+            delta_residual_pct=((grouped_delta - total_delta) / abs(total_delta) * 100 if total_delta != 0 else None),
+        )
+
+    @staticmethod
+    def _is_effectively_zero_delta(
+        total_delta: float,
+        *,
+        baseline_total: float,
+        current_total: float,
+    ) -> bool:
+        scale = max(abs(baseline_total), abs(current_total))
+        return abs(total_delta) <= _ZERO_DELTA_EPSILON * scale if scale else total_delta == 0
+
+    @staticmethod
+    def _has_material_component_change(
+        deltas: List[float],
+        *,
+        baseline_total: float,
+        current_total: float,
+    ) -> bool:
+        threshold = _ADDITIVITY_TOLERANCE * max(abs(baseline_total), abs(current_total))
+        return any(abs(delta) > threshold for delta in deltas)
+
+    def _coerce_finite_metric(
+        self,
+        value: Any,
+        *,
+        period: Literal["baseline", "current"],
+        columns: List[str],
+        row_count: int,
+        dimension: Optional[str] = None,
+    ) -> float:
+        if value is None:
+            self._raise_validation_error(
+                code="NON_NUMERIC_METRIC_VALUE",
+                message=f"Metric value is NULL in a {period} grouped row.",
+                period=period,
+                dimension=dimension,
+                columns=columns,
+                row_count=row_count,
+            )
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError, OverflowError):
+            numeric_value = math.nan
+        if not math.isfinite(numeric_value):
+            self._raise_validation_error(
+                code="NON_NUMERIC_METRIC_VALUE",
+                message=f"Metric value {value!r} is not a finite number in the {period} result.",
+                period=period,
+                dimension=dimension,
+                columns=columns,
+                row_count=row_count,
+            )
+        return numeric_value
+
+    def _resolve_column(
+        self,
+        *,
+        requested: str,
+        columns: List[str],
+        missing_code: str,
+        period: Literal["baseline", "current"],
+        row_count: int,
+        dimension: Optional[str] = None,
+    ) -> str:
+        exact_matches = [column for column in columns if column.casefold() == requested.casefold()]
+        if len(exact_matches) == 1:
+            return exact_matches[0]
+
+        requested_leaf = self._column_leaf(requested)
+        leaf_matches = [
+            column for column in columns if self._column_leaf(column).casefold() == requested_leaf.casefold()
+        ]
+        if len(leaf_matches) == 1:
+            return leaf_matches[0]
+
+        detail = "not found" if not leaf_matches else f"ambiguous ({', '.join(leaf_matches)})"
+        kind = "metric" if missing_code == "MISSING_METRIC_COLUMN" else "dimension"
+        self._raise_validation_error(
+            code=missing_code,
+            message=f"Requested {kind} column '{requested}' was {detail} in the {period} result.",
+            period=period,
+            dimension=dimension,
+            columns=columns,
+            row_count=row_count,
+        )
+
+    @staticmethod
+    def _column_leaf(column: str) -> str:
+        return column.rsplit(".", 1)[-1].rsplit("__", 1)[-1]
+
+    @staticmethod
+    def _normalize_dimension_value(value: Any) -> Optional[JsonScalar]:
+        if value is None:
+            return None
+        try:
+            if not isinstance(value, (str, bytes)) and math.isnan(value):
+                return None
+        except (TypeError, ValueError):
+            pass
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int):
+            return value
+        if isinstance(value, Decimal):
+            if value == value.to_integral_value():
+                return int(value)
+            normalized = float(value)
+            return normalized if math.isfinite(normalized) else str(value)
+        if isinstance(value, float):
+            return value if math.isfinite(value) else str(value)
+        if isinstance(value, (date, datetime)):
+            return value.isoformat()
+        if isinstance(value, str):
+            return value
         return str(value)
+
+    @staticmethod
+    def _dimension_key(value: Optional[JsonScalar]) -> str:
+        return f"{type(value).__name__}:{json.dumps(value, ensure_ascii=False, sort_keys=True)}"
+
+    @staticmethod
+    def _display_dimension_value(value: Optional[JsonScalar]) -> str:
+        return "(null)" if value is None else str(value)
+
+    @staticmethod
+    def _window_days(start: str, end: str) -> Optional[int]:
+        try:
+            return (date.fromisoformat(end) - date.fromisoformat(start)).days + 1
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _raise_validation_error(
+        *,
+        code: str,
+        message: str,
+        period: Optional[str] = None,
+        dimension: Optional[str] = None,
+        columns: Optional[List[str]] = None,
+        row_count: Optional[int] = None,
+    ) -> None:
+        raise AttributionValidationException(
+            AttributionValidationErrorPayload(
+                code=code,
+                message=message,
+                period=period,
+                dimension=dimension,
+                columns=columns or [],
+                row_count=row_count,
+            )
+        )

--- a/datus/tools/func_tool/attribution_utils.py
+++ b/datus/tools/func_tool/attribution_utils.py
@@ -30,7 +30,7 @@ _ZERO_DELTA_EPSILON = 1e-6
 
 
 class DimensionRanking(BaseModel):
-    """Ranking score for a dimension's explanatory power."""
+    """Ranking score for a dimension's change concentration."""
 
     dimension: str = Field(..., description="Dimension name")
     score: float = Field(
@@ -111,7 +111,7 @@ class AttributionAnalysisResult(BaseModel):
 
     metric_name: str = Field(..., description="Metric being analyzed")
     candidate_dimensions: List[str] = Field(..., description="Input candidate dimensions")
-    dimension_ranking: List[DimensionRanking] = Field(..., description="Dimensions ranked by importance")
+    dimension_ranking: List[DimensionRanking] = Field(..., description="Dimensions ranked by change concentration")
     selected_dimensions: List[str] = Field(..., description="Dimensions selected for analysis")
     top_dimension_values: List[DimensionValueContribution] = Field(
         ..., description="Legacy cross-dimension list of top contributors"
@@ -285,6 +285,7 @@ class DimensionAttributionUtil:
                 current_total=current_total,
                 baseline_values=[item[1] for item in baseline_lookup.values()],
                 current_values=[item[1] for item in current_lookup.values()],
+                total_delta_is_zero=total_delta_is_zero,
             )
             if additivity_check.status == "failed":
                 warnings.append(
@@ -551,6 +552,7 @@ class DimensionAttributionUtil:
         current_total: float,
         baseline_values: List[float],
         current_values: List[float],
+        total_delta_is_zero: bool,
     ) -> AdditivityCheck:
         baseline_sum = sum(baseline_values)
         current_sum = sum(current_values)
@@ -577,7 +579,9 @@ class DimensionAttributionUtil:
             current_residual=current_residual,
             baseline_residual_pct=(baseline_residual / abs(baseline_total) * 100 if baseline_total != 0 else None),
             current_residual_pct=(current_residual / abs(current_total) * 100 if current_total != 0 else None),
-            delta_residual_pct=((grouped_delta - total_delta) / abs(total_delta) * 100 if total_delta != 0 else None),
+            delta_residual_pct=(
+                (grouped_delta - total_delta) / abs(total_delta) * 100 if not total_delta_is_zero else None
+            ),
         )
 
     @staticmethod

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -24,7 +24,10 @@ from pydantic import BaseModel
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.metric.store import MetricRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
-from datus.tools.func_tool.attribution_utils import DimensionAttributionUtil
+from datus.tools.func_tool.attribution_utils import (
+    AttributionValidationException,
+    DimensionAttributionUtil,
+)
 from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, normalize_null, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.semantic_tools.base import BaseSemanticAdapter
@@ -1465,6 +1468,9 @@ class SemanticTools:
         anomaly_context: Optional[AnomalyContext] = None,
         max_selected_dimensions: int = 3,
         top_n_values: int = 10,
+        where: Optional[str] = None,
+        path: Optional[List[str]] = None,
+        max_dimension_values: int = 500,
     ) -> FuncToolResult:
         """
         Unified attribution analysis for anomaly investigation.
@@ -1483,6 +1489,9 @@ class SemanticTools:
             anomaly_context: Optional anomaly detection context (AnomalyContext with rule and observed_change_pct)
             max_selected_dimensions: Maximum dimensions to select (default 3)
             top_n_values: Number of top dimension values to return (default 10)
+            where: Optional SQL boolean expression applied to every attribution query
+            path: Optional subject tree path for metric scoping
+            max_dimension_values: Maximum grouped values per dimension (hard-capped at 1000)
 
         Returns:
             FuncToolResult with:
@@ -1522,6 +1531,9 @@ class SemanticTools:
                     anomaly_context=anomaly_context_dict,
                     max_selected_dimensions=max_selected_dimensions,
                     top_n_values=top_n_values,
+                    where=where,
+                    path=path,
+                    max_dimension_values=max_dimension_values,
                 )
             )
 
@@ -1530,6 +1542,13 @@ class SemanticTools:
                 result=result.model_dump(),
             )
 
+        except AttributionValidationException as e:
+            logger.warning("Attribution result validation failed: %s", e.payload.message)
+            return FuncToolResult(
+                success=0,
+                error=e.payload.message,
+                result=e.payload.model_dump(),
+            )
         except Exception as e:
             logger.error(f"Error in attribution analysis: {e}")
             return FuncToolResult(

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -1473,11 +1473,11 @@ class SemanticTools:
         max_dimension_values: int = 500,
     ) -> FuncToolResult:
         """
-        Unified attribution analysis for anomaly investigation.
+        Descriptive dimension analysis for metric changes.
 
-        Automatically ranks candidate dimensions by explanatory power and calculates
-        delta contributions for the most important dimensions. Perfect for LLM-driven
-        root cause analysis of metric anomalies.
+        Ranks candidate dimensions by change concentration and calculates delta
+        contributions for selected dimensions. Results describe where a metric change
+        is concentrated; they do not establish causation.
 
         Args:
             metric_name: Metric to analyze(from list_metrics/search_metrics)

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -113,6 +113,9 @@ class TestAskMetricsAgenticNode:
         assert "do not call `search_metrics` for metrics that match these entries directly" in prompt
         assert "When the subject tree gives a direct metric/path match" in prompt
         assert "dedicated catalog metric" in prompt
+        assert "## Attribution Playbook" in prompt
+        assert "typed `filter_hint`" in prompt
+        assert "Read contribution details only from `per_dimension`" in prompt
         assert "Do not invent helper metrics" in prompt
         assert "do not add a `where` filter that enumerates dimension values" in prompt
         assert "Query complete metric results by default" in prompt

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -1301,11 +1301,12 @@ class TestBuildAttributionAnalyze:
             input_data={"function_name": "attribution_analyze"},
             output_data={
                 "raw_output": '{"success": 1, "result": {"dimension_ranking": ["d1", "d2"], '
-                '"selected_dimensions": ["d1"], "top_dimension_values": []}}'
+                '"selected_dimensions": ["d1"], "top_dimension_values": [], '
+                '"warnings": [{"code": "UNEQUAL_WINDOWS"}]}}'
             },
         )
         tc = _build_attribution_analyze(a, verbose=False)
-        assert "1 dimensions analyzed" in tc.compact_result
+        assert tc.compact_result == "1 dimension analyzed, 1 warning"
 
 
 # ── Filesystem tools ──────────────────────────────────────────────

--- a/tests/unit_tests/schemas/test_tool_summary.py
+++ b/tests/unit_tests/schemas/test_tool_summary.py
@@ -458,9 +458,16 @@ class TestSemanticFormatters:
     def test_attribution_analyze(self):
         out = _summarize(
             "attribution_analyze",
-            {"success": 1, "result": {"dimension_ranking": list(range(8)), "selected_dimensions": list(range(3))}},
+            {
+                "success": 1,
+                "result": {
+                    "dimension_ranking": list(range(8)),
+                    "selected_dimensions": list(range(3)),
+                    "warnings": [{"code": "UNEQUAL_WINDOWS"}],
+                },
+            },
         )
-        assert out == "sel 3/8 dims"
+        assert out == "sel 3/8 dims; warn…"
 
 
 class TestGenerationFormatters:

--- a/tests/unit_tests/schemas/test_tool_summary.py
+++ b/tests/unit_tests/schemas/test_tool_summary.py
@@ -8,9 +8,9 @@ These tests pin the wording produced by every registered formatter so a
 future formatter regression is caught before it reaches the CLI compact
 line or the SSE ``shortDesc`` payload.
 
-Contract: every non-filesystem summary must be ≤ ``SUMMARY_TEXT_MAX_CHARS``
-(19) characters; filesystem tools (``read_file``, ``write_file``,
-``edit_file``, ``glob``, ``grep``) bypass the clip and return verbatim.
+Contract: summaries are normally ≤ ``SUMMARY_TEXT_MAX_CHARS`` (19)
+characters. Tools whose compact summaries require complete identifiers,
+including filesystem tools and attribution analysis, bypass the clip.
 """
 
 from __future__ import annotations
@@ -21,8 +21,8 @@ from typing import Any
 import pytest
 
 from datus.schemas.tool_summary import (
-    FS_TOOLS_NO_CLIP,
     SUMMARY_TEXT_MAX_CHARS,
+    SUMMARY_TOOLS_NO_CLIP,
     TOOL_SUMMARY_REGISTRY,
     ToolSummaryRegistry,
     detect_tool_failure,
@@ -462,12 +462,13 @@ class TestSemanticFormatters:
                 "success": 1,
                 "result": {
                     "dimension_ranking": list(range(8)),
-                    "selected_dimensions": list(range(3)),
+                    "selected_dimensions": ["region", "platform", "channel"],
                     "warnings": [{"code": "UNEQUAL_WINDOWS"}],
                 },
             },
         )
-        assert out == "sel 3/8 dims; warn…"
+        assert out == "selected region,platform,channel; warnings UNEQUAL_WINDOWS"
+        assert len(out) > SUMMARY_TEXT_MAX_CHARS
 
 
 class TestGenerationFormatters:
@@ -929,7 +930,7 @@ def test_failure_path_uniform(tool: str):
         ("list_databases", ["mydb"], "1 db"),
         # Semantic fallbacks
         ("validate_semantic", {"valid": False, "issues": []}, "invalid"),
-        ("attribution_analyze", {"selected_dimensions": [1]}, "sel 1 dim"),
+        ("attribution_analyze", {"selected_dimensions": ["region"]}, "selected region"),
         ("query_metrics", {"columns": ["a", "b"]}, "2 cols"),
         ("query_metrics", {"data": {"original_rows": 7}}, "7 rows"),
         # Generation fallbacks
@@ -1046,7 +1047,6 @@ _LENGTH_CONTRACT_SAMPLES: list[tuple[str, Any]] = [
     ("get_dimensions", {"items": [{"name": "d"} for _ in range(50)], "total": 9999}),
     ("query_metrics", {"columns": ["x"] * 50, "data": {"original_rows": 99999}}),
     ("validate_semantic", {"valid": False, "issues": list(range(999))}),
-    ("attribution_analyze", {"dimension_ranking": list(range(99)), "selected_dimensions": list(range(99))}),
     ("search_metrics", [{}] * 99),
     ("search_reference_sql", [{}] * 99),
     ("search_semantic_objects", [{}] * 99),
@@ -1110,9 +1110,9 @@ _LENGTH_CONTRACT_SAMPLES: list[tuple[str, Any]] = [
 
 @pytest.mark.parametrize("tool, result", _LENGTH_CONTRACT_SAMPLES)
 def test_summary_length_contract_under_20(tool: str, result: Any):
-    """Every non-fs tool summary must be ≤ SUMMARY_TEXT_MAX_CHARS (19) characters."""
+    """Every normally clipped tool summary must be at most 19 characters."""
     out = TOOL_SUMMARY_REGISTRY.summarize_dict({"success": 1, "result": result}, tool)
-    assert tool not in FS_TOOLS_NO_CLIP, "fs tools are not part of this contract"
+    assert tool not in SUMMARY_TOOLS_NO_CLIP, "unclipped tools are not part of this contract"
     assert len(out) <= SUMMARY_TEXT_MAX_CHARS, f"{tool}: {out!r} ({len(out)} chars)"
 
 

--- a/tests/unit_tests/tools/func_tool/test_attribution_utils.py
+++ b/tests/unit_tests/tools/func_tool/test_attribution_utils.py
@@ -1,0 +1,329 @@
+"""Tests for attribution result validation and runtime guardrails."""
+
+import math
+
+import pytest
+
+from datus.tools.func_tool.attribution_utils import (
+    AttributionAnalysisResult,
+    AttributionValidationException,
+    DimensionAttributionUtil,
+)
+from datus.tools.semantic_tools.models import QueryResult
+
+
+class ScriptedAdapter:
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls = []
+
+    async def query_metrics(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.results.pop(0)
+
+
+def result(columns, *rows):
+    return QueryResult(columns=columns, data=list(rows))
+
+
+async def analyze(adapter, **kwargs):
+    return await DimensionAttributionUtil(adapter).attribution_analyze(
+        metric_name="revenue",
+        candidate_dimensions=kwargs.pop("candidate_dimensions", ["orders.region"]),
+        baseline_start=kwargs.pop("baseline_start", "2026-01-01"),
+        baseline_end=kwargs.pop("baseline_end", "2026-01-07"),
+        current_start=kwargs.pop("current_start", "2026-01-08"),
+        current_end=kwargs.pop("current_end", "2026-01-14"),
+        **kwargs,
+    )
+
+
+@pytest.mark.ci
+class TestAttributionAnalysis:
+    @pytest.mark.asyncio
+    async def test_passes_scope_and_builds_per_dimension_filters(self):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 30}),
+                result(["revenue"], {"revenue": 50}),
+                result(
+                    ["region", "revenue"],
+                    {"region": 7, "revenue": 10},
+                    {"region": None, "revenue": 20},
+                ),
+                result(
+                    ["region", "revenue"],
+                    {"region": 7, "revenue": 30},
+                    {"region": None, "revenue": 20},
+                ),
+            ]
+        )
+
+        output = await analyze(
+            adapter,
+            where="game = 'demo'",
+            path=["games", "revenue"],
+            max_dimension_values=25,
+        )
+
+        assert all(call["where"] == "game = 'demo'" for call in adapter.calls)
+        assert all(call["path"] == ["games", "revenue"] for call in adapter.calls)
+        assert [call.get("limit") for call in adapter.calls] == [None, None, 26, 26]
+        contributions = output.per_dimension["orders.region"].contributions
+        assert contributions[0].filter_hint.model_dump() == {
+            "dimension": "orders.region",
+            "operator": "eq",
+            "value": 7,
+        }
+        assert contributions[1].dimension_values == {"orders.region": "(null)"}
+        assert contributions[1].filter_hint.operator == "is_null"
+        assert output.per_dimension["orders.region"].additivity_check.status == "passed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("baseline", "expected_code"),
+        [
+            (result([]), "NO_DATA_BASELINE"),
+            (result(["revenue"], {"revenue": None}), "NULL_TOTAL_BASELINE"),
+            (result(["revenue"], {"revenue": 0}), "ZERO_OR_NO_DATA_BASELINE"),
+        ],
+    )
+    async def test_totals_only_uses_the_same_coverage_warnings(self, baseline, expected_code):
+        adapter = ScriptedAdapter([baseline, result(["revenue"], {"revenue": 10})])
+
+        output = await analyze(adapter, candidate_dimensions=[])
+
+        assert output.per_dimension == {}
+        assert output.dimension_ranking == []
+        assert output.selected_dimensions == []
+        assert output.comparison_metadata["baseline"]["total"] == 0
+        assert output.warnings[0].code == expected_code
+
+    @pytest.mark.asyncio
+    async def test_empty_grouped_period_preserves_zero_total_coverage_warning(self):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 10}),
+                result(["revenue"], {"revenue": 0}),
+                result(["region", "revenue"], {"region": "US", "revenue": 10}),
+                result([]),
+            ]
+        )
+
+        output = await analyze(adapter)
+
+        assert "ZERO_OR_NO_DATA_CURRENT" in [warning.code for warning in output.warnings]
+        contribution = output.per_dimension["orders.region"].contributions[0]
+        assert contribution.current == 0
+        assert contribution.delta == -10
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("bad_total", "expected_code"),
+        [
+            (
+                result(["revenue"], {"revenue": 1}, {"revenue": 2}),
+                "MULTI_ROW_TOTAL",
+            ),
+            (result(["other"], {"other": 1}), "MISSING_METRIC_COLUMN"),
+            (
+                result(["revenue"], {"revenue": math.nan}),
+                "NON_NUMERIC_METRIC_VALUE",
+            ),
+        ],
+    )
+    async def test_rejects_invalid_total_shapes(self, bad_total, expected_code):
+        adapter = ScriptedAdapter([bad_total, result(["revenue"], {"revenue": 10})])
+
+        with pytest.raises(AttributionValidationException) as exc_info:
+            await analyze(adapter, candidate_dimensions=[])
+
+        assert exc_info.value.payload.code == expected_code
+        assert exc_info.value.payload.period == "baseline"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("grouped", "expected_code"),
+        [
+            (
+                result(["revenue"], {"revenue": 10}),
+                "MISSING_DIMENSION_COLUMN",
+            ),
+            (
+                result(["region", "revenue"], {"region": "US", "revenue": None}),
+                "NON_NUMERIC_METRIC_VALUE",
+            ),
+            (
+                result(
+                    ["region", "revenue"],
+                    {"region": "US", "revenue": 5},
+                    {"region": "US", "revenue": 5},
+                ),
+                "DUPLICATE_DIMENSION_KEY",
+            ),
+        ],
+    )
+    async def test_rejects_invalid_grouped_shapes(self, grouped, expected_code):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 10}),
+                result(["revenue"], {"revenue": 10}),
+                grouped,
+                result(["region", "revenue"], {"region": "US", "revenue": 10}),
+            ]
+        )
+
+        with pytest.raises(AttributionValidationException) as exc_info:
+            await analyze(adapter)
+
+        assert exc_info.value.payload.code == expected_code
+        assert exc_info.value.payload.dimension == "orders.region"
+        assert exc_info.value.payload.period == "baseline"
+
+    @pytest.mark.asyncio
+    async def test_checks_each_period_additivity_even_when_delta_residual_cancels(self):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 100}),
+                result(["revenue"], {"revenue": 100}),
+                result(
+                    ["region", "revenue"],
+                    {"region": "US", "revenue": 60},
+                    {"region": "EU", "revenue": 50},
+                ),
+                result(
+                    ["region", "revenue"],
+                    {"region": "US", "revenue": 70},
+                    {"region": "EU", "revenue": 40},
+                ),
+            ]
+        )
+
+        output = await analyze(adapter)
+
+        check = output.per_dimension["orders.region"].additivity_check
+        assert check.status == "failed"
+        assert check.baseline_residual == 10
+        assert check.current_residual == 10
+        assert check.delta_residual_pct is None
+        assert "NON_ADDITIVE_DIMENSION" in [warning.code for warning in output.warnings]
+
+    @pytest.mark.asyncio
+    async def test_zero_total_still_checks_additivity_and_reports_offsetting_changes(self):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 0}),
+                result(["revenue"], {"revenue": 0}),
+                result(
+                    ["region", "revenue"],
+                    {"region": "US", "revenue": 10},
+                    {"region": "EU", "revenue": -10},
+                ),
+                result(
+                    ["region", "revenue"],
+                    {"region": "US", "revenue": 20},
+                    {"region": "EU", "revenue": -20},
+                ),
+            ]
+        )
+
+        output = await analyze(adapter)
+
+        dimension = output.per_dimension["orders.region"]
+        assert dimension.additivity_check.status == "passed"
+        assert dimension.score == 0
+        assert all(item.contribution_pct_of_total_delta == 0 for item in dimension.contributions)
+        assert "ZERO_TOTAL_DELTA_WITH_COMPONENT_CHANGES" in [warning.code for warning in output.warnings]
+
+    @pytest.mark.asyncio
+    async def test_union_cardinality_truncates_dimension_and_excludes_legacy_ranking(self):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 2}),
+                result(["revenue"], {"revenue": 2}),
+                result(
+                    ["region", "revenue"],
+                    {"region": "A", "revenue": 1},
+                    {"region": "B", "revenue": 1},
+                ),
+                result(
+                    ["region", "revenue"],
+                    {"region": "B", "revenue": 1},
+                    {"region": "C", "revenue": 1},
+                ),
+            ]
+        )
+
+        output = await analyze(adapter, max_dimension_values=2)
+
+        dimension = output.per_dimension["orders.region"]
+        assert adapter.calls[2]["limit"] == 3
+        assert dimension.truncated is True
+        assert dimension.score is None
+        assert dimension.additivity_check.status == "skipped"
+        assert output.dimension_ranking == []
+        assert output.selected_dimensions == []
+        assert output.warnings[-1].code == "HIGH_CARDINALITY_DIMENSION"
+
+    @pytest.mark.asyncio
+    async def test_hard_caps_dimension_limit_and_records_requested_value(self):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 1}),
+                result(["revenue"], {"revenue": 1}),
+                result(["region", "revenue"], {"region": "A", "revenue": 1}),
+                result(["region", "revenue"], {"region": "A", "revenue": 1}),
+            ]
+        )
+
+        output = await analyze(adapter, max_dimension_values=5000)
+
+        assert adapter.calls[2]["limit"] == 1001
+        assert output.comparison_metadata["requested_max_dimension_values"] == 5000
+        assert output.comparison_metadata["effective_max_dimension_values"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_warns_for_unequal_concrete_windows(self):
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": 1}),
+                result(["revenue"], {"revenue": 1}),
+            ]
+        )
+
+        output = await analyze(
+            adapter,
+            candidate_dimensions=[],
+            baseline_end="2026-01-03",
+        )
+
+        assert output.comparison_metadata["baseline"]["days"] == 3
+        assert output.comparison_metadata["current"]["days"] == 7
+        assert "UNEQUAL_WINDOWS" in [warning.code for warning in output.warnings]
+
+    def test_old_serialized_result_gets_defaults_for_new_fields(self):
+        output = AttributionAnalysisResult.model_validate(
+            {
+                "metric_name": "revenue",
+                "candidate_dimensions": ["region"],
+                "dimension_ranking": [{"dimension": "region", "score": 1.0}],
+                "selected_dimensions": ["region"],
+                "top_dimension_values": [
+                    {
+                        "dimension_values": {"region": "US"},
+                        "baseline": 1,
+                        "current": 2,
+                        "delta": 1,
+                        "contribution_pct_of_total_delta": 100,
+                    }
+                ],
+                "comparison_metadata": {
+                    "baseline": {"start": "2026-01-01", "end": "2026-01-01"},
+                    "current": {"start": "2026-01-02", "end": "2026-01-02"},
+                },
+            }
+        )
+
+        assert output.per_dimension == {}
+        assert output.warnings == []
+        assert output.top_dimension_values[0].filter_hint is None

--- a/tests/unit_tests/tools/func_tool/test_attribution_utils.py
+++ b/tests/unit_tests/tools/func_tool/test_attribution_utils.py
@@ -236,6 +236,26 @@ class TestAttributionAnalysis:
         assert "ZERO_TOTAL_DELTA_WITH_COMPONENT_CHANGES" in [warning.code for warning in output.warnings]
 
     @pytest.mark.asyncio
+    async def test_effectively_zero_delta_omits_delta_residual_percentage(self):
+        baseline_total = 1_000_000_000
+        adapter = ScriptedAdapter(
+            [
+                result(["revenue"], {"revenue": baseline_total}),
+                result(["revenue"], {"revenue": baseline_total + 0.001}),
+                result(["region", "revenue"], {"region": "US", "revenue": baseline_total}),
+                result(["region", "revenue"], {"region": "US", "revenue": baseline_total + 1}),
+            ]
+        )
+
+        output = await analyze(adapter)
+
+        dimension = output.per_dimension["orders.region"]
+        assert dimension.additivity_check.status == "passed"
+        assert dimension.additivity_check.delta_residual_pct is None
+        assert dimension.score == 0
+        assert dimension.contributions[0].contribution_pct_of_total_delta == 0
+
+    @pytest.mark.asyncio
     async def test_union_cardinality_truncates_dimension_and_excludes_legacy_ranking(self):
         adapter = ScriptedAdapter(
             [

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -2379,6 +2379,15 @@ class TestAttributionAnalyze:
 
         assert {"where", "path", "max_dimension_values"}.issubset(schema["properties"])
 
+    def test_tool_description_is_explicitly_non_causal(self, semantic_tools_with_adapter):
+        tool, _ = semantic_tools_with_adapter
+
+        description = trans_to_function_tool(tool.attribution_analyze).description.lower()
+
+        assert "descriptive dimension analysis" in description
+        assert "do not establish causation" in description
+        assert "root cause analysis" not in description
+
     def test_no_attribution_tool_returns_error(self, semantic_tools_ext):
         result = semantic_tools_ext.attribution_analyze(
             metric_name="revenue",

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -9,7 +9,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from datus.tools.func_tool.base import FuncToolResult, normalize_null
+from datus.tools.func_tool.attribution_utils import (
+    AttributionValidationErrorPayload,
+    AttributionValidationException,
+)
+from datus.tools.func_tool.base import FuncToolResult, normalize_null, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.metric_queryability import extract_metric_queryability_contracts
 from datus.tools.func_tool.semantic_tools import _run_async
@@ -2368,6 +2372,13 @@ class TestValidateSemantic:
 
 
 class TestAttributionAnalyze:
+    def test_tool_schema_exposes_drilldown_guardrail_parameters(self, semantic_tools_with_adapter):
+        tool, _ = semantic_tools_with_adapter
+
+        schema = trans_to_function_tool(tool.attribution_analyze).params_json_schema
+
+        assert {"where", "path", "max_dimension_values"}.issubset(schema["properties"])
+
     def test_no_attribution_tool_returns_error(self, semantic_tools_ext):
         result = semantic_tools_ext.attribution_analyze(
             metric_name="revenue",
@@ -2390,6 +2401,7 @@ class TestAttributionAnalyze:
             "dimension_ranking": [],
             "selected_dimensions": [],
             "top_dimension_values": {},
+            "warnings": [{"code": "UNEQUAL_WINDOWS", "message": "not equal"}],
         }
 
         with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=mock_result):
@@ -2401,9 +2413,27 @@ class TestAttributionAnalyze:
                 current_start="2024-01-08",
                 current_end="2024-01-14",
                 anomaly_context={"rule": "3sigma", "observed_change_pct": 20.0},
+                where="region = 'US'",
+                path=["sales"],
+                max_dimension_values=25,
             )
 
         assert result.success == 1
+        assert result.result["warnings"][0]["code"] == "UNEQUAL_WINDOWS"
+        mock_attribution.attribution_analyze.assert_called_once_with(
+            metric_name="revenue",
+            candidate_dimensions=["region"],
+            baseline_start="2024-01-01",
+            baseline_end="2024-01-07",
+            current_start="2024-01-08",
+            current_end="2024-01-14",
+            anomaly_context={"rule": "3sigma", "observed_change_pct": 20.0},
+            max_selected_dimensions=3,
+            top_n_values=10,
+            where="region = 'US'",
+            path=["sales"],
+            max_dimension_values=25,
+        )
 
     def test_success_none_anomaly_context(self, semantic_tools_with_adapter):
         tool, mock_adapter = semantic_tools_with_adapter
@@ -2443,6 +2473,34 @@ class TestAttributionAnalyze:
 
         assert result.success == 0
         assert "analysis failed" in result.error
+
+    def test_validation_exception_returns_structured_failure(self, semantic_tools_with_adapter):
+        tool, mock_adapter = semantic_tools_with_adapter
+        tool._attribution_tool = Mock()
+        payload = AttributionValidationErrorPayload(
+            code="MULTI_ROW_TOTAL",
+            message="Expected one total row.",
+            period="baseline",
+            columns=["revenue"],
+            row_count=2,
+        )
+
+        with patch(
+            "datus.tools.func_tool.semantic_tools._run_async",
+            side_effect=AttributionValidationException(payload),
+        ):
+            result = tool.attribution_analyze(
+                metric_name="revenue",
+                candidate_dimensions=["region"],
+                baseline_start="2024-01-01",
+                baseline_end="2024-01-07",
+                current_start="2024-01-08",
+                current_end="2024-01-14",
+            )
+
+        assert result.success == 0
+        assert result.error == "Expected one total row."
+        assert result.result == payload.model_dump()
 
 
 class TestExtractDbConfig:


### PR DESCRIPTION
## Why

`attribution_analyze` previously treated missing or malformed adapter output as zero/unknown values, offered no scoped drill-down filter, and could calculate contribution percentages from truncated or non-additive grouped results. It was also described as root-cause analysis even though the calculation is descriptive delta decomposition.

These behaviors could produce confident but misleading attribution results, especially for COUNT DISTINCT metrics, empty periods, offsetting component changes, and high-cardinality dimensions.

## Solution

- Pass `where` and `path` through every total and grouped metric query so the agent can perform parent-filtered drill-down.
- Validate adapter result shapes and return structured validation errors instead of silently coercing invalid data.
- Add per-dimension additivity checks and structured warnings for coverage ambiguity, non-additive dimensions, unequal windows, effectively-zero total deltas, and high cardinality.
- Bound grouped queries before loading results, keep truncated dimensions out of legacy rankings, and expose typed `filter_hint` values for safe follow-up filters.
- Preserve legacy result fields while adding guarded `per_dimension` output and comparison metadata.
- Update the AskMetrics attribution playbook, compact summaries, and tool description so the model treats the output as descriptive rather than causal.

## Test Cases

- Added unit coverage for parameter propagation, result-shape failures, qualified columns, NULL dimension values, coverage warnings, additivity, near-zero deltas, cardinality limits, legacy deserialization, wrapper errors, summaries, and prompt/tool-schema behavior.
- Validated the real OSI execution path against the prepared `game` dataset, including ranking, filtered drill-down, non-additive metrics, zero/no-data handling, and high-cardinality truncation.
- PR test mapping: 3425 passed, 6 skipped.
- Diff coverage: 92%.
- Diff test audit: P0=0, P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced attribution analysis with per-dimension contribution details, warnings, coverage metadata, and optional drill-down filters.
  * Added safeguards and clear warnings for unequal time windows, high-cardinality dimensions, non-additive results, and zero or missing data.
  * Improved attribution summaries to show selected dimensions and warning codes.

* **Bug Fixes**
  * Added structured validation errors for invalid or inconsistent analysis results.
  * Improved handling of null values, legacy results, and malformed metric data.

* **Documentation**
  * Added an Attribution Playbook with guidance for metric comparisons, dimension selection, drill-downs, and warning interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->