### PR TITLE
[Refactor] Expose table_name_field_order as the shared identifier shape

### DIFF
--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -229,6 +229,50 @@ def metadata_identifier(
     return ".".join(parts)
 
 
+#: Widest identifier shape, in right-align order. Used for dialects that declare
+#: no namespace capabilities at all (adapter not installed, or one that reports
+#: none): assuming the widest shape keeps a qualified prefix in a namespace field
+#: instead of collapsing it into ``table_name``.
+_WIDEST_FIELD_ORDER = ("catalog_name", "database_name", "schema_name", "table_name")
+
+
+def table_name_field_order(dialect: str = "snowflake") -> List[str]:
+    """Return the fields a dotted identifier right-aligns into for *dialect*.
+
+    Single source of truth for the identifier *shape*, shared by
+    :func:`parse_table_name_parts` (which right-aligns onto this order) and by
+    callers that need to **emit** an identifier or scope token with a matching
+    segment count. Emitting fewer segments than the order has silently lands
+    every literal in the wrong field: ``default_catalog.*`` on StarRocks
+    (``[catalog, database, table]``) parses as ``{database: default_catalog,
+    table: *}`` and matches no real table.
+
+    Adapters that ship their own ``get_identifier_parser`` are expected to
+    right-align the same way; their order still follows the capabilities they
+    declare.
+    """
+    d = parse_dialect((dialect or "").strip().lower())
+    from datus.tools.db_tools import connector_registry
+
+    # Built-in connectors
+    if d == DBType.SQLITE:
+        return ["database_name", "table_name"]
+    if d == DBType.DUCKDB:
+        return ["database_name", "schema_name", "table_name"]
+    # External dialects: derive from registry
+    fields = []
+    if connector_registry.support_catalog(d):
+        fields.append("catalog_name")
+    if connector_registry.support_database(d):
+        fields.append("database_name")
+    if connector_registry.support_schema(d):
+        fields.append("schema_name")
+    if not fields:
+        return list(_WIDEST_FIELD_ORDER)
+    fields.append("table_name")
+    return fields
+
+
 def parse_table_name_parts(full_table_name: str, dialect: str = "snowflake") -> Dict[str, str]:
     """
     Parse a full table name into its component parts (catalog, database, schema, table).
@@ -259,26 +303,6 @@ def parse_table_name_parts(full_table_name: str, dialect: str = "snowflake") -> 
         return {field: str(parsed[field] or "") for field in expected_fields}
 
     dialect = parse_dialect(raw_dialect)
-
-    # Build field mapping dynamically from registry capabilities
-    def _build_field_mapping(d: str) -> list:
-        from datus.tools.db_tools import connector_registry
-
-        # Built-in connectors
-        if d == DBType.SQLITE:
-            return ["database_name", "table_name"]
-        if d == DBType.DUCKDB:
-            return ["database_name", "schema_name", "table_name"]
-        # External dialects: derive from registry
-        fields = []
-        if connector_registry.support_catalog(d):
-            fields.append("catalog_name")
-        if connector_registry.support_database(d):
-            fields.append("database_name")
-        if connector_registry.support_schema(d):
-            fields.append("schema_name")
-        fields.append("table_name")
-        return fields
 
     # Split the table name by dots
     # Handle different quote styles: `backticks`, "double quotes", [brackets]
@@ -326,30 +350,21 @@ def parse_table_name_parts(full_table_name: str, dialect: str = "snowflake") -> 
     if not parts:
         return result
 
-    # Get field mapping for the dialect, or use default mapping
-    field_mapping = _build_field_mapping(dialect)
-    if len(field_mapping) > 1:
-        max_parts = len(field_mapping)
+    # Right-align the parts onto the dialect's field order (always >= 2 fields,
+    # so an unknown dialect degrades to the widest shape rather than to a bare
+    # table name).
+    field_mapping = table_name_field_order(dialect)
+    max_parts = len(field_mapping)
 
-        # If we have more parts than expected, take the last N parts
-        if len(parts) > max_parts:
-            parts = parts[-max_parts:]
+    # If we have more parts than expected, take the last N parts
+    if len(parts) > max_parts:
+        parts = parts[-max_parts:]
 
-        # Map parts to fields according to the configuration
-        # We map from right to left (table_name is always the last part)
-        for i, part in enumerate(reversed(parts)):
-            if i < len(field_mapping):
-                field_name = field_mapping[-(i + 1)]  # Get field name from right to left
-                result[field_name] = part
-    else:
-        # Default behavior for unknown dialects: assume last part is table name
-        result["table_name"] = parts[-1]
-        if len(parts) > 1:
-            result["schema_name"] = parts[-2]
-        if len(parts) > 2:
-            result["database_name"] = parts[-3]
-        if len(parts) > 3:
-            result["catalog_name"] = parts[-4]
+    # Map parts to fields according to the configuration
+    # We map from right to left (table_name is always the last part)
+    for i, part in enumerate(reversed(parts)):
+        field_name = field_mapping[-(i + 1)]  # Get field name from right to left
+        result[field_name] = part
 
     return result
 

--- a/tests/unit_tests/utils/test_sql_utils.py
+++ b/tests/unit_tests/utils/test_sql_utils.py
@@ -6,6 +6,7 @@ from datus.tools.db_tools import connector_registry
 from datus.utils.constants import DBType, SQLType
 from datus.utils.json_utils import llm_result2json
 from datus.utils.sql_utils import (
+    _WIDEST_FIELD_ORDER,
     _fallback_sql_type,
     _first_statement,
     _is_escaped,
@@ -26,6 +27,7 @@ from datus.utils.sql_utils import (
     parse_table_names_parts,
     read_workspace_sql_file,
     strip_sql_comments,
+    table_name_field_order,
 )
 
 _CONNECTOR_REGISTRY_SNAPSHOT_ATTRS = (
@@ -1779,3 +1781,73 @@ class TestParseSqlStatementKind:
     def test_case_insensitive_keywords(self):
         assert parse_sql_statement_kind("drop table t", "") == "drop"
         assert parse_sql_statement_kind("Truncate Table t", "") == "truncate"
+
+
+class TestTableNameFieldOrder:
+    """``table_name_field_order`` is the shape contract shared by the parser and
+    by every caller that *emits* a dotted identifier (scope tokens, metadata
+    identifiers)."""
+
+    def test_mysql_has_no_schema_level(self):
+        assert table_name_field_order("mysql") == ["database_name", "table_name"]
+
+    def test_starrocks_puts_catalog_first(self):
+        assert table_name_field_order("starrocks") == ["catalog_name", "database_name", "table_name"]
+
+    def test_postgres_family_resolves_through_parse_dialect(self):
+        """``postgresql`` maps to the ``postgres`` parser dialect; capabilities
+        must still resolve or the order silently degrades to the widest shape."""
+        assert table_name_field_order("postgresql") == ["database_name", "schema_name", "table_name"]
+
+    def test_sqlite_is_two_segments(self):
+        assert table_name_field_order(DBType.SQLITE) == ["database_name", "table_name"]
+
+    def test_duckdb_keeps_its_schema_level(self):
+        assert table_name_field_order(DBType.DUCKDB) == ["database_name", "schema_name", "table_name"]
+
+    def test_capability_less_dialect_falls_back_to_widest_shape(self):
+        """A dialect that declares no namespaces (adapter absent) must not
+        collapse to a bare table name — a qualified prefix has to land in a
+        namespace field so callers keep the segments they were given."""
+        assert table_name_field_order("frobnicate") == [
+            "catalog_name",
+            "database_name",
+            "schema_name",
+            "table_name",
+        ]
+
+    def test_blank_dialect_is_accepted(self):
+        assert table_name_field_order("") == list(_WIDEST_FIELD_ORDER)
+
+    @pytest.mark.parametrize(
+        "dialect",
+        ["mysql", "starrocks", "postgresql", "snowflake", DBType.SQLITE, DBType.DUCKDB, "frobnicate"],
+    )
+    def test_parse_right_aligns_onto_the_declared_order(self, dialect):
+        """Cross-component contract: a token built with one segment per field
+        parses back with every literal in the field it was emitted for. This is
+        what keeps emitted scope tokens matchable."""
+        order = table_name_field_order(dialect)
+        token = ".".join(field.removesuffix("_name") for field in order)
+
+        parsed = parse_table_name_parts(token, dialect=dialect)
+
+        assert parsed == {
+            "catalog_name": "catalog" if "catalog_name" in order else "",
+            "database_name": "database" if "database_name" in order else "",
+            "schema_name": "schema" if "schema_name" in order else "",
+            "table_name": "table",
+        }
+
+    @pytest.mark.parametrize("dialect", ["mysql", "starrocks", "postgresql", DBType.DUCKDB])
+    def test_short_token_right_aligns_and_leaves_the_leading_field_empty(self, dialect):
+        """The failure mode the order exists to prevent: one segment short and
+        every literal shifts left by a field."""
+        order = table_name_field_order(dialect)
+
+        parsed = parse_table_name_parts("x.*", dialect=dialect)
+
+        assert parsed[order[-2]] == "x"
+        assert parsed["table_name"] == "*"
+        for field in order[:-2]:
+            assert parsed[field] == ""


### PR DESCRIPTION
## Why

`parse_table_name_parts` right-aligns a dotted identifier onto a dialect-specific field order (`[catalog, database, table]` for StarRocks, `[database, schema, table]` for the Postgres family, `[database, table]` for SQLite, …). That order lived in a closure inside the function, so every caller that needs to **emit** an identifier with a matching segment count — scope tokens for `SubAgentConfig.scoped_context.tables`, `metadata_identifier`, the SaaS catalog tree — had to re-derive the shape from `connector_registry.support_*`.

The two derivations already disagree. For a dialect that declares no namespace capabilities (adapter not installed, or one that reports none), the parser falls back to the widest `catalog.database.schema.table` shape, while an emitter reading `support_*` sees zero namespaces and produces a two-segment `<db>.*` — whose literal then right-aligns into `schema_name` and matches nothing. SQLite's two-segment shape is likewise hardcoded in the parser only, so an emitter agrees with it by luck rather than by contract.

Downstream symptom this unblocks: Datus-backend builds `ask_report` / `ask_dashboard` scope tokens from `support_*` and needs the parser's own shape to stop emitting tokens the matcher can't match.

## Solution

Lift the closure to a module-level `table_name_field_order(dialect) -> List[str]` returning the same `*_name` keys `parse_table_name_parts` produces, and have the parser consume it.

Key decisions:

- **The order always has >= 2 fields.** A capability-less dialect returns the widest shape explicitly (`_WIDEST_FIELD_ORDER`) instead of `["table_name"]`, which is exactly what the parser's old `len(field_mapping) > 1` fallback branch computed by hand. That branch is now dead code and is removed, so the right-align loop handles every dialect uniformly.
- **Capabilities are still resolved through `parse_dialect`**, keeping the existing `postgresql` -> `postgres` lookup behavior intact.
- **Adapters with a custom `get_identifier_parser` keep short-circuiting** ahead of the field-order path; their shape is expected to follow their declared capabilities, which is now stated in the docstring.

Verified behavior-preserving with a differential harness comparing the new path against the previous implementation across 16 dialects x 9 token shapes (bare, 2/3/4/5-segment, wildcard-bearing): identical output on every combination.

## Test Cases

Unit tests only — this is a pure refactor of a parsing helper with no external dependencies, so it belongs in the CI tier per the testing rules.

`tests/unit_tests/utils/test_sql_utils.py` -> new `TestTableNameFieldOrder`:

- Per-dialect orders: MySQL (no schema level), StarRocks (catalog first), Postgres family (resolves through `parse_dialect`), SQLite (2 segments), DuckDB (keeps its schema level).
- Capability-less and blank dialects fall back to the widest shape rather than collapsing to a bare table name.
- **Cross-component contract** (parametrized over 7 dialects): a token emitted with one segment per declared field parses back with every literal in the field it was emitted for — this is the property emitters depend on.
- The failure mode the contract prevents: a token one segment short right-aligns and shifts every literal left by one field.

Existing `tests/unit_tests/utils/test_sql_utils.py` (202 tests) and `tests/unit_tests/tools/db_tools/` pass unchanged. `ci/audit_tests.py --diff-only` reports P0=0, P1=0.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-name parsing across supported SQL dialects.
  * Correctly preserves catalog, database, schema, and table segments for qualified names.
  * Added safer fallback behavior for unknown or unsupported dialects.
  * Prevented namespace segments from shifting incorrectly when parsing short identifiers.

* **Tests**
  * Added coverage for dialect-specific parsing, fallback behavior, blank dialects, and round-trip identifier parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->