### PR TITLE
[BugFix] Propagate metric publish preflight errors

### DIFF
--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -914,10 +914,11 @@ class GenMetricsAgenticNode(AgenticNode):
             try:
                 self._ensure_metric_dry_runs(metric_names)
             except Exception as exc:
-                logger.exception(f"publish_metrics preflight failed for metrics={metric_names}: {exc}")
+                error_message = str(exc) or type(exc).__name__
+                logger.exception(f"publish_metrics preflight failed for metrics={metric_names}: {error_message}")
                 return FuncToolResult(
                     success=0,
-                    error=str(exc),
+                    error=error_message,
                     result={
                         "code": "metric_publish_preflight_failed",
                         "stage": "query_metrics_dry_run",

--- a/datus/agent/node/gen_metrics_agentic_node.py
+++ b/datus/agent/node/gen_metrics_agentic_node.py
@@ -18,6 +18,7 @@ from datus.agent.node.stream_run_context import StreamRunContext
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
 from datus.schemas.semantic_agentic_node_models import GenMetricsNodeResult, SemanticNodeInput
+from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.filesystem_tools import FilesystemFuncTool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.func_tool.generation_tools import GenerationTools, MetricOutputBinding
@@ -910,7 +911,20 @@ class GenMetricsAgenticNode(AgenticNode):
                 self.generation_evidence.metric_sqls,
             )
         if metric_names:
-            self._ensure_metric_dry_runs(metric_names)
+            try:
+                self._ensure_metric_dry_runs(metric_names)
+            except Exception as exc:
+                logger.exception(f"publish_metrics preflight failed for metrics={metric_names}: {exc}")
+                return FuncToolResult(
+                    success=0,
+                    error=str(exc),
+                    result={
+                        "code": "metric_publish_preflight_failed",
+                        "stage": "query_metrics_dry_run",
+                        "metric_file": metric_file,
+                        "metrics": metric_names,
+                    },
+                )
 
         publish_kwargs: Dict[str, Any] = {"metric_file": abs_metric_file}
         if metric_output_bindings is not None:

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -1364,6 +1364,7 @@ class TestExecuteStreamGenMetricsError:
 
     def test_publish_metrics_falls_back_to_exception_type_for_empty_error(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
 
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         node.generation_tools = MagicMock()
@@ -1375,8 +1376,15 @@ class TestExecuteStreamGenMetricsError:
 
         result = node.publish_metrics("metrics/order_metrics.yml")
 
+        assert isinstance(result, FuncToolResult)
         assert result.success == 0
         assert result.error == "RuntimeError"
+        assert result.result == {
+            "code": "metric_publish_preflight_failed",
+            "stage": "query_metrics_dry_run",
+            "metric_file": "metrics/order_metrics.yml",
+            "metrics": ["order_count"],
+        }
         node.generation_tools.publish_metrics.assert_not_called()
 
     def test_final_metric_publish_accepts_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -1335,6 +1335,7 @@ class TestExecuteStreamGenMetricsError:
 
     def test_publish_metrics_returns_preflight_error_to_tool_caller(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+        from datus.tools.func_tool.base import FuncToolResult
 
         node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
         node.generation_tools = MagicMock()
@@ -1350,6 +1351,7 @@ class TestExecuteStreamGenMetricsError:
 
         result = node.publish_metrics("metrics/order_metrics.yml")
 
+        assert isinstance(result, FuncToolResult)
         assert result.success == 0
         assert result.error == error
         assert result.result == {
@@ -1358,6 +1360,23 @@ class TestExecuteStreamGenMetricsError:
             "metric_file": "metrics/order_metrics.yml",
             "metrics": ["order_count"],
         }
+        node.generation_tools.publish_metrics.assert_not_called()
+
+    def test_publish_metrics_falls_back_to_exception_type_for_empty_error(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.generation_tools = MagicMock()
+        node.generation_tools._extract_metric_names_from_file.return_value = ["order_count"]
+        node.generation_tools._extract_metric_definitions_from_file.return_value = {}
+        node.generation_tools._metric_names_requiring_dry_run.return_value = ["order_count"]
+        node._resolve_metric_artifact_path = MagicMock(return_value="/tmp/order_metrics.yml")
+        node._ensure_metric_dry_runs = MagicMock(side_effect=RuntimeError())
+
+        result = node.publish_metrics("metrics/order_metrics.yml")
+
+        assert result.success == 0
+        assert result.error == "RuntimeError"
         node.generation_tools.publish_metrics.assert_not_called()
 
     def test_final_metric_publish_accepts_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):

--- a/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py
@@ -1333,6 +1333,33 @@ class TestExecuteStreamGenMetricsError:
         with pytest.raises(RuntimeError, match="did not complete a warehouse dry-run"):
             node._ensure_metric_dry_runs(["order_count"])
 
+    def test_publish_metrics_returns_preflight_error_to_tool_caller(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
+
+        node = GenMetricsAgenticNode(agent_config=real_agent_config, execution_mode="workflow")
+        node.generation_tools = MagicMock()
+        node.generation_tools._extract_metric_names_from_file.return_value = ["order_count"]
+        node.generation_tools._extract_metric_definitions_from_file.return_value = {}
+        node.generation_tools._metric_names_requiring_dry_run.return_value = ["order_count"]
+        node._resolve_metric_artifact_path = MagicMock(return_value="/tmp/order_metrics.yml")
+        error = (
+            "query_metrics(dry_run=True) failed for generated metric(s) order_count: "
+            "Warehouse dry-run failed: invalid identifier 'DISC_PRICE'"
+        )
+        node._ensure_metric_dry_runs = MagicMock(side_effect=RuntimeError(error))
+
+        result = node.publish_metrics("metrics/order_metrics.yml")
+
+        assert result.success == 0
+        assert result.error == error
+        assert result.result == {
+            "code": "metric_publish_preflight_failed",
+            "stage": "query_metrics_dry_run",
+            "metric_file": "metrics/order_metrics.yml",
+            "metrics": ["order_count"],
+        }
+        node.generation_tools.publish_metrics.assert_not_called()
+
     def test_final_metric_publish_accepts_grouped_source_sql_dry_run(self, real_agent_config, mock_llm_create):
         from datus.agent.node.gen_metrics_agentic_node import GenMetricsAgenticNode
         from datus.schemas.semantic_agentic_node_models import SourceQueryEvidence


### PR DESCRIPTION
## Summary

- catch metric dry-run failures at the `publish_metrics` tool boundary
- log the complete preflight exception traceback
- return a structured `FuncToolResult` containing the concrete warehouse error and failure stage

## Root cause

When the publish preflight dry-run failed, the exception escaped `publish_metrics`. The tool observation could therefore be empty while the upper workflow only reported a generic publish failure, preventing the model and operators from seeing the underlying warehouse error.

## Impact

The model now receives a recoverable tool result with `success=0`, the original error text, and `metric_publish_preflight_failed` metadata. Operators can correlate that result with the complete stack trace in application logs.

## Related

- Adapter error preservation and traceback logging: https://github.com/Datus-ai/datus-db-adapters/pull/88

## Validation

- `tests/unit_tests/agent/node/test_gen_metrics_agentic_node.py`: `74 passed`
- Ruff passed for both changed files
- `git diff --check` passed

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric publishing error handling by returning clear, structured failure details when validation fails.
  * Prevented publishing from proceeding after a metric queryability validation error.  
* **Tests**
  * Added coverage confirming validation failures are reported correctly and publishing is not invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric publishing error handling by returning clear, structured failure details when validation fails.
  * Prevented publishing from proceeding after a metric queryability validation error.
* **Tests**
  * Added coverage confirming validation failures are reported correctly and publishing is not invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->