### PR TITLE
[BugFix] Keep the previous turn's answer on mid-run Ctrl+O reprint

### DIFF
--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -48,6 +48,31 @@ def _truncate_middle(text: str, max_len: int = 120) -> str:
     return text[:keep] + " ... " + text[-keep:]
 
 
+def resolve_assistant_body(action: ActionHistory) -> str:
+    """Return the user-facing body carried by an ASSISTANT action's ``output``.
+
+    ``raw_output`` is what the model layer writes for streamed assistant text;
+    ``response`` is what node result models (e.g. ``ChatNodeResult.response``)
+    carry on the terminal ``<node>_response`` wrapper action — that wrapper's own
+    ``messages`` is only a boilerplate summary ("chat interaction completed
+    successfully"). Returns ``""`` when no body is present, so callers rendering
+    a wrapper can tell "no body" apart from that boilerplate — unlike
+    :func:`_get_assistant_content`, which falls back to ``messages``.
+    """
+    from datus.utils.text_utils import strip_litellm_placeholder
+
+    if not isinstance(action.output, dict):
+        return ""
+    for key in ("raw_output", "response"):
+        value = action.output.get(key)
+        if not isinstance(value, str):
+            continue
+        body = strip_litellm_placeholder(value)
+        if body.strip():
+            return body
+    return ""
+
+
 def _get_assistant_content(action: ActionHistory) -> str:
     """Extract display content from an ASSISTANT action, preferring output.raw_output."""
     from datus.utils.text_utils import strip_litellm_placeholder

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -23,6 +23,7 @@ from datus.cli.action_display.renderers import (
     is_task_anchor_input,
     parse_task_tool_input,
     render_assistant_response_markdown,
+    resolve_assistant_body,
 )
 from datus.schemas.action_history import (
     INTERRUPTED_ACTION_TYPE,
@@ -716,16 +717,26 @@ class InlineStreamingContext:
                         ):
                             continue
                         if a.action_type.endswith("_response") and a.action_type != "response":
-                            wrapper = a
-                            break
+                            if wrapper is None:
+                                wrapper = a
+                            continue
                         if a.action_type == "response" and plain is None:
                             plain = a
-                    chosen = wrapper or plain
-                    if chosen is not None:
-                        self.display.renderer.print_renderables(
-                            self.display.console,
-                            self.display.renderer.render_main_action(chosen, verbose=verbose),
-                        )
+                    # Pick the first candidate that actually carries a body.
+                    # A wrapper whose node result has no text body would
+                    # otherwise render its boilerplate ``messages`` ("chat
+                    # interaction completed successfully") in place of the
+                    # turn's answer, since ``render_action_history`` already
+                    # dropped the plain ``response`` that holds the real text.
+                    body = ""
+                    for candidate in (wrapper, plain):
+                        if candidate is None:
+                            continue
+                        body = resolve_assistant_body(candidate)
+                        if body:
+                            break
+                    if body:
+                        self.display.console.print(render_assistant_response_markdown(body))
 
                 self.display.render_multi_turn_history(
                     self._history_turns, verbose=verbose, per_turn_callback=_render_turn_response

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -19,6 +19,7 @@ from datus.cli.action_display.renderers import (
     _get_assistant_content,
     is_task_anchor_input,
     parse_task_tool_input,
+    resolve_assistant_body,
 )
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.utils.text_utils import LITELLM_EMPTY_PLACEHOLDER
@@ -1290,3 +1291,61 @@ class TestGetAssistantContentPlaceholderFiltering:
             output_data={"raw_output": "SELECT * FROM users"},
         )
         assert _get_assistant_content(action) == "SELECT * FROM users"
+
+
+@pytest.mark.ci
+class TestResolveAssistantBody:
+    """``resolve_assistant_body`` never falls back to boilerplate ``messages``."""
+
+    def test_prefers_raw_output_over_response(self):
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            messages="boilerplate",
+            output_data={"raw_output": "streamed text", "response": "node result"},
+        )
+        assert resolve_assistant_body(action) == "streamed text"
+
+    def test_falls_back_to_response_key(self):
+        """Node wrapper results (``ChatNodeResult``) carry no ``raw_output``."""
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            action_type="chat_response",
+            messages="chat interaction completed successfully",
+            output_data={"success": True, "response": "The orders table has 42 rows."},
+        )
+        assert resolve_assistant_body(action) == "The orders table has 42 rows."
+
+    def test_returns_empty_when_no_body_keys(self):
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            action_type="chat_response",
+            messages="chat interaction completed successfully",
+            output_data={"success": True, "response": "   ", "tokens_used": 12},
+        )
+        assert resolve_assistant_body(action) == ""
+
+    def test_returns_empty_when_output_not_dict(self):
+        action = _make_action(ActionRole.ASSISTANT, ActionStatus.SUCCESS, messages="only messages")
+        action.output = "string output"
+        assert resolve_assistant_body(action) == ""
+
+    def test_skips_non_string_body_values(self):
+        """Structured tool-shaped payloads are not renderable markdown bodies."""
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            output_data={"raw_output": {"success": True, "result": "x"}, "response": "plain text"},
+        )
+        assert resolve_assistant_body(action) == "plain text"
+
+    def test_strips_litellm_placeholder_body(self):
+        action = _make_action(
+            ActionRole.ASSISTANT,
+            ActionStatus.SUCCESS,
+            messages="boilerplate",
+            output_data={"raw_output": LITELLM_EMPTY_PLACEHOLDER, "response": "real body"},
+        )
+        assert resolve_assistant_body(action) == "real body"

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -714,6 +714,86 @@ class TestUnifiedReprint:
         # up once, in the user header at the top — which we also emit).
         assert output.count("original question") == 1
 
+    def _completed_chat_turn(self, *, wrapper_response: str) -> list:
+        """A finished chat turn exactly as ``chat_commands`` records it.
+
+        ``all_turn_actions`` stores ``incremental_actions`` (tool calls plus the
+        model layer's plain ``response``) followed by the node's
+        ``chat_response`` wrapper, whose ``output`` is
+        ``ChatNodeResult.model_dump()`` — i.e. a ``response`` key and no
+        ``raw_output``.
+        """
+        return [
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                messages="ok",
+                input_data={"function_name": "list_tables"},
+            ),
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                action_type="response",
+                messages="The orders table has 42 rows.",
+                output_data={"raw_output": "The orders table has 42 rows.", "is_thinking": False},
+            ),
+            _make_action(
+                ActionRole.ASSISTANT,
+                ActionStatus.SUCCESS,
+                action_type="chat_response",
+                messages="chat interaction completed successfully",
+                output_data={"success": True, "response": wrapper_response, "tokens_used": 10},
+            ),
+        ]
+
+    def test_reprint_history_turn_renders_wrapper_response_body(self):
+        """Mid-run Ctrl+O must reprint the previous turn's answer, not the
+        wrapper's boilerplate summary.
+
+        ``render_action_history`` drops both the ``chat_response`` wrapper and
+        the trailing plain ``response``, so the per-turn callback is the only
+        thing painting the answer. Reading the wrapper's ``messages`` there
+        replaced completed answers with "chat interaction completed
+        successfully" after toggling verbose mid-stream.
+        """
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=100)
+        display = ActionHistoryDisplay(console)
+
+        ctx = InlineStreamingContext(
+            [],
+            display,
+            history_turns=[("how many rows in orders?", self._completed_chat_turn(wrapper_response="42 rows total."))],
+            current_user_message="now check customers",
+        )
+        ctx._processed_index = 0
+
+        ctx._reprint_history(verbose=False)
+
+        output = buf.getvalue()
+        assert "42 rows total." in output
+        assert "interaction completed successfully" not in output
+
+    def test_reprint_history_turn_falls_back_to_plain_response_body(self):
+        """An empty wrapper body falls through to the plain ``response`` text."""
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=100)
+        display = ActionHistoryDisplay(console)
+
+        ctx = InlineStreamingContext(
+            [],
+            display,
+            history_turns=[("how many rows in orders?", self._completed_chat_turn(wrapper_response=""))],
+            current_user_message="now check customers",
+        )
+        ctx._processed_index = 0
+
+        ctx._reprint_history(verbose=True)
+
+        output = buf.getvalue()
+        assert "The orders table has 42 rows." in output
+        assert "interaction completed successfully" not in output
+
     def test_reprint_verbose_mode_with_active_groups(self):
         """Reprint in verbose mode shows active groups with in-progress indicator."""
         buf = StringIO()


### PR DESCRIPTION
## Why

While an agent turn is running, pressing Ctrl+O (verbose toggle) sometimes replaced the **previous** turns' final answers with the boilerplate line `chat interaction completed successfully`.

Root cause: mid-run Ctrl+O rebuilds the transcript through `InlineStreamingContext._reprint_history`, which is a different code path from the post-run reprint in `chat_commands._full_screen_reprint`.

- `render_action_history` intentionally skips both the depth-0 `<node>_response` wrapper and the trailing plain `response` action, leaving the per-turn callback responsible for painting the answer (`display.py:259`, `display.py:268`).
- The post-run callback uses `_render_final_response`, which reads `output["response"] or output["raw_output"]` — correct.
- The mid-run callback instead called `render_main_action(wrapper)` → `_get_assistant_content`, which only looks at `output["raw_output"]`. The wrapper's output is the node result dump (`ChatNodeResult.response`, no `raw_output`), so it fell through to `action.messages` — the boilerplate string built in `agentic_node.py:3075` (`f"{node_name} interaction completed successfully"`).

So any completed chat turn lost its answer as soon as the user toggled verbose mid-stream; it only looked intermittent because the very first turn has no history to repaint.

## Solution

- Add `resolve_assistant_body()` in `action_display/renderers.py`: resolves an assistant action's body from `output["raw_output"]` then `output["response"]`, accepts strings only, and **never** falls back to `messages`, so callers rendering a terminal wrapper can tell "no body" apart from the wrapper's boilerplate summary. `_get_assistant_content` keeps its existing semantics, so sub-agent verbose lines are untouched.
- `_reprint_history`'s per-turn callback now renders the first candidate (wrapper, then plain `response`) that actually carries a body, printing it as markdown instead of routing the wrapper through the trace renderer.
- Fix the candidate scan while there: it used to `break` on the first wrapper, so `plain` stayed `None` whenever a wrapper existed and the documented "fall back to the plain response action" branch was unreachable. It now keeps scanning, which makes the empty-wrapper fallback real.

Tradeoff considered: reusing `chat_commands._render_final_response` for history turns would also restore SQL / validation panels in the mid-run repaint, but it would have to be injected into the streaming context and it re-copies historical SQL to the clipboard as a side effect from the refresh daemon thread. Keeping the mid-run repaint to markdown-only preserves today's behaviour and confines the change to the defect.

## Test Cases

Unit tests only — the defect is entirely in the CLI rendering layer, and the existing suites for it are unit-level (`tests/unit_tests/cli/action_display/`). Both new streaming tests are true regressions: they fail on `datus/main` with the boilerplate string in the output.

- `tests/unit_tests/cli/action_display/test_streaming.py::TestUnifiedReprint`
  - `test_reprint_history_turn_renders_wrapper_response_body` — builds a finished chat turn exactly as `chat_commands` records it (tool + plain `response` + `chat_response` wrapper whose output is `ChatNodeResult.model_dump()`), asserts the answer is reprinted and `interaction completed successfully` never appears.
  - `test_reprint_history_turn_falls_back_to_plain_response_body` — empty wrapper body falls through to the plain `response` text (covers the previously unreachable branch).
- `tests/unit_tests/cli/action_display/test_renderers.py::TestResolveAssistantBody` — resolution order, `response` fallback, whitespace-only body, non-dict output, non-string values, LiteLLM placeholder filtering.

Gates: `uv run pytest tests/unit_tests/cli/ -q` → 3844 passed; `ci/run-pr-tests.py` impacted-unit suite → 426 passed, diff coverage **100%**; `ci/audit_tests.py --diff-only` → **P0=0** (one pre-existing P1 `or_assert` at `test_renderers.py:988`, untouched by this PR); ruff format + check clean. The harness's acceptance suite fails locally for environment reasons only (this checkout's `./.datus/config.yml` pins a `default_datasource` absent from `tests/conf/agent.yml`, plus missing locally-built test data) — verified identical failures on `datus/main` at `804cb3ea`.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history reprints to display the actual assistant response instead of generic action details.
  * Added fallback handling so available response text is shown when the primary response body is empty.
  * Filtered out blank content, unsupported response formats, and placeholder text from displayed responses.

* **Tests**
  * Added coverage for response extraction, fallback behavior, and completed chat-turn rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->