### PR TITLE
[Enhancement] Localize the finalize stage progress bubbles

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -38,7 +38,7 @@ from pydantic import BaseModel
 
 from datus.agent.node.agentic_node import AgenticNode, _resolve_language_name
 from datus.agent.node.visual_artifact._visual_artifact_finalize import (
-    FINALIZE_STAGE_TEXT,
+    finalize_stage_text,
     narrative_outputs_present,
     run_finalize_analysis,
 )
@@ -847,7 +847,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             if item is sentinel:
                 break
             stage = int(item) if isinstance(item, int) else 0
-            text = FINALIZE_STAGE_TEXT.get(stage)
+            text = finalize_stage_text(stage, getattr(self.agent_config, "language", None))
             if not text:
                 continue
             yield ActionHistory(

--- a/datus/agent/node/visual_artifact/_visual_artifact_finalize.py
+++ b/datus/agent/node/visual_artifact/_visual_artifact_finalize.py
@@ -74,12 +74,34 @@ _JINJA_INTERP_RE = re.compile(r"\{\{.*?\}\}", re.DOTALL)
 # User-visible status text for each finalize stage. The node streams these
 # via a single chat bubble (CREATE then UPDATE_MESSAGE on the same id) so
 # the user sees the bubble's content swap stage-to-stage while finalize's
-# 10-15 s of LLM + describe_table work runs.
-FINALIZE_STAGE_TEXT = {
-    1: "Generating insights and follow-up questions...",
-    2: "Refining analysis intent...",
-    3: "Caching referenced table schemas, almost done...",
+# 10-15 s of LLM + describe_table work runs. Keyed by language so the
+# bubble matches the pinned ``agent_config.language`` — the finalize
+# *outputs* already follow it (see ``language_directive``), and an
+# English-only bubble over a Chinese artifact reads as a glitch.
+FINALIZE_STAGE_TEXT: Dict[str, Dict[int, str]] = {
+    "en": {
+        1: "Generating insights and follow-up questions...",
+        2: "Refining analysis intent...",
+        3: "Caching referenced table schemas, almost done...",
+    },
+    "zh": {
+        1: "正在生成洞察与后续问题...",
+        2: "正在提炼分析意图...",
+        3: "正在缓存引用的表结构，即将完成...",
+    },
 }
+
+
+def finalize_stage_text(stage: int, language: Optional[str] = None) -> Optional[str]:
+    """Resolve the status line for ``stage`` in the configured language.
+
+    ``language`` is ``agent_config.language`` as-is: any ``zh*`` code picks
+    the Chinese copy; everything else — including unpinned — falls back to
+    English. Unknown stages return ``None`` (caller skips the bubble).
+    """
+    code = (language or "").strip().lower()
+    table = FINALIZE_STAGE_TEXT["zh"] if code.startswith("zh") else FINALIZE_STAGE_TEXT["en"]
+    return table.get(stage)
 
 
 # Subject-library-aware tool names whose action history we surface as

--- a/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
+++ b/tests/unit_tests/agent/node/test_visual_artifact_finalize.py
@@ -34,6 +34,7 @@ from datus.agent.node.visual_artifact._visual_artifact_finalize import (
     collect_query_briefs,
     collect_query_previews,
     consistency_check,
+    finalize_stage_text,
     parse_finalize_output,
     run_finalize_analysis,
     run_intent_curation,
@@ -2174,3 +2175,30 @@ class TestRunFinalizeSkipNarrative:
         assert result["ok"] is True
         assert model.generate_with_json_output.call_count == 1
         assert (analysis_dir / "insights.json").is_file()
+
+
+# --------------------------------------------------------------------------- #
+# finalize_stage_text                                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestFinalizeStageText:
+    def test_unpinned_language_falls_back_to_english(self):
+        assert finalize_stage_text(1) == "Generating insights and follow-up questions..."
+        assert finalize_stage_text(1, None) == "Generating insights and follow-up questions..."
+        assert finalize_stage_text(1, "   ") == "Generating insights and follow-up questions..."
+
+    @pytest.mark.parametrize("code", ["zh", "ZH", "zh-CN", "zh-cn", "zh-TW"])
+    def test_zh_codes_pick_chinese_copy(self, code: str):
+        assert finalize_stage_text(1, code) == "正在生成洞察与后续问题..."
+        assert finalize_stage_text(2, code) == "正在提炼分析意图..."
+        assert finalize_stage_text(3, code) == "正在缓存引用的表结构，即将完成..."
+
+    @pytest.mark.parametrize("code", ["en", "ja", "fr", "custom-lang"])
+    def test_non_zh_codes_pick_english_copy(self, code: str):
+        assert finalize_stage_text(2, code) == "Refining analysis intent..."
+
+    @pytest.mark.parametrize("language", [None, "zh", "en"])
+    def test_unknown_stage_returns_none(self, language):
+        assert finalize_stage_text(0, language) is None
+        assert finalize_stage_text(99, language) is None


### PR DESCRIPTION
## Why

The per-stage finalize progress bubble (`FINALIZE_STAGE_TEXT`, streamed as `finalize_progress` actions while the 10-15 s finalize LLM + describe_table work runs) was English-only. Since #1217 the finalize *outputs* (insights / suggested questions) follow the pinned `agent_config.language`, so a Chinese-pinned session ends up with a Chinese artifact narrated by an English status bubble — it reads as a glitch.

## Solution

- Key `FINALIZE_STAGE_TEXT` by language (`en` / `zh`), keeping the existing English copy as-is and adding a Chinese counterpart per stage.
- Add `finalize_stage_text(stage, language)`: any `zh*` code (`zh`, `zh-CN`, `zh-TW`, case-insensitive) resolves to the Chinese copy; everything else — including unpinned — falls back to English, preserving today's behavior. Unknown stages still return `None` so the streaming site keeps skipping the bubble.
- `BaseVisualArtifactAgenticNode._stream_post_build` resolves the text through the helper with `agent_config.language` instead of indexing the dict directly.

Selection is deterministic (config-driven) rather than inferred from the user's prompt language: the progress bubble streams *before* any LLM output exists, and `agent_config.language` is the same pin the finalize outputs already honor (the SaaS backend sets it per request).

## Test Cases

`tests/unit_tests/agent/node/test_visual_artifact_finalize.py::TestFinalizeStageText` — unpinned/blank fallback to English, `zh*` code variants pick the Chinese copy for all 3 stages, non-`zh` codes keep English, unknown stages return `None`. No integration test added: the streaming path around the text is unchanged and already covered by the existing `finalize_progress` SSE converter tests.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
