### PR TITLE
[Enhancement] Recognize self-join period-over-period SQL in metric candidate mining

### DIFF
--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -4020,18 +4020,35 @@ class SemanticDiscoveryTools:
             yield expr
 
     def _self_join_offset_window(self, date_func: Any) -> str:
-        """Extract an offset window like ``'1 year'`` from DATE_SUB/DATE_ADD."""
+        """Extract an offset window like ``'1 year'`` from DATE_SUB/DATE_ADD.
+
+        sqlglot represents the interval differently across dialects: some parse
+        ``INTERVAL 1 YEAR`` into an ``exp.Interval`` (``expression`` arg), while
+        starrocks/doris normalize it to a string literal plus a separate ``unit``
+        arg. Both forms are handled here. The unit is pluralized for non-singular
+        counts so the resulting ``offset_window`` matches the LAG path's
+        ``_infer_period_offset_window`` format (e.g. ``2 months``), keeping the
+        same ``period_over_period.offset_window`` and merge-key identities.
+        """
         from sqlglot import expressions as exp
 
+        count = None
+        unit_text = ""
         interval = date_func.args.get("expression")
-        if not isinstance(interval, exp.Interval):
-            return ""
-        count = getattr(interval.this, "this", None)
-        unit = interval.args.get("unit")
-        unit_text = getattr(unit, "this", None) or ""
+        if isinstance(interval, exp.Interval):
+            count = getattr(interval.this, "this", None)
+            unit = interval.args.get("unit")
+            unit_text = getattr(unit, "this", None) or ""
+        else:
+            count = getattr(interval, "this", None)
+            unit = date_func.args.get("unit")
+            unit_text = getattr(unit, "this", None) or ""
         if count is None or not unit_text:
             return ""
-        return f"{count} {self._normalize_identifier(str(unit_text))}"
+        unit = self._normalize_identifier(str(unit_text))
+        if str(count) != "1" and not unit.endswith("s"):
+            unit = f"{unit}s"
+        return f"{count} {unit}"
 
     def _visible_period_shift_outputs(
         self,

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -3252,6 +3252,12 @@ class SemanticDiscoveryTools:
                         if base_candidate:
                             base_candidates[self._metric_candidate_merge_key(base_candidate)] = base_candidate
 
+                # Self-join period shifts: e.g. ``FROM monthly c LEFT JOIN monthly p
+                # ON p.time = DATE_SUB(c.time, INTERVAL 1 YEAR)`` produces a
+                # previous-period output projection that behaves like a LAG output.
+                for self_join_alias, detail in self._self_join_period_shift_outputs(select, projection_index).items():
+                    shift_outputs_by_select.setdefault(select_name, {})[self_join_alias] = detail
+
             for select_name, select in self._named_selects_for_period_analysis(parsed):
                 source_names = self._direct_source_names(select)
                 visible_shifts = self._visible_period_shift_outputs(
@@ -3842,6 +3848,190 @@ class SemanticDiscoveryTools:
                 candidate["source_select"] = projection_info.get("select_name", source)
                 return candidate
         return None
+
+    def _self_join_period_shift_outputs(
+        self,
+        select: Any,
+        projection_index: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Detect self-join period shifts and return ``{alias: detail}`` outputs.
+
+        Recognizes fixed period-over-period metrics expressed as a self-join on a
+        time-offset predicate, e.g.::
+
+            WITH monthly AS (...)
+            SELECT
+                c.metric_time__month,
+                c.activity_count,
+                p.activity_count AS previous_year_activity_count
+            FROM monthly c
+            LEFT JOIN monthly p
+              ON p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)
+
+        The ``p.activity_count AS previous_year_activity_count`` projection is a
+        previous-period output: it is emitted by the JOIN'd (previous) alias of the
+        same source. Its ``detail`` reuses the same shape as
+        ``_period_shift_output_detail`` so downstream projection analysis can build
+        ``previous_value`` / ``delta`` / ``percent_change`` / ``ratio`` candidates.
+        """
+        from sqlglot import expressions as exp
+
+        sources = self._self_join_source_aliases(select)
+        if len(sources) < 2:
+            return {}
+
+        source_counts: Dict[str, int] = defaultdict(int)
+        for source_name, _alias in sources:
+            source_counts[source_name] += 1
+        self_joined = {name for name, count in source_counts.items() if count >= 2}
+        if not self_joined:
+            return {}
+
+        outputs: Dict[str, Dict[str, Any]] = {}
+        for join in select.args.get("joins") or []:
+            on = join.args.get("on")
+            if on is None:
+                continue
+            shift = self._parse_self_join_time_shift(on, sources, self_joined)
+            if not shift:
+                continue
+            previous_alias, _current_alias, offset_window, time_column = shift
+            source_name = next((name for name, alias in sources if alias == previous_alias), "")
+            if not source_name:
+                source_name = next((name for name in self_joined), "")
+            for projection in select.expressions:
+                expr = projection.this if isinstance(projection, exp.Alias) else projection
+                alias = projection.alias if isinstance(projection, exp.Alias) else projection.alias_or_name
+                if not alias:
+                    continue
+                cols = [
+                    col
+                    for col in expr.find_all(exp.Column)
+                    if self._normalize_identifier(col.table) == self._normalize_identifier(previous_alias)
+                ]
+                if not cols:
+                    continue
+                input_metric = self._safe_name(cols[0].name)
+                detail = {
+                    "alias": self._safe_name(alias),
+                    "input_metric": input_metric,
+                    "offset_window": offset_window,
+                    "window_function": "SELF_JOIN",
+                    "source_names": [source_name] if source_name else list(self_joined),
+                    "window": {
+                        "function": "SELF_JOIN",
+                        "order_by": [{"expr": time_column, "direction": "ASC"}],
+                    },
+                }
+                outputs[self._normalize_identifier(alias)] = detail
+        return outputs
+
+    def _self_join_source_aliases(self, select: Any) -> List[tuple]:
+        """Return ``(source_name, alias)`` pairs for FROM and JOIN clauses."""
+        from sqlglot import expressions as exp
+
+        sources: List[tuple] = []
+
+        def add_source(node: Any) -> None:
+            if isinstance(node, exp.Table):
+                sources.append((self._safe_name(node.name), self._safe_name(node.alias_or_name or node.name)))
+            elif isinstance(node, exp.Subquery):
+                sources.append(
+                    (
+                        self._safe_name(node.alias_or_name or "derived_datasource"),
+                        self._safe_name(node.alias_or_name or ""),
+                    )
+                )
+            else:
+                name = self._safe_name(getattr(node, "alias_or_name", "") or "")
+                sources.append((name, name))
+
+        from_clause = select.args.get("from_") or select.args.get("from")
+        if from_clause is not None and getattr(from_clause, "this", None) is not None:
+            add_source(from_clause.this)
+        for join in select.args.get("joins") or []:
+            if getattr(join, "this", None) is not None:
+                add_source(join.this)
+        return sources
+
+    def _parse_self_join_time_shift(
+        self,
+        on: Any,
+        sources: List[tuple],
+        self_joined: set,
+    ) -> Optional[tuple]:
+        """Return ``(previous_alias, current_alias, offset_window, time_column)``.
+
+        Parses a self-join time-offset equality predicate:
+        ``prev.time = DATE_SUB(curr.time, INTERVAL n UNIT)`` or
+        ``DATE_ADD(prev.time, INTERVAL n UNIT) = curr.time``.
+
+        ``sources`` is the ``(source_name, alias)`` list from
+        ``_self_join_source_aliases``; ``self_joined`` is the set of source names
+        referenced more than once. Only shifts between two aliases of the same
+        self-joined source are recognized.
+        """
+        from sqlglot import expressions as exp
+
+        alias_to_source = {self._normalize_identifier(alias): source for source, alias in sources if alias}
+        for predicate in self._iter_and_conditions(on):
+            if not isinstance(predicate, exp.EQ):
+                continue
+            left, right = predicate.this, predicate.args.get("expression")
+            column_side, func_side = None, None
+            if isinstance(left, exp.Column) and isinstance(right, (exp.DateSub, exp.DateAdd)):
+                column_side, func_side = left, right
+            elif isinstance(right, exp.Column) and isinstance(left, (exp.DateSub, exp.DateAdd)):
+                column_side, func_side = right, left
+            if column_side is None or func_side is None:
+                continue
+            func_arg = func_side.this
+            if not isinstance(func_arg, exp.Column):
+                continue
+            if isinstance(func_side, exp.DateSub):
+                # DATE_SUB(curr.time, ...): func arg is current, column side is previous
+                current_col, previous_col = func_arg, column_side
+            else:  # exp.DateAdd
+                # DATE_ADD(prev.time, ...): func arg is previous, column side is current
+                previous_col, current_col = func_arg, column_side
+            previous_alias = self._normalize_identifier(previous_col.table or "")
+            current_alias = self._normalize_identifier(current_col.table or "")
+            if not previous_alias or not current_alias or previous_alias == current_alias:
+                continue
+            prev_source = alias_to_source.get(previous_alias, "")
+            curr_source = alias_to_source.get(current_alias, "")
+            if not prev_source or prev_source != curr_source or prev_source not in self_joined:
+                continue
+            offset_window = self._self_join_offset_window(func_side)
+            if not offset_window:
+                continue
+            time_column = previous_col.name or current_col.name
+            return previous_alias, current_alias, offset_window, time_column
+        return None
+
+    def _iter_and_conditions(self, expr: Any):
+        """Yield the leaf predicates of an AND chain."""
+        from sqlglot import expressions as exp
+
+        if isinstance(expr, exp.And):
+            yield from self._iter_and_conditions(expr.this)
+            yield from self._iter_and_conditions(expr.args.get("expression"))
+        else:
+            yield expr
+
+    def _self_join_offset_window(self, date_func: Any) -> str:
+        """Extract an offset window like ``'1 year'`` from DATE_SUB/DATE_ADD."""
+        from sqlglot import expressions as exp
+
+        interval = date_func.args.get("expression")
+        if not isinstance(interval, exp.Interval):
+            return ""
+        count = getattr(interval.this, "this", None)
+        unit = interval.args.get("unit")
+        unit_text = getattr(unit, "this", None) or ""
+        if count is None or not unit_text:
+            return ""
+        return f"{count} {self._normalize_identifier(str(unit_text))}"
 
     def _visible_period_shift_outputs(
         self,

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -3895,7 +3895,7 @@ class SemanticDiscoveryTools:
             shift = self._parse_self_join_time_shift(on, sources, self_joined)
             if not shift:
                 continue
-            previous_alias, _current_alias, offset_window, time_column = shift
+            previous_alias, _current_alias, offset_window, time_column, group_dimensions = shift
             source_name = next((name for name, alias in sources if alias == previous_alias), "")
             if not source_name:
                 source_name = next((name for name in self_joined), "")
@@ -3922,6 +3922,7 @@ class SemanticDiscoveryTools:
                         "function": "SELF_JOIN",
                         "order_by": [{"expr": time_column, "direction": "ASC"}],
                     },
+                    "group_dimensions": group_dimensions,
                 }
                 outputs[self._normalize_identifier(alias)] = detail
         return outputs
@@ -3960,11 +3961,14 @@ class SemanticDiscoveryTools:
         sources: List[tuple],
         self_joined: set,
     ) -> Optional[tuple]:
-        """Return ``(previous_alias, current_alias, offset_window, time_column)``.
+        """Return ``(previous_alias, current_alias, offset_window, time_column,
+        group_dimensions)``.
 
         Parses a self-join time-offset equality predicate:
         ``prev.time = DATE_SUB(curr.time, INTERVAL n UNIT)`` or
-        ``DATE_ADD(prev.time, INTERVAL n UNIT) = curr.time``.
+        ``DATE_ADD(prev.time, INTERVAL n UNIT) = curr.time``. Same-dimension
+        equality predicates (e.g. ``p.product_type = c.product_type``) are
+        collected as partition/grouping evidence.
 
         ``sources`` is the ``(source_name, alias)`` list from
         ``_self_join_source_aliases``; ``self_joined`` is the set of source names
@@ -3974,10 +3978,29 @@ class SemanticDiscoveryTools:
         from sqlglot import expressions as exp
 
         alias_to_source = {self._normalize_identifier(alias): source for source, alias in sources if alias}
+        group_dimensions: List[str] = []
         for predicate in self._iter_and_conditions(on):
             if not isinstance(predicate, exp.EQ):
                 continue
             left, right = predicate.this, predicate.args.get("expression")
+            # Same-dimension equality between the two self-join aliases is
+            # partition/grouping evidence, not a time offset.
+            if isinstance(left, exp.Column) and isinstance(right, exp.Column):
+                left_alias = self._normalize_identifier(left.table or "")
+                right_alias = self._normalize_identifier(right.table or "")
+                left_source = alias_to_source.get(left_alias, "")
+                right_source = alias_to_source.get(right_alias, "")
+                if (
+                    left_source
+                    and left_source == right_source
+                    and left_source in self_joined
+                    and left.name == right.name
+                    and left.name
+                ):
+                    dim = self._safe_name(left.name)
+                    if dim not in group_dimensions:
+                        group_dimensions.append(dim)
+                continue
             column_side, func_side = None, None
             if isinstance(left, exp.Column) and isinstance(right, (exp.DateSub, exp.DateAdd)):
                 column_side, func_side = left, right
@@ -4006,7 +4029,7 @@ class SemanticDiscoveryTools:
             if not offset_window:
                 continue
             time_column = previous_col.name or current_col.name
-            return previous_alias, current_alias, offset_window, time_column
+            return previous_alias, current_alias, offset_window, time_column, group_dimensions
         return None
 
     def _iter_and_conditions(self, expr: Any):
@@ -4161,6 +4184,11 @@ class SemanticDiscoveryTools:
                 "referenced_metrics": [],
             }
         )
+        # Same-dimension self-join predicates (e.g. p.product_type = c.product_type)
+        # are partition/grouping evidence; preserve them in the candidate.
+        for group_dim in detail.get("group_dimensions", []):
+            if group_dim not in candidate.get("dimensions", []):
+                candidate.setdefault("dimensions", []).append(group_dim)
         candidate.pop("inputs", None)
         candidate.pop("required_input_metrics", None)
         candidate.pop("offset_window", None)

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -1722,6 +1722,243 @@ class TestMetricCandidateAnalyzer:
         }
         assert "inputs" not in previous
 
+    def test_self_join_yoy_percent_change_becomes_fixed_period_metric(self):
+        tools = _make_tools()
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.activity_count,
+                        p.activity_count AS previous_year_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)
+                )
+                SELECT
+                    metric_time__month,
+                    activity_count,
+                    previous_year_activity_count,
+                    (activity_count - previous_year_activity_count) * 1.0
+                        / NULLIF(previous_year_activity_count, 0) AS activity_count_yoy_percent_change
+                FROM compared
+                """
+            ]
+        )
+
+        assert result.success == 1
+        percent_change = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_yoy_percent_change"
+        )
+        assert percent_change["metric_type"] == "period_over_period"
+        assert percent_change["expression"] == "COUNT(DISTINCT ac_code)"
+        assert percent_change["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "1 year",
+            "calculation": "percent_change",
+        }
+        assert "inputs" not in percent_change
+
+    def test_self_join_yoy_delta_becomes_fixed_period_metric(self):
+        tools = _make_tools()
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.activity_count,
+                        p.activity_count AS previous_year_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)
+                )
+                SELECT
+                    metric_time__month,
+                    activity_count,
+                    previous_year_activity_count,
+                    activity_count - previous_year_activity_count AS activity_count_yoy_delta
+                FROM compared
+                """
+            ]
+        )
+
+        assert result.success == 1
+        delta = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_yoy_delta"
+        )
+        assert delta["metric_type"] == "period_over_period"
+        assert delta["expression"] == "COUNT(DISTINCT ac_code)"
+        assert delta["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "1 year",
+            "calculation": "delta",
+        }
+        assert "inputs" not in delta
+
+    def test_self_join_yoy_ratio_becomes_fixed_period_metric(self):
+        tools = _make_tools()
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.activity_count,
+                        p.activity_count AS previous_year_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)
+                )
+                SELECT
+                    metric_time__month,
+                    activity_count,
+                    previous_year_activity_count,
+                    activity_count * 1.0 / NULLIF(previous_year_activity_count, 0) AS activity_count_yoy_ratio
+                FROM compared
+                """
+            ]
+        )
+
+        assert result.success == 1
+        ratio = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_yoy_ratio"
+        )
+        assert ratio["metric_type"] == "period_over_period"
+        assert ratio["expression"] == "COUNT(DISTINCT ac_code)"
+        assert ratio["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "1 year",
+            "calculation": "ratio",
+        }
+        assert "inputs" not in ratio
+
+    def test_self_join_with_additional_grouping_key(self):
+        tools = _make_tools()
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        product_type,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date), product_type
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.product_type,
+                        c.activity_count,
+                        p.activity_count AS previous_year_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON p.product_type = c.product_type
+                      AND p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)
+                )
+                SELECT
+                    metric_time__month,
+                    product_type,
+                    activity_count,
+                    previous_year_activity_count,
+                    (activity_count - previous_year_activity_count) * 1.0
+                        / NULLIF(previous_year_activity_count, 0) AS activity_count_yoy_percent_change
+                FROM compared
+                """
+            ]
+        )
+
+        assert result.success == 1
+        percent_change = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_yoy_percent_change"
+        )
+        assert percent_change["metric_type"] == "period_over_period"
+        assert percent_change["expression"] == "COUNT(DISTINCT ac_code)"
+        assert percent_change["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "1 year",
+            "calculation": "percent_change",
+        }
+        assert "inputs" not in percent_change
+
+    def test_self_join_reversed_date_add_predicate_form(self):
+        tools = _make_tools()
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.activity_count,
+                        p.activity_count AS previous_year_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON DATE_ADD(p.metric_time__month, INTERVAL 1 YEAR) = c.metric_time__month
+                )
+                SELECT
+                    metric_time__month,
+                    activity_count,
+                    previous_year_activity_count,
+                    (activity_count - previous_year_activity_count) * 1.0
+                        / NULLIF(previous_year_activity_count, 0) AS activity_count_yoy_percent_change
+                FROM compared
+                """
+            ]
+        )
+
+        assert result.success == 1
+        percent_change = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_yoy_percent_change"
+        )
+        assert percent_change["metric_type"] == "period_over_period"
+        assert percent_change["expression"] == "COUNT(DISTINCT ac_code)"
+        assert percent_change["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "1 year",
+            "calculation": "percent_change",
+        }
+        assert "inputs" not in percent_change
+
     def test_period_shift_aliases_are_scoped_to_source_select(self):
         tools = _make_tools()
         result = tools._analyze_metric_candidates(

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -1959,6 +1959,69 @@ class TestMetricCandidateAnalyzer:
         }
         assert "inputs" not in percent_change
 
+    @pytest.mark.parametrize(
+        ("dialect", "join_predicate"),
+        [
+            # starrocks normalizes DATE_ADD(p.t, INTERVAL 1 YEAR) into a string
+            # literal plus a separate unit arg; make sure the shift is still found.
+            ("starrocks", "DATE_ADD(p.metric_time__month, INTERVAL 1 YEAR) = c.metric_time__month"),
+            # snowflake parses DATE_SUB(c.t, INTERVAL 1 YEAR) as an exp.Interval.
+            ("snowflake", "p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)"),
+        ],
+    )
+    def test_self_join_recognized_in_non_default_dialect(self, dialect, join_predicate):
+        db_tool = _make_db_tool(
+            agent_config=SimpleNamespace(
+                current_datasource="analytics",
+                current_db_config=lambda _name: SimpleNamespace(type=dialect),
+            )
+        )
+        tools = _make_tools(db_tool)
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                f"""
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.activity_count,
+                        p.activity_count AS previous_year_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON {join_predicate}
+                )
+                SELECT
+                    metric_time__month,
+                    activity_count,
+                    previous_year_activity_count,
+                    (activity_count - previous_year_activity_count) * 1.0
+                        / NULLIF(previous_year_activity_count, 0) AS activity_count_yoy_percent_change
+                FROM compared
+                """
+            ],
+        )
+
+        assert result.success == 1
+        percent_change = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_yoy_percent_change"
+        )
+        assert percent_change["metric_type"] == "period_over_period"
+        assert percent_change["expression"] == "COUNT(DISTINCT ac_code)"
+        assert percent_change["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "1 year",
+            "calculation": "percent_change",
+        }
+        assert "inputs" not in percent_change
+
     def test_period_shift_aliases_are_scoped_to_source_select(self):
         tools = _make_tools()
         result = tools._analyze_metric_candidates(

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -1913,6 +1913,58 @@ class TestMetricCandidateAnalyzer:
         }
         assert "inputs" not in percent_change
 
+    def test_self_join_join_predicate_grouping_key_is_preserved(self):
+        """Same-dimension equality in the self-join predicate is grouping evidence."""
+        tools = _make_tools()
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.activity_count,
+                        p.activity_count AS previous_year_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON p.product_type = c.product_type
+                      AND p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)
+                )
+                SELECT
+                    metric_time__month,
+                    activity_count,
+                    previous_year_activity_count,
+                    (activity_count - previous_year_activity_count) * 1.0
+                        / NULLIF(previous_year_activity_count, 0) AS activity_count_yoy_percent_change
+                FROM compared
+                """
+            ]
+        )
+
+        assert result.success == 1
+        percent_change = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_yoy_percent_change"
+        )
+        assert percent_change["metric_type"] == "period_over_period"
+        assert percent_change["expression"] == "COUNT(DISTINCT ac_code)"
+        # product_type appears only in the self-join predicate; it must still be
+        # preserved as a partition/grouping dimension.
+        assert "product_type" in percent_change["dimensions"]
+        assert percent_change["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "1 year",
+            "calculation": "percent_change",
+        }
+        assert "inputs" not in percent_change
+
     def test_self_join_reversed_date_add_predicate_form(self):
         tools = _make_tools()
         result = tools._analyze_metric_candidates(
@@ -1970,7 +2022,7 @@ class TestMetricCandidateAnalyzer:
             ("snowflake", "p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 1 YEAR)"),
         ],
     )
-    def test_self_join_recognized_in_non_default_dialect(self, dialect, join_predicate):
+    def test_self_join_recognized_in_non_default_dialect(self, dialect: str, join_predicate: str):
         db_tool = _make_db_tool(
             agent_config=SimpleNamespace(
                 current_datasource="analytics",

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -1905,6 +1905,7 @@ class TestMetricCandidateAnalyzer:
         )
         assert percent_change["metric_type"] == "period_over_period"
         assert percent_change["expression"] == "COUNT(DISTINCT ac_code)"
+        assert "product_type" in percent_change["dimensions"]
         assert percent_change["period_over_period"] == {
             "time_grain": "month",
             "offset_window": "1 year",
@@ -2018,6 +2019,53 @@ class TestMetricCandidateAnalyzer:
         assert percent_change["period_over_period"] == {
             "time_grain": "month",
             "offset_window": "1 year",
+            "calculation": "percent_change",
+        }
+        assert "inputs" not in percent_change
+
+    def test_self_join_multi_count_offset_pluralizes_unit(self):
+        tools = _make_tools()
+        result = tools._analyze_metric_candidates(
+            sql_queries=[
+                """
+                WITH monthly AS (
+                    SELECT
+                        DATE_TRUNC('month', start_date) AS metric_time__month,
+                        COUNT(DISTINCT ac_code) AS activity_count
+                    FROM v_udata_ac_info
+                    GROUP BY DATE_TRUNC('month', start_date)
+                ),
+                compared AS (
+                    SELECT
+                        c.metric_time__month,
+                        c.activity_count,
+                        p.activity_count AS previous_activity_count
+                    FROM monthly c
+                    LEFT JOIN monthly p
+                      ON p.metric_time__month = DATE_SUB(c.metric_time__month, INTERVAL 2 YEAR)
+                )
+                SELECT
+                    metric_time__month,
+                    activity_count,
+                    previous_activity_count,
+                    (activity_count - previous_activity_count) * 1.0
+                        / NULLIF(previous_activity_count, 0) AS activity_count_2y_percent_change
+                FROM compared
+                """
+            ]
+        )
+
+        assert result.success == 1
+        percent_change = next(
+            candidate
+            for candidate in result.result["direct_metric_candidates"]
+            if candidate["name"] == "activity_count_2y_percent_change"
+        )
+        assert percent_change["metric_type"] == "period_over_period"
+        assert percent_change["expression"] == "COUNT(DISTINCT ac_code)"
+        assert percent_change["period_over_period"] == {
+            "time_grain": "month",
+            "offset_window": "2 years",
             "calculation": "percent_change",
         }
         assert "inputs" not in percent_change


### PR DESCRIPTION
## Why

Issue #1109: `analyze_metric_candidates_from_history` deterministically recognizes `LAG()`-based period-over-period SQL and emits `direct_metric_candidates` with `metric_type: period_over_period`, but self-join period-over-period SQL was not recognized as a fixed period-over-period metric. For example, a monthly YoY comparison written as a self-join on a time-offset predicate produced zero period-over-period candidates, so these metrics relied on LLM interpretation of success-story text instead of deterministic AST recognition.

## Solution

Added a generic self-join period-shift detector to `SemanticDiscoveryTools._period_over_period_metric_candidates`:

- `_self_join_period_shift_outputs` detects same-source aggregate CTE/subquery aliases joined to themselves (e.g. `FROM monthly c LEFT JOIN monthly p`).
- `_parse_self_join_time_shift` parses time-offset equality predicates (`prev.time = DATE_SUB(curr.time, INTERVAL n UNIT)` and the reversed `DATE_ADD(prev.time, INTERVAL n UNIT) = curr.time` form), preserving same-dimension equality predicates (e.g. `p.product_type = c.product_type`) as partition evidence.
- The previous-side metric projection (`p.activity_count AS previous_year_activity_count`) is converted into the same internal shift detail used by the LAG path, so the existing projection analysis reuses its calculation detection for `previous_value`, `delta`, `percent_change`, and `ratio`.
- The candidate is self-contained and does not include derived `inputs`.

## Test Cases

Added parser-level unit tests in `tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py`:

- `test_self_join_yoy_percent_change_becomes_fixed_period_metric`
- `test_self_join_yoy_delta_becomes_fixed_period_metric`
- `test_self_join_yoy_ratio_becomes_fixed_period_metric`
- `test_self_join_with_additional_grouping_key`
- `test_self_join_reversed_date_add_predicate_form`

Each test asserts the candidate lands in `direct_metric_candidates` with `metric_type: period_over_period`, keeps the base aggregate expression, has the expected `time_grain` / `offset_window` / `calculation`, and does not include `inputs`.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Improved period-over-period metric discovery for self-joined data sources.
  * Supports year-over-year calculations using date offsets, including percent change, delta, and ratio metrics.
  * Preserves grouping keys and recognizes date-offset conditions in either direction.

* **Bug Fixes**
  * Corrected detection of prior-period projections in self-join queries.

* **Tests**
  * Added regression coverage for monthly year-over-year metric scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved period-over-period metric discovery for self-joined data sources.
  * Supports year-over-year percent change, delta, and ratio calculations using date offsets.
  * Preserves grouping keys and recognizes date-offset conditions in either direction.
  * Supports monthly and multi-year comparisons across common SQL dialects.

* **Bug Fixes**
  * Corrected detection of prior-period projections in self-join queries.

* **Tests**
  * Added regression coverage for grouped, reversed, and multi-year date-offset scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->