### PR TITLE
[Enhancement] Honor the caller's response language in data_visualization

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -33,6 +33,7 @@ from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.base import BaseInput, BaseResult
 from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.language_utils import resolve_language_name as _resolve_language_name
 from datus.utils.loggings import get_logger
 from datus.utils.message_utils import build_structured_content
 from datus.utils.node_utils import build_database_context
@@ -46,33 +47,6 @@ if TYPE_CHECKING:
     from datus.tools.skill_tools.skill_manager import SkillManager
 
 logger = get_logger(__name__)
-
-
-_LANGUAGE_NAME_MAP: Dict[str, str] = {
-    "en": "English",
-    "zh": "Chinese",
-    "zh-cn": "Chinese",
-    "zh-tw": "Traditional Chinese",
-    "ja": "Japanese",
-    "ko": "Korean",
-    "es": "Spanish",
-    "fr": "French",
-    "de": "German",
-    "pt": "Portuguese",
-    "ru": "Russian",
-    "it": "Italian",
-}
-
-
-def _resolve_language_name(code: str) -> str:
-    """Map a language code (e.g. ``"zh"``) to a human-readable name.
-
-    Unknown codes are returned as-is so operators can plug in custom values
-    without a code change.
-    """
-    if not code:
-        return "English"
-    return _LANGUAGE_NAME_MAP.get(code.strip().lower(), code)
 
 
 class AgenticNode(Node):

--- a/datus/api/models/visualization_models.py
+++ b/datus/api/models/visualization_models.py
@@ -21,6 +21,13 @@ class DataVisualizationRequest(BaseModel):
     chart_type: Optional[ChartType] = Field(None, description="Desired chart type; omit for auto-recommendation")
     sql: Optional[str] = Field(None, description="SQL query that produced the data (enables metadata extraction)")
     user_question: Optional[str] = Field(None, description="User's original question (improves insight quality)")
+    language: Optional[str] = Field(
+        None,
+        description=(
+            "Response language override for the generated text (reason / filters / insight), "
+            "e.g. 'en', 'zh'. Falls back to agent.language from yaml when unset."
+        ),
+    )
 
 
 # ── Response payloads ────────────────────────────────────────────────

--- a/datus/api/routes/visualization_routes.py
+++ b/datus/api/routes/visualization_routes.py
@@ -38,6 +38,7 @@ async def data_visualization(
         chart_type=request.chart_type,
         sql=request.sql,
         user_question=request.user_question,
+        language=request.language,
     )
 
     if not result["success"]:

--- a/datus/api/services/visualization_service.py
+++ b/datus/api/services/visualization_service.py
@@ -64,6 +64,7 @@ class DataVisualizationService:
         chart_type: Optional[str],
         sql: Optional[str],
         user_question: Optional[str],
+        language: Optional[str],
     ) -> str:
         """Compute a stable hash for the request payload."""
         payload = json.dumps(
@@ -73,6 +74,7 @@ class DataVisualizationService:
                 "chart_type": chart_type,
                 "sql": sql,
                 "user_question": user_question,
+                "language": language,
             },
             sort_keys=True,
             default=str,
@@ -96,16 +98,21 @@ class DataVisualizationService:
         chart_type: Optional[str] = None,
         sql: Optional[str] = None,
         user_question: Optional[str] = None,
+        language: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Return a chart recommendation dict, using cache when available."""
-        key = self._cache_key(csv_data, chart_type, sql, user_question)
+        """Return a chart recommendation dict, using cache when available.
+
+        ``language`` is part of the cache key: the same dataset asked for in
+        two languages must not share one cached answer.
+        """
+        key = self._cache_key(csv_data, chart_type, sql, user_question, language)
 
         cached = self._cache.get(key)
         if cached is not None:
             self._cache.move_to_end(key)
             return cached
 
-        result = self._generate_uncached(csv_data, chart_type, sql, user_question)
+        result = self._generate_uncached(csv_data, chart_type, sql, user_question, language)
         self._cache_set(key, result)
         return result
 
@@ -119,6 +126,7 @@ class DataVisualizationService:
         chart_type: Optional[str],
         sql: Optional[str],
         user_question: Optional[str],
+        language: Optional[str] = None,
     ) -> Dict[str, Any]:
         # ── Build DataFrame ───────────────────────────────────────
         try:
@@ -151,9 +159,9 @@ class DataVisualizationService:
         try:
             viz_input = VisualizationInput(data=df)
             if has_context:
-                result = tool.execute_with_context(viz_input, sql=sql, user_question=user_question)
+                result = tool.execute_with_context(viz_input, sql=sql, user_question=user_question, language=language)
             else:
-                result = tool.execute(viz_input)
+                result = tool.execute(viz_input, language=language)
         except Exception as exc:
             logger.error(f"Visualization tool execution failed: {exc}")
             return {

--- a/datus/api/services/visualization_service.py
+++ b/datus/api/services/visualization_service.py
@@ -102,10 +102,14 @@ class DataVisualizationService:
     ) -> Dict[str, Any]:
         """Return a chart recommendation dict, using cache when available.
 
-        ``language`` is part of the cache key: the same dataset asked for in
-        two languages must not share one cached answer.
+        The language is part of the cache key: the same dataset asked for in
+        two languages must not share one cached answer. It has to be the
+        *effective* language — an omitted override resolves to
+        ``agent_config.language`` inside the tool, so keying on the raw ``None``
+        would serve the old answer after that default changes.
         """
-        key = self._cache_key(csv_data, chart_type, sql, user_question, language)
+        effective_language = language or getattr(self._agent_config, "language", None)
+        key = self._cache_key(csv_data, chart_type, sql, user_question, effective_language)
 
         cached = self._cache.get(key)
         if cached is not None:

--- a/datus/prompts/prompt_templates/visualization_system_1.0.j2
+++ b/datus/prompts/prompt_templates/visualization_system_1.0.j2
@@ -16,3 +16,8 @@ Rules:
 - If comparing categories, use "Bar Chart".
 - If checking correlation between two numbers, use "Scatter plot".
 - If it cannot be confirmed, "chart_type" returns Unknown.
+{% if language_directive %}
+
+{{ language_directive }}
+- The value of "reason" must follow this language; column names and JSON keys stay as-is.
+{% endif %}

--- a/datus/prompts/prompt_templates/visualization_with_context_1.0.j2
+++ b/datus/prompts/prompt_templates/visualization_with_context_1.0.j2
@@ -28,7 +28,7 @@ Based on ALL the information above, return ONLY a **JSON** object with the follo
 
 ### Data Context (required when SQL or User Question is provided)
 - "period": The time range extracted from WHERE conditions, formatted as "YYYY-MM-DD ~ YYYY-MM-DD" or a readable period like "Q4 2025". Return null if no time condition exists or no SQL is provided.
-- "filters": A list of human-readable filter descriptions extracted from WHERE conditions (exclude time range conditions). Describe filters in natural language, e.g. "BP购买" instead of "purchasesource = BATTLEPASS_PROGRESS". Return an empty list if no filters or no SQL is provided.
+- "filters": A list of human-readable filter descriptions extracted from WHERE conditions (exclude time range conditions). Describe filters in natural language, e.g. "Battle Pass purchase" instead of "purchasesource = BATTLEPASS_PROGRESS". Return an empty list if no filters or no SQL is provided.
 - "insight": A concise analytical summary (2-4 sentences) of the data. Highlight key findings, comparisons, anomalies, or trends. Focus on what the data reveals, not how it was queried.
 
 ### Rules

--- a/datus/prompts/prompt_templates/visualization_with_context_1.0.j2
+++ b/datus/prompts/prompt_templates/visualization_with_context_1.0.j2
@@ -28,8 +28,8 @@ Based on ALL the information above, return ONLY a **JSON** object with the follo
 
 ### Data Context (required when SQL or User Question is provided)
 - "period": The time range extracted from WHERE conditions, formatted as "YYYY-MM-DD ~ YYYY-MM-DD" or a readable period like "Q4 2025". Return null if no time condition exists or no SQL is provided.
-- "filters": A list of human-readable filter descriptions extracted from WHERE conditions (exclude time range conditions). Use the user's question language to describe filters when possible, e.g. "BP购买" instead of "purchasesource = BATTLEPASS_PROGRESS". Return an empty list if no filters or no SQL is provided.
-- "insight": A concise analytical summary (2-4 sentences) of the data. Highlight key findings, comparisons, anomalies, or trends. Use the same language as the user's question. Focus on what the data reveals, not how it was queried.
+- "filters": A list of human-readable filter descriptions extracted from WHERE conditions (exclude time range conditions). Describe filters in natural language, e.g. "BP购买" instead of "purchasesource = BATTLEPASS_PROGRESS". Return an empty list if no filters or no SQL is provided.
+- "insight": A concise analytical summary (2-4 sentences) of the data. Highlight key findings, comparisons, anomalies, or trends. Focus on what the data reveals, not how it was queried.
 
 ### Rules
 - If there is a date/time column, prioritize "Line Chart" or "Bar Chart" and use date as x_col.
@@ -39,3 +39,10 @@ Based on ALL the information above, return ONLY a **JSON** object with the follo
 - For "filters", translate technical SQL conditions into user-friendly descriptions.
 - For "insight", analyze the actual data values, not just describe the query structure.
 - If neither SQL nor User Question is provided, omit "period", "filters", and "insight" from the response.
+{% if language_directive %}
+
+{{ language_directive }}
+- The values of "reason", "filters" and "insight" must follow this language; column names, SQL and JSON keys stay as-is.
+{% else %}
+- Write "reason", "filters" and "insight" in the same language as the User Question; fall back to English when no question is provided.
+{% endif %}

--- a/datus/tools/llms_tools/visualization_tool.py
+++ b/datus/tools/llms_tools/visualization_tool.py
@@ -23,6 +23,7 @@ from datus.models.base import LLMBaseModel
 from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.visualization import VisualizationInput, VisualizationOutput, VisualizationWithContextOutput
 from datus.tools.base import BaseTool
+from datus.utils.language_utils import resolve_language_name
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -77,8 +78,12 @@ class VisualizationTool(BaseTool):
             logger.debug(f"Lazy visualization model resolution failed: {exc}")
             return None
 
-    def execute(self, input_data: VisualizationInput) -> VisualizationOutput:
-        """Generate visualization recommendation using LLM if available, otherwise heuristics."""
+    def execute(self, input_data: VisualizationInput, language: Optional[str] = None) -> VisualizationOutput:
+        """Generate visualization recommendation using LLM if available, otherwise heuristics.
+
+        ``language`` pins the human-readable output (``reason``) to a language
+        code; it falls back to ``agent_config.language`` when unset.
+        """
         if not isinstance(input_data, VisualizationInput):
             raise TypeError("VisualizationTool expects VisualizationInput as input data.")
 
@@ -96,7 +101,7 @@ class VisualizationTool(BaseTool):
         result = None
         if self.model:
             try:
-                result = self._llm_based_recommendation(dataframe)
+                result = self._llm_based_recommendation(dataframe, language=language)
             except Exception as exc:
                 logger.warning(f"LLM visualization recommendation failed, falling back to heuristics: {exc}")
 
@@ -110,11 +115,16 @@ class VisualizationTool(BaseTool):
         input_data: VisualizationInput,
         sql: Optional[str] = None,
         user_question: Optional[str] = None,
+        language: Optional[str] = None,
     ) -> VisualizationWithContextOutput:
         """Generate visualization with data context (showing, period, filters, insight).
 
         Uses a single merged LLM call. Falls back to rule-based heuristics
         (without context metadata) if the LLM call fails.
+
+        ``language`` pins the human-readable output (``reason``, ``filters``,
+        ``insight``) to a language code; it falls back to
+        ``agent_config.language`` when unset.
         """
         if not isinstance(input_data, VisualizationInput):
             raise TypeError("VisualizationTool expects VisualizationInput as input data.")
@@ -147,7 +157,7 @@ class VisualizationTool(BaseTool):
         # Try context-aware LLM call
         if self.model:
             try:
-                result = self._llm_with_context(dataframe, sql, user_question)
+                result = self._llm_with_context(dataframe, sql, user_question, language=language)
                 if result is not None:
                     return result
             except Exception as exc:
@@ -172,6 +182,7 @@ class VisualizationTool(BaseTool):
         df: pd.DataFrame,
         sql: Optional[str],
         user_question: Optional[str],
+        language: Optional[str] = None,
     ) -> Optional[VisualizationWithContextOutput]:
         """Single LLM call returning chart config + context metadata."""
         prompt = get_prompt_manager(agent_config=self.agent_config).render_template(
@@ -181,6 +192,7 @@ class VisualizationTool(BaseTool):
             data_preview=self._format_data_preview(df),
             sql=sql or "",
             user_question=user_question or "",
+            language_directive=self._language_directive(language),
         )
 
         response = self.model.generate_with_json_output(prompt)
@@ -229,6 +241,35 @@ class VisualizationTool(BaseTool):
         )
 
     # ------------------------------------------------------------------ #
+    # Response language
+    # ------------------------------------------------------------------ #
+    def _language_directive(self, language: Optional[str]) -> str:
+        """Render the ``response_language`` section, or ``""`` when unpinned.
+
+        This tool is a standalone LLM call with no system prompt, so the
+        directive every agentic node gets injected has to be restated in the
+        prompt itself — otherwise an English template is answered in English
+        regardless of the language the caller asked for.
+        """
+        raw = language or getattr(self.agent_config, "language", None)
+        code = str(raw).strip() if raw else ""
+        if not code:
+            return ""
+        language_name = resolve_language_name(code)
+        try:
+            section = get_prompt_manager(agent_config=self.agent_config).render_template(
+                "response_language",
+                version=None,
+                language_code=code,
+                language_name=language_name,
+            )
+        except Exception as exc:
+            # A render failure must not silently drop a pinned language.
+            logger.warning(f"Failed to render response_language template: {exc}")
+            return f"# Response Language\n- Use: {language_name} ({code})"
+        return section.strip() or f"# Response Language\n- Use: {language_name} ({code})"
+
+    # ------------------------------------------------------------------ #
     # Data preparation
     # ------------------------------------------------------------------ #
     def _convert_to_dataframe(self, data: Any) -> Optional[pd.DataFrame]:
@@ -253,13 +294,16 @@ class VisualizationTool(BaseTool):
     # ------------------------------------------------------------------ #
     # LLM recommendation
     # ------------------------------------------------------------------ #
-    def _llm_based_recommendation(self, df: pd.DataFrame) -> Optional[VisualizationOutput]:
+    def _llm_based_recommendation(
+        self, df: pd.DataFrame, language: Optional[str] = None
+    ) -> Optional[VisualizationOutput]:
         """Use LLM to recommend visualization configuration."""
         prompt = get_prompt_manager(agent_config=self.agent_config).render_template(
             self.PROMPT_TEMPLATE,
             version=self.prompt_version,
             columns_info=self._format_columns_info(df),
             data_preview=self._format_data_preview(df),
+            language_directive=self._language_directive(language),
         )
 
         response = self.model.generate_with_json_output(prompt)

--- a/datus/tools/llms_tools/visualization_tool.py
+++ b/datus/tools/llms_tools/visualization_tool.py
@@ -251,8 +251,11 @@ class VisualizationTool(BaseTool):
         prompt itself — otherwise an English template is answered in English
         regardless of the language the caller asked for.
         """
-        raw = language or getattr(self.agent_config, "language", None)
-        code = str(raw).strip() if raw else ""
+        # A blank explicit override is "unset", not "no language" — otherwise a
+        # caller sending an empty field would suppress the configured default.
+        explicit = str(language).strip() if language else ""
+        fallback = getattr(self.agent_config, "language", None)
+        code = explicit or (str(fallback).strip() if fallback else "")
         if not code:
             return ""
         language_name = resolve_language_name(code)

--- a/datus/utils/language_utils.py
+++ b/datus/utils/language_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Shared helpers for the pinned response language.
+
+Lives in ``utils`` rather than next to the agentic nodes because standalone
+LLM calls outside the node stack (e.g. the visualization tool) need the same
+code → name mapping without importing the node layer.
+"""
+
+from typing import Dict, Optional
+
+LANGUAGE_NAME_MAP: Dict[str, str] = {
+    "en": "English",
+    "zh": "Chinese",
+    "zh-cn": "Chinese",
+    "zh-tw": "Traditional Chinese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "it": "Italian",
+}
+
+
+def resolve_language_name(code: Optional[str]) -> str:
+    """Map a language code (e.g. ``"zh"``) to a human-readable name.
+
+    Unknown codes are returned as-is so operators can plug in custom values
+    without a code change.
+    """
+    if not code:
+        return "English"
+    return LANGUAGE_NAME_MAP.get(code.strip().lower(), code)

--- a/tests/unit_tests/api/routes/test_visualization_routes.py
+++ b/tests/unit_tests/api/routes/test_visualization_routes.py
@@ -165,12 +165,14 @@ class TestServiceDelegation:
         valid_payload["chart_type"] = "Bar"
         valid_payload["sql"] = "SELECT date, sales FROM t"
         valid_payload["user_question"] = "Show me sales"
+        valid_payload["language"] = "zh-CN"
         client.post("/api/v1/data_visualization", json=valid_payload)
 
         kw = svc.visualization.generate.call_args.kwargs
         assert kw["chart_type"] == "Bar"
         assert kw["sql"] == "SELECT date, sales FROM t"
         assert kw["user_question"] == "Show me sales"
+        assert kw["language"] == "zh-CN"
 
     def test_optional_params_default_to_none(self, valid_payload):
         from datus.api.deps import get_datus_service
@@ -186,3 +188,4 @@ class TestServiceDelegation:
         assert kw["chart_type"] is None
         assert kw["sql"] is None
         assert kw["user_question"] is None
+        assert kw["language"] is None

--- a/tests/unit_tests/api/services/test_visualization_service.py
+++ b/tests/unit_tests/api/services/test_visualization_service.py
@@ -367,6 +367,19 @@ class TestResponseLanguage:
         assert first is second
         mock_cls.return_value.execute.assert_called_once()
 
+    def test_agent_config_language_change_busts_the_cache(self, mock_agent_config, csv_data):
+        """Without an override the tool resolves agent_config.language — so must the key."""
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+
+            mock_agent_config.language = "en"
+            svc.generate(csv_data)
+            mock_agent_config.language = "zh-CN"
+            svc.generate(csv_data)
+
+        assert mock_cls.return_value.execute.call_count == 2
+
     def test_language_defaults_to_none(self, mock_agent_config, csv_data):
         with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
             mock_cls.return_value.execute.return_value = _mock_tool_result()

--- a/tests/unit_tests/api/services/test_visualization_service.py
+++ b/tests/unit_tests/api/services/test_visualization_service.py
@@ -323,3 +323,54 @@ class TestCaching:
                 assert mock_cls.return_value.execute.call_count == 4
         finally:
             viz_mod._MAX_CACHE_SIZE = original
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. Response language
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestResponseLanguage:
+    def test_language_forwarded_to_tool(self, mock_agent_config, csv_data):
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data, language="zh-CN")
+
+        assert mock_cls.return_value.execute.call_args.kwargs["language"] == "zh-CN"
+
+    def test_language_forwarded_to_tool_with_context(self, mock_agent_config, csv_data):
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls, patch(_TOOL_PROMPT_PATH):
+            mock_cls.return_value.execute_with_context.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data, sql="SELECT a", language="zh-CN")
+
+        assert mock_cls.return_value.execute_with_context.call_args.kwargs["language"] == "zh-CN"
+
+    def test_different_language_not_cached(self, mock_agent_config, csv_data):
+        """The same dataset asked for in two languages must not share one cached answer."""
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data, language="en")
+            svc.generate(csv_data, language="zh-CN")
+
+        assert mock_cls.return_value.execute.call_count == 2
+
+    def test_same_language_hits_cache(self, mock_agent_config, csv_data):
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            first = svc.generate(csv_data, language="zh-CN")
+            second = svc.generate(csv_data, language="zh-CN")
+
+        assert first is second
+        mock_cls.return_value.execute.assert_called_once()
+
+    def test_language_defaults_to_none(self, mock_agent_config, csv_data):
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data)
+
+        assert mock_cls.return_value.execute.call_args.kwargs["language"] is None

--- a/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
+++ b/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
@@ -412,3 +412,122 @@ class TestLlmBasedRecommendation:
 
         # x_col should fall back to a column that exists
         assert result.x_col == "cat"
+
+
+class TestLanguageDirective:
+    """The tool is a standalone LLM call, so a pinned language has to reach the prompt."""
+
+    def test_no_language_returns_empty_directive(self):
+        tool = _make_tool()
+        assert tool._language_directive(None) == ""
+
+    def test_blank_language_returns_empty_directive(self):
+        tool = _make_tool()
+        assert tool._language_directive("   ") == ""
+
+    def test_explicit_language_renders_template(self):
+        tool = _make_tool()
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "# Response Language\n- Use: Chinese (zh)"
+            directive = tool._language_directive("zh")
+
+        kw = mock_gpm.return_value.render_template.call_args.kwargs
+        assert kw["language_code"] == "zh"
+        assert kw["language_name"] == "Chinese"
+        assert directive == "# Response Language\n- Use: Chinese (zh)"
+
+    def test_falls_back_to_agent_config_language(self):
+        config = MagicMock()
+        config.language = "ja"
+        tool = VisualizationTool(agent_config=config, model=MagicMock())
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "directive"
+            tool._language_directive(None)
+
+        assert mock_gpm.return_value.render_template.call_args.kwargs["language_name"] == "Japanese"
+
+    def test_explicit_language_wins_over_agent_config(self):
+        config = MagicMock()
+        config.language = "ja"
+        tool = VisualizationTool(agent_config=config, model=MagicMock())
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "directive"
+            tool._language_directive("zh-CN")
+
+        kw = mock_gpm.return_value.render_template.call_args.kwargs
+        assert kw["language_code"] == "zh-CN"
+        assert kw["language_name"] == "Chinese"
+
+    def test_render_failure_falls_back_to_minimal_directive(self):
+        tool = _make_tool()
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.side_effect = Exception("template missing")
+            directive = tool._language_directive("zh")
+
+        assert directive == "# Response Language\n- Use: Chinese (zh)"
+
+    def test_empty_render_falls_back_to_minimal_directive(self):
+        tool = _make_tool()
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "   "
+            directive = tool._language_directive("fr")
+
+        assert directive == "# Response Language\n- Use: French (fr)"
+
+    def test_execute_passes_directive_into_prompt(self):
+        mock_model = MagicMock()
+        mock_model.generate_with_json_output.return_value = {
+            "chart_type": "Bar Chart",
+            "x_col": "cat",
+            "y_cols": ["val"],
+            "reason": "bar",
+        }
+        tool = _make_tool(model=mock_model)
+        df = pd.DataFrame({"cat": ["A", "B"], "val": [1, 2]})
+
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "directive"
+            tool.execute(_make_input(df), language="zh")
+
+        # The last render is the prompt itself; the directive render precedes it.
+        prompt_call = mock_gpm.return_value.render_template.call_args_list[-1]
+        assert prompt_call.kwargs["language_directive"] == "directive"
+
+    def test_execute_with_context_passes_directive_into_prompt(self):
+        mock_model = MagicMock()
+        mock_model.generate_with_json_output.return_value = {
+            "chart_type": "Bar Chart",
+            "x_col": "cat",
+            "y_cols": ["val"],
+            "reason": "bar",
+            "period": None,
+            "filters": [],
+            "insight": "grew",
+        }
+        tool = _make_tool(model=mock_model)
+        df = pd.DataFrame({"cat": ["A", "B"], "val": [1, 2]})
+
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "directive"
+            result = tool.execute_with_context(_make_input(df), sql="SELECT 1", language="zh")
+
+        prompt_call = mock_gpm.return_value.render_template.call_args_list[-1]
+        assert prompt_call.kwargs["language_directive"] == "directive"
+        assert result.success is True
+
+    def test_prompt_carries_empty_directive_when_unpinned(self):
+        mock_model = MagicMock()
+        mock_model.generate_with_json_output.return_value = {
+            "chart_type": "Bar Chart",
+            "x_col": "cat",
+            "y_cols": ["val"],
+            "reason": "bar",
+        }
+        tool = _make_tool(model=mock_model)
+        df = pd.DataFrame({"cat": ["A", "B"], "val": [1, 2]})
+
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "prompt"
+            tool.execute(_make_input(df))
+
+        assert mock_gpm.return_value.render_template.call_args.kwargs["language_directive"] == ""

--- a/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
+++ b/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
@@ -446,6 +446,19 @@ class TestLanguageDirective:
 
         assert mock_gpm.return_value.render_template.call_args.kwargs["language_name"] == "Japanese"
 
+    def test_blank_explicit_language_falls_back_to_agent_config(self):
+        """A blank override is 'unset' — it must not suppress the configured default."""
+        config = MagicMock()
+        config.language = "ja"
+        tool = VisualizationTool(agent_config=config, model=MagicMock())
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "directive"
+            tool._language_directive("   ")
+
+        kw = mock_gpm.return_value.render_template.call_args.kwargs
+        assert kw["language_code"] == "ja"
+        assert kw["language_name"] == "Japanese"
+
     def test_explicit_language_wins_over_agent_config(self):
         config = MagicMock()
         config.language = "ja"

--- a/tests/unit_tests/utils/test_language_utils.py
+++ b/tests/unit_tests/utils/test_language_utils.py
@@ -1,0 +1,34 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for datus/utils/language_utils.py — CI level, zero external deps."""
+
+import pytest
+
+from datus.utils.language_utils import LANGUAGE_NAME_MAP, resolve_language_name
+
+
+class TestResolveLanguageName:
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            ("en", "English"),
+            ("zh", "Chinese"),
+            ("zh-cn", "Chinese"),
+            ("zh-tw", "Traditional Chinese"),
+            ("ja", "Japanese"),
+        ],
+    )
+    def test_known_codes(self, code, expected):
+        assert resolve_language_name(code) == expected
+
+    @pytest.mark.parametrize("code", ["EN", "ZH-CN", " zh ", "Ja"])
+    def test_case_and_whitespace_insensitive(self, code):
+        assert resolve_language_name(code) == LANGUAGE_NAME_MAP[code.strip().lower()]
+
+    def test_unknown_code_returned_as_is(self):
+        assert resolve_language_name("xx-yy") == "xx-yy"
+
+    @pytest.mark.parametrize("code", ["", None])
+    def test_empty_defaults_to_english(self, code):
+        assert resolve_language_name(code) == "English"


### PR DESCRIPTION
## Why

`/api/v1/data_visualization` never consumed the caller's language. Every agentic node gets the `response_language` directive injected from `agent_config.language` (and `/chat/stream` can override it per request via `StreamChatInput.language`), but the visualization tool is a standalone LLM call with no system prompt — so the directive never reached it.

Result: `reason`, `filters` and `insight` came back in whatever language the English prompt template nudged the model toward, regardless of the language the user is actually working in. The Semantic Hub chart tab (which proxies through the backend's `/hub/visualization`) had no way to ask for a language at all.

## Solution

- `DataVisualizationRequest.language` — optional per-request override, mirroring `StreamChatInput.language`. Unset keeps the yaml-level `agent.language` default.
- The route passes it to `DataVisualizationService.generate`, which threads it into the tool **and folds it into the cache key** — the same dataset asked for in two languages must not share one cached answer.
- `VisualizationTool.execute` / `execute_with_context` take `language` and render the shared `response_language` template into the prompt, falling back to `agent_config.language` when the caller omits it. A template-render failure degrades to a minimal `# Response Language` directive rather than silently dropping a pinned language (same reasoning as `_finalize_language_directive` in the visual-artifact node).
- Both visualization prompt templates gained a `language_directive` block. When it is absent the context template keeps the old behavior explicitly ("same language as the User Question"); the two ad-hoc "use the user's question language" clauses moved into that one place so a pinned language cannot conflict with them.
- The `_LANGUAGE_NAME_MAP` / `_resolve_language_name` pair moved out of `agentic_node.py` into `datus/utils/language_utils.py` so a tool can reuse it without importing the node layer. `agentic_node` re-imports it under the old private name, so existing callers are untouched.

Frontends send it through the matching Datus-backend / Datus-saas changes; unset stays backward-compatible everywhere.

## Test Cases

Unit tests only — this is a prompt/plumbing change with no external dependency:

- `tests/unit_tests/utils/test_language_utils.py` (new) — code → name resolution, case/whitespace handling, unknown codes passed through, empty → English.
- `tests/unit_tests/tools/llms_tools/test_visualization_tool.py` — new `TestLanguageDirective`: unpinned → empty directive, explicit code wins over `agent_config.language`, render failure and empty render both fall back to the minimal directive, and both `execute` / `execute_with_context` put the directive into the rendered prompt.
- `tests/unit_tests/api/services/test_visualization_service.py` — new `TestResponseLanguage`: language forwarded on both tool paths, different languages miss the cache, same language hits it.
- `tests/unit_tests/api/routes/test_visualization_routes.py` — the delegation tests now assert `language` in both the supplied and the omitted case.

`ci/run-pr-tests.py upstream/main`: diff coverage 100%; `ci/audit_tests.py --diff-only` reports P0=0. The failures it reports (`tests/integration/storage/test_platform_doc*`, `test_doc_search`, `tests/integration/cli/*`, `utils/test_compress_utils`) reproduce on a clean checkout of this branch's base — they need locally built test data and are unrelated to this change.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Visualization requests can now specify a preferred response language.
  * Chart recommendations and explanations are generated in the selected language while preserving column names and JSON keys.
  * Language codes are normalized with English used as the default.

* **Bug Fixes**
  * Prevented visualization results from being incorrectly reused across different response languages.
  * Added fallback handling when language-specific instructions cannot be rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visualization requests can now specify a preferred response language.
  * Chart recommendations and explanations are generated in the selected language while preserving column names and JSON keys.
  * Language codes are normalized, with English used by default.

* **Bug Fixes**
  * Prevented visualization results from being incorrectly reused across different response languages.
  * Added fallback handling when language-specific instructions cannot be rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->