### PR TITLE
[Feature] apply the configured tool filter to agent-facing server instances

### DIFF
--- a/datus/api/services/mcp_service.py
+++ b/datus/api/services/mcp_service.py
@@ -5,7 +5,6 @@ Stateless per-request service that wraps MCPManager with a tenant-specific
 config path derived from the agent_config.
 """
 
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 from datus.api.models.base_models import Result
@@ -36,24 +35,14 @@ class MCPService:
 
     @staticmethod
     def _create_manager(agent_config: AgentConfig) -> MCPManager:
-        """Create an MCPManager whose config_path points to the tenant's home."""
-        config_path = Path(agent_config.home) / "conf" / ".mcp.json"
-        config_path.parent.mkdir(parents=True, exist_ok=True)
+        """Create an MCPManager for this tenant's agent config.
 
-        manager = MCPManager.__new__(MCPManager)
-        # Replicate the fields that __init__ normally sets, but with our
-        # custom config_path instead of the global singleton path.
-        import threading
-
-        from datus.tools.mcp_tools.mcp_config import MCPConfig
-
-        manager.config_path = config_path
-        manager.config = MCPConfig()
-        manager._lock = threading.Lock()
-        manager.load_config()
-
-        logger.info(f"Created MCPManager with config path: {config_path}")
-        return manager
+        Handing it the config is enough: the manager takes the servers from
+        ``services.mcp_servers`` when the host supplies them in memory, and
+        otherwise falls back to ``{agent.home}/conf/.mcp.json`` — the same
+        tenant-scoped path this used to build by hand.
+        """
+        return MCPManager(agent_config=agent_config)
 
     # ------------------------------------------------------------------
     # Server CRUD

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -361,6 +361,11 @@ class ServicesConfig:
     semantic_layer: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     bi_platforms: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     schedulers: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    # MCP servers in the `.mcp.json` shape, keyed by server name. A host that
+    # owns these definitions (the SaaS backend builds them from its database)
+    # passes them here instead of writing a file, so credentials stay in memory
+    # and a change to one is visible to config fingerprinting.
+    mcp_servers: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
     @property
     def default_datasource(self) -> Optional[str]:
@@ -397,6 +402,7 @@ class ServicesConfig:
             semantic_layer=raw.get("semantic_layer", {}),
             bi_platforms=bi_platforms_raw or {},
             schedulers=raw.get("schedulers", {}),
+            mcp_servers=raw.get("mcp_servers") or {},
         )
 
 

--- a/datus/tools/mcp_tools/mcp_manager.py
+++ b/datus/tools/mcp_tools/mcp_manager.py
@@ -81,8 +81,15 @@ class MCPManager:
     - Status monitoring and health checks
     - Config file persistence
 
-    Configuration path:
-    - Fixed at {agent.home}/conf/.mcp.json (default: ~/.datus/conf/.mcp.json)
+    Two configuration sources, in this order:
+
+    1. ``agent_config.services["mcp_servers"]`` — servers supplied in memory by
+       the host (the SaaS backend assembles them from its database). Nothing is
+       read from or written to disk, so credentials never land on a shared
+       volume and there is no file/state to drift out of sync. Mutating calls
+       are refused: the host owns the definitions.
+    2. ``{agent.home}/conf/.mcp.json`` — the standalone/CLI source, editable
+       through this manager as before.
     """
 
     def __init__(
@@ -94,9 +101,9 @@ class MCPManager:
         """
         Initialize the MCP manager.
 
-        MCP configuration is fixed at {agent.home}/conf/.mcp.json.
-        Configure agent.home in agent.yml to change the root directory.
-        The path cannot be overridden to ensure consistent configuration management.
+        The file path is fixed at {agent.home}/conf/.mcp.json — configure
+        agent.home to move it. It is only consulted when the agent config does
+        not carry MCP servers itself.
         """
         from datus.utils.path_manager import get_path_manager
 
@@ -107,8 +114,32 @@ class MCPManager:
         self.config: MCPConfig = MCPConfig()
         self._lock = threading.Lock()
 
-        # Load existing config
-        self.load_config()
+        servers = self._servers_from_agent_config(agent_config)
+        self.externally_managed = servers is not None
+        if self.externally_managed:
+            self.config = MCPConfig.from_config_format({"mcpServers": servers})
+            logger.info(f"Loaded {len(self.config.servers)} MCP server(s) from the agent config")
+        else:
+            self.load_config()
+
+    @staticmethod
+    def _servers_from_agent_config(agent_config: Optional[Any]) -> Optional[dict]:
+        """Servers the host passed in memory, or None to fall back to the file.
+
+        An empty/absent section means "this host does not manage MCP", not
+        "this host manages zero servers" — otherwise simply having an agent
+        config would hide a CLI user's own `.mcp.json`.
+        """
+        services = getattr(agent_config, "services", None)
+        if services is None:
+            return None
+
+        # ServicesConfig dataclass in a loaded config; a plain dict in tests and
+        # in any host that assembles the section by hand.
+        servers = services.get("mcp_servers") if isinstance(services, dict) else getattr(services, "mcp_servers", None)
+        if isinstance(servers, dict) and servers:
+            return servers
+        return None
 
     def load_config(self) -> bool:
         """
@@ -162,6 +193,21 @@ class MCPManager:
             logger.error(f"Error saving config: {e}")
             return False
 
+    _EXTERNALLY_MANAGED_MSG = (
+        "MCP servers are managed by the host application for this project and cannot be changed here"
+    )
+
+    def _refuse_if_externally_managed(self) -> Optional[Tuple[bool, str]]:
+        """Block writes when the servers came from the agent config.
+
+        Persisting them would write a file that nothing reads back — the host
+        rebuilds the in-memory section on every request — so the edit would
+        look like it worked and quietly disappear.
+        """
+        if self.externally_managed:
+            return False, self._EXTERNALLY_MANAGED_MSG
+        return None
+
     def add_server(self, config: AnyMCPServerConfig) -> Tuple[bool, str]:
         """
         Add a new MCP server config.
@@ -172,6 +218,10 @@ class MCPManager:
         Returns:
             Tuple of (success, message)
         """
+        refusal = self._refuse_if_externally_managed()
+        if refusal:
+            return refusal
+
         try:
             with self._lock:
                 if config.name in self.config.servers:
@@ -199,6 +249,10 @@ class MCPManager:
         Returns:
             Tuple of (success, message)
         """
+        refusal = self._refuse_if_externally_managed()
+        if refusal:
+            return refusal
+
         try:
             with self._lock:
                 if name not in self.config.servers:
@@ -343,6 +397,10 @@ class MCPManager:
 
     def set_tool_filter(self, server_name: str, tool_filter: ToolFilterConfig) -> Tuple[bool, str]:
         """Set tool filter configuration for a server."""
+        refusal = self._refuse_if_externally_managed()
+        if refusal:
+            return refusal
+
         try:
             with self._lock:
                 config = self.get_server_config(server_name)

--- a/datus/tools/mcp_tools/mcp_manager.py
+++ b/datus/tools/mcp_tools/mcp_manager.py
@@ -16,10 +16,11 @@ import threading
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from agents import Agent, RunContextWrapper, Usage
-from agents.mcp import MCPServerStdioParams
 
-# Aliased on purpose: this module defines its own ``create_static_tool_filter``
-# returning Datus' pydantic model, which the SDK does not understand.
+# ``create_static_tool_filter`` is aliased on purpose: this module defines its
+# own function of that name returning Datus' pydantic model, which the SDK does
+# not understand. ``ToolFilter`` is the SDK's own union and already covers None.
+from agents.mcp import MCPServerStdioParams, ToolFilter
 from agents.mcp import create_static_tool_filter as sdk_static_tool_filter
 from agents.mcp.server import MCPServerSse, MCPServerSseParams, MCPServerStreamableHttp, MCPServerStreamableHttpParams
 
@@ -463,7 +464,7 @@ class MCPManager:
             logger.error(f"Failed to create server instance: {e}")
             return None, {"error": str(e)}
 
-    def _sdk_tool_filter(self, config: AnyMCPServerConfig):
+    def _sdk_tool_filter(self, config: AnyMCPServerConfig) -> ToolFilter:
         """Translate our ``ToolFilterConfig`` into the SDK's static filter.
 
         Without this the filter is only honoured by ``MCPManager.list_tools``
@@ -484,7 +485,9 @@ class MCPManager:
         # ends up exposing zero tools when handed anything else.
         return sdk_static_tool_filter(allowed_tool_names=allowed, blocked_tool_names=blocked)
 
-    def _create_stdio_server(self, config: STDIOServerConfig, expanded_config: Dict[str, Any], tool_filter=None):
+    def _create_stdio_server(
+        self, config: STDIOServerConfig, expanded_config: Dict[str, Any], tool_filter: ToolFilter = None
+    ):
         """Create STDIO server instance."""
         env_vars = config.env or {}
 
@@ -506,7 +509,7 @@ class MCPManager:
         }
         return server_instance, details
 
-    def _create_sse_server(self, expanded_config: Dict[str, Any], tool_filter=None):
+    def _create_sse_server(self, expanded_config: Dict[str, Any], tool_filter: ToolFilter = None):
         """Create SSE server instance."""
         url = expanded_config.get("url")
         if not url:
@@ -521,7 +524,7 @@ class MCPManager:
         details = {"url": url, "headers_count": len(headers) if headers else 0, "timeout": timeout}
         return server_instance, details
 
-    def _create_http_server(self, expanded_config: Dict[str, Any], tool_filter=None):
+    def _create_http_server(self, expanded_config: Dict[str, Any], tool_filter: ToolFilter = None):
         """Create HTTP server instance."""
         url = expanded_config.get("url")
         if not url:

--- a/datus/tools/mcp_tools/mcp_manager.py
+++ b/datus/tools/mcp_tools/mcp_manager.py
@@ -17,6 +17,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from agents import Agent, RunContextWrapper, Usage
 from agents.mcp import MCPServerStdioParams
+
+# Aliased on purpose: this module defines its own ``create_static_tool_filter``
+# returning Datus' pydantic model, which the SDK does not understand.
+from agents.mcp import create_static_tool_filter as sdk_static_tool_filter
 from agents.mcp.server import MCPServerSse, MCPServerSseParams, MCPServerStreamableHttp, MCPServerStreamableHttpParams
 
 from datus.tools.mcp_tools.mcp_config import (
@@ -246,7 +250,7 @@ class MCPManager:
             return False, error_msg, {}
 
         # Create server instance
-        server_instance, connectivity_details = self._create_server_instance(config)
+        server_instance, connectivity_details = self._create_server_instance(config, with_tool_filter=False)
         if not server_instance:
             error_msg = connectivity_details.get("error", "Failed to create server instance")
             return False, f"Failed to create server instance for '{name}': {error_msg}", connectivity_details
@@ -270,7 +274,7 @@ class MCPManager:
                 return False, error_msg, []
 
             # Create server instance
-            server_instance, details = self._create_server_instance(config)
+            server_instance, details = self._create_server_instance(config, with_tool_filter=False)
             if not server_instance:
                 error_msg = details.get("error", "Failed to create server instance")
                 return False, f"Failed to connect to server '{server_name}': {error_msg}", []
@@ -371,26 +375,58 @@ class MCPManager:
             logger.error(f"Error getting tool filter for server {server_name}: {e}")
             return False, f"Error getting tool filter: {e}", None
 
-    def _create_server_instance(self, config: AnyMCPServerConfig) -> Tuple[Any, Dict[str, Any]]:
-        """Create MCP server instance based on config type."""
+    def _create_server_instance(
+        self, config: AnyMCPServerConfig, with_tool_filter: bool = True
+    ) -> Tuple[Any, Dict[str, Any]]:
+        """Create MCP server instance based on config type.
+
+        ``with_tool_filter`` binds the configured filter to the instance so an
+        agent handed this server can only ever see the allowed tools. The
+        management APIs pass ``False``: they must be able to report the
+        server's full surface (and do their own filtering afterwards), or a
+        blocked tool could never be re-enabled from the UI.
+        """
         try:
             # Expand environment variables in config
             config_dict = config.model_dump()
             expanded_config = expand_config_env_vars(config_dict)
 
+            tool_filter = self._sdk_tool_filter(config) if with_tool_filter else None
+
             if config.type == MCPServerType.STDIO:
-                return self._create_stdio_server(config, expanded_config)
+                return self._create_stdio_server(config, expanded_config, tool_filter)
             elif config.type == MCPServerType.SSE:
-                return self._create_sse_server(expanded_config)
+                return self._create_sse_server(expanded_config, tool_filter)
             elif config.type == MCPServerType.HTTP:
-                return self._create_http_server(expanded_config)
+                return self._create_http_server(expanded_config, tool_filter)
             else:
                 return None, {"error": f"Unsupported server type: {config.type}"}
         except Exception as e:
             logger.error(f"Failed to create server instance: {e}")
             return None, {"error": str(e)}
 
-    def _create_stdio_server(self, config: STDIOServerConfig, expanded_config: Dict[str, Any]):
+    def _sdk_tool_filter(self, config: AnyMCPServerConfig):
+        """Translate our ``ToolFilterConfig`` into the SDK's static filter.
+
+        Without this the filter is only honoured by ``MCPManager.list_tools``
+        — i.e. by the management API — while an agent handed the raw server
+        instance still sees, and can call, every tool the server exposes.
+        """
+        tool_filter = getattr(config, "tool_filter", None)
+        if not tool_filter or not tool_filter.enabled:
+            return None
+
+        allowed = tool_filter.allowed_tool_names
+        blocked = tool_filter.blocked_tool_names
+        if allowed is None and blocked is None:
+            return None
+
+        # ``sdk_static_tool_filter``, not this module's same-named helper: the
+        # SDK only understands its own TypedDict (or a callable) and silently
+        # ends up exposing zero tools when handed anything else.
+        return sdk_static_tool_filter(allowed_tool_names=allowed, blocked_tool_names=blocked)
+
+    def _create_stdio_server(self, config: STDIOServerConfig, expanded_config: Dict[str, Any], tool_filter=None):
         """Create STDIO server instance."""
         env_vars = config.env or {}
 
@@ -400,7 +436,11 @@ class MCPManager:
             env=env_vars,
         )
 
-        server_instance = SilentMCPServerStdio(params=server_params, client_session_timeout_seconds=60)
+        server_instance = SilentMCPServerStdio(
+            params=server_params,
+            client_session_timeout_seconds=60,
+            tool_filter=tool_filter,
+        )
         details = {
             "command": expanded_config.get("command"),
             "args": expanded_config.get("args", []),
@@ -408,7 +448,7 @@ class MCPManager:
         }
         return server_instance, details
 
-    def _create_sse_server(self, expanded_config: Dict[str, Any]):
+    def _create_sse_server(self, expanded_config: Dict[str, Any], tool_filter=None):
         """Create SSE server instance."""
         url = expanded_config.get("url")
         if not url:
@@ -419,11 +459,11 @@ class MCPManager:
         headers["Accept"] = "text/event-stream"
 
         server_params = MCPServerSseParams(url=url, headers=headers, timeout=timeout, sse_read_timeout=timeout)
-        server_instance = MCPServerSse(params=server_params, client_session_timeout_seconds=60)
+        server_instance = MCPServerSse(params=server_params, client_session_timeout_seconds=60, tool_filter=tool_filter)
         details = {"url": url, "headers_count": len(headers) if headers else 0, "timeout": timeout}
         return server_instance, details
 
-    def _create_http_server(self, expanded_config: Dict[str, Any]):
+    def _create_http_server(self, expanded_config: Dict[str, Any], tool_filter=None):
         """Create HTTP server instance."""
         url = expanded_config.get("url")
         if not url:
@@ -442,7 +482,9 @@ class MCPManager:
             sse_read_timeout=timeout,
             terminate_on_close=True,
         )
-        server_instance = MCPServerStreamableHttp(params=server_params, client_session_timeout_seconds=60)
+        server_instance = MCPServerStreamableHttp(
+            params=server_params, client_session_timeout_seconds=60, tool_filter=tool_filter
+        )
         details = {"url": url, "headers_count": len(merged_headers), "timeout": timeout}
         return server_instance, details
 

--- a/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
+++ b/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from datus.configuration.agent_config import ServicesConfig
 from datus.tools.mcp_tools.mcp_config import (
     HTTPServerConfig,
     MCPConfig,
@@ -764,6 +765,21 @@ class TestServersFromAgentConfig:
 
         assert manager.externally_managed is False
         assert [s.name for s in manager.list_servers()] == ["local"]
+
+    def test_loads_through_the_real_services_config(self, tmp_path):
+        """The production path is AgentConfig -> ServicesConfig dataclass, not a
+        plain dict. Cover it end to end: an untyped section is dropped by
+        `from_dict` and never reaches the manager, which is exactly how this
+        broke once — every dict-shaped test stayed green while the agent read
+        nothing."""
+        services = ServicesConfig.from_dict({"mcp_servers": self.SERVERS})
+        assert services.mcp_servers == self.SERVERS
+
+        manager = self._manager(tmp_path, services)
+
+        assert manager.externally_managed is True
+        assert [s.name for s in manager.list_servers()] == ["github"]
+        assert not (tmp_path / "conf" / ".mcp.json").exists()
 
     def test_writes_are_refused(self, tmp_path):
         manager = self._manager(tmp_path, {"mcp_servers": self.SERVERS})

--- a/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
+++ b/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from datus.tools.mcp_tools.mcp_config import (
+    HTTPServerConfig,
     MCPConfig,
     MCPServerType,
     SSEServerConfig,
@@ -610,3 +611,59 @@ class TestCleanup:
         # cleanup() is a no-op finalizer; verify manager state remains intact
         assert isinstance(manager.config, MCPConfig)
         assert manager.config_path.name == ".mcp.json"
+
+
+# ---------------------------------------------------------------------------
+# Runtime tool filtering
+# ---------------------------------------------------------------------------
+
+
+class TestSdkToolFilter:
+    """The filter has to reach the SDK server instance, not just list_tools."""
+
+    def _http_config(self, tool_filter=None):
+        return HTTPServerConfig(name="srv", url="https://mcp.example.com/mcp", tool_filter=tool_filter)
+
+    def test_returns_none_without_filter(self, tmp_path):
+        manager = _make_manager(tmp_path)
+        assert manager._sdk_tool_filter(self._http_config()) is None
+
+    def test_returns_none_when_disabled(self, tmp_path):
+        manager = _make_manager(tmp_path)
+        tf = ToolFilterConfig(enabled=False, allowed_tool_names=["a"])
+        assert manager._sdk_tool_filter(self._http_config(tf)) is None
+
+    def test_returns_none_when_nothing_listed(self, tmp_path):
+        """enabled=True with no names is "no restriction", not "allow nothing"."""
+        manager = _make_manager(tmp_path)
+        tf = ToolFilterConfig(enabled=True)
+        assert manager._sdk_tool_filter(self._http_config(tf)) is None
+
+    def test_translates_to_the_sdk_shape(self, tmp_path):
+        """Must be the SDK's mapping — its own model would silently filter all."""
+        manager = _make_manager(tmp_path)
+        tf = ToolFilterConfig(enabled=True, allowed_tool_names=["a"], blocked_tool_names=["b"])
+
+        result = manager._sdk_tool_filter(self._http_config(tf))
+
+        assert isinstance(result, dict)
+        assert result["allowed_tool_names"] == ["a"]
+        assert result["blocked_tool_names"] == ["b"]
+
+    def test_agent_facing_instance_carries_the_filter(self, tmp_path):
+        manager = _make_manager(tmp_path)
+        tf = ToolFilterConfig(enabled=True, allowed_tool_names=["a"])
+
+        instance, _ = manager._create_server_instance(self._http_config(tf))
+
+        assert instance.tool_filter == {"allowed_tool_names": ["a"]}
+
+    def test_management_instance_sees_the_full_surface(self, tmp_path):
+        """list_tools/connectivity must report every tool, or a blocked one
+        could never be re-enabled from the UI."""
+        manager = _make_manager(tmp_path)
+        tf = ToolFilterConfig(enabled=True, allowed_tool_names=["a"])
+
+        instance, _ = manager._create_server_instance(self._http_config(tf), with_tool_filter=False)
+
+        assert instance.tool_filter is None

--- a/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
+++ b/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
@@ -667,3 +667,77 @@ class TestSdkToolFilter:
         instance, _ = manager._create_server_instance(self._http_config(tf), with_tool_filter=False)
 
         assert instance.tool_filter is None
+
+
+# ---------------------------------------------------------------------------
+# In-memory servers supplied by the host (SaaS)
+# ---------------------------------------------------------------------------
+
+
+class TestServersFromAgentConfig:
+    """The host passes servers through AgentConfig; nothing touches the disk."""
+
+    SERVERS = {
+        "github": {
+            "type": "http",
+            "url": "https://api.example.com/mcp/",
+            "headers": {"Authorization": "Bearer tok"},
+        }
+    }
+
+    def _manager(self, tmp_path: Path, services) -> MCPManager:
+        mock_path_manager = MagicMock()
+        config_file = tmp_path / "conf" / ".mcp.json"
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        mock_path_manager.mcp_config_path.return_value = config_file
+        mock_path_manager.ensure_dirs.return_value = None
+        agent_config = SimpleNamespace(services=services)
+
+        with patch("datus.utils.path_manager.get_path_manager", return_value=mock_path_manager):
+            return MCPManager(agent_config=agent_config)
+
+    def test_loads_servers_without_reading_the_file(self, tmp_path):
+        manager = self._manager(tmp_path, {"mcp_servers": self.SERVERS})
+
+        assert manager.externally_managed is True
+        assert [s.name for s in manager.list_servers()] == ["github"]
+        assert manager.get_server_config("github").headers == {"Authorization": "Bearer tok"}
+        # The file was never created, so credentials never hit the volume.
+        assert not (tmp_path / "conf" / ".mcp.json").exists()
+
+    def test_in_memory_servers_win_over_a_file(self, tmp_path):
+        config_file = tmp_path / "conf" / ".mcp.json"
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(json.dumps({"mcpServers": {"stale": {"type": "http", "url": "https://old"}}}))
+
+        manager = self._manager(tmp_path, {"mcp_servers": self.SERVERS})
+
+        assert [s.name for s in manager.list_servers()] == ["github"]
+
+    def test_empty_section_falls_back_to_the_file(self, tmp_path):
+        """An absent section means "this host doesn't manage MCP" — a CLI user's
+        own file must keep working."""
+        config_file = tmp_path / "conf" / ".mcp.json"
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(json.dumps({"mcpServers": {"local": {"type": "http", "url": "https://local"}}}))
+
+        manager = self._manager(tmp_path, {"mcp_servers": {}})
+
+        assert manager.externally_managed is False
+        assert [s.name for s in manager.list_servers()] == ["local"]
+
+    def test_writes_are_refused(self, tmp_path):
+        manager = self._manager(tmp_path, {"mcp_servers": self.SERVERS})
+
+        added, add_msg = manager.add_server(HTTPServerConfig(name="another", url="https://y/mcp"))
+        removed, remove_msg = manager.remove_server("github")
+        filtered, filter_msg = manager.set_tool_filter(
+            "github", ToolFilterConfig(enabled=True, allowed_tool_names=["a"])
+        )
+
+        # Persisting would write a file nothing reads back, so the edit would
+        # look like it worked and quietly disappear on the next request.
+        assert (added, removed, filtered) == (False, False, False)
+        for msg in (add_msg, remove_msg, filter_msg):
+            assert "managed by the host" in msg
+        assert [s.name for s in manager.list_servers()] == ["github"]

--- a/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
+++ b/tests/unit_tests/tools/mcp_tools/test_mcp_manager.py
@@ -363,6 +363,45 @@ class TestMCPManagerAsync:
         assert tools == []
 
     @pytest.mark.asyncio
+    async def test_check_connectivity_asks_for_the_unfiltered_surface(self, tmp_path):
+        """Connectivity reports a tool count, so it must see every tool."""
+        manager = _make_manager(tmp_path)
+        config = STDIOServerConfig(name="srv", command="python")
+        manager.config.add_server(config)
+
+        with patch.object(manager, "_create_server_instance", return_value=(None, {"error": "fail"})) as create:
+            await manager.check_connectivity("srv")
+
+        create.assert_called_once_with(config, with_tool_filter=False)
+
+    @pytest.mark.asyncio
+    async def test_list_tools_asks_for_the_unfiltered_surface(self, tmp_path):
+        """It filters afterwards, and `apply_filter=False` callers (the picker
+        UI) must be able to see a blocked tool — otherwise it could never be
+        re-enabled."""
+        manager = _make_manager(tmp_path)
+        config = STDIOServerConfig(name="srv", command="python")
+        manager.config.add_server(config)
+
+        with patch.object(manager, "_create_server_instance", return_value=(None, {"error": "fail"})) as create:
+            await manager.list_tools("srv")
+
+        create.assert_called_once_with(config, with_tool_filter=False)
+
+    @pytest.mark.asyncio
+    async def test_call_tool_keeps_the_filter_bound(self, tmp_path):
+        """Defence in depth: call_tool already refuses a blocked name, and the
+        instance stays filtered on top of that."""
+        manager = _make_manager(tmp_path)
+        config = STDIOServerConfig(name="srv", command="python")
+        manager.config.add_server(config)
+
+        with patch.object(manager, "_create_server_instance", return_value=(None, {"error": "fail"})) as create:
+            await manager.call_tool("srv", "some_tool", {})
+
+        create.assert_called_once_with(config)
+
+    @pytest.mark.asyncio
     async def test_list_tools_success_with_filter(self, tmp_path):
         manager = _make_manager(tmp_path)
         tf = ToolFilterConfig(allowed_tool_names=["read"])


### PR DESCRIPTION
A server's `ToolFilterConfig` was only ever honoured by `MCPManager.list_tools` — i.e. by the management API. An agent handed the instance from `_create_server_instance` (`chat_agentic_node`, `gen_sql_agentic_node`) received the server's **full** tool surface and could call a tool the operator had explicitly blocked.

Found while verifying Datus-saas' per-project MCP tool filter in a browser: with an allowlist of `search_issues` + `list_commits` saved, the chat agent was still offered `get_file_contents`, `create_pull_request` and `delete_file`, and would have called any of them. The filter looked enforced in the UI and in the CRUD API while being advisory everywhere it mattered.

## Change

`_create_server_instance(config, with_tool_filter=True)` binds the filter to the SDK server instance, so an agent can only ever see the allowed tools. The three factories accept and forward it.

The management paths pass `with_tool_filter=False` on purpose:

- `list_tools` applies its own filter afterwards and needs the raw list for `apply_filter=False`;
- `check_connectivity` should report the true tool count;
- the picker UI reads that unfiltered list — with the filter bound, a blocked tool disappears from the list and **can never be re-enabled**. (I shipped that regression to myself first; it is what the two management call-sites now guard against.)

`call_tool` keeps the filter bound: it already refuses a blocked tool by name beforehand, so this is defence in depth.

## The name-collision trap

This module exports its own `create_static_tool_filter` returning Datus' pydantic `ToolFilterConfig`. The SDK understands only its own `ToolFilterStatic` TypedDict or a callable, and when handed anything else it takes the dynamic-filter branch and ends up exposing **zero** tools — silently, with no error. The SDK helper is therefore imported aliased as `sdk_static_tool_filter`, with a comment at the import site. Passing the wrong one is an easy mistake to repeat.

## Tests

`tests/unit_tests/tools/mcp_tools/` — 237 passed, including six new cases: no filter / disabled / enabled-but-empty all yield `None` (an empty allowlist must mean "no restriction", never "allow nothing"); the translation produces the SDK's dict shape; the agent-facing instance carries the filter; the management instance does not.

Verified end to end against a live MCP server: the model is offered exactly the allowlisted tools, and `tools/call` reaches the server.

## Related

Datus-saas #727 and Datus-backend #395 introduce the per-project filter that this makes real. Without this change the filter is enforced only in the UI and the CRUD API.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring tool filters when connecting to MCP servers over STDIO, SSE, and HTTP.
  * Applied configured filters to agent-facing server connections while allowing management operations to inspect the complete available tool set.
* **Bug Fixes**
  * Improved handling of disabled or empty tool-filter configurations to prevent unintended filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Follow-up in this PR: in-memory MCP servers

Pushed after review feedback on the SaaS side, because it removes the reason the file existed there at all.

`ServicesConfig` gains an `mcp_servers` section, so a host that owns the definitions — the SaaS backend builds them from its database — passes them through `AgentConfig` and `MCPManager` reads them from memory. `<agent.home>/conf/.mcp.json` stays as the standalone/CLI source and is used whenever that section is empty, so a CLI user's own file keeps working untouched.

Why it matters beyond tidiness:

- decrypted credentials no longer land on a volume shared across a tenant's projects;
- one source of truth instead of a file plus a cache that drifted apart (two of the SaaS branch's bugs were exactly that);
- being a real dataclass field, a rotated credential or changed URL now moves the `AgentConfig` fingerprint, which is what evicts the cached `DatusService`. Routing it through an untyped `services` dict did **not** — `ServicesConfig.from_dict` dropped the unknown key silently, which is how this was found.

Writes (`add_server` / `remove_server` / `set_tool_filter`) are refused when the servers came from the config: persisting them would write a file nothing reads back, so the edit would look like it worked and vanish on the next request.

`MCPService` no longer hand-builds a manager through `__new__`; handing it the agent config yields the same tenant-scoped path plus the in-memory source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for host-provided in-memory MCP server configurations.
  * Added fallback to `.mcp.json` when host-provided configurations are unavailable.
  * Added tool-filter support for MCP servers over STDIO, SSE, and HTTP.
  * Management operations can inspect all available tools while agent connections use configured filters.
* **Bug Fixes**
  * Improved handling of disabled or empty tool filters.
  * Prevented unsupported changes to externally managed MCP server configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->