### PR TITLE
[BugFix] Strengthen task type guidance

### DIFF
--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -288,7 +288,11 @@ class SubAgentTaskTool:
             "properties": {
                 "type": {
                     "type": "string",
-                    "description": "The subagent type to delegate to",
+                    "description": (
+                        "Required. Select exactly one subagent name from the Available types "
+                        "listed in this tool description. Never omit this argument, even when "
+                        "the intended subagent is obvious from context."
+                    ),
                 },
                 "prompt": {
                     "type": "string",
@@ -349,9 +353,9 @@ class SubAgentTaskTool:
         from disk so the new ``prompt`` is appended to existing turn history.
         """
         if not type:
-            return FuncToolResult(success=0, error="Missing required parameter: type")
+            return FuncToolResult(success=0, error=self._missing_parameter_retry("type"))
         if not prompt:
-            return FuncToolResult(success=0, error="Missing required parameter: prompt")
+            return FuncToolResult(success=0, error=self._missing_parameter_retry("prompt"))
 
         try:
             return await self._execute_node(
@@ -360,6 +364,18 @@ class SubAgentTaskTool:
         except Exception as e:
             logger.error(f"Task tool execution error (type={type}): {e}")
             return FuncToolResult(success=0, error=f"Task execution failed: {str(e)}")
+
+    def _missing_parameter_retry(self, parameter: str) -> str:
+        """Build an actionable retry message for a missing required argument."""
+        available = self._get_available_types()
+        available_text = ", ".join(available) or "(none currently available)"
+        example_type = "gen_sql" if "gen_sql" in available else (available[0] if available else "<available type>")
+        return (
+            f"Missing required parameter: {parameter}. Retry task() with all required arguments. "
+            f"Set `type` to exactly one of these Available types: {available_text}. "
+            f'Example: task(type="{example_type}", prompt="<task or question>", '
+            'description="<short one-line goal>").'
+        )
 
     # ── node creation ─────────────────────────────────────────────────
 
@@ -1411,6 +1427,13 @@ class SubAgentTaskTool:
         available = self._get_available_types()
 
         lines = [
+            "Required call contract:",
+            "- Every task() call MUST include `type`, `prompt`, and `description`.",
+            "- `type` MUST be exactly one name from the Available types below. Never omit it, "
+            "even when the intended subagent is obvious from context.",
+            '- Call format: task(type="<available type>", prompt="<task or question>", '
+            'description="<short one-line goal>")',
+            "",
             "Delegate work to a specialized subagent when the requested deliverable belongs to that "
             "subagent's owning workflow or platform. Task complexity is not the deciding factor: "
             "a simple scheduled job, dashboard, persisted table, semantic model, metric definition, "

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -368,8 +368,15 @@ class SubAgentTaskTool:
     def _missing_parameter_retry(self, parameter: str) -> str:
         """Build an actionable retry message for a missing required argument."""
         available = self._get_available_types()
-        available_text = ", ".join(available) or "(none currently available)"
-        example_type = "gen_sql" if "gen_sql" in available else (available[0] if available else "<available type>")
+        if not available:
+            return (
+                f"Missing required parameter: {parameter}. "
+                "No subagent types are currently available. "
+                "Update the subagent allowlist or agent configuration before retrying."
+            )
+
+        available_text = ", ".join(available)
+        example_type = "gen_sql" if "gen_sql" in available else available[0]
         return (
             f"Missing required parameter: {parameter}. Retry task() with all required arguments. "
             f"Set `type` to exactly one of these Available types: {available_text}. "
@@ -1428,7 +1435,7 @@ class SubAgentTaskTool:
 
         lines = [
             "Required call contract:",
-            "- Every task() call MUST include `type`, `prompt`, and `description`.",
+            "- Every task tool call MUST include `type`, `prompt`, and `description`.",
             "- `type` MUST be exactly one name from the Available types below. Never omit it, "
             "even when the intended subagent is obvious from context.",
             '- Call format: task(type="<available type>", prompt="<task or question>", '

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -80,6 +80,13 @@ class TestAvailableTools:
         assert "prompt" in schema["properties"]
         assert set(schema["required"]) == {"type", "prompt", "description"}
 
+    def test_type_schema_description_requires_available_type(self, task_tool):
+        schema = task_tool.available_tools()[0].params_json_schema
+        type_description = schema["properties"]["type"]["description"]
+        assert "Required" in type_description
+        assert "Available types" in type_description
+        assert "Never omit" in type_description
+
     @pytest.mark.asyncio
     async def test_repairs_arguments_for_replay_without_executing(self, task_tool):
         tool = task_tool.available_tools()[0]
@@ -635,6 +642,13 @@ class TestResolveNodeType:
 
 @pytest.mark.ci
 class TestBuildTaskDescription:
+    def test_starts_with_required_call_contract(self, task_tool):
+        desc = task_tool._build_task_description()
+        assert desc.startswith("Required call contract:")
+        assert "Every task() call MUST include `type`, `prompt`, and `description`." in desc
+        assert "`type` MUST be exactly one name from the Available types below" in desc
+        assert 'task(type="<available type>"' in desc
+
     def test_contains_all_types(self, task_tool):
         desc = task_tool._build_task_description()
         assert "gen_sql" in desc
@@ -1075,12 +1089,18 @@ class TestTaskExecution:
         result = await task_tool.task(type="", prompt="test")
         assert result.success == 0
         assert "Missing required parameter: type" in result.error
+        assert "Retry task() with all required arguments" in result.error
+        assert "sales_analyst" in result.error
+        assert 'task(type="gen_sql"' in result.error
 
     @pytest.mark.asyncio
     async def test_execute_missing_prompt(self, task_tool):
         result = await task_tool.task(type="gen_sql", prompt="")
         assert result.success == 0
         assert "Missing required parameter: prompt" in result.error
+        assert "Retry task() with all required arguments" in result.error
+        assert "Available types" in result.error
+        assert 'prompt="<task or question>"' in result.error
 
     @pytest.mark.asyncio
     async def test_execute_custom_subagent(self, task_tool):

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -645,7 +645,7 @@ class TestBuildTaskDescription:
     def test_starts_with_required_call_contract(self, task_tool):
         desc = task_tool._build_task_description()
         assert desc.startswith("Required call contract:")
-        assert "Every task() call MUST include `type`, `prompt`, and `description`." in desc
+        assert "Every task tool call MUST include `type`, `prompt`, and `description`." in desc
         assert "`type` MUST be exactly one name from the Available types below" in desc
         assert 'task(type="<available type>"' in desc
 
@@ -1092,6 +1092,18 @@ class TestTaskExecution:
         assert "Retry task() with all required arguments" in result.error
         assert "sales_analyst" in result.error
         assert 'task(type="gen_sql"' in result.error
+
+    @pytest.mark.asyncio
+    async def test_execute_missing_type_when_no_subagents_are_available(self, mock_agent_config):
+        task_tool = SubAgentTaskTool(agent_config=mock_agent_config, allowed_subagents=[])
+
+        result = await task_tool.task(type="", prompt="test")
+
+        assert result.success == 0
+        assert "Missing required parameter: type" in result.error
+        assert "No subagent types are currently available" in result.error
+        assert "Update the subagent allowlist or agent configuration" in result.error
+        assert "Example:" not in result.error
 
     @pytest.mark.asyncio
     async def test_execute_missing_prompt(self, task_tool):


### PR DESCRIPTION
## Why

The `task` tool schema marks `type` as required, but its model-facing description did not explicitly require selecting and emitting one of the advertised subagent names. Some valid JSON tool calls therefore omitted `type` and failed with a generic missing-parameter error even when the model had already identified the intended subagent.

## Solution

- Put the required `task(type=..., prompt=..., description=...)` call contract at the top of the tool description.
- Clarify on the `type` property that the argument must select exactly one name from `Available types` and must never be omitted.
- Return actionable retry errors for missing `type` or `prompt`, including the currently available subagent names and a complete call example.
- Keep the existing free-form type schema, runtime routing, allowlist behavior, and non-strict JSON mode unchanged.

## Test Cases

- `uv run pytest -q tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py` (`196 passed`)
- `uv run ruff check datus/tools/func_tool/sub_agent_task_tool.py tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py`
- `uv run ruff format --check datus/tools/func_tool/sub_agent_task_tool.py tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **Improvements**
  * Added clearer guidance for creating subagent tasks, including required `type`, `prompt`, and `description` fields.
  * Improved validation messages with available subagent types and an example of a valid retry.
  * Task instructions now consistently describe the required call format.

* **Tests**
  * Added coverage for task schema requirements and enhanced validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added clearer guidance for creating subagent tasks, including required `type`, `prompt`, and `description` fields.
  * Improved validation messages with available subagent types and an example of a valid retry.
  * Task instructions now consistently describe the required call format and accepted task types.

* **Tests**
  * Added coverage for task schema requirements, missing arguments, available task types, and enhanced validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->