### PR TITLE
[BugFix] Avoid persistent semantic model lock files

### DIFF
--- a/datus/storage/semantic_model/artifact_file.py
+++ b/datus/storage/semantic_model/artifact_file.py
@@ -27,31 +27,15 @@ def artifact_revision(content: bytes) -> str:
 
 @contextmanager
 def semantic_artifact_lock(target_path: Path) -> Iterator[None]:
-    """Serialize one semantic artifact across threads and shared workers.
-
-    The process-local lock covers platforms without ``fcntl``. On Unix, the
-    adjacent lock file also coordinates workers that share the project files.
-    """
+    """Serialize one semantic artifact across threads in this process."""
 
     target_path = target_path.resolve(strict=False)
     key = str(target_path)
     with _ARTIFACT_LOCKS_GUARD:
         thread_lock = _ARTIFACT_LOCKS.setdefault(key, threading.RLock())
 
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = target_path.parent / f".{target_path.name}.lock"
-    with thread_lock, lock_path.open("a+b") as lock_file:
-        try:
-            import fcntl
-        except ImportError:  # pragma: no cover - Windows fallback
-            fcntl = None
-        if fcntl is not None:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            if fcntl is not None:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    with thread_lock:
+        yield
 
 
 def atomic_write_bytes(target_path: Path, content: bytes, *, mode: Optional[int] = None) -> None:

--- a/tests/unit_tests/storage/semantic_model/test_artifact_file.py
+++ b/tests/unit_tests/storage/semantic_model/test_artifact_file.py
@@ -1,0 +1,14 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from datus.storage.semantic_model.artifact_file import semantic_artifact_lock
+
+
+def test_semantic_artifact_lock_does_not_create_files(tmp_path):
+    target = tmp_path / "semantic_models" / "orders.yml"
+
+    with semantic_artifact_lock(target):
+        assert not target.parent.exists()
+
+    assert not target.parent.exists()


### PR DESCRIPTION
## Summary

- keep semantic artifact mutation serialized with a process-local, per-path `RLock`
- remove the adjacent `.lock` file and `fcntl` coordination from semantic model generation and API saves
- add a regression test that verifies acquiring the lock does not create directories or files

## Why

Semantic model authoring is coordinated within one Datus process. The cross-process lock added an unnecessary persistent `.yaml.lock` artifact beside generated semantic models, even after the mutation completed.

## Impact

OSI semantic model generation and saves no longer leave lock files in semantic model directories. Existing same-process API/agent serialization, revision checks, and atomic writes remain unchanged.

## Validation

- `831 passed` across the affected semantic authoring, API, generation, filesystem, target, and permission unit tests
- `ruff check` and `ruff format --check` on the changed Python files
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic artifact locking to avoid creating target directories as a side effect.
  * Simplified lock behavior for more predictable local synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->