### PR TITLE
[BugFix] Attach configured MCP servers in AgenticNode base so every subagent honors its mcp selection

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -197,6 +197,12 @@ class AgenticNode(Node):
         # Parse node configuration from agent.yml (available to all agentic nodes)
         self.node_config = self._parse_node_config(agent_config, self.get_node_name())
 
+        # Attach the MCP servers named in node_config["mcp"] unless the caller
+        # supplied explicit instances. Done here so every agentic node honors
+        # its configured selection — subclasses must not re-implement this.
+        if not self.mcp_servers:
+            self.mcp_servers = self._setup_mcp_servers()
+
         # Setup permission manager (after node_config is available)
         self._setup_permission_manager()
 
@@ -2178,6 +2184,59 @@ class AgenticNode(Node):
 
         logger.info(f"Parsed node configuration for '{node_name}': {config}")
         return config
+
+    def _setup_mcp_servers(self) -> Dict[str, Any]:
+        """Build MCP server instances from the comma-separated ``node_config["mcp"]``."""
+        mcp_servers = {}
+
+        config_value = self.node_config.get("mcp", "")
+        if not config_value:
+            return mcp_servers
+
+        mcp_server_names = [p.strip() for p in config_value.split(",") if p.strip()]
+
+        for server_name in mcp_server_names:
+            try:
+                server = self._setup_mcp_server_from_config(server_name)
+                if server:
+                    mcp_servers[server_name] = server
+
+            except Exception as e:
+                logger.error(f"Failed to setup MCP server '{server_name}': {e}")
+
+        logger.debug(f"Setup {len(mcp_servers)} MCP servers: {list(mcp_servers.keys())}")
+        return mcp_servers
+
+    def _setup_mcp_server_from_config(self, server_name: str) -> Optional[Any]:
+        """Build one MCP server instance via MCPManager.
+
+        MCPManager resolves definitions from the in-memory
+        ``agent_config.services["mcp_servers"]`` first (SaaS host) and falls
+        back to ``{agent.home}/conf/.mcp.json`` (CLI/standalone).
+        """
+        try:
+            from datus.tools.mcp_tools.mcp_manager import MCPManager
+
+            mcp_manager = MCPManager(agent_config=self.agent_config)
+            server_config = mcp_manager.get_server_config(server_name)
+
+            if not server_config:
+                logger.warning(f"MCP server '{server_name}' not found in configuration")
+                return None
+
+            server_instance, details = mcp_manager._create_server_instance(server_config)
+
+            if server_instance:
+                logger.debug(f"Added MCP server '{server_name}' from configuration: {details}")
+                return server_instance
+            else:
+                error_msg = details.get("error", "Unknown error")
+                logger.warning(f"Failed to create MCP server '{server_name}': {error_msg}")
+                return None
+
+        except Exception as e:
+            logger.error(f"Failed to setup MCP server '{server_name}' from config: {e}")
+            return None
 
     def _setup_permission_manager(self) -> None:
         """

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -10,7 +10,7 @@ chat interactions with markdown output, database/filesystem tool support,
 skills, and permissions. This node is fully independent from GenSQLAgenticNode.
 """
 
-from typing import Any, Dict, Literal, Optional
+from typing import Dict, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.gen_sql_agentic_node import prepare_template_context
@@ -115,9 +115,6 @@ class ChatAgenticNode(AgenticNode):
         # Execution mode: "interactive" enables ask_user tool; "workflow"
         # disables it so the agent never pauses for user input.
         self.execution_mode = execution_mode
-
-        # Initialize MCP servers based on configuration
-        self.mcp_servers = self._setup_mcp_servers()
 
         # Setup tools
         self.setup_tools()
@@ -339,56 +336,6 @@ class ChatAgenticNode(AgenticNode):
             return {"chat": chat_config["permissions"]}
 
         return {}
-
-    # ── MCP Servers ─────────────────────────────────────────────────────
-
-    def _setup_mcp_servers(self) -> Dict[str, Any]:
-        """Set up MCP servers based on configuration."""
-        mcp_servers = {}
-
-        config_value = self.node_config.get("mcp", "")
-        if not config_value:
-            return mcp_servers
-
-        mcp_server_names = [p.strip() for p in config_value.split(",") if p.strip()]
-
-        for server_name in mcp_server_names:
-            try:
-                server = self._setup_mcp_server_from_config(server_name)
-                if server:
-                    mcp_servers[server_name] = server
-
-            except Exception as e:
-                logger.error(f"Failed to setup MCP server '{server_name}': {e}")
-
-        logger.debug(f"Setup {len(mcp_servers)} MCP servers: {list(mcp_servers.keys())}")
-        return mcp_servers
-
-    def _setup_mcp_server_from_config(self, server_name: str) -> Optional[Any]:
-        """Setup MCP server from {agent.home}/conf/.mcp.json using mcp_manager."""
-        try:
-            from datus.tools.mcp_tools.mcp_manager import MCPManager
-
-            mcp_manager = MCPManager(agent_config=self.agent_config)
-            server_config = mcp_manager.get_server_config(server_name)
-
-            if not server_config:
-                logger.warning(f"MCP server '{server_name}' not found in configuration")
-                return None
-
-            server_instance, details = mcp_manager._create_server_instance(server_config)
-
-            if server_instance:
-                logger.debug(f"Added MCP server '{server_name}' from configuration: {details}")
-                return server_instance
-            else:
-                error_msg = details.get("error", "Unknown error")
-                logger.warning(f"Failed to create MCP server '{server_name}': {error_msg}")
-                return None
-
-        except Exception as e:
-            logger.error(f"Failed to setup MCP server '{server_name}' from config: {e}")
-            return None
 
     # ── System Prompt ───────────────────────────────────────────────────
 

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -106,18 +106,10 @@ class GenSQLAgenticNode(AgenticNode):
             input_data=input_data,
             agent_config=agent_config,
             tools=tools or [],
-            mcp_servers={},  # Initialize empty, will setup after parent init
+            mcp_servers={},
             scope=scope,
             is_subagent=is_subagent,
             session_id=session_id,
-        )
-
-        # Initialize MCP servers based on configuration (after node_config is available)
-        self.mcp_servers = self._setup_mcp_servers()
-
-        # Debug: Log final MCP servers assignment
-        logger.debug(
-            f"GenSQLAgenticNode final mcp_servers: {len(self.mcp_servers)} servers - {list(self.mcp_servers.keys())}"
         )
 
         # Setup tools based on configuration (includes subagent task tool wiring)
@@ -516,61 +508,6 @@ class GenSQLAgenticNode(AgenticNode):
                 logger.warning(f"Method '{method_name}' not found in {tool_type}")
         except Exception as e:
             logger.error(f"Failed to setup {tool_type}.{method_name}: {e}")
-
-    def _setup_mcp_server_from_config(self, server_name: str) -> Optional[Any]:
-        """Setup MCP server from {agent.home}/conf/.mcp.json using mcp_manager."""
-        try:
-            from datus.tools.mcp_tools.mcp_manager import MCPManager
-
-            # Use MCPManager to get server config
-            mcp_manager = MCPManager(agent_config=self.agent_config)
-            server_config = mcp_manager.get_server_config(server_name)
-
-            if not server_config:
-                logger.warning(f"MCP server '{server_name}' not found in configuration")
-                return None
-
-            # Create server instance using the manager
-            server_instance, details = mcp_manager._create_server_instance(server_config)
-
-            if server_instance:
-                logger.debug(f"Added MCP server '{server_name}' from configuration: {details}")
-                return server_instance
-            else:
-                error_msg = details.get("error", "Unknown error")
-                logger.warning(f"Failed to create MCP server '{server_name}': {error_msg}")
-                return None
-
-        except Exception as e:
-            logger.error(f"Failed to setup MCP server '{server_name}' from config: {e}")
-            return None
-
-    def _setup_mcp_servers(self) -> Dict[str, Any]:
-        """Set up MCP servers based on configuration."""
-        mcp_servers = {}
-
-        config_value = self.node_config.get("mcp", "")
-        if not config_value:
-            return mcp_servers
-
-        mcp_server_names = [p.strip() for p in config_value.split(",") if p.strip()]
-
-        for server_name in mcp_server_names:
-            try:
-                server = self._setup_mcp_server_from_config(server_name)
-                if server:
-                    mcp_servers[server_name] = server
-
-            except Exception as e:
-                logger.error(f"Failed to setup MCP server '{server_name}': {e}")
-
-        logger.debug(f"Setup {len(mcp_servers)} MCP servers: {list(mcp_servers.keys())}")
-
-        # Debug: Log detailed info about each server
-        for name, server in mcp_servers.items():
-            logger.debug(f"MCP server '{name}': type={type(server)}, instance={server}")
-
-        return mcp_servers
 
     def _get_available_tool_names(self) -> list[str]:
         """Return native tool names plus discoverable MCP tool names."""

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -167,6 +167,42 @@ class TestParseNodeConfig:
 
 
 # ---------------------------------------------------------------------------
+# TestSetupMcpServerFromConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSetupMcpServerFromConfig:
+    @staticmethod
+    def _manager(server_config, instance, details):
+        manager = MagicMock()
+        manager.get_server_config.return_value = server_config
+        manager._create_server_instance.return_value = (instance, details)
+        return manager
+
+    def test_returns_instance_on_success(self):
+        node = _make_node()
+        server = MagicMock()
+        manager = self._manager(MagicMock(), server, {"transport": "http"})
+
+        with patch("datus.tools.mcp_tools.mcp_manager.MCPManager", return_value=manager):
+            assert node._setup_mcp_server_from_config("srv") is server
+        manager.get_server_config.assert_called_once_with("srv")
+
+    def test_returns_none_when_instance_creation_fails(self):
+        node = _make_node()
+        manager = self._manager(MagicMock(), None, {"error": "connect refused"})
+
+        with patch("datus.tools.mcp_tools.mcp_manager.MCPManager", return_value=manager):
+            assert node._setup_mcp_server_from_config("srv") is None
+
+    def test_returns_none_when_manager_raises(self):
+        node = _make_node()
+
+        with patch("datus.tools.mcp_tools.mcp_manager.MCPManager", side_effect=RuntimeError("bad config")):
+            assert node._setup_mcp_server_from_config("srv") is None
+
+
+# ---------------------------------------------------------------------------
 # TestResolveWorkspaceRoot
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -278,6 +278,25 @@ class TestAskMetricsAgenticNode:
         assert text_node.subject_tree_prompt_limit == text_node.SUBJECT_TREE_PROMPT_LIMIT
         assert bool_node.subject_tree_prompt_limit == bool_node.SUBJECT_TREE_PROMPT_LIMIT
 
+    def test_mcp_servers_attached_from_node_config(self, real_agent_config, mock_llm_create):
+        """A custom agent's ``mcp`` selection is attached by the AgenticNode base."""
+        tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
+        mock_server = MagicMock()
+
+        with patch(
+            "datus.agent.node.agentic_node.AgenticNode._setup_mcp_server_from_config",
+            return_value=mock_server,
+        ) as mock_setup:
+            node, _, _ = _make_node(
+                real_agent_config,
+                tree=tree,
+                node_config={"type": "ask_metrics", "mcp": "test_server"},
+                node_name="mcp_metric_agent",
+            )
+
+        mock_setup.assert_called_once_with("test_server")
+        assert node.mcp_servers == {"test_server": mock_server}
+
     def test_tools_follow_custom_configuration(self, real_agent_config, mock_llm_create):
         tree = {"Sales": {"Orders": {"metrics": ["revenue"]}}}
 


### PR DESCRIPTION
## Why

A custom sub-agent with an MCP selection (`agentic_nodes.<name>.mcp`, persisted by the SaaS backend from the subagent's `mcp` field) never gets its MCP tools at runtime unless its node class happens to be `chat` or `gen_sql`.

`AgenticNode` passes `self.mcp_servers` into `generate_with_tools_stream` for every node, but only `ChatAgenticNode` and `GenSQLAgenticNode` (duplicated code) actually built server instances from `node_config["mcp"]`. Every other node class — `AskMetricsAgenticNode`, `ExploreAgenticNode`, the `DeliverableAgenticNode` family (`gen_report`/`gen_dashboard`/`gen_job`/`gen_table`/`scheduler`), the visual-artifact nodes — hardcodes `mcp_servers={}`, so the configured servers were silently ignored.

Observed in SaaS: an `ask_metrics` subagent bound to an MCP server (`"mcp": "RivalSearchMCP"` in the subagent row, correctly materialized into `.mcp.json` and the node config) replies "I don't have that tool" when asked to use one of the server's tools.

## Solution

Hoist MCP server setup into the `AgenticNode` base class:

- `_setup_mcp_servers()` / `_setup_mcp_server_from_config()` move verbatim from `ChatAgenticNode` into `AgenticNode`.
- Base `__init__` attaches the servers right after `node_config` is parsed, only when the caller didn't supply explicit instances (`if not self.mcp_servers`). All node subclasses pass `mcp_servers={}` today, so every node now honors its configured `mcp` selection; callers that inject real instances keep them.
- Delete the duplicated implementations in `ChatAgenticNode` and `GenSQLAgenticNode` (behavior unchanged for those two — setup now simply runs during base init instead of after it).

This also makes the per-project MCP binding written into the built-in `gen_report` / `gen_dashboard` / `gen_job` node configs by the SaaS backend actually take effect — previously only `chat` and `gen_sql` could attach.

## Test Cases

- `tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py::TestAskMetricsAgenticNode::test_mcp_servers_attached_from_node_config` — new: a custom (non-chat/gen_sql) agent with `mcp` in its node config gets the server attached by the base class.
- Existing MCP setup tests in `test_chat_agentic_node.py` and `test_gen_sql_agentic_node.py` keep passing against the inherited base implementation, covering the no-config and configured paths.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Configured MCP servers are now loaded automatically when creating an agentic node without explicitly supplied server instances.
  * Successfully initialized servers are made available using their configured names.
* **Bug Fixes**
  * Missing or failed MCP server configurations are skipped gracefully, allowing node creation to continue.
* **Tests**
  * Added coverage verifying that configured MCP servers are attached correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configured MCP servers are now loaded automatically when creating an agentic node without explicitly supplied server instances.
  * Successfully initialized servers are made available using their configured names.
* **Bug Fixes**
  * Missing or failed MCP server configurations are skipped gracefully, allowing node creation to continue.
* **Tests**
  * Added coverage verifying that configured MCP servers are attached correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->