### PR TITLE
[BugFix] Mark returned tool failures as failed trace observations

### DIFF
--- a/datus/observability/openai_agents.py
+++ b/datus/observability/openai_agents.py
@@ -6,8 +6,15 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import Any, cast
+
+from datus.observability.manager import get_observability_manager
+from datus.schemas.tool_summary import detect_tool_failure
+
+_TOOL_ERROR_MESSAGE_MAX_CHARS = 500
+_TOOL_ERROR_MESSAGE_FALLBACK = "Tool returned an unsuccessful result"
 
 
 class DatusOpenAIAgentsInstrumentor:
@@ -137,6 +144,13 @@ class DatusOpenInferenceTracingProcessor(_OpenInferenceTracingProcessorBase):  #
             tool_call_id = mcp_data.get("tool_call_id")
             if tool_call_id:
                 otel_span.set_attribute("tool.id", str(tool_call_id))
+            if detect_tool_failure(data.output):
+                span.set_error(
+                    {
+                        "message": _tool_failure_message(data.output),
+                        "data": {"exception.type": "ToolError"},
+                    }
+                )
 
     def shutdown(self) -> None:
         self._merged_root_agent_span_ids.clear()
@@ -160,3 +174,34 @@ def _set_numeric_attribute(span: Any, key: str, value: Any) -> None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return
     span.set_attribute(key, value)
+
+
+def _tool_failure_message(output: Any) -> str:
+    payload = _tool_result_mapping(output)
+    error = payload.get("error") if payload is not None else None
+    if not isinstance(error, str) or not error.strip():
+        nested = _tool_result_mapping(payload.get("raw_output")) if payload is not None else None
+        error = nested.get("error") if nested is not None else None
+    if not isinstance(error, str) or not error.strip():
+        return _TOOL_ERROR_MESSAGE_FALLBACK
+
+    try:
+        redacted = get_observability_manager().redact(error)
+    except Exception:  # pragma: no cover - redaction is best-effort and must not break tool execution.
+        return _TOOL_ERROR_MESSAGE_FALLBACK
+    message = " ".join(str(redacted).split()) or _TOOL_ERROR_MESSAGE_FALLBACK
+    if len(message) <= _TOOL_ERROR_MESSAGE_MAX_CHARS:
+        return message
+    return message[: _TOOL_ERROR_MESSAGE_MAX_CHARS - 1].rstrip() + "…"
+
+
+def _tool_result_mapping(output: Any) -> Mapping[str, Any] | None:
+    if isinstance(output, Mapping):
+        return output
+    if not isinstance(output, str):
+        return None
+    try:
+        parsed = json.loads(output)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, Mapping) else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "aiohttp>=3.11.16",
     "xlsxwriter>=3.2.2",
     "openai-agents[litellm]==0.7.0",
-    "openinference-instrumentation-openai-agents>=1.0.0",
+    "openinference-instrumentation-openai-agents==1.6.2",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",

--- a/tests/unit_tests/observability/test_openai_agents.py
+++ b/tests/unit_tests/observability/test_openai_agents.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -10,9 +11,13 @@ from opentelemetry import baggage, context
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
+import datus.observability.openai_agents as openai_agents_module
 from datus.observability.adapters.langfuse import _LangfuseBaggageSpanProcessor
 from datus.observability.adapters.otlp import _BaggageAttributeSpanProcessor
+from datus.observability.config import TracingConfig
+from datus.observability.manager import ObservabilityManager
 from datus.observability.openai_agents import DatusOpenInferenceTracingProcessor
 
 
@@ -31,6 +36,9 @@ class FakeSpan:
     started_at: str = ""
     ended_at: str = ""
     error: dict | None = None
+
+    def set_error(self, error: dict) -> None:
+        self.error = error
 
 
 def _now_iso() -> str:
@@ -100,3 +108,88 @@ def test_openai_agents_processor_fails_lazily_when_dependency_missing(monkeypatc
 
     with pytest.raises(RuntimeError, match="openinference"):
         module.DatusOpenInferenceTracingProcessor(object())
+
+
+def test_openai_agents_processor_marks_returned_tool_failures(monkeypatch):
+    from agents.tracing.span_data import AgentSpanData, FunctionSpanData
+    from openinference.instrumentation import OITracer, TraceConfig
+
+    observability = ObservabilityManager()
+    observability._tracing_config = TracingConfig.from_dict(
+        {
+            "enabled": True,
+            "redact": {"patterns": [r"secret-\d+"]},
+        }
+    )
+    monkeypatch.setattr(openai_agents_module, "get_observability_manager", lambda: observability)
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    processor = DatusOpenInferenceTracingProcessor(OITracer(provider.get_tracer(__name__), config=TraceConfig()))
+    trace = FakeTrace()
+    root_agent_span = FakeSpan(
+        span_data=AgentSpanData(name="chat", tools=["query_metrics"], output_type="str"),
+        span_id="span_agent",
+        started_at=_now_iso(),
+    )
+    replay_error = (
+        "Malformed JSON arguments for tool 'query_metrics' were repaired for replay. "
+        "The tool was not executed. Retry the tool with one complete JSON object."
+    )
+    outputs = {
+        "func_failure": {"success": 0, "error": "query failed", "result": None},
+        "error_only": json.dumps({"success": "unknown", "error": f"secret-123\n{'details ' * 100}"}),
+        "replay_failure": {"success": 0, "error": replay_error, "result": None},
+        "native_failure": {
+            "success": False,
+            "raw_output": json.dumps({"success": 0, "error": "native query failed"}),
+            "summary": "Failed",
+        },
+        "success": {"success": 1, "error": None, "result": {"rows": 1}},
+    }
+    tool_spans = [
+        FakeSpan(
+            span_data=FunctionSpanData(name=name, input="{}", output=output),
+            span_id=f"span_{name}",
+            parent_id=root_agent_span.span_id,
+            started_at=_now_iso(),
+        )
+        for name, output in outputs.items()
+    ]
+
+    try:
+        processor.on_trace_start(trace)
+        processor.on_span_start(root_agent_span)
+        for tool_span in tool_spans:
+            processor.on_span_start(tool_span)
+            tool_span.ended_at = _now_iso()
+            processor.on_span_end(tool_span)
+        root_agent_span.ended_at = _now_iso()
+        processor.on_span_end(root_agent_span)
+        processor.on_trace_end(trace)
+    finally:
+        processor.shutdown()
+
+    spans = exporter.get_finished_spans()
+    provider.shutdown()
+    span_by_name = {span.name: span for span in spans}
+    sdk_span_by_name = {span.span_data.name: span for span in tool_spans}
+
+    for name in ("func_failure", "error_only", "replay_failure", "native_failure"):
+        assert span_by_name[name].status.status_code is StatusCode.ERROR
+        expected_output = json.loads(outputs[name]) if isinstance(outputs[name], str) else outputs[name]
+        assert json.loads(span_by_name[name].attributes["output.value"]) == expected_output
+
+    assert sdk_span_by_name["func_failure"].error["message"] == "query failed"
+    redacted_message = sdk_span_by_name["error_only"].error["message"]
+    assert "secret-123" not in redacted_message
+    assert "[REDACTED]" in redacted_message
+    assert "\n" not in redacted_message
+    assert len(redacted_message) <= 500
+    assert "not executed" in sdk_span_by_name["replay_failure"].error["message"]
+    assert sdk_span_by_name["native_failure"].error["message"] == "native query failed"
+
+    assert span_by_name["success"].status.status_code is StatusCode.OK
+    assert sdk_span_by_name["success"].error is None
+    assert json.loads(span_by_name["success"].attributes["output.value"]) == outputs["success"]

--- a/uv.lock
+++ b/uv.lock
@@ -795,7 +795,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.11.0" },
     { name = "openai", specifier = ">=2.8.0,<2.45.0" },
     { name = "openai-agents", extras = ["litellm"], specifier = "==0.7.0" },
-    { name = "openinference-instrumentation-openai-agents", specifier = ">=1.0.0" },
+    { name = "openinference-instrumentation-openai-agents", specifier = "==1.6.2" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "openinference-instrumentation-openai-agents"
-version = "1.5.1"
+version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "openinference-instrumentation" },
@@ -2606,18 +2606,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/65/a39fa0a276216db1f3ca46cb5b31c910e18590855e9dcb1a49867d2cf262/openinference_instrumentation_openai_agents-1.5.1.tar.gz", hash = "sha256:3282832eeeb95be0606efaf99c9180f072736888b84680eab0163209a30c420b", size = 12832, upload-time = "2026-05-18T18:51:33.511Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/f1/8d97d6c859854f6d5546af805185a03376604d73d744e90b3308eaddd9bb/openinference_instrumentation_openai_agents-1.6.2.tar.gz", hash = "sha256:efffff2606e552b6cb8481c6e5738b8c104b6e6e72ead13773ee5b0bdc86aabd", size = 26586, upload-time = "2026-07-30T16:38:28.049Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/ff/d8f76ec95cfdb3e042015b71ea3b68cf3c9aade5c0fcf3e5e1485753fdfc/openinference_instrumentation_openai_agents-1.5.1-py3-none-any.whl", hash = "sha256:f12359ee16d91fe04704e552c94df5b042456b9a8734b5ea082ab30b8c3d2216", size = 14538, upload-time = "2026-05-18T18:51:32.094Z" },
+    { url = "https://files.pythonhosted.org/packages/26/15/2f6f3890675c626eeac81ce7994f7762bb25c3a3a4a5b00e41e712c3fd47/openinference_instrumentation_openai_agents-1.6.2-py3-none-any.whl", hash = "sha256:0d9fcf4cb24dd22c57ed035f31c807135fbccc67347e11cfdc01b39e835d35d9", size = 28995, upload-time = "2026-07-30T16:38:26.879Z" },
 ]
 
 [[package]]
 name = "openinference-semantic-conventions"
-version = "0.1.29"
+version = "0.1.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/6b/9ed67f9ce8c92436b297207abde730800b00bdec7e114f71b8dfe91cd26b/openinference_semantic_conventions-0.1.29.tar.gz", hash = "sha256:bbeb6472777a45a574169894bb9c4d80c6832a8befd32ab238cb875438ce1044", size = 12959, upload-time = "2026-04-22T00:39:27.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/3e/8f96e000651a01c801d98736c63aaf4140dd5a68a325cad92045c53484dd/openinference_semantic_conventions-0.1.31.tar.gz", hash = "sha256:39bed2e6edabb5b8dd983e22d3d4914e660ff1f8a49d7df8ceae938af5bb5836", size = 13966, upload-time = "2026-08-01T16:13:21.334Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/7b/45ad1b95315b5563baa7338c8e8088bb1af66905c46e1bd1fe6ecbe30ea8/openinference_semantic_conventions-0.1.29-py3-none-any.whl", hash = "sha256:f45e0b1cf79fe407af4722bcf391a01565f0878c95be3ebcc9382245d0367cc5", size = 10582, upload-time = "2026-04-22T00:39:27.066Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d5/9d32686b8911ca79001dd0a352e89069a0b3749446b37859494805dd1bf1/openinference_semantic_conventions-0.1.31-py3-none-any.whl", hash = "sha256:ae7eee916622dc9f64ea14cae26911c78653b1c0d7a62a56788934d5830f3472", size = 11241, upload-time = "2026-08-01T16:13:20.153Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Tools commonly return application-level failures as `FuncToolResult(success=0, error=...)` without raising an exception. OpenInference therefore exported those tool spans with a successful/default status, so Langfuse trace and session scans could miss real failures, especially when a later retry succeeded.

Closes #1245.

## Solution

- Pin `openinference-instrumentation-openai-agents` to `1.6.2` to match the SaaS tracing environment.
- Detect standard tool failure envelopes at the shared OpenInference `FunctionSpanData` export boundary.
- Set an explicit `ToolError` span error with a redacted, single-line, length-bounded status message.
- Preserve the original tool output and existing retry/runtime behavior.
- Handle both direct SDK outputs and the wrapped native-provider output shape without adding provider-specific implementations.

## Test Cases

- `uv run pytest -q tests/unit_tests/observability tests/unit_tests/schemas/test_tool_summary.py tests/unit_tests/models/test_claude_model.py::TestGenerateWithMcpStream::test_tool_failure_yields_failed_action tests/unit_tests/models/test_openai_compatible.py::TestDetectToolFailure` (`348 passed`)
- `uv run pytest -q tests/unit_tests/observability/test_openai_agents.py tests/unit_tests/observability/test_native_agents.py tests/unit_tests/tools/func_tool/test_base.py` (`27 passed`)
- `uv run ruff format --check datus/observability/openai_agents.py tests/unit_tests/observability/test_openai_agents.py`
- `uv run ruff check datus/observability/openai_agents.py tests/unit_tests/observability/test_openai_agents.py`
- `uv lock --check`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool failures are now correctly reflected in observability spans with error status.
  * Error details are sanitized, truncated, and safely extracted from structured or JSON-formatted tool responses.
  * Successful tool executions continue to be reported without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->