### PR TITLE
[Feature] Address the SemanticModel API by file instead of by table

### DIFF
--- a/datus/agent/node/semantic_authoring.py
+++ b/datus/agent/node/semantic_authoring.py
@@ -140,6 +140,29 @@ def osi_semantic_model_directory(agent_config: Any = None) -> Optional[Path]:
     return _osi_semantic_model_dir(agent_config)
 
 
+def osi_semantic_models_root(agent_config: Any = None) -> Optional[Path]:
+    """Return the semantic-model root shared by every datasource.
+
+    File-addressed APIs resolve against this root rather than the active
+    datasource's subdirectory, so a project with several datasources can reach
+    all of their models.
+    """
+    if agent_config is None:
+        return None
+
+    path_manager = getattr(agent_config, "path_manager", None)
+    models_dir = getattr(path_manager, "semantic_models_dir", None)
+    if models_dir is not None:
+        return Path(str(models_dir)).expanduser()
+
+    project_root = getattr(agent_config, "project_root", None)
+    if not isinstance(project_root, (str, Path)):
+        project_root = getattr(path_manager, "project_root", None)
+    if project_root:
+        return Path(str(project_root)).expanduser() / "subject" / "semantic_models"
+    return None
+
+
 def _table_lookup_names(value: Any) -> set[str]:
     """Return stable lookup keys for a logical or fully-qualified table name."""
     parts = [part.strip().strip('`"[]') for part in re.split(r"[./]", str(value or "").strip())]

--- a/datus/api/models/__init__.py
+++ b/datus/api/models/__init__.py
@@ -105,9 +105,10 @@ from datus.api.models.table_models import (
     GetTableDetailInput,
     IndexInfo,
     SaveSemanticModelData,
-    SemanticModelInput,
+    SaveSemanticModelInput,
     TableDetailData,
     ValidateSemanticModelData,
+    ValidateSemanticModelInput,
 )
 
 __all__ = [
@@ -176,8 +177,9 @@ __all__ = [
     "GetTableDetailData",
     "GetSemanticModelData",
     "SaveSemanticModelData",
-    "SemanticModelInput",
+    "SaveSemanticModelInput",
     "ValidateSemanticModelData",
+    "ValidateSemanticModelInput",
     # explorer_models
     "SubjectNodeType",
     "SubjectNode",

--- a/datus/api/models/table_models.py
+++ b/datus/api/models/table_models.py
@@ -84,31 +84,40 @@ class GetTablesColumnsData(BaseModel):
 # ========== SemanticModel Models ==========
 
 
+SEMANTIC_MODEL_FILE_DESCRIPTION = (
+    "Project-relative semantic model file, e.g. subject/semantic_models/<datasource>/<name>.yml"
+)
+
+
 class GetSemanticModelData(BaseModel):
     """Get semantic model result data."""
 
     yaml: str = Field(..., description="SemanticModel YAML content")
-    semantic_model_name: Optional[str] = Field(None, description="Stable semantic model name")
-    semantic_model_file: Optional[str] = Field(None, description="Datasource-scoped semantic model file")
-    revision: Optional[str] = Field(None, description="SHA-256 revision of the YAML content")
+    semantic_model_name: Optional[str] = Field(None, description="Semantic model name declared by the YAML")
+    semantic_model_file: str = Field(..., description=SEMANTIC_MODEL_FILE_DESCRIPTION)
+    revision: str = Field(..., description="SHA-256 revision of the YAML content")
 
 
-class SemanticModelInput(BaseModel):
+class ValidateSemanticModelInput(BaseModel):
+    """Validate semantic model input."""
+
+    semantic_model_file: str = Field(..., description=SEMANTIC_MODEL_FILE_DESCRIPTION)
+    yaml: str = Field(..., description="SemanticModel YAML content")
+    semantic_model_name: Optional[str] = Field(
+        None,
+        description="Optional assertion that the YAML declares this semantic model",
+    )
+
+
+class SaveSemanticModelInput(ValidateSemanticModelInput):
     """Save semantic model input."""
 
-    table: str = Field("", description="Full table name; retained as a legacy target selector")
-    yaml: str = Field(..., description="SemanticModel YAML content")
-    catalog: Optional[str] = Field(None, description="Current catalog context")
-    database: Optional[str] = Field(None, description="Current database context")
-    db_schema: Optional[str] = Field(None, description="Current schema context")
-    semantic_model_name: Optional[str] = Field(None, description="Semantic model owning a shared physical table")
-    semantic_model_file: Optional[str] = Field(
-        None,
-        description="Datasource-scoped semantic model file returned by GET /semantic_model",
-    )
     expected_revision: Optional[str] = Field(
         None,
-        description="Optional SHA-256 revision used to reject concurrent overwrites",
+        description=(
+            "SHA-256 revision returned by the last GET. Omit to skip the concurrency "
+            "check; supply it to reject overwrites of a file changed since it loaded."
+        ),
     )
 
 

--- a/datus/api/routes/table_routes.py
+++ b/datus/api/routes/table_routes.py
@@ -9,13 +9,15 @@ from fastapi import APIRouter, Query
 from datus.api.deps import ServiceDep
 from datus.api.models.base_models import Result
 from datus.api.models.table_models import (
+    SEMANTIC_MODEL_FILE_DESCRIPTION,
     GetSemanticModelData,
     GetTableDetailData,
     GetTablesColumnsData,
     GetTablesColumnsInput,
     SaveSemanticModelData,
-    SemanticModelInput,
+    SaveSemanticModelInput,
     ValidateSemanticModelData,
+    ValidateSemanticModelInput,
 )
 
 router = APIRouter(prefix="/api/v1", tags=["table"])
@@ -63,28 +65,14 @@ async def get_tables_columns(
     "/semantic_model",
     response_model=Result[GetSemanticModelData],
     summary="Get Semantic Model",
-    description="Get SemanticModel YAML configuration for a specific table",
+    description="Read one SemanticModel YAML artifact together with its stable identity and revision",
 )
 async def get_semantic_model(
     svc: ServiceDep,
-    table: str = Query(
-        ...,
-        description="Full table name e.g. 'production_db.public.frpm' or 'db.schema.table'",
-    ),
-    catalog: str | None = Query(None, description="Current catalog context"),
-    database: str | None = Query(None, description="Current database context"),
-    db_schema: str | None = Query(None, description="Current schema context"),
-    semantic_model_name: str | None = Query(None, description="Semantic model owning a shared physical table"),
+    semantic_model_file: str = Query(..., description=SEMANTIC_MODEL_FILE_DESCRIPTION),
 ) -> Result[GetSemanticModelData]:
     """Get SemanticModel YAML."""
-    return await asyncio.to_thread(
-        svc.datasource.get_semantic_model,
-        table,
-        catalog=catalog,
-        database=database,
-        db_schema=db_schema,
-        semantic_model_name=semantic_model_name,
-    )
+    return await asyncio.to_thread(svc.datasource.get_semantic_model, semantic_model_file)
 
 
 @router.post(
@@ -94,7 +82,7 @@ async def get_semantic_model(
     description="Atomically save and reconcile one SemanticModel YAML artifact",
 )
 async def save_semantic_model(
-    request: SemanticModelInput,
+    request: SaveSemanticModelInput,
     svc: ServiceDep,
 ) -> Result[SaveSemanticModelData]:
     """Save SemanticModel YAML and reconcile its Knowledge Base rows."""
@@ -105,10 +93,10 @@ async def save_semantic_model(
     "/semantic_model/validate",
     response_model=Result[ValidateSemanticModelData],
     summary="Validate Semantic Model",
-    description="Validate SemanticModel YAML structure and syntax",
+    description="Validate SemanticModel YAML structure and syntax without writing it",
 )
 async def validate_semantic_model(
-    request: SemanticModelInput,
+    request: ValidateSemanticModelInput,
     svc: ServiceDep,
 ) -> Result[ValidateSemanticModelData]:
     """Validate SemanticModel YAML."""

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -26,11 +26,12 @@ from datus.api.models.table_models import (
     GetTableDetailData,
     GetTablesColumnsData,
     SaveSemanticModelData,
-    SemanticModelInput,
+    SaveSemanticModelInput,
     TableColumnBrief,
     TableColumns,
     TableDetailData,
     ValidateSemanticModelData,
+    ValidateSemanticModelInput,
 )
 from datus.cli.generation_hooks import GenerationHooks
 from datus.configuration.agent_config_loader import AgentConfig
@@ -39,7 +40,6 @@ from datus.storage.semantic_model.artifact_file import (
     atomic_write_bytes,
     semantic_artifact_lock,
 )
-from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.tools.db_tools.capabilities import supports_namespace
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
@@ -69,7 +69,6 @@ class DatasourceService:
 
         self.db_manager = DBManager(agent_config.datasource_configs)
         self.current_datasource = agent_config.current_datasource
-        self.semantic_rag = SemanticModelRAG(self.agent_config) if self.current_datasource else None
 
         self.current_db_connector = None
         self.current_db_name = None
@@ -80,23 +79,6 @@ class DatasourceService:
         self._columns_cache: dict[str, list[ColumnInfo]] = {}
         self._schema_lock = threading.Lock()
         self._initialize_connection()
-
-    def _ensure_semantic_rag(self) -> SemanticModelRAG:
-        """Create semantic model storage only after a datasource is selected."""
-
-        if self.semantic_rag is not None:
-            return self.semantic_rag
-        self.current_datasource = self.agent_config.current_datasource
-        if not self.current_datasource:
-            from datus.utils.exceptions import DatusException
-            from datus.utils.exceptions import ErrorCode as StorageErrorCode
-
-            raise DatusException(
-                StorageErrorCode.STORAGE_INVALID_ARGUMENT,
-                message_args={"error_message": "No datasource is selected"},
-            )
-        self.semantic_rag = SemanticModelRAG(self.agent_config, datasource_id=self.current_datasource)
-        return self.semantic_rag
 
     def _active_semantic_adapter(self) -> str:
         resolver = getattr(self.agent_config, "resolve_semantic_adapter", None)
@@ -517,73 +499,46 @@ class DatasourceService:
                 results.append(TableColumns(table=full_path, columns=columns))
         return Result(success=True, data=GetTablesColumnsData(tables=results))
 
-    def _get_semantic_model(
-        self,
-        full_name: str,
-        *,
-        catalog: Optional[str] = None,
-        database: Optional[str] = None,
-        db_schema: Optional[str] = None,
-        semantic_model_name: Optional[str] = None,
-    ):
-        # Parse table name parts
-        name_parts = parse_table_name_parts(full_name, self.current_db_connector.get_type())
-        current_db_config = self.agent_config.current_db_config()
-        catalog_name = catalog or name_parts["catalog_name"] or current_db_config.catalog
-        database_name = database or name_parts["database_name"] or self.current_db_name or current_db_config.database
-        schema_name = db_schema or name_parts["schema_name"] or current_db_config.schema
-        table_name = name_parts["table_name"]
+    def _semantic_models_root(self) -> Optional[Path]:
+        """Return the semantic-model root shared by every datasource."""
 
-        # Get semantic model using SemanticMetricsRAG
-        lookup_kwargs = dict(
-            catalog_name=catalog_name,
-            database_name=database_name,
-            schema_name=schema_name,
-            table_name=table_name,
-        )
-        if semantic_model_name:
-            lookup_kwargs["semantic_model_name"] = semantic_model_name
-        semantic_model = self._ensure_semantic_rag().get_semantic_model(**lookup_kwargs)
-        return semantic_model
+        from datus.agent.node.semantic_authoring import osi_semantic_models_root
 
-    def _semantic_model_root(self) -> Optional[Path]:
-        """Return the canonical semantic-model root for the active datasource."""
-
-        from datus.agent.node.semantic_authoring import osi_semantic_model_directory
-
-        root = osi_semantic_model_directory(self.agent_config)
+        root = osi_semantic_models_root(self.agent_config)
         return root.expanduser().resolve(strict=False) if root is not None else None
 
     def _semantic_model_display_path(self, path: Path) -> str:
-        """Return the stable datasource-scoped path exposed by the API."""
+        """Return the stable project-relative path exposed by the API."""
 
-        root = self._semantic_model_root()
+        root = self._semantic_models_root()
         if root is None:
             return str(path)
         relative = path.resolve(strict=False).relative_to(root)
-        datasource = str(getattr(self.agent_config, "current_datasource", "") or "default").strip() or "default"
-        return (Path("subject") / "semantic_models" / datasource / relative).as_posix()
+        return (Path("subject") / "semantic_models" / relative).as_posix()
 
-    def _resolve_explicit_semantic_model_file(self, semantic_model_file: str) -> Path:
-        """Resolve an API file selector without trusting client absolute paths."""
+    def _resolve_semantic_model_file(self, semantic_model_file: str) -> Path:
+        """Resolve an API file selector without trusting client absolute paths.
+
+        The selector is resolved against the whole ``subject/semantic_models``
+        tree rather than the active datasource's subdirectory, so every
+        datasource configured for the project is addressable.
+        """
 
         selector = str(semantic_model_file or "").strip()
         if not selector:
             raise ValueError("semantic_model_file is required")
         raw_path = Path(selector).expanduser()
         if raw_path.is_absolute():
-            raise ValueError("semantic_model_file must be a datasource-scoped relative path")
+            raise ValueError("semantic_model_file must be a project-relative path")
 
-        root = self._semantic_model_root()
+        root = self._semantic_models_root()
         if root is None:
-            raise ValueError("The active datasource semantic-model directory is unavailable")
-        datasource = str(getattr(self.agent_config, "current_datasource", "") or "default").strip() or "default"
+            raise ValueError("The project semantic-model directory is unavailable")
         parts = raw_path.parts
-        prefix = ("subject", "semantic_models", datasource)
-        if parts[: len(prefix)] == prefix:
-            parts = parts[len(prefix) :]
-        elif parts[:2] == ("semantic_models", datasource):
+        if parts[:2] == ("subject", "semantic_models"):
             parts = parts[2:]
+        elif parts[:1] == ("semantic_models",):
+            parts = parts[1:]
         if not parts:
             raise ValueError("semantic_model_file must identify a YAML file")
 
@@ -591,7 +546,7 @@ class DatasourceService:
         try:
             candidate.relative_to(root)
         except ValueError as exc:
-            raise ValueError("semantic_model_file escapes the active datasource directory") from exc
+            raise ValueError("semantic_model_file escapes the semantic-model directory") from exc
         if candidate.suffix.lower() not in {".yml", ".yaml"}:
             raise ValueError("semantic_model_file must be a .yml or .yaml file")
         if not candidate.is_file():
@@ -599,66 +554,8 @@ class DatasourceService:
         try:
             candidate.resolve(strict=True).relative_to(root)
         except (OSError, ValueError) as exc:
-            raise ValueError("semantic_model_file resolves outside the active datasource directory") from exc
+            raise ValueError("semantic_model_file resolves outside the semantic-model directory") from exc
         return candidate
-
-    def _validated_storage_semantic_model_path(self, raw_path: str) -> Path:
-        """Validate a trusted storage lookup against the live datasource root."""
-
-        candidate = Path(str(raw_path or "")).expanduser().resolve(strict=False)
-        if not str(raw_path or "").strip():
-            raise ValueError("Stored semantic model path is empty")
-        root = self._semantic_model_root()
-        if root is not None:
-            try:
-                candidate.relative_to(root)
-            except ValueError as exc:
-                raise ValueError("Stored semantic model path escapes the active datasource directory") from exc
-        return candidate
-
-    def _resolve_semantic_model_path(
-        self,
-        full_name: str = "",
-        *,
-        catalog: Optional[str] = None,
-        database: Optional[str] = None,
-        db_schema: Optional[str] = None,
-        semantic_model_name: Optional[str] = None,
-        semantic_model_file: Optional[str] = None,
-    ) -> Optional[Path]:
-        """Resolve a stable file first, then filesystem model name, then legacy KB lookup."""
-
-        if semantic_model_file:
-            return self._resolve_explicit_semantic_model_file(semantic_model_file)
-
-        requested_name = str(semantic_model_name or "").strip()
-        if requested_name and self._is_osi_semantic_layer():
-            from datus.agent.node.semantic_authoring import inspect_osi_semantic_model_inventory
-
-            inventory = inspect_osi_semantic_model_inventory(self.agent_config)
-            matches = [
-                model
-                for model in [*(inventory.get("models") or []), *(inventory.get("recoverable_models") or [])]
-                if str(model.get("semantic_model_name") or "").strip() == requested_name
-            ]
-            unique_paths = {str(model.get("absolute_path") or "") for model in matches if model.get("absolute_path")}
-            if len(unique_paths) > 1:
-                raise ValueError(f"Semantic model name is ambiguous: {requested_name}")
-            if unique_paths:
-                return self._validated_storage_semantic_model_path(unique_paths.pop())
-
-        if not str(full_name or "").strip():
-            return None
-        semantic_model = self._get_semantic_model(
-            full_name,
-            catalog=catalog,
-            database=database,
-            db_schema=db_schema,
-            semantic_model_name=semantic_model_name,
-        )
-        if not semantic_model:
-            return None
-        return self._validated_storage_semantic_model_path(semantic_model.get("yaml_path", ""))
 
     @staticmethod
     def _osi_candidate_identity(yaml_content: str) -> tuple[Optional[str], bool, Optional[str]]:
@@ -690,7 +587,7 @@ class DatasourceService:
 
     def _validate_semantic_content(
         self,
-        request: SemanticModelInput,
+        request: ValidateSemanticModelInput,
         semantic_model_path: Path,
     ) -> tuple[bool, List[str], Optional[str], bool]:
         """Validate submitted content without mutating the live artifact."""
@@ -717,9 +614,6 @@ class DatasourceService:
             file_path=str(semantic_model_path),
             datus_home=self.agent_config.home,
             datasource=self.agent_config.current_datasource,
-            catalog=request.catalog,
-            database=request.database,
-            db_schema=request.db_schema,
         )
         return is_valid, errors, request.semantic_model_name, False
 
@@ -741,45 +635,29 @@ class DatasourceService:
         payload = result.result if isinstance(result.result, dict) else {}
         return bool(result.success and payload.get("valid", False)), payload, str(result.error or "")
 
-    def get_semantic_model(
-        self,
-        full_name: str,
-        *,
-        catalog: Optional[str] = None,
-        database: Optional[str] = None,
-        db_schema: Optional[str] = None,
-        semantic_model_name: Optional[str] = None,
-    ) -> Result[GetSemanticModelData]:
-        """Get SemanticModel YAML.
-
-        Business logic:
-        1. Parse table name to get catalog, database, schema, table components
-        2. Use SemanticMetricsRAG.get_semantic_model() to retrieve semantic model by table_name
-        3. Get semantic_file_path from the result
-        4. Return the raw YAML file content
+    def get_semantic_model(self, semantic_model_file: str) -> Result[GetSemanticModelData]:
+        """Read one SemanticModel YAML artifact.
 
         Args:
-            full_name: Full table name: [catalog.][database.][schema.]table
+            semantic_model_file: Project-relative path under ``subject/semantic_models``.
 
         Returns:
-            Result[GetSemanticModelData] with YAML content
+            Result[GetSemanticModelData] with the YAML plus the identity and
+            revision a later save needs.
         """
         try:
-            semantic_model_path = self._resolve_semantic_model_path(
-                full_name,
-                catalog=catalog,
-                database=database,
-                db_schema=db_schema,
-                semantic_model_name=semantic_model_name,
+            semantic_model_path = self._resolve_semantic_model_file(semantic_model_file)
+        except ValueError as exc:
+            return Result[GetSemanticModelData](
+                success=False,
+                errorCode=ErrorCode.INVALID_PARAMETERS,
+                errorMessage=str(exc),
             )
-            if semantic_model_path is None:
-                return Result[GetSemanticModelData](
-                    success=True,
-                )
 
+        try:
             content = semantic_model_path.read_bytes()
             yaml_content = content.decode("utf-8")
-            declared_name = str(semantic_model_name or "").strip() or None
+            declared_name = None
             try:
                 document = yaml.safe_load(yaml_content)
                 declared = document.get("semantic_model") if isinstance(document, dict) else None
@@ -808,7 +686,7 @@ class DatasourceService:
                 errorMessage=str(e),
             )
 
-    async def save_semantic_model(self, request: SemanticModelInput) -> Result[SaveSemanticModelData]:
+    async def save_semantic_model(self, request: SaveSemanticModelInput) -> Result[SaveSemanticModelData]:
         """Atomically save and reconcile one semantic model artifact."""
 
         try:
@@ -821,27 +699,14 @@ class DatasourceService:
                 errorMessage=str(exc),
             )
 
-    def _save_semantic_model_sync(self, request: SemanticModelInput) -> Result[SaveSemanticModelData]:
+    def _save_semantic_model_sync(self, request: SaveSemanticModelInput) -> Result[SaveSemanticModelData]:
         try:
-            semantic_model_path = self._resolve_semantic_model_path(
-                request.table,
-                catalog=request.catalog,
-                database=request.database,
-                db_schema=request.db_schema,
-                semantic_model_name=request.semantic_model_name,
-                semantic_model_file=request.semantic_model_file,
-            )
+            semantic_model_path = self._resolve_semantic_model_file(request.semantic_model_file)
         except ValueError as exc:
             return Result[SaveSemanticModelData](
                 success=False,
                 errorCode=ErrorCode.INVALID_PARAMETERS,
                 errorMessage=str(exc),
-            )
-        if semantic_model_path is None:
-            return Result[SaveSemanticModelData](
-                success=False,
-                errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                errorMessage=f"Semantic model not found for target: {request.semantic_model_name or request.table}",
             )
 
         display_path = self._semantic_model_display_path(semantic_model_path)
@@ -1055,24 +920,11 @@ class DatasourceService:
                 ),
             )
 
-    async def validate_semantic_model(self, request: SemanticModelInput) -> Result[ValidateSemanticModelData]:
+    async def validate_semantic_model(self, request: ValidateSemanticModelInput) -> Result[ValidateSemanticModelData]:
         """Validate submitted SemanticModel YAML without changing the live artifact."""
         logger.info("Validating semantic model YAML")
         try:
-            semantic_model_path = self._resolve_semantic_model_path(
-                request.table,
-                catalog=request.catalog,
-                database=request.database,
-                db_schema=request.db_schema,
-                semantic_model_name=request.semantic_model_name,
-                semantic_model_file=request.semantic_model_file,
-            )
-            if semantic_model_path is None:
-                return Result[ValidateSemanticModelData](
-                    success=False,
-                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage=f"Semantic model not found for target: {request.semantic_model_name or request.table}",
-                )
+            semantic_model_path = self._resolve_semantic_model_file(request.semantic_model_file)
             is_valid, error_messages, _model_name, _has_metrics = self._validate_semantic_content(
                 request,
                 semantic_model_path,

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -534,11 +534,12 @@ class DatasourceService:
         root = self._semantic_models_root()
         if root is None:
             raise ValueError("The project semantic-model directory is unavailable")
+        # Only the canonical project-relative form is stripped; anything else is
+        # taken as-is under the root. Accepting a bare ``semantic_models/`` alias
+        # too would be ambiguous for a datasource named ``semantic_models``.
         parts = raw_path.parts
         if parts[:2] == ("subject", "semantic_models"):
             parts = parts[2:]
-        elif parts[:1] == ("semantic_models",):
-            parts = parts[1:]
         if not parts:
             raise ValueError("semantic_model_file must identify a YAML file")
 
@@ -556,6 +557,38 @@ class DatasourceService:
         except (OSError, ValueError) as exc:
             raise ValueError("semantic_model_file resolves outside the semantic-model directory") from exc
         return candidate
+
+    def _semantic_model_datasource(self, path: Path) -> str:
+        """Return the datasource directory a resolved artifact sits under."""
+
+        root = self._semantic_models_root()
+        if root is None:
+            return ""
+        relative = path.resolve(strict=False).relative_to(root)
+        return relative.parts[0] if len(relative.parts) > 1 else ""
+
+    def _resolve_writable_semantic_model_file(self, semantic_model_file: str) -> Path:
+        """Resolve a save/validate target, refusing another datasource's model.
+
+        Reads span the whole tree, but every write-side stage is built around
+        ``current_datasource``: metricflow validation takes it as an argument,
+        the OSI adapter resolves the target inside the active datasource's
+        inventory, and the knowledge-base sync stamps its rows with it. Writing
+        another datasource's artifact would therefore file its rows under the
+        wrong datasource, so reject it with a message that says what to do.
+        Threading a per-request datasource through those stages is the real
+        fix and needs its own change.
+        """
+
+        path = self._resolve_semantic_model_file(semantic_model_file)
+        datasource = self._semantic_model_datasource(path)
+        active = str(getattr(self.agent_config, "current_datasource", "") or "").strip()
+        if datasource and active and datasource != active:
+            raise ValueError(
+                f"semantic_model_file belongs to datasource {datasource!r}, but {active!r} is active; "
+                "switch the active datasource before saving this model"
+            )
+        return path
 
     @staticmethod
     def _osi_candidate_identity(yaml_content: str) -> tuple[Optional[str], bool, Optional[str]]:
@@ -701,7 +734,7 @@ class DatasourceService:
 
     def _save_semantic_model_sync(self, request: SaveSemanticModelInput) -> Result[SaveSemanticModelData]:
         try:
-            semantic_model_path = self._resolve_semantic_model_file(request.semantic_model_file)
+            semantic_model_path = self._resolve_writable_semantic_model_file(request.semantic_model_file)
         except ValueError as exc:
             return Result[SaveSemanticModelData](
                 success=False,
@@ -924,7 +957,10 @@ class DatasourceService:
         """Validate submitted SemanticModel YAML without changing the live artifact."""
         logger.info("Validating semantic model YAML")
         try:
-            semantic_model_path = self._resolve_semantic_model_file(request.semantic_model_file)
+            # Same addressing rule as save: validating a file you would not be
+            # allowed to save is a confusing asymmetry, and the metricflow
+            # validator is itself scoped to the active datasource.
+            semantic_model_path = self._resolve_writable_semantic_model_file(request.semantic_model_file)
             is_valid, error_messages, _model_name, _has_metrics = self._validate_semantic_content(
                 request,
                 semantic_model_path,

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -484,6 +484,36 @@ class TestGetSemanticModel:
         assert result.success is True
         assert result.data.semantic_model_file == "subject/semantic_models/lakehouse/orders.yml"
 
+    @pytest.mark.asyncio
+    async def test_save_semantic_model_rejects_a_non_active_datasource(self, tmp_path):
+        """Reads span every datasource; writes must stay on the active one.
+
+        The validators and the knowledge-base sync are all scoped to
+        ``current_datasource``, so saving another datasource's artifact would
+        file its rows under the wrong datasource.
+        """
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        _yaml_file, selector = _write_model(tmp_path, _osi_yaml(), datasource="lakehouse")
+
+        result = await svc.save_semantic_model(SaveSemanticModelInput(semantic_model_file=selector, yaml=_osi_yaml()))
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_PARAMETERS"
+        assert "lakehouse" in result.errorMessage
+        assert "warehouse" in result.errorMessage
+
+    @pytest.mark.asyncio
+    async def test_validate_semantic_model_rejects_a_non_active_datasource(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        _yaml_file, selector = _write_model(tmp_path, _osi_yaml(), datasource="lakehouse")
+
+        result = await svc.validate_semantic_model(
+            ValidateSemanticModelInput(semantic_model_file=selector, yaml=_osi_yaml())
+        )
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_PARAMETERS"
+
     def test_get_semantic_model_accepts_a_selector_without_the_subject_prefix(self, tmp_path):
         svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
         _yaml_file, _selector = _write_model(tmp_path, _osi_yaml())

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -12,7 +12,11 @@ import pytest
 
 from datus.api.models.base_models import Result
 from datus.api.models.database_models import ListDatabasesInput
-from datus.api.models.table_models import SemanticModelInput, ValidateSemanticModelData
+from datus.api.models.table_models import (
+    SaveSemanticModelInput,
+    ValidateSemanticModelData,
+    ValidateSemanticModelInput,
+)
 from datus.api.services.database_service import DatasourceService
 from datus.storage.semantic_model.artifact_file import artifact_revision, semantic_artifact_lock
 from datus.tools.db_tools.db_manager import DBManager
@@ -20,14 +24,32 @@ from datus.tools.func_tool.metric_filesystem_tools import MetricFilesystemFuncTo
 from datus.tools.func_tool.osi_target_tools import OsiSemanticModelTargetState
 
 
-def _service_with_semantic_adapter(adapter: str = "metricflow") -> DatasourceService:
+def _service_with_semantic_adapter(
+    adapter: str = "metricflow", *, models_root: Path | None = None
+) -> DatasourceService:
     svc = DatasourceService.__new__(DatasourceService)
     svc.agent_config = SimpleNamespace(
         home="/datus-home",
         current_datasource="warehouse",
         resolve_semantic_adapter=lambda: adapter,
+        path_manager=SimpleNamespace(semantic_models_dir=models_root),
     )
     return svc
+
+
+def _write_model(
+    models_root: Path,
+    content: str,
+    *,
+    datasource: str = "warehouse",
+    name: str = "orders.yml",
+) -> tuple[Path, str]:
+    """Create one artifact and return ``(absolute path, API selector)``."""
+
+    target = models_root / datasource / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content)
+    return target, f"subject/semantic_models/{datasource}/{name}"
 
 
 def _osi_yaml(*, metric_name: str = "") -> str:
@@ -67,14 +89,13 @@ class TestDatasourceServiceInit:
         svc = DatasourceService(agent_config=real_agent_config)
         assert isinstance(svc.db_manager, DBManager)
 
-    def test_init_without_datasource_defers_semantic_rag(self, real_agent_config):
-        """Init does not open datasource-scoped semantic storage before datasource selection."""
+    def test_init_without_datasource(self, real_agent_config):
+        """Init tolerates a config with no datasource selected."""
         real_agent_config.current_datasource = ""
 
         svc = DatasourceService(agent_config=real_agent_config)
 
         assert svc.current_datasource == ""
-        assert svc.semantic_rag is None
 
 
 class TestDatabaseServiceGetDatabaseType:
@@ -150,12 +171,12 @@ class TestSemanticLayerServiceBranches:
         assert errors == ["bad osi yaml"]
 
     @pytest.mark.asyncio
-    async def test_validate_semantic_model_uses_osi_validator(self):
-        svc = _service_with_semantic_adapter("osi")
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": "/tmp/orders.yml"})
+    async def test_validate_semantic_model_uses_osi_validator(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        yaml_file, selector = _write_model(tmp_path, _osi_yaml())
         svc._validate_osi_semantic_yaml = MagicMock(return_value=(False, ["missing semantic_models"]))
-        request = SemanticModelInput(
-            table="orders",
+        request = ValidateSemanticModelInput(
+            semantic_model_file=selector,
             yaml="version: 1.0.0\nsemantic_model:\n  - name: orders\n    datasets: []\n",
         )
 
@@ -163,18 +184,15 @@ class TestSemanticLayerServiceBranches:
 
         assert result.success is True
         assert result.data == ValidateSemanticModelData(valid=False, invalid_message=["missing semantic_models"])
-        svc._validate_osi_semantic_yaml.assert_called_once_with(request.yaml, str(Path("/tmp/orders.yml").resolve()))
+        svc._validate_osi_semantic_yaml.assert_called_once_with(request.yaml, str(yaml_file.resolve()))
 
     @pytest.mark.asyncio
-    async def test_validate_semantic_model_uses_metricflow_validator(self):
-        svc = _service_with_semantic_adapter("metricflow")
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": "/tmp/orders.yml"})
-        request = SemanticModelInput(
-            table="orders",
+    async def test_validate_semantic_model_uses_metricflow_validator(self, tmp_path):
+        svc = _service_with_semantic_adapter("metricflow", models_root=tmp_path)
+        yaml_file, selector = _write_model(tmp_path, "semantic_model:\n  name: orders\n")
+        request = ValidateSemanticModelInput(
+            semantic_model_file=selector,
             yaml="semantic_model:\n  name: orders\n",
-            catalog="cat",
-            database="db",
-            db_schema="schema",
         )
 
         with patch("datus.api.utils.semantic_validation.validate_semantic_yaml", return_value=(True, [])) as validate:
@@ -184,24 +202,37 @@ class TestSemanticLayerServiceBranches:
         assert result.data == ValidateSemanticModelData(valid=True, invalid_message=None)
         validate.assert_called_once_with(
             yaml_content=request.yaml,
-            file_path=str(Path("/tmp/orders.yml").resolve()),
+            file_path=str(yaml_file.resolve()),
             datus_home="/datus-home",
             datasource="warehouse",
-            catalog="cat",
-            database="db",
-            db_schema="schema",
         )
 
     @pytest.mark.asyncio
+    async def test_validate_semantic_model_rejects_unknown_file(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+
+        result = await svc.validate_semantic_model(
+            ValidateSemanticModelInput(
+                semantic_model_file="subject/semantic_models/warehouse/ghost.yml",
+                yaml=_osi_yaml(),
+            )
+        )
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_PARAMETERS"
+        assert "not found" in result.errorMessage
+
+    @pytest.mark.asyncio
     async def test_save_semantic_model_uses_osi_sync_tool(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        yaml_file = tmp_path / "orders.yml"
-        yaml_file.write_text("version: 1.0.0\nsemantic_model:\n  - name: orders\n    datasets: []\n")
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        yaml_file, selector = _write_model(
+            tmp_path,
+            "version: 1.0.0\nsemantic_model:\n  - name: orders\n    datasets: []\n",
+        )
         svc._validate_osi_semantic_yaml = MagicMock(return_value=(True, []))
         svc._full_osi_validation = MagicMock(return_value=(True, {"valid": True, "issues": []}, ""))
-        request = SemanticModelInput(
-            table="orders",
+        request = SaveSemanticModelInput(
+            semantic_model_file=selector,
             yaml=(
                 "version: 1.0.0\nsemantic_model:\n  - name: orders\n    datasets:\n"
                 "      - name: orders\n        source: orders\n    metrics: []\n"
@@ -229,11 +260,12 @@ class TestSemanticLayerServiceBranches:
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_uses_metricflow_sync(self, tmp_path):
-        svc = _service_with_semantic_adapter("metricflow")
-        yaml_file = tmp_path / "orders.yml"
-        yaml_file.write_text("semantic_model:\n  name: orders\n")
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
-        request = SemanticModelInput(table="orders", yaml="semantic_model:\n  name: updated_orders\n")
+        svc = _service_with_semantic_adapter("metricflow", models_root=tmp_path)
+        yaml_file, selector = _write_model(tmp_path, "semantic_model:\n  name: orders\n")
+        request = SaveSemanticModelInput(
+            semantic_model_file=selector,
+            yaml="semantic_model:\n  name: updated_orders\n",
+        )
 
         with (
             patch("datus.api.utils.semantic_validation.validate_semantic_yaml", return_value=(True, [])),
@@ -254,15 +286,13 @@ class TestSemanticLayerServiceBranches:
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_rejects_stale_revision(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        yaml_file = tmp_path / "orders.yml"
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
         original = _osi_yaml()
-        yaml_file.write_text(original)
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        yaml_file, selector = _write_model(tmp_path, original)
 
         result = await svc.save_semantic_model(
-            SemanticModelInput(
-                table="orders",
+            SaveSemanticModelInput(
+                semantic_model_file=selector,
                 yaml=_osi_yaml(metric_name="order_count"),
                 expected_revision="sha256:stale",
             )
@@ -275,12 +305,10 @@ class TestSemanticLayerServiceBranches:
         assert yaml_file.read_text() == original
 
     def test_api_save_serializes_against_agent_metric_mutation(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        yaml_file = tmp_path / "orders.yml"
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
         original = _osi_yaml()
         updated = _osi_yaml(metric_name="api_metric")
-        yaml_file.write_text(original)
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        yaml_file, selector = _write_model(tmp_path, original)
         svc._validate_osi_semantic_yaml = MagicMock(return_value=(True, []))
 
         validation_started = threading.Event()
@@ -303,7 +331,7 @@ class TestSemanticLayerServiceBranches:
             mode="bound",
         )
         agent_tool = MetricFilesystemFuncTool(
-            root_path=str(tmp_path),
+            root_path=str(yaml_file.parent),
             current_node="gen_metrics",
             authoring_format="osi",
             osi_target_state=target_state,
@@ -330,8 +358,8 @@ class TestSemanticLayerServiceBranches:
             with ThreadPoolExecutor(max_workers=2) as executor:
                 api_future = executor.submit(
                     svc._save_semantic_model_sync,
-                    SemanticModelInput(
-                        table="orders",
+                    SaveSemanticModelInput(
+                        semantic_model_file=selector,
                         yaml=updated,
                         expected_revision=artifact_revision(original.encode()),
                     ),
@@ -353,18 +381,16 @@ class TestSemanticLayerServiceBranches:
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_restores_yaml_after_full_validation_failure(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        yaml_file = tmp_path / "orders.yml"
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
         original = _osi_yaml()
-        yaml_file.write_text(original)
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        yaml_file, selector = _write_model(tmp_path, original)
         svc._validate_osi_semantic_yaml = MagicMock(return_value=(True, []))
         svc._full_osi_validation = MagicMock(
             return_value=(False, {"valid": False, "issues": [{"message": "bad metric"}]}, "bad metric")
         )
 
         result = await svc.save_semantic_model(
-            SemanticModelInput(table="orders", yaml=_osi_yaml(metric_name="bad_metric"))
+            SaveSemanticModelInput(semantic_model_file=selector, yaml=_osi_yaml(metric_name="bad_metric"))
         )
 
         assert result.success is False
@@ -374,16 +400,14 @@ class TestSemanticLayerServiceBranches:
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_restores_yaml_when_full_validation_raises(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        yaml_file = tmp_path / "orders.yml"
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
         original = _osi_yaml()
-        yaml_file.write_text(original)
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        yaml_file, selector = _write_model(tmp_path, original)
         svc._validate_osi_semantic_yaml = MagicMock(return_value=(True, []))
         svc._full_osi_validation = MagicMock(side_effect=RuntimeError("validator unavailable"))
 
         result = await svc.save_semantic_model(
-            SemanticModelInput(table="orders", yaml=_osi_yaml(metric_name="order_count"))
+            SaveSemanticModelInput(semantic_model_file=selector, yaml=_osi_yaml(metric_name="order_count"))
         )
 
         assert result.success is False
@@ -394,17 +418,15 @@ class TestSemanticLayerServiceBranches:
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_keeps_valid_yaml_when_sync_fails(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        yaml_file = tmp_path / "orders.yml"
-        yaml_file.write_text(_osi_yaml())
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        yaml_file, selector = _write_model(tmp_path, _osi_yaml())
         svc._validate_osi_semantic_yaml = MagicMock(return_value=(True, []))
         svc._full_osi_validation = MagicMock(return_value=(True, {"valid": True, "issues": []}, ""))
         updated = _osi_yaml(metric_name="order_count")
 
         with patch("datus.tools.func_tool.generation_tools.GenerationTools") as tools_cls:
             tools_cls.return_value.sync_osi_to_db.return_value = {"success": False, "error": "storage down"}
-            result = await svc.save_semantic_model(SemanticModelInput(table="orders", yaml=updated))
+            result = await svc.save_semantic_model(SaveSemanticModelInput(semantic_model_file=selector, yaml=updated))
 
         assert result.success is False
         assert result.errorCode == "SEMANTIC_MODEL_SYNC_FAILED"
@@ -415,19 +437,17 @@ class TestSemanticLayerServiceBranches:
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_unchanged_yaml_still_repairs_kb(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        yaml_file = tmp_path / "orders.yml"
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
         content = _osi_yaml()
-        yaml_file.write_text(content)
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        _yaml_file, selector = _write_model(tmp_path, content)
         svc._validate_osi_semantic_yaml = MagicMock(return_value=(True, []))
         svc._full_osi_validation = MagicMock(return_value=(True, {"valid": True, "issues": []}, ""))
 
         with patch("datus.tools.func_tool.generation_tools.GenerationTools") as tools_cls:
             tools_cls.return_value.sync_osi_to_db.return_value = {"success": True}
             result = await svc.save_semantic_model(
-                SemanticModelInput(
-                    table="orders",
+                SaveSemanticModelInput(
+                    semantic_model_file=selector,
                     yaml=content,
                     expected_revision=artifact_revision(content.encode()),
                 )
@@ -438,54 +458,76 @@ class TestSemanticLayerServiceBranches:
 
 
 class TestGetSemanticModel:
-    """Tests for get_semantic_model and validate_semantic_model."""
+    """Tests for the file-addressed get_semantic_model."""
 
     def test_get_semantic_model_returns_stable_file_identity_and_revision(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        svc.agent_config.path_manager = SimpleNamespace(semantic_model_path=lambda _datasource: tmp_path)
-        yaml_file = tmp_path / "orders.yml"
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
         content = _osi_yaml()
-        yaml_file.write_text(content)
-        svc._get_semantic_model = MagicMock(return_value={"yaml_path": str(yaml_file)})
+        _yaml_file, selector = _write_model(tmp_path, content)
 
-        result = svc.get_semantic_model("orders")
+        result = svc.get_semantic_model(selector)
 
         assert result.success is True
+        assert result.data.yaml == content
         assert result.data.semantic_model_name == "orders"
         assert result.data.semantic_model_file == "subject/semantic_models/warehouse/orders.yml"
         assert result.data.revision == artifact_revision(content.encode())
 
-    @pytest.mark.asyncio
-    async def test_save_semantic_model_accepts_stable_file_without_kb_lookup(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        svc.agent_config.path_manager = SimpleNamespace(semantic_model_path=lambda _datasource: tmp_path)
-        yaml_file = tmp_path / "orders.yml"
-        yaml_file.write_text(_osi_yaml())
-        svc._get_semantic_model = MagicMock(side_effect=AssertionError("KB lookup must not be used"))
-        svc._validate_osi_semantic_yaml = MagicMock(return_value=(True, []))
-        svc._full_osi_validation = MagicMock(return_value=(True, {"valid": True, "issues": []}, ""))
+    def test_get_semantic_model_reaches_a_non_active_datasource(self, tmp_path):
+        """Resolution spans the whole tree, not just the first configured datasource."""
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        content = _osi_yaml()
+        _yaml_file, selector = _write_model(tmp_path, content, datasource="lakehouse")
 
-        with patch("datus.tools.func_tool.generation_tools.GenerationTools") as tools_cls:
-            tools_cls.return_value.sync_osi_to_db.return_value = {"success": True}
-            result = await svc.save_semantic_model(
-                SemanticModelInput(
-                    yaml=_osi_yaml(metric_name="order_count"),
-                    semantic_model_file="subject/semantic_models/warehouse/orders.yml",
-                    semantic_model_name="orders",
-                    expected_revision=artifact_revision(yaml_file.read_bytes()),
-                )
-            )
+        result = svc.get_semantic_model(selector)
 
         assert result.success is True
-        svc._get_semantic_model.assert_not_called()
+        assert result.data.semantic_model_file == "subject/semantic_models/lakehouse/orders.yml"
+
+    def test_get_semantic_model_accepts_a_selector_without_the_subject_prefix(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        _yaml_file, _selector = _write_model(tmp_path, _osi_yaml())
+
+        result = svc.get_semantic_model("warehouse/orders.yml")
+
+        assert result.success is True
+        assert result.data.semantic_model_file == "subject/semantic_models/warehouse/orders.yml"
+
+    def test_get_semantic_model_rejects_unknown_file(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+
+        result = svc.get_semantic_model("subject/semantic_models/warehouse/ghost.yml")
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_PARAMETERS"
+        assert isinstance(result, Result)
+
+    def test_get_semantic_model_rejects_absolute_path(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        yaml_file, _selector = _write_model(tmp_path, _osi_yaml())
+
+        result = svc.get_semantic_model(str(yaml_file))
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_PARAMETERS"
+        assert "project-relative" in result.errorMessage
+
+    def test_get_semantic_model_rejects_non_yaml_suffix(self, tmp_path):
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
+        (tmp_path / "warehouse").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "warehouse" / "orders.txt").write_text("nope")
+
+        result = svc.get_semantic_model("subject/semantic_models/warehouse/orders.txt")
+
+        assert result.success is False
+        assert ".yml" in result.errorMessage
 
     @pytest.mark.asyncio
     async def test_save_semantic_model_rejects_file_escape(self, tmp_path):
-        svc = _service_with_semantic_adapter("osi")
-        svc.agent_config.path_manager = SimpleNamespace(semantic_model_path=lambda _datasource: tmp_path)
+        svc = _service_with_semantic_adapter("osi", models_root=tmp_path)
 
         result = await svc.save_semantic_model(
-            SemanticModelInput(
+            SaveSemanticModelInput(
                 yaml=_osi_yaml(),
                 semantic_model_file="../outside.yml",
                 semantic_model_name="orders",
@@ -495,79 +537,6 @@ class TestGetSemanticModel:
         assert result.success is False
         assert result.errorCode == "INVALID_PARAMETERS"
         assert "escapes" in result.errorMessage
-
-    def test_get_semantic_model_nonexistent(self, real_agent_config):
-        """get_semantic_model for nonexistent table returns empty result."""
-        svc = DatasourceService(agent_config=real_agent_config)
-        result = svc.get_semantic_model("nonexistent_table_xyz")
-        # Should return success=True with no data, or success=False
-        assert isinstance(result, Result)
-
-    def test_get_semantic_model_for_known_table(self, real_agent_config):
-        """get_semantic_model for known table (may return empty if no semantic model built)."""
-        svc = DatasourceService(agent_config=real_agent_config)
-        result = svc.get_semantic_model("schools")
-        # The table exists but may not have a semantic model file
-        assert isinstance(result, Result)
-
-    def test_get_semantic_model_prefers_runtime_db_context(self, real_agent_config):
-        """Runtime catalog/database/schema context is used for semantic model lookup."""
-        svc = DatasourceService(agent_config=real_agent_config)
-        call = {}
-
-        class FakeSemanticRag:
-            def get_semantic_model(
-                self,
-                *,
-                catalog_name: str,
-                database_name: str,
-                schema_name: str,
-                table_name: str,
-            ):
-                call.update(
-                    catalog_name=catalog_name,
-                    database_name=database_name,
-                    schema_name=schema_name,
-                    table_name=table_name,
-                )
-                return None
-
-        svc._ensure_semantic_rag = lambda: FakeSemanticRag()
-
-        result = svc.get_semantic_model(
-            "embedded_catalog.embedded_db.embedded_schema.schools",
-            catalog="runtime_catalog",
-            database="runtime_db",
-            db_schema="runtime_schema",
-        )
-
-        assert isinstance(result, Result)
-        assert call == {
-            "catalog_name": "runtime_catalog",
-            "database_name": "runtime_db",
-            "schema_name": "runtime_schema",
-            "table_name": "schools",
-        }
-
-    def test_get_semantic_model_passes_explicit_model_name(self, real_agent_config):
-        svc = DatasourceService(agent_config=real_agent_config)
-        semantic_rag = MagicMock()
-        semantic_rag.get_semantic_model.return_value = None
-        svc._ensure_semantic_rag = lambda: semantic_rag
-
-        svc._get_semantic_model("schools", semantic_model_name="education")
-
-        assert semantic_rag.get_semantic_model.call_args.kwargs["semantic_model_name"] == "education"
-
-    @pytest.mark.asyncio
-    async def test_validate_semantic_model_nonexistent(self, real_agent_config):
-        """validate_semantic_model for nonexistent table returns error."""
-        from datus.api.models.table_models import SemanticModelInput
-
-        svc = DatasourceService(agent_config=real_agent_config)
-        request = SemanticModelInput(table="nonexistent_xyz", yaml="metric:\n  name: test\n")
-        result = await svc.validate_semantic_model(request)
-        assert result.success is False
 
 
 class TestListDatabases:


### PR DESCRIPTION
Follow-up to #1237. The three `/api/v1/semantic_model` endpoints were built for the table-detail pane, which addressed a model through the physical table it described. That pane is going away — the Datus-saas IDE now edits the YAML artifact directly and knows only its project-relative path.

## What changes

**The file is the identity.**

- `GET /api/v1/semantic_model` takes `semantic_model_file` and returns the YAML plus the `semantic_model_name` and `revision` a later save needs. `table` is gone.
- `POST /api/v1/semantic_model` and `POST /api/v1/semantic_model/validate` take the same selector, split into `SaveSemanticModelInput` / `ValidateSemanticModelInput` (only save carries `expected_revision`).
- `table`, `catalog`, `database` and `db_schema` are removed from every request. The last three were never read — `validate_semantic_yaml` discards them on its first line (`del catalog, database, db_schema`) — and the KB lookup they fed is no longer reachable.

**Resolution spans every datasource.** `_resolve_semantic_model_file` now resolves against the whole `subject/semantic_models` tree instead of the active datasource's subdirectory. `current_datasource` is just the first configured datasource, so a project with several of them could previously only reach one datasource's models; every other one failed with `Semantic model file not found`. Traversal is still confined to that root (absolute paths, `..` escapes and non-YAML suffixes are all rejected).

**Dead code dropped.** The KB-lookup helpers (`_get_semantic_model`, `_resolve_semantic_model_path`, `_validated_storage_semantic_model_path`, `_ensure_semantic_rag`) and the eager `SemanticModelRAG` handle in `DatasourceService` had no remaining callers.

## Breaking change

This is a breaking API change with a single caller — the Datus-saas IDE, whose matching PR ships alongside. Datus-backend needs a submodule bump once this lands.

## Tests

`tests/unit_tests/api/services/test_database_service.py` is reworked onto file selectors, plus new coverage for reaching a non-active datasource, the `subject/`-less selector form, unknown files, absolute paths and non-YAML suffixes. `pytest tests/unit_tests/api tests/unit_tests/agent/node` — 2987 passed.

Verified end to end against a real project through the saas IDE: synced save, revision conflict, validation failure and retry all behave as intended.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added project-wide semantic model file management.
  * Semantic models can now be retrieved, validated, and saved using relative YAML file paths.
  * Added revision tracking and concurrency checks when saving semantic models.
  * Validation now supports optional model-name checks and confirms results without writing changes.

* **Bug Fixes**
  * Improved protection against invalid paths, unsupported files, missing artifacts, and symlink traversal.
  * Failed writes are restored automatically after validation errors.
  * Added repair handling for unchanged semantic model files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-wide semantic model file management.
  * Retrieve, validate, and save semantic models using relative YAML file paths.
  * Added revision tracking and concurrency checks when saving.
  * Validation supports optional model-name checks without writing changes.

* **Bug Fixes**
  * Improved protection against invalid paths, unsupported files, missing artifacts, and symlink traversal.
  * Prevented cross-datasource artifact access.
  * Failed writes are restored automatically after validation errors.
  * Added repair handling for unchanged semantic model files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->