### PR TITLE
[BugFix] Prevent pgvector Testcontainers leaks in nightly tests

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       DATUS_AGENT_REF: ${{ github.event.inputs.datus_agent_ref || github.ref_name }}
       NIGHTLY_GROUP_FILTER: ${{ github.event.inputs.nightly_group_filter || '' }}
+      DATUS_TEST_RUN_ID: datus-agent-${{ github.run_id }}-${{ github.run_attempt }}
       # The job deliberately overlays packages from the adapter checkouts after
       # the locked project sync. Do not let later `uv run` commands restore the
       # registry builds from uv.lock over those checkout packages.

--- a/ci/cleanup-run-testcontainers.sh
+++ b/ci/cleanup-run-testcontainers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+run_id="${DATUS_TEST_RUN_ID:-}"
+if [ -z "$run_id" ]; then
+  echo "DATUS_TEST_RUN_ID is not set; skipping Testcontainers cleanup"
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is not available; skipping Testcontainers cleanup"
+  exit 0
+fi
+
+if ! container_output="$(
+  docker ps -aq \
+    --filter "label=org.testcontainers=true" \
+    --filter "label=com.datus.ci.run-id=${run_id}"
+)"; then
+  echo "Failed to list Testcontainers for run ${run_id}" >&2
+  exit 1
+fi
+
+container_ids=()
+while IFS= read -r container_id; do
+  [ -n "$container_id" ] && container_ids+=("$container_id")
+done <<< "$container_output"
+
+if [ "${#container_ids[@]}" -eq 0 ]; then
+  echo "No Testcontainers found for run ${run_id}"
+  exit 0
+fi
+
+cleanup_failed=0
+for container_id in "${container_ids[@]}"; do
+  container_run_id="$(docker inspect --format '{{index .Config.Labels "com.datus.ci.run-id"}}' "$container_id" 2>/dev/null || true)"
+  if [ "$container_run_id" != "$run_id" ]; then
+    echo "Skipping container ${container_id}: run label does not match"
+    continue
+  fi
+  docker rm -fv "$container_id" || cleanup_failed=1
+done
+
+remaining="$(
+  docker ps -aq \
+    --filter "label=org.testcontainers=true" \
+    --filter "label=com.datus.ci.run-id=${run_id}" \
+    | wc -l
+)"
+if [ "$remaining" -ne 0 ]; then
+  echo "Failed to remove ${remaining} Testcontainers for run ${run_id}" >&2
+  cleanup_failed=1
+fi
+
+exit "$cleanup_failed"

--- a/ci/cleanup-run-testcontainers.sh
+++ b/ci/cleanup-run-testcontainers.sh
@@ -41,12 +41,15 @@ for container_id in "${container_ids[@]}"; do
   docker rm -fv "$container_id" || cleanup_failed=1
 done
 
-remaining="$(
+if ! remaining="$(
   docker ps -aq \
     --filter "label=org.testcontainers=true" \
     --filter "label=com.datus.ci.run-id=${run_id}" \
     | wc -l
-)"
+)"; then
+  echo "Failed to list remaining Testcontainers for run ${run_id}" >&2
+  cleanup_failed=1
+fi
 if [ "$remaining" -ne 0 ]; then
   echo "Failed to remove ${remaining} Testcontainers for run ${run_id}" >&2
   cleanup_failed=1

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -804,12 +804,14 @@ cleanup_all() {
     rm -rf "$NIGHTLY_PYTEST_BASETEMP"
   fi
   cleanup_all_compose
+  "$REPO_ROOT/ci/cleanup-run-testcontainers.sh"
 }
 
 if [ "${1:-}" = "--cleanup-only" ]; then
   NIGHTLY_SKIP_MANIFEST_FINALIZE=1
   cleanup_all
-  exit 0
+  cleanup_status=$?
+  exit "$cleanup_status"
 fi
 
 handle_interrupt() {

--- a/tests/unit_tests/ci/test_testcontainer_cleanup_contract.py
+++ b/tests/unit_tests/ci/test_testcontainer_cleanup_contract.py
@@ -22,3 +22,9 @@ def test_nightly_exports_and_cleans_the_same_run_id():
     assert '"$REPO_ROOT/ci/cleanup-run-testcontainers.sh"' in nightly
     assert "cleanup_status=$?" in nightly
     assert 'exit "$cleanup_status"' in nightly
+
+    cleanup_start = workflow.index("- name: Stop nightly services")
+    cleanup_end = workflow.index("\n      - name:", cleanup_start + 1)
+    cleanup_step = workflow[cleanup_start:cleanup_end]
+    assert "if: always()" in cleanup_step
+    assert "ci/run-nightly-tests.sh --cleanup-only" in cleanup_step

--- a/tests/unit_tests/ci/test_testcontainer_cleanup_contract.py
+++ b/tests/unit_tests/ci/test_testcontainer_cleanup_contract.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLEANUP_SCRIPT = REPO_ROOT / "ci" / "cleanup-run-testcontainers.sh"
+NIGHTLY_SCRIPT = REPO_ROOT / "ci" / "run-nightly-tests.sh"
+NIGHTLY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-nightly.yml"
+
+
+def test_cleanup_is_scoped_to_the_current_testcontainers_run():
+    script = CLEANUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "label=org.testcontainers=true" in script
+    assert "label=com.datus.ci.run-id=${run_id}" in script
+    assert 'docker rm -fv "$container_id"' in script
+
+
+def test_nightly_exports_and_cleans_the_same_run_id():
+    workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+    nightly = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+
+    assert "DATUS_TEST_RUN_ID: datus-agent-${{ github.run_id }}-${{ github.run_attempt }}" in workflow
+    assert '"$REPO_ROOT/ci/cleanup-run-testcontainers.sh"' in nightly
+    assert "cleanup_status=$?" in nightly
+    assert 'exit "$cleanup_status"' in nightly

--- a/tests/unit_tests/storage/_backend_discovery.py
+++ b/tests/unit_tests/storage/_backend_discovery.py
@@ -2,21 +2,12 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Discover available storage backends for parameterized testing.
-
-Test environments are discovered via entry points:
-    datus.storage.rdb.testing    -- RDB test environment providers
-    datus.storage.vector.testing -- Vector test environment providers
-
-Each entry point references a factory function returning a TestEnv instance.
-Built-in backends (sqlite, lance) use no-op TestEnv implementations.
-"""
+"""Discover and provision storage backends for parameterized tests."""
 
 from __future__ import annotations
 
-import atexit
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from datus_storage_base.testing import RdbTestEnv, TestEnvConfig, VectorTestEnv
 
@@ -27,14 +18,8 @@ logger = get_logger(__name__)
 _DEFAULT_RDB = "sqlite"
 _DEFAULT_VECTOR = "lance"
 
-# Active test environments keyed by entry point name
-_active_rdb_envs: Dict[str, RdbTestEnv] = {}
-_active_vector_envs: Dict[str, VectorTestEnv] = {}
-
-
-# ---------------------------------------------------------------------------
-# Built-in no-op TestEnv implementations for file-based backends
-# ---------------------------------------------------------------------------
+RdbTestEnvFactory = Callable[[], RdbTestEnv]
+VectorTestEnvFactory = Callable[[], VectorTestEnv]
 
 
 class _SqliteTestEnv(RdbTestEnv):
@@ -47,10 +32,10 @@ class _SqliteTestEnv(RdbTestEnv):
         pass
 
     def clear_data(self, datasource: str) -> None:
-        pass  # tmp_path provides isolation
+        pass
 
     def get_config(self) -> TestEnvConfig:
-        return TestEnvConfig(backend_type="sqlite", params={})
+        return TestEnvConfig(backend_type=_DEFAULT_RDB, params={})
 
 
 class _LanceTestEnv(VectorTestEnv):
@@ -63,28 +48,32 @@ class _LanceTestEnv(VectorTestEnv):
         pass
 
     def clear_data(self, datasource: str) -> None:
-        pass  # tmp_path provides isolation
+        pass
 
     def get_config(self) -> TestEnvConfig:
-        return TestEnvConfig(backend_type="lance", params={})
+        return TestEnvConfig(backend_type=_DEFAULT_VECTOR, params={})
 
 
-# Singleton instances for built-in backends
-_builtin_sqlite_env = _SqliteTestEnv()
-_builtin_lance_env = _LanceTestEnv()
+@dataclass(frozen=True)
+class BackendTestSpec:
+    """A side-effect-free description of one backend test combination."""
 
+    rdb_type: str = _DEFAULT_RDB
+    vector_type: str = _DEFAULT_VECTOR
+    rdb_factory: Optional[RdbTestEnvFactory] = field(default=None, repr=False)
+    vector_factory: Optional[VectorTestEnvFactory] = field(default=None, repr=False)
 
-# ---------------------------------------------------------------------------
-# BackendTestConfig
-# ---------------------------------------------------------------------------
+    @property
+    def id(self) -> str:
+        return f"{self.rdb_type}+{self.vector_type}"
 
 
 @dataclass
 class BackendTestConfig:
-    """Describes one rdb+vector backend combination for parameterized tests."""
+    """A provisioned rdb+vector backend combination."""
 
-    rdb_type: str = "sqlite"
-    vector_type: str = "lance"
+    rdb_type: str = _DEFAULT_RDB
+    vector_type: str = _DEFAULT_VECTOR
     rdb_params: Dict[str, Any] = field(default_factory=dict)
     vector_params: Dict[str, Any] = field(default_factory=dict)
     rdb_test_env: Optional[RdbTestEnv] = field(default=None, repr=False)
@@ -93,11 +82,6 @@ class BackendTestConfig:
     @property
     def id(self) -> str:
         return f"{self.rdb_type}+{self.vector_type}"
-
-
-# ---------------------------------------------------------------------------
-# Entry-point-based discovery
-# ---------------------------------------------------------------------------
 
 
 def _load_entry_points(group: str) -> Dict[str, Any]:
@@ -117,122 +101,86 @@ def _load_entry_points(group: str) -> Dict[str, Any]:
     return results
 
 
-def _discover_via_entry_points() -> List[BackendTestConfig]:
-    """Auto-discover test environments via entry points.
-
-    Discovery flow:
-        1. Scan entry_points("datus.storage.rdb.testing")
-        2. For each: factory = ep.load(), env = factory(), env.setup()
-        3. Scan entry_points("datus.storage.vector.testing")
-        4. Pair by entry point name (same name -> pair together)
-        5. Single-side entries pair with the default backend
-    """
-    configs: List[BackendTestConfig] = []
-
-    # Discover RDB test environments
+def _discover_via_entry_points() -> List[BackendTestSpec]:
+    """Discover backend factories without constructing or starting environments."""
     rdb_factories = _load_entry_points("datus.storage.rdb.testing")
-    for name, factory in rdb_factories.items():
-        try:
-            env = factory()
-            env.setup()
-            _active_rdb_envs[name] = env
-            logger.info(f"RDB test env '{name}' ready")
-        except Exception as e:
-            logger.debug(f"RDB test env '{name}' setup failed: {e}")
-
-    # Discover Vector test environments
     vector_factories = _load_entry_points("datus.storage.vector.testing")
-    for name, factory in vector_factories.items():
-        try:
-            env = factory()
-            env.setup()
-            _active_vector_envs[name] = env
-            logger.info(f"Vector test env '{name}' ready")
-        except Exception as e:
-            logger.debug(f"Vector test env '{name}' setup failed: {e}")
+    specs: List[BackendTestSpec] = []
 
-    # Pair by common name
-    all_names = set(_active_rdb_envs.keys()) | set(_active_vector_envs.keys())
-    for name in sorted(all_names):
-        rdb_env = _active_rdb_envs.get(name)
-        vec_env = _active_vector_envs.get(name)
-
-        if rdb_env is not None:
-            rdb_cfg = rdb_env.get_config()
-            rdb_type = rdb_cfg.backend_type
-            rdb_params = rdb_cfg.params
-        else:
-            rdb_type = _DEFAULT_RDB
-            rdb_params = {}
-
-        if vec_env is not None:
-            vec_cfg = vec_env.get_config()
-            vec_type = vec_cfg.backend_type
-            vec_params = vec_cfg.params
-        else:
-            vec_type = _DEFAULT_VECTOR
-            vec_params = {}
-
-        if rdb_type == _DEFAULT_RDB and vec_type == _DEFAULT_VECTOR:
+    for name in sorted(set(rdb_factories) | set(vector_factories)):
+        rdb_factory = rdb_factories.get(name)
+        vector_factory = vector_factories.get(name)
+        rdb_type = name if rdb_factory is not None else _DEFAULT_RDB
+        vector_type = name if vector_factory is not None else _DEFAULT_VECTOR
+        if rdb_type == _DEFAULT_RDB and vector_type == _DEFAULT_VECTOR:
             continue
-
-        configs.append(
-            BackendTestConfig(
+        specs.append(
+            BackendTestSpec(
                 rdb_type=rdb_type,
-                vector_type=vec_type,
-                rdb_params=rdb_params,
-                vector_params=vec_params,
-                rdb_test_env=rdb_env,
-                vector_test_env=vec_env,
+                vector_type=vector_type,
+                rdb_factory=rdb_factory,
+                vector_factory=vector_factory,
             )
         )
-        logger.info(f"Auto-discovered backend combo: {rdb_type}+{vec_type}")
-
-    return configs
+    return specs
 
 
-# ---------------------------------------------------------------------------
-# Cleanup
-# ---------------------------------------------------------------------------
-
-
-def cleanup_test_environments() -> None:
-    """Tear down all active test environments."""
-    for name in reversed(list(_active_vector_envs.keys())):
-        try:
-            _active_vector_envs[name].teardown()
-        except Exception as e:
-            logger.debug(f"Vector test env '{name}' teardown failed: {e}")
-    _active_vector_envs.clear()
-
-    for name in reversed(list(_active_rdb_envs.keys())):
-        try:
-            _active_rdb_envs[name].teardown()
-        except Exception as e:
-            logger.debug(f"RDB test env '{name}' teardown failed: {e}")
-    _active_rdb_envs.clear()
-
-
-# Safety net: ensure cleanup even if pytest crashes
-atexit.register(cleanup_test_environments)
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
-def discover_test_backends() -> List[BackendTestConfig]:
-    """Return the list of backend configs to parameterize storage tests with.
-
-    1. Always includes the default sqlite+lance config (with built-in TestEnv).
-    2. Auto-discovers additional backends via entry points.
-    """
+def discover_test_backends() -> List[BackendTestSpec]:
+    """Return backend specifications without starting external resources."""
     backends = [
-        BackendTestConfig(
-            rdb_test_env=_builtin_sqlite_env,
-            vector_test_env=_builtin_lance_env,
+        BackendTestSpec(
+            rdb_factory=_SqliteTestEnv,
+            vector_factory=_LanceTestEnv,
         )
     ]
     backends.extend(_discover_via_entry_points())
     return backends
+
+
+def _teardown_environments(environments: List[RdbTestEnv | VectorTestEnv]) -> None:
+    for env in reversed(environments):
+        try:
+            env.teardown()
+        except Exception as e:
+            logger.debug(f"Test environment teardown failed: {e}")
+
+
+def setup_test_backend(spec: BackendTestSpec) -> BackendTestConfig:
+    """Provision one backend specification and clean partial setup on failure."""
+    started: List[RdbTestEnv | VectorTestEnv] = []
+    rdb_env: Optional[RdbTestEnv] = None
+    vector_env: Optional[VectorTestEnv] = None
+    try:
+        if spec.rdb_factory is not None:
+            rdb_env = spec.rdb_factory()
+            started.append(rdb_env)
+            rdb_env.setup()
+            rdb_config = rdb_env.get_config()
+        else:
+            rdb_config = TestEnvConfig(backend_type=spec.rdb_type, params={})
+
+        if spec.vector_factory is not None:
+            vector_env = spec.vector_factory()
+            started.append(vector_env)
+            vector_env.setup()
+            vector_config = vector_env.get_config()
+        else:
+            vector_config = TestEnvConfig(backend_type=spec.vector_type, params={})
+    except Exception:
+        _teardown_environments(started)
+        raise
+
+    return BackendTestConfig(
+        rdb_type=rdb_config.backend_type,
+        vector_type=vector_config.backend_type,
+        rdb_params=rdb_config.params,
+        vector_params=vector_config.params,
+        rdb_test_env=rdb_env,
+        vector_test_env=vector_env,
+    )
+
+
+def teardown_test_backend(backend: BackendTestConfig) -> None:
+    """Tear down a provisioned backend in reverse setup order."""
+    environments = [env for env in (backend.rdb_test_env, backend.vector_test_env) if env is not None]
+    _teardown_environments(environments)

--- a/tests/unit_tests/storage/_backend_discovery.py
+++ b/tests/unit_tests/storage/_backend_discovery.py
@@ -139,11 +139,17 @@ def discover_test_backends() -> list[BackendTestSpec]:
 
 
 def _teardown_environments(environments: list[RdbTestEnv | VectorTestEnv]) -> None:
+    interruption: BaseException | None = None
     for env in reversed(environments):
         try:
             env.teardown()
         except Exception as e:
             logger.debug(f"Test environment teardown failed: {e}")
+        except BaseException as exc:
+            if interruption is None:
+                interruption = exc
+    if interruption is not None:
+        raise interruption
 
 
 def setup_test_backend(spec: BackendTestSpec) -> BackendTestConfig:

--- a/tests/unit_tests/storage/_backend_discovery.py
+++ b/tests/unit_tests/storage/_backend_discovery.py
@@ -6,8 +6,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any
 
 from datus_storage_base.testing import RdbTestEnv, TestEnvConfig, VectorTestEnv
 
@@ -60,8 +61,8 @@ class BackendTestSpec:
 
     rdb_type: str = _DEFAULT_RDB
     vector_type: str = _DEFAULT_VECTOR
-    rdb_factory: Optional[RdbTestEnvFactory] = field(default=None, repr=False)
-    vector_factory: Optional[VectorTestEnvFactory] = field(default=None, repr=False)
+    rdb_factory: RdbTestEnvFactory | None = field(default=None, repr=False)
+    vector_factory: VectorTestEnvFactory | None = field(default=None, repr=False)
 
     @property
     def id(self) -> str:
@@ -74,19 +75,19 @@ class BackendTestConfig:
 
     rdb_type: str = _DEFAULT_RDB
     vector_type: str = _DEFAULT_VECTOR
-    rdb_params: Dict[str, Any] = field(default_factory=dict)
-    vector_params: Dict[str, Any] = field(default_factory=dict)
-    rdb_test_env: Optional[RdbTestEnv] = field(default=None, repr=False)
-    vector_test_env: Optional[VectorTestEnv] = field(default=None, repr=False)
+    rdb_params: dict[str, Any] = field(default_factory=dict)
+    vector_params: dict[str, Any] = field(default_factory=dict)
+    rdb_test_env: RdbTestEnv | None = field(default=None, repr=False)
+    vector_test_env: VectorTestEnv | None = field(default=None, repr=False)
 
     @property
     def id(self) -> str:
         return f"{self.rdb_type}+{self.vector_type}"
 
 
-def _load_entry_points(group: str) -> Dict[str, Any]:
+def _load_entry_points(group: str) -> dict[str, Any]:
     """Load entry points for the given group, returning {name: loaded_object}."""
-    results: Dict[str, Any] = {}
+    results: dict[str, Any] = {}
     try:
         from importlib.metadata import entry_points
 
@@ -101,11 +102,11 @@ def _load_entry_points(group: str) -> Dict[str, Any]:
     return results
 
 
-def _discover_via_entry_points() -> List[BackendTestSpec]:
+def _discover_via_entry_points() -> list[BackendTestSpec]:
     """Discover backend factories without constructing or starting environments."""
     rdb_factories = _load_entry_points("datus.storage.rdb.testing")
     vector_factories = _load_entry_points("datus.storage.vector.testing")
-    specs: List[BackendTestSpec] = []
+    specs: list[BackendTestSpec] = []
 
     for name in sorted(set(rdb_factories) | set(vector_factories)):
         rdb_factory = rdb_factories.get(name)
@@ -125,7 +126,7 @@ def _discover_via_entry_points() -> List[BackendTestSpec]:
     return specs
 
 
-def discover_test_backends() -> List[BackendTestSpec]:
+def discover_test_backends() -> list[BackendTestSpec]:
     """Return backend specifications without starting external resources."""
     backends = [
         BackendTestSpec(
@@ -137,7 +138,7 @@ def discover_test_backends() -> List[BackendTestSpec]:
     return backends
 
 
-def _teardown_environments(environments: List[RdbTestEnv | VectorTestEnv]) -> None:
+def _teardown_environments(environments: list[RdbTestEnv | VectorTestEnv]) -> None:
     for env in reversed(environments):
         try:
             env.teardown()
@@ -147,9 +148,9 @@ def _teardown_environments(environments: List[RdbTestEnv | VectorTestEnv]) -> No
 
 def setup_test_backend(spec: BackendTestSpec) -> BackendTestConfig:
     """Provision one backend specification and clean partial setup on failure."""
-    started: List[RdbTestEnv | VectorTestEnv] = []
-    rdb_env: Optional[RdbTestEnv] = None
-    vector_env: Optional[VectorTestEnv] = None
+    started: list[RdbTestEnv | VectorTestEnv] = []
+    rdb_env: RdbTestEnv | None = None
+    vector_env: VectorTestEnv | None = None
     try:
         if spec.rdb_factory is not None:
             rdb_env = spec.rdb_factory()
@@ -166,7 +167,7 @@ def setup_test_backend(spec: BackendTestSpec) -> BackendTestConfig:
             vector_config = vector_env.get_config()
         else:
             vector_config = TestEnvConfig(backend_type=spec.vector_type, params={})
-    except Exception:
+    except BaseException:
         _teardown_environments(started)
         raise
 

--- a/tests/unit_tests/storage/conftest.py
+++ b/tests/unit_tests/storage/conftest.py
@@ -5,6 +5,8 @@ discovered backends so that store-level tests automatically repeat on every
 available rdb+vector combination.
 """
 
+from collections.abc import Iterator
+
 import pytest
 from datus_storage_base.backend_config import RdbBackendConfig, StorageBackendConfig, VectorBackendConfig
 
@@ -12,6 +14,7 @@ from datus.storage.backend_holder import init_backends, reset_backends
 from datus.storage.registry import clear_storage_registry
 from datus.utils.path_manager import DatusPathManager, reset_path_manager, set_current_path_manager
 from tests.unit_tests.storage._backend_discovery import (
+    BackendTestConfig,
     discover_test_backends,
     setup_test_backend,
     teardown_test_backend,
@@ -21,7 +24,7 @@ _BACKEND_SPECS = discover_test_backends()
 
 
 @pytest.fixture(scope="session", params=_BACKEND_SPECS, ids=lambda backend: backend.id)
-def _storage_backend_environment(request):
+def _storage_backend_environment(request) -> Iterator[BackendTestConfig]:
     """Own one backend environment for the lifetime of its parameterized test session."""
     try:
         backend = setup_test_backend(request.param)
@@ -47,7 +50,7 @@ def storage_test_project():
 
 
 @pytest.fixture(autouse=True)
-def _init_storage_backends(_storage_backend_environment, tmp_path, storage_test_project):
+def _init_storage_backends(_storage_backend_environment, tmp_path, storage_test_project) -> Iterator[BackendTestConfig]:
     """Ensure storage backends are configured with a valid data_dir for every storage test."""
     backend = _storage_backend_environment
     config = StorageBackendConfig(

--- a/tests/unit_tests/storage/conftest.py
+++ b/tests/unit_tests/storage/conftest.py
@@ -11,9 +11,28 @@ from datus_storage_base.backend_config import RdbBackendConfig, StorageBackendCo
 from datus.storage.backend_holder import init_backends, reset_backends
 from datus.storage.registry import clear_storage_registry
 from datus.utils.path_manager import DatusPathManager, reset_path_manager, set_current_path_manager
-from tests.unit_tests.storage._backend_discovery import discover_test_backends
+from tests.unit_tests.storage._backend_discovery import (
+    discover_test_backends,
+    setup_test_backend,
+    teardown_test_backend,
+)
 
-_BACKENDS = discover_test_backends()
+_BACKEND_SPECS = discover_test_backends()
+
+
+@pytest.fixture(scope="session", params=_BACKEND_SPECS, ids=lambda backend: backend.id)
+def _storage_backend_environment(request):
+    """Own one backend environment for the lifetime of its parameterized test session."""
+    try:
+        backend = setup_test_backend(request.param)
+    except Exception as exc:
+        pytest.skip(  # audit-noqa: try_except_skip - external backend availability is optional
+            f"Storage backend {request.param.id} is unavailable: {exc}"
+        )
+    try:
+        yield backend
+    finally:
+        teardown_test_backend(backend)
 
 
 @pytest.fixture
@@ -27,10 +46,10 @@ def storage_test_project():
     return "test"
 
 
-@pytest.fixture(autouse=True, params=_BACKENDS, ids=lambda b: b.id)
-def _init_storage_backends(request, tmp_path, storage_test_project):
+@pytest.fixture(autouse=True)
+def _init_storage_backends(_storage_backend_environment, tmp_path, storage_test_project):
     """Ensure storage backends are configured with a valid data_dir for every storage test."""
-    backend = request.param
+    backend = _storage_backend_environment
     config = StorageBackendConfig(
         rdb=RdbBackendConfig(type=backend.rdb_type, params=backend.rdb_params),
         vector=VectorBackendConfig(type=backend.vector_type, params=backend.vector_params),
@@ -76,22 +95,14 @@ def agent_project_name(storage_test_project):
     return storage_test_project
 
 
-def pytest_sessionfinish(session, exitstatus):
-    """Clean up backend test environments at session end."""
-    from tests.unit_tests.storage._backend_discovery import cleanup_test_environments
-
-    cleanup_test_environments()
-
-
 def pytest_runtest_setup(item):
     """Skip tests based on backend_specific marker."""
     for marker in item.iter_markers("backend_specific"):
         required = marker.args[0] if marker.args else None
         if not required:
             continue
-        # Find the backend config from the _init_storage_backends param
-        backend = None
-        if hasattr(item, "callspec") and "_init_storage_backends" in item.callspec.params:
-            backend = item.callspec.params["_init_storage_backends"]
-        if backend and required != backend.rdb_type and required != backend.vector_type:
+        backend_spec = None
+        if hasattr(item, "callspec") and "_storage_backend_environment" in item.callspec.params:
+            backend_spec = item.callspec.params["_storage_backend_environment"]
+        if backend_spec and required != backend_spec.rdb_type and required != backend_spec.vector_type:
             pytest.skip(f"Requires {required} backend")

--- a/tests/unit_tests/storage/test_backend_discovery.py
+++ b/tests/unit_tests/storage/test_backend_discovery.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Tests for backend discovery with TestEnv-based lifecycle management."""
+"""Tests for side-effect-free backend discovery and fixture-owned lifecycle."""
 
 from unittest.mock import MagicMock, patch
 
@@ -11,26 +11,17 @@ from datus_storage_base.testing import RdbTestEnv, TestEnvConfig, VectorTestEnv
 
 from tests.unit_tests.storage._backend_discovery import (
     BackendTestConfig,
-    _active_rdb_envs,
-    _active_vector_envs,
+    BackendTestSpec,
     _discover_via_entry_points,
-    cleanup_test_environments,
+    _LanceTestEnv,
+    _SqliteTestEnv,
     discover_test_backends,
+    setup_test_backend,
+    teardown_test_backend,
 )
 
 
-@pytest.fixture(autouse=True)
-def _clean_active_envs():
-    """Ensure active env dicts are clean before and after each test."""
-    _active_rdb_envs.clear()
-    _active_vector_envs.clear()
-    yield
-    _active_rdb_envs.clear()
-    _active_vector_envs.clear()
-
-
 def _make_mock_rdb_env(backend_type="postgresql", params=None):
-    """Create a mock RdbTestEnv that returns the given config."""
     env = MagicMock(spec=RdbTestEnv)
     env.get_config.return_value = TestEnvConfig(
         backend_type=backend_type,
@@ -40,7 +31,6 @@ def _make_mock_rdb_env(backend_type="postgresql", params=None):
 
 
 def _make_mock_vector_env(backend_type="postgresql", params=None):
-    """Create a mock VectorTestEnv that returns the given config."""
     env = MagicMock(spec=VectorTestEnv)
     env.get_config.return_value = TestEnvConfig(
         backend_type=backend_type,
@@ -49,213 +39,125 @@ def _make_mock_vector_env(backend_type="postgresql", params=None):
     return env
 
 
-def _make_mock_factory(env):
-    """Create a factory function that returns the given env."""
-    return MagicMock(return_value=env)
-
-
 class TestDiscoverTestBackends:
-    """Tests for the main discover_test_backends() function."""
-
     def test_always_includes_default(self):
-        """sqlite+lance is always first in the returned list."""
-        backends = discover_test_backends()
-        assert len(backends) >= 1
-        assert backends[0].rdb_type == "sqlite"
-        assert backends[0].vector_type == "lance"
-        assert backends[0].id == "sqlite+lance"
-
-    def test_default_has_builtin_test_envs(self):
-        """Default config has built-in TestEnv instances."""
-        backends = discover_test_backends()
-        assert isinstance(backends[0].rdb_test_env, RdbTestEnv)
-        assert isinstance(backends[0].vector_test_env, VectorTestEnv)
-
-    def test_calls_entry_point_discovery(self):
-        """discover_test_backends() calls _discover_via_entry_points()."""
         with patch(
             "tests.unit_tests.storage._backend_discovery._discover_via_entry_points",
             return_value=[],
-        ) as mock_discover:
+        ):
             backends = discover_test_backends()
-            mock_discover.assert_called_once()
-            assert len(backends) == 1  # only default
 
+        assert backends == [
+            BackendTestSpec(
+                rdb_factory=_SqliteTestEnv,
+                vector_factory=_LanceTestEnv,
+            )
+        ]
 
-class TestDiscoverViaEntryPoints:
-    """Tests for _discover_via_entry_points() with TestEnv-based lifecycle."""
-
-    def test_paired_backend(self):
-        """When both RDB and vector have same entry point name, they are paired."""
-        rdb_env = _make_mock_rdb_env()
-        vec_env = _make_mock_vector_env()
-
-        rdb_factories = {"postgresql": _make_mock_factory(rdb_env)}
-        vec_factories = {"postgresql": _make_mock_factory(vec_env)}
+    def test_entry_point_discovery_does_not_construct_environments(self):
+        rdb_factory = MagicMock()
+        vector_factory = MagicMock()
 
         with patch(
             "tests.unit_tests.storage._backend_discovery._load_entry_points",
-            side_effect=lambda group: rdb_factories if "rdb" in group else vec_factories,
+            side_effect=lambda group: {"postgresql": rdb_factory} if "rdb" in group else {"postgresql": vector_factory},
         ):
-            configs = _discover_via_entry_points()
+            specs = _discover_via_entry_points()
 
-        assert len(configs) == 1
-        assert configs[0].rdb_type == "postgresql"
-        assert configs[0].vector_type == "postgresql"
-        assert configs[0].rdb_test_env is rdb_env
-        assert configs[0].vector_test_env is vec_env
-        rdb_env.setup.assert_called_once()
-        vec_env.setup.assert_called_once()
+        assert [spec.id for spec in specs] == ["postgresql+postgresql"]
+        rdb_factory.assert_not_called()
+        vector_factory.assert_not_called()
 
     def test_rdb_only_pairs_with_lance(self):
-        """RDB-only entry point pairs with default lance vector."""
-        rdb_env = _make_mock_rdb_env(backend_type="mysql", params={"host": "localhost"})
-        rdb_factories = {"mysql": _make_mock_factory(rdb_env)}
-
+        rdb_factory = MagicMock()
         with patch(
             "tests.unit_tests.storage._backend_discovery._load_entry_points",
-            side_effect=lambda group: rdb_factories if "rdb" in group else {},
+            side_effect=lambda group: {"mysql": rdb_factory} if "rdb" in group else {},
         ):
-            configs = _discover_via_entry_points()
+            specs = _discover_via_entry_points()
 
-        assert len(configs) == 1
-        assert configs[0].rdb_type == "mysql"
-        assert configs[0].vector_type == "lance"
-        assert configs[0].rdb_test_env is rdb_env
-        assert configs[0].vector_test_env is None
+        assert specs == [BackendTestSpec(rdb_type="mysql", vector_type="lance", rdb_factory=rdb_factory)]
 
     def test_vector_only_pairs_with_sqlite(self):
-        """Vector-only entry point pairs with default sqlite RDB."""
-        vec_env = _make_mock_vector_env(backend_type="milvus", params={"host": "localhost"})
-        vec_factories = {"milvus": _make_mock_factory(vec_env)}
-
+        vector_factory = MagicMock()
         with patch(
             "tests.unit_tests.storage._backend_discovery._load_entry_points",
-            side_effect=lambda group: {} if "rdb" in group else vec_factories,
+            side_effect=lambda group: {} if "rdb" in group else {"milvus": vector_factory},
         ):
-            configs = _discover_via_entry_points()
+            specs = _discover_via_entry_points()
 
-        assert len(configs) == 1
-        assert configs[0].rdb_type == "sqlite"
-        assert configs[0].vector_type == "milvus"
-        assert configs[0].rdb_test_env is None
-        assert configs[0].vector_test_env is vec_env
+        assert specs == [BackendTestSpec(rdb_type="sqlite", vector_type="milvus", vector_factory=vector_factory)]
 
-    def test_setup_raises_exception_skips(self):
-        """Entry point is skipped gracefully when setup() raises."""
+
+class TestBackendLifecycle:
+    def test_setup_and_teardown_paired_backend(self):
         rdb_env = _make_mock_rdb_env()
-        rdb_env.setup.side_effect = RuntimeError("Docker not available")
-        rdb_factories = {"postgresql": _make_mock_factory(rdb_env)}
+        vector_env = _make_mock_vector_env()
+        spec = BackendTestSpec(
+            rdb_type="postgresql",
+            vector_type="postgresql",
+            rdb_factory=MagicMock(return_value=rdb_env),
+            vector_factory=MagicMock(return_value=vector_env),
+        )
 
-        with patch(
-            "tests.unit_tests.storage._backend_discovery._load_entry_points",
-            side_effect=lambda group: rdb_factories if "rdb" in group else {},
-        ):
-            configs = _discover_via_entry_points()
+        backend = setup_test_backend(spec)
+        teardown_test_backend(backend)
 
-        assert len(configs) == 0
+        rdb_env.setup.assert_called_once()
+        vector_env.setup.assert_called_once()
+        rdb_env.teardown.assert_called_once()
+        vector_env.teardown.assert_called_once()
+        assert backend.id == "postgresql+postgresql"
 
-    def test_factory_raises_exception_skips(self):
-        """Entry point is skipped gracefully when factory() raises."""
-        factory = MagicMock(side_effect=RuntimeError("Import error"))
-        rdb_factories = {"postgresql": factory}
-
-        with patch(
-            "tests.unit_tests.storage._backend_discovery._load_entry_points",
-            side_effect=lambda group: rdb_factories if "rdb" in group else {},
-        ):
-            configs = _discover_via_entry_points()
-
-        assert len(configs) == 0
-
-
-class TestCleanupTestEnvironments:
-    """Tests for cleanup_test_environments()."""
-
-    def test_teardown_called_on_cleanup(self):
-        """Verify teardown() is called during cleanup."""
+    def test_partial_setup_failure_tears_down_started_environments(self):
         rdb_env = _make_mock_rdb_env()
-        _active_rdb_envs["postgresql"] = rdb_env
+        vector_env = _make_mock_vector_env()
+        vector_env.setup.side_effect = RuntimeError("Docker unavailable")
+        spec = BackendTestSpec(
+            rdb_type="postgresql",
+            vector_type="postgresql",
+            rdb_factory=MagicMock(return_value=rdb_env),
+            vector_factory=MagicMock(return_value=vector_env),
+        )
 
-        cleanup_test_environments()
+        with pytest.raises(RuntimeError, match="Docker unavailable"):
+            setup_test_backend(spec)
 
         rdb_env.teardown.assert_called_once()
-        assert len(_active_rdb_envs) == 0
-        assert len(_active_vector_envs) == 0
+        vector_env.teardown.assert_called_once()
 
-    def test_teardown_called_for_both_types(self):
-        """Both RDB and vector environments are torn down."""
+    def test_factory_failure_does_not_leak_previous_environment(self):
         rdb_env = _make_mock_rdb_env()
-        vec_env = _make_mock_vector_env()
-        _active_rdb_envs["postgresql"] = rdb_env
-        _active_vector_envs["postgresql"] = vec_env
+        spec = BackendTestSpec(
+            rdb_type="postgresql",
+            vector_type="postgresql",
+            rdb_factory=MagicMock(return_value=rdb_env),
+            vector_factory=MagicMock(side_effect=RuntimeError("factory failed")),
+        )
 
-        cleanup_test_environments()
+        with pytest.raises(RuntimeError, match="factory failed"):
+            setup_test_backend(spec)
 
         rdb_env.teardown.assert_called_once()
-        vec_env.teardown.assert_called_once()
-        assert len(_active_rdb_envs) == 0
-        assert len(_active_vector_envs) == 0
 
-    def test_teardown_exception_does_not_stop_others(self):
-        """An exception in one teardown does not prevent others from running."""
-        rdb_env1 = _make_mock_rdb_env()
-        rdb_env2 = _make_mock_rdb_env()
-        rdb_env1.teardown.side_effect = RuntimeError("teardown failed")
-        _active_rdb_envs["first"] = rdb_env1
-        _active_rdb_envs["second"] = rdb_env2
-
-        cleanup_test_environments()
-
-        rdb_env1.teardown.assert_called_once()
-        rdb_env2.teardown.assert_called_once()
-        assert len(_active_rdb_envs) == 0
-
-    def test_teardown_registered_during_discovery(self):
-        """Test environments are registered in _active_*_envs during discovery."""
+    def test_teardown_exception_does_not_stop_other_cleanup(self):
         rdb_env = _make_mock_rdb_env()
-        rdb_factories = {"postgresql": _make_mock_factory(rdb_env)}
+        vector_env = _make_mock_vector_env()
+        vector_env.teardown.side_effect = RuntimeError("teardown failed")
+        backend = BackendTestConfig(rdb_test_env=rdb_env, vector_test_env=vector_env)
 
-        with patch(
-            "tests.unit_tests.storage._backend_discovery._load_entry_points",
-            side_effect=lambda group: rdb_factories if "rdb" in group else {},
-        ):
-            _discover_via_entry_points()
+        teardown_test_backend(backend)
 
-        assert "postgresql" in _active_rdb_envs
-
-        # Cleanup calls teardown
-        cleanup_test_environments()
+        vector_env.teardown.assert_called_once()
         rdb_env.teardown.assert_called_once()
 
 
 class TestBackendTestConfig:
-    """Tests for BackendTestConfig dataclass."""
-
     def test_default_values(self):
-        """Default config is sqlite+lance with empty params."""
-        cfg = BackendTestConfig()
-        assert cfg.rdb_type == "sqlite"
-        assert cfg.vector_type == "lance"
-        assert cfg.rdb_params == {}
-        assert cfg.vector_params == {}
-        assert cfg.rdb_test_env is None
-        assert cfg.vector_test_env is None
+        config = BackendTestConfig()
 
-    def test_id_property(self):
-        """id property returns 'rdb+vector' format."""
-        cfg = BackendTestConfig(rdb_type="postgres", vector_type="pgvector")
-        assert cfg.id == "postgres+pgvector"
-
-    def test_with_test_env(self):
-        """BackendTestConfig can hold TestEnv references."""
-        rdb_env = _make_mock_rdb_env()
-        vec_env = _make_mock_vector_env()
-        cfg = BackendTestConfig(
-            rdb_type="postgresql",
-            vector_type="postgresql",
-            rdb_test_env=rdb_env,
-            vector_test_env=vec_env,
-        )
-        assert cfg.rdb_test_env is rdb_env
-        assert cfg.vector_test_env is vec_env
+        assert config.id == "sqlite+lance"
+        assert config.rdb_params == {}
+        assert config.vector_params == {}
+        assert config.rdb_test_env is None
+        assert config.vector_test_env is None

--- a/tests/unit_tests/storage/test_backend_discovery.py
+++ b/tests/unit_tests/storage/test_backend_discovery.py
@@ -188,6 +188,26 @@ class TestBackendLifecycle:
         rdb_env.teardown.assert_called_once()
         assert teardown_order == ["vector", "rdb"]
 
+    def test_teardown_interrupt_does_not_stop_other_cleanup(self):
+        teardown_order = []
+        rdb_env = _make_mock_rdb_env()
+        vector_env = _make_mock_vector_env()
+
+        def interrupt_vector_teardown():
+            teardown_order.append("vector")
+            raise KeyboardInterrupt
+
+        rdb_env.teardown.side_effect = lambda: teardown_order.append("rdb")
+        vector_env.teardown.side_effect = interrupt_vector_teardown
+        backend = BackendTestConfig(rdb_test_env=rdb_env, vector_test_env=vector_env)
+
+        with pytest.raises(KeyboardInterrupt):
+            teardown_test_backend(backend)
+
+        vector_env.teardown.assert_called_once()
+        rdb_env.teardown.assert_called_once()
+        assert teardown_order == ["vector", "rdb"]
+
 
 class TestBackendTestConfig:
     def test_default_values(self):

--- a/tests/unit_tests/storage/test_backend_discovery.py
+++ b/tests/unit_tests/storage/test_backend_discovery.py
@@ -91,8 +91,11 @@ class TestDiscoverTestBackends:
 
 class TestBackendLifecycle:
     def test_setup_and_teardown_paired_backend(self):
+        teardown_order = []
         rdb_env = _make_mock_rdb_env()
         vector_env = _make_mock_vector_env()
+        rdb_env.teardown.side_effect = lambda: teardown_order.append("rdb")
+        vector_env.teardown.side_effect = lambda: teardown_order.append("vector")
         spec = BackendTestSpec(
             rdb_type="postgresql",
             vector_type="postgresql",
@@ -107,12 +110,16 @@ class TestBackendLifecycle:
         vector_env.setup.assert_called_once()
         rdb_env.teardown.assert_called_once()
         vector_env.teardown.assert_called_once()
+        assert teardown_order == ["vector", "rdb"]
         assert backend.id == "postgresql+postgresql"
 
     def test_partial_setup_failure_tears_down_started_environments(self):
+        teardown_order = []
         rdb_env = _make_mock_rdb_env()
         vector_env = _make_mock_vector_env()
         vector_env.setup.side_effect = RuntimeError("Docker unavailable")
+        rdb_env.teardown.side_effect = lambda: teardown_order.append("rdb")
+        vector_env.teardown.side_effect = lambda: teardown_order.append("vector")
         spec = BackendTestSpec(
             rdb_type="postgresql",
             vector_type="postgresql",
@@ -125,6 +132,28 @@ class TestBackendLifecycle:
 
         rdb_env.teardown.assert_called_once()
         vector_env.teardown.assert_called_once()
+        assert teardown_order == ["vector", "rdb"]
+
+    def test_keyboard_interrupt_tears_down_started_environments(self):
+        teardown_order = []
+        rdb_env = _make_mock_rdb_env()
+        vector_env = _make_mock_vector_env()
+        vector_env.setup.side_effect = KeyboardInterrupt
+        rdb_env.teardown.side_effect = lambda: teardown_order.append("rdb")
+        vector_env.teardown.side_effect = lambda: teardown_order.append("vector")
+        spec = BackendTestSpec(
+            rdb_type="postgresql",
+            vector_type="postgresql",
+            rdb_factory=MagicMock(return_value=rdb_env),
+            vector_factory=MagicMock(return_value=vector_env),
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            setup_test_backend(spec)
+
+        rdb_env.teardown.assert_called_once()
+        vector_env.teardown.assert_called_once()
+        assert teardown_order == ["vector", "rdb"]
 
     def test_factory_failure_does_not_leak_previous_environment(self):
         rdb_env = _make_mock_rdb_env()
@@ -141,15 +170,23 @@ class TestBackendLifecycle:
         rdb_env.teardown.assert_called_once()
 
     def test_teardown_exception_does_not_stop_other_cleanup(self):
+        teardown_order = []
         rdb_env = _make_mock_rdb_env()
         vector_env = _make_mock_vector_env()
-        vector_env.teardown.side_effect = RuntimeError("teardown failed")
+
+        def fail_vector_teardown():
+            teardown_order.append("vector")
+            raise RuntimeError("teardown failed")
+
+        rdb_env.teardown.side_effect = lambda: teardown_order.append("rdb")
+        vector_env.teardown.side_effect = fail_vector_teardown
         backend = BackendTestConfig(rdb_test_env=rdb_env, vector_test_env=vector_env)
 
         teardown_test_backend(backend)
 
         vector_env.teardown.assert_called_once()
         rdb_env.teardown.assert_called_once()
+        assert teardown_order == ["vector", "rdb"]
 
 
 class TestBackendTestConfig:


### PR DESCRIPTION
## Summary

- make storage backend discovery side-effect free and defer environment setup to a session-scoped pytest fixture
- guarantee reverse-order teardown for successful and partially initialized backend environments
- remove the global environment registries, `atexit` hook, and `pytest_sessionfinish` cleanup path
- assign a unique Testcontainers run ID in nightly and remove only containers carrying that exact run label
- surface cleanup failures from the dedicated `always()` cleanup step

## Root cause

Storage backend environments were started while `conftest.py` was imported in every pytest-xdist worker. The backend discovery unit tests then cleared the same global registries that owned those environments, so session cleanup no longer had references to the running pgvector containers.

The fixture now owns the complete setup/yield/teardown lifecycle. Collection only discovers factories and cannot start Docker resources.

## Safety

The nightly fallback requires both `org.testcontainers=true` and the exact `com.datus.ci.run-id` value for the current workflow run. It never performs a daemon-wide Testcontainers cleanup on the shared runner.

Depends on Datus-ai/datus-storage-adapters#11, which adds the run label at every PostgreSQL Testcontainers creation site. Merge that PR first.

Closes #1214.

## Validation

- focused lifecycle and cleanup tests: 11 passed
- storage-adapters label tests: 2 passed
- real Docker run under `pytest-xdist -n 2`: 18 passed; pgvector container count returned from 0 to 0
- collection-only check: pgvector container count stayed at 0
- scoped cleanup check: current-run container removed while a differently labeled container remained
- cleanup failure propagation check returned exit status 1
- Ruff check/format, Bash syntax, workflow YAML, and `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly test cleanup to safely remove only containers created by the current run.
  * Nightly workflows now report cleanup failures instead of silently succeeding.

* **Tests**
  * Added coverage to verify container cleanup isolation and failure reporting.
  * Improved storage backend test setup and teardown, including safer cleanup after partial failures and more reliable backend discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly test cleanup to safely remove only containers created by the current run.
  * Nightly workflows now report cleanup failures instead of silently succeeding.

* **Tests**
  * Added coverage for container cleanup isolation, failure reporting, and run tracking.
  * Improved storage backend test discovery, setup, teardown, and recovery after partial failures or interruptions.
  * Ensured test environments are cleaned up reliably, including when setup or teardown encounters errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->