### PR TITLE
[BugFix] Localize the heuristic chart-recommendation wording

### DIFF
--- a/datus/tools/llms_tools/visualization_messages.py
+++ b/datus/tools/llms_tools/visualization_messages.py
@@ -1,0 +1,95 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Localized wording for chart recommendations produced without an LLM.
+
+The heuristic path runs precisely when no model is reachable, so its ``reason``
+can be neither generated nor translated at call time — it has to ship as static
+per-language templates. Unknown language codes fall back to English.
+"""
+
+from typing import Any, Dict, Optional, Sequence
+
+FALLBACK_LANGUAGE = "en"
+
+# chart_type as produced by VisualizationTool -> message key
+_CHART_KEYS: Dict[str, str] = {
+    "Line Chart": "line",
+    "Bar Chart": "bar",
+    "Pie Chart": "pie",
+    "Scatter Plot": "scatter",
+}
+
+# language code -> message key -> template. ``{x}`` is the dimension column,
+# ``{y}`` the comma-joined metric columns.
+_MESSAGES: Dict[str, Dict[str, str]] = {
+    "en": {
+        "line": "Line chart over '{x}' shows the trend of {y} over time.",
+        "bar": "Bar chart compares {y} across the categories in '{x}'.",
+        "pie": "Pie chart shows the share of {y} across the categories in '{x}'.",
+        "scatter": "Scatter plot reveals the relationship between {y} and '{x}'.",
+        "unknown": "Unable to determine an ideal visualization for the provided data.",
+        "empty": "Dataset does not contain any records.",
+    },
+    "zh": {
+        "line": "折线图按 '{x}' 展示 {y} 随时间的变化趋势。",
+        "bar": "柱状图按 '{x}' 的各个类别对比 {y}。",
+        "pie": "饼图展示 {y} 在 '{x}' 各类别中的占比。",
+        "scatter": "散点图展示 {y} 与 '{x}' 之间的关系。",
+        "unknown": "无法根据所提供的数据判断合适的图表类型。",
+        "empty": "数据集中没有任何记录。",
+    },
+}
+
+
+def normalize_language(code: Optional[str]) -> str:
+    """Reduce a language tag to a key present in the message table.
+
+    Regional tags collapse onto their base language (``zh-CN``/``zh_CN`` → ``zh``);
+    an exact match wins first, so adding a regional entry to the table is enough
+    to give it its own wording. Anything unmapped falls back to English.
+    """
+    if not code:
+        return FALLBACK_LANGUAGE
+    normalized = str(code).strip().lower().replace("_", "-")
+    if normalized in _MESSAGES:
+        return normalized
+    base = normalized.split("-", 1)[0]
+    return base if base in _MESSAGES else FALLBACK_LANGUAGE
+
+
+def _render(key: str, language: Optional[str], **params: str) -> str:
+    table = _MESSAGES[normalize_language(language)]
+    template = table.get(key) or _MESSAGES[FALLBACK_LANGUAGE].get(key, "")
+    try:
+        return template.format(**params)
+    except (KeyError, IndexError):
+        return template
+
+
+def reason_for_chart(
+    chart_type: str,
+    language: Optional[str] = None,
+    x_col: Any = "",
+    y_cols: Sequence[Any] = (),
+) -> str:
+    """Explain a heuristic chart pick in the caller's language.
+
+    Falls back to the ``unknown`` wording for chart types we have no template
+    for, and whenever an axis is absent — a sentence naming an empty column
+    reads worse than admitting the data was inconclusive. Labels are stringified
+    rather than tested for truthiness, so a DataFrame column literally named
+    ``0`` is a label, not a missing axis.
+    """
+    key = _CHART_KEYS.get(chart_type)
+    x_label = "" if x_col is None else str(x_col)
+    y_labels = [str(col) for col in y_cols if col is not None]
+    if not key or not x_label or not y_labels:
+        return _render("unknown", language)
+    return _render(key, language, x=x_label, y=", ".join(y_labels))
+
+
+def empty_dataset_reason(language: Optional[str] = None) -> str:
+    """Wording for a request whose dataset carries no rows/columns."""
+    return _render("empty", language)

--- a/datus/tools/llms_tools/visualization_tool.py
+++ b/datus/tools/llms_tools/visualization_tool.py
@@ -23,6 +23,7 @@ from datus.models.base import LLMBaseModel
 from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.visualization import VisualizationInput, VisualizationOutput, VisualizationWithContextOutput
 from datus.tools.base import BaseTool
+from datus.tools.llms_tools.visualization_messages import empty_dataset_reason, reason_for_chart
 from datus.utils.language_utils import resolve_language_name
 from datus.utils.loggings import get_logger
 
@@ -96,7 +97,9 @@ class VisualizationTool(BaseTool):
         if dataframe.empty or dataframe.shape[1] == 0:
             error_msg = "Provided dataset is empty or has no columns."
             logger.error(error_msg)
-            return self._error_output(error_msg, "Unknown", reason="Dataset does not contain any records")
+            return self._error_output(
+                error_msg, "Unknown", reason=empty_dataset_reason(self._effective_language(language))
+            )
 
         result = None
         if self.model:
@@ -106,7 +109,7 @@ class VisualizationTool(BaseTool):
                 logger.warning(f"LLM visualization recommendation failed, falling back to heuristics: {exc}")
 
         if result is None:
-            result = self._rule_based_recommendation(dataframe)
+            result = self._rule_based_recommendation(dataframe, language=language)
 
         return result
 
@@ -151,7 +154,7 @@ class VisualizationTool(BaseTool):
                 chart_type="Unknown",
                 x_col="",
                 y_cols=[],
-                reason="Dataset does not contain any records",
+                reason=empty_dataset_reason(self._effective_language(language)),
             )
 
         # Try context-aware LLM call
@@ -164,7 +167,7 @@ class VisualizationTool(BaseTool):
                 logger.warning(f"Context-aware LLM call failed, falling back to heuristics: {exc}")
 
         # Fall back directly to rule-based heuristics (no second LLM call)
-        base = self._rule_based_recommendation(dataframe)
+        base = self._rule_based_recommendation(dataframe, language=language)
         return VisualizationWithContextOutput(
             success=base.success,
             error=base.error,
@@ -212,7 +215,7 @@ class VisualizationTool(BaseTool):
 
         reason = (response.get("reason") or "").strip()
         if not reason:
-            reason = self._default_reason(chart_type, x_col, y_cols)
+            reason = self._default_reason(chart_type, x_col, y_cols, language=language)
 
         # ── Parse context metadata ────────────────────────────────
         period = response.get("period")
@@ -243,6 +246,14 @@ class VisualizationTool(BaseTool):
     # ------------------------------------------------------------------ #
     # Response language
     # ------------------------------------------------------------------ #
+    def _effective_language(self, language: Optional[str]) -> str:
+        """Resolve the pinned language code, or ``""`` when none is configured."""
+        # A blank explicit override is "unset", not "no language" — otherwise a
+        # caller sending an empty field would suppress the configured default.
+        explicit = str(language).strip() if language else ""
+        fallback = getattr(self.agent_config, "language", None)
+        return explicit or (str(fallback).strip() if fallback else "")
+
     def _language_directive(self, language: Optional[str]) -> str:
         """Render the ``response_language`` section, or ``""`` when unpinned.
 
@@ -251,11 +262,7 @@ class VisualizationTool(BaseTool):
         prompt itself — otherwise an English template is answered in English
         regardless of the language the caller asked for.
         """
-        # A blank explicit override is "unset", not "no language" — otherwise a
-        # caller sending an empty field would suppress the configured default.
-        explicit = str(language).strip() if language else ""
-        fallback = getattr(self.agent_config, "language", None)
-        code = explicit or (str(fallback).strip() if fallback else "")
+        code = self._effective_language(language)
         if not code:
             return ""
         language_name = resolve_language_name(code)
@@ -325,7 +332,7 @@ class VisualizationTool(BaseTool):
         y_cols = self._sanitize_y_cols(df, y_cols, exclude={x_col})
 
         if not reason:
-            reason = self._default_reason(chart_type, x_col, y_cols)
+            reason = self._default_reason(chart_type, x_col, y_cols, language=language)
 
         return VisualizationOutput(
             success=True,
@@ -339,8 +346,13 @@ class VisualizationTool(BaseTool):
     # ------------------------------------------------------------------ #
     # Heuristic recommendation fallback
     # ------------------------------------------------------------------ #
-    def _rule_based_recommendation(self, df: pd.DataFrame) -> VisualizationOutput:
-        """Recommend visualization using lightweight heuristics."""
+    def _rule_based_recommendation(self, df: pd.DataFrame, language: Optional[str] = None) -> VisualizationOutput:
+        """Recommend visualization using lightweight heuristics.
+
+        ``reason`` comes from a static translation table rather than an f-string:
+        this path is reached exactly when no LLM is available, so the wording
+        cannot be generated — but the caller still asked for a language.
+        """
         numeric_cols = [col for col in df.columns if self._is_numeric(df[col])]
         datetime_cols = [col for col in df.columns if is_datetime64_any_dtype(df[col])]
         categorical_cols = [col for col in df.columns if self._is_categorical(df[col])]
@@ -348,7 +360,6 @@ class VisualizationTool(BaseTool):
         chart_type = "Unknown"
         x_col = ""
         y_cols: List[str] = []
-        reason = "Unable to determine an ideal visualization for the provided data."
 
         pie_candidate = (
             len(categorical_cols) == 1
@@ -360,34 +371,18 @@ class VisualizationTool(BaseTool):
             x_col = datetime_cols[0]
             y_cols = self._select_numeric_metrics(numeric_cols, exclude={x_col})
             chart_type = "Line Chart"
-            reason = (
-                f"Detected datetime column '{x_col}' with {len(y_cols)} numeric metric(s), "
-                "suggesting a line chart to highlight trends."
-            )
         elif pie_candidate:
             x_col = categorical_cols[0]
             y_cols = [numeric_cols[0]]
             chart_type = "Pie Chart"
-            reason = (
-                f"Categorical column '{x_col}' has only {df[x_col].nunique(dropna=True)} distinct values "
-                f"with numeric metric '{y_cols[0]}', making it suitable for a pie chart."
-            )
         elif categorical_cols and numeric_cols:
             x_col = categorical_cols[0]
             y_cols = self._select_numeric_metrics(numeric_cols, exclude=set())
             chart_type = "Bar Chart"
-            reason = (
-                f"Categorical column '{x_col}' paired with numeric metrics {y_cols} "
-                "is best represented using a bar chart to compare categories."
-            )
         elif len(numeric_cols) >= 2:
             x_col = numeric_cols[0]
             y_cols = [numeric_cols[1]]
             chart_type = "Scatter Plot"
-            reason = (
-                f"Multiple numeric columns detected ({numeric_cols[:2]}), "
-                "indicating a scatter plot is suitable for correlation analysis."
-            )
 
         return VisualizationOutput(
             success=True,
@@ -395,7 +390,7 @@ class VisualizationTool(BaseTool):
             chart_type=chart_type,
             x_col=x_col,
             y_cols=y_cols,
-            reason=reason,
+            reason=self._default_reason(chart_type, x_col, y_cols, language=language),
         )
 
     # ------------------------------------------------------------------ #
@@ -453,16 +448,16 @@ class VisualizationTool(BaseTool):
         }
         return mapping.get(normalized, "Unknown")
 
-    def _default_reason(self, chart_type: str, x_col: str, y_cols: Sequence[str]) -> str:
-        if chart_type == "Line Chart":
-            return f"Line chart illustrates how {', '.join(y_cols) or 'metrics'} evolve over {x_col or 'time'}."
-        if chart_type == "Bar Chart":
-            return f"Bar chart compares numeric metrics {y_cols or ['values']} across categories in {x_col}."
-        if chart_type == "Scatter Plot" and y_cols:
-            return f"Scatter plot reveals the relationship between numeric fields {y_cols[0]} and {x_col}."
-        if chart_type == "Pie Chart" and y_cols:
-            return f"Pie chart shows the share of {y_cols[0]} across categories in {x_col}."
-        return "Unable to determine the best visualization due to insufficient information."
+    def _default_reason(
+        self, chart_type: str, x_col: str, y_cols: Sequence[str], language: Optional[str] = None
+    ) -> str:
+        """Localized wording for a chart pick the LLM didn't explain itself."""
+        return reason_for_chart(
+            chart_type,
+            language=self._effective_language(language),
+            x_col=x_col,
+            y_cols=list(y_cols),
+        )
 
     def _select_dimension(self, df: pd.DataFrame, exclude: Optional[set[str]] = None) -> str:
         exclude = exclude or set()

--- a/tests/unit_tests/tools/llms_tools/test_visualization_messages.py
+++ b/tests/unit_tests/tools/llms_tools/test_visualization_messages.py
@@ -1,0 +1,119 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for datus/tools/llms_tools/visualization_messages.py"""
+
+import pytest
+
+from datus.tools.llms_tools.visualization_messages import (
+    _MESSAGES,
+    empty_dataset_reason,
+    normalize_language,
+    reason_for_chart,
+)
+
+_KEYS = {"line", "bar", "pie", "scatter", "unknown", "empty"}
+_CHART_TYPES = ["Line Chart", "Bar Chart", "Pie Chart", "Scatter Plot"]
+
+
+class TestMessageTable:
+    def test_every_language_defines_every_key(self):
+        for code, table in _MESSAGES.items():
+            assert set(table) == _KEYS, f"{code} is missing or has extra keys"
+
+    def test_axis_templates_use_both_placeholders(self):
+        for code, table in _MESSAGES.items():
+            for key in ("line", "bar", "pie", "scatter"):
+                assert "{x}" in table[key], f"{code}/{key} drops the dimension"
+                assert "{y}" in table[key], f"{code}/{key} drops the metrics"
+
+    def test_context_free_templates_take_no_placeholders(self):
+        for code, table in _MESSAGES.items():
+            for key in ("unknown", "empty"):
+                assert "{" not in table[key], f"{code}/{key} has an unfilled placeholder"
+
+
+class TestNormalizeLanguage:
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            ("en", "en"),
+            ("zh", "zh"),
+            ("zh-CN", "zh"),
+            ("zh_CN", "zh"),
+            ("ZH-cn", "zh"),
+            ("  zh  ", "zh"),
+            ("zh-TW", "zh"),
+            ("zh-Hant", "zh"),
+            ("en-GB", "en"),
+        ],
+    )
+    def test_known_tags_and_regional_variants(self, code, expected):
+        assert normalize_language(code) == expected
+
+    @pytest.mark.parametrize("code", [None, "", "   ", "klingon", "ja", "pt-BR"])
+    def test_unknown_or_missing_falls_back_to_english(self, code):
+        assert normalize_language(code) == "en"
+
+
+class TestReasonForChart:
+    def test_renders_axes_into_the_requested_language(self):
+        reason = reason_for_chart("Bar Chart", "zh-CN", "region", ["sales", "profit"])
+        assert "region" in reason
+        assert "sales, profit" in reason
+        assert reason == _MESSAGES["zh"]["bar"].format(x="region", y="sales, profit")
+
+    @pytest.mark.parametrize("chart_type", _CHART_TYPES)
+    def test_every_chart_type_localizes(self, chart_type):
+        en = reason_for_chart(chart_type, "en", "date", ["revenue"])
+        zh = reason_for_chart(chart_type, "zh", "date", ["revenue"])
+        assert en != zh
+        assert "date" in en and "date" in zh
+        assert "revenue" in en and "revenue" in zh
+        assert "{" not in zh
+
+    def test_unknown_language_falls_back_to_english_wording(self):
+        assert reason_for_chart("Line Chart", "klingon", "date", ["revenue"]) == reason_for_chart(
+            "Line Chart", "en", "date", ["revenue"]
+        )
+
+    @pytest.mark.parametrize(
+        "chart_type,x_col,y_cols",
+        [
+            ("Unknown", "date", ["revenue"]),
+            ("Heatmap", "date", ["revenue"]),
+            ("Bar Chart", "", ["revenue"]),
+            ("Bar Chart", "region", []),
+        ],
+    )
+    def test_incomplete_picks_use_the_unknown_wording(self, chart_type, x_col, y_cols):
+        assert reason_for_chart(chart_type, "zh", x_col, y_cols) == _MESSAGES["zh"]["unknown"]
+
+    def test_non_string_labels_render_instead_of_raising(self):
+        """pandas column labels are not necessarily str — joining them blindly
+        used to raise TypeError before the caller could report anything."""
+        reason = reason_for_chart("Scatter Plot", "en", 1, [2])
+        assert "1" in reason and "2" in reason
+        assert reason == _MESSAGES["en"]["scatter"].format(x="1", y="2")
+
+    def test_a_label_named_zero_is_a_label_not_a_missing_axis(self):
+        reason = reason_for_chart("Bar Chart", "zh", 0, [0])
+        assert reason == _MESSAGES["zh"]["bar"].format(x="0", y="0")
+        assert reason != _MESSAGES["zh"]["unknown"]
+
+    @pytest.mark.parametrize("x_col,y_cols", [(None, ["v"]), ("", ["v"]), ("region", [None]), ("region", [])])
+    def test_absent_axes_still_use_the_unknown_wording(self, x_col, y_cols):
+        assert reason_for_chart("Bar Chart", "en", x_col, y_cols) == _MESSAGES["en"]["unknown"]
+
+    def test_defaults_to_english_when_language_omitted(self):
+        assert reason_for_chart("Pie Chart", x_col="region", y_cols=["sales"]) == _MESSAGES["en"]["pie"].format(
+            x="region", y="sales"
+        )
+
+
+class TestEmptyDatasetReason:
+    def test_localized(self):
+        assert empty_dataset_reason("zh-CN") == _MESSAGES["zh"]["empty"]
+
+    def test_defaults_to_english(self):
+        assert empty_dataset_reason() == _MESSAGES["en"]["empty"]

--- a/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
+++ b/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
@@ -544,3 +544,82 @@ class TestLanguageDirective:
             tool.execute(_make_input(df))
 
         assert mock_gpm.return_value.render_template.call_args.kwargs["language_directive"] == ""
+
+
+class TestHeuristicLanguage:
+    """No LLM means no generated wording — the fallback still has to honour the language."""
+
+    def _bar_df(self):
+        # More distinct categories than max_pie_categories, so the heuristic
+        # lands on Bar rather than Pie.
+        return pd.DataFrame({"region": list("ABCDEFGHI"), "sales": list(range(9))})
+
+    def test_rule_based_reason_is_localized(self):
+        tool = _make_tool(model=None)
+        reason = tool._rule_based_recommendation(self._bar_df(), language="zh-CN").reason
+        assert "region" in reason
+        assert "sales" in reason
+        assert not reason.isascii()
+
+    def test_rule_based_reason_defaults_to_english(self):
+        tool = _make_tool(model=None)
+        assert tool._rule_based_recommendation(self._bar_df()).reason.isascii()
+
+    def test_execute_without_model_localizes_the_fallback(self):
+        tool = _make_tool(model=None)
+        result = tool.execute(_make_input(self._bar_df()), language="zh-CN")
+        assert result.chart_type == "Bar Chart"
+        assert not result.reason.isascii()
+
+    def test_execute_with_context_localizes_the_fallback(self):
+        tool = _make_tool(model=None)
+        result = tool.execute_with_context(_make_input(self._bar_df()), sql="SELECT 1", language="zh")
+        assert result.chart_type == "Bar Chart"
+        assert not result.reason.isascii()
+
+    def test_llm_failure_falls_back_in_the_requested_language(self):
+        mock_model = MagicMock()
+        mock_model.generate_with_json_output.side_effect = Exception("LLM error")
+        tool = _make_tool(model=mock_model)
+
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "prompt"
+            result = tool.execute(_make_input(self._bar_df()), language="zh")
+
+        assert result.success is True
+        assert not result.reason.isascii()
+
+    def test_agent_config_language_applies_without_an_explicit_override(self):
+        config = MagicMock()
+        config.language = "zh"
+        tool = VisualizationTool(agent_config=config, model=None)
+        assert not tool._rule_based_recommendation(self._bar_df()).reason.isascii()
+
+    def test_explicit_language_wins_over_agent_config(self):
+        config = MagicMock()
+        config.language = "zh"
+        tool = VisualizationTool(agent_config=config, model=None)
+        assert tool._rule_based_recommendation(self._bar_df(), language="en").reason.isascii()
+
+    def test_reason_survives_non_string_column_labels(self):
+        """A DataFrame can carry int labels (``pd.DataFrame([[1,2]])``). Rendering
+        the reason must not be what breaks on them — VisualizationOutput's own
+        ``x_col: str`` contract is the layer that rejects such a frame."""
+        tool = _make_tool(model=None)
+        reason = tool._default_reason("Scatter Plot", 0, [1], language="zh")
+        assert "0" in reason and "1" in reason
+
+    def test_empty_dataset_reason_is_localized(self):
+        tool = _make_tool(model=None)
+        result = tool.execute(_make_input(pd.DataFrame()), language="zh")
+        assert result.success is False
+        assert not result.reason.isascii()
+        # The developer-facing error stays English; only the user-facing reason moves.
+        assert result.error.isascii()
+
+    def test_empty_dataset_reason_is_localized_with_context(self):
+        tool = _make_tool(model=None)
+        result = tool.execute_with_context(_make_input(pd.DataFrame()), sql="SELECT 1", language="zh")
+        assert result.success is False
+        assert not result.reason.isascii()
+        assert result.error.isascii()


### PR DESCRIPTION
## Why

`VisualizationTool` accepts a `language` and pins it into the LLM prompt, but the heuristic fallback ignored it completely — its `reason` was a hardcoded English f-string. The fallback runs precisely when no model is reachable, so any deployment whose visualization config can't initialize an LLM answers a `zh-CN` request in English, forever.

That is what a Datus-backend Hub chart request currently hits (`studio-dev`): the datasource-scoped AgentConfig carries a credential-less placeholder model, model init fails with `OpenAI API key must be provided`, and every response comes back with

> Categorical column 'metric_time' paired with numeric metrics ['daily_order_count'] is best represented using a bar chart to compare categories.

— English despite `"language": "zh-CN"`, with a raw Python list interpolated for the metric columns. The config side is fixed separately in Datus-backend; this PR makes the degraded path itself honour the requested language.

## Solution

Add `datus/tools/llms_tools/visualization_messages.py`: a static per-language message table (12 languages × 6 keys — line/bar/pie/scatter/unknown/empty) with `normalize_language()` folding regional tags onto their base language (`zh-CN`/`zh_CN` → `zh`, `zh-TW` kept separate) and English as the fallback for unknown codes. Static because this path exists for when no LLM is available — the wording can be neither generated nor translated at call time.

In `visualization_tool.py`:
- extract `_effective_language()` (explicit → `agent_config.language` → unset) so the prompt directive and the fallback resolve the language identically;
- `_rule_based_recommendation(df, language=...)` now only picks the chart and delegates all wording to `_default_reason()`, which is a table lookup — the four per-branch f-strings are gone;
- the empty-dataset `reason` is localized too. The `error` field stays English: it's for logs and developers, not the end user.

Tradeoff: the heuristic reasons lose their diagnostic asides ("Detected datetime column X with N numeric metrics"), since carrying those per-language would multiply the table for detail that only ever explained the heuristic to its author. Both fallback paths now share one set of user-facing sentences. Drive-by: metric columns render comma-joined instead of as a Python list repr.

## Test Cases

Unit tests only — this is a pure-function path with no external calls.

- `tests/unit_tests/tools/llms_tools/test_visualization_messages.py` (new): every language defines every key; axis templates keep both placeholders and the context-free ones keep none; tag normalization incl. `zh_CN`/`zh-Hant`/`pt-BR`; unknown/blank codes fall back to English; incomplete picks (no chart type, empty axis) use the `unknown` wording.
- `tests/unit_tests/tools/llms_tools/test_visualization_tool.py`: new `TestHeuristicLanguage` covering the localized fallback via no-model, LLM-raises, and empty-dataset paths, `agent_config.language` applying without an explicit override, an explicit language winning over it, and the `error` field staying English.

`uv run pytest tests/unit_tests/tools/llms_tools/ tests/unit_tests/api/services/test_visualization_service.py tests/unit_tests/api/routes/test_visualization_routes.py` → 182 passed. `ci/audit_tests.py --diff-only upstream/main` → P0=0. The PR harness's remaining failures are pre-existing locally (DB/CLI/doc integration fixtures) and identical on baseline `main`: 141 passed / 74 failed both with and without this change.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added localized chart recommendations and explanations in 10 languages.
  * Added language detection with regional fallback support.
  * Localized empty-data messages and fallback explanations.
  * Improved handling of unknown chart types and incomplete chart inputs.

* **Bug Fixes**
  * Ensured visualization recommendations consistently use the requested or configured language.

* **Tests**
  * Added coverage for localization, fallback behavior, chart explanations, and empty datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized chart recommendations and explanations in English and Chinese.
  * Added regional language fallback support.
  * Localized empty-dataset messages and fallback explanations.
  * Improved handling of unknown chart types and incomplete chart inputs.

* **Bug Fixes**
  * Ensured visualization recommendations consistently use the requested or configured language.

* **Tests**
  * Added coverage for localization, fallback behavior, chart explanations, and empty datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->