### PR TITLE
[BugFix] Surface the adapter's query-validation rejection in metric preview

### DIFF
--- a/datus/api/models/explorer_models.py
+++ b/datus/api/models/explorer_models.py
@@ -151,15 +151,32 @@ class MetricDimensionsData(BaseModel):
 
 
 class MetricDimensionPreflight(BaseModel):
-    """Why the requested dimensions are not all supported by the metric."""
+    """Why the adapter rejected the preview before compiling any SQL.
+
+    Covers both rejection shapes: unsupported dimensions (``invalid_dimensions``
+    / ``common_dimensions``), and the adapter's structured query validation
+    (``code`` plus the ``required_*`` / ``suggested_retry`` fields, mirroring
+    ``SemanticValidationError``). Fields irrelevant to a given rejection stay
+    empty, so a client renders whichever it finds.
+    """
 
     message: str = Field(..., description="Human-readable explanation")
+    code: Optional[str] = Field(None, description="Validation category when known, e.g. 'time_grain_required'")
     invalid_dimensions: List[Dict[str, Any]] = Field(
         default_factory=list, description="Requested dimensions the metric does not support"
     )
     common_dimensions: List[str] = Field(default_factory=list, description="Dimensions the metric does support")
     suggested_metric_groups: List[Dict[str, Any]] = Field(
         default_factory=list, description="Compatible metric/dimension groupings"
+    )
+    required_dimensions: List[str] = Field(
+        default_factory=list, description="Dimensions the caller must add for the query to compile"
+    )
+    required_time_granularity: Optional[str] = Field(
+        None, description="Required or corrected time granularity, e.g. 'day'"
+    )
+    suggested_retry: Optional[Dict[str, Any]] = Field(
+        None, description="Concrete preview arguments the caller can retry with"
     )
 
 
@@ -170,7 +187,7 @@ class MetricPreviewData(BaseModel):
     sql: Optional[str] = Field(None, description="Runnable SQL compiled from the metric definition")
     database: Optional[str] = Field(None, description="Physical database the SQL should run against")
     preflight_error: Optional[MetricDimensionPreflight] = Field(
-        None, description="Set instead of sql when the requested dimensions are invalid"
+        None, description="Set instead of sql when the adapter rejected the query"
     )
 
 

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -808,8 +808,9 @@ class ExplorerService:
         Uses dry-run so nothing executes here: the frontend hands the returned
         SQL to the existing SQL-result panel, which runs it and renders the
         table / chart. Only already-saved (registered) metrics are supported.
-        When requested dimensions aren't supported, returns a structured
-        ``preflight_error`` (with the metric's valid dimensions) instead of SQL.
+        When the adapter rejects the query — unsupported dimensions, or a
+        validation failure such as a grain with no time dimension to hang it on
+        — returns a structured ``preflight_error`` instead of SQL.
         """
         from datus.api.models.config_models import ErrorCode
 
@@ -879,19 +880,29 @@ class ExplorerService:
                     data=MetricPreviewData(metric=metric_name, sql=sql, database=database),
                 )
 
-            # A dimension preflight failure carries structured detail; surface it
-            # so the UI can guide the user instead of showing a raw error.
+            # A structured rejection — unsupported dimensions, or the adapter's
+            # query validation (e.g. a grain with no time dimension in the
+            # group-by) — carries fields the UI can act on. Surface them instead
+            # of flattening the whole thing into an error string.
             detail = func_result.result
-            if isinstance(detail, dict) and detail.get("invalid_dimensions") is not None:
+            if isinstance(detail, dict) and (
+                detail.get("invalid_dimensions") is not None or detail.get("code") is not None
+            ):
                 return Result[MetricPreviewData](
                     success=True,
                     data=MetricPreviewData(
                         metric=metric_name,
                         preflight_error=MetricDimensionPreflight(
-                            message=func_result.error or "Some dimensions are not supported by this metric.",
+                            message=func_result.error
+                            or detail.get("message")
+                            or "This metric cannot be previewed with the requested arguments.",
+                            code=detail.get("code"),
                             invalid_dimensions=detail.get("invalid_dimensions") or [],
                             common_dimensions=detail.get("common_dimensions") or [],
                             suggested_metric_groups=detail.get("suggested_metric_groups") or [],
+                            required_dimensions=detail.get("required_dimensions") or [],
+                            required_time_granularity=detail.get("required_time_granularity"),
+                            suggested_retry=detail.get("suggested_retry"),
                         ),
                     ),
                 )

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -979,10 +979,79 @@ class TestExplorerServicePreviewMetric:
         assert result.success is True
         assert result.data.sql is None
         pf = result.data.preflight_error
-        assert pf is not None
         assert pf.common_dimensions == ["metric_time", "region"]
         assert pf.invalid_dimensions[0]["name"] == "country"
         assert pf.suggested_metric_groups[0]["dimensions"] == ["region"]
+
+    async def test_query_validation_rejection_is_structured(self, real_agent_config, monkeypatch):
+        """A validation rejection keeps its code and retry hint instead of collapsing
+        into an error string. Built from the producer's own model so the field names
+        stay in sync with datus_semantic_core."""
+        from datus_semantic_core.models import SemanticValidationError
+
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        payload = SemanticValidationError(
+            code="time_grain_required",
+            metrics=["revenue"],
+            required_dimensions=["raw_orders.order_date"],
+            required_time_granularity="day",
+            suggested_retry={
+                "metrics": ["revenue"],
+                "dimensions": ["raw_orders.id", "raw_orders.order_date"],
+                "time_granularity": "day",
+            },
+            message="time_granularity was given but no requested dimension is a time dimension",
+        )
+        query_metrics = MagicMock(
+            return_value=self._func_result(success=0, error=payload.message, result=payload.model_dump())
+        )
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(
+            MetricPreviewInput(
+                subject_path=["revenue"],
+                dimensions=["raw_orders.id"],
+                time_granularity="day",
+            )
+        )
+
+        assert result.success is True
+        assert result.data.sql is None
+        pf = result.data.preflight_error
+        assert pf.code == "time_grain_required"
+        assert pf.required_dimensions == ["raw_orders.order_date"]
+        assert pf.required_time_granularity == "day"
+        assert pf.suggested_retry["dimensions"] == ["raw_orders.id", "raw_orders.order_date"]
+        assert pf.message == payload.message
+        # Dimension-preflight fields stay empty for this rejection shape.
+        assert pf.invalid_dimensions == []
+        assert pf.common_dimensions == []
+
+    async def test_dimension_preflight_keeps_validation_fields_empty(self, real_agent_config, monkeypatch):
+        """The dimension-preflight shape carries no code/retry hint, and must not
+        invent one."""
+        from datus.api.models.explorer_models import MetricPreviewInput
+
+        preflight = {
+            "metrics": ["revenue"],
+            "invalid_dimensions": [{"name": "country"}],
+            "common_dimensions": ["region"],
+        }
+        query_metrics = MagicMock(
+            return_value=self._func_result(success=0, error="dimension preflight failed", result=preflight)
+        )
+        self._patch_tools(monkeypatch, adapter=MagicMock(), query_metrics=query_metrics)
+
+        svc = ExplorerService(agent_config=real_agent_config)
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["revenue"], dimensions=["country"]))
+
+        pf = result.data.preflight_error
+        assert pf.code is None
+        assert pf.required_dimensions == []
+        assert pf.required_time_granularity is None
+        assert pf.suggested_retry is None
 
     async def test_no_sql_compiled_fails(self, real_agent_config, monkeypatch):
         """When neither metadata nor data carry SQL, report a clean failure."""


### PR DESCRIPTION
## Why

The semantic adapter rejects a preview whose grain has no time dimension to hang off. Repro on dev (`jeff_shop_live`, dosi adapter), `POST /api/v1/subject/metric/preview`:

```json
{"subject_path": ["orders","revenue","aov","average_gross_order_value"],
 "dimensions": ["raw_orders.id"], "time_granularity": "day", "limit": 100}
```
```json
{"success": false, "errorCode": "PROVIDER_CONFIG_ERROR",
 "errorMessage": "time_granularity was given but no requested dimension is a time dimension | time dimensions: raw_orders.order_date"}
```

The adapter raises a structured `SemanticValidationError` here — `code="time_grain_required"`, `required_dimensions=["raw_orders.order_date"]`, and a ready-to-run `suggested_retry`. `preview_metric` only recognised the *dimension-preflight* shape (keyed off `invalid_dimensions`), so this rejection fell through to the generic branch and every actionable field was flattened into an `errorMessage` string. The caller is left with English prose where it had a machine-readable "add this dimension and retry".

`query_metrics` already maps the payload correctly (`semantic_tools.py`, `query_metrics validation rejection: code=...`) — only the API service dropped it.

## Solution

Widen the structured branch to any rejection carrying a `code`, and pass the validation fields through `MetricDimensionPreflight`: `code`, `required_dimensions`, `required_time_granularity`, `suggested_retry`.

Key decisions:

- **One model, not two.** `MetricDimensionPreflight` now covers both rejection shapes rather than adding a parallel type to `MetricPreviewData`. Fields irrelevant to a given rejection stay empty, so a client renders whichever it finds and existing dimension-preflight consumers are untouched.
- **`code` is the discriminator**, not the presence of a specific field — `SemanticValidationError` defaults `code` to `validation_error`, so every adapter rejection routes here, including future codes this backend has never heard of.
- **Tradeoff:** a validation rejection now returns `success=true` with `preflight_error` instead of `success=false`/`PROVIDER_CONFIG_ERROR`. That matches how the dimension preflight already behaves (a rejected *query* is not a *provider config* failure), and existing clients that render `preflight_error` degrade gracefully — they show the same message they used to get, just via the preflight panel. `message` still carries the adapter's text verbatim.

The paired frontend fix (Datus-saas#744, merged) stops the UI from constructing that combination in the first place; this change is what makes the rejection actionable for callers that still hit it — chat / agent flows calling `query_metrics` directly, and any API consumer.

## Test Cases

Two unit tests in `tests/unit_tests/api/services/test_explorer_service.py`:

- `test_query_validation_rejection_is_structured` — builds the payload from the producer's own `datus_semantic_core.models.SemanticValidationError` (not a hand-written dict) so a field rename upstream fails the test instead of silently dropping data; asserts `code` / `required_dimensions` / `required_time_granularity` / `suggested_retry` all survive and the dimension-preflight fields stay empty.
- `test_dimension_preflight_keeps_validation_fields_empty` — pins the other direction: the dimension-preflight shape must not invent a `code` or a retry hint.

Gates run locally: `ruff format` + `ruff check` clean; `ci/audit_tests.py --diff-only upstream/main` → **P0=0, P1=0**; `ci/run-pr-tests.py upstream/main` → impacted unit tests **873 passed**. The harness also reports 1 failure + 3 errors in `tests/integration/cli/test_cli_commands.py::test_tables_command` and `tests/integration/tools/test_func_tools_db.py::TestSqliteMultiConnector` — these reproduce identically on a clean `upstream/main` worktree (missing local test data: "unable to open database file" / "Datasource not found in config"), so they are pre-existing environment failures, not regressions.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured preflight details for rejected metric queries, including error codes, required dimensions, time granularity, and retry guidance.
  * Improved reporting of adapter-rejected queries during metric previews.

* **Bug Fixes**
  * Dimension-related preflight responses now correctly distinguish them from broader query-validation failures.
  * Updated preview error descriptions to reflect all adapter query rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->