### PR TITLE
[BugFix] Report a failed object listing as connected, not disconnected

### DIFF
--- a/datus/api/models/database_models.py
+++ b/datus/api/models/database_models.py
@@ -19,6 +19,9 @@ class DatabaseInfo(BaseModel):
     tables_count: Optional[int] = Field(None, description="Number of tables in the database")
     last_accessed: Optional[str] = Field(None, description="Last access timestamp")
     tables: Optional[List[str]] = Field(None, description="List of table names")
+    error: Optional[str] = Field(
+        None, description="Why the object listing is unavailable, when the connection itself is usable"
+    )
 
 
 class ListDatabasesInput(BaseModel):

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -182,6 +182,25 @@ class DatasourceService:
                 last_accessed=now,
             )
 
+        def _listing_failed(db_name: str, error: str, schema: Optional[str] = None) -> DatabaseInfo:
+            """The connection works but its objects could not be enumerated.
+
+            Reporting this as ``disconnected`` used to hide the real cause and contradict
+            the agent, which keeps querying the same database successfully.
+            """
+            return DatabaseInfo(
+                name=db_name,
+                uri=_get_uri(connector),
+                type=dialect,
+                current=(db_name == connector.database_name),
+                catalog_name=catalog_name,
+                schema_name=schema,
+                connection_status="connected",
+                tables_count=None,
+                last_accessed=now,
+                error=error,
+            )
+
         try:
             if not connector.test_connection():
                 return [_disconnected(connector.database_name)]
@@ -211,14 +230,14 @@ class DatasourceService:
                 db_names = []
         except Exception as e:
             logger.warning("Failed to enumerate databases for %s: %s", connector.database_name, e)
-            return [_disconnected(connector.database_name)]
+            return [_listing_failed(connector.database_name, str(e))]
 
         db_infos: List[DatabaseInfo] = []
         for db_name in db_names:
             if has_schema:
                 # 2) Resolve schemas for this db — a single failing db must not
-                # abort the whole listing. Report the db as disconnected and
-                # keep going.
+                # abort the whole listing. Report the db with its listing error
+                # and keep going.
                 if request.schema_name:
                     schemas = [request.schema_name]
                 elif hasattr(connector, "get_schemas"):
@@ -235,7 +254,7 @@ class DatasourceService:
                             dialect,
                             e,
                         )
-                        db_infos.append(_disconnected(db_name))
+                        db_infos.append(_listing_failed(db_name, str(e)))
                         continue
                 else:
                     schemas = ["public"]
@@ -255,19 +274,7 @@ class DatasourceService:
                             schema,
                             e,
                         )
-                        db_infos.append(
-                            DatabaseInfo(
-                                name=db_name,
-                                uri=_get_uri(connector),
-                                type=dialect,
-                                current=(db_name == connector.database_name),
-                                catalog_name=catalog_name,
-                                schema_name=schema,
-                                connection_status="disconnected",
-                                tables_count=None,
-                                last_accessed=now,
-                            )
-                        )
+                        db_infos.append(_listing_failed(db_name, str(e), schema=schema))
                         continue
 
                     db_infos.append(
@@ -293,7 +300,7 @@ class DatasourceService:
                     tables.sort()
                 except Exception as e:
                     logger.warning("Failed to get tables for db=%s: %s", db_name, e)
-                    db_infos.append(_disconnected(db_name))
+                    db_infos.append(_listing_failed(db_name, str(e)))
                     continue
 
                 db_infos.append(

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import NoReturn
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -725,6 +726,148 @@ class TestGetConnectionInfoScoping:
 
         assert [i.name for i in infos] == ["ga4"]
         assert connector.get_databases_calls == 0
+
+
+class _FakeSchemaConnector:
+    """Schema-capable connector whose per-database and per-schema listings can
+    each be made to fail independently."""
+
+    dialect = "postgresql"
+    catalog_name = None
+    connection_string = "postgresql://u:p@host:5432/warehouse"
+
+    def __init__(self, database_name: str, failing_schemas_db: str = "", failing_tables_schema: str = ""):
+        self.database_name = database_name
+        self._failing_schemas_db = failing_schemas_db
+        self._failing_tables_schema = failing_tables_schema
+
+    def get_effective_capabilities(self) -> set[str]:
+        return {"database", "schema"}
+
+    def test_connection(self) -> bool:  # audit-noqa: zero_assert_test — connector API stub, not a test
+        return True
+
+    def get_databases(self, catalog_name: str = "", include_sys: bool = False) -> list[str]:
+        return ["warehouse", "staging"]
+
+    def get_schemas(self, catalog_name: str = "", database_name: str = "", include_sys: bool = False) -> list[str]:
+        if database_name == self._failing_schemas_db:
+            raise RuntimeError("schema enumeration timed out")
+        return ["public", "reporting"]
+
+    def get_tables(self, catalog_name: str = "", database_name: str = "", schema_name: str = "") -> list[str]:
+        if schema_name == self._failing_tables_schema:
+            raise RuntimeError("table enumeration timed out")
+        return ["t2", "t1"]
+
+
+class TestGetConnectionInfoListingFailure:
+    """A reachable database whose objects cannot be listed is not a disconnected one."""
+
+    def test_table_listing_failure_stays_connected_and_reports_the_error(self, real_agent_config, _no_schema_dialect):
+        """Reporting ``disconnected`` hid the real cause and contradicted the agent,
+        which keeps querying the same database successfully."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeServerConnector(database_name="benchmark")
+
+        def _raise(catalog_name: str = "", database_name: str = "", schema_name: str = "") -> NoReturn:
+            raise RuntimeError("THRIFT_EAGAIN (timed out)")
+
+        connector.get_tables = _raise
+
+        infos = svc._get_connection_info(connector, "benchmark", ListDatabasesInput())
+
+        assert [i.name for i in infos] == ["benchmark"]
+        assert infos[0].connection_status == "connected"
+        assert infos[0].schema_name is None
+        assert infos[0].tables is None
+        assert infos[0].tables_count is None
+        assert "THRIFT_EAGAIN" in infos[0].error
+
+    def test_database_enumeration_failure_reports_the_error(self, real_agent_config, _no_schema_dialect):
+        """Without a configured database there is nothing left to iterate, so the
+        datasource is reported once — connected, with the reason attached."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeServerConnector(database_name="")
+
+        def _raise(catalog_name: str = "", include_sys: bool = False) -> NoReturn:
+            raise RuntimeError("SHOW DATABASES timed out")
+
+        connector.get_databases = _raise
+
+        infos = svc._get_connection_info(connector, "ds", ListDatabasesInput())
+
+        assert len(infos) == 1
+        assert infos[0].connection_status == "connected"
+        assert infos[0].schema_name is None
+        assert infos[0].tables is None
+        assert infos[0].tables_count is None
+        assert "SHOW DATABASES timed out" in infos[0].error
+
+    def test_schema_resolution_failure_does_not_abort_sibling_databases(self, real_agent_config):
+        """One database that cannot resolve its schemas must not cost the others
+        their listing."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeSchemaConnector(database_name="", failing_schemas_db="staging")
+
+        infos = svc._get_connection_info(connector, "ds", ListDatabasesInput())
+
+        failed = [i for i in infos if i.name == "staging"]
+        assert len(failed) == 1
+        assert failed[0].connection_status == "connected"
+        assert failed[0].schema_name is None
+        assert failed[0].tables is None
+        assert failed[0].tables_count is None
+        assert "schema enumeration timed out" in failed[0].error
+
+        healthy = [i for i in infos if i.name == "warehouse"]
+        assert [i.schema_name for i in healthy] == ["public", "reporting"]
+        assert all(i.connection_status == "connected" and i.error is None for i in healthy)
+        assert all(i.tables == ["t1", "t2"] and i.tables_count == 2 for i in healthy)
+
+    def test_table_fetch_failure_is_scoped_to_its_schema(self, real_agent_config):
+        """A failing schema is reported with its own name; sibling schemas still list."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeSchemaConnector(database_name="warehouse", failing_tables_schema="reporting")
+
+        infos = svc._get_connection_info(connector, "ds", ListDatabasesInput())
+
+        assert [i.name for i in infos] == ["warehouse", "warehouse"]
+        assert [i.schema_name for i in infos] == ["public", "reporting"]
+
+        assert infos[0].error is None
+        assert infos[0].tables == ["t1", "t2"]
+        assert infos[0].tables_count == 2
+
+        assert infos[1].connection_status == "connected"
+        assert infos[1].tables is None
+        assert infos[1].tables_count is None
+        assert "table enumeration timed out" in infos[1].error
+
+    def test_requested_schema_filter_is_honoured_when_its_tables_fail(self, real_agent_config):
+        """An explicit schema_name skips resolution, so the filter is what fails."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeSchemaConnector(database_name="warehouse", failing_tables_schema="reporting")
+
+        infos = svc._get_connection_info(connector, "ds", ListDatabasesInput(schema_name="reporting"))
+
+        assert len(infos) == 1
+        assert infos[0].name == "warehouse"
+        assert infos[0].schema_name == "reporting"
+        assert infos[0].connection_status == "connected"
+        assert infos[0].tables is None
+        assert "table enumeration timed out" in infos[0].error
+
+    def test_failed_connection_test_is_still_disconnected(self, real_agent_config, _no_schema_dialect):
+        """The disconnected status stays reserved for an unusable connection."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = _FakeServerConnector(database_name="benchmark")
+        connector.test_connection = lambda: False
+
+        infos = svc._get_connection_info(connector, "benchmark", ListDatabasesInput())
+
+        assert infos[0].connection_status == "disconnected"
+        assert infos[0].error is None
 
 
 class TestGetTableSchema:


### PR DESCRIPTION
## Why

`/api/v1/catalog/list` reported a database as `disconnected` with `tables: null` whenever its objects could not be listed, even though the connection test had just passed. The real reason was swallowed into a `logger.warning`, so the API gave the frontend nothing to show.

A user hit this on a StarRocks deployment: the tree showed `store_support_data` as disconnected and empty, while the agent kept querying that same database successfully in chat. The backend log told the real story:

```
Failed to get tables for db=store_support_data: error_code=500006, ...
(1064, 'call frontend service failed, address=TNetworkAddress(hostname=..., port=9020),
 reason=THRIFT_EAGAIN (timed out): BE:11003')
```

The connection was fine; only the `information_schema` metadata scan timed out. Reporting that as `disconnected` is both wrong and undiagnosable from the API alone.

## Solution

- Keep `connection_status` for what the connection test actually reported. A failure to enumerate databases, schemas, or tables now yields `connected` plus a new optional `DatabaseInfo.error` carrying the underlying message.
- `_disconnected()` stays reserved for a connection test that failed or raised.
- The new field is additive and optional, so existing clients are unaffected; the UI can now explain why a database looks empty instead of showing a false "unreachable" state.

The StarRocks-side cause (information_schema falling over where `SHOW` works) is fixed separately in datus-db-adapters; this PR makes the API honest regardless of which adapter or failure mode is involved.

## Test Cases

`tests/unit_tests/api/services/test_database_service.py` — `TestGetConnectionInfoListingFailure`, one case per failure path:

- no-schema table fetch fails → `connected`, no tables/count, error text surfaced;
- database enumeration fails → the datasource is still reported once, connected, with the reason;
- schema resolution fails for one database → that entry carries the error while sibling databases keep their full schema/table listing;
- a per-schema table fetch fails → the entry carries its own `schema_name` and error, and the sibling schema still lists its tables;
- an explicit `schema_name` filter skips resolution, so the filtered schema is what reports the failure;
- a failing connection test is still `disconnected` with no `error`.

`uv run python ci/audit_tests.py --diff-only upstream/main` → P0=0, P1=0. The PR harness' remaining failures are pre-existing local-env gaps (`datus_semantic_osi` / metricflow optional packages not installed) in explorer-service and integration tests, unrelated to these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database connections that remain usable are now correctly shown as connected when listing databases, schemas, or tables fails.
  * Error details are displayed when database metadata cannot be retrieved.
  * Available databases and schemas continue to appear even when sibling entries encounter listing errors.
  * Failed connections remain clearly marked as disconnected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
