### PR TITLE
[Refactor] ask_metrics: stop caching query rejections in the node

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -88,7 +88,6 @@ class AskMetricsAgenticNode(AgenticNode):
         self.subject_tree_mode: str = "none"
         self.subject_tree_prompt: str = ""
         self._metric_catalog_cache: Optional[Dict[str, Dict[str, Any]]] = None
-        self._failed_query_signatures: set[tuple] = set()
         self._selected_final_metric_result_id: Optional[str] = None
         self.startup_error: Optional[str] = None
 
@@ -433,12 +432,12 @@ class AskMetricsAgenticNode(AgenticNode):
         Query metric values.
 
         Return complete metric results by default. Do not pass limit just to
-        preview data, reduce output size, or be conservative; the system
-        compresses visible tool output and caches the full result. Use limit
-        only when the user explicitly asks for Top N, first N, maximum N rows,
-        a preview, or another row-count restriction. When using limit for Top
-        N/Bottom N, also pass order_by so the truncation has stable business
-        meaning.
+        preview data, reduce output size, or be conservative; the visible tool
+        output is compressed while the full result is cached and used for the
+        final output. Use limit only when the user explicitly asks for Top N,
+        first N, maximum N rows, a preview, or another row-count restriction.
+        When using limit for Top N/Bottom N, also pass order_by so the
+        truncation has stable business meaning.
 
         For fixed period-over-period metrics such as month-over-month or
         year-over-year, query the dedicated catalog metric directly. For window
@@ -481,20 +480,6 @@ class AskMetricsAgenticNode(AgenticNode):
         # metric_time grouping is derived from each metric's definition and
         # applied by the semantic adapter; the node no longer injects it here.
 
-        # De-duplicate deterministic validation failures: once a metric/dimension/
-        # granularity combination has been rejected, do not re-issue the identical
-        # query — return actionable guidance so the planner adjusts instead of looping.
-        signature = self._query_signature(expanded_metrics, normalized_dimensions, time_granularity, where)
-        if signature in self._failed_query_signatures:
-            return FuncToolResult(
-                success=0,
-                error=(
-                    "query_metrics already failed for this metric/dimension/granularity "
-                    "combination. Adjust the metrics, dimensions, or granularity — or split "
-                    "the query into compatible metric groups — instead of retrying identical "
-                    "arguments."
-                ),
-            )
         query_kwargs = {
             "metrics": expanded_metrics,
             "dimensions": normalized_dimensions,
@@ -508,36 +493,7 @@ class AskMetricsAgenticNode(AgenticNode):
             "dry_run": dry_run,
         }
         result = self.semantic_tools.query_metrics(**query_kwargs)
-        if self._is_deterministic_validation_failure(result):
-            self._failed_query_signatures.add(signature)
         return self._apply_query_result_column_aliases(result)
-
-    @staticmethod
-    def _query_signature(
-        metrics: List[str],
-        dimensions: Optional[List[str]],
-        time_granularity: Optional[str],
-        where: Optional[str],
-    ) -> tuple:
-        """Stable key for a query_metrics invocation used to suppress identical retries."""
-        return (
-            tuple(sorted(metrics or [])),
-            tuple(sorted(dimensions or [])),
-            str(time_granularity or "").strip().lower(),
-            str(where or "").strip(),
-        )
-
-    @staticmethod
-    def _is_deterministic_validation_failure(result: FuncToolResult) -> bool:
-        """True when query_metrics failed for a deterministic semantic validation reason.
-
-        Transient/infra failures are excluded so a retry with the same arguments is
-        only suppressed when re-issuing it cannot succeed.
-        """
-        if not isinstance(result, FuncToolResult) or result.success != 0:
-            return False
-        payload = result.result if isinstance(result.result, dict) else {}
-        return payload.get("error_type") == "semantic_validation_error"
 
     def select_final_metric_result(self, result_id: str) -> FuncToolResult:
         """

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -868,6 +868,14 @@ class SemanticTools:
         """
         Query metrics data (requires adapter).
 
+        Return complete metric results by default. Do not pass limit just to
+        preview data, reduce output size, or be conservative; the visible tool
+        output is compressed while the full result is cached and used for the
+        final output. Use limit only when the user explicitly asks for Top N,
+        first N, maximum N rows, a preview, or another row-count restriction.
+        When using limit for Top N/Bottom N, also pass order_by so the
+        truncation has stable business meaning.
+
         Args:
             metrics: List of metric names to query
             dimensions: Optional list of dimensions to group by (from get_dimensions)

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -668,7 +668,7 @@ class TestAskMetricsAgenticNode:
             dry_run=False,
         )
 
-    def test_query_metrics_dedupes_deterministic_validation_failure(self, real_agent_config, mock_llm_create):
+    def test_query_metrics_forwards_repeated_validation_failures(self, real_agent_config, mock_llm_create):
         node, semantic_tools, _ = _make_node(
             real_agent_config,
             tree={"Sales": {"Orders": {"metrics": ["order_count"]}}},
@@ -676,7 +676,7 @@ class TestAskMetricsAgenticNode:
         semantic_tools.list_metrics.return_value = FuncToolResult(
             result={"items": [{"name": "order_count", "metadata": {}}], "has_more": False}
         )
-        semantic_tools.query_metrics.return_value = FuncToolResult(
+        rejection = FuncToolResult(
             success=0,
             error="cumulative metric requires metric_time",
             result={
@@ -684,18 +684,21 @@ class TestAskMetricsAgenticNode:
                 "code": "cumulative_requires_metric_time",
             },
         )
+        semantic_tools.query_metrics.return_value = rejection
 
         first = node.query_metrics(metrics=["order_count"], dimensions=["product_type"])
         assert first.success == 0
         assert semantic_tools.query_metrics.call_count == 1
 
-        # An identical retry after a deterministic validation failure is short-circuited.
+        # An identical retry reaches the adapter again and returns the adapter's own
+        # rejection: the node keeps no cross-call state, so a model reload that makes
+        # the query valid takes effect immediately.
         second = node.query_metrics(metrics=["order_count"], dimensions=["product_type"])
         assert second.success == 0
-        assert "already failed" in (second.error or "")
-        assert semantic_tools.query_metrics.call_count == 1
+        assert second.result["code"] == "cumulative_requires_metric_time"
+        assert semantic_tools.query_metrics.call_count == 2
 
-    def test_query_metrics_does_not_dedupe_transient_failure(self, real_agent_config, mock_llm_create):
+    def test_query_metrics_forwards_repeated_transient_failures(self, real_agent_config, mock_llm_create):
         node, semantic_tools, _ = _make_node(
             real_agent_config,
             tree={"Sales": {"Orders": {"metrics": ["order_count"]}}},
@@ -703,7 +706,6 @@ class TestAskMetricsAgenticNode:
         semantic_tools.list_metrics.return_value = FuncToolResult(
             result={"items": [{"name": "order_count", "metadata": {}}], "has_more": False}
         )
-        # A non-validation (infra) failure must not suppress a retry.
         semantic_tools.query_metrics.return_value = FuncToolResult(
             success=0, error="Failed to query metrics: connection lost"
         )


### PR DESCRIPTION
## Why

`query_metrics` keeps a node-lifetime set of failed `(metrics, dimensions, granularity, where)` signatures and short-circuits any identical retry.

It was added in #1104 alongside the fix for what actually caused the looping — the node injecting a `metric_time` grouping the adapter rejected. That root cause was delegated to the adapter in the same PR, and the end-to-end validation there reported:

> `query_metrics` invoked 41x with **zero** `metric_time` rejections.

So the de-dup never had an occasion to fire.

What it defends against is the model re-issuing an identical call after a rejection. That premise does not hold: the call and its rejection are adjacent turns in the model's own context — it can already see what it just sent. And the adapter's `SemanticValidationError` carries `code`, `unsupported_dimensions`, `required_time_granularity` and a ready-to-run `suggested_retry`, which is everything needed to revise the query.

**It also mis-fires.** The signature set only ever grows, while the Dosi adapter reloads its model on file mtime. A user who hits a rejection, edits the semantic model to fix it, and asks the same question again gets:

```
query_metrics already failed for this metric/dimension/granularity combination.
```

…for a query that is now valid. The only way out is a new session.

## Solution

Remove `_failed_query_signatures`, `_query_signature` and `_is_deterministic_validation_failure`. Every call reaches the adapter and returns the adapter's own structured rejection, so a model reload takes effect immediately.

Separately, move the **result-handling contract** into `SemanticTools.query_metrics` itself:

> the visible tool output is compressed while the full result is cached and used for the final output — do not pass `limit` to shrink output

The mechanism (`_cache_query_metrics_result` + `compressor.compress` + `update_context` restoring the full CSV) lives in `SemanticTools` and applies to **every** caller, but the guidance existed only in AskMetrics' docstring. Other nodes' models see the compressed preview with no explanation, and `limit` is pushed down to SQL — so a model shrinking output "to be helpful" silently truncates what the user receives. AskMetrics keeps its copy because its docstring fully replaces the tool's.

## Test Cases

- `test_query_metrics_forwards_repeated_validation_failures` — an identical retry after a deterministic rejection reaches the adapter again and returns the adapter's payload (previously asserted the short-circuit)
- `test_query_metrics_forwards_repeated_transient_failures` — unchanged behaviour, renamed off the de-dup vocabulary
- `tests/unit_tests/agent/node/` + `tests/unit_tests/tools/func_tool/`: **3772 passed, 1 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated query validation failures are now retried consistently instead of being suppressed.
  * Metric queries return complete results by default, with clearer guidance for previews and ranked queries.

* **Tests**
  * Updated coverage to verify that identical validation failures are forwarded on every retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->