### PR TITLE
[Refactor] ask_metrics: stop inferring window-metric dependencies in the node

### DIFF
--- a/datus/agent/node/ask_metrics_agentic_node.py
+++ b/datus/agent/node/ask_metrics_agentic_node.py
@@ -87,7 +87,6 @@ class AskMetricsAgenticNode(AgenticNode):
         self.subject_tree_metric_entries: List[Dict[str, Any]] = []
         self.subject_tree_mode: str = "none"
         self.subject_tree_prompt: str = ""
-        self._metric_catalog_cache: Optional[Dict[str, Dict[str, Any]]] = None
         self._failed_query_signatures: set[tuple] = set()
         self._selected_final_metric_result_id: Optional[str] = None
         self.startup_error: Optional[str] = None
@@ -440,10 +439,10 @@ class AskMetricsAgenticNode(AgenticNode):
         N/Bottom N, also pass order_by so the truncation has stable business
         meaning.
 
-        For fixed period-over-period metrics such as month-over-month or
-        year-over-year, query the dedicated catalog metric directly. For window
-        metrics, AskMetrics expands the request to include related executable
-        metrics when they are already present in the catalog.
+        For derived metrics such as month-over-month, year-over-year or moving
+        averages, query the dedicated catalog metric directly. When the answer
+        also needs the underlying series or the window's row count, request
+        those metrics explicitly alongside it.
 
         Joined dimensions always use matched-rows join semantics: fact rows
         that cannot match the requested dimension are excluded. Unmatched-fact
@@ -467,8 +466,8 @@ class AskMetricsAgenticNode(AgenticNode):
         if not self.semantic_tools:
             return FuncToolResult(success=0, error="semantic tools unavailable")
 
-        expanded_metrics = self._expand_metric_dependencies(metrics)
-        if not expanded_metrics:
+        normalized_metrics = self._normalize_string_list(metrics)
+        if not normalized_metrics:
             return FuncToolResult(
                 success=0,
                 error=(
@@ -484,7 +483,7 @@ class AskMetricsAgenticNode(AgenticNode):
         # De-duplicate deterministic validation failures: once a metric/dimension/
         # granularity combination has been rejected, do not re-issue the identical
         # query — return actionable guidance so the planner adjusts instead of looping.
-        signature = self._query_signature(expanded_metrics, normalized_dimensions, time_granularity, where)
+        signature = self._query_signature(normalized_metrics, normalized_dimensions, time_granularity, where)
         if signature in self._failed_query_signatures:
             return FuncToolResult(
                 success=0,
@@ -496,7 +495,7 @@ class AskMetricsAgenticNode(AgenticNode):
                 ),
             )
         query_kwargs = {
-            "metrics": expanded_metrics,
+            "metrics": normalized_metrics,
             "dimensions": normalized_dimensions,
             "path": path,
             "time_start": time_start,
@@ -558,220 +557,6 @@ class AskMetricsAgenticNode(AgenticNode):
 
         self._selected_final_metric_result_id = result_id
         return FuncToolResult(result={"result_id": result_id})
-
-    def _expand_metric_dependencies(self, metrics: Optional[List[str]]) -> List[str]:
-        return self._expand_window_metrics(metrics)
-
-    def _expand_window_metrics(self, metrics: Optional[List[str]]) -> List[str]:
-        requested_metrics = self._normalize_string_list(metrics)
-        if not requested_metrics:
-            return []
-
-        catalog = self._metric_catalog()
-        if not catalog:
-            return requested_metrics
-
-        expanded: List[str] = []
-        for metric_name in requested_metrics:
-            metric = catalog.get(metric_name)
-            if not metric:
-                self._append_unique(expanded, metric_name)
-                continue
-
-            for bundled_metric in self._window_metric_bundle(metric_name, metric, catalog):
-                self._append_unique(expanded, bundled_metric)
-
-        return expanded
-
-    @classmethod
-    def _window_metric_bundle(
-        cls,
-        metric_name: str,
-        metric: Dict[str, Any],
-        catalog: Dict[str, Dict[str, Any]],
-    ) -> List[str]:
-        metadata = cls._metric_metadata(metric)
-        if not cls._is_window_metric(metadata):
-            return [metric_name]
-
-        if cls._metadata_text(metadata, "window_aggregation").lower() == "row_count":
-            return [metric_name]
-
-        bundle: List[str] = []
-        base_metric = cls._find_window_base_metric(metric_name, metric, catalog)
-        if base_metric:
-            cls._append_unique(bundle, base_metric)
-
-        if cls._window_metric_needs_window_count(metadata):
-            for count_metric in cls._matching_window_count_metrics(metric_name, metadata, catalog):
-                cls._append_unique(bundle, count_metric)
-
-        cls._append_unique(bundle, metric_name)
-        return bundle
-
-    def _metric_catalog(self) -> Dict[str, Dict[str, Any]]:
-        if self._metric_catalog_cache is not None:
-            return self._metric_catalog_cache
-        if not self.semantic_tools:
-            return {}
-
-        catalog: Dict[str, Dict[str, Any]] = {}
-        offset = 0
-        limit = 500
-        for _ in range(10):
-            try:
-                result = self.semantic_tools.list_metrics(limit=limit, offset=offset)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("Unable to load ask_metrics metric catalog: %s", exc)
-                break
-
-            if not isinstance(result, FuncToolResult) or result.success == 0:
-                logger.debug("Unable to load ask_metrics metric catalog: %s", getattr(result, "error", None))
-                break
-
-            payload = result.result if isinstance(result.result, dict) else {}
-            items = payload.get("items", []) if isinstance(payload, dict) else []
-            for item in items:
-                if isinstance(item, dict) and item.get("name"):
-                    catalog[str(item["name"])] = item
-
-            if not isinstance(payload, dict) or not payload.get("has_more"):
-                break
-            extra = payload.get("extra") if isinstance(payload.get("extra"), dict) else {}
-            next_offset = extra.get("next_offset")
-            if not isinstance(next_offset, int) or next_offset <= offset:
-                break
-            offset = next_offset
-
-        self._metric_catalog_cache = catalog
-        return catalog
-
-    @classmethod
-    def _find_window_base_metric(
-        cls,
-        metric_name: str,
-        metric: Dict[str, Any],
-        catalog: Dict[str, Dict[str, Any]],
-    ) -> Optional[str]:
-        metadata = cls._metric_metadata(metric)
-        explicit_name = cls._first_metadata_text(
-            metadata,
-            ("base_metric", "base_metric_name", "source_metric", "source_metric_name"),
-        )
-        if explicit_name and explicit_name in catalog and explicit_name != metric_name:
-            return explicit_name
-
-        metric_signature = cls._metric_measure_signature(metric)
-        if not metric_signature:
-            return None
-
-        dataset = cls._metadata_text(metadata, "dataset")
-        for candidate_name, candidate in catalog.items():
-            if candidate_name == metric_name:
-                continue
-            candidate_metadata = cls._metric_metadata(candidate)
-            if cls._is_window_metric(candidate_metadata):
-                continue
-            if not cls._is_base_metric_candidate(candidate_metadata):
-                continue
-            candidate_dataset = cls._metadata_text(candidate_metadata, "dataset")
-            if dataset and candidate_dataset and dataset != candidate_dataset:
-                continue
-            if metric_signature.intersection(cls._metric_measure_signature(candidate)):
-                return candidate_name
-
-        return None
-
-    @classmethod
-    def _matching_window_count_metrics(
-        cls,
-        metric_name: str,
-        metadata: Dict[str, Any],
-        catalog: Dict[str, Dict[str, Any]],
-    ) -> List[str]:
-        matches: List[str] = []
-        dataset = cls._metadata_text(metadata, "dataset")
-        time_dimension = cls._metadata_text(metadata, "time_dimension")
-        window = cls._metadata_text(metadata, "window")
-        grain_to_date = cls._metadata_text(metadata, "grain_to_date")
-
-        for candidate_name, candidate in catalog.items():
-            if candidate_name == metric_name:
-                continue
-            candidate_metadata = cls._metric_metadata(candidate)
-            if cls._metadata_text(candidate_metadata, "window_aggregation").lower() != "row_count":
-                continue
-            if dataset and cls._metadata_text(candidate_metadata, "dataset") != dataset:
-                continue
-            if time_dimension and cls._metadata_text(candidate_metadata, "time_dimension") != time_dimension:
-                continue
-            if window and cls._metadata_text(candidate_metadata, "window") != window:
-                continue
-            if grain_to_date and cls._metadata_text(candidate_metadata, "grain_to_date") != grain_to_date:
-                continue
-            cls._append_unique(matches, candidate_name)
-
-        return matches
-
-    @classmethod
-    def _window_metric_needs_window_count(cls, metadata: Dict[str, Any]) -> bool:
-        aggregation = cls._metadata_text(metadata, "window_aggregation").lower()
-        return aggregation in {"avg", "average", "mean"}
-
-    @classmethod
-    def _is_window_metric(cls, metadata: Dict[str, Any]) -> bool:
-        if not metadata:
-            return False
-        if cls._metadata_text(metadata, "window") or cls._metadata_text(metadata, "grain_to_date"):
-            return True
-        return bool(cls._metadata_text(metadata, "window_aggregation"))
-
-    @classmethod
-    def _is_base_metric_candidate(cls, metadata: Dict[str, Any]) -> bool:
-        metric_kind = cls._metadata_text(metadata, "metric_kind").lower()
-        if not metric_kind:
-            return True
-        return metric_kind in {"aggregate", "measure_proxy", "simple"}
-
-    @staticmethod
-    def _metric_metadata(metric: Dict[str, Any]) -> Dict[str, Any]:
-        metadata = metric.get("metadata") if isinstance(metric, dict) else {}
-        return metadata if isinstance(metadata, dict) else {}
-
-    @classmethod
-    def _metric_measure_signature(cls, metric: Dict[str, Any]) -> set[str]:
-        metadata = cls._metric_metadata(metric)
-        values: List[str] = []
-        for key in ("measure", "measure_expr", "expr"):
-            value = metadata.get(key)
-            if isinstance(value, str):
-                values.append(value)
-
-        for key in ("measures", "base_measures"):
-            value = metric.get(key)
-            if isinstance(value, list):
-                values.extend(str(item) for item in value if str(item).strip())
-            elif isinstance(value, str):
-                values.append(value)
-
-        return {cls._normalize_metric_expression(value) for value in values if cls._normalize_metric_expression(value)}
-
-    @staticmethod
-    def _normalize_metric_expression(value: str) -> str:
-        return "".join(str(value or "").lower().split())
-
-    @staticmethod
-    def _metadata_text(metadata: Dict[str, Any], key: str) -> str:
-        value = metadata.get(key)
-        return value.strip() if isinstance(value, str) else ""
-
-    @classmethod
-    def _first_metadata_text(cls, metadata: Dict[str, Any], keys: tuple[str, ...]) -> str:
-        for key in keys:
-            value = cls._metadata_text(metadata, key)
-            if value:
-                return value
-        return ""
 
     @staticmethod
     def _normalize_string_list(value: Optional[List[str]]) -> List[str]:
@@ -875,11 +660,6 @@ class AskMetricsAgenticNode(AgenticNode):
         writer.writerow(aliased_header)
         writer.writerows(reader)
         return buf.getvalue()
-
-    @staticmethod
-    def _append_unique(values: List[str], value: str) -> None:
-        if value not in values:
-            values.append(value)
 
     async def _before_stream(self, ctx: StreamRunContext) -> None:
         if self.startup_error:

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -523,7 +523,14 @@ class TestAskMetricsAgenticNode:
             dry_run=False,
         )
 
-    def test_query_metrics_expands_rolling_average_metric_bundle(self, real_agent_config, mock_llm_create):
+    def test_query_metrics_forwards_requested_metrics_unchanged(self, real_agent_config, mock_llm_create):
+        """The node no longer derives companion metrics from catalog metadata.
+
+        Which metrics a derived metric depends on belongs to the semantic model,
+        not to naming conventions and free-text metadata read back by the agent.
+        A caller that wants the underlying series or a window row count asks for
+        those metrics explicitly.
+        """
         node, semantic_tools, _ = _make_node(
             real_agent_config,
             tree={"Commerce": {"Orders": {"metrics": ["moving_3_month_order_count_avg"]}}},
@@ -531,39 +538,9 @@ class TestAskMetricsAgenticNode:
         semantic_tools.list_metrics.return_value = FuncToolResult(
             result={
                 "items": [
-                    {
-                        "name": "order_count",
-                        "measures": ["orders.order_id"],
-                        "metadata": {
-                            "dataset": "orders",
-                            "expr": "COUNT(DISTINCT order_id)",
-                            "metric_kind": "aggregate",
-                            "measure": "order_id",
-                        },
-                    },
-                    {
-                        "name": "moving_window_month_count",
-                        "metadata": {
-                            "dataset": "orders",
-                            "time_dimension": "metric_time__month",
-                            "window": "3 months",
-                            "window_aggregation": "row_count",
-                            "metric_kind": "cumulative",
-                        },
-                    },
-                    {
-                        "name": "moving_3_month_order_count_avg",
-                        "measures": ["orders.order_id"],
-                        "metadata": {
-                            "dataset": "orders",
-                            "time_dimension": "metric_time__month",
-                            "window": "3 months",
-                            "window_aggregation": "avg",
-                            "metric_kind": "cumulative",
-                            "expr": "COUNT(DISTINCT order_id)",
-                            "measure": "order_id",
-                        },
-                    },
+                    {"name": "order_count", "metadata": {}},
+                    {"name": "moving_window_month_count", "metadata": {}},
+                    {"name": "moving_3_month_order_count_avg", "metadata": {}},
                 ],
                 "has_more": False,
             }
@@ -572,10 +549,8 @@ class TestAskMetricsAgenticNode:
 
         node.query_metrics(metrics=["moving_3_month_order_count_avg"], dimensions=[])
 
-        # The node still expands the executable metric bundle; metric_time grouping
-        # is delegated to the semantic adapter and no longer injected here.
         semantic_tools.query_metrics.assert_called_once_with(
-            metrics=["order_count", "moving_window_month_count", "moving_3_month_order_count_avg"],
+            metrics=["moving_3_month_order_count_avg"],
             dimensions=[],
             path=None,
             time_start=None,
@@ -587,60 +562,13 @@ class TestAskMetricsAgenticNode:
             dry_run=False,
         )
 
-    def test_query_metrics_expands_running_extrema_metric_bundle(self, real_agent_config, mock_llm_create):
+    def test_query_metrics_forwards_multiple_metrics_in_order(self, real_agent_config, mock_llm_create):
         node, semantic_tools, _ = _make_node(
             real_agent_config,
-            tree={
-                "Commerce": {
-                    "Orders": {
-                        "metrics": [
-                            "average_order_amount",
-                            "running_min_average_order_amount",
-                            "running_max_average_order_amount",
-                        ]
-                    }
-                }
-            },
+            tree={"Commerce": {"Orders": {"metrics": ["average_order_amount"]}}},
         )
         semantic_tools.list_metrics.return_value = FuncToolResult(
-            result={
-                "items": [
-                    {
-                        "name": "average_order_amount",
-                        "metadata": {
-                            "dataset": "orders",
-                            "expr": "AVG(order_amount)",
-                            "metric_kind": "aggregate",
-                            "measure": "order_amount",
-                        },
-                    },
-                    {
-                        "name": "running_min_average_order_amount",
-                        "metadata": {
-                            "dataset": "orders",
-                            "grain_to_date": "month",
-                            "time_dimension": "metric_time__month",
-                            "window_aggregation": "min",
-                            "metric_kind": "cumulative",
-                            "expr": "AVG(order_amount)",
-                            "measure": "order_amount",
-                        },
-                    },
-                    {
-                        "name": "running_max_average_order_amount",
-                        "metadata": {
-                            "dataset": "orders",
-                            "grain_to_date": "month",
-                            "time_dimension": "metric_time__month",
-                            "window_aggregation": "max",
-                            "metric_kind": "cumulative",
-                            "expr": "AVG(order_amount)",
-                            "measure": "order_amount",
-                        },
-                    },
-                ],
-                "has_more": False,
-            }
+            result={"items": [{"name": "average_order_amount", "metadata": {}}], "has_more": False}
         )
         semantic_tools.query_metrics.return_value = FuncToolResult(result={"columns": [], "data": []})
 
@@ -649,14 +577,8 @@ class TestAskMetricsAgenticNode:
             dimensions=["metric_time__month"],
         )
 
-        # Metric bundle expansion is preserved; caller-supplied dimensions pass
-        # through unchanged and grain injection is left to the semantic adapter.
         semantic_tools.query_metrics.assert_called_once_with(
-            metrics=[
-                "average_order_amount",
-                "running_min_average_order_amount",
-                "running_max_average_order_amount",
-            ],
+            metrics=["running_min_average_order_amount", "running_max_average_order_amount"],
             dimensions=["metric_time__month"],
             path=None,
             time_start=None,


### PR DESCRIPTION
## Why

`query_metrics` expands a requested window metric into a bundle — its base metric plus, for averages, the matching window row-count metric — so the answer carries the underlying series and the count the average was computed over.

**The need is real.** A 7-day moving average without the raw series can't tell you whether a dip is real or smoothed away, and without the window count you can't see that the first few points were averaged over 3 rows instead of 7. Deriving it *in the node* is the problem.

Nothing declares those relationships, so the node reverse-engineers them:

- an explicit name under any of **four** accepted keys (`base_metric`, `base_metric_name`, `source_metric`, `source_metric_name`) — four spellings means there was never a convention;
- failing that, a set intersection over **measure expression strings**, normalised by lowercasing and stripping whitespace — `COUNT(*)` and `count(1)` miss;
- window counts matched by requiring `dataset`, `time_dimension`, `window` and `grain_to_date` to be pairwise equal **as free text**.

Each pass scans the whole catalog, which is why `_metric_catalog()` pages up to 5000 metrics into a node-lifetime cache.

**Every field it reads is MetricFlow-shaped.** The Dosi adapter exposes

```python
MetricDefinition(..., metadata={"datasets": [...]})
```

and nothing else — no `window`, `window_aggregation`, `grain_to_date`, `time_dimension` or `base_metric`. So `_is_window_metric` is always `False` and `_window_metric_bundle` returns its input unchanged. Verified directly:

```
metadata          : {'datasets': ['orders']}
_is_window_metric : False
bundle            : ['order_count_7d_avg']
```

The inference and the 5000-metric fetch are dead weight on that path — the same shape as the query preflight removed in #1251.

Where a derived metric's dependencies belong is the semantic model. OSI `Metric` is `#[serde(deny_unknown_fields)]` but reserves `custom_extensions` and `ai_context` extras, so a model can carry them without the agent guessing.

## Solution

Remove the inference (`_expand_metric_dependencies`, `_expand_window_metrics`, `_window_metric_bundle`, `_find_window_base_metric`, `_matching_window_count_metrics`, `_window_metric_needs_window_count`, `_is_window_metric`, `_is_base_metric_candidate`, `_metric_measure_signature`, `_normalize_metric_expression`, `_metric_metadata`, `_metadata_text`, `_first_metadata_text`, `_append_unique`) together with `_metric_catalog()` and its cache. Requested metrics are normalised and forwarded as-is.

The tool docstring now tells the model to request the underlying series or the window row count explicitly when the answer needs them, instead of promising an expansion that no longer happens.

## Test Cases

- `test_query_metrics_forwards_requested_metrics_unchanged` / `test_query_metrics_forwards_multiple_metrics_in_order` replace the two bundle-expansion tests: requested metrics reach the adapter verbatim
- `tests/unit_tests/agent/node/` + `tests/unit_tests/tools/func_tool/`: **3772 passed, 1 skipped**

Net **-298 lines**.

## Note

Stacked on the same area as #1255 (removing the rejection cache) but touches disjoint code — either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Metric queries now request only the metrics explicitly provided.
  * Derived and underlying metrics must be requested separately when needed.
  * Requested metrics are forwarded in the same order supplied.
* **Bug Fixes**
  * Prevented automatic expansion of metric dependencies, reducing unexpected or unnecessary metric results.
  * Improved consistency for rolling-average and running-extrema metric queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->