### PR TITLE
[Enhancement] Drop the filesystem tools' file-extension whitelist

### DIFF
--- a/datus/tools/func_tool/filesystem_tools.py
+++ b/datus/tools/func_tool/filesystem_tools.py
@@ -28,33 +28,23 @@ logger = get_logger(__name__)
 
 
 class FilesystemConfig:
-    """Configuration for filesystem operations"""
+    """Configuration for filesystem operations.
+
+    There is intentionally no extension whitelist: the agent works on real
+    repositories that contain shell scripts, Terraform, Scala, notebooks,
+    dotfiles and so on, and a whitelist only ever produced the asymmetric
+    "``write_file`` succeeded but ``read_file`` refuses to read it back"
+    failure mode. Access is gated by zone (see :class:`FilesystemFuncTool`),
+    read-only anchors and the permission layer instead. Binary content is
+    still rejected naturally, via the UTF-8 decode error.
+    """
 
     def __init__(
         self,
         root_path: str = None,
-        allowed_extensions: List[str] = None,
         max_file_size: int = 200 * 1024,
     ):
         self.root_path = root_path or os.getcwd()
-        self.allowed_extensions = allowed_extensions or [
-            ".txt",
-            ".md",
-            ".py",
-            ".js",
-            ".jsx",
-            ".ts",
-            ".tsx",
-            ".json",
-            ".yaml",
-            ".yml",
-            ".csv",
-            ".sql",
-            ".j2",
-            ".html",
-            ".css",
-            ".xml",
-        ]
         self.max_file_size = max_file_size
 
 
@@ -250,12 +240,6 @@ class FilesystemFuncTool(BaseTool):
             return None
         return resolved.resolved
 
-    def _is_allowed_file(self, file_path: Path) -> bool:
-        """Check if file extension is allowed"""
-        if not self.config.allowed_extensions:
-            return True
-        return file_path.suffix.lower() in self.config.allowed_extensions
-
     # ------------------------------------------------------------- read/write
 
     def read_file(self, path: str, offset: int = 0, limit: int = 0) -> FuncToolResult:
@@ -293,9 +277,6 @@ class FilesystemFuncTool(BaseTool):
 
             if not target_path.is_file():
                 return FuncToolResult(success=0, error=f"Path is not a file: {resolved.display}")
-
-            if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
 
             max_bytes = self.config.max_file_size
             use_slice = offset > 0 or limit > 0
@@ -372,9 +353,6 @@ class FilesystemFuncTool(BaseTool):
             if resolved.read_only:
                 return self._read_only_reject(resolved)
 
-            # write_file intentionally skips the extension whitelist: the agent
-            # must be able to emit any text artifact (shell/infra/scala/etc.).
-            # Zone, read-only and strict-external gating above still apply.
             target_path = resolved.resolved
             guard_error = self._mutation_guard_error(target_path)
             if guard_error is not None:
@@ -438,9 +416,6 @@ class FilesystemFuncTool(BaseTool):
             if not target_path.is_file():
                 return FuncToolResult(success=0, error=f"Path is not a regular file: {resolved.display}")
 
-            if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
-
             try:
                 target_path.unlink()
                 self._notify_mutation(target_path)
@@ -490,9 +465,6 @@ class FilesystemFuncTool(BaseTool):
 
             if not target_path.is_file():
                 return FuncToolResult(success=0, error=f"Path is not a file: {resolved.display}")
-
-            if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
 
             try:
                 content = target_path.read_text(encoding="utf-8")
@@ -853,8 +825,6 @@ class FilesystemFuncTool(BaseTool):
                 report_relative_to = self._root_resolved
 
             def _search_file(file_path: Path, reported_file: str) -> List[dict]:
-                if not self._is_allowed_file(file_path):
-                    return []
                 try:
                     if file_path.stat().st_size > self.config.max_file_size:
                         return []

--- a/datus/tools/func_tool/metric_filesystem_tools.py
+++ b/datus/tools/func_tool/metric_filesystem_tools.py
@@ -1174,8 +1174,6 @@ class OsiSemanticModelFilesystemFuncTool(MetricFilesystemFuncTool):
                 return FuncToolResult(success=0, error=f"File not found: {resolved.display}")
             if not target_path.is_file():
                 return FuncToolResult(success=0, error=f"Path is not a file: {resolved.display}")
-            if not self._is_allowed_file(target_path):
-                return FuncToolResult(success=0, error=f"File type not allowed: {resolved.display}")
             try:
                 content = target_path.read_text(encoding="utf-8")
                 new_content, error = apply_single_replacement(content, old_string, new_string)

--- a/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_filesystem_tools.py
@@ -39,18 +39,13 @@ class TestFilesystemConfig:
         cfg = FilesystemConfig(root_path=str(tmp_path))
         assert cfg.root_path == str(tmp_path)
 
-    def test_default_allowed_extensions(self):
+    def test_default_max_file_size(self):
         cfg = FilesystemConfig()
-        assert ".py" in cfg.allowed_extensions
-        assert ".txt" in cfg.allowed_extensions
-        assert ".json" in cfg.allowed_extensions
-        # Dashboard artifact templates land as ``<slug>.sql.j2`` — Path.suffix
-        # returns ``.j2`` only, so the bare ``.j2`` entry is what gates them.
-        assert ".j2" in cfg.allowed_extensions
+        assert cfg.max_file_size == 200 * 1024
 
-    def test_custom_allowed_extensions(self):
-        cfg = FilesystemConfig(allowed_extensions=[".py"])
-        assert cfg.allowed_extensions == [".py"]
+    def test_custom_max_file_size(self):
+        cfg = FilesystemConfig(max_file_size=1024)
+        assert cfg.max_file_size == 1024
 
 
 class TestMutationCallback:
@@ -107,23 +102,56 @@ class TestGetSafePath:
 
 
 # ---------------------------------------------------------------------------
-# FilesystemFuncTool - _is_allowed_file
+# FilesystemFuncTool - extension-agnostic access
 # ---------------------------------------------------------------------------
 
 
-class TestIsAllowedFile:
-    def test_allowed_extension(self, tmp_path):
-        tool = _make_tool(str(tmp_path))
-        assert tool._is_allowed_file(Path("file.py")) is True
+class TestAnyExtensionIsAccessible:
+    """No operation gates on the file extension. Real repositories carry shell
+    scripts, Terraform, notebooks and extension-less dotfiles, and the agent
+    must be able to read back anything it can write.
+    """
 
-    def test_disallowed_extension(self, tmp_path):
+    @pytest.mark.parametrize(
+        "name",
+        ["deploy.sh", "main.tf", "app.scala", "pyproject.toml", "notebook.ipynb", "Dockerfile", ".env"],
+    )
+    def test_read_edit_delete_roundtrip(self, tmp_path, name):
         tool = _make_tool(str(tmp_path))
-        assert tool._is_allowed_file(Path("file.exe")) is False
 
-    def test_no_extension_filter(self, tmp_path):
-        tool = FilesystemFuncTool(root_path=str(tmp_path))
-        tool.config.allowed_extensions = []
-        assert tool._is_allowed_file(Path("file.exe")) is True
+        assert tool.write_file(name, "token here\n").success == 1
+
+        read = tool.read_file(name)
+        assert read.success == 1
+        assert read.result == "token here\n"
+
+        assert tool.edit_file(name, "token", "value").success == 1
+        assert (tmp_path / name).read_text() == "value here\n"
+
+        assert tool.delete_file(name).success == 1
+        assert not (tmp_path / name).exists()
+
+    def test_grep_matches_non_source_extensions(self, tmp_path):
+        (tmp_path / "deploy.sh").write_text("export TARGET=prod\n")
+        (tmp_path / "main.tf").write_text('variable "TARGET" {}\n')
+        tool = _make_tool(str(tmp_path))
+
+        result = tool.grep("TARGET")
+
+        assert result.success == 1
+        files = {m["file"] for m in result.result["matches"]}
+        assert files == {"deploy.sh", "main.tf"}
+
+    def test_binary_read_still_rejected(self, tmp_path):
+        """Undecodable content is rejected by the UTF-8 guard, not by a
+        suffix whitelist — so the rejection follows the bytes, not the name."""
+        (tmp_path / "payload.bin").write_bytes(b"\xff\xfe\x00\x01")
+        tool = _make_tool(str(tmp_path))
+
+        result = tool.read_file("payload.bin")
+
+        assert result.success == 0
+        assert "binary" in result.error.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -153,14 +181,6 @@ class TestReadFile:
         result = tool.read_file("mydir")
         assert result.success == 0
         assert "not a file" in result.error.lower()
-
-    def test_read_disallowed_extension(self, tmp_path):
-        f = tmp_path / "binary.exe"
-        f.write_bytes(b"\x00\x01\x02")
-        tool = _make_tool(str(tmp_path))
-        result = tool.read_file("binary.exe")
-        assert result.success == 0
-        assert "not allowed" in result.error.lower()
 
     def test_read_file_too_large(self, tmp_path):
         f = tmp_path / "big.txt"
@@ -263,20 +283,12 @@ class TestWriteFile:
         assert result.success == 1
         assert (tmp_path / "subdir" / "nested" / "file.txt").exists()
 
-    def test_write_skips_extension_whitelist(self, tmp_path):
-        """write_file accepts any text artifact regardless of extension; the
-        whitelist only gates read/edit/delete, not creation."""
+    def test_write_arbitrary_extension(self, tmp_path):
+        """write_file accepts any text artifact regardless of extension."""
         tool = _make_tool(str(tmp_path))
         result = tool.write_file("infra/deploy.sh", "#!/bin/sh\necho hi\n")
         assert result.success == 1
         assert (tmp_path / "infra" / "deploy.sh").read_text() == "#!/bin/sh\necho hi\n"
-
-    def test_write_non_whitelisted_extension_in_zone(self, tmp_path):
-        """A previously-rejected extension (.exe) now writes successfully."""
-        tool = _make_tool(str(tmp_path))
-        result = tool.write_file("file.exe", "binary")
-        assert result.success == 1
-        assert (tmp_path / "file.exe").read_text() == "binary"
 
     def test_write_path_traversal_classified_external(self, tmp_path):
         """Write with ``../`` escape also classifies EXTERNAL — gating lives
@@ -377,12 +389,13 @@ class TestEditFile:
         result = tool.edit_file("missing.py", "x", "y")
         assert result.success == 0
 
-    def test_edit_disallowed_extension(self, tmp_path):
-        f = tmp_path / "file.exe"
-        f.write_bytes(b"binary")
+    def test_edit_binary_file_rejected(self, tmp_path):
+        f = tmp_path / "payload.bin"
+        f.write_bytes(b"\xff\xfe\x00\x01")
         tool = _make_tool(str(tmp_path))
-        result = tool.edit_file("file.exe", "x", "y")
+        result = tool.edit_file("payload.bin", "x", "y")
         assert result.success == 0
+        assert "binary" in result.error.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`FilesystemConfig` carried a 15-entry extension whitelist (`.txt .md .py .js .jsx .ts .tsx .json .yaml .yml .csv .sql .j2 .html .css .xml`) that gated `read_file`, `edit_file`, `delete_file` and `grep`. `write_file` was already exempt, so the two halves disagreed: the agent could write `infra/deploy.sh` and then be told `File type not allowed` when it tried to read the same file back. The same applied to Terraform, Scala, TOML, notebooks and extension-less files such as `Dockerfile`, and `grep` silently dropped every match inside them — which reads as "no matches" rather than "not searched".

The whitelist also keyed the decision off the filename rather than the content, so a text file named `.exe` was refused while binary bytes inside a `.txt` were happily accepted.

## Solution

Removed the whitelist outright rather than defaulting it to empty, so no dead configuration path is left behind:

- Deleted `FilesystemConfig.allowed_extensions` and the `_is_allowed_file()` helper.
- Removed the four `File type not allowed` rejections in `read_file`, `delete_file`, `edit_file` and the silent skip inside `grep`'s `_search_file`.
- Removed the same rejection from `OsiSemanticModelFilesystemFuncTool.edit_file`.
- Dropped the now-stale comment in `write_file` explaining why *it* skipped the whitelist.

Access is still gated by the layers that actually carry security meaning: path-zone classification (`.datus/**` stays `HIDDEN`, `../` escapes stay `EXTERNAL` and reach the permission hook), read-only anchors, and `max_file_size` (200 KB, unchanged). Binary content is still rejected — now via the existing UTF-8 decode guard (`Cannot read binary file` / `Cannot edit binary file`), so the decision follows the bytes instead of the name.

Tradeoff accepted: `grep` now attempts to read every non-ignored file in range instead of pre-filtering by suffix. The size check and the decode guard already bound that cost, and it is what makes matches in `.sh` / `.tf` findable at all.

Deliberately left in place, because these are domain contracts and not generic type limits:

- `RENDER_ALLOWED_SUFFIXES` — `reports|dashboards/<id>/render/` still accepts only `.jsx/.js/.css`, so data files keep flowing through `save_query` and stay well-formed.
- `semantic_model_file` must still resolve to `.yml/.yaml`.

## Test Cases

All in `tests/unit_tests/tools/func_tool/test_filesystem_tools.py`. Per the repo's no-tombstone-tests rule, the tests covering the removed code were deleted rather than inverted into `not hasattr` style assertions, and replaced with behavioral coverage:

- New `TestAnyExtensionIsAccessible`, parametrized over `deploy.sh`, `main.tf`, `app.scala`, `pyproject.toml`, `notebook.ipynb`, `Dockerfile` (no suffix) and `.env`, each running the full write → read → edit → delete round trip.
- New `test_grep_matches_non_source_extensions` — asserts `grep` reports matches from both `.sh` and `.tf`, the case that previously returned an empty result set.
- `test_binary_read_still_rejected` and `test_edit_binary_file_rejected` pin the decode guard as the remaining rejection path. The old `test_edit_disallowed_extension` would have passed for the wrong reason after this change (missing `old_string` instead of a type rejection), so it was rewritten with an assertion on the error message.
- Removed `TestIsAllowedFile`, `test_default_allowed_extensions`, `test_custom_allowed_extensions` and `test_read_disallowed_extension`; `FilesystemConfig` construction is now covered via `max_file_size`.

Verification:

- `uv run python ci/run-pr-tests.py datus/main` — 215 passed, 0 failed, **diff coverage 100.00%**
- `uv run python ci/audit_tests.py --paths tests/unit_tests/tools/func_tool/test_filesystem_tools.py` — **P0=0, P1=0**
- `uv run pytest tests/unit_tests/tools/func_tool/` — 1975 passed, 6 skipped
- `ruff format` + `ruff check` on `datus/ tests/` — clean

No integration or nightly tests were added: the change removes a gate inside the filesystem tool rather than adding a code path across components, and the contract it affects (which extensions each operation accepts) is fully observable at the unit tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filesystem operations now support files with any extension.
  * File access continues to respect path restrictions, permissions, read-only settings, size limits, and text encoding requirements.

* **Bug Fixes**
  * File editing no longer incorrectly rejects files based on their extensions.

* **Tests**
  * Added coverage for arbitrary file extensions and binary-content rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->