### PR TITLE
[Feature] Expose metric-to-dataset mapping to tool transformers

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -286,6 +286,8 @@ agent:
       metricflow: {}
       # metricflow:                 # alternative: pin as global default
       #   default: true
+      #   metric_catalog_page_size: 500   # rows per list_metrics request when
+      #   metric_catalog_max_pages: 2000  # building the metric->dataset map
     bi_platforms:
       superset:
         type: superset

--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -286,8 +286,13 @@ agent:
       metricflow: {}
       # metricflow:                 # alternative: pin as global default
       #   default: true
-      #   metric_catalog_page_size: 500   # rows per list_metrics request when
-      #   metric_catalog_max_pages: 2000  # building the metric->dataset map
+      #   metric_catalog_page_size: 5000  # rows per list_metrics request when
+      #   metric_catalog_max_pages: 200   # building the metric->dataset map.
+      #                                   # Together they bound how many metrics
+      #                                   # are readable (1M by default); the
+      #                                   # real ceiling is rows the adapter
+      #                                   # actually returns per page x pages.
+      #                                   # Exceeding it denies metric queries.
     bi_platforms:
       superset:
         type: superset

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -151,6 +151,9 @@ def _signature_accepts_parameter(parameters, name: str) -> bool:
     return name in parameters or any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
 
 
+# `metric_datasets` fetches the whole catalog in one request.
+_METRIC_DATASETS_PAGE_SIZE = 1_000_000
+
 _TIME_GRANULARITY_ORDER = ("day", "week", "month", "quarter", "year")
 _TIME_GRANULARITIES = set(_TIME_GRANULARITY_ORDER)
 
@@ -420,6 +423,30 @@ class SemanticTools:
 
     def get_cached_query_metrics_result(self, cache_key: str) -> Optional[dict]:
         return self._query_metrics_result_cache.get(cache_key)
+
+    def metric_datasets(self) -> Dict[str, List[str]]:
+        """Metric name -> datasets it reads, for the tool-transformer context.
+
+        Read fresh on each call so a metric added after a model reload is visible.
+        """
+        adapter = self.adapter
+        if adapter is None:
+            return {}
+
+        lightweight = getattr(adapter, "metric_datasets", None)
+        if callable(lightweight):
+            return {
+                str(name): [str(ds) for ds in datasets or []] for name, datasets in _run_async(lightweight()).items()
+            }
+
+        mapping: Dict[str, List[str]] = {}
+        for metric in _run_async(adapter.list_metrics(limit=_METRIC_DATASETS_PAGE_SIZE, offset=0)):
+            name = str(getattr(metric, "name", "") or "")
+            if not name:
+                continue
+            metadata = _normalize_metric_metadata(getattr(metric, "metadata", None))
+            mapping[name] = [str(dataset) for dataset in (metadata.get("datasets") or [])]
+        return mapping
 
     def _configured_adapter_type(self) -> Optional[str]:
         """Return the configured adapter type without instantiating the adapter."""

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -80,16 +80,18 @@ def _normalize_metric_metadata(raw) -> dict:
     return safe_metadata
 
 
-def _normalize_dataset_names(raw) -> List[str]:
+def _normalize_dataset_names(raw: Any) -> List[str]:
     """Dataset names an adapter reports for a metric, as a list of non-empty strings.
 
-    A lone string names one dataset; iterating it would yield characters.
+    A lone string names one dataset; iterating it would yield characters. Only
+    string entries are kept — coercing anything else would invent names like
+    "None" that a policy could match on.
     """
     if isinstance(raw, str):
         name = raw.strip()
         return [name] if name else []
     if isinstance(raw, (list, tuple, set)):
-        return [str(item).strip() for item in raw if str(item).strip()]
+        return [item.strip() for item in raw if isinstance(item, str) and item.strip()]
     return []
 
 
@@ -455,9 +457,19 @@ class SemanticTools:
 
         lightweight = getattr(adapter, "metric_datasets", None)
         if callable(lightweight):
-            return {
-                str(name): _normalize_dataset_names(datasets) for name, datasets in _run_async(lightweight()).items()
-            }
+            reported = _run_async(lightweight())
+            if not isinstance(reported, Mapping):
+                logger.warning(
+                    "Adapter metric_datasets returned %s; reporting the mapping as unavailable.",
+                    type(reported).__name__,
+                )
+                return None
+            mapping = {}
+            for name, datasets in reported.items():
+                metric_name = str(name or "").strip()
+                if metric_name:
+                    mapping[metric_name] = _normalize_dataset_names(datasets)
+            return mapping
 
         page_size, max_pages = self._metric_catalog_paging()
         mapping: Dict[str, List[str]] = {}

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -151,8 +151,10 @@ def _signature_accepts_parameter(parameters, name: str) -> bool:
     return name in parameters or any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
 
 
-# `metric_datasets` fetches the whole catalog in one request.
-_METRIC_DATASETS_PAGE_SIZE = 1_000_000
+# `metric_datasets` pages through the catalog until a page comes back short.
+# The cap bounds an adapter that ignores `offset` and keeps returning full pages.
+_METRIC_DATASETS_PAGE_SIZE = 500
+_METRIC_DATASETS_MAX_PAGES = 200
 
 _TIME_GRANULARITY_ORDER = ("day", "week", "month", "quarter", "year")
 _TIME_GRANULARITIES = set(_TIME_GRANULARITY_ORDER)
@@ -424,14 +426,17 @@ class SemanticTools:
     def get_cached_query_metrics_result(self, cache_key: str) -> Optional[dict]:
         return self._query_metrics_result_cache.get(cache_key)
 
-    def metric_datasets(self) -> Dict[str, List[str]]:
+    def metric_datasets(self) -> Optional[Dict[str, List[str]]]:
         """Metric name -> datasets it reads, for the tool-transformer context.
 
-        Read fresh on each call so a metric added after a model reload is visible.
+        ``None`` when no adapter is configured; ``{}`` when the catalog is empty.
+        Consumers treat a name missing from the map as "no such metric", so every
+        page is read. Result is fresh on each call, making a metric added after a
+        model reload visible.
         """
         adapter = self.adapter
         if adapter is None:
-            return {}
+            return None
 
         lightweight = getattr(adapter, "metric_datasets", None)
         if callable(lightweight):
@@ -440,13 +445,24 @@ class SemanticTools:
             }
 
         mapping: Dict[str, List[str]] = {}
-        for metric in _run_async(adapter.list_metrics(limit=_METRIC_DATASETS_PAGE_SIZE, offset=0)):
-            name = str(getattr(metric, "name", "") or "")
-            if not name:
-                continue
-            metadata = _normalize_metric_metadata(getattr(metric, "metadata", None))
-            mapping[name] = [str(dataset) for dataset in (metadata.get("datasets") or [])]
-        return mapping
+        offset = 0
+        for _ in range(_METRIC_DATASETS_MAX_PAGES):
+            page = list(_run_async(adapter.list_metrics(limit=_METRIC_DATASETS_PAGE_SIZE, offset=offset)))
+            for metric in page:
+                name = str(getattr(metric, "name", "") or "")
+                if not name:
+                    continue
+                metadata = _normalize_metric_metadata(getattr(metric, "metadata", None))
+                mapping[name] = [str(dataset) for dataset in (metadata.get("datasets") or [])]
+            if len(page) < _METRIC_DATASETS_PAGE_SIZE:
+                return mapping
+            offset += len(page)
+
+        logger.warning(
+            "Metric catalog exceeded %d pages; dataset mapping may be incomplete.",
+            _METRIC_DATASETS_MAX_PAGES,
+        )
+        return None
 
     def _configured_adapter_type(self) -> Optional[str]:
         """Return the configured adapter type without instantiating the adapter."""

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -80,6 +80,19 @@ def _normalize_metric_metadata(raw) -> dict:
     return safe_metadata
 
 
+def _normalize_dataset_names(raw) -> List[str]:
+    """Dataset names an adapter reports for a metric, as a list of non-empty strings.
+
+    A lone string names one dataset; iterating it would yield characters.
+    """
+    if isinstance(raw, str):
+        name = raw.strip()
+        return [name] if name else []
+    if isinstance(raw, (list, tuple, set)):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    return []
+
+
 def _normalize_name_list(value) -> List[str]:
     """Normalize LLM-provided string/list arguments into a clean list of names."""
     value = normalize_null(value)
@@ -153,9 +166,10 @@ def _signature_accepts_parameter(parameters, name: str) -> bool:
 
 # Defaults for `metric_datasets` paging; override per adapter under
 # `services.semantic_layer.<adapter>` with `metric_catalog_page_size` /
-# `metric_catalog_max_pages`.
-_METRIC_DATASETS_PAGE_SIZE = 500
-_METRIC_DATASETS_MAX_PAGES = 2000
+# `metric_catalog_max_pages`. The page is large because an adapter may rebuild
+# its whole catalog per request, making each extra page cost a full pass.
+_METRIC_DATASETS_PAGE_SIZE = 5000
+_METRIC_DATASETS_MAX_PAGES = 200
 
 _TIME_GRANULARITY_ORDER = ("day", "week", "month", "quarter", "year")
 _TIME_GRANULARITIES = set(_TIME_GRANULARITY_ORDER)
@@ -442,7 +456,7 @@ class SemanticTools:
         lightweight = getattr(adapter, "metric_datasets", None)
         if callable(lightweight):
             return {
-                str(name): [str(ds) for ds in datasets or []] for name, datasets in _run_async(lightweight()).items()
+                str(name): _normalize_dataset_names(datasets) for name, datasets in _run_async(lightweight()).items()
             }
 
         page_size, max_pages = self._metric_catalog_paging()
@@ -457,8 +471,12 @@ class SemanticTools:
                 if not name:
                     continue
                 metadata = _normalize_metric_metadata(getattr(metric, "metadata", None))
-                mapping[name] = [str(dataset) for dataset in (metadata.get("datasets") or [])]
+                mapping[name] = _normalize_dataset_names(metadata.get("datasets"))
             offset += len(page)
+
+        # A catalog that fills the bound exactly is complete; one more request tells them apart.
+        if not list(_run_async(adapter.list_metrics(limit=page_size, offset=offset))):
+            return mapping
 
         logger.warning(
             "Metric catalog still returning rows after %d pages; reporting the mapping as unavailable.",

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -151,10 +151,11 @@ def _signature_accepts_parameter(parameters, name: str) -> bool:
     return name in parameters or any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values())
 
 
-# `metric_datasets` pages through the catalog until a page comes back short.
-# The cap bounds an adapter that ignores `offset` and keeps returning full pages.
+# Defaults for `metric_datasets` paging; override per adapter under
+# `services.semantic_layer.<adapter>` with `metric_catalog_page_size` /
+# `metric_catalog_max_pages`.
 _METRIC_DATASETS_PAGE_SIZE = 500
-_METRIC_DATASETS_MAX_PAGES = 200
+_METRIC_DATASETS_MAX_PAGES = 2000
 
 _TIME_GRANULARITY_ORDER = ("day", "week", "month", "quarter", "year")
 _TIME_GRANULARITIES = set(_TIME_GRANULARITY_ORDER)
@@ -444,25 +445,49 @@ class SemanticTools:
                 str(name): [str(ds) for ds in datasets or []] for name, datasets in _run_async(lightweight()).items()
             }
 
+        page_size, max_pages = self._metric_catalog_paging()
         mapping: Dict[str, List[str]] = {}
         offset = 0
-        for _ in range(_METRIC_DATASETS_MAX_PAGES):
-            page = list(_run_async(adapter.list_metrics(limit=_METRIC_DATASETS_PAGE_SIZE, offset=offset)))
+        for _ in range(max_pages):
+            page = list(_run_async(adapter.list_metrics(limit=page_size, offset=offset)))
+            if not page:
+                return mapping
             for metric in page:
                 name = str(getattr(metric, "name", "") or "")
                 if not name:
                     continue
                 metadata = _normalize_metric_metadata(getattr(metric, "metadata", None))
                 mapping[name] = [str(dataset) for dataset in (metadata.get("datasets") or [])]
-            if len(page) < _METRIC_DATASETS_PAGE_SIZE:
-                return mapping
             offset += len(page)
 
         logger.warning(
-            "Metric catalog exceeded %d pages; dataset mapping may be incomplete.",
-            _METRIC_DATASETS_MAX_PAGES,
+            "Metric catalog still returning rows after %d pages; reporting the mapping as unavailable.",
+            max_pages,
         )
         return None
+
+    def _metric_catalog_paging(self) -> Tuple[int, int]:
+        """Page size and page cap for `metric_datasets`, from the adapter's config."""
+        config: Dict[str, Any] = {}
+        getter = getattr(self.agent_config, "get_semantic_layer_config", None)
+        if callable(getter):
+            try:
+                config = getter(self.adapter_type) or {}
+            except Exception as e:  # noqa: BLE001 - a bad config must not break tool calls
+                logger.warning("Could not read semantic layer config for metric paging: %s", e)
+
+        def _positive(key: str, default: int) -> int:
+            try:
+                value = int(config.get(key) or default)
+            except (TypeError, ValueError):
+                logger.warning("Invalid %s=%r; using %d", key, config.get(key), default)
+                return default
+            return value if value > 0 else default
+
+        return (
+            _positive("metric_catalog_page_size", _METRIC_DATASETS_PAGE_SIZE),
+            _positive("metric_catalog_max_pages", _METRIC_DATASETS_MAX_PAGES),
+        )
 
     def _configured_adapter_type(self) -> Optional[str]:
         """Return the configured adapter type without instantiating the adapter."""

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -162,6 +162,23 @@ def wrap_tool_with_transformers(
     return FunctionTool(**carried)
 
 
+def _metric_datasets(node: Any) -> Optional[Dict[str, List[str]]]:
+    """Metric-to-datasets map from the node's semantic tools.
+
+    ``None`` when the node has no semantic tools or the catalog cannot be read;
+    ``{}`` when the adapter reports no metrics.
+    """
+    semantic_tools = getattr(node, "semantic_tools", None)
+    getter = getattr(semantic_tools, "metric_datasets", None)
+    if not callable(getter):
+        return None
+    try:
+        return getter()
+    except Exception as e:  # noqa: BLE001 - an unreadable catalog must not break tool calls
+        logger.warning("Could not read metric datasets for transformer context: %s", e)
+        return None
+
+
 def apply_tool_transformers(node: Any, transformers_by_pattern: Dict[str, List[ToolTransformer]]) -> int:
     """Wrap matching tools on ``node`` with the given transformers, in place.
 
@@ -202,6 +219,9 @@ def apply_tool_transformers(node: Any, transformers_by_pattern: Dict[str, List[T
             # plugin profile (``get_plugin_profile``) and datasource metadata.
             # Duck-typed access only — transformers must not import datus.*.
             "agent_config": agent_config,
+            # Metric name -> datasets it reads, so transformers enforcing read
+            # policies over metric queries know which physical data is touched.
+            "metric_datasets": _metric_datasets(node),
         }
 
     parsed_by_pattern = {pattern: parse_tool_patterns([pattern]) for pattern in transformers_by_pattern}

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -173,10 +173,14 @@ def _metric_datasets(node: Any) -> Optional[Dict[str, List[str]]]:
     if not callable(getter):
         return None
     try:
-        return getter()
+        mapping = getter()
     except Exception as e:  # noqa: BLE001 - an unreadable catalog must not break tool calls
         logger.warning("Could not read metric datasets for transformer context: %s", e)
         return None
+    if mapping is not None and not isinstance(mapping, dict):
+        logger.warning("Ignoring metric datasets of unexpected type %s", type(mapping).__name__)
+        return None
+    return mapping
 
 
 def apply_tool_transformers(node: Any, transformers_by_pattern: Dict[str, List[ToolTransformer]]) -> int:

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -647,6 +647,51 @@ class TestQueryMetricsCompression:
         assert result.result["metadata"]["join_policy"] == "match_only"
         assert result.result["metadata"]["join_policy_filtered_rows"] == 3
 
+    def test_metric_datasets_maps_names_from_catalog_metadata(self, semantic_tools):
+        """The adapter reports which datasets each metric reads."""
+        metrics = [
+            SimpleNamespace(name="revenue", metadata={"datasets": ["orders"]}),
+            SimpleNamespace(name="signups", metadata={"datasets": ["users"]}),
+        ]
+        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda **kwargs: metrics)
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=metrics):
+            assert semantic_tools.metric_datasets() == {"revenue": ["orders"], "signups": ["users"]}
+
+    def test_metric_datasets_requests_every_metric_in_one_page(self, semantic_tools):
+        """The whole catalog arrives in one request."""
+        captured = {}
+
+        def list_metrics(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        semantic_tools._adapter = SimpleNamespace(list_metrics=list_metrics)
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
+            semantic_tools.metric_datasets()
+
+        assert captured["offset"] == 0
+        assert captured["limit"] >= 1_000_000
+
+    def test_metric_datasets_keeps_metrics_without_dataset_information(self, semantic_tools):
+        """A metric reported without dataset information maps to an empty list."""
+        metrics = [SimpleNamespace(name="orphan", metadata={})]
+        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda **kwargs: metrics)
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=metrics):
+            assert semantic_tools.metric_datasets() == {"orphan": []}
+
+    def test_metric_datasets_prefers_the_adapter_lightweight_accessor(self, semantic_tools):
+        """Adapters may skip building a MetricDefinition per metric."""
+
+        def fail_list_metrics(**kwargs):
+            raise AssertionError("should not fall back to list_metrics")
+
+        semantic_tools._adapter = SimpleNamespace(
+            metric_datasets=lambda: {"revenue": ["orders"]},
+            list_metrics=fail_list_metrics,
+        )
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
+            assert semantic_tools.metric_datasets() == {"revenue": ["orders"]}
+
 
 # ---------------------------------------------------------------------------
 # Extended fixtures (no adapter_type)

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -729,6 +729,7 @@ class TestQueryMetricsCompression:
             ("orders", ["orders"]),
             (["orders", "users"], ["orders", "users"]),
             (["orders", "", "  "], ["orders"]),
+            (["orders", None, 1], ["orders"]),
             (None, []),
             (42, []),
         ],
@@ -767,6 +768,22 @@ class TestQueryMetricsCompression:
         """An unavailable catalog is distinct from a readable empty one."""
         with patch.object(type(semantic_tools), "adapter", property(lambda self: None)):
             assert semantic_tools.metric_datasets() is None
+
+    @pytest.mark.parametrize("reported", [None, ["orders"], "orders"])
+    def test_metric_datasets_rejects_a_non_mapping_from_the_accessor(self, semantic_tools, reported):
+        """An invalid provider result must not reach the transformer context."""
+        semantic_tools._adapter = SimpleNamespace(metric_datasets=lambda: reported, list_metrics=lambda **kwargs: [])
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
+            assert semantic_tools.metric_datasets() is None
+
+    def test_metric_datasets_skips_unnamed_metrics_from_the_accessor(self, semantic_tools):
+        """Both read paths drop metrics without a usable name."""
+        semantic_tools._adapter = SimpleNamespace(
+            metric_datasets=lambda: {None: ["x"], "": ["y"], " revenue ": ["orders"]},
+            list_metrics=lambda **kwargs: [],
+        )
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
+            assert semantic_tools.metric_datasets() == {"revenue": ["orders"]}
 
     def test_metric_datasets_prefers_the_adapter_lightweight_accessor(self, semantic_tools):
         """Adapters may skip building a MetricDefinition per metric."""

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -657,20 +657,38 @@ class TestQueryMetricsCompression:
         with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=metrics):
             assert semantic_tools.metric_datasets() == {"revenue": ["orders"], "signups": ["users"]}
 
-    def test_metric_datasets_requests_every_metric_in_one_page(self, semantic_tools):
-        """The whole catalog arrives in one request."""
-        captured = {}
+    def test_metric_datasets_reads_every_page(self, semantic_tools):
+        """A truncated read would hide metrics from a policy that scopes by dataset."""
+        from datus.tools.func_tool.semantic_tools import _METRIC_DATASETS_PAGE_SIZE
 
-        def list_metrics(**kwargs):
-            captured.update(kwargs)
-            return []
+        first = [
+            SimpleNamespace(name=f"m{i}", metadata={"datasets": ["orders"]}) for i in range(_METRIC_DATASETS_PAGE_SIZE)
+        ]
+        second = [SimpleNamespace(name="tail", metadata={"datasets": ["users"]})]
+        offsets = []
+
+        def list_metrics(limit, offset):
+            offsets.append(offset)
+            return first if offset == 0 else second
 
         semantic_tools._adapter = SimpleNamespace(list_metrics=list_metrics)
         with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
-            semantic_tools.metric_datasets()
+            mapping = semantic_tools.metric_datasets()
 
-        assert captured["offset"] == 0
-        assert captured["limit"] >= 1_000_000
+        assert offsets == [0, _METRIC_DATASETS_PAGE_SIZE]
+        assert mapping["tail"] == ["users"]
+        assert len(mapping) == _METRIC_DATASETS_PAGE_SIZE + 1
+
+    def test_metric_datasets_gives_up_on_an_adapter_that_ignores_offset(self, semantic_tools):
+        """An incomplete map must not look like a complete one."""
+        from datus.tools.func_tool.semantic_tools import _METRIC_DATASETS_PAGE_SIZE
+
+        page = [
+            SimpleNamespace(name=f"m{i}", metadata={"datasets": ["orders"]}) for i in range(_METRIC_DATASETS_PAGE_SIZE)
+        ]
+        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda limit, offset: page)
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
+            assert semantic_tools.metric_datasets() is None
 
     def test_metric_datasets_keeps_metrics_without_dataset_information(self, semantic_tools):
         """A metric reported without dataset information maps to an empty list."""
@@ -678,6 +696,11 @@ class TestQueryMetricsCompression:
         semantic_tools._adapter = SimpleNamespace(list_metrics=lambda **kwargs: metrics)
         with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=metrics):
             assert semantic_tools.metric_datasets() == {"orphan": []}
+
+    def test_metric_datasets_without_an_adapter_is_none(self, semantic_tools):
+        """An unavailable catalog is distinct from a readable empty one."""
+        with patch.object(type(semantic_tools), "adapter", property(lambda self: None)):
+            assert semantic_tools.metric_datasets() is None
 
     def test_metric_datasets_prefers_the_adapter_lightweight_accessor(self, semantic_tools):
         """Adapters may skip building a MetricDefinition per metric."""

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -705,6 +705,41 @@ class TestQueryMetricsCompression:
         ):
             assert semantic_tools.metric_datasets() is None
 
+    def test_metric_datasets_accepts_a_catalog_that_exactly_fills_the_bound(self, semantic_tools):
+        """Filling the page bound is not the same as exceeding it."""
+        max_pages = 3
+
+        def list_metrics(limit, offset):
+            if offset >= max_pages:
+                return []
+            return [SimpleNamespace(name=f"m{offset}", metadata={"datasets": ["orders"]})]
+
+        semantic_tools._adapter = SimpleNamespace(list_metrics=list_metrics)
+        with (
+            patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro),
+            patch.object(SemanticTools, "_metric_catalog_paging", return_value=(1, max_pages)),
+        ):
+            mapping = semantic_tools.metric_datasets()
+
+        assert sorted(mapping) == ["m0", "m1", "m2"]
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("orders", ["orders"]),
+            (["orders", "users"], ["orders", "users"]),
+            (["orders", "", "  "], ["orders"]),
+            (None, []),
+            (42, []),
+        ],
+    )
+    def test_metric_datasets_normalizes_the_reported_shape(self, semantic_tools, raw, expected):
+        """A lone string names one dataset; iterating it would yield characters."""
+        metrics = [SimpleNamespace(name="revenue", metadata={"datasets": raw})]
+        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda limit, offset: metrics if offset == 0 else [])
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
+            assert semantic_tools.metric_datasets() == {"revenue": expected}
+
     def test_metric_catalog_paging_reads_the_adapter_config(self, semantic_tools):
         semantic_tools.agent_config.get_semantic_layer_config = lambda adapter_type=None: {
             "metric_catalog_page_size": 50,

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -15,7 +15,7 @@ from datus.tools.func_tool.attribution_utils import (
 )
 from datus.tools.func_tool.base import FuncToolResult, normalize_null, trans_to_function_tool
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
-from datus.tools.func_tool.semantic_tools import _run_async
+from datus.tools.func_tool.semantic_tools import SemanticTools, _run_async
 from datus.tools.semantic_tools.models import QueryResult, ValidationResult
 
 
@@ -653,48 +653,79 @@ class TestQueryMetricsCompression:
             SimpleNamespace(name="revenue", metadata={"datasets": ["orders"]}),
             SimpleNamespace(name="signups", metadata={"datasets": ["users"]}),
         ]
-        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda **kwargs: metrics)
-        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=metrics):
+        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda limit, offset: metrics if offset == 0 else [])
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
             assert semantic_tools.metric_datasets() == {"revenue": ["orders"], "signups": ["users"]}
 
-    def test_metric_datasets_reads_every_page(self, semantic_tools):
+    def test_metric_datasets_reads_until_an_empty_page(self, semantic_tools):
         """A truncated read would hide metrics from a policy that scopes by dataset."""
-        from datus.tools.func_tool.semantic_tools import _METRIC_DATASETS_PAGE_SIZE
-
-        first = [
-            SimpleNamespace(name=f"m{i}", metadata={"datasets": ["orders"]}) for i in range(_METRIC_DATASETS_PAGE_SIZE)
+        pages = [
+            [SimpleNamespace(name="a", metadata={"datasets": ["orders"]})],
+            [SimpleNamespace(name="b", metadata={"datasets": ["users"]})],
+            [],
         ]
-        second = [SimpleNamespace(name="tail", metadata={"datasets": ["users"]})]
         offsets = []
 
         def list_metrics(limit, offset):
             offsets.append(offset)
-            return first if offset == 0 else second
+            return pages[len(offsets) - 1]
 
         semantic_tools._adapter = SimpleNamespace(list_metrics=list_metrics)
         with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
             mapping = semantic_tools.metric_datasets()
 
-        assert offsets == [0, _METRIC_DATASETS_PAGE_SIZE]
-        assert mapping["tail"] == ["users"]
-        assert len(mapping) == _METRIC_DATASETS_PAGE_SIZE + 1
+        assert offsets == [0, 1, 2]
+        assert mapping == {"a": ["orders"], "b": ["users"]}
+
+    def test_metric_datasets_keeps_paging_when_the_adapter_caps_the_page(self, semantic_tools):
+        """An adapter may honour offset while returning fewer rows than requested."""
+        served = []
+
+        def list_metrics(limit, offset):
+            served.append((limit, offset))
+            if offset >= 3:
+                return []
+            return [SimpleNamespace(name=f"m{offset}", metadata={"datasets": ["orders"]})]
+
+        semantic_tools._adapter = SimpleNamespace(list_metrics=list_metrics)
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
+            mapping = semantic_tools.metric_datasets()
+
+        assert [offset for _, offset in served] == [0, 1, 2, 3]
+        assert sorted(mapping) == ["m0", "m1", "m2"]
 
     def test_metric_datasets_gives_up_on_an_adapter_that_ignores_offset(self, semantic_tools):
         """An incomplete map must not look like a complete one."""
+        semantic_tools._adapter = SimpleNamespace(
+            list_metrics=lambda limit, offset: [SimpleNamespace(name="m", metadata={"datasets": ["orders"]})]
+        )
+        with (
+            patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro),
+            patch.object(SemanticTools, "_metric_catalog_paging", return_value=(500, 3)),
+        ):
+            assert semantic_tools.metric_datasets() is None
+
+    def test_metric_catalog_paging_reads_the_adapter_config(self, semantic_tools):
+        semantic_tools.agent_config.get_semantic_layer_config = lambda adapter_type=None: {
+            "metric_catalog_page_size": 50,
+            "metric_catalog_max_pages": 10,
+        }
+        assert semantic_tools._metric_catalog_paging() == (50, 10)
+
+    @pytest.mark.parametrize("bad", [0, -1, "abc", None])
+    def test_metric_catalog_paging_falls_back_on_bad_values(self, semantic_tools, bad):
         from datus.tools.func_tool.semantic_tools import _METRIC_DATASETS_PAGE_SIZE
 
-        page = [
-            SimpleNamespace(name=f"m{i}", metadata={"datasets": ["orders"]}) for i in range(_METRIC_DATASETS_PAGE_SIZE)
-        ]
-        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda limit, offset: page)
-        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
-            assert semantic_tools.metric_datasets() is None
+        semantic_tools.agent_config.get_semantic_layer_config = lambda adapter_type=None: {
+            "metric_catalog_page_size": bad
+        }
+        assert semantic_tools._metric_catalog_paging()[0] == _METRIC_DATASETS_PAGE_SIZE
 
     def test_metric_datasets_keeps_metrics_without_dataset_information(self, semantic_tools):
         """A metric reported without dataset information maps to an empty list."""
         metrics = [SimpleNamespace(name="orphan", metadata={})]
-        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda **kwargs: metrics)
-        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=metrics):
+        semantic_tools._adapter = SimpleNamespace(list_metrics=lambda limit, offset: metrics if offset == 0 else [])
+        with patch("datus.tools.func_tool.semantic_tools._run_async", side_effect=lambda coro: coro):
             assert semantic_tools.metric_datasets() == {"orphan": []}
 
     def test_metric_datasets_without_an_adapter_is_none(self, semantic_tools):

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -329,6 +329,58 @@ class TestApplyToolTransformers:
         assert seen["principal"] == {"tenant": {"id": "t1"}}
         assert seen["project_root"] == "/proj"
         assert seen["agent_config"] is node.agent_config
+        assert seen["metric_datasets"] is None
+
+    @pytest.mark.asyncio
+    async def test_context_carries_metric_datasets_from_semantic_tools(self):
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.semantic_tools = SimpleNamespace(metric_datasets=lambda: {"revenue": ["orders"]})
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] == {"revenue": ["orders"]}
+
+    @pytest.mark.asyncio
+    async def test_metric_datasets_read_fresh_per_call(self):
+        seen = []
+        catalog = {"revenue": ["orders"]}
+
+        def transformer(tool_name, args, context):
+            seen.append(context["metric_datasets"])
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.semantic_tools = SimpleNamespace(metric_datasets=lambda: dict(catalog))
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+        catalog["signups"] = ["users"]
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen == [{"revenue": ["orders"]}, {"revenue": ["orders"], "signups": ["users"]}]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_metric_catalog_yields_none(self):
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        def boom():
+            raise RuntimeError("catalog unavailable")
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.semantic_tools = SimpleNamespace(metric_datasets=boom)
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] is None
 
     @pytest.mark.asyncio
     async def test_principal_read_fresh_per_call(self):

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -365,6 +365,21 @@ class TestApplyToolTransformers:
         assert seen == [{"revenue": ["orders"]}, {"revenue": ["orders"], "signups": ["users"]}]
 
     @pytest.mark.asyncio
+    async def test_metric_datasets_of_unexpected_type_is_dropped(self):
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.semantic_tools = SimpleNamespace(metric_datasets=lambda: "not a mapping")
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] is None
+
+    @pytest.mark.asyncio
     async def test_unreadable_metric_catalog_yields_none(self):
         seen = {}
 


### PR DESCRIPTION
## Why

A transformer enforcing read policies over `query_metrics` cannot tell from the arguments which physical data a metric touches — the arguments carry metric *names*, not tables.

Without that, a policy can only match on metric names. The failure mode is silent: a metric added later reads protected data but is not covered until someone remembers to update the policy, and forgetting leaks rather than errors.

**The adapter already knows.** dosi-engine derives each metric's datasets from its compiled expression:

```rust
// dosi-engine/src/list.rs
json!({ "name": m.name, "kind": m.kind, "datasets": m.datasets, ... })
```

and `DosiAdapter.list_metrics` reports it as `metadata["datasets"]`. The link simply stopped at the tool layer.

## Solution

**`SemanticTools.metric_datasets()`** reshapes the catalog into `name -> datasets`. It prefers an adapter-provided `metric_datasets()` when one exists (skipping a `MetricDefinition` per metric), otherwise reads `list_metrics`.

One request returns the whole catalog, and the result is **not cached** — dosi reloads its model on file mtime, so a cached map would make a metric added mid-session indistinguishable from a missing one, and a consumer that treats "absent" as "no such metric" would then silently skip it.

**`tool_middleware`** publishes it as `context["metric_datasets"]`, duck-typed off the node exactly as `principal` and `agent_config` already are. `None` (no semantic tools, or an unreadable catalog) stays distinct from `{}` so a policy can tell a failed lookup from an empty catalog and fail closed on the former.

Not exposed as an agent tool — absent from `all_tools_name` and `available_tools`, like `get_cached_query_metrics_result`.

## Test Cases

- `test_semantic_tools.py` — mapping from catalog metadata; whole catalog in one request; metrics reported without dataset information; the adapter's lightweight accessor taking precedence
- `test_tool_middleware.py` — the context field is present; read fresh per call; `None` when the catalog raises
- `tests/unit_tests/tools/` + `agent/`: **5678 passed, 1 skipped**

## Consumer

`datus-sql-policies` uses this for `metric_row_filter` policies, which match on the datasets a metric reads so that a new metric over a protected dataset is covered without a policy edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added metric-to-dataset catalog information to tool processing context.
  * Added support for retrieving metric datasets through available catalog providers.
  * Gracefully handles unavailable or incomplete catalog metadata.

* **Bug Fixes**
  * Catalog information is refreshed for each tool invocation.
  * Failures while retrieving catalog data no longer interrupt processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metric-to-dataset catalog information to tool processing context.
  * Added support for retrieving metric datasets through available catalog providers.
  * Added configurable pagination for larger metric catalogs.

* **Bug Fixes**
  * Catalog information is refreshed for each tool invocation.
  * Failures, unavailable providers, and incomplete catalog data no longer interrupt processing.
  * Unnamed metrics are excluded from catalog results.
  * Invalid pagination settings safely fall back to defaults.

* **Documentation**
  * Added example configuration for catalog page size and pagination limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->