### PR TITLE
[BugFix] Keep a running tool visible across a Ctrl+O verbose toggle

### DIFF
--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -972,6 +972,26 @@ class ActionRenderer:
             return Text.from_markup(f"[dim]  \u23bf  {body}[/dim]")
         return Text.from_markup(body)
 
+    def render_running_tool(self, action: ActionHistory, frame: str, verbose: bool) -> List[RenderableType]:
+        """Render a still-running tool as permanent (non-Live) output.
+
+        The blinking frame lives in the pinned region, which is torn down
+        whenever the screen is rebuilt (Ctrl+O verbose snapshot). Re-emitting
+        the running tool here keeps an in-flight call visible instead of
+        letting it vanish from the transcript until it completes.
+
+        Verbose mode appends the same argument block
+        :meth:`_render_main_tool` prints for a completed call; the output
+        block is necessarily absent because the tool has not returned yet.
+        """
+        from datus.cli.action_display.tool_content import extract_args_markup
+
+        result: List[RenderableType] = [self.render_processing(action, frame)]
+        if verbose:
+            result.extend(Text.from_markup(f"    {line}") for line in extract_args_markup(action))
+        result.append(Text(""))
+        return result
+
     # -- utility renderables ------------------------------------------------
 
     def render_user_header(self, message: str) -> RenderableType:

--- a/datus/cli/action_display/streaming.py
+++ b/datus/cli/action_display/streaming.py
@@ -584,77 +584,7 @@ class InlineStreamingContext:
             # Check for verbose toggle request (Ctrl+O)
             if self._verbose_toggle_event.is_set():
                 self._verbose_toggle_event.clear()
-                self._verbose = not self._verbose
-
-                if self._verbose:
-                    # Entering verbose mode: freeze — show snapshot, stop all Live displays
-                    self._verbose_frozen = True
-                    self._stop_processing_live()
-                    self._stop_subagent_live()
-                    with self._print_lock:
-                        if self._clear_screen_callback is not None:
-                            try:
-                                self._clear_screen_callback()
-                            except Exception as exc:
-                                logger.debug(
-                                    "clear_screen_callback raised in verbose toggle: %s",
-                                    exc,
-                                    exc_info=True,
-                                )
-                        else:
-                            self.display.console.clear()
-                            sys.stdout.write("\033[3J")
-                            sys.stdout.flush()
-                        if self._clear_header_callback is not None:
-                            try:
-                                self._clear_header_callback()
-                            except Exception as exc:
-                                logger.debug(
-                                    "clear_header_callback raised in verbose toggle: %s",
-                                    exc,
-                                    exc_info=True,
-                                )
-                        self.display.console.print(
-                            "[bold bright_black]  \u23af switched to verbose mode (frozen) \u23af[/]"
-                        )
-                    self._reprint_history(verbose=True, show_active_groups=True)
-                    # Do NOT restart any Live displays — screen is frozen
-                else:
-                    # Returning to compact mode: unfreeze — resume real-time processing
-                    self._verbose_frozen = False
-                    self._stop_processing_live()
-                    self._stop_subagent_live()
-                    with self._print_lock:
-                        if self._clear_screen_callback is not None:
-                            try:
-                                self._clear_screen_callback()
-                            except Exception as exc:
-                                logger.debug(
-                                    "clear_screen_callback raised in verbose toggle: %s",
-                                    exc,
-                                    exc_info=True,
-                                )
-                        else:
-                            self.display.console.clear()
-                            sys.stdout.write("\033[3J")
-                            sys.stdout.flush()
-                        if self._clear_header_callback is not None:
-                            try:
-                                self._clear_header_callback()
-                            except Exception as exc:
-                                logger.debug(
-                                    "clear_header_callback raised in compact toggle: %s",
-                                    exc,
-                                    exc_info=True,
-                                )
-                        self.display.console.print("[bold bright_black]  \u23af switched to compact mode \u23af[/]")
-                    self._reprint_history(verbose=self._verbose)
-                    # Restart Live for any remaining active subagent groups.
-                    # In TUI mode the pinned region re-draws from LiveDisplayState
-                    # on its own; explicit re-emission handles non-TUI Rich Live.
-                    if self._subagent_groups:
-                        with self._print_lock:
-                            self._update_subagent_groups_live()
+                self._apply_verbose_toggle()
 
             if not self._paused and not self._verbose_frozen:
                 if self._tui_mode:
@@ -672,12 +602,71 @@ class InlineStreamingContext:
                     self._repaint_live()
             self._stop_event.wait(timeout=0.25)
 
+    # -- verbose toggle (Ctrl+O) -------------------------------------------
+
+    def _clear_screen_for_toggle(self, mode_label: str) -> None:
+        """Wipe the screen and pinned header ahead of a Ctrl+O rebuild.
+
+        Callers hold ``_print_lock``. Callback failures are non-fatal: a stale
+        screen is far better than losing the rebuilt transcript underneath it.
+        """
+        if self._clear_screen_callback is not None:
+            try:
+                self._clear_screen_callback()
+            except Exception as exc:
+                logger.debug("clear_screen_callback raised in %s toggle: %s", mode_label, exc, exc_info=True)
+        else:
+            self.display.console.clear()
+            sys.stdout.write("\033[3J")
+            sys.stdout.flush()
+        if self._clear_header_callback is not None:
+            try:
+                self._clear_header_callback()
+            except Exception as exc:
+                logger.debug("clear_header_callback raised in %s toggle: %s", mode_label, exc, exc_info=True)
+
+    def _apply_verbose_toggle(self) -> None:
+        """Flip the display mode and rebuild the screen for it.
+
+        Verbose freezes the transcript into a static snapshot (all Live
+        displays stay down); compact unfreezes and hands the pinned region back
+        to the Live painter.
+        """
+        self._verbose = not self._verbose
+        # Blank the pinned region through the freeze flag rather than
+        # ``_stop_processing_live``: that would drop ``_processing_action`` and
+        # strand an in-flight tool. Its PROCESSING entry was already consumed
+        # by ``_process_actions`` and the reprinted history slice skips
+        # PROCESSING rows, so nothing would ever redraw the frame — the tool
+        # would silently vanish until it returned. Keeping the state intact
+        # also lets the compact side re-pin it for free.
+        self._verbose_frozen = self._verbose
+        self._repaint_live()
+        mode_label = "verbose" if self._verbose else "compact"
+        banner = "switched to verbose mode (frozen)" if self._verbose else "switched to compact mode"
+        with self._print_lock:
+            self._clear_screen_for_toggle(mode_label)
+            self.display.console.print(f"[bold bright_black]  \u23af {banner} \u23af[/]")
+
+        if self._verbose:
+            # Frozen: no Live display is restarted, so the running tool has to
+            # be part of the static snapshot.
+            self._reprint_history(verbose=True, show_active_groups=True, running_action=self._processing_action)
+            return
+
+        self._reprint_history(verbose=False)
+        # Hand the pinned region back to the Live painter, which redraws the
+        # running-tool frame / subagent rolling window from the state that
+        # survived the freeze.
+        self._repaint_live()
+
     # -- unified reprint history -------------------------------------------
 
     def _reprint_history(
         self,
         verbose: bool,
         show_active_groups: bool = False,
+        running_action: Optional[ActionHistory] = None,
     ) -> None:
         """Unified reprint of all already-processed actions.
 
@@ -688,6 +677,11 @@ class InlineStreamingContext:
             verbose: Whether to render in verbose mode (True=expanded, False=collapsed).
             show_active_groups: If True, render active subagent groups as static output
                 with an "in progress" indicator (used for verbose/frozen snapshot).
+            running_action: Main-agent tool still in flight, if any. Rendered as
+                static output at the end of the snapshot because the reprint
+                replaces the pinned region that normally carries its blinking
+                frame. ``render_action_history`` skips PROCESSING rows, so this
+                is the only way an in-flight tool survives the rebuild.
         """
         with self._print_lock:
             # 1. Render previous turns (with per-turn response rendering)
@@ -798,6 +792,14 @@ class InlineStreamingContext:
                             self.display.console,
                             self.display.renderer.render_subagent_action(buffered, verbose=True),
                         )
+                    # The subagent's own in-flight tool lives in the pinned
+                    # rolling window (``_build_subagent_live_lines``), which the
+                    # frozen snapshot replaces — re-emit it as static output.
+                    group_processing = group.get("processing_action")
+                    if group_processing is not None:
+                        self.display.console.print(
+                            self.display.renderer.render_processing(group_processing, _PROCESSING_SYMBOL)
+                        )
                     # Show "in progress" indicator
                     dur_str = ""
                     if group["start_time"]:
@@ -806,6 +808,14 @@ class InlineStreamingContext:
                     self.display.console.print(
                         f"[dim]  \u23bf  \u23f3 in progress ({group['tool_count']} tool uses{dur_str})...[/dim]"
                     )
+            # 5. Re-emit the main-agent tool that is still running, so the
+            # snapshot ends where the user's attention was instead of dropping
+            # the call until it returns.
+            if running_action is not None:
+                self.display.renderer.print_renderables(
+                    self.display.console,
+                    self.display.renderer.render_running_tool(running_action, _PROCESSING_SYMBOL, verbose),
+                )
 
     # -- core processing (async mode) --------------------------------------
 

--- a/tests/unit_tests/cli/action_display/test_streaming.py
+++ b/tests/unit_tests/cli/action_display/test_streaming.py
@@ -753,6 +753,194 @@ class TestUnifiedReprint:
         assert "3 tool uses" in output
 
 
+# ── Ctrl+O toggle while a tool is still running ──────────────────
+
+
+def _pinned_text(live_state) -> str:
+    """Flatten the pinned region into plain text."""
+    return "\n".join("".join(seg for _style, seg in line.segments) for line in live_state.snapshot())
+
+
+@pytest.mark.ci
+class TestVerboseToggleKeepsRunningTool:
+    """A tool that is still executing must survive a Ctrl+O rebuild.
+
+    Its blinking frame lives in the pinned region, and the reprinted history
+    slice deliberately skips PROCESSING rows, so both directions of the toggle
+    need explicit handling — otherwise an in-flight call disappears from the
+    screen until it returns.
+    """
+
+    def _build_ctx(self):
+        """Context with one main-agent tool pinned as running (TUI path)."""
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+
+        running = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            action_type="list_tables",
+            messages="list_tables",
+            input_data={
+                "function_name": "list_tables",
+                "arguments": {"catalog": "main", "schema": "public"},
+            },
+            action_id="call-1",
+            start_time=datetime.now() - timedelta(seconds=3),
+        )
+        ctx = InlineStreamingContext([running], display, current_user_message="show the tables", live_state=live_state)
+        # Mirror the live path: _process_actions pins the frame and steps past
+        # the PROCESSING entry (its SUCCESS twin has not arrived yet).
+        ctx._process_actions()
+        # Screen clearing is the terminal's job; keep the buffer readable.
+        ctx.set_clear_screen_callback(lambda: None)
+        return ctx, buf, live_state, running
+
+    def test_running_tool_starts_pinned_not_in_scrollback(self):
+        """Baseline: the frame is Live-only, which is why the toggle can lose it."""
+        ctx, buf, live_state, running = self._build_ctx()
+
+        assert ctx._processing_action is running
+        assert ctx._processed_index == 1
+        assert "list_tables" not in buf.getvalue()
+        assert "list_tables" in _pinned_text(live_state)
+
+    def test_verbose_snapshot_renders_running_tool_with_args(self):
+        """Ctrl+O → verbose: the frozen snapshot keeps the running call."""
+        ctx, buf, _live_state, _running = self._build_ctx()
+
+        ctx._apply_verbose_toggle()
+
+        output = buf.getvalue()
+        assert ctx._verbose is True
+        assert "list_tables" in output
+        assert "running" in output
+        # Verbose expands every argument — that is what Ctrl+O is for.
+        assert "catalog: main" in output
+        assert "schema: public" in output
+
+    def test_compact_toggle_repins_running_tool(self):
+        """Ctrl+O → verbose → compact: the frame returns to the pinned region."""
+        ctx, _buf, live_state, running = self._build_ctx()
+
+        ctx._apply_verbose_toggle()
+        # The frozen snapshot owns the whole screen — nothing may stay pinned,
+        # but the frame's state has to survive so compact can restore it.
+        assert live_state.line_count() == 0
+        assert ctx._processing_action is running
+
+        ctx._apply_verbose_toggle()
+
+        assert ctx._verbose is False
+        assert ctx._processing_action is running
+        assert "list_tables" in _pinned_text(live_state)
+
+    def test_toggle_without_clear_callbacks_still_rebuilds(self):
+        """No host clear-screen hook: the toggle clears the console itself."""
+        ctx, buf, _live_state, _running = self._build_ctx()
+        ctx.set_clear_screen_callback(None)
+
+        ctx._apply_verbose_toggle()
+
+        assert ctx._verbose is True
+        assert "list_tables" in buf.getvalue()
+
+    def test_toggle_survives_failing_clear_callbacks(self):
+        """A raising clear hook must not take the rebuilt transcript with it.
+
+        A stale screen is recoverable; losing the reprinted history — including
+        the running tool — is not.
+        """
+        ctx, buf, _live_state, _running = self._build_ctx()
+
+        def _boom() -> None:
+            raise RuntimeError("terminal went away")
+
+        ctx.set_clear_screen_callback(_boom)
+        ctx.set_clear_header_callback(_boom)
+
+        ctx._apply_verbose_toggle()
+
+        assert ctx._verbose is True
+        assert "list_tables" in buf.getvalue()
+        assert "running" in buf.getvalue()
+
+    def test_restored_frame_is_released_when_the_tool_completes(self):
+        """The re-pinned frame is not sticky: its SUCCESS twin still clears it."""
+        ctx, buf, live_state, running = self._build_ctx()
+
+        ctx._apply_verbose_toggle()
+        ctx._apply_verbose_toggle()
+        buf.truncate(0)
+        buf.seek(0)
+
+        ctx.actions.append(
+            _make_action(
+                ActionRole.TOOL,
+                ActionStatus.SUCCESS,
+                action_type="list_tables",
+                messages="list_tables",
+                input_data=running.input,
+                output_data={"result": "orders, customers"},
+                action_id="complete_call-1",
+                start_time=running.start_time,
+                end_time=datetime.now(),
+            )
+        )
+        ctx._process_actions()
+
+        assert ctx._processing_action is None
+        assert live_state.line_count() == 0
+        # Completed exactly once in the scrollback — the restored frame must
+        # not have left a second copy behind.
+        assert buf.getvalue().count("list_tables") == 1
+
+    def test_verbose_snapshot_renders_subagent_running_tool(self):
+        """A subagent's own in-flight tool survives the freeze too."""
+        from datus.cli.tui.live_display_state import LiveDisplayState
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        live_state = LiveDisplayState()
+        display = ActionHistoryDisplay(console, live_state=live_state)
+
+        anchor = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=0,
+            action_id="grp-1",
+            action_type="task",
+            messages="task(gen_metrics)",
+            input_data={"type": "gen_metrics", "prompt": "compute base metrics"},
+        )
+        inner_running = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.PROCESSING,
+            depth=1,
+            action_type="profile_table",
+            messages="profile_table",
+            input_data={"function_name": "profile_table", "arguments": {"table": "orders"}},
+            parent_action_id="grp-1",
+        )
+        ctx = InlineStreamingContext(
+            [anchor, inner_running], display, current_user_message="build metrics", live_state=live_state
+        )
+        ctx._process_actions()
+        ctx.set_clear_screen_callback(lambda: None)
+        assert ctx._subagent_groups["grp-1"]["processing_action"] is inner_running
+
+        ctx._apply_verbose_toggle()
+
+        output = buf.getvalue()
+        assert "gen_metrics" in output
+        assert "profile_table" in output
+        assert "in progress" in output
+
+
 # ── INTERACTION handling in streaming ─────────────────────────────
 
 


### PR DESCRIPTION
## Why

Pressing Ctrl+O while a tool was still executing made that tool call disappear from the screen until it finished.

The running frame lives **only** in the pinned live region, and three things combined to drop it:

1. The toggle called `_stop_processing_live()`, which resets `_processing_action` to `None`.
2. `_reprint_history()` replays `actions[:_processed_index]`, and `render_action_history` deliberately skips PROCESSING `TOOL` rows (`display.py`).
3. The tool's PROCESSING entry had already been consumed by `_process_actions` (the index moved past it), while its paired SUCCESS entry had not arrived yet.

So the verbose snapshot had nothing to draw, and the way back to compact had no state left to re-pin. A subagent group's own in-flight tool (`group["processing_action"]`) had the same gap.

## Solution

- **Do not tear down the running state to blank the screen.** `_repaint_live()` already clears the pinned region whenever `_verbose_frozen` is set, so the toggle now flips that flag and repaints instead of calling `_stop_processing_live()`. The running-tool state survives the freeze, which means the compact side re-pins it with a single `_repaint_live()` — no explicit restore path, no extra field to keep in sync.
- **Render the in-flight tool into the frozen snapshot.** `_reprint_history()` takes a new `running_action` argument and emits it via a new `ActionRenderer.render_running_tool()` — the familiar `○ 🔧 tool(...) · running Ns` line, plus the full argument block in verbose (the output block is necessarily absent, the tool has not returned). The subagent snapshot likewise re-emits its group's `processing_action`.
- **Extracted `_apply_verbose_toggle()`** out of `_refresh_loop`, which also folds the two byte-identical clear-screen blocks into one `_clear_screen_for_toggle()` helper. This keeps the toggle directly testable instead of only reachable from the background daemon thread.

Tradeoff considered: an alternative was to stash the action in a dedicated `_frozen_processing_action` field and restore it on unfreeze. Leaning on the existing `_verbose_frozen` guard in `_repaint_live` was chosen instead — it removes state rather than adding it, and keeps a single source of truth for what the pinned region shows.

## Test Cases

`tests/unit_tests/cli/action_display/test_streaming.py` — new `TestVerboseToggleKeepsRunningTool` (7 cases, exercising the real TUI path with `LiveDisplayState`):

- baseline that the frame starts Live-only and is absent from the scrollback (this is *why* the toggle could lose it)
- verbose snapshot renders the running tool with its expanded arguments
- verbose → compact re-pins the frame, and the state survives the freeze
- the restored frame is not sticky — the SUCCESS twin still releases it, and the completed call lands in the scrollback exactly once
- a subagent's own in-flight tool survives the freeze
- the toggle still rebuilds when no host clear-screen hook is registered, and when those hooks raise

Each fix was mutation-checked: reverting any one of the three (snapshot render, frozen-state retention, subagent processing row) fails a distinct test.

No integration/nightly tests added — this is terminal-rendering behaviour with no external dependency, fully covered at the unit tier.

Verification: `ruff format`/`check` clean; `tests/unit_tests/cli/` 3846 passed; `ci/audit_tests.py` P0=0 P1=0; `ci/run-pr-tests.py` impacted unit tests exit 0 with diff coverage **97%** (the one uncovered line is the dispatch call inside the background refresh thread). The acceptance suite's failures on my machine are pre-existing environment issues (local `.datus/config.yml` points at a `tencent` datasource; test KB data not built) — confirmed identical before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Running tools now remain visible in the transcript while processing.
  * Verbose mode displays the tool’s arguments and current status.
  * Switching between verbose and compact views preserves in-progress tools and resumes pinned display correctly.
  * Screen refreshes now retain active tool activity, even when screen clearing is unavailable or encounters an error.
  * Completed tools continue to be displayed without duplicate output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
