### PR TITLE
[BugFix] Keep a transformer rewrite out of the conversation history

### DIFF
--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -88,18 +88,24 @@ def _restore_tool_call_args(tool_ctx: Any, args_str: str) -> None:
     next turn's messages replay. A rewrite left there shows the model a call
     it never made: it "corrects" itself back to its original query, which is
     rewritten again — a loop that re-wraps the previous rewrite each round.
+
+    ``tool_call`` is the one the SDK persists and replays, so it is restored
+    on its own: a context that refuses ``tool_arguments`` still gets it back.
     """
     if tool_ctx is None:
         return
     try:
         tool_ctx.tool_arguments = args_str
+    except Exception as e:  # noqa: BLE001 - a frozen or foreign context must not fail the call
+        logger.debug("Tool middleware: could not restore tool_arguments: %s", e)
+    try:
         tool_call = getattr(tool_ctx, "tool_call", None)
         if isinstance(tool_call, dict):
             tool_call["arguments"] = args_str
         elif tool_call is not None:
             tool_call.arguments = args_str
     except Exception as e:  # noqa: BLE001 - a frozen or foreign context must not fail the call
-        logger.debug("Tool middleware: could not restore the original arguments: %s", e)
+        logger.debug("Tool middleware: could not restore the tool call arguments: %s", e)
 
 
 def wrap_tool_with_transformers(

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -30,6 +30,8 @@ Transformer contract (duck-typed so plugin packages never import ``datus.*``):
 * ``context`` carries request-scoped data injected at wrap time (see
   :func:`apply_tool_transformers`): ``node_name``, ``principal``,
   ``project_root``.
+* A rewrite changes what executes, not what the conversation records: the
+  model's own arguments are restored onto the tool call afterwards.
 """
 
 from __future__ import annotations
@@ -76,6 +78,28 @@ def _denial_payload(tool_name: str, reason: str) -> dict:
         "error": f"Tool call '{tool_name}' was blocked by policy: {reason}",
         "result": None,
     }
+
+
+def _restore_tool_call_args(tool_ctx: Any, args_str: str) -> None:
+    """Put the model's own arguments back on the SDK tool call.
+
+    Tools canonicalise the arguments they received onto ``tool_ctx`` (see
+    ``write_back_tool_args``), and that is what session persistence and the
+    next turn's messages replay. A rewrite left there shows the model a call
+    it never made: it "corrects" itself back to its original query, which is
+    rewritten again — a loop that re-wraps the previous rewrite each round.
+    """
+    if tool_ctx is None:
+        return
+    try:
+        tool_ctx.tool_arguments = args_str
+        tool_call = getattr(tool_ctx, "tool_call", None)
+        if isinstance(tool_call, dict):
+            tool_call["arguments"] = args_str
+        elif tool_call is not None:
+            tool_call.arguments = args_str
+    except Exception as e:  # noqa: BLE001 - a frozen or foreign context must not fail the call
+        logger.debug("Tool middleware: could not restore the original arguments: %s", e)
 
 
 def wrap_tool_with_transformers(
@@ -141,7 +165,10 @@ def wrap_tool_with_transformers(
                 )
             args = result
 
-        return await original.on_invoke_tool(tool_ctx, json.dumps(args, ensure_ascii=False))
+        try:
+            return await original.on_invoke_tool(tool_ctx, json.dumps(args, ensure_ascii=False))
+        finally:
+            _restore_tool_call_args(tool_ctx, args_str)
 
     transforming_invoke._datus_tool_transformed = True  # type: ignore[attr-defined]
 

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -236,17 +236,23 @@ class TestWrapToolWithTransformers:
 
 
 def _add_scope(tool_name, args, context):
+    """Transformer standing in for a row-filter policy."""
     args["sql"] = args["sql"] + " WHERE tenant_id = 't1'"
     return args
 
 
 def _make_write_back_tool(record=None, raises=False, name="execute_sql"):
-    """A tool that canonicalises its arguments onto the context, as datus tools do."""
+    """A tool that canonicalises its arguments onto whatever the context accepts,
+    as datus tools do via ``write_back_tool_args``.
+    """
 
     async def invoke(tool_ctx, args_str):
         if record is not None:
             record.append(args_str)
-        tool_ctx.tool_arguments = args_str
+        try:
+            tool_ctx.tool_arguments = args_str
+        except AttributeError:
+            pass
         if isinstance(tool_ctx.tool_call, dict):
             tool_ctx.tool_call["arguments"] = args_str
         else:
@@ -265,6 +271,7 @@ def _make_write_back_tool(record=None, raises=False, name="execute_sql"):
 
 
 def _make_ctx(args_str, as_dict=False):
+    """A ToolContext stand-in carrying both writable argument slots."""
     tool_call = {"arguments": args_str} if as_dict else SimpleNamespace(arguments=args_str)
     return SimpleNamespace(tool_arguments=args_str, tool_call=tool_call)
 
@@ -351,6 +358,26 @@ class TestOriginalArgumentsSurviveRewrite:
 
         assert result["success"] == 1
         assert json.loads(record[0])["sql"].endswith("WHERE tenant_id = 't1'")
+
+    @pytest.mark.asyncio
+    async def test_read_only_tool_arguments_still_restores_the_tool_call(self):
+        """``tool_call`` is what the SDK replays, so it is restored on its own."""
+        sent = json.dumps({"sql": "SELECT * FROM orders"})
+
+        class _ReadOnlyArguments:
+            def __init__(self):
+                self.tool_call = SimpleNamespace(arguments=sent)
+
+            @property
+            def tool_arguments(self):
+                return sent
+
+        ctx = _ReadOnlyArguments()
+        wrapped = wrap_tool_with_transformers(_make_write_back_tool(), [_add_scope])
+
+        await wrapped.on_invoke_tool(ctx, sent)
+
+        assert ctx.tool_call.arguments == sent
 
     @pytest.mark.asyncio
     async def test_unsettable_context_does_not_fail_the_call(self):

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -235,6 +235,136 @@ class TestWrapToolWithTransformers:
         assert json.loads(record[0]) == {"sql": "SELECT '租户'"}
 
 
+def _add_scope(tool_name, args, context):
+    args["sql"] = args["sql"] + " WHERE tenant_id = 't1'"
+    return args
+
+
+def _make_write_back_tool(record=None, raises=False, name="execute_sql"):
+    """A tool that canonicalises its arguments onto the context, as datus tools do."""
+
+    async def invoke(tool_ctx, args_str):
+        if record is not None:
+            record.append(args_str)
+        tool_ctx.tool_arguments = args_str
+        if isinstance(tool_ctx.tool_call, dict):
+            tool_ctx.tool_call["arguments"] = args_str
+        else:
+            tool_ctx.tool_call.arguments = args_str
+        if raises:
+            raise RuntimeError("boom")
+        return {"success": 1, "result": None, "error": None}
+
+    return FunctionTool(
+        name=name,
+        description="test tool",
+        params_json_schema={"type": "object", "properties": {"sql": {"type": "string"}}},
+        on_invoke_tool=invoke,
+        strict_json_schema=False,
+    )
+
+
+def _make_ctx(args_str, as_dict=False):
+    tool_call = {"arguments": args_str} if as_dict else SimpleNamespace(arguments=args_str)
+    return SimpleNamespace(tool_arguments=args_str, tool_call=tool_call)
+
+
+class TestOriginalArgumentsSurviveRewrite:
+    """Datus tools write the arguments they received back onto the SDK tool call,
+    which is what the session persists and the next turn replays. A rewrite left
+    there shows the model a call it never made.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_call_keeps_what_the_model_sent(self):
+        sent = json.dumps({"sql": "SELECT * FROM orders"})
+        ctx = _make_ctx(sent)
+        record = []
+        wrapped = wrap_tool_with_transformers(_make_write_back_tool(record=record), [_add_scope])
+
+        await wrapped.on_invoke_tool(ctx, sent)
+
+        assert json.loads(record[0])["sql"] == "SELECT * FROM orders WHERE tenant_id = 't1'"
+        assert ctx.tool_arguments == sent
+        assert ctx.tool_call.arguments == sent
+
+    @pytest.mark.asyncio
+    async def test_injected_argument_is_kept_out_too(self):
+        """Metric policies add a ``where`` the model never wrote; same rule applies."""
+        sent = json.dumps({"metrics": ["revenue"]})
+        ctx = _make_ctx(sent)
+        record = []
+
+        def add_where(tool_name, args, context):
+            args["where"] = "orders.store_id IN ('S001')"
+            return args
+
+        wrapped = wrap_tool_with_transformers(_make_write_back_tool(record=record, name="query_metrics"), [add_where])
+
+        await wrapped.on_invoke_tool(ctx, sent)
+
+        assert json.loads(record[0])["where"] == "orders.store_id IN ('S001')"
+        assert "where" not in json.loads(ctx.tool_call.arguments)
+
+    @pytest.mark.asyncio
+    async def test_dict_shaped_tool_call_is_restored(self):
+        sent = json.dumps({"sql": "SELECT * FROM orders"})
+        ctx = _make_ctx(sent, as_dict=True)
+        wrapped = wrap_tool_with_transformers(_make_write_back_tool(), [_add_scope])
+
+        await wrapped.on_invoke_tool(ctx, sent)
+
+        assert ctx.tool_call["arguments"] == sent
+
+    @pytest.mark.asyncio
+    async def test_restored_even_when_the_tool_raises(self):
+        sent = json.dumps({"sql": "SELECT * FROM orders"})
+        ctx = _make_ctx(sent)
+        wrapped = wrap_tool_with_transformers(_make_write_back_tool(raises=True), [_add_scope])
+
+        with pytest.raises(RuntimeError):
+            await wrapped.on_invoke_tool(ctx, sent)
+
+        assert ctx.tool_call.arguments == sent
+
+    @pytest.mark.asyncio
+    async def test_denied_call_leaves_the_tool_call_untouched(self):
+        sent = json.dumps({"sql": "SELECT * FROM orders"})
+        ctx = _make_ctx(sent)
+
+        def deny(tool_name, args, context):
+            raise PermissionError("no principal")
+
+        wrapped = wrap_tool_with_transformers(_make_write_back_tool(), [deny])
+        result = await wrapped.on_invoke_tool(ctx, sent)
+
+        assert result["success"] == 0
+        assert ctx.tool_call.arguments == sent
+
+    @pytest.mark.asyncio
+    async def test_context_without_a_tool_call_is_tolerated(self):
+        sent = json.dumps({"sql": "SELECT * FROM orders"})
+        record = []
+        wrapped = wrap_tool_with_transformers(_make_tool(record=record), [_add_scope])
+
+        result = await wrapped.on_invoke_tool(None, sent)
+
+        assert result["success"] == 1
+        assert json.loads(record[0])["sql"].endswith("WHERE tenant_id = 't1'")
+
+    @pytest.mark.asyncio
+    async def test_unsettable_context_does_not_fail_the_call(self):
+        class _Frozen:
+            __slots__ = ()
+
+        record = []
+        wrapped = wrap_tool_with_transformers(_make_tool(record=record), [_add_scope])
+
+        result = await wrapped.on_invoke_tool(_Frozen(), json.dumps({"sql": "SELECT 1"}))
+
+        assert result["success"] == 1
+
+
 def _make_node(tools, registry_map=None, proxied=None):
     return SimpleNamespace(
         tools=tools,


### PR DESCRIPTION
## Problem

With a `row_filter` read policy configured, the model loops: it sends the same
query up to 9 times, each round narrating that it mistakenly added a market
filter and has to take it back out, and the executed SQL gains one nesting
layer per round.

## Root cause

Datus tools canonicalise the arguments they receive back onto the SDK tool call:

```
tool_middleware.py   original.on_invoke_tool(ctx, json.dumps(args))   # rewritten JSON
        ↓
func_tool/base.py    parse_tool_args(args_str) → canonical_json       # rewritten
func_tool/base.py    write_back_tool_args(tool_ctx, canonical_json)
func_tool/base.py        tool_call.arguments = canonical_json          # SDK raw_item
        ↓
the SDK persists that raw_item to the session and replays it as the next turn's messages
```

`write_back_tool_args` exists to repair a model's truncated/invalid JSON, and
assumes what it receives is what the model sent. Tool transformers broke that
assumption: the rewrite landed in the model's own `tool_calls[].arguments`.

The model then sees a query it never wrote, "corrects" itself back to its
original, gets rewritten again — and copies the rewritten form from history,
which the policy wraps once more.

Confirmed against a live run: langfuse gen#1 **output** carries the model's
original SQL, gen#2 **input** already carries the rewritten one, and the
session sqlite stores the rewritten form.

Both enforcement paths were affected — `db_tools.execute_sql`
(`database.py:964`) and `semantic_tools.query_metrics` / `attribution_analyze`
(`semantic_tools.py:802,804`) are built by the same `trans_to_function_tool`
factory. The metric path accumulates `where` predicates instead of nesting
subqueries.

## Fix

Restore the model's own arguments onto the tool call once the tool has run, so
a rewrite changes what executes and not what the conversation records.

The malformed-JSON path is untouched: those arguments never reach a
transformer, so the tool's canonicalisation still applies to them.

## Verification

End to end, same question and principal:

| | before | after |
|---|---|---|
| tool calls | 9 (loop) | **1** |
| SQL the model sees | rewritten, nested 2 deep | its own original |
| session storage | rewritten | **original** |
| result | 27 | **27** |

The policy still applies (380 rows total, 27 for the caller's market); the
model simply never sees the rewrite, so it has nothing to "correct".

- 7 new tests. Temporarily disabling the fix fails exactly 3 of them and leaves
  the other 30 passing.
- `tests/unit_tests/tools/`: 3687 passed, 0 errors.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original tool-call arguments after transformed tool execution.
  * Improved argument handling across successful, failed, denied, and read-only tool calls.
  * Added safeguards for missing or immutable execution contexts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->