### PR TITLE
[BugFix] Give the tool transformers and the native SQL policy one principal

### DIFF
--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -116,7 +116,6 @@ class DBFuncTool:
         default_database: Optional[str] = None,
         sub_agent_name: Optional[str] = None,
         scoped_tables: Optional[Iterable[str]] = None,
-        principal: Optional[Dict[str, Any]] = None,
         connector_cache_size: int = DEFAULT_CONNECTOR_CACHE_SIZE,
         read_only: bool = False,
     ):
@@ -133,8 +132,6 @@ class DBFuncTool:
                               configured for its datasource); defaults to the datasource config's ``database``.
             sub_agent_name: Optional sub-agent name for scoped context
             scoped_tables: Optional explicit table scope patterns
-            principal: Request-scoped SQL policy attributes. When omitted,
-                       falls back to ``agent_config.principal`` if present.
             connector_cache_size: Max connectors to cache (LRU eviction), default 8
             read_only: When True, ``execute_sql`` hard-rejects any non-read
                        statement (INSERT/UPDATE/DELETE/DDL/MERGE/...) at the tool
@@ -169,8 +166,6 @@ class DBFuncTool:
         model_name = agent_config.active_model().model if agent_config else "gpt-3.5-turbo"
         self.compressor = DataCompressor(model_name=model_name)
         self.agent_config = agent_config
-        principal_source = principal if principal is not None else getattr(agent_config, "principal", {})
-        self.principal: Dict[str, Any] = dict(principal_source) if isinstance(principal_source, dict) else {}
         self.sub_agent_name = sub_agent_name
         self.read_only = read_only
         if agent_config and metadata_fts_enabled(agent_config):
@@ -197,6 +192,18 @@ class DBFuncTool:
         except Exception:
             self._table_semantic_profiles = None
             self.has_table_semantic_profiles = False
+
+    @property
+    def principal(self) -> Dict[str, Any]:
+        """Request-scoped SQL policy attributes, read from the config on access.
+
+        The API assigns this onto a per-request clone of the config. Resolving it
+        per access rather than caching it at construction keeps this tool and the
+        plugin tool-transformers on one value: they enforce the same policies and
+        must not disagree about who is asking.
+        """
+        principal = getattr(self.agent_config, "principal", None)
+        return dict(principal) if isinstance(principal, dict) else {}
 
     def _has_schema_storage(self) -> bool:
         if not self.schema_rag:

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -195,18 +195,58 @@ def wrap_tool_with_transformers(
     return FunctionTool(**carried)
 
 
+def _metric_catalog_providers(node: Any) -> List[Any]:
+    """Semantic tool groups on ``node`` that can report a metric-to-datasets map.
+
+    Found by what the object declares, not by the attribute holding it — the
+    same rule ``_iter_tool_groups`` uses to classify tools, and the reason a
+    node may hold its semantic tools under any name (``gen_semantic_model``
+    uses ``semantic_func_tool``). Aliases of one instance collapse to one
+    provider.
+    """
+    iter_groups = getattr(node, "_iter_tool_groups", None)
+    if callable(iter_groups):
+        try:
+            candidates = list(iter_groups())
+        except Exception as e:  # noqa: BLE001 - tool discovery must not break tool calls
+            logger.warning("Could not enumerate tool groups for transformer context: %s", e)
+            return []
+    else:
+        candidates = [getattr(node, name, None) for name in sorted(vars(node))]
+
+    providers: List[Any] = []
+    seen: set = set()
+    for candidate in candidates:
+        if candidate is None or id(candidate) in seen:
+            continue
+        if getattr(candidate, "permission_category", None) != "semantic_tools":
+            continue
+        if not callable(getattr(candidate, "metric_datasets", None)):
+            continue
+        seen.add(id(candidate))
+        providers.append(candidate)
+    return providers
+
+
 def _metric_datasets(node: Any) -> Optional[Dict[str, List[str]]]:
     """Metric-to-datasets map from the node's semantic tools.
 
-    ``None`` when the node has no semantic tools or the catalog cannot be read;
-    ``{}`` when the adapter reports no metrics.
+    ``None`` when no single provider can be identified or the catalog cannot be
+    read; ``{}`` when the adapter reports no metrics. Several providers means
+    several catalogs, and picking one would scope a policy against the wrong
+    metrics — the transformers reading this deny on ``None``.
     """
-    semantic_tools = getattr(node, "semantic_tools", None)
-    getter = getattr(semantic_tools, "metric_datasets", None)
-    if not callable(getter):
+    providers = _metric_catalog_providers(node)
+    if not providers:
+        return None
+    if len(providers) > 1:
+        logger.warning(
+            "Node exposes %d semantic tool groups; cannot pick one metric catalog for transformer context",
+            len(providers),
+        )
         return None
     try:
-        mapping = getter()
+        mapping = providers[0].metric_datasets()
     except Exception as e:  # noqa: BLE001 - an unreadable catalog must not break tool calls
         logger.warning("Could not read metric datasets for transformer context: %s", e)
         return None

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -245,9 +245,12 @@ def apply_tool_transformers(node: Any, transformers_by_pattern: Dict[str, List[T
 
     def context_provider() -> Dict[str, Any]:
         # Read request-scoped values fresh on every tool call: the API layer
-        # sets ``db_func_tool.principal`` per request, after tools are wrapped.
-        principal = getattr(getattr(node, "db_func_tool", None), "principal", None)
+        # assigns ``principal`` onto a per-request clone of the config, which
+        # is also where ``DBFuncTool`` reads its own copy from. Reading the
+        # config directly covers nodes whose tool set excludes ``db_tools`` and
+        # therefore never build a DBFuncTool at all (``ask_metrics`` is one).
         agent_config = getattr(node, "agent_config", None)
+        principal = getattr(agent_config, "principal", None)
         return {
             "node_name": node_name,
             "principal": dict(principal) if isinstance(principal, dict) else {},

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -212,7 +212,13 @@ def _metric_catalog_providers(node: Any) -> List[Any]:
             logger.warning("Could not enumerate tool groups for transformer context: %s", e)
             return []
     else:
-        candidates = [getattr(node, name, None) for name in sorted(vars(node))]
+        # Same shape test ``_iter_tool_groups`` applies, for objects that do not
+        # implement it (a type is a class, not a mounted group).
+        candidates = [
+            value
+            for value in (getattr(node, name, None) for name in sorted(vars(node)))
+            if not isinstance(value, type) and callable(getattr(value, "available_tools", None))
+        ]
 
     providers: List[Any] = []
     seen: set = set()

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -398,8 +398,8 @@ def _make_node(tools, registry_map=None, proxied=None):
         tool_registry=ToolRegistry(registry_map or {}),
         proxied_tool_names=proxied or set(),
         get_node_name=lambda: "chat",
-        db_func_tool=SimpleNamespace(principal={"tenant": {"id": "t1"}}),
-        agent_config=SimpleNamespace(project_root="/proj"),
+        db_func_tool=SimpleNamespace(),
+        agent_config=SimpleNamespace(project_root="/proj", principal={"tenant": {"id": "t1"}}),
     )
 
 
@@ -489,6 +489,41 @@ class TestApplyToolTransformers:
         assert seen["metric_datasets"] is None
 
     @pytest.mark.asyncio
+    async def test_principal_reaches_a_node_without_db_tools(self):
+        """``ask_metrics`` builds no DBFuncTool, and a metric policy still needs
+        the principal.
+        """
+        seen = []
+
+        def transformer(tool_name, args, context):
+            seen.append(context["principal"])
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.db_func_tool = None
+        node.agent_config.principal = {"store_ids": ["S001"]}
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen == [{"store_ids": ["S001"]}]
+
+    @pytest.mark.asyncio
+    async def test_principal_absent_from_the_config_stays_empty(self):
+        seen = []
+
+        def transformer(tool_name, args, context):
+            seen.append(context["principal"])
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.db_func_tool = None
+        node.agent_config = SimpleNamespace(project_root="/proj")
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen == [{}]
+
+    @pytest.mark.asyncio
     async def test_context_carries_metric_datasets_from_semantic_tools(self):
         seen = {}
 
@@ -565,7 +600,7 @@ class TestApplyToolTransformers:
         node = _make_node([_make_tool("execute_sql")])
         apply_tool_transformers(node, {"execute_sql": [transformer]})
         await node.tools[0].on_invoke_tool(None, "{}")
-        node.db_func_tool.principal = {"tenant": {"id": "t2"}}
+        node.agent_config.principal = {"tenant": {"id": "t2"}}
         await node.tools[0].on_invoke_tool(None, "{}")
 
         assert seen == [{"tenant": {"id": "t1"}}, {"tenant": {"id": "t2"}}]

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -405,7 +405,11 @@ def _make_node(tools, registry_map=None, proxied=None):
 
 def _semantic_group(metric_datasets):
     """A tool group shaped the way provider discovery looks for one."""
-    return SimpleNamespace(permission_category="semantic_tools", metric_datasets=metric_datasets)
+    return SimpleNamespace(
+        permission_category="semantic_tools",
+        metric_datasets=metric_datasets,
+        available_tools=lambda: [],
+    )
 
 
 class TestApplyToolTransformers:
@@ -683,13 +687,24 @@ class TestApplyToolTransformers:
             seen.update(context)
             return args
 
+        calls = []
         group = _semantic_group(lambda: {"revenue": ["orders"]})
         node = _make_node([_make_tool("query_metrics")])
         node._hidden = group
-        node._iter_tool_groups = lambda: [group]
+        # Visible to a ``vars(node)`` scan but not mounted; the fallback would
+        # see two providers here and give up, so a passing assertion below can
+        # only come from the iterator.
+        node._excluded = _semantic_group(lambda: {"signups": ["users"]})
+
+        def iter_tool_groups():
+            calls.append(True)
+            return [group]
+
+        node._iter_tool_groups = iter_tool_groups
         apply_tool_transformers(node, {"query_metrics": [transformer]})
         await node.tools[0].on_invoke_tool(None, "{}")
 
+        assert calls == [True]
         assert seen["metric_datasets"] == {"revenue": ["orders"]}
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -403,6 +403,11 @@ def _make_node(tools, registry_map=None, proxied=None):
     )
 
 
+def _semantic_group(metric_datasets):
+    """A tool group shaped the way provider discovery looks for one."""
+    return SimpleNamespace(permission_category="semantic_tools", metric_datasets=metric_datasets)
+
+
 class TestApplyToolTransformers:
     @pytest.mark.asyncio
     async def test_wraps_matching_tool_by_name(self):
@@ -532,7 +537,7 @@ class TestApplyToolTransformers:
             return args
 
         node = _make_node([_make_tool("query_metrics")])
-        node.semantic_tools = SimpleNamespace(metric_datasets=lambda: {"revenue": ["orders"]})
+        node.semantic_tools = _semantic_group(lambda: {"revenue": ["orders"]})
         apply_tool_transformers(node, {"query_metrics": [transformer]})
         await node.tools[0].on_invoke_tool(None, "{}")
 
@@ -548,7 +553,7 @@ class TestApplyToolTransformers:
             return args
 
         node = _make_node([_make_tool("query_metrics")])
-        node.semantic_tools = SimpleNamespace(metric_datasets=lambda: dict(catalog))
+        node.semantic_tools = _semantic_group(lambda: dict(catalog))
         apply_tool_transformers(node, {"query_metrics": [transformer]})
         await node.tools[0].on_invoke_tool(None, "{}")
         catalog["signups"] = ["users"]
@@ -565,7 +570,7 @@ class TestApplyToolTransformers:
             return args
 
         node = _make_node([_make_tool("query_metrics")])
-        node.semantic_tools = SimpleNamespace(metric_datasets=lambda: "not a mapping")
+        node.semantic_tools = _semantic_group(lambda: "not a mapping")
         apply_tool_transformers(node, {"query_metrics": [transformer]})
         await node.tools[0].on_invoke_tool(None, "{}")
 
@@ -583,11 +588,109 @@ class TestApplyToolTransformers:
             raise RuntimeError("catalog unavailable")
 
         node = _make_node([_make_tool("query_metrics")])
-        node.semantic_tools = SimpleNamespace(metric_datasets=boom)
+        node.semantic_tools = _semantic_group(boom)
         apply_tool_transformers(node, {"query_metrics": [transformer]})
         await node.tools[0].on_invoke_tool(None, "{}")
 
         assert seen["metric_datasets"] is None
+
+    @pytest.mark.asyncio
+    async def test_catalog_found_under_an_aliased_attribute(self):
+        """``gen_semantic_model`` holds its semantic tools as ``semantic_func_tool``."""
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.semantic_func_tool = _semantic_group(lambda: {"revenue": ["orders"]})
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] == {"revenue": ["orders"]}
+
+    @pytest.mark.asyncio
+    async def test_catalog_found_under_any_attribute_name(self):
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.whatever_we_call_it = _semantic_group(lambda: {"revenue": ["orders"]})
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] == {"revenue": ["orders"]}
+
+    @pytest.mark.asyncio
+    async def test_one_instance_under_two_names_is_one_provider(self):
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        group = _semantic_group(lambda: {"revenue": ["orders"]})
+        node.semantic_tools = group
+        node.semantic_func_tool = group
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] == {"revenue": ["orders"]}
+
+    @pytest.mark.asyncio
+    async def test_two_distinct_providers_yield_none(self):
+        """Two catalogs, no way to tell which one scopes the query — deny."""
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.semantic_tools = _semantic_group(lambda: {"revenue": ["orders"]})
+        node.other_semantic_tools = _semantic_group(lambda: {"signups": ["users"]})
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_group_from_another_category_is_not_a_provider(self):
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        node = _make_node([_make_tool("query_metrics")])
+        node.db_tools = SimpleNamespace(permission_category="db_tools", metric_datasets=lambda: {"x": ["y"]})
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] is None
+
+    @pytest.mark.asyncio
+    async def test_iter_tool_groups_is_used_when_the_node_provides_it(self):
+        """Real nodes classify their own groups; discovery defers to that."""
+        seen = {}
+
+        def transformer(tool_name, args, context):
+            seen.update(context)
+            return args
+
+        group = _semantic_group(lambda: {"revenue": ["orders"]})
+        node = _make_node([_make_tool("query_metrics")])
+        node._hidden = group
+        node._iter_tool_groups = lambda: [group]
+        apply_tool_transformers(node, {"query_metrics": [transformer]})
+        await node.tools[0].on_invoke_tool(None, "{}")
+
+        assert seen["metric_datasets"] == {"revenue": ["orders"]}
 
     @pytest.mark.asyncio
     async def test_principal_read_fresh_per_call(self):

--- a/tests/unit_tests/tools/test_sql_policy.py
+++ b/tests/unit_tests/tools/test_sql_policy.py
@@ -65,6 +65,24 @@ class DatasourceCaptureEnforcer:
         return EnforcementResult(allowed=True, sql=sql)
 
 
+class PrincipalCaptureEnforcer:
+    last_principal: dict[str, Any] | None = None
+
+    def __init__(self, config: SqlPolicyConfig) -> None:
+        self.config = config
+
+    def enforce_read(
+        self,
+        sql: str,
+        *,
+        datasource: str,
+        dialect: str,
+        principal: dict[str, Any] | None,
+    ) -> EnforcementResult:
+        PrincipalCaptureEnforcer.last_principal = principal
+        return EnforcementResult(allowed=True, sql=sql)
+
+
 class DenySqlPolicyEnforcer:
     def __init__(self, config: SqlPolicyConfig) -> None:
         self.config = config
@@ -235,6 +253,65 @@ def test_db_func_tool_applies_sql_policy_provider_before_query_execution():
     assert result.success == 1
     executed_sql = connector.execute_query.call_args.args[0]
     assert executed_sql == "SELECT * FROM orders WHERE store_id = 'S001'"
+
+
+def test_db_func_tool_principal_follows_the_config_after_construction():
+    """This tool and the plugin tool-transformers enforce the same policies, so
+    both resolve the principal from the config instead of caching a copy.
+    """
+    connector = Mock()
+    connector.dialect = "sqlite"
+    connector.get_databases.return_value = []
+    query_result = Mock()
+    query_result.success = True
+    query_result.sql_return = [{"order_id": 1}]
+    connector.execute_query.return_value = query_result
+
+    config = _provider_config().model_copy(
+        update={"provider": "tests.unit_tests.tools.test_sql_policy:PrincipalCaptureEnforcer"}
+    )
+    agent_config = SimpleNamespace(
+        active_model=lambda: SimpleNamespace(model="test-model"),
+        sql_policy_config=config,
+        principal={"store_ids": ["S001"]},
+    )
+
+    with (
+        patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+        patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+    ):
+        mock_rag.return_value.schema_store.table_size.return_value = 0
+        mock_sem.return_value.get_size.return_value = 0
+        tool = DBFuncTool(connector, agent_config=agent_config)
+
+    assert tool.principal == {"store_ids": ["S001"]}
+
+    agent_config.principal = {"store_ids": ["S002"]}
+    tool.read_query("SELECT * FROM orders", datasource="default")
+
+    assert tool.principal == {"store_ids": ["S002"]}
+    assert PrincipalCaptureEnforcer.last_principal == {"store_ids": ["S002"]}
+
+
+def test_db_func_tool_principal_is_empty_without_one_on_the_config():
+    connector = Mock()
+    connector.dialect = "sqlite"
+    connector.get_databases.return_value = []
+
+    agent_config = SimpleNamespace(
+        active_model=lambda: SimpleNamespace(model="test-model"),
+        sql_policy_config=_provider_config(),
+    )
+
+    with (
+        patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+        patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+    ):
+        mock_rag.return_value.schema_store.table_size.return_value = 0
+        mock_sem.return_value.get_size.return_value = 0
+        tool = DBFuncTool(connector, agent_config=agent_config)
+
+    assert tool.principal == {}
 
 
 def test_db_func_tool_ignores_mock_sql_policy_config():


### PR DESCRIPTION
Three defects that keep a `metric_row_filter` policy from working, all in how
the transformer context is assembled and where the principal lives. The first
was hit in a live run; the others are one rename or one caller away from the
same symptom.

## 1. The principal came from `db_func_tool`

A metric query carrying a valid `X-Datus-Principal` header was denied
fail-closed, reporting the principal field as missing. The SQL path worked, so
the header itself was fine.

`context_provider` read the principal from `node.db_func_tool.principal`.
`AskMetricsAgenticNode.setup_tools()` sets `self.db_func_tool = None` and only
builds one when the configured tool set includes `db_tools` — which
`ask_metrics` does not. `getattr` fell through to `{}`, and every metric policy
denied.

Not specific to `ask_metrics`: any subagent with semantic tools but no
`db_tools` hits it, including a `gen_report` subagent whose `tools:` lists only
`semantic_tools` and `context_search_tools`. That is exactly the population a
metric policy is meant to cover.

**Fix:** read `agent_config.principal`, which the API assigns onto a
per-request `deepcopy` of the config.

## 2. The two enforcement paths could see different principals

`DBFuncTool` snapshotted the principal at construction and accepted an explicit
`principal=` override; the transformers now read the config. Both enforce the
same read policies, so a caller passing the override — or an entry point
assigning the principal after the tool is built — could make the native SQL
policy and a plugin policy disagree about who is asking.

**Fix:** drop the constructor argument (no caller passed it, 0 of 128 sites) and
resolve `DBFuncTool.principal` from the config on access. One source, one value,
for both paths. The old snapshot held the right value only because nodes happen
to be built after the assignment.

The comment claiming the API sets `db_func_tool.principal` per request after
wrapping described behaviour that does not exist; it is removed.

## 3. The metric catalog was found by attribute name

`_metric_datasets` read `node.semantic_tools`. Nodes may hold their semantic
tools under any name — `gen_semantic_model` uses `semantic_func_tool`, and
`test_same_group_referenced_twice_registered_once` documents aliasing as
supported. The tool registry already classifies groups by what they *declare*,
so such a node has its tools matched by a transformer pattern and is then denied
for a catalog the middleware could not find.

**Fix:** discover providers by declaration — `permission_category ==
"semantic_tools"` plus a callable `metric_datasets` — deferring to
`_iter_tool_groups` when the node exposes it, deduplicated by identity so
aliases of one instance count once. Two distinct providers means two catalogs
with no way to tell which scopes the query, so that yields `None` and the
transformers deny fail-closed. The fallback scan applies the same shape test
`_iter_tool_groups` does.

No node currently exposes `query_metrics` under an aliased attribute, so this
part is preventive.

## Verification

On a real `AskMetricsAgenticNode` (not a stub), with a policy configured:

| | before | after |
|---|---|---|
| `db_func_tool` | `None` | `None` (unchanged) |
| principal reaching the transformer | `{}` → denied | `{'market_codes': [...]}` |
| metric catalog providers found | — | 1 |
| `metric_datasets` | resolved | resolved |

End to end through the API the denial is gone and the policy predicate is
injected into the metric query.

Each change has tests that fail when it is reverted — 3, 2 and 4 respectively,
with the rest passing. `tests/unit_tests/tools/`: 3699 passed. The full
`tests/unit_tests/` run is clean apart from
`TestExplorerServiceMetricFlowAuthoring`, which fails identically on unmodified
`main` for a missing optional `datus_semantic_metricflow` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool discovery supports semantic groups, aliases, and arbitrary node attributes.
  * Duplicate tool references are automatically removed.
  * Metric datasets are retrieved from the uniquely valid provider with capability-based filtering.

* **Bug Fixes**
  * Discovery failures are handled gracefully.
  * Ambiguous provider configurations are rejected.
  * Principal context works without database tools and defaults safely when unavailable.
  * Principal values refresh correctly across repeated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->