### PR TITLE
[Feature] add submit_task_result for orchestrator-driven runs

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2517,6 +2517,29 @@ class AgenticNode(Node):
             logger.error(f"Failed to setup ask_user tool: {e}")
             self.ask_user_tool = None
 
+    def _setup_task_result_tool(self):
+        """Setup the structured task-outcome tool, for orchestrator-driven runs.
+
+        Only wired up when the request declared an orchestrator origin: an
+        ordinary IDE chat has a human reading the answer and no need to declare
+        an outcome. The caller reads the resulting tool call off the stream and
+        stops the run, so this is effectively how such a run ends.
+        """
+        if getattr(self.agent_config, "_request_origin", None) != "orchestrator":
+            self.task_result_tool = None
+            return
+
+        try:
+            from datus.tools.func_tool.task_result_tools import TaskResultTool
+
+            self.task_result_tool = TaskResultTool()
+            if self.tools is not None:
+                self.tools.extend(self.task_result_tool.available_tools())
+            logger.debug("Setup submit_task_result tool")
+        except Exception as e:
+            logger.error(f"Failed to setup task result tool: {e}")
+            self.task_result_tool = None
+
     def _setup_sub_agent_task_tool(self):
         """Setup SubAgentTaskTool based on subagents config or node default.
 

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -274,6 +274,12 @@ class ChatAgenticNode(AgenticNode):
             self.tools.extend(self.sub_agent_task_tool.available_tools())
         if self.ask_user_tool:
             self.tools.extend(self.ask_user_tool.available_tools())
+        # None unless the request declared an orchestrator origin. Must be re-added
+        # here and not only in setup_tools: every rebuild (task-database switch,
+        # skill reload) clears the list, and dropping this one silently strips the
+        # dispatcher's only structured way to learn how the run ended.
+        if getattr(self, "task_result_tool", None):
+            self.tools.extend(self.task_result_tool.available_tools())
         # Plan-mode tools (confirm_plan + todo_*) for main agents; no-op for sub-agents.
         self._register_plan_mode_tools()
         # The rebuilt list holds fresh, unwrapped FunctionTool instances —

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -150,6 +150,8 @@ class ChatAgenticNode(AgenticNode):
         # Setup ask_user tool for clarification questions (interactive mode only)
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
+        # No-op unless the request declared an orchestrator origin.
+        self._setup_task_result_tool()
         self._rebuild_tools()
         self._setup_platform_doc_tools()
 

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -135,6 +135,15 @@ class ChatInput(BaseModel):
     # Core message fields
     message: str = Field(..., description="Chat message")
     session_id: Optional[str] = Field(None, description="Session ID")
+    origin: Optional[str] = Field(
+        default=None,
+        description=(
+            "Who started this run. 'orchestrator' means an external orchestrator "
+            "dispatched it rather than a person typing, and the agent is given the "
+            "submit_task_result tool so it can declare a structured outcome the "
+            "caller can act on. Leave unset for ordinary chat."
+        ),
+    )
     model: Optional[str] = Field(
         default=None,
         description=(

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -368,6 +368,11 @@ class ChatTaskManager:
         # the literal "." for the SQL files root because the IDE owns its own
         # workspace path).
         agent_config._client_source = effective_source
+        # Who dispatched this run. Read by ``_setup_task_result_tool`` to decide
+        # whether the agent gets a way to declare a structured outcome. Stashed
+        # on the cloned config, like _client_source, so concurrent requests on
+        # the same project do not see each other's origin.
+        agent_config._request_origin = getattr(request, "origin", None)
         # Per-request response language override. Empty / None keeps the
         # yaml-level ``agent.language`` default intact.
         if request.language:

--- a/datus/tools/func_tool/__init__.py
+++ b/datus/tools/func_tool/__init__.py
@@ -20,6 +20,7 @@ from datus.tools.func_tool.report_artifact_tools import ReportArtifactTools, Rep
 from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
 from datus.tools.func_tool.semantic_tools import SemanticTools
 from datus.tools.func_tool.sub_agent_task_tool import SubAgentTaskTool
+from datus.tools.func_tool.task_result_tools import PlanItem, TaskArtifact, TaskResultTool
 from datus.tools.func_tool.web_tool import WebTool
 
 __all__ = [
@@ -46,6 +47,9 @@ __all__ = [
     "SemanticDiscoveryTools",
     "PlatformDocSearchTool",
     "SubAgentTaskTool",
+    "TaskResultTool",
+    "PlanItem",
+    "TaskArtifact",
     "OrchestratorIssueTools",
     "OsiSemanticModelTargetState",
     "OsiSemanticModelTargetTools",

--- a/datus/tools/func_tool/task_result_tools.py
+++ b/datus/tools/func_tool/task_result_tools.py
@@ -18,10 +18,11 @@ ordinary IDE chat never sees it.
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+import json
+from typing import Any, List, Literal, Optional, Type, Union
 
 from agents import FunctionTool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.utils.loggings import get_logger
@@ -50,6 +51,55 @@ class TaskArtifact(BaseModel):
     kind: str = Field(description="csv | report | dashboard | metric | table | file")
     ref: str = Field(description="Identifier or path the caller can resolve.")
     title: Optional[str] = Field(default=None, description="Human-readable label.")
+
+
+def _as_dicts(value: Any, model: Type[BaseModel], field: str) -> Union[List[dict], str]:
+    """Normalise a list-of-objects argument to plain dicts, or return an error string.
+
+    The invoker calls tool methods with the raw parsed JSON, so annotating a
+    parameter ``List[TaskArtifact]`` buys nothing at runtime — what arrives is a
+    list of dicts (and sometimes a JSON string, which some models emit for nested
+    arrays). Validating through the model here is what actually enforces the
+    schema, and keeps ``.model_dump()`` from blowing up on a dict.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return f"{field} must be a list (got unparseable string)"
+    if not isinstance(value, list):
+        return f"{field} must be a list"
+
+    out: List[dict] = []
+    for i, item in enumerate(value):
+        if isinstance(item, model):
+            out.append(item.model_dump())
+        elif isinstance(item, dict):
+            try:
+                out.append(model(**item).model_dump())
+            except ValidationError as exc:
+                return f"{field}[{i}] is invalid: {exc.errors()[0].get('msg', 'bad value')}"
+        else:
+            return f"{field}[{i}] must be an object"
+    return out
+
+
+def _as_strings(value: Any, field: str) -> Union[List[str], str]:
+    """Same normalisation for a list-of-strings argument."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            # A bare sentence is a reasonable thing for a model to send here.
+            return [value] if value.strip() else []
+        value = parsed
+    if not isinstance(value, list):
+        return f"{field} must be a list of strings"
+    return [str(v) for v in value if str(v).strip()]
 
 
 class TaskResultTool:
@@ -97,13 +147,31 @@ class TaskResultTool:
         if not summary or not summary.strip():
             return FuncToolResult(success=0, error="summary must not be empty")
 
-        if outcome in ("needs_development", "blocked") and not gap_reasons:
+        if outcome not in ("answered", "needs_development", "blocked"):
+            return FuncToolResult(
+                success=0,
+                error=f"outcome must be one of answered | needs_development | blocked (got '{outcome}')",
+            )
+
+        artifact_dicts = _as_dicts(artifacts, TaskArtifact, "artifacts")
+        if isinstance(artifact_dicts, str):
+            return FuncToolResult(success=0, error=artifact_dicts)
+
+        plan_dicts = _as_dicts(plan_items, PlanItem, "plan_items")
+        if isinstance(plan_dicts, str):
+            return FuncToolResult(success=0, error=plan_dicts)
+
+        reasons = _as_strings(gap_reasons, "gap_reasons")
+        if isinstance(reasons, str):
+            return FuncToolResult(success=0, error=reasons)
+
+        if outcome in ("needs_development", "blocked") and not reasons:
             return FuncToolResult(
                 success=0,
                 error=f"outcome '{outcome}' requires gap_reasons explaining what is missing",
             )
 
-        if outcome == "needs_development" and not plan_items:
+        if outcome == "needs_development" and not plan_dicts:
             return FuncToolResult(
                 success=0,
                 error="outcome 'needs_development' requires plan_items describing what to build",
@@ -112,9 +180,9 @@ class TaskResultTool:
         self.submitted = {
             "outcome": outcome,
             "summary": summary.strip(),
-            "artifacts": [a.model_dump() for a in artifacts or []],
-            "gap_reasons": list(gap_reasons or []),
-            "plan_items": [p.model_dump() for p in plan_items or []],
+            "artifacts": artifact_dicts,
+            "gap_reasons": reasons,
+            "plan_items": plan_dicts,
             "estimate": estimate,
         }
         logger.info(f"task result submitted: outcome={outcome} artifacts={len(self.submitted['artifacts'])}")

--- a/datus/tools/func_tool/task_result_tools.py
+++ b/datus/tools/func_tool/task_result_tools.py
@@ -99,7 +99,17 @@ def _as_strings(value: Any, field: str) -> Union[List[str], str]:
         value = parsed
     if not isinstance(value, list):
         return f"{field} must be a list of strings"
-    return [str(v) for v in value if str(v).strip()]
+
+    out: List[str] = []
+    for i, item in enumerate(value):
+        # Not str(): a dict here would become "{'reason': ...}" and be rendered
+        # to the requester verbatim as a gap reason. Rejecting by index tells
+        # the model which entry to fix, the same way _as_dicts does.
+        if not isinstance(item, str):
+            return f"{field}[{i}] must be a string"
+        if item.strip():
+            out.append(item)
+    return out
 
 
 class TaskResultTool:

--- a/datus/tools/func_tool/task_result_tools.py
+++ b/datus/tools/func_tool/task_result_tools.py
@@ -1,0 +1,131 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Structured task outcome, for runs started by an external orchestrator.
+
+An orchestrator that dispatches work here has to know how the run ended before
+it can decide what happens next — was the question answered, does something need
+building first, or is the project simply unable to help? Parsing that back out
+of prose is unreliable in three separate ways: the model may not say it, the
+wording drifts, and a JSON block gets wrapped in fences. A tool call is
+schema-validated, arrives as its own frame in the stream, and the schema itself
+is far better at steering the model than an instruction to "end with JSON".
+
+The tool is only injected when the request declares an orchestrator origin, so
+ordinary IDE chat never sees it.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from agents import FunctionTool
+from pydantic import BaseModel, Field
+
+from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Same closed set the caller's deliverables use. Deliberately not a private
+# vocabulary: a second enum plus a mapping is one more thing to forget to update
+# when a kind is added, and the failure would be silent.
+PlanItemKind = Literal["dimension", "table", "metric", "report", "dashboard", "dag"]
+
+TaskOutcome = Literal["answered", "needs_development", "blocked"]
+
+
+class PlanItem(BaseModel):
+    """One thing that has to be built before the request can be answered."""
+
+    kind: PlanItemKind = Field(description="What sort of object this is.")
+    name: str = Field(description="Proposed object name, e.g. 'dim_market_maker'.")
+    description: str = Field(default="", description="One line on what it is and where it comes from.")
+
+
+class TaskArtifact(BaseModel):
+    """Something produced during the run that the caller can link to."""
+
+    kind: str = Field(description="csv | report | dashboard | metric | table | file")
+    ref: str = Field(description="Identifier or path the caller can resolve.")
+    title: Optional[str] = Field(default=None, description="Human-readable label.")
+
+
+class TaskResultTool:
+    """Lets a dispatched run declare how it ended."""
+
+    permission_category: str = "tools"
+
+    def __init__(self) -> None:
+        self.submitted: Optional[dict] = None
+
+    def available_tools(self) -> List[FunctionTool]:
+        return [trans_to_function_tool(self.submit_task_result, strict_mode=False)]
+
+    def submit_task_result(
+        self,
+        outcome: TaskOutcome,
+        summary: str,
+        artifacts: Optional[List[TaskArtifact]] = None,
+        gap_reasons: Optional[List[str]] = None,
+        plan_items: Optional[List[PlanItem]] = None,
+        estimate: Optional[str] = None,
+    ) -> FuncToolResult:
+        """Report how this task ended. Call this exactly once, as your final action.
+
+        Args:
+            outcome: One of —
+                ``answered``: you produced the answer or the artifact that was asked for.
+                ``needs_development``: you cannot answer yet because something has to be
+                    built first. Give BOTH ``gap_reasons`` and ``plan_items`` in the same
+                    call — they are two halves of one judgement ("because A and B are
+                    missing, build X and Y"), and the caller renders them together.
+                ``blocked``: you cannot answer and cannot propose a build either — no
+                    data source, no permission, out of scope. Give ``gap_reasons``.
+                    Do not invent a plan to avoid this outcome; a human is handed the
+                    request when you use it, which is the correct result.
+            summary: A few sentences the caller reads instead of your full transcript.
+                Include the grain and definitions you settled on — you are the only one
+                who knows what you had to decide along the way.
+            artifacts: Anything produced that the caller can link to.
+            gap_reasons: Concretely what is missing. Required for ``needs_development``
+                and ``blocked``.
+            plan_items: What to build, for ``needs_development``.
+            estimate: Rough effort for the plan, e.g. "1.5 person-days".
+        """
+        if not summary or not summary.strip():
+            return FuncToolResult(success=0, error="summary must not be empty")
+
+        if outcome in ("needs_development", "blocked") and not gap_reasons:
+            return FuncToolResult(
+                success=0,
+                error=f"outcome '{outcome}' requires gap_reasons explaining what is missing",
+            )
+
+        if outcome == "needs_development" and not plan_items:
+            return FuncToolResult(
+                success=0,
+                error="outcome 'needs_development' requires plan_items describing what to build",
+            )
+
+        self.submitted = {
+            "outcome": outcome,
+            "summary": summary.strip(),
+            "artifacts": [a.model_dump() for a in artifacts or []],
+            "gap_reasons": list(gap_reasons or []),
+            "plan_items": [p.model_dump() for p in plan_items or []],
+            "estimate": estimate,
+        }
+        logger.info(f"task result submitted: outcome={outcome} artifacts={len(self.submitted['artifacts'])}")
+
+        return FuncToolResult(
+            result={
+                "acknowledged": True,
+                "outcome": outcome,
+                # The caller reads the tool call itself off the stream and stops the
+                # run, so anything said after this is discarded. Say so, rather than
+                # letting the model spend a turn on a closing paragraph nobody reads.
+                "note": "Result recorded. Stop here — no further output is used.",
+            }
+        )

--- a/datus/tools/func_tool/task_result_tools.py
+++ b/datus/tools/func_tool/task_result_tools.py
@@ -177,6 +177,19 @@ class TaskResultTool:
                 error="outcome 'needs_development' requires plan_items describing what to build",
             )
 
+        # A plan contradicts 'blocked' — that outcome means no build can be
+        # proposed either. Rejecting rather than dropping is what tells the model
+        # it picked the wrong outcome; the caller only renders a plan card for
+        # 'needs_development', so a silent accept would discard the work.
+        if outcome == "blocked" and plan_dicts:
+            return FuncToolResult(
+                success=0,
+                error=(
+                    "outcome 'blocked' cannot carry plan_items — if you can propose "
+                    "something to build, the outcome is 'needs_development'"
+                ),
+            )
+
         self.submitted = {
             "outcome": outcome,
             "summary": summary.strip(),

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -1701,6 +1701,40 @@ class TestChatAgenticNodeRebuildTools:
         tool_names = [t.name for t in node.tools]
         assert "ask_user" in tool_names
 
+    def test_orchestrator_origin_survives_rebuild(self, real_agent_config, mock_llm_create):
+        """setup_tools() ends in _rebuild_tools(), which clears the list — so a tool
+        only appended by its own _setup_* helper never reaches the model. That is
+        exactly how submit_task_result shipped inert."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        real_agent_config._request_origin = "orchestrator"
+        node = ChatAgenticNode(
+            node_id="test_rebuild_task_result",
+            description="Test rebuild with submit_task_result",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+
+        assert "submit_task_result" in [t.name for t in node.tools]
+
+        # A mid-session rebuild (task-database switch, skill reload) must keep it.
+        node._rebuild_tools()
+        assert "submit_task_result" in [t.name for t in node.tools]
+
+    def test_ordinary_chat_never_sees_submit_task_result(self, real_agent_config, mock_llm_create):
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        real_agent_config._request_origin = None
+        node = ChatAgenticNode(
+            node_id="test_rebuild_no_task_result",
+            description="Test rebuild without submit_task_result",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+
+        node._rebuild_tools()
+        assert "submit_task_result" not in [t.name for t in node.tools]
+
     def test_rebuild_tools_resets_transformer_flag(self, real_agent_config, mock_llm_create):
         """Rebuilding replaces wrapped FunctionTools with fresh unwrapped ones,
         so plugin tool transformers must re-apply on the next hook composition

--- a/tests/unit_tests/tools/func_tool/test_task_result_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_task_result_tools.py
@@ -1,0 +1,117 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for submit_task_result.
+
+The validation here is the point of the tool. An orchestrator branches on
+``outcome``, so an outcome that arrives without the fields that make it
+actionable is worse than no call at all — it looks successful and decides
+nothing.
+"""
+
+from datus.tools.func_tool.task_result_tools import PlanItem, TaskArtifact, TaskResultTool
+
+
+def test_answered_records_summary_and_artifacts():
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(
+        outcome="answered",
+        summary="Semantic layer already had perp_notional_volume; produced last week by venue.",
+        artifacts=[TaskArtifact(kind="csv", ref="s3://run/1.csv", title="Weekly volume")],
+    )
+
+    assert result.success
+    assert tool.submitted["outcome"] == "answered"
+    assert tool.submitted["artifacts"][0]["kind"] == "csv"
+
+
+def test_needs_development_requires_both_halves():
+    """gap_reasons and plan_items are two halves of one judgement — "because A
+    is missing, build B" — and the caller renders them as a pair."""
+    tool = TaskResultTool()
+
+    missing_plan = tool.submit_task_result(
+        outcome="needs_development",
+        summary="No market-maker dimension exists.",
+        gap_reasons=["no dim_market_maker"],
+    )
+    assert not missing_plan.success
+    assert "plan_items" in missing_plan.error
+
+    missing_gap = tool.submit_task_result(
+        outcome="needs_development",
+        summary="Need to build a few things.",
+        plan_items=[PlanItem(kind="dimension", name="dim_market_maker")],
+    )
+    assert not missing_gap.success
+    assert "gap_reasons" in missing_gap.error
+
+    assert tool.submitted is None
+
+
+def test_needs_development_accepted_with_both():
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(
+        outcome="needs_development",
+        summary="Retention by market maker needs a dimension and a backfill first.",
+        gap_reasons=["no market_maker dimension", "counterparty is a raw address"],
+        plan_items=[
+            PlanItem(kind="dimension", name="dim_market_maker", description="42 maker addresses"),
+            PlanItem(kind="metric", name="mm_taker_retention_30d"),
+        ],
+        estimate="1.5 person-days",
+    )
+
+    assert result.success
+    assert [p["kind"] for p in tool.submitted["plan_items"]] == ["dimension", "metric"]
+    assert tool.submitted["estimate"] == "1.5 person-days"
+
+
+def test_blocked_requires_gap_reasons():
+    """Blocked hands the request to a human, which is a real outcome — but only
+    if it says why."""
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(outcome="blocked", summary="Cannot help with this.")
+
+    assert not result.success
+    assert "gap_reasons" in result.error
+
+
+def test_blocked_needs_no_plan():
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(
+        outcome="blocked",
+        summary="The billing warehouse is not connected to this project.",
+        gap_reasons=["no datasource bound for billing"],
+    )
+
+    assert result.success
+    assert tool.submitted["plan_items"] == []
+
+
+def test_empty_summary_rejected():
+    """The summary is what the caller reads instead of the transcript; a blank
+    one silently drops everything the run learned."""
+    tool = TaskResultTool()
+
+    assert not tool.submit_task_result(outcome="answered", summary="   ").success
+
+
+def test_result_tells_the_model_to_stop():
+    """The caller stops the run on seeing this call, so anything said afterwards
+    is discarded — better to say so than to let a closing paragraph be written
+    and thrown away."""
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(outcome="answered", summary="Done.")
+
+    assert "Stop here" in result.result["note"]
+
+
+def test_available_tools_exposes_one_function():
+    assert len(TaskResultTool().available_tools()) == 1

--- a/tests/unit_tests/tools/func_tool/test_task_result_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_task_result_tools.py
@@ -98,6 +98,24 @@ def test_blocked_needs_no_plan():
     assert tool.submitted["plan_items"] == []
 
 
+def test_blocked_rejects_a_plan():
+    """ "Blocked" means no build can be proposed either. A plan alongside it means
+    the model wanted 'needs_development' — say so instead of dropping the plan,
+    which is what the caller would otherwise do."""
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(
+        outcome="blocked",
+        summary="Billing is not connected.",
+        gap_reasons=["no datasource bound for billing"],
+        plan_items=[PlanItem(kind="table", name="stg_billing")],
+    )
+
+    assert not result.success
+    assert "needs_development" in result.error
+    assert tool.submitted is None
+
+
 def test_empty_summary_rejected():
     """The summary is what the caller reads instead of the transcript; a blank
     one silently drops everything the run learned."""

--- a/tests/unit_tests/tools/func_tool/test_task_result_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_task_result_tools.py
@@ -205,6 +205,24 @@ async def test_invoker_reports_a_malformed_item_instead_of_raising():
 
 
 @pytest.mark.asyncio
+async def test_invoker_rejects_a_non_string_gap_reason():
+    """str() on a dict yields "{'reason': ...}", which would be shown to the
+    requester verbatim as the reason a project could not answer."""
+    tool = TaskResultTool()
+
+    result = await _invoke(
+        tool,
+        outcome="blocked",
+        summary="Cannot help.",
+        gap_reasons=[{"reason": "no datasource"}],
+    )
+
+    assert not result["success"]
+    assert "gap_reasons[0]" in result["error"]
+    assert tool.submitted is None
+
+
+@pytest.mark.asyncio
 async def test_invoker_still_enforces_the_outcome_contract():
     tool = TaskResultTool()
 

--- a/tests/unit_tests/tools/func_tool/test_task_result_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_task_result_tools.py
@@ -10,6 +10,10 @@ actionable is worse than no call at all — it looks successful and decides
 nothing.
 """
 
+import json
+
+import pytest
+
 from datus.tools.func_tool.task_result_tools import PlanItem, TaskArtifact, TaskResultTool
 
 
@@ -115,3 +119,78 @@ def test_result_tells_the_model_to_stop():
 
 def test_available_tools_exposes_one_function():
     assert len(TaskResultTool().available_tools()) == 1
+
+
+# ── The path production actually takes ──────────────────────────────────────
+#
+# Calling the bound method with pydantic instances, as the tests above do,
+# exercises a signature nothing invokes at runtime: the invoker built by
+# ``trans_to_function_tool`` calls ``method(**args_dict)`` with the raw parsed
+# JSON, so nested objects arrive as plain dicts. Every test below goes through
+# ``on_invoke_tool`` so that difference cannot hide again.
+
+
+async def _invoke(tool: TaskResultTool, **args) -> dict:
+    return await tool.available_tools()[0].on_invoke_tool(None, json.dumps(args))
+
+
+@pytest.mark.asyncio
+async def test_invoker_accepts_nested_objects_as_dicts():
+    tool = TaskResultTool()
+
+    result = await _invoke(
+        tool,
+        outcome="needs_development",
+        summary="Retention by market maker needs a dimension first.",
+        gap_reasons=["no market_maker dimension"],
+        plan_items=[{"kind": "dimension", "name": "dim_market_maker", "description": "42 addresses"}],
+        artifacts=[{"kind": "csv", "ref": "s3://run/1.csv", "title": "Draft"}],
+    )
+
+    assert result["success"]
+    assert tool.submitted["plan_items"][0]["name"] == "dim_market_maker"
+    assert tool.submitted["artifacts"][0]["kind"] == "csv"
+
+
+@pytest.mark.asyncio
+async def test_invoker_accepts_a_nested_array_sent_as_a_json_string():
+    """Some models serialise nested arrays rather than nesting them."""
+    tool = TaskResultTool()
+
+    result = await _invoke(
+        tool,
+        outcome="answered",
+        summary="Done.",
+        artifacts=json.dumps([{"kind": "report", "ref": "rpt_1"}]),
+    )
+
+    assert result["success"]
+    assert tool.submitted["artifacts"][0]["ref"] == "rpt_1"
+
+
+@pytest.mark.asyncio
+async def test_invoker_reports_a_malformed_item_instead_of_raising():
+    """A raise here aborts the whole interaction; an error string lets the model
+    correct itself in-turn."""
+    tool = TaskResultTool()
+
+    result = await _invoke(
+        tool,
+        outcome="answered",
+        summary="Done.",
+        artifacts=[{"ref": "missing-kind"}],
+    )
+
+    assert not result["success"]
+    assert "artifacts[0]" in result["error"]
+    assert tool.submitted is None
+
+
+@pytest.mark.asyncio
+async def test_invoker_still_enforces_the_outcome_contract():
+    tool = TaskResultTool()
+
+    result = await _invoke(tool, outcome="needs_development", summary="Something is missing.")
+
+    assert not result["success"]
+    assert "gap_reasons" in result["error"]


### PR DESCRIPTION
Needed by the Datus Mission Orchestrator, which dispatches work here over `/chat/stream` and has to branch on how the run ended.

## Why a tool and not a convention

Recovering the outcome from prose fails three separate ways: the model may not say it, the wording drifts between runs, and a JSON block comes back wrapped in code fences. A tool call is schema-validated, arrives as its own frame in the stream, and — the part that matters most in practice — the schema steers the model far better than an instruction to "finish with JSON".

## Scope

`origin` on `ChatInput` gates the injection, so ordinary IDE chat never sees the tool. It rides on the cloned `AgentConfig` next to `_client_source`, which is what keeps concurrent requests on one project from seeing each other's origin.

## The validation is the substance

| outcome | requires | why |
| --- | --- | --- |
| `answered` | summary | — |
| `needs_development` | `gap_reasons` **and** `plan_items` | Two halves of one judgement — "because A is missing, build B". The caller renders them as a pair, and a model asked for them separately tends to stop after the first. |
| `blocked` | `gap_reasons`, no plan | Exists so a model that genuinely cannot help says so rather than inventing a plan to look useful. It hands the request to a human, which is the correct outcome. |

An empty summary is rejected: the summary is what the caller reads *instead of* the transcript, so a blank one silently discards everything the run learned.

`plan_items.kind` reuses the caller's deliverable vocabulary (`dimension | table | metric | report | dashboard | dag`) rather than defining a private one. Two enums plus a mapping is one more thing to miss when a kind is added, and that failure mode is silent.

The tool's own result tells the model to stop — the caller stops the run on seeing the call, so a closing paragraph written afterwards is discarded either way.

## Tests

`tests/unit_tests/tools/func_tool/test_task_result_tools.py` — 8 passing.

Design: `Datus-saas/design-docs/mission-board/orchestrator-design.md` §6.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added structured task-result reporting for orchestrated runs.
  * Task results can include outcomes, summaries, artifacts, development plans, gap reasons, and estimates.
  * Added validation to ensure required details are provided for incomplete or blocked tasks.
  * Added support for identifying whether a chat request originated from an orchestrator.
* **Bug Fixes**
  * Task-result reporting is now limited to orchestrator-initiated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured task-result reporting for orchestrated runs.
  * Results can include outcomes, summaries, artifacts, development plans, gap reasons, and estimates.
  * Added support for identifying the source of a chat request.
  * Task-result reporting remains available when chat tools are refreshed.
* **Bug Fixes**
  * Limited task-result reporting to orchestrator-initiated requests.
  * Added validation for required and incompatible task-result details.
  * Improved handling of structured and serialized result data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->