### PR TITLE
[BugFix] Gate nightly Doris tests on SQL readiness

### DIFF
--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -1409,6 +1409,19 @@ PY
   return 1
 }
 
+wait_for_doris_client_readiness() {
+  local timeout_seconds="${1:-600}"
+
+  uv run --no-sync python "$DB_ADAPTERS_ROOT/datus-doris/scripts/wait_for_doris.py" \
+    --timeout "$timeout_seconds" 2>&1 | tee -a "$LOG_FILE"
+  local status=${PIPESTATUS[0]}
+  if [ "$status" -ne 0 ]; then
+    test_exit_code="$status"
+    return "$status"
+  fi
+  return 0
+}
+
 wait_for_compose_client_readiness() {
   local group_name="$1"
   local airflow_base
@@ -1438,7 +1451,7 @@ wait_for_compose_client_readiness() {
       wait_for_starrocks_client_readiness 300
       ;;
     "Doris Adapter Tests")
-      wait_for_tcp_readiness "Doris" "${DORIS_HOST:-127.0.0.1}" "${DORIS_PORT:-9030}" 600
+      wait_for_doris_client_readiness "${DORIS_READY_TIMEOUT:-600}"
       ;;
     "Trino Adapter Tests")
       wait_for_http_readiness "Trino" "http://${TRINO_HOST:-127.0.0.1}:${TRINO_PORT:-8080}/v1/info" 300

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -1,8 +1,17 @@
+import os
+import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-nightly.yml"
 NIGHTLY_SCRIPT = REPO_ROOT / "ci" / "run-nightly-tests.sh"
+
+
+def _bash_function_source(name: str) -> str:
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+    start = script.index(f"{name}() {{")
+    end = script.index("\n}\n", start) + len("\n}\n")
+    return script[start:end]
 
 
 def test_nightly_preserves_checkout_packages_after_locked_sync():
@@ -70,4 +79,40 @@ def test_nightly_runs_doris_agent_contract_from_checkout():
     assert 'echo "DORIS_HTTP_HOST_PORT=28031" >> $GITHUB_ENV' in workflow
     assert 'DORIS_COMPOSE="${DORIS_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-doris/docker-compose.yml}"' in script
     assert 'run_compose_suite "Doris Adapter Tests"' in script
+    assert 'uv run --no-sync python "$DB_ADAPTERS_ROOT/datus-doris/scripts/wait_for_doris.py"' in script
+    assert 'wait_for_doris_client_readiness "${DORIS_READY_TIMEOUT:-600}"' in script
+    assert 'wait_for_tcp_readiness "Doris"' not in script
     assert "tests/integration/adapters/test_doris.py" in script
+
+
+def test_doris_readiness_failure_is_logged_and_propagated(tmp_path):
+    log_file = tmp_path / "nightly.log"
+    function_source = _bash_function_source("wait_for_doris_client_readiness")
+    harness = f"""
+set -u
+set -o pipefail
+test_exit_code=0
+uv() {{
+  echo "simulated Doris readiness failure"
+  return 23
+}}
+{function_source}
+wait_for_doris_client_readiness 17
+readiness_status=$?
+printf 'readiness_status=%s test_exit_code=%s\n' "$readiness_status" "$test_exit_code"
+"""
+
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "DB_ADAPTERS_ROOT": str(tmp_path / "db-adapters"),
+            "LOG_FILE": str(log_file),
+        },
+    )
+
+    assert "readiness_status=23 test_exit_code=23" in result.stdout
+    assert "simulated Doris readiness failure" in log_file.read_text(encoding="utf-8")

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -93,6 +93,7 @@ set -u
 set -o pipefail
 test_exit_code=0
 uv() {{
+  printf 'uv_args=%s\n' "$*"
   echo "simulated Doris readiness failure"
   return 23
 }}
@@ -115,4 +116,5 @@ printf 'readiness_status=%s test_exit_code=%s\n' "$readiness_status" "$test_exit
     )
 
     assert "readiness_status=23 test_exit_code=23" in result.stdout
+    assert "--timeout 17" in result.stdout
     assert "simulated Doris readiness failure" in log_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- replace the Doris nightly TCP-only readiness gate with the adapter's SQL/BE/DDL readiness helper
- preserve helper output in the nightly log and propagate readiness failures to the final harness exit code
- add a behavioral regression test for nonzero exit propagation and log persistence

## Root cause

In [nightly run 31276861766](https://github.com/Datus-ai/Datus-agent/actions/runs/31276861766), the Doris FE and BE containers were Docker-healthy and the FE query port accepted TCP connections before Doris had an alive backend. The integration suite then started and failed with `No backend available as scan node`.

The initial direct helper integration also bypassed the nightly log and did not update the global test exit code, which could skip the Doris tests while leaving the job green. This change routes the helper through the same blocking/logging contract as the other readiness checks.

## Impact

Doris adapter tests now start only after Doris can execute `SELECT 1`, report an alive backend, and create/drop a temporary OLAP table. Readiness timeouts are archived and fail the nightly job instead of producing a false green.

## Validation

- `uv run pytest tests/unit_tests/ci -q` (196 passed)
- `uv run ruff check tests/unit_tests/ci ci`
- `uv run ruff format --check tests/unit_tests/ci ci`
- `bash -n ci/run-nightly-tests.sh`
- `shellcheck -S error ci/run-nightly-tests.sh`
- `uv lock --check`
- `git diff --check`

A full Docker-backed Doris nightly run has not been reproduced locally; GitHub Actions remains the end-to-end verification.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Doris environment readiness checks by validating client-level availability instead of relying only on network connectivity.
  * Added configurable readiness timeouts, with failures clearly logged and correctly propagated to nightly test results.

* **Tests**
  * Added coverage for readiness failures, timeout handling, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Doris environment readiness checks by validating client-level availability instead of relying only on network connectivity.
  * Added configurable readiness timeouts, with failures clearly logged and correctly propagated to nightly test results.

* **Tests**
  * Added coverage for readiness failures, timeout handling, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->