### PR TITLE
[BugFix] Run a subagent under the permission profile its parent is actually on

### DIFF
--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -1086,63 +1086,21 @@ class ChatTaskManager:
         ``/profile`` flow can still mutate the global field because it
         owns the process exclusively; this API path cannot.
 
-        No-ops when ``permission_mode`` is falsy, the node has no
-        ``permission_manager`` (e.g. workflow nodes that skip the skill
-        setup), or the requested profile already matches the active one.
-        Failure handling is split deliberately:
+        Because the override lives on the node, a subagent built later from
+        the same shared config does not see it — ``SubAgentTaskTool`` copies
+        it down explicitly.
 
-        * Building ``user_overrides`` from ``agent.yml`` fails closed —
-          raises so the outer ``_run_loop`` aborts the turn and emits an
-          SSE error. Silently dropping malformed user rules would apply
-          the bare profile base, which can be **broader** than the
-          operator-configured posture (e.g. yaml had an explicit DENY
-          we'd lose), so the safe move is to refuse the switch loudly.
-        * ``switch_profile`` failures (unknown profile, malformed merge
-          result) are logged and swallowed because at that point the
-          node still has its original, server-default profile installed.
+        See :func:`apply_profile_override` for the no-op and failure rules;
+        a raise from there aborts the turn in ``_run_loop`` and emits an SSE
+        error, which is the intended fail-closed behaviour.
         """
-        if not permission_mode:
-            return
-        permission_manager = getattr(node, "permission_manager", None)
-        if permission_manager is None:
-            return
-        if getattr(permission_manager, "active_profile", None) == permission_mode:
-            return
+        from datus.tools.permission.profile_override import apply_profile_override
 
-        from datus.tools.permission.profiles import build_user_overrides
-
-        raw_permissions = getattr(agent_config, "_raw_permissions", {}) or {}
-        raw_user = {k: v for k, v in raw_permissions.items() if k != "profile"}
-        try:
-            user_overrides = build_user_overrides(permission_mode, raw_user)
-        except Exception as exc:
-            logger.error(
-                "Cannot build user overrides for permission_mode=%r from agent.yml: %s; "
-                "refusing to switch profile to avoid broadening permissions beyond the "
-                "operator-configured rules",
-                permission_mode,
-                exc,
-                exc_info=True,
-            )
-            raise RuntimeError(
-                f"Failed to apply permission_mode={permission_mode!r}: agent.yml permissions.rules is malformed ({exc})"
-            ) from exc
-
-        try:
-            permission_manager.switch_profile(permission_mode, user_overrides=user_overrides)
-        except Exception as e:
-            logger.error(
-                "Failed to switch permission profile to %r for session=%s: %s",
-                permission_mode,
-                getattr(node, "session_id", None),
-                e,
-            )
-            return
-
-        logger.info(
-            "Applied per-request permission profile %r for session=%s",
+        apply_profile_override(
+            getattr(node, "permission_manager", None),
+            agent_config,
             permission_mode,
-            getattr(node, "session_id", None),
+            subject=f"session={getattr(node, 'session_id', None)}",
         )
 
     # ------------------------------------------------------------------

--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -399,22 +399,55 @@ class SubAgentTaskTool:
         """
         # Builtin system subagents have non-standard constructors
         if subagent_type in SYS_SUB_AGENTS:
-            return self._create_builtin_node(subagent_type, session_id=session_id)
+            node = self._create_builtin_node(subagent_type, session_id=session_id)
+        else:
+            node_type, node_name = self._resolve_node_type(subagent_type)
+            node_id = f"task_{subagent_type}_{uuid.uuid4().hex[:8]}"
+            description = f"SubAgent task: {subagent_type}"
 
-        node_type, node_name = self._resolve_node_type(subagent_type)
-        node_id = f"task_{subagent_type}_{uuid.uuid4().hex[:8]}"
-        description = f"SubAgent task: {subagent_type}"
+            from datus.agent.node.node import Node
 
-        from datus.agent.node.node import Node
+            node = Node.new_instance(
+                node_id=node_id,
+                description=description,
+                node_type=node_type,
+                agent_config=self.agent_config,
+                node_name=node_name,
+                is_subagent=True,
+                session_id=session_id,
+            )
 
-        return Node.new_instance(
-            node_id=node_id,
-            description=description,
-            node_type=node_type,
-            agent_config=self.agent_config,
-            node_name=node_name,
-            is_subagent=True,
-            session_id=session_id,
+        self._inherit_permission_profile(node)
+        return node
+
+    def _inherit_permission_profile(self, node: Any) -> None:
+        """Run the child under the profile the parent is actually running under.
+
+        A per-request ``permission_mode`` is applied to the top-level node's
+        ``PermissionManager`` only — ``AgentConfig`` is shared across
+        concurrent requests, so the override deliberately never touches it.
+        The child is built from that same shared config, so without this it
+        falls back to the server default: a user who asked for ``dangerous``
+        gets permission prompts as soon as the work lands in a subagent.
+
+        Workflow children are left alone — they force ``dangerous`` by design
+        (see ``AgenticNode._setup_permission_manager``), and copying an
+        interactive parent's profile down would narrow that.
+        """
+        if getattr(node, "execution_mode", None) == "workflow":
+            return
+
+        parent_manager = getattr(self._parent_node, "permission_manager", None)
+        if parent_manager is None:
+            return
+
+        from datus.tools.permission.profile_override import apply_profile_override
+
+        apply_profile_override(
+            getattr(node, "permission_manager", None),
+            self.agent_config,
+            getattr(parent_manager, "active_profile", None),
+            subject=f"subagent node={getattr(node, 'node_id', None)}",
         )
 
     def _resolve_execution_mode(self) -> Literal["interactive", "workflow"]:

--- a/datus/tools/permission/profile_override.py
+++ b/datus/tools/permission/profile_override.py
@@ -1,0 +1,102 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Apply a permission profile to a single node's manager, in place.
+
+Both callers face the same constraint: ``AgentConfig`` is shared by every
+concurrent request in a SaaS deployment, so a per-request profile can only
+live on the node's own ``PermissionManager`` — never on
+``agent_config.active_profile_name``. That is also why a subagent, built from
+the same shared config, has to be told explicitly what its parent is running
+under (see ``SubAgentTaskTool._inherit_permission_profile``).
+"""
+
+from typing import Any, Optional
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+def apply_profile_override(
+    permission_manager: Any,
+    agent_config: Any,
+    profile_name: Optional[str],
+    *,
+    subject: str = "",
+) -> bool:
+    """Switch ``permission_manager`` to ``profile_name``.
+
+    No-ops when ``profile_name`` is falsy, there is no manager (e.g. workflow
+    nodes that skip the skill setup), or the profile is already active.
+    Failure handling is split deliberately:
+
+    * Building ``user_overrides`` from ``agent.yml`` fails closed — raises, so
+      the caller aborts rather than applying the bare profile base, which can
+      be **broader** than the operator-configured posture (an explicit DENY in
+      the yaml would be lost).
+    * ``switch_profile`` failures (unknown profile, malformed merge result)
+      are logged and swallowed: the manager still has its original,
+      server-default profile installed, which is the safe side to land on.
+
+    Args:
+        permission_manager: The node's ``PermissionManager``, or ``None``.
+        agent_config: Source of the raw ``permissions`` block from agent.yml.
+        profile_name: Target profile (``normal`` / ``auto`` / ``dangerous``).
+        subject: Free-form identifier for the log line (session, node name).
+
+    Returns:
+        True when the profile actually changed.
+
+    Raises:
+        DatusException: ``COMMON_CONFIG_ERROR`` if agent.yml's user rules
+            cannot be rebuilt — the same code ``switch_profile`` reports an
+            unusable permission configuration with.
+    """
+    if not profile_name or permission_manager is None:
+        return False
+    if getattr(permission_manager, "active_profile", None) == profile_name:
+        return False
+
+    # Imported here, not at module scope, so the yaml-parsing failure path
+    # stays patchable in tests.
+    from datus.tools.permission.profiles import build_user_overrides
+
+    raw_permissions = getattr(agent_config, "_raw_permissions", {}) or {}
+    raw_user = {k: v for k, v in raw_permissions.items() if k != "profile"}
+    try:
+        user_overrides = build_user_overrides(profile_name, raw_user)
+    except Exception as exc:
+        logger.error(
+            "Cannot build user overrides for permission_mode=%r from agent.yml: %s; "
+            "refusing to switch profile to avoid broadening permissions beyond the "
+            "operator-configured rules",
+            profile_name,
+            exc,
+            exc_info=True,
+        )
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        raise DatusException(
+            code=ErrorCode.COMMON_CONFIG_ERROR,
+            message_args={
+                "config_error": (
+                    f"cannot apply permission_mode={profile_name!r}: agent.yml permissions.rules is malformed ({exc})"
+                )
+            },
+        ) from exc
+
+    try:
+        permission_manager.switch_profile(profile_name, user_overrides=user_overrides)
+    except Exception as e:
+        logger.error(
+            "Failed to switch permission profile to %r for %s: %s",
+            profile_name,
+            subject or "node",
+            e,
+        )
+        return False
+
+    logger.info("Applied permission profile %r for %s", profile_name, subject or "node")
+    return True

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -237,12 +237,15 @@ class TestApplyPermissionModeOverride:
             _explode,
         )
 
-        with pytest.raises(RuntimeError, match="permission_mode='auto'"):
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        with pytest.raises(DatusException, match="permission_mode='auto'") as excinfo:
             manager._apply_permission_mode_override(
                 node,
                 self._make_agent_config({"rules": [{"bad": "shape"}]}),
                 "auto",
             )
+        assert excinfo.value.code == ErrorCode.COMMON_CONFIG_ERROR
         node.permission_manager.switch_profile.assert_not_called()
 
     def test_swallows_switch_profile_failure(self):

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -735,6 +735,88 @@ class TestNodeCreation:
         assert node2 is node_b
 
 
+# ── permission profile inheritance ─────────────────────────────────
+
+
+def _child(execution_mode="interactive", profile="normal"):
+    node = Mock(name="child")
+    node.execution_mode = execution_mode
+    node.node_id = "task_explore_abc"
+    manager = MagicMock()
+    manager.active_profile = profile
+    node.permission_manager = manager
+    return node
+
+
+def _parent(profile="dangerous"):
+    node = Mock(name="parent")
+    manager = MagicMock()
+    manager.active_profile = profile
+    node.permission_manager = manager
+    return node
+
+
+class TestSubagentInheritsPermissionProfile:
+    """A per-request permission_mode lives on the parent node's manager only.
+
+    The child is built from the shared AgentConfig, so without an explicit
+    copy it starts on the server default — and a user who asked for
+    ``dangerous`` gets permission prompts the moment the work moves into a
+    subagent.
+    """
+
+    def test_child_runs_under_the_parent_profile(self, task_tool):
+        child = _child(profile="normal")
+        task_tool.set_parent_node(_parent(profile="dangerous"))
+
+        with patch("datus.agent.node.node.Node.new_instance", return_value=child):
+            task_tool._create_node("explore")
+
+        child.permission_manager.switch_profile.assert_called_once()
+        assert child.permission_manager.switch_profile.call_args[0][0] == "dangerous"
+
+    def test_nothing_to_copy_without_a_parent(self, task_tool):
+        child = _child(profile="normal")
+
+        with patch("datus.agent.node.node.Node.new_instance", return_value=child):
+            task_tool._create_node("explore")
+
+        child.permission_manager.switch_profile.assert_not_called()
+
+    def test_leaves_a_workflow_child_alone(self, task_tool):
+        """Workflow nodes force ``dangerous`` by design — narrowing them here
+        would quietly change what unattended flows are allowed to do."""
+        child = _child(execution_mode="workflow", profile="dangerous")
+        task_tool.set_parent_node(_parent(profile="normal"))
+
+        with patch("datus.agent.node.node.Node.new_instance", return_value=child):
+            task_tool._create_node("explore")
+
+        child.permission_manager.switch_profile.assert_not_called()
+
+    def test_skips_a_child_already_on_that_profile(self, task_tool):
+        child = _child(profile="dangerous")
+        task_tool.set_parent_node(_parent(profile="dangerous"))
+
+        with patch("datus.agent.node.node.Node.new_instance", return_value=child):
+            task_tool._create_node("explore")
+
+        child.permission_manager.switch_profile.assert_not_called()
+
+    def test_builtin_subagents_inherit_too(self, task_tool):
+        # gen_table-style builtins take the non-standard constructor path,
+        # which is the one the DDL confirmation card came out of.
+        child = _child(profile="normal")
+        task_tool.set_parent_node(_parent(profile="dangerous"))
+
+        with patch.object(task_tool, "_create_builtin_node", return_value=child):
+            node = task_tool._create_node(next(iter(SYS_SUB_AGENTS)))
+
+        assert node is child
+        child.permission_manager.switch_profile.assert_called_once()
+        assert child.permission_manager.switch_profile.call_args[0][0] == "dangerous"
+
+
 # ── _build_node_input ──────────────────────────────────────────────
 
 

--- a/tests/unit_tests/tools/permission/test_profile_override.py
+++ b/tests/unit_tests/tools/permission/test_profile_override.py
@@ -1,0 +1,94 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""CI-level tests for apply_profile_override.
+
+The helper is what carries a per-request permission profile onto one node's
+manager — the API path cannot put it on the shared AgentConfig, and the
+subagent path has no other way to learn what its parent is running under.
+Its return value is the contract callers branch on, so every path asserts it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.tools.permission.profile_override import apply_profile_override
+
+
+def _agent_config(raw_permissions=None):
+    return SimpleNamespace(active_profile_name="normal", _raw_permissions=raw_permissions or {})
+
+
+def _manager(active_profile="normal", switch_side_effect=None):
+    manager = MagicMock()
+    manager.active_profile = active_profile
+    if switch_side_effect is not None:
+        manager.switch_profile.side_effect = switch_side_effect
+    return manager
+
+
+class TestApplyProfileOverride:
+    def test_noop_without_a_profile_name(self):
+        manager = _manager()
+        assert apply_profile_override(manager, _agent_config(), None) is False
+        manager.switch_profile.assert_not_called()
+
+    def test_noop_without_a_manager(self):
+        # Workflow nodes skip the skill setup and never get one.
+        assert apply_profile_override(None, _agent_config(), "dangerous") is False
+
+    def test_noop_when_the_profile_is_already_active(self):
+        manager = _manager(active_profile="dangerous")
+        assert apply_profile_override(manager, _agent_config(), "dangerous") is False
+        manager.switch_profile.assert_not_called()
+
+    def test_switches_without_user_overrides(self):
+        manager = _manager()
+        assert apply_profile_override(manager, _agent_config(), "auto") is True
+        manager.switch_profile.assert_called_once_with("auto", user_overrides=None)
+
+    def test_switches_with_user_overrides_built_from_agent_yml(self):
+        from datus.tools.permission.permission_config import PermissionConfig
+
+        manager = _manager()
+        raw = {"rules": [{"tool": "db_tools", "pattern": "*", "permission": "ask"}]}
+
+        assert apply_profile_override(manager, _agent_config(raw), "dangerous") is True
+
+        args, kwargs = manager.switch_profile.call_args
+        assert args == ("dangerous",)
+        assert isinstance(kwargs["user_overrides"], PermissionConfig)
+
+    def test_drops_the_profile_key_from_the_raw_rules(self):
+        # ``profile`` names the posture; it is not itself a rule.
+        manager = _manager()
+        raw = {"profile": "normal"}
+
+        assert apply_profile_override(manager, _agent_config(raw), "auto") is True
+        manager.switch_profile.assert_called_once_with("auto", user_overrides=None)
+
+    def test_raises_when_the_user_rules_cannot_be_rebuilt(self, monkeypatch):
+        """Fail closed: the bare profile base can be broader than the yaml."""
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        manager = _manager()
+
+        def _explode(*_args, **_kwargs):
+            raise ValueError("malformed rule")
+
+        monkeypatch.setattr("datus.tools.permission.profiles.build_user_overrides", _explode)
+
+        with pytest.raises(DatusException, match="permission_mode='auto'") as excinfo:
+            apply_profile_override(manager, _agent_config({"rules": [{"bad": "shape"}]}), "auto")
+        assert excinfo.value.code == ErrorCode.COMMON_CONFIG_ERROR
+        assert isinstance(excinfo.value.__cause__, ValueError)
+        manager.switch_profile.assert_not_called()
+
+    def test_swallows_a_failing_switch(self):
+        """The manager keeps its original profile, which is the safe side."""
+        manager = _manager(switch_side_effect=RuntimeError("unknown profile"))
+
+        assert apply_profile_override(manager, _agent_config(), "nope") is False


### PR DESCRIPTION
## Why

A per-request `permission_mode` (`StreamChatInput.permission_mode`) is applied to the **top-level node's** `PermissionManager` only — `AgentConfig` is shared by every concurrent request in a SaaS deployment, so `_apply_permission_mode_override` deliberately never touches `agent_config.active_profile_name`.

`SubAgentTaskTool` builds its children from that same shared config. It propagates `execution_mode` (`_resolve_execution_mode`) but not the profile, so the child falls back to whatever the server default is — typically `normal`. A user who asked for `dangerous` therefore gets permission prompts again the moment the work moves into a subagent, and the mode they chose silently stops applying halfway through the run.

Found while tracing why a Mission Board run dispatched with `permission_mode='dangerous'` still stopped for confirmations: `gen_table` and friends run as subagents.

## Solution

Copy the parent's active profile onto the child after construction, in `_create_node`, so both paths are covered — the builtin constructors (`_create_builtin_node`) and the `Node.new_instance` factory.

Key decisions:

- **Workflow children are left alone.** `AgenticNode._setup_permission_manager` forces `dangerous` for `execution_mode="workflow"` by design; copying an interactive parent's profile down would *narrow* what unattended flows (bootstrap, scheduler, benchmarks) may do. The guard is on the child's own `execution_mode`, which is already inherited from the parent.
- **The switch is one shared helper**, `datus/tools/permission/profile_override.py::apply_profile_override`, rather than a second implementation next to `ChatTaskManager._apply_permission_mode_override` — which now delegates to it. Same no-op rules (falsy profile / no manager / already active), same split failure handling: fail **closed** when `agent.yml`'s user rules cannot be rebuilt (the bare profile base can be broader than the operator's rules), raising `DatusException(COMMON_CONFIG_ERROR)` — the same code `PermissionManager.switch_profile` reports an unusable permission configuration with, log-and-swallow a failing `switch_profile` (the manager keeps its original profile, which is the safe side).
- `build_user_overrides` stays a function-local import inside the helper, so the yaml-failure path remains patchable in tests.

Not addressed here: nothing changes about `ask_user`. It is `ALLOW` in every profile on purpose, and a subagent that needs to clarify something should still be able to ask — `dangerous` grants write access, not silence.

## Test Cases

Unit tests only; this is a wiring fix with no external dependencies.

- **`tests/unit_tests/tools/permission/test_profile_override.py`** (new, mirrors the new module): every branch of the helper asserted through its return value — no-op without a profile name / without a manager / when already active; switch with and without user overrides; the `profile` key dropped from the raw rules; fail-closed `DatusException` (asserted by error code, and that the original `ValueError` stays chained) when the rules cannot be rebuilt; swallowed `switch_profile` failure.
- **`tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py`** → `TestSubagentInheritsPermissionProfile`: child runs under the parent's profile; nothing copied when there is no parent; a workflow child is left alone; a child already on that profile is skipped; builtin subagents (the `_create_builtin_node` path) inherit too.
- `uv run python ci/audit_tests.py --repo-root . --diff-only upstream/main` → `P0=0, P1=0`. `ci/run-pr-tests.py` diff coverage **100%**; the 17 `test_explorer_service.py::TestExplorerServiceOSIAuthoring` failures it reports reproduce identically on a clean `upstream/main` checkout and are unrelated to this change.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Interactive subagents now inherit the active permission profile from their parent.
  * Permission profile changes preserve existing configuration and user-defined permissions.

* **Bug Fixes**
  * Profile application now handles missing, inactive, and failed profile changes more safely.
  * Permission-related failures during a chat turn are surfaced as stream errors instead of being silently ignored.
  * Workflow subagents remain unaffected by interactive profile inheritance.

* **Tests**
  * Added coverage for profile inheritance, profile switching, no-op scenarios, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive subagents now inherit their parent’s active permission profile.
  * Permission profile changes preserve existing configuration and user-defined permissions.

* **Bug Fixes**
  * Profile application handles missing, inactive, and failed profile changes more safely.
  * Permission failures during a chat turn are surfaced as stream errors.
  * Workflow subagents remain unaffected by profile inheritance.

* **Tests**
  * Added coverage for profile inheritance, switching, no-op scenarios, and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->