### PR TITLE
[Feature] add OrcaRouter as a named LLM provider

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -25,7 +25,7 @@ agent:
   #   slash command in the CLI can then switch between any model exposed by
   #   that provider without rewriting YAML. Supported providers (keys) are
   #   shipped in ``conf/providers.yml``: openai, claude, claude_subscription,
-  #   codex, deepseek, kimi, qwen, gemini, glm, minimax, openrouter,
+  #   codex, deepseek, kimi, qwen, gemini, glm, minimax, openrouter, orcarouter,
   #   alibaba_coding, bigmodel_coding, zai_coding, minimax_coding, kimi_coding.
   #
   # - ``agent.models.<name>`` (legacy / custom)
@@ -52,6 +52,9 @@ agent:
       api_key: ${DEEPSEEK_API_KEY}
     gemini:
       api_key: ${GEMINI_API_KEY}
+    # OrcaRouter unified gateway (one key, 150+ models across vendors).
+    orcarouter:
+      api_key: ${ORCAROUTER_API_KEY}
     # Claude Pro/Max (subscription token via `claude setup-token`, auto-detected).
     claude_subscription:
       auth_type: subscription

--- a/conf/providers.yml
+++ b/conf/providers.yml
@@ -105,6 +105,23 @@ providers:
       - google/gemini-2.5-pro
       - deepseek/deepseek-chat
 
+  # OrcaRouter unified gateway — one API key, 150+ models routed by vendor/slug.
+  # Model ids keep the vendor/slug namespace; the LiteLLM adapter prepends the
+  # openai/ provider prefix and routes the full namespace to the base URL below.
+  orcarouter:
+    type: orcarouter
+    base_url: https://api.orcarouter.ai/v1
+    api_key_env: ORCAROUTER_API_KEY
+    default_model: deepseek/deepseek-chat
+    models:
+      - deepseek/deepseek-chat
+      - deepseek/deepseek-v4-flash
+      - openai/gpt-5.5
+      - openai/gpt-5.4-mini
+      - anthropic/claude-sonnet-4.6
+      - google/gemini-2.5-flash
+      - orcarouter/auto
+
   # Coding Plan providers (vendor Anthropic-compatible endpoints)
   alibaba_coding:
     type: claude

--- a/datus/conf/providers.yml
+++ b/datus/conf/providers.yml
@@ -105,6 +105,23 @@ providers:
       - google/gemini-2.5-pro
       - deepseek/deepseek-chat
 
+  # OrcaRouter unified gateway — one API key, 150+ models routed by vendor/slug.
+  # Model ids keep the vendor/slug namespace; the LiteLLM adapter prepends the
+  # openai/ provider prefix and routes the full namespace to the base URL below.
+  orcarouter:
+    type: orcarouter
+    base_url: https://api.orcarouter.ai/v1
+    api_key_env: ORCAROUTER_API_KEY
+    default_model: deepseek/deepseek-chat
+    models:
+      - deepseek/deepseek-chat
+      - deepseek/deepseek-v4-flash
+      - openai/gpt-5.5
+      - openai/gpt-5.4-mini
+      - anthropic/claude-sonnet-4.6
+      - google/gemini-2.5-flash
+      - orcarouter/auto
+
   # Coding Plan providers (vendor Anthropic-compatible endpoints)
   alibaba_coding:
     type: claude

--- a/datus/models/base.py
+++ b/datus/models/base.py
@@ -38,6 +38,7 @@ class LLMBaseModel(ABC):  # Changed from BaseModel to LLMBaseModel
         LLMProvider.KIMI: "KimiModel",
         LLMProvider.CODEX: "CodexModel",
         LLMProvider.OPENROUTER: "OpenRouterModel",
+        LLMProvider.ORCAROUTER: "OrcaRouterModel",
         LLMProvider.MINIMAX: "MiniMaxModel",
         LLMProvider.GLM: "GLMModel",
     }

--- a/datus/models/litellm_adapter.py
+++ b/datus/models/litellm_adapter.py
@@ -136,6 +136,7 @@ class LiteLLMAdapter:
         "gemini": "gemini/",
         "kimi": "moonshot/",  # Moonshot AI - https://docs.litellm.ai/docs/providers/moonshot
         "openrouter": "openrouter/",  # OpenRouter unified gateway
+        "orcarouter": "openai/",  # OrcaRouter - OpenAI-compatible gateway
         "minimax": "openai/",  # MiniMax - OpenAI-compatible API
         "glm": "openai/",  # Zhipu GLM - OpenAI-compatible API
     }
@@ -149,6 +150,7 @@ class LiteLLMAdapter:
         "gemini": None,  # Use LiteLLM default (native Gemini API, not OpenAI-compatible)
         "kimi": "https://api.moonshot.ai/v1",  # Moonshot AI global endpoint
         "openrouter": None,  # Use LiteLLM default (https://openrouter.ai/api/v1)
+        "orcarouter": "https://api.orcarouter.ai/v1",  # OrcaRouter unified gateway
         "minimax": "https://api.minimaxi.com/v1",  # MiniMax OpenAI-compatible endpoint
         "glm": "https://open.bigmodel.cn/api/paas/v4",  # Zhipu GLM OpenAI-compatible endpoint
     }
@@ -177,6 +179,7 @@ class LiteLLMAdapter:
         "qwen": ["dashscope.aliyuncs.com"],
         "gemini": ["generativelanguage.googleapis.com"],
         "kimi": ["api.moonshot.ai", "api.moonshot.cn", "api.kimi.com"],
+        "orcarouter": ["api.orcarouter.ai"],
         "minimax": ["api.minimaxi.com"],
         "glm": ["open.bigmodel.cn"],
     }
@@ -245,8 +248,9 @@ class LiteLLMAdapter:
             The detected provider name
         """
         # Skip auto-detection for providers that must not be overridden
-        # (e.g., openrouter models contain provider/ prefix that would trigger false detection)
-        if provider.lower() == "openrouter":
+        # (e.g., openrouter models contain provider/ prefix that would trigger false detection;
+        #  orcarouter namespaced models would be auto-detected away from the gateway too)
+        if provider.lower() in ("openrouter", "orcarouter"):
             return provider
 
         model_lower = model.lower()
@@ -318,6 +322,14 @@ class LiteLLMAdapter:
         # even when model name contains / (e.g., anthropic/claude-sonnet-4)
         if self.provider == "openrouter":
             return self.model if self.model.startswith("openrouter/") else f"openrouter/{self.model}"
+
+        # OrcaRouter models always need the openai/ prefix so LiteLLM strips the
+        # provider segment and routes the full vendor/slug namespace (e.g.
+        # openai/deepseek/deepseek-chat) to the OrcaRouter base URL. Unconditional:
+        # a model that already starts with openai/ (e.g. openai/gpt-5.5) must still
+        # reach OrcaRouter with its full namespace, so it becomes openai/openai/gpt-5.5.
+        if self.provider == "orcarouter":
+            return f"openai/{self.model}"
 
         # If model already has a prefix, don't add another
         if "/" in self.model:
@@ -395,8 +407,8 @@ class LiteLLMAdapter:
         - **Anthropic Claude** uses :class:`CacheControlLitellmModel` so the
           prompt caching control markers survive the LiteLLM transform.
         - **Every other OpenAI-compatible provider** (DeepSeek, Kimi, Qwen,
-          Gemini, OpenRouter, GLM, MiniMax, vLLM, and self-hosted proxies)
-          uses :class:`LitellmModel` as before.
+          Gemini, OpenRouter, OrcaRouter, GLM, MiniMax, vLLM, and self-hosted
+          proxies) uses :class:`LitellmModel` as before.
 
         Kimi/Moonshot thinking models still go through the LiteLLM path and
         continue to rely on :mod:`datus.models.sdk_patches` for the

--- a/datus/models/orcarouter_model.py
+++ b/datus/models/orcarouter_model.py
@@ -1,0 +1,51 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+OrcaRouter Model - Unified AI gateway supporting 150+ models.
+
+Thin wrapper over OpenAICompatibleModel. OrcaRouter provides an OpenAI-compatible
+API, so all features (streaming, tool calling, JSON mode) work out of the box.
+
+Model names keep the OrcaRouter ``vendor/slug`` namespace (e.g.
+``deepseek/deepseek-chat``, ``openai/gpt-5.5``); the LiteLLM adapter prepends
+the ``openai/`` provider prefix and routes the full namespace to the base URL.
+"""
+
+import os
+from typing import Optional
+
+from datus.configuration.agent_config import ModelConfig
+from datus.models.openai_compatible import OpenAICompatibleModel
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+
+class OrcaRouterModel(OpenAICompatibleModel):
+    """
+    OrcaRouter model implementation.
+
+    Routes requests through OrcaRouter's unified gateway to any supported
+    provider (OpenAI, Anthropic, Google, DeepSeek, Qwen, etc.).
+
+    Model names follow the OrcaRouter convention: provider/model-name
+    e.g., deepseek/deepseek-chat, openai/gpt-5.5, orcarouter/auto
+    """
+
+    def __init__(self, model_config: ModelConfig, **kwargs):
+        super().__init__(model_config, **kwargs)
+
+    def _get_api_key(self) -> str:
+        """Get OrcaRouter API key from config or environment."""
+        api_key = self.model_config.api_key or os.environ.get("ORCAROUTER_API_KEY")
+        if not api_key:
+            from datus.utils.exceptions import DatusException, ErrorCode
+
+            raise DatusException(ErrorCode.COMMON_ENV, message_args={"env_var": "ORCAROUTER_API_KEY"})
+        return api_key
+
+    def _get_base_url(self) -> Optional[str]:
+        """Get OrcaRouter base URL from config or default."""
+        return self.model_config.base_url or "https://api.orcarouter.ai/v1"

--- a/datus/utils/constants.py
+++ b/datus/utils/constants.py
@@ -32,6 +32,7 @@ class LLMProvider(StrEnum):
     GPT = "gpt"  # Alternative name for OpenAI
     CODEX = "codex"  # OpenAI Codex (ChatGPT subscription, OAuth authentication)
     OPENROUTER = "openrouter"  # OpenRouter unified AI gateway
+    ORCAROUTER = "orcarouter"  # OrcaRouter unified AI gateway
 
 
 class EmbeddingProvider(StrEnum):

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -97,7 +97,7 @@ The `agent.models` section is used for self-hosted or private-deployment LLM end
 **Required Parameters per custom entry:**
 
 - **Entry key (`models.<key>`)** — Logical identifier, referenced by `target: {custom: <key>}` or node `model` fields
-- **`type`** — Interface type (`openai`, `claude`, `deepseek`, `kimi`, `gemini`, `minimax`, `glm`, `codex`, `openrouter`)
+- **`type`** — Interface type (`openai`, `claude`, `deepseek`, `kimi`, `gemini`, `minimax`, `glm`, `codex`, `openrouter`, `orcarouter`)
 - **`base_url`** — API endpoint URL
 - **`api_key`** — API key (supports `${ENV_VAR}` substitution)
 - **`model`** — Model name / SKU
@@ -205,12 +205,19 @@ Providers are defined in `conf/providers.yml` and activated by adding credential
 | `minimax` | `MiniMax-M2.7`, `MiniMax-M2.5` | `minimax` | API key |
 | `glm` | `glm-5`, `glm-4.7` | `glm` | API key |
 | `openrouter` | `anthropic/claude-sonnet-4`, `openai/gpt-4o` | `openrouter` | API key |
+| `orcarouter` | `deepseek/deepseek-chat`, `openai/gpt-5.5` | `orcarouter` | API key |
 
 !!! tip "OpenRouter — one key, 300+ models"
     `openrouter` is a unified gateway: a single `OPENROUTER_API_KEY` routes to any
     vendor. Its model names use the `vendor/slug` form (e.g. `google/gemini-2.5-pro`).
     The `/model` picker fetches the full live catalog from OpenRouter and lets you
     type to filter it.
+
+!!! tip "OrcaRouter — one key, 150+ models"
+    `orcarouter` is a unified gateway: a single `ORCAROUTER_API_KEY` routes to any
+    vendor. Its model names use the same `vendor/slug` form (e.g.
+    `deepseek/deepseek-chat`, `orcarouter/auto`). Keys start with `sk-orca-`;
+    get one at https://www.orcarouter.ai/console.
 
 ### Special-auth providers
 
@@ -244,7 +251,7 @@ All providers support environment-variable references in `api_key`, for example:
 api_key: ${OPENAI_API_KEY}
 ```
 
-For OpenAI, DeepSeek, Claude, Kimi, Qwen, Gemini, and OpenRouter, the configuration wizard can prompt with provider-specific environment variable hints (e.g. `${OPENROUTER_API_KEY}`). For `minimax`, `glm`, and the `*_coding` providers, you can still enter values such as `${MINIMAX_API_KEY}`, `${GLM_API_KEY}`, `${KIMI_API_KEY}`, or `${DASHSCOPE_API_KEY}` directly.
+For OpenAI, DeepSeek, Claude, Kimi, Qwen, Gemini, OpenRouter, and OrcaRouter, the configuration wizard can prompt with provider-specific environment variable hints (e.g. `${OPENROUTER_API_KEY}`). For `minimax`, `glm`, and the `*_coding` providers, you can still enter values such as `${MINIMAX_API_KEY}`, `${GLM_API_KEY}`, `${KIMI_API_KEY}`, or `${DASHSCOPE_API_KEY}` directly.
 
 The current implementation also auto-applies fixed parameter overrides for a few models:
 
@@ -274,6 +281,8 @@ With the new provider-level configuration, you only need to set credentials. All
           api_key: ${DASHSCOPE_API_KEY}
         openrouter:
           api_key: ${OPENROUTER_API_KEY}
+        orcarouter:
+          api_key: ${ORCAROUTER_API_KEY}
     ```
 
 === "Claude Subscription"

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -128,11 +128,18 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 | `minimax` | `MiniMax-M2.7`、`MiniMax-M2.5` | `minimax` | API Key |
 | `glm` | `glm-5`、`glm-4.7` | `glm` | API Key |
 | `openrouter` | `anthropic/claude-sonnet-4`、`openai/gpt-4o` | `openrouter` | API Key |
+| `orcarouter` | `deepseek/deepseek-chat`、`openai/gpt-5.5` | `orcarouter` | API Key |
 
 !!! tip "OpenRouter —— 一把 Key，300+ 模型"
     `openrouter` 是统一网关：一个 `OPENROUTER_API_KEY` 即可路由到任意厂商。
     其模型名采用 `vendor/slug` 形式（如 `google/gemini-2.5-pro`）。`/model`
     选择器会拉取 OpenRouter 的完整在线目录，并支持输入关键字过滤。
+
+!!! tip "OrcaRouter —— 一把 Key，150+ 模型"
+    `orcarouter` 是统一网关：一个 `ORCAROUTER_API_KEY` 即可路由到任意厂商。
+    其模型名同样采用 `vendor/slug` 形式（如 `deepseek/deepseek-chat`、
+    `orcarouter/auto`）。Key 以 `sk-orca-` 开头，可在
+    https://www.orcarouter.ai/console 获取。
 
 ### 特殊认证 provider
 
@@ -166,7 +173,7 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 api_key: ${OPENAI_API_KEY}
 ```
 
-对于 OpenAI、DeepSeek、Claude、Kimi、Qwen、Gemini、OpenRouter，配置向导会自动提示对应环境变量（如 `${OPENROUTER_API_KEY}`）。对于 `minimax`、`glm` 和各类 `*_coding` provider，你也可以在输入 API Key 时直接填入 `${MINIMAX_API_KEY}`、`${GLM_API_KEY}`、`${KIMI_API_KEY}`、`${DASHSCOPE_API_KEY}` 这类环境变量引用。
+对于 OpenAI、DeepSeek、Claude、Kimi、Qwen、Gemini、OpenRouter、OrcaRouter，配置向导会自动提示对应环境变量（如 `${OPENROUTER_API_KEY}`）。对于 `minimax`、`glm` 和各类 `*_coding` provider，你也可以在输入 API Key 时直接填入 `${MINIMAX_API_KEY}`、`${GLM_API_KEY}`、`${KIMI_API_KEY}`、`${DASHSCOPE_API_KEY}` 这类环境变量引用。
 
 另外，当前实现会对少数模型自动补充固定参数覆盖：
 
@@ -236,6 +243,15 @@ openrouter:
   base_url: https://openrouter.ai/api/v1
   api_key: ${OPENROUTER_API_KEY}
   model: anthropic/claude-sonnet-4   # vendor/slug 形式
+```
+
+=== "OrcaRouter"
+```yaml
+orcarouter:
+  type: orcarouter
+  base_url: https://api.orcarouter.ai/v1
+  api_key: ${ORCAROUTER_API_KEY}
+  model: deepseek/deepseek-chat      # vendor/slug 形式
 ```
 
 === "Alibaba Coding Plan"

--- a/tests/regression/test_regression_llm.py
+++ b/tests/regression/test_regression_llm.py
@@ -70,6 +70,11 @@ PROVIDER_MODELS = {
         "env_var": "CODEX_OAUTH_TOKEN",  # CI gate only; CodexModel uses OAuthManager token storage
         "models": ["o3-codex"],
     },
+    "R08-orcarouter": {
+        "type": "orcarouter",
+        "env_var": "ORCAROUTER_API_KEY",
+        "models": ["deepseek/deepseek-chat", "openai/gpt-4.1-mini"],
+    },
 }
 
 # Models with restricted sampling parameters (reasoning/thinking models)

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2212,6 +2212,13 @@ class TestProviderConfigurationDispatch:
                     "default_model": "anthropic/claude-sonnet-4",
                     "models": ["anthropic/claude-sonnet-4", "openai/gpt-4o"],
                 },
+                "orcarouter": {
+                    "type": "orcarouter",
+                    "base_url": "https://api.orcarouter.ai/v1",
+                    "api_key_env": "ORCAROUTER_API_KEY",
+                    "default_model": "deepseek/deepseek-chat",
+                    "models": ["deepseek/deepseek-chat", "openai/gpt-5.5"],
+                },
             },
             "model_overrides": {
                 "kimi-k2.5": {"temperature": 1.0, "top_p": 0.95},
@@ -2279,6 +2286,22 @@ class TestProviderConfigurationDispatch:
         assert active.api_key == "sk-or-test"
         assert active.model == "openai/gpt-4o"
         assert active.base_url == "https://openrouter.ai/api/v1"
+
+    def test_orcarouter_provider_synthesizes_orcarouter_model_config(self, tmp_path):
+        """A provider whose catalog ``type`` is ``orcarouter`` resolves to an
+        orcarouter ModelConfig that drives ``OrcaRouterModel`` via MODEL_TYPE_MAP,
+        keeping the full ``vendor/slug`` model name and the gateway base URL."""
+        cfg = self._make(
+            tmp_path,
+            providers={"orcarouter": {"api_key": "sk-orca-test"}},
+            target_provider="orcarouter",
+            target_model="deepseek/deepseek-chat",
+        )
+        active = cfg.active_model()
+        assert active.type == "orcarouter"
+        assert active.api_key == "sk-orca-test"
+        assert active.model == "deepseek/deepseek-chat"
+        assert active.base_url == "https://api.orcarouter.ai/v1"
 
     def test_model_overrides_applied_when_synthesizing(self, tmp_path):
         cfg = self._make(

--- a/tests/unit_tests/models/test_litellm_adapter.py
+++ b/tests/unit_tests/models/test_litellm_adapter.py
@@ -178,6 +178,42 @@ class TestOpenRouterModelName:
         assert adapter.litellm_model_name == "openrouter/anthropic/claude-sonnet-4"
 
 
+class TestOrcaRouterModelName:
+    def test_orcarouter_prefixes_vendor_slug(self):
+        """OrcaRouter namespaced models need the openai/ prefix so LiteLLM strips
+        it and routes the full vendor/slug namespace to the OrcaRouter base URL."""
+        adapter = LiteLLMAdapter(provider="orcarouter", model="deepseek/deepseek-chat", api_key="key")
+        assert adapter.litellm_model_name == "openai/deepseek/deepseek-chat"
+
+    def test_orcarouter_prefixes_own_namespace(self):
+        """Models in the orcarouter/ namespace (e.g. orcarouter/auto) keep the
+        namespace behind the openai/ provider prefix."""
+        adapter = LiteLLMAdapter(provider="orcarouter", model="orcarouter/auto", api_key="key")
+        assert adapter.litellm_model_name == "openai/orcarouter/auto"
+
+    def test_orcarouter_keeps_full_namespace_even_when_openai_prefixed(self):
+        """A model that already carries the openai/ namespace must still reach
+        OrcaRouter with its full id, so the provider prefix is added unconditionally."""
+        adapter = LiteLLMAdapter(provider="orcarouter", model="openai/gpt-5.5", api_key="key")
+        assert adapter.litellm_model_name == "openai/openai/gpt-5.5"
+
+    def test_orcarouter_default_base_url(self):
+        """OrcaRouter's OpenAI-compatible base URL is registered as the default."""
+        adapter = LiteLLMAdapter(provider="orcarouter", model="deepseek/deepseek-chat", api_key="key")
+        assert adapter.base_url == "https://api.orcarouter.ai/v1"
+
+    def test_orcarouter_not_autodetected(self):
+        """Namespaced models should NOT be auto-detected away from the gateway."""
+        adapter = LiteLLMAdapter(provider="orcarouter", model="deepseek/deepseek-chat", api_key="key")
+        assert adapter.provider == "orcarouter"
+
+    def test_orcarouter_unprefixed_deepseek_stays_orcarouter(self):
+        """Unprefixed model like deepseek-chat should NOT be auto-detected away."""
+        adapter = LiteLLMAdapter(provider="orcarouter", model="deepseek-chat", api_key="key")
+        assert adapter.provider == "orcarouter"
+        assert adapter.litellm_model_name == "openai/deepseek-chat"
+
+
 class TestGetCompletionKwargs:
     def test_includes_model(self):
         adapter = LiteLLMAdapter(provider="openai", model="gpt-4o", api_key="sk-test")

--- a/tests/unit_tests/models/test_orcarouter_model.py
+++ b/tests/unit_tests/models/test_orcarouter_model.py
@@ -39,9 +39,7 @@ def _make_model_config(model="deepseek/deepseek-chat", api_key=None, base_url=No
 
 class TestOrcaRouterModel:
     def test_uses_configured_api_key_and_base_url(self):
-        model = OrcaRouterModel(
-            _make_model_config(api_key="sk-orca-test", base_url="https://custom.example/v1")
-        )
+        model = OrcaRouterModel(_make_model_config(api_key="sk-orca-test", base_url="https://custom.example/v1"))
         assert model.api_key == "sk-orca-test"
         assert model.base_url == "https://custom.example/v1"
 

--- a/tests/unit_tests/models/test_orcarouter_model.py
+++ b/tests/unit_tests/models/test_orcarouter_model.py
@@ -1,0 +1,62 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Unit tests for datus/models/orcarouter_model.py.
+
+CI-level: zero external dependencies. All LiteLLM / OpenAI SDK calls mocked.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.models.orcarouter_model import OrcaRouterModel
+from datus.utils.exceptions import DatusException, ErrorCode
+
+
+def _make_model_config(model="deepseek/deepseek-chat", api_key=None, base_url=None):
+    cfg = MagicMock()
+    cfg.model = model
+    cfg.type = "orcarouter"
+    cfg.api_key = api_key
+    cfg.base_url = base_url
+    cfg.temperature = None
+    cfg.top_p = None
+    cfg.enable_thinking = False
+    cfg.reasoning_effort = None
+    cfg.default_headers = None
+    cfg.max_retry = 3
+    cfg.retry_interval = 0.0
+    cfg.strict_json_schema = True
+    cfg.save_llm_trace = False
+    cfg.auth_type = "api_key"
+    cfg.use_native_api = False
+    cfg.ssl_verify = None
+    return cfg
+
+
+class TestOrcaRouterModel:
+    def test_uses_configured_api_key_and_base_url(self):
+        model = OrcaRouterModel(
+            _make_model_config(api_key="sk-orca-test", base_url="https://custom.example/v1")
+        )
+        assert model.api_key == "sk-orca-test"
+        assert model.base_url == "https://custom.example/v1"
+
+    def test_api_key_falls_back_to_environment(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-env")
+        model = OrcaRouterModel(_make_model_config(api_key=None))
+        assert model.api_key == "sk-orca-env"
+
+    def test_missing_api_key_raises_datus_exception(self, monkeypatch):
+        monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+        with pytest.raises(DatusException) as exc_info:
+            OrcaRouterModel(_make_model_config(api_key=None))
+        assert exc_info.value.code == ErrorCode.COMMON_ENV
+
+    def test_base_url_defaults_to_orcarouter_gateway(self, monkeypatch):
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-env")
+        model = OrcaRouterModel(_make_model_config(api_key=None, base_url=None))
+        assert model.base_url == "https://api.orcarouter.ai/v1"


### PR DESCRIPTION
## Why

Datus already treats OpenRouter as a unified-gateway provider (`type: openrouter`) - one API key routes to hundreds of models across vendors. OrcaRouter is the same kind of OpenAI-compatible gateway: a single key exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen and more behind one endpoint. Adding it as a named provider lets users switch to OrcaRouter through the existing `/model` flow and `agent.providers` config, without hand-writing a custom endpoint or a LiteLLM model name.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint - screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Solution

Mirror the existing OpenRouter wiring end to end:

- `datus/utils/constants.py` - new `LLMProvider.ORCAROUTER` enum value.
- `datus/models/base.py` - `MODEL_TYPE_MAP` entry routing `type: orcarouter` to `OrcaRouterModel`.
- `datus/models/orcarouter_model.py` (new) - thin wrapper over `OpenAICompatibleModel`, reads `ORCAROUTER_API_KEY`, defaults the base URL to `https://api.orcarouter.ai/v1`.
- `datus/models/litellm_adapter.py` - `orcarouter` maps to the `openai/` LiteLLM provider prefix with the gateway base URL registered as the default. `_get_litellm_model_name` always prepends `openai/` so LiteLLM strips the provider segment and the full `vendor/slug` namespace reaches OrcaRouter (e.g. `deepseek/deepseek-chat`). Auto-detection is skipped for `orcarouter`, same as OpenRouter.
- `conf/providers.yml` + `datus/conf/providers.yml` - catalog entry with an offline model list; `agent.providers.orcarouter` in `conf/agent.yml.example`.
- Docs (`docs/configuration/agent.md`, `agent.zh.md`), unit tests, and a regression provider entry.

## Test Cases

- `tests/unit_tests/models/test_litellm_adapter.py` - new `TestOrcaRouterModelName` covering the `openai/` prefix (namespaced, `orcarouter/auto`, already-`openai/`-prefixed), the default base URL, and detection skip.
- `tests/unit_tests/models/test_orcarouter_model.py` (new) - instantiates `OrcaRouterModel` to cover `_get_api_key` (config value, `ORCAROUTER_API_KEY` env fallback, missing-key `DatusException`) and `_get_base_url` (custom base URL and gateway default).
- `tests/unit_tests/configuration/test_agent_config.py` - `test_orcarouter_provider_synthesizes_orcarouter_model_config` (catalog `type: orcarouter` resolves to an `orcarouter` `ModelConfig`).
- `tests/regression/test_regression_llm.py` - `R08-orcarouter` added to `PROVIDER_MODELS` (nightly, gated on `ORCAROUTER_API_KEY`).
- Live verification against the exact endpoint and LiteLLM wiring this PR registers:
  - `GET https://api.orcarouter.ai/v1/models` -> 200, 189 models listed
  - `POST https://api.orcarouter.ai/v1/chat/completions` with `deepseek/deepseek-chat` -> 200 with the expected reply
  - invalid key -> 401 (fails loud, no silent fallback)
  - Adapter model-name resolution run against the modified `litellm_adapter.py` source: `deepseek/deepseek-chat` -> `openai/deepseek/deepseek-chat`, `openai/gpt-5.5` -> `openai/openai/gpt-5.5`, `orcarouter/auto` -> `openai/orcarouter/auto`; existing providers unchanged.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported AI provider.
  * Supports OrcaRouter’s OpenAI-compatible gateway, configurable API keys, default models, and fallback models.
  * Added provider discovery and configuration wizard support.

* **Documentation**
  * Added English and Chinese setup guidance, credential instructions, model naming details, and configuration examples.

* **Tests**
  * Added coverage for provider configuration, model routing, credentials, endpoints, and supported model formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported AI provider.
  * Supports OrcaRouter’s OpenAI-compatible gateway, API-key configuration, default models, and fallback models.
  * Added provider discovery and configuration wizard support.

* **Documentation**
  * Added English and Chinese setup guidance, credential instructions, model naming details, and configuration examples.

* **Tests**
  * Added coverage for provider configuration, model routing, credentials, endpoints, and supported model formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->