### PR TITLE
[BugFix] Use reliable California school metric seeds

### DIFF
--- a/datus/sample_data/california_schools/success_story.csv
+++ b/datus/sample_data/california_schools/success_story.csv
@@ -1,3 +1,4 @@
 question,sql
-Please list the lowest three eligible free rates for students aged 5-17 in continuation schools.,SELECT `Free Meal Count (Ages 5-17)` / `Enrollment (Ages 5-17)` FROM frpm WHERE `Educational Option Type` = 'Continuation School' AND `Free Meal Count (Ages 5-17)` / `Enrollment (Ages 5-17)` IS NOT NULL ORDER BY `Free Meal Count (Ages 5-17)` / `Enrollment (Ages 5-17)` ASC LIMIT 3
-Please list the zip code of all the charter schools in Fresno County Office of Education.,SELECT T2.Zip FROM frpm AS T1 INNER JOIN schools AS T2 ON T1.CDSCode = T2.CDSCode WHERE T1.`District Name` = 'Fresno County Office of Education' AND T1.`Charter School (Y/N)` = 1
+How many schools are in the California school directory?,SELECT COUNT(DISTINCT CDSCode) AS school_count FROM schools
+How many charter schools are in the California school directory?,SELECT SUM(Charter) AS charter_school_count FROM schools
+How many magnet schools are in the California school directory?,SELECT SUM(Magnet) AS magnet_school_count FROM schools


### PR DESCRIPTION
## Summary

- replace the California Schools ranking/detail SQL seeds with three explicit aggregate metric queries
- cover total schools, charter schools, and magnet schools using the `schools` table
- keep the nightly bootstrap input focused on SQL that maps directly to reusable metrics

## Why

The previous success-story rows were a ranked free-meal-rate query and a detail join returning school ZIP codes. They did not provide stable, reusable aggregate metric definitions for the nightly semantic-model and metric generation flow.

This change uses single-table aggregate queries with explicit output aliases, so the generated measures and metrics can be validated against the source SQLite data.

Related failing run: https://github.com/Datus-ai/Datus-agent/actions/runs/31429991241

## Validation

- metadata bootstrap succeeded: 4 tables / 3 values
- metrics bootstrap succeeded: 3 metrics generated
- MetricFlow live results matched the source SQLite queries:
  - `school_count = 17686`
  - `charter_school_count = 1729`
  - `magnet_school_count = 519`
- `pytest -m nightly tests/integration/tools/test_context_search.py::TestContextSearchTools::test_search_metrics tests/integration/tools/test_context_search.py::TestContextSearchTools::test_get_metrics`: 2 passed
- `pytest -m nightly tests/integration/agent/test_gen_metrics_agentic.py`: 4 passed

The full nightly suite was not run.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
