### PR TITLE
[Enhancement] Integrate adapter dialect operations and database skills

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -159,6 +159,7 @@ jobs:
             --reinstall-package datus-snowflake \
             --reinstall-package datus-doris \
             --reinstall-package datus-hologres \
+            --reinstall-package datus-oracle \
             --reinstall-package datus-storage-base \
             --reinstall-package datus-storage-postgresql \
             pytest-playwright \
@@ -177,6 +178,7 @@ jobs:
             ./external/datus-db-adapters/datus-starrocks \
             ./external/datus-db-adapters/datus-doris \
             ./external/datus-db-adapters/datus-hologres \
+            ./external/datus-db-adapters/datus-oracle \
             ./external/datus-db-adapters/datus-trino \
             ./external/datus-db-adapters/datus-greenplum \
             ./external/datus-db-adapters/datus-hive \

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -34,6 +34,7 @@ PACKAGE_NAMES = (
     "datus-starrocks",
     "datus-doris",
     "datus-hologres",
+    "datus-oracle",
     "datus-trino",
     "datus-greenplum",
     "datus-hive",

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -50,6 +50,7 @@ class DatabaseAdapterContract(BaseModel):
     db_type: str
     parser_dialect: str | None = None
     required_hooks: tuple[str, ...] = ()
+    dialect_operation_methods: tuple[str, ...] = ()
 
 
 DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
@@ -63,6 +64,13 @@ DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
         db_type="oracle",
         parser_dialect="oracle",
         required_hooks=("get_sql_generation_notes", "get_dialect_operations"),
+        dialect_operation_methods=(
+            "render_limit",
+            "render_count",
+            "quote_identifier",
+            "infer_transfer_type",
+            "write_dataframe",
+        ),
     ),
 }
 
@@ -163,10 +171,24 @@ def verify_database_adapter_imports() -> list[str]:
         if expected_parser and registry.get_parser_dialect(db_type) != expected_parser:
             errors.append(f"{module_name} parser dialect is not {expected_parser}")
 
+        registered_hooks = {}
         for hook_name in contract.required_hooks:
             getter = getattr(registry, hook_name, None)
-            if not callable(getter) or not getter(db_type):
+            hook = getter(db_type) if callable(getter) else None
+            if not hook:
                 errors.append(f"{module_name} did not register {hook_name}")
+            else:
+                registered_hooks[hook_name] = hook
+
+        operations = registered_hooks.get("get_dialect_operations")
+        if operations is not None:
+            missing_methods = [
+                name for name in contract.dialect_operation_methods if not callable(getattr(operations, name, None))
+            ]
+            if missing_methods:
+                errors.append(
+                    f"{module_name} dialect operations are missing callable methods: {', '.join(missing_methods)}"
+                )
 
     return errors
 

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -23,6 +23,7 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-starrocks": "datus-db-adapters/datus-starrocks",
     "datus-doris": "datus-db-adapters/datus-doris",
     "datus-hologres": "datus-db-adapters/datus-hologres",
+    "datus-oracle": "datus-db-adapters/datus-oracle",
     "datus-trino": "datus-db-adapters/datus-trino",
     "datus-greenplum": "datus-db-adapters/datus-greenplum",
     "datus-hive": "datus-db-adapters/datus-hive",
@@ -57,6 +58,11 @@ DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
         db_type="hologres",
         parser_dialect="postgres",
         required_hooks=("get_identifier_parser", "get_sql_generation_notes"),
+    ),
+    "datus_oracle": DatabaseAdapterContract(
+        db_type="oracle",
+        parser_dialect="oracle",
+        required_hooks=("get_sql_generation_notes", "get_dialect_operations"),
     ),
 }
 

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2415,7 +2415,11 @@ class AgenticNode(Node):
         if not self.agent_config:
             return []
         getter = getattr(self.agent_config, "current_db_configs", None)
-        configs = getter() if callable(getter) else getattr(self.agent_config, "datasource_configs", {})
+        try:
+            configs = getter() if callable(getter) else getattr(self.agent_config, "datasource_configs", {})
+        except Exception as exc:
+            logger.debug("Failed to read database configs for skill candidates: %s", exc)
+            return []
         if not isinstance(configs, dict):
             return []
 
@@ -2466,6 +2470,7 @@ class AgenticNode(Node):
         if not skills_to_inject:
             return base_prompt
 
+        required_skill_names = set(required_skills)
         sections = []
         for skill_name in skills_to_inject:
             success, message, content = self.skill_manager.load_skill(
@@ -2475,6 +2480,9 @@ class AgenticNode(Node):
                 node_class=self.get_node_class_name(),
             )
             if not success or not content:
+                if skill_name not in required_skill_names:
+                    logger.debug("Skipping optional database skill '%s': %s", skill_name, message)
+                    continue
                 from datus.utils.exceptions import DatusException, ErrorCode
 
                 raise DatusException(
@@ -2489,6 +2497,8 @@ class AgenticNode(Node):
             sections.append(f"<required_skill name={xml_quoteattr(skill_name)}>\n{content}\n</required_skill>")
             logger.info(f"Injected required skill '{skill_name}' into system prompt for '{self.get_node_name()}'")
 
+        if not sections:
+            return base_prompt
         return base_prompt + "\n\n" + "\n\n".join(sections)
 
     @staticmethod

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2410,6 +2410,24 @@ class AgenticNode(Node):
             return []
         return [pattern.strip() for pattern in patterns.split(",") if pattern.strip()]
 
+    def _get_database_skill_candidates(self) -> List[str]:
+        """Return conventional skill names for the configured database types."""
+        if not self.agent_config:
+            return []
+        getter = getattr(self.agent_config, "current_db_configs", None)
+        configs = getter() if callable(getter) else getattr(self.agent_config, "datasource_configs", {})
+        if not isinstance(configs, dict):
+            return []
+
+        candidates = []
+        for config in configs.values():
+            db_type = config.get("type", "") if isinstance(config, dict) else getattr(config, "type", "")
+            db_type = getattr(db_type, "value", db_type)
+            normalized = str(db_type or "").strip().lower().replace("_", "-")
+            if normalized:
+                candidates.append(f"db-{normalized}-sql")
+        return list(dict.fromkeys(candidates))
+
     def _inject_required_skills(self, base_prompt: str) -> str:
         """Append required-skill content to the system prompt deterministically.
 
@@ -2425,7 +2443,8 @@ class AgenticNode(Node):
                 fails fast instead.
         """
         required_skills = self._get_required_skills()
-        if not required_skills:
+        database_candidates = self._get_database_skill_candidates()
+        if not required_skills and not database_candidates:
             return base_prompt
 
         if not self.skill_manager:
@@ -2439,8 +2458,16 @@ class AgenticNode(Node):
 
         from xml.sax.saxutils import quoteattr as xml_quoteattr
 
+        # Database skills follow a convention but remain adapter-optional. Only
+        # inject candidates actually contributed by an installed adapter; class-
+        # declared required skills retain their fail-fast contract.
+        database_skills = [name for name in database_candidates if self.skill_manager.get_skill(name) is not None]
+        skills_to_inject = list(dict.fromkeys([*required_skills, *database_skills]))
+        if not skills_to_inject:
+            return base_prompt
+
         sections = []
-        for skill_name in required_skills:
+        for skill_name in skills_to_inject:
             success, message, content = self.skill_manager.load_skill(
                 skill_name,
                 self.get_node_name(),

--- a/datus/cli/datasource_app.py
+++ b/datus/cli/datasource_app.py
@@ -49,6 +49,7 @@ INSTALLABLE_TYPES = (
     "hive",
     "hologres",
     "mysql",
+    "oracle",
     "postgresql",
     "redshift",
     "snowflake",

--- a/datus/tools/db_tools/__init__.py
+++ b/datus/tools/db_tools/__init__.py
@@ -4,7 +4,7 @@
 
 from datus_db_core import AdapterMetadata, BaseSqlConnector, ConnectorRegistry, connector_registry
 
-from .capabilities import get_effective_capabilities, supports_namespace
+from .capabilities import get_dialect_operations, get_effective_capabilities, supports_namespace
 from .sqlite_connector import SQLiteConnector
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "connector_registry",
     "ConnectorRegistry",
     "AdapterMetadata",
+    "get_dialect_operations",
     "get_effective_capabilities",
     "supports_namespace",
 ]

--- a/datus/tools/db_tools/capabilities.py
+++ b/datus/tools/db_tools/capabilities.py
@@ -34,3 +34,16 @@ def get_effective_capabilities(connector: Optional[Any] = None, dialect: str = "
 
 def supports_namespace(namespace: str, connector: Optional[Any] = None, dialect: str = "") -> bool:
     return namespace in get_effective_capabilities(connector=connector, dialect=dialect)
+
+
+def get_dialect_operations(connector: Optional[Any] = None, dialect: str = "") -> Optional[Any]:
+    """Return adapter-provided deterministic SQL operations when available.
+
+    ``datus-db-core`` added this optional registry hook after Agent 0.3.9. Use
+    ``getattr`` so an Agent environment that still has the older core keeps its
+    existing behavior until an adapter requiring the new capability upgrades it.
+    """
+    if connector is not None:
+        dialect = dialect or getattr(connector, "dialect", "")
+    getter = getattr(connector_registry, "get_dialect_operations", None)
+    return getter(str(dialect or "").strip().lower()) if callable(getter) else None

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -24,7 +24,11 @@ from datus.storage.schema_metadata import create_metadata_rag
 from datus.storage.schema_metadata.store import SchemaWithValueRAG
 from datus.storage.semantic_model.store import SemanticModelRAG
 from datus.storage.table_semantic_profile.store import TableSemanticProfileRAG
-from datus.tools.db_tools.capabilities import get_effective_capabilities, supports_namespace
+from datus.tools.db_tools.capabilities import (
+    get_dialect_operations,
+    get_effective_capabilities,
+    supports_namespace,
+)
 from datus.tools.db_tools.db_manager import DBManager, db_manager_instance
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.utils.compress_utils import DataCompressor
@@ -346,6 +350,10 @@ class DBFuncTool:
     def connector(self) -> BaseSqlConnector:
         """Get the primary/default connector (for backward compatibility)."""
         return self._primary_connector
+
+    def dialect_operations(self, datasource: Optional[str] = "", database: str = "") -> Optional[Any]:
+        """Resolve optional deterministic SQL operations for a routed connector."""
+        return get_dialect_operations(connector=self._get_connector(datasource, database))
 
     def _get_connector(self, datasource: Optional[str] = None, database: str = "") -> BaseSqlConnector:
         """
@@ -2126,6 +2134,7 @@ class DBFuncTool:
             )
 
         dialect = str(getattr(target_conn, "dialect", "") or "").lower()
+        operations = get_dialect_operations(connector=target_conn)
         seen_columns = set()
         column_defs = []
         try:
@@ -2137,10 +2146,17 @@ class DBFuncTool:
                         error=f"Cannot create target table because source query returned duplicate column '{column}'",
                     )
                 seen_columns.add(column_key)
-                column_defs.append(
-                    f"  {self._quote_column_identifier(column, dialect)} "
-                    f"{self._infer_transfer_column_type(df[column], dialect)}"
+                quoted_column = (
+                    operations.quote_identifier(column)
+                    if operations is not None
+                    else self._quote_column_identifier(column, dialect)
                 )
+                column_type = (
+                    operations.infer_transfer_type(df[column])
+                    if operations is not None
+                    else self._infer_transfer_column_type(df[column], dialect)
+                )
+                column_defs.append(f"  {quoted_column} {column_type}")
         except Exception as e:
             return FuncToolResult(success=0, error=f"Failed to infer target table schema: {str(e)}")
 
@@ -2241,6 +2257,9 @@ class DBFuncTool:
                 "Do NOT fall back to a different target datasource — STOP and report this error to the user.",
             )
 
+        source_operations = get_dialect_operations(connector=source_conn)
+        target_operations = get_dialect_operations(connector=target_conn)
+
         # Authoritative source row count — wrap the user's source_sql in a COUNT
         # subquery so reconciliation does not need to re-run anything later.
         # One extra query is cheap on OLTP engines and still acceptable on
@@ -2248,7 +2267,11 @@ class DBFuncTool:
         source_row_count: Optional[int] = None
         try:
             if hasattr(source_conn, "execute_query"):
-                count_sql = f"SELECT COUNT(*) AS __datus_count FROM ({cleaned_sql}) AS __datus_src"
+                count_sql = (
+                    source_operations.render_count(cleaned_sql, "__datus_src")
+                    if source_operations is not None
+                    else f"SELECT COUNT(*) AS __datus_count FROM ({cleaned_sql}) AS __datus_src"
+                )
                 count_result = source_conn.execute_query(count_sql)
                 if count_result.success and count_result.sql_return:
                     # execute_query returns a list of rows; first row, first col is the count
@@ -2362,47 +2385,53 @@ class DBFuncTool:
         # Also convert numpy types to native Python types
         df = df.astype(object).where(df.notna(), other=None)
 
-        # Batch INSERT using connector's execute_insert (adapter-agnostic)
-        # Quote column names to handle reserved words (e.g., status, order, select).
-        # Use dialect-appropriate quoting: backticks for MySQL/StarRocks, double quotes for others.
-        columns = list(df.columns)
-        dialect = str(getattr(target_conn, "dialect", "") or "").lower()
-        col_names = ", ".join(self._quote_column_identifier(c, dialect) for c in columns)
-
         rows_written = 0
         try:
-            for batch_start in range(0, row_count, batch_size):
-                batch_end = min(batch_start + batch_size, row_count)
-                batch_df = df.iloc[batch_start:batch_end]
-
-                # Build batch INSERT statement with inline values
-                value_rows = []
-                for _, row in batch_df.iterrows():
-                    values = []
-                    for val in row:
-                        if val is None:
-                            values.append("NULL")
-                        elif isinstance(val, bool):
-                            values.append("TRUE" if val else "FALSE")
-                        elif isinstance(val, (int, float)):
-                            values.append(str(val))
-                        else:
-                            escaped = str(val).replace("'", "''")
-                            values.append(f"'{escaped}'")
-                    value_rows.append(f"({', '.join(values)})")
-
-                insert_sql = f"INSERT INTO {target_table} ({col_names}) VALUES {', '.join(value_rows)}"
-                result = target_conn.execute_insert(insert_sql)
-                if not result.success:
-                    return FuncToolResult(
-                        success=0,
-                        error=f"Transfer failed after writing {rows_written} rows: {result.error}",
+            if target_operations is not None:
+                rows_written = int(
+                    target_operations.write_dataframe(
+                        target_conn,
+                        target_table,
+                        df,
+                        batch_size,
                     )
-                rows_written += len(batch_df)
+                )
+            else:
+                # Legacy adapters keep the existing inline multi-row INSERT path.
+                columns = list(df.columns)
+                dialect = str(getattr(target_conn, "dialect", "") or "").lower()
+                col_names = ", ".join(self._quote_column_identifier(c, dialect) for c in columns)
+                for batch_start in range(0, row_count, batch_size):
+                    batch_end = min(batch_start + batch_size, row_count)
+                    batch_df = df.iloc[batch_start:batch_end]
 
-            # Commit the transaction to release locks (critical for SQLAlchemy-based connectors)
-            if hasattr(target_conn, "connection") and hasattr(target_conn.connection, "commit"):
-                target_conn.connection.commit()
+                    value_rows = []
+                    for _, row in batch_df.iterrows():
+                        values = []
+                        for val in row:
+                            if val is None:
+                                values.append("NULL")
+                            elif isinstance(val, bool):
+                                values.append("TRUE" if val else "FALSE")
+                            elif isinstance(val, (int, float)):
+                                values.append(str(val))
+                            else:
+                                escaped = str(val).replace("'", "''")
+                                values.append(f"'{escaped}'")
+                        value_rows.append(f"({', '.join(values)})")
+
+                    insert_sql = f"INSERT INTO {target_table} ({col_names}) VALUES {', '.join(value_rows)}"
+                    result = target_conn.execute_insert(insert_sql)
+                    if not result.success:
+                        return FuncToolResult(
+                            success=0,
+                            error=f"Transfer failed after writing {rows_written} rows: {result.error}",
+                        )
+                    rows_written += len(batch_df)
+
+                # Commit the transaction to release locks (critical for SQLAlchemy-based connectors)
+                if hasattr(target_conn, "connection") and hasattr(target_conn.connection, "commit"):
+                    target_conn.connection.commit()
 
         except Exception as e:
             return FuncToolResult(

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -351,10 +351,6 @@ class DBFuncTool:
         """Get the primary/default connector (for backward compatibility)."""
         return self._primary_connector
 
-    def dialect_operations(self, datasource: Optional[str] = "", database: str = "") -> Optional[Any]:
-        """Resolve optional deterministic SQL operations for a routed connector."""
-        return get_dialect_operations(connector=self._get_connector(datasource, database))
-
     def _get_connector(self, datasource: Optional[str] = None, database: str = "") -> BaseSqlConnector:
         """
         Get connector for the specified (datasource, database).

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -444,7 +444,7 @@ class SemanticDiscoveryTools:
             database=database,
             schema_name=schema_name,
         )
-        column_refs = [self._quote_sql_identifier(column) for column in normalized_columns]
+        column_refs = [self._quote_sql_identifier(column, database) for column in normalized_columns]
         null_predicate = " OR ".join(f"{column_ref} IS NULL" for column_ref in column_refs)
         non_null_predicate = " AND ".join(f"{column_ref} IS NOT NULL" for column_ref in column_refs)
         grouped_columns = ", ".join(column_refs)
@@ -1681,7 +1681,7 @@ class SemanticDiscoveryTools:
         database: str,
         top_n: int,
     ) -> Dict[str, Any]:
-        column_ref = self._quote_sql_identifier(column_name)
+        column_ref = self._quote_sql_identifier(column_name, database)
         stats_exprs = [
             "COUNT(*) AS row_count",
             f"COUNT({column_ref}) AS non_null_count",
@@ -1714,10 +1714,12 @@ class SemanticDiscoveryTools:
                     profile["temporal_summary"] = temporal_summary
 
         if kind in {"categorical", "boolean"} and top_n > 0:
-            top_sql = (
+            top_sql = self._render_profile_limit(
                 f"SELECT {column_ref} AS value, COUNT(*) AS count "
                 f"FROM {table_ref} WHERE {column_ref} IS NOT NULL "
-                f"GROUP BY {column_ref} ORDER BY count DESC LIMIT {max(top_n, 1)}"
+                f"GROUP BY {column_ref} ORDER BY count DESC",
+                max(top_n, 1),
+                database,
             )
             top_values = self._run_profile_rows_query(top_sql, database)
             top_values = [row for row in top_values if isinstance(row, dict) and not row.get("error")]
@@ -1806,11 +1808,13 @@ class SemanticDiscoveryTools:
                 break
             left_column = pair["left_column"]
             right_column = pair["right_column"]
-            left_ref = self._quote_sql_identifier(left_column)
-            right_ref = self._quote_sql_identifier(right_column)
-            sql = (
+            left_ref = self._quote_sql_identifier(left_column, database)
+            right_ref = self._quote_sql_identifier(right_column, database)
+            sql = self._render_profile_limit(
                 f"SELECT {left_ref} AS left_value, {right_ref} AS right_value "
-                f"FROM {table_ref} WHERE {left_ref} IS NOT NULL AND {right_ref} IS NOT NULL LIMIT 1000"
+                f"FROM {table_ref} WHERE {left_ref} IS NOT NULL AND {right_ref} IS NOT NULL",
+                1000,
+                database,
             )
             rows = self._run_profile_rows_query(sql, database)
             deltas = []
@@ -1950,8 +1954,8 @@ class SemanticDiscoveryTools:
             seen.add(key)
             source_ref = self._profile_table_reference(source_table, catalog, database, schema_name)
             target_ref = self._profile_table_reference(target_table, catalog, database, schema_name)
-            source_col_refs = [self._quote_sql_identifier(column) for column in source_columns]
-            target_col_refs = [self._quote_sql_identifier(column) for column in target_columns]
+            source_col_refs = [self._quote_sql_identifier(column, database) for column in source_columns]
+            target_col_refs = [self._quote_sql_identifier(column, database) for column in target_columns]
             join_condition = " AND ".join(
                 f"src.{source_column} = tgt.{target_column}"
                 for source_column, target_column in zip(source_col_refs, target_col_refs)
@@ -2075,7 +2079,7 @@ class SemanticDiscoveryTools:
         if "." in table_name:
             return table_name
         parts = [part for part in (catalog, database, schema_name, table_name) if part]
-        return ".".join(self._quote_sql_identifier(part) for part in parts)
+        return ".".join(self._quote_sql_identifier(part, database) for part in parts)
 
     def _validate_key_candidate_columns(self, columns: List[str]) -> List[str]:
         if not isinstance(columns, list) or not columns:
@@ -2106,7 +2110,7 @@ class SemanticDiscoveryTools:
             ]
         if not parts or any(not part for part in parts):
             raise ValueError("table_name contains an empty qualified-name component")
-        return ".".join(self._quote_sql_identifier(part) for part in parts)
+        return ".".join(self._quote_sql_identifier(part, database) for part in parts)
 
     def _required_profile_count(self, stats: Dict[str, Any], key: str) -> int:
         value = self._profile_number(self._profile_stat_value(stats, key))
@@ -2131,7 +2135,20 @@ class SemanticDiscoveryTools:
                 return value
         return None
 
-    def _quote_sql_identifier(self, value: str) -> str:
+    def _dialect_operations(self, database: str = "") -> Optional[Any]:
+        resolver = getattr(self.db_tool, "dialect_operations", None)
+        return resolver(database=database) if callable(resolver) else None
+
+    def _render_profile_limit(self, sql: str, limit: int, database: str) -> str:
+        operations = self._dialect_operations(database)
+        if operations is not None:
+            return operations.render_limit(sql, limit)
+        return f"{sql} LIMIT {int(limit)}"
+
+    def _quote_sql_identifier(self, value: str, database: str = "") -> str:
+        operations = self._dialect_operations(database)
+        if operations is not None:
+            return operations.quote_identifier(value)
         value = str(value).strip().strip('"`[]')
         if value and value.replace("_", "").isalnum() and not value[0].isdigit():
             return value

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -28,6 +28,7 @@ This design keeps the core package lightweight while allowing you to add support
 | Trino | datus-trino | `pip install datus-trino` | Ready |
 | Apache Doris | datus-doris | `pip install datus-doris` | Ready |
 | Hologres | datus-hologres | `pip install datus-hologres` | Ready |
+| Oracle | datus-oracle | `pip install datus-oracle` | Ready |
 
 ## Installation
 
@@ -72,6 +73,9 @@ pip install datus-doris
 
 # Hologres
 pip install datus-hologres
+
+# Oracle
+pip install datus-oracle
 ```
 
 Once installed, Datus Agent will automatically detect and load the adapter.
@@ -271,6 +275,22 @@ Hologres (Alibaba Cloud) uses the PostgreSQL wire protocol with AccessKey creden
 accepts either a plain hostname or a `hostname:port` console endpoint; an explicit `port` must match an
 embedded one.
 
+### Oracle
+
+```yaml
+oracle_data:
+  type: oracle
+  host: localhost
+  port: 1521
+  username: datus_user
+  password: your_password
+  service_name: FREEPDB1
+  schema: DATUS_USER
+```
+
+Configure exactly one connection target: `service_name` (recommended), `sid`, or `dsn`. The service/PDB
+selects the connection target but is not part of an SQL object name; qualify objects as `SCHEMA.TABLE`.
+
 ### Multiple Database Entries
 
 ```yaml
@@ -371,6 +391,12 @@ All adapters support:
 - Console endpoint normalization (`hostname` or `hostname:port`)
 - SSL connection modes (disable, allow, prefer, require, verify-ca, verify-full)
 
+#### Oracle
+- Oracle Database 19c SQL and PL/SQL syntax guidance through the adapter-provided skill
+- Service name, SID, or DSN connection targets
+- Schema-scoped metadata discovery through `ALL_*` dictionary views
+- Oracle-compatible profiling and bound-parameter data transfers
+
 ## Troubleshooting
 
 ### Adapter Not Found
@@ -403,6 +429,7 @@ Some adapters require additional system dependencies:
 - **Trino**: Requires `trino` (installed automatically)
 - **Apache Doris**: Requires `datus-mysql` and `pymysql` (installed automatically)
 - **Hologres**: Requires `datus-postgresql` and `psycopg2-binary` (installed automatically)
+- **Oracle**: Requires `oracledb` (installed automatically; Thin mode needs no Oracle Client)
 
 ## Architecture
 
@@ -422,7 +449,8 @@ datus-agent (Core)
     │   ├── datus-hive
     │   ├── datus-spark
     │   ├── datus-clickhouse
-    │   └── datus-trino
+    │   ├── datus-trino
+    │   └── datus-oracle
     │
     └── Native SDK Adapters
         ├── datus-snowflake

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -28,6 +28,7 @@ Datus 使用模块化适配器架构，允许连接不同的数据库：
 | Trino | datus-trino | `pip install datus-trino` | 可用 |
 | Apache Doris | datus-doris | `pip install datus-doris` | 可用 |
 | Hologres | datus-hologres | `pip install datus-hologres` | 可用 |
+| Oracle | datus-oracle | `pip install datus-oracle` | 可用 |
 
 ## 安装
 
@@ -69,6 +70,9 @@ pip install datus-doris
 
 # Hologres
 pip install datus-hologres
+
+# Oracle
+pip install datus-oracle
 ```
 
 安装后，Datus Agent 会自动检测并加载适配器。
@@ -263,6 +267,22 @@ Hologres（阿里云）使用 PostgreSQL wire 协议和 AccessKey 凭证。`acce
 也可作为 `username`/`password` 的别名。`host` 支持纯 hostname 或 `hostname:port` 形式的控制台
 endpoint；显式配置的 `port` 必须与 endpoint 中内嵌的端口一致。
 
+### Oracle
+
+```yaml
+oracle_data:
+  type: oracle
+  host: localhost
+  port: 1521
+  username: datus_user
+  password: your_password
+  service_name: FREEPDB1
+  schema: DATUS_USER
+```
+
+连接目标必须且只能配置一个：`service_name`（推荐）、`sid` 或 `dsn`。service/PDB 只用于选择连接目标，
+不属于 SQL 对象名；对象应使用 `SCHEMA.TABLE` 限定。
+
 ## 多数据库连接
 
 可以在 `agent.services.datasources` 下配置多个独立数据源连接：
@@ -358,6 +378,12 @@ agent:
 - 控制台 endpoint 归一化（`hostname` 或 `hostname:port`）
 - SSL 连接模式（disable、allow、prefer、require、verify-ca、verify-full）
 
+#### Oracle
+- 通过 adapter 提供的 skill 注入 Oracle Database 19c SQL 和 PL/SQL 语法知识
+- 支持 service name、SID 或 DSN 连接目标
+- 通过 `ALL_*` 数据字典视图发现 schema 范围内的元数据
+- Oracle 兼容的 profiling 和绑定参数数据传输
+
 ## 故障排除
 
 ### 适配器未找到
@@ -389,6 +415,7 @@ pip install datus-mysql
 - **Trino**：需要 `trino`（自动安装）
 - **Apache Doris**：需要 `datus-mysql` 和 `pymysql`（自动安装）
 - **Hologres**：需要 `datus-postgresql` 和 `psycopg2-binary`（自动安装）
+- **Oracle**：需要 `oracledb`（自动安装；Thin 模式不需要 Oracle Client）
 
 ## 架构
 
@@ -408,7 +435,8 @@ datus-agent (核心)
     │   ├── datus-hive
     │   ├── datus-spark
     │   ├── datus-clickhouse
-    │   └── datus-trino
+    │   ├── datus-trino
+    │   └── datus-oracle
     │
     └── 原生 SDK 适配器
         ├── datus-snowflake

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -1268,3 +1268,36 @@ Use FETCH FIRST instead of LIMIT.
         assert '<required_skill name="db-oracle-sql">' in result
         assert "Use FETCH FIRST instead of LIMIT." in result
         assert "db-postgresql-sql" not in result
+
+    def test_database_skill_config_failure_leaves_prompt_unchanged(self, mock_agent_config, skill_manager):
+        mock_agent_config.current_db_configs.side_effect = RuntimeError("config unavailable")
+        node = self._make_node(mock_agent_config, skill_manager, None)
+
+        assert node._inject_required_skills("base prompt") == "base prompt"
+
+    def test_database_skill_outside_node_scope_is_skipped(
+        self,
+        mock_agent_config,
+        skill_manager,
+        temp_skills_dir,
+    ):
+        skill_dir = temp_skills_dir / "db-oracle-sql"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            """---
+name: db-oracle-sql
+description: Oracle SQL generation rules
+allowed_agents:
+  - another_node
+---
+
+# Oracle SQL
+
+Use FETCH FIRST instead of LIMIT.
+"""
+        )
+        skill_manager.refresh()
+        mock_agent_config.current_db_configs.return_value = {"oracle_prod": {"type": "oracle"}}
+        node = self._make_node(mock_agent_config, skill_manager, None)
+
+        assert node._inject_required_skills("base prompt") == "base prompt"

--- a/tests/unit_tests/agent/node/test_agentic_node_skills.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_skills.py
@@ -103,6 +103,7 @@ def mock_agent_config():
     config.skills_config = None
     config.prompt_version = None
     config.project_root = "."
+    config.current_db_configs.return_value = {}
 
     # Prevent model creation by returning None for active_model
     config.active_model.return_value = None
@@ -1235,3 +1236,35 @@ class TestRequiredSkillsInjection:
         node = self._make_node(mock_agent_config, skill_manager, " sql-analysis ,, data-profiler ")
 
         assert node._get_required_skills() == ["sql-analysis", "data-profiler"]
+
+    def test_installed_database_skill_is_injected(
+        self,
+        mock_agent_config,
+        skill_manager,
+        temp_skills_dir,
+    ):
+        skill_dir = temp_skills_dir / "db-oracle-sql"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            """---
+name: db-oracle-sql
+description: Oracle SQL generation rules
+---
+
+# Oracle SQL
+
+Use FETCH FIRST instead of LIMIT.
+"""
+        )
+        skill_manager.refresh()
+        mock_agent_config.current_db_configs.return_value = {
+            "oracle_prod": {"type": "oracle"},
+            "postgres_prod": {"type": "postgresql"},
+        }
+        node = self._make_node(mock_agent_config, skill_manager, None)
+
+        result = node._inject_required_skills("base prompt")
+
+        assert '<required_skill name="db-oracle-sql">' in result
+        assert "Use FETCH FIRST instead of LIMIT." in result
+        assert "db-postgresql-sql" not in result

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -56,7 +56,7 @@ def test_nightly_installs_storage_packages_from_latest_checkout():
 def test_nightly_installs_new_database_adapters_from_latest_checkout():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    for package_name in ("datus-doris", "datus-hologres"):
+    for package_name in ("datus-doris", "datus-hologres", "datus-oracle"):
         assert f"--reinstall-package {package_name}" in workflow
         assert f"./external/datus-db-adapters/{package_name}" in workflow
 

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -49,6 +49,7 @@ def test_expected_sources_include_storage_packages():
 def test_expected_sources_include_new_database_adapters():
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-doris"] == "datus-db-adapters/datus-doris"
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-hologres"] == "datus-db-adapters/datus-hologres"
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-oracle"] == "datus-db-adapters/datus-oracle"
 
 
 def test_expected_sources_include_dosi_semantic_adapter():
@@ -60,14 +61,16 @@ def test_expected_sources_include_dosi_semantic_adapter():
 def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda db_type: "postgres" if db_type == "hologres" else None,
+        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
         get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
-        get_sql_generation_notes=lambda db_type: "notes" if db_type == "hologres" else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_dialect_operations=lambda db_type: object() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
@@ -77,14 +80,16 @@ def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
 def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypatch):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda _db_type: None,
+        get_parser_dialect=lambda db_type: "oracle" if db_type == "oracle" else None,
         get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
-        get_sql_generation_notes=lambda db_type: "notes" if db_type == "hologres" else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_dialect_operations=lambda db_type: object() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
@@ -107,18 +112,43 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
 def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, missing_hook: str, expected_error: str):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda db_type: "postgres" if db_type == "hologres" else None,
-        get_identifier_parser=lambda _db_type: None if missing_hook == "get_identifier_parser" else object(),
-        get_sql_generation_notes=lambda _db_type: None if missing_hook == "get_sql_generation_notes" else "notes",
+        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
+        get_identifier_parser=lambda db_type: (
+            None if db_type != "hologres" or missing_hook == "get_identifier_parser" else object()
+        ),
+        get_sql_generation_notes=lambda db_type: (
+            None if db_type == "hologres" and missing_hook == "get_sql_generation_notes" else "notes"
+        ),
+        get_dialect_operations=lambda db_type: object() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
     assert verify_sources.verify_database_adapter_imports() == [expected_error]
+
+
+def test_verify_database_adapter_imports_requires_oracle_operations(monkeypatch):
+    registry = SimpleNamespace(
+        get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
+        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
+        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_dialect_operations=lambda _db_type: None,
+    )
+    modules = {
+        "datus_db_core": SimpleNamespace(connector_registry=registry),
+        "datus_doris": SimpleNamespace(register=lambda: None),
+        "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_oracle": SimpleNamespace(register=lambda: None),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_database_adapter_imports() == ["datus_oracle did not register get_dialect_operations"]
 
 
 def test_verify_local_sources_rejects_registry_package(monkeypatch, tmp_path):

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -28,6 +28,23 @@ def _local_distribution(path: Path) -> _FakeDistribution:
     return _FakeDistribution(json.dumps({"url": path.resolve().as_uri(), "dir_info": {}}))
 
 
+class _FakeDialectOperations:
+    def render_limit(self, sql, limit):
+        return sql
+
+    def render_count(self, sql, alias):
+        return sql
+
+    def quote_identifier(self, name):
+        return name
+
+    def infer_transfer_type(self, series):
+        return "TEXT"
+
+    def write_dataframe(self, connector, table, dataframe, batch_size):
+        return 0
+
+
 def test_verify_local_sources_accepts_every_expected_checkout(monkeypatch, tmp_path):
     external_root = tmp_path / "external"
     distributions = {
@@ -64,7 +81,7 @@ def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
         get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
         get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
         get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
-        get_dialect_operations=lambda db_type: object() if db_type == "oracle" else None,
+        get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
@@ -83,7 +100,7 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
         get_parser_dialect=lambda db_type: "oracle" if db_type == "oracle" else None,
         get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
         get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
-        get_dialect_operations=lambda db_type: object() if db_type == "oracle" else None,
+        get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
@@ -119,7 +136,7 @@ def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, mi
         get_sql_generation_notes=lambda db_type: (
             None if db_type == "hologres" and missing_hook == "get_sql_generation_notes" else "notes"
         ),
-        get_dialect_operations=lambda db_type: object() if db_type == "oracle" else None,
+        get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
@@ -149,6 +166,29 @@ def test_verify_database_adapter_imports_requires_oracle_operations(monkeypatch)
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
     assert verify_sources.verify_database_adapter_imports() == ["datus_oracle did not register get_dialect_operations"]
+
+
+def test_verify_database_adapter_imports_requires_complete_oracle_operations(monkeypatch):
+    operations = _FakeDialectOperations()
+    operations.render_count = None
+    registry = SimpleNamespace(
+        get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
+        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
+        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_dialect_operations=lambda db_type: operations if db_type == "oracle" else None,
+    )
+    modules = {
+        "datus_db_core": SimpleNamespace(connector_registry=registry),
+        "datus_doris": SimpleNamespace(register=lambda: None),
+        "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_oracle": SimpleNamespace(register=lambda: None),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_database_adapter_imports() == [
+        "datus_oracle dialect operations are missing callable methods: render_count"
+    ]
 
 
 def test_verify_local_sources_rejects_registry_package(monkeypatch, tmp_path):

--- a/tests/unit_tests/cli/test_datasource_commands.py
+++ b/tests/unit_tests/cli/test_datasource_commands.py
@@ -443,7 +443,7 @@ class TestDatasourceAppViews:
             assert ("sqlite", "sqlite", True) in app._db_types
 
     def test_new_database_adapters_are_installable(self):
-        assert {"doris", "hologres"} <= set(INSTALLABLE_TYPES)
+        assert {"doris", "hologres", "oracle"} <= set(INSTALLABLE_TYPES)
 
     def test_enter_config_form(self):
         cli = _make_cli()

--- a/tests/unit_tests/tools/db_tools/test_capabilities.py
+++ b/tests/unit_tests/tools/db_tools/test_capabilities.py
@@ -3,7 +3,8 @@
 
 from datus_db_core import connector_registry
 
-from datus.tools.db_tools.capabilities import get_effective_capabilities, supports_namespace
+from datus.tools.db_tools import capabilities as capabilities_module
+from datus.tools.db_tools.capabilities import get_dialect_operations, get_effective_capabilities, supports_namespace
 
 
 class DynamicConnector:
@@ -38,3 +39,25 @@ def test_static_capabilities_remain_fallback_for_existing_adapters():
     finally:
         connector_registry._capabilities.clear()
         connector_registry._capabilities.update(saved)
+
+
+def test_dialect_operations_are_resolved_from_connector_dialect(monkeypatch):
+    operations = object()
+    calls = []
+    monkeypatch.setattr(
+        connector_registry,
+        "get_dialect_operations",
+        lambda dialect: calls.append(dialect) or operations,
+        raising=False,
+    )
+
+    connector = type("OracleConnector", (), {"dialect": "ORACLE"})()
+
+    assert get_dialect_operations(connector=connector) is operations
+    assert calls == ["oracle"]
+
+
+def test_dialect_operations_remain_optional_for_older_core(monkeypatch):
+    monkeypatch.setattr(capabilities_module, "connector_registry", object())
+
+    assert get_dialect_operations(dialect="oracle") is None

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -1265,6 +1265,57 @@ class TestTransferQueryResult:
         assert '"is_open" BOOLEAN' in ddl_calls[1]
         assert "INSERT INTO tgt.users" in target.execute_insert.call_args.args[0]
 
+    def test_transfer_dispatches_registered_dialect_operations(self):
+        import pandas as pd
+
+        df = pd.DataFrame({"id": [1, 2], "is_open": [True, False]})
+        source = self._make_source_connector(df)
+        source.execute_query.return_value = Mock(success=True, sql_return=[(2,)])
+        target, _ = self._make_target_connector()
+        target.execute_ddl.side_effect = [
+            Mock(success=False, error="ORA-00942: table or view does not exist"),
+            Mock(success=True),
+        ]
+
+        source_operations = Mock()
+        source_operations.render_count.return_value = (
+            "SELECT COUNT(*) AS __datus_count FROM (SELECT id, is_open FROM users) __datus_src"
+        )
+        target_operations = Mock()
+        target_operations.quote_identifier.side_effect = lambda name: f'"{name.upper()}"'
+        target_operations.infer_transfer_type.side_effect = lambda _series: "NUMBER"
+        target_operations.write_dataframe.return_value = 2
+
+        def resolve_operations(*, connector=None, dialect=""):
+            del dialect
+            return source_operations if connector is source else target_operations
+
+        tool = self._make_multi_tool(source, target)
+        with patch("datus.tools.func_tool.database.get_dialect_operations", side_effect=resolve_operations):
+            result = tool.transfer_query_result(
+                source_sql="SELECT id, is_open FROM users",
+                source_datasource="source_db",
+                target_table="tgt.users",
+                target_datasource="target_db",
+                mode="replace",
+                batch_size=100,
+            )
+
+        assert result.success == 1
+        source_operations.render_count.assert_called_once_with(
+            "SELECT id, is_open FROM users",
+            "__datus_src",
+        )
+        source.execute_query.assert_called_once_with(source_operations.render_count.return_value)
+        create_sql = target.execute_ddl.call_args_list[1].args[0]
+        assert '"ID" NUMBER' in create_sql
+        assert '"IS_OPEN" NUMBER' in create_sql
+        target_operations.write_dataframe.assert_called_once()
+        assert target_operations.write_dataframe.call_args.args[0] is target
+        assert target_operations.write_dataframe.call_args.args[1] == "tgt.users"
+        assert target_operations.write_dataframe.call_args.args[3] == 100
+        target.execute_insert.assert_not_called()
+
     def test_transfer_replace_creates_missing_target_table_for_mysql_contraction(self):
         import pandas as pd
 

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -22,6 +22,7 @@ def _make_db_tool(agent_config=None, sub_agent_name="test_agent"):
     db_tool = MagicMock()
     db_tool.agent_config = agent_config or MagicMock()
     db_tool.sub_agent_name = sub_agent_name
+    db_tool.dialect_operations.return_value = None
     return db_tool
 
 
@@ -916,6 +917,66 @@ class TestProfileSemanticModelEvidence:
 
         assert "top_values_sql" in profile
         assert "top_values" not in profile
+
+    def test_profiles_use_registered_dialect_operations(self):
+        db_tool = _make_db_tool()
+        operations = SimpleNamespace(
+            quote_identifier=lambda name: f'"{name.upper()}"',
+            render_limit=lambda sql, limit: f"{sql} FETCH FIRST {limit} ROWS ONLY",
+        )
+        db_tool.dialect_operations.return_value = operations
+        db_tool.read_query.side_effect = [
+            FuncToolResult(
+                success=1,
+                result={"compressed_data": "index,row_count,non_null_count,distinct_count\n0,2,2,2\n"},
+            ),
+            FuncToolResult(
+                success=1,
+                result={"compressed_data": "index,value,count\n0,open,1\n1,closed,1\n"},
+            ),
+        ]
+        tools = _make_tools(db_tool)
+
+        profile = tools._profile_single_column(
+            table_ref='"ORDERS"',
+            column_name="status",
+            column_type="VARCHAR2",
+            kind="categorical",
+            database="oracle_prod",
+            top_n=2,
+        )
+
+        assert 'COUNT("STATUS")' in profile["stats_sql"]
+        assert profile["top_values_sql"].endswith("FETCH FIRST 2 ROWS ONLY")
+        assert " LIMIT " not in profile["top_values_sql"]
+        db_tool.dialect_operations.assert_called_with(database="oracle_prod")
+
+    def test_duration_profile_uses_registered_limit_syntax(self):
+        db_tool = _make_db_tool()
+        db_tool.dialect_operations.return_value = SimpleNamespace(
+            quote_identifier=lambda name: f'"{name.upper()}"',
+            render_limit=lambda sql, limit: f"{sql} FETCH FIRST {limit} ROWS ONLY",
+        )
+        db_tool.read_query.return_value = FuncToolResult(
+            success=1,
+            result={"compressed_data": ("index,left_value,right_value\n0,2025-01-01,2025-01-03\n")},
+        )
+        tools = _make_tools(db_tool)
+
+        profiles = tools._profile_date_duration_pairs(
+            table_ref='"EVENTS"',
+            columns=[
+                {"name": "opened_at", "type": "DATE"},
+                {"name": "closed_at", "type": "DATE"},
+            ],
+            database="oracle_prod",
+        )
+
+        assert profiles[0]["delta_days"]["max"] == 2
+        sql = db_tool.read_query.call_args.args[0]
+        assert '"OPENED_AT"' in sql
+        assert sql.endswith("FETCH FIRST 1000 ROWS ONLY")
+        assert " LIMIT " not in sql
 
     def test_deep_profiles_explicit_table_without_sql_evidence(self):
         db_tool = _make_db_tool()


### PR DESCRIPTION
## Summary

- consume optional adapter-provided `DialectOperations` in transfer and semantic profiling paths
- automatically inject installed `db-<type>-sql` skills for configured datasources
- expose the Oracle adapter through datasource installation, nightly source checks, manifests, and user documentation
- preserve the existing SQL path for adapters that do not register dialect operations and for environments using an older `datus-db-core`

## Why

Agent-side transfer and profile code currently renders common SQL directly, including `LIMIT`, table aliases with `AS`, inline multi-row `VALUES`, and generic transfer types. Those defaults are not valid for every database. Adapter PR Datus-ai/datus-db-adapters#84 introduces the generic operations contract and Oracle implementation; this PR consumes that contract without adding Oracle-specific SQL branches to Agent.

Database dialect knowledge is also adapter-owned. Agent now deterministically injects an installed adapter skill following the `db-<type>-sql` convention, while silently skipping adapters that have not contributed one.

## Compatibility

- no dependency version or lockfile changes
- `get_dialect_operations` is resolved with `getattr`, so older core installations retain the previous behavior
- adapters without registered operations retain the existing transfer and profile SQL path

## Validation

- `276 passed` across affected transfer, profiler, skills, CLI, and nightly contract tests
- `ruff check`
- `ruff format --check`
- local entry-point smoke test using the adapter/core checkout from Datus-ai/datus-db-adapters#84, confirming both `OracleDialectOperations` and `db-oracle-sql` discovery

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added Oracle as an installable and supported database adapter.
  * Added Oracle connection support for service name, SID, and DSN targets.
  * Improved database operations with dialect-aware SQL generation, identifier quoting, data transfer, and result handling.
  * Automatically selects database-specific SQL skills based on configured data sources.

* **Documentation**
  * Added English and Chinese documentation covering Oracle setup, capabilities, and requirements.

* **Bug Fixes**
  * Preserved compatibility with adapters that do not provide advanced dialect operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oracle as an installable and supported database adapter.
  * Added Oracle connection support for service name, SID, and DSN targets.
  * Improved database operations with dialect-aware SQL generation, identifier quoting, data transfer, and result handling.
  * Automatically selects database-specific SQL skills based on configured data sources.

* **Documentation**
  * Added English and Chinese documentation covering Oracle setup, capabilities, and requirements.

* **Bug Fixes**
  * Preserved compatibility with adapters that do not provide advanced dialect operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->