### PR TITLE
[BugFix] Stop repeating one paragraph per parallel tool call; let submit_task_result run unprompted; identify artifacts by slug

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2572,10 +2572,36 @@ class AgenticNode(Node):
             self.task_result_tool = TaskResultTool()
             if self.tools is not None:
                 self.tools.extend(self.task_result_tool.available_tools())
+            self._allow_task_result_tool()
             logger.debug("Setup submit_task_result tool")
         except Exception as e:
             logger.error(f"Failed to setup task result tool: {e}")
             self.task_result_tool = None
+
+    def _allow_task_result_tool(self):
+        """Exempt ``submit_task_result`` from the permission prompt.
+
+        Same reasoning as ``ask_user``: this is the channel the run reports
+        through, not a resource it touches. Under ``normal`` / ``auto`` it
+        matches no ALLOW rule and lands on ``default=ASK``, so a finished
+        dispatch stopped to ask permission to say it had finished — and the
+        card sat in the thread waiting for a human.
+
+        Declared here rather than in ``profiles.py`` because the tool itself is
+        injected here, only for orchestrator origins. A rule in the shared
+        profiles would outlive the tool and name it for every other caller.
+        ``add_persistent_rule`` so a later ``/profile`` switch, which rebuilds
+        ``global_config``, does not drop it.
+        """
+        if self.permission_manager is None:
+            return
+
+        from datus.tools.permission.permission_config import PermissionLevel, PermissionRule
+
+        category = getattr(self.task_result_tool, "permission_category", "tools")
+        self.permission_manager.add_persistent_rule(
+            PermissionRule(tool=category, pattern="submit_task_result", permission=PermissionLevel.ALLOW)
+        )
 
     def _setup_sub_agent_task_tool(self):
         """Setup SubAgentTaskTool based on subagents config or node default.

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -2578,7 +2578,7 @@ class AgenticNode(Node):
             logger.error(f"Failed to setup task result tool: {e}")
             self.task_result_tool = None
 
-    def _allow_task_result_tool(self):
+    def _allow_task_result_tool(self) -> None:
         """Exempt ``submit_task_result`` from the permission prompt.
 
         Same reasoning as ``ask_user``: this is the channel the run reports

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -105,24 +105,57 @@ def _assistant_content_fingerprint(event: SSEEvent) -> str:
 def _should_skip_duplicate_assistant_message(
     action,
     event: SSEEvent,
-    seen_fingerprints: set[str],
+    seen_fingerprints: dict[str, str],
 ) -> bool:
+    """Return True when this event repeats text already sent this turn.
+
+    ``seen_fingerprints`` maps rendered text -> the message_id that first
+    carried it, because UPDATE has to be judged differently from CREATE:
+
+    * CREATE re-stating known text is always a duplicate.
+    * UPDATE re-stating it is a duplicate only under a *different* message_id.
+      An UPDATE on the id that already owns the text is the legitimate
+      overwrite path (streamed thinking deltas replaced by the finished
+      response, ``finalize_progress`` stepping one bubble through its stages).
+
+    Judging UPDATE at all is the point: one assistant turn carrying text plus N
+    parallel tool calls opens N ``thinking_stream_*`` messages that each stream
+    the same prose and each close with an UPDATE. Skipping UPDATE entirely —
+    which this did — let all N through, and a mission thread rendered the same
+    paragraph four times in a row.
+    """
     if action.role != ActionRole.ASSISTANT or action.status != ActionStatus.SUCCESS:
         return False
     if action.action_type == "thinking_delta":
         return False
     if event.event != "message" or not isinstance(event.data, SSEMessageData):
         return False
-    if event.data.type != SSEDataType.CREATE_MESSAGE:
+    if event.data.type not in (SSEDataType.CREATE_MESSAGE, SSEDataType.UPDATE_MESSAGE):
         return False
+
     fingerprint = _assistant_content_fingerprint(event)
-    return bool(fingerprint and fingerprint in seen_fingerprints)
+    if not fingerprint:
+        return False
+
+    owner = seen_fingerprints.get(fingerprint)
+    if owner is None:
+        return False
+    if event.data.type == SSEDataType.UPDATE_MESSAGE:
+        return owner != event.data.payload.message_id
+    return True
 
 
-def _remember_assistant_message(event: SSEEvent, seen_fingerprints: set[str]) -> None:
+def _remember_assistant_message(event: SSEEvent, seen_fingerprints: dict[str, str]) -> None:
     fingerprint = _assistant_content_fingerprint(event)
-    if fingerprint:
-        seen_fingerprints.add(fingerprint)
+    if not fingerprint:
+        return
+    # First writer wins — it is the one whose UPDATEs stay legitimate.
+    seen_fingerprints.setdefault(fingerprint, _message_id_of(event))
+
+
+def _message_id_of(event: SSEEvent) -> str:
+    data = event.data
+    return data.payload.message_id if isinstance(data, SSEMessageData) else ""
 
 
 def _should_include_final_response(action, assistant_response_sent: bool) -> bool:
@@ -702,7 +735,7 @@ class ChatTaskManager:
                 # by a stale assistant_response_sent carried over between passes.
                 assistant_response_sent = False
                 tool_result_seen = False
-                seen_assistant_message_fingerprints: set[str] = set()
+                seen_assistant_message_fingerprints: dict[str, str] = {}
                 async for action in node.execute_stream_with_interactions(action_history):
                     action_count += 1
 

--- a/datus/tools/func_tool/task_result_tools.py
+++ b/datus/tools/func_tool/task_result_tools.py
@@ -46,10 +46,21 @@ class PlanItem(BaseModel):
 
 
 class TaskArtifact(BaseModel):
-    """Something produced during the run that the caller can link to."""
+    """Something produced during the run that the caller can link to.
+
+    ``slug`` was ``ref``, described as "identifier or path" — and the vaguer
+    word got the vaguer answer: runs reported ``reports/<slug>/`` when the slug
+    alone is what opens the artifact. Nothing downstream resolves a path, so a
+    caller wanting to link to the report had to strip the decoration back off.
+    """
 
     kind: str = Field(description="csv | report | dashboard | metric | table | file")
-    ref: str = Field(description="Identifier or path the caller can resolve.")
+    slug: str = Field(
+        description=(
+            "The artifact's own slug, exactly as it was created — e.g. "
+            "'store_anomaly_root_cause_2026_06'. Not a path, a URL or a filename."
+        )
+    )
     title: Optional[str] = Field(default=None, description="Human-readable label.")
 
 
@@ -148,7 +159,9 @@ class TaskResultTool:
             summary: A few sentences the caller reads instead of your full transcript.
                 Include the grain and definitions you settled on — you are the only one
                 who knows what you had to decide along the way.
-            artifacts: Anything produced that the caller can link to.
+            artifacts: Anything produced that the caller can link to. Identify each
+                one by its ``slug`` alone — the caller opens it by slug, and a path
+                around it only has to be stripped back off.
             gap_reasons: Concretely what is missing. Required for ``needs_development``
                 and ``blocked``.
             plan_items: What to build, for ``needs_development``.

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -1721,6 +1721,31 @@ class TestChatAgenticNodeRebuildTools:
         node._rebuild_tools()
         assert "submit_task_result" in [t.name for t in node.tools]
 
+    def test_submit_task_result_does_not_prompt(self, real_agent_config, mock_llm_create):
+        """It is the channel the run reports through, so it must never ASK.
+
+        The ``tools`` bucket has no ALLOW rule matching it, so without the
+        injected one it falls to ``default=ASK`` and a finished dispatch stops
+        to ask permission to say it finished. Asserting the resolved level, not
+        the rule's presence: rules are last-match-wins while the injection
+        inserts at the front, so "the rule is there" does not imply it decides.
+        """
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+        from datus.tools.permission.permission_config import PermissionLevel
+
+        real_agent_config._request_origin = "orchestrator"
+        node = ChatAgenticNode(
+            node_id="test_task_result_permission",
+            description="Test submit_task_result permission",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+
+        assert (
+            node.permission_manager.check_permission("tools", "submit_task_result", node.get_node_name())
+            == PermissionLevel.ALLOW
+        )
+
     def test_ordinary_chat_never_sees_submit_task_result(self, real_agent_config, mock_llm_create):
         from datus.agent.node.chat_agentic_node import ChatAgenticNode
 

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -22,7 +22,9 @@ from datus.api.services.chat_task_manager import (
     _coalesce_deltas,
     _fill_database_context,
     _is_thinking_delta,
+    _remember_assistant_message,
     _should_include_final_response,
+    _should_skip_duplicate_assistant_message,
 )
 
 
@@ -2401,3 +2403,71 @@ class TestResolveMetricSqlPaths:
         mgr = ChatTaskManager()
         assert mgr._resolve_metric_paths(MagicMock(), []) == ([], [])
         assert mgr._resolve_sql_paths(MagicMock(), None) == ([], [])
+
+
+# ---------------------------------------------------------------------------
+# Duplicate assistant-message suppression
+# ---------------------------------------------------------------------------
+
+
+def _make_assistant_message(text: str, message_id: str, data_type):
+    return SSEEvent(
+        id=1,
+        event="message",
+        data=SSEMessageData(
+            type=data_type,
+            payload=SSEMessagePayload(
+                message_id=message_id,
+                role="assistant",
+                content=[IMessageContent(type="markdown", payload={"content": text})],
+            ),
+        ),
+        timestamp="2025-01-01T00:00:00Z",
+    )
+
+
+def _response_action():
+    from datus.schemas.action_history import ActionRole, ActionStatus
+
+    return SimpleNamespace(role=ActionRole.ASSISTANT, status=ActionStatus.SUCCESS, action_type="response")
+
+
+class TestDuplicateAssistantMessage:
+    """One turn's text must reach the client once, whatever frame carries it."""
+
+    def test_repeated_create_is_skipped(self):
+        seen: dict[str, str] = {}
+        first = _make_assistant_message("same prose", "m1", SSEDataType.CREATE_MESSAGE)
+        _remember_assistant_message(first, seen)
+
+        again = _make_assistant_message("same prose", "m2", SSEDataType.CREATE_MESSAGE)
+        assert _should_skip_duplicate_assistant_message(_response_action(), again, seen) is True
+
+    def test_update_from_another_message_is_skipped(self):
+        """The reported bug: text + N parallel tool calls opens N streams that
+        each close with an UPDATE carrying the same prose."""
+        seen: dict[str, str] = {}
+        first = _make_assistant_message("parallel prose", "thinking_stream_a", SSEDataType.UPDATE_MESSAGE)
+        assert _should_skip_duplicate_assistant_message(_response_action(), first, seen) is False
+        _remember_assistant_message(first, seen)
+
+        for other in ("thinking_stream_b", "thinking_stream_c", "thinking_stream_d"):
+            twin = _make_assistant_message("parallel prose", other, SSEDataType.UPDATE_MESSAGE)
+            assert _should_skip_duplicate_assistant_message(_response_action(), twin, seen) is True
+
+    def test_update_on_its_own_message_passes(self):
+        """Overwriting one's own bubble is the legitimate UPDATE path — streamed
+        deltas replaced by the finished response, finalize_progress stages."""
+        seen: dict[str, str] = {}
+        first = _make_assistant_message("stage text", "m1", SSEDataType.CREATE_MESSAGE)
+        _remember_assistant_message(first, seen)
+
+        overwrite = _make_assistant_message("stage text", "m1", SSEDataType.UPDATE_MESSAGE)
+        assert _should_skip_duplicate_assistant_message(_response_action(), overwrite, seen) is False
+
+    def test_distinct_text_passes(self):
+        seen: dict[str, str] = {}
+        _remember_assistant_message(_make_assistant_message("first", "m1", SSEDataType.CREATE_MESSAGE), seen)
+
+        other = _make_assistant_message("second", "m2", SSEDataType.UPDATE_MESSAGE)
+        assert _should_skip_duplicate_assistant_message(_response_action(), other, seen) is False

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -540,6 +540,81 @@ class TestChatTaskManagerBehavior:
         # Both passes' replies reach the client despite identical text.
         assert len(assistant_events) == 2
 
+    @pytest.mark.asyncio
+    async def test_run_loop_emits_parallel_tool_call_prose_once(self, real_agent_config):
+        """One turn's text reaches the client once, however many streams carry it.
+
+        An assistant turn with text plus N parallel tool calls opens N
+        ``thinking_stream_*`` messages that each stream the same prose and each
+        close with an UPDATE. De-dup used to look at CREATE only, so all N went
+        through and the thread showed the paragraph N times.
+
+        Driven through ``_run_loop`` rather than the helpers: what makes the
+        UPDATE path reachable at all is the loop's own ``is_update`` bookkeeping,
+        and the skip has to happen before ``_push_event`` for the first frame to
+        be the one remembered.
+        """
+        from datus.api.models.cli_models import StreamChatInput
+        from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+
+        prose = "让我先探索数据和指标定义。"
+
+        class FakeNode:
+            session_id = "s-parallel"
+
+            def __init__(self):
+                self.pending_input_queue = None
+                self.input = None
+
+            def get_node_name(self):
+                return "chat"
+
+            async def execute_stream_with_interactions(self, action_history_manager):
+                # Two streams, same prose. Each streams a delta first, which is
+                # what turns its own closing `response` into an UPDATE.
+                for action_id in ("thinking_stream_a", "thinking_stream_b"):
+                    yield ActionHistory(
+                        action_id=action_id,
+                        role=ActionRole.ASSISTANT,
+                        action_type="thinking_delta",
+                        messages="",
+                        input={},
+                        output={"delta": prose},
+                        status=ActionStatus.SUCCESS,
+                    )
+                    yield ActionHistory(
+                        action_id=action_id,
+                        role=ActionRole.ASSISTANT,
+                        action_type="response",
+                        messages=prose,
+                        input={},
+                        output={"response": prose, "is_thinking": False},
+                        status=ActionStatus.SUCCESS,
+                    )
+
+            async def get_last_turn_usage(self):
+                return None
+
+        manager = ChatTaskManager()
+        manager._create_node = lambda *args, **kwargs: FakeNode()  # type: ignore[method-assign]
+        manager._create_node_input = lambda **kwargs: SimpleNamespace(**kwargs)  # type: ignore[method-assign]
+        task = ChatTask(session_id="s-parallel", asyncio_task=MagicMock())
+
+        await manager._run_loop(
+            task,
+            real_agent_config,
+            StreamChatInput(message="analyse", session_id="s-parallel", stream_response=True),
+        )
+
+        rendered = [
+            item
+            for event in task.events
+            if event.event == "message" and isinstance(event.data, SSEMessageData)
+            for item in event.data.payload.content
+            if item.type == "markdown" and item.payload.get("content") == prose
+        ]
+        assert len(rendered) == 1
+
     def test_drain_pending_for_continuation_variants(self):
         """Covers all branches of the drain helper: no queue, empty, interrupted
         (cleared), and a normal FIFO drain."""

--- a/tests/unit_tests/tools/func_tool/test_task_result_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_task_result_tools.py
@@ -23,7 +23,7 @@ def test_answered_records_summary_and_artifacts():
     result = tool.submit_task_result(
         outcome="answered",
         summary="Semantic layer already had perp_notional_volume; produced last week by venue.",
-        artifacts=[TaskArtifact(kind="csv", ref="s3://run/1.csv", title="Weekly volume")],
+        artifacts=[TaskArtifact(kind="csv", slug="weekly_volume", title="Weekly volume")],
     )
 
     assert result.success
@@ -162,7 +162,7 @@ async def test_invoker_accepts_nested_objects_as_dicts():
         summary="Retention by market maker needs a dimension first.",
         gap_reasons=["no market_maker dimension"],
         plan_items=[{"kind": "dimension", "name": "dim_market_maker", "description": "42 addresses"}],
-        artifacts=[{"kind": "csv", "ref": "s3://run/1.csv", "title": "Draft"}],
+        artifacts=[{"kind": "csv", "slug": "draft_volume", "title": "Draft"}],
     )
 
     assert result["success"]
@@ -179,11 +179,11 @@ async def test_invoker_accepts_a_nested_array_sent_as_a_json_string():
         tool,
         outcome="answered",
         summary="Done.",
-        artifacts=json.dumps([{"kind": "report", "ref": "rpt_1"}]),
+        artifacts=json.dumps([{"kind": "report", "slug": "rpt_1"}]),
     )
 
     assert result["success"]
-    assert tool.submitted["artifacts"][0]["ref"] == "rpt_1"
+    assert tool.submitted["artifacts"][0]["slug"] == "rpt_1"
 
 
 @pytest.mark.asyncio
@@ -196,7 +196,7 @@ async def test_invoker_reports_a_malformed_item_instead_of_raising():
         tool,
         outcome="answered",
         summary="Done.",
-        artifacts=[{"ref": "missing-kind"}],
+        artifacts=[{"slug": "missing-kind"}],
     )
 
     assert not result["success"]
@@ -230,3 +230,37 @@ async def test_invoker_still_enforces_the_outcome_contract():
 
     assert not result["success"]
     assert "gap_reasons" in result["error"]
+
+
+def test_artifact_is_identified_by_slug_not_a_path():
+    """The field is the slug the caller opens the artifact by.
+
+    Named ``ref`` and described as "identifier or path", it collected
+    ``reports/<slug>/`` — decoration nothing downstream resolves, which a caller
+    wanting to link to the report then had to strip back off.
+    """
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(
+        outcome="answered",
+        summary="Root-cause report produced.",
+        artifacts=[{"kind": "report", "slug": "store_anomaly_root_cause_2026_06", "title": "Root cause"}],
+    )
+
+    assert result.success
+    assert tool.submitted["artifacts"][0]["slug"] == "store_anomaly_root_cause_2026_06"
+    assert "ref" not in tool.submitted["artifacts"][0]
+
+
+def test_artifact_without_a_slug_is_rejected():
+    tool = TaskResultTool()
+
+    result = tool.submit_task_result(
+        outcome="answered",
+        summary="Done.",
+        artifacts=[{"kind": "report", "title": "No slug"}],
+    )
+
+    assert not result.success
+    assert "artifacts[0]" in result.error
+    assert tool.submitted is None


### PR DESCRIPTION
Two defects seen on the same dispatched mission (dev, mission `n1yiscxsijzeynhc41u5ucok`).

## 1. The same paragraph rendered four times in a row

An assistant turn carrying text plus N parallel tool calls opens N
`thinking_stream_*` messages. Each streams the same prose and each closes with an
`UPDATE_MESSAGE` — so the consumer gets the paragraph N times. Repeats matched the
fan-out exactly: 4 parallel calls → 4 copies, 2 → 2. Captured off the wire:

```
04:55:58 id=30  UPDATE_MESSAGE markdown thinking_stream_158943c7
04:56:02 id=67  UPDATE_MESSAGE markdown thinking_stream_3b78b211
04:56:07 id=100 UPDATE_MESSAGE markdown thinking_stream_d6ba86ec
04:56:11 id=133 UPDATE_MESSAGE markdown thinking_stream_0f3bcfa1
```

`_should_skip_duplicate_assistant_message` already fingerprints assistant text, but
bailed out on anything that was not `CREATE_MESSAGE`, so every one of these went
through.

It now judges `UPDATE_MESSAGE` too. The fingerprint set becomes a map of text ->
first message_id that carried it, because the two frame types need different rules:
a CREATE restating known text is always a duplicate, while an UPDATE is one only
under a *different* message_id. Updating one's own bubble stays untouched — that is
the legitimate overwrite path (streamed deltas replaced by the finished response,
`finalize_progress` stepping a bubble through its stages).

## 2. `submit_task_result` stopped to ask permission

It matches no ALLOW rule in the `tools` bucket, so under `normal` / `auto` it lands
on `default=ASK`. A dispatch that had finished its analysis and written its report
then raised a Permission Request to say it had finished, and the card sat in the
thread waiting for a human.

Same reasoning as `ask_user`: this is the channel the run reports through, not a
resource it touches.

The rule is declared in `_setup_task_result_tool`, next to the injection, rather
than in `profiles.py`. The tool only exists for orchestrator-origin requests; a rule
in the shared profiles would outlive it and name it for every other caller.
`add_persistent_rule` so a later `/profile` switch, which rebuilds `global_config`,
does not drop it.

## Tests

`TestDuplicateAssistantMessage` covers all four frame combinations (repeated CREATE,
cross-message UPDATE, self UPDATE, distinct text). The permission test asserts the
*resolved* level rather than the rule's presence — rules are last-match-wins while
the injection inserts at the front, so "the rule is there" would not prove it decides.

`tests/unit_tests/agent/node/test_chat_agentic_node.py` +
`tests/unit_tests/api/services/test_chat_task_manager.py`: 210 passed.
Pre-existing on main and untouched here: 17 failures in `test_explorer_service.py`
(verified identical on a clean `upstream/main`).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate assistant messages from appearing during repeated or parallel updates.
  * Preserved legitimate updates to the same assistant message.
  * Orchestrated tasks can now submit results without an unnecessary permission prompt.
  * Permission remains enabled when switching permission profiles.

* **Tests**
  * Added coverage for task-result permissions and assistant-message duplicate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 3. An artifact is identified by its slug, not a path

`TaskArtifact.ref`, described as "identifier or path the caller can resolve", collected
`reports/store_anomaly_root_cause_2026_06/` — but nothing downstream resolves a path. The
slug alone is what opens the artifact, so a caller wanting to link to the report had to
strip the decoration back off. The vaguer word got the vaguer answer.

Renamed to `slug`, with a description that says what it is and what it is not.

Callers reading the old name: the orchestrator's only use is
`String(item.title ?? item.ref)`, a label fallback behind `title` — its matching change
accepts both, so an older agent keeps working against a newer orchestrator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate assistant messages during repeated or parallel updates.
  * Preserved legitimate updates to the same assistant message.
  * Orchestrated tasks can submit results without unnecessary permission prompts.
  * Permission remains enabled when switching permission profiles.

* **Improvements**
  * Task artifacts now use a dedicated slug for identification instead of a reference value.

* **Tests**
  * Added coverage for task-result permissions, artifact slugs, and assistant-message duplicate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->