### PR TITLE
[Feature] Carry manifest-declared delegate profiles in plugin runtime context

### DIFF
--- a/datus/plugins/base.py
+++ b/datus/plugins/base.py
@@ -122,6 +122,12 @@ Only ``manifest_version`` is required — every other key is optional::
           type: string
           description: "API base URL"
           default: "https://api.example.com"
+        provider:
+          type: string
+          description: "Provider plugin name"
+          x-plugin-profile-ref:
+            profile_field: provider_profile
+            default_profile: same-name
     # Inline JSON Schema (an object schema) describing ONE profile of
     # ``agent.plugins.<name>``. Drives the ``/plugins`` TUI form (property
     # order == field order; ``required`` and ``default`` are honoured) and
@@ -130,6 +136,13 @@ Only ``manifest_version`` is required — every other key is optional::
     # renderer strips them. TUI-entered values are strings, so prefer
     # ``type: string`` with ``pattern``/``enum``; values containing
     # ``${ENV_VAR}`` placeholders are exempt from value-level validation.
+    # ``x-plugin-profile-ref`` declares a one-hop runtime profile delegation
+    # for managed/AuthProvider execution. Its ``profile_field`` names the
+    # sibling field containing the referenced plugin's profile name;
+    # ``default_profile: same-name`` falls back to this profile's injected
+    # ``name``. Datus resolves only the referenced plugin/profile and carries
+    # it in the command-scoped runtime context, so composed plugins never need
+    # a Python/package dependency or access to the complete AgentConfig.
 
     commands:
       - name: sync

--- a/datus/plugins/runtime_context.py
+++ b/datus/plugins/runtime_context.py
@@ -11,9 +11,9 @@ minimum invocation-specific configuration across that process boundary without
 requiring an on-disk ``agent.yml``.
 
 The context is intentionally passed through one command-scoped environment
-variable.  It contains only the invoked plugin's resolved profile and, when
-needed, the exact plugin directory selected by the normal managed-store /
-``agent.plugin_paths`` precedence.
+variable.  It contains only the invoked plugin's resolved profile, any
+manifest-declared one-hop delegate profiles, and the exact plugin directories
+selected by the normal managed-store / ``agent.plugin_paths`` precedence.
 
 The Bash command itself is preserved verbatim: :func:`prepare_plugin_invocation`
 locates the single ``datus`` command word and inserts an inline environment
@@ -70,12 +70,21 @@ class PluginRuntimeContextError(ValueError):
 
 
 @dataclass(frozen=True)
+class PluginRuntimeTarget:
+    """One pre-authorized plugin profile available to a composed invocation."""
+
+    profile: Dict[str, Any]
+    plugin_path: Optional[str] = None
+
+
+@dataclass(frozen=True)
 class PluginRuntimeContext:
     """Configuration consumed by one ``datus <plugin>`` subprocess."""
 
     plugin_name: str
     profile: Dict[str, Any]
     plugin_path: Optional[str] = None
+    delegates: Dict[str, PluginRuntimeTarget] = field(default_factory=dict)
     version: int = RUNTIME_CONTEXT_VERSION
 
     def encode(self) -> str:
@@ -87,6 +96,13 @@ class PluginRuntimeContext:
                     "plugin_name": self.plugin_name,
                     "profile": self.profile,
                     "plugin_path": self.plugin_path,
+                    "delegates": {
+                        name: {
+                            "profile": target.profile,
+                            "plugin_path": target.plugin_path,
+                        }
+                        for name, target in self.delegates.items()
+                    },
                 },
                 ensure_ascii=False,
                 separators=(",", ":"),
@@ -124,16 +140,49 @@ class PluginRuntimeContext:
         plugin_path = data.get("plugin_path")
         if not isinstance(plugin_name, str) or not plugin_name:
             raise PluginRuntimeContextError("Plugin runtime context has no valid plugin name")
-        if expected_plugin is not None and plugin_name != expected_plugin:
-            raise PluginRuntimeContextError(f"Plugin runtime context is for `{plugin_name}`, not `{expected_plugin}`")
         if not isinstance(profile, dict):
             raise PluginRuntimeContextError("Plugin runtime context profile must be an object")
         if plugin_path is not None and (not isinstance(plugin_path, str) or not plugin_path.strip()):
             raise PluginRuntimeContextError("Plugin runtime context path must be a non-empty string")
-        return cls(
+        raw_delegates = data.get("delegates", {})
+        if not isinstance(raw_delegates, dict):
+            raise PluginRuntimeContextError("Plugin runtime context delegates must be an object")
+        delegates: Dict[str, PluginRuntimeTarget] = {}
+        for delegate_name, raw_target in raw_delegates.items():
+            if not isinstance(delegate_name, str) or not delegate_name or delegate_name == plugin_name:
+                raise PluginRuntimeContextError("Plugin runtime context has an invalid delegate name")
+            if not isinstance(raw_target, dict):
+                raise PluginRuntimeContextError(f"Plugin runtime context delegate `{delegate_name}` must be an object")
+            delegate_profile = raw_target.get("profile")
+            delegate_path = raw_target.get("plugin_path")
+            if not isinstance(delegate_profile, dict):
+                raise PluginRuntimeContextError(
+                    f"Plugin runtime context delegate `{delegate_name}` profile must be an object"
+                )
+            if delegate_path is not None and (not isinstance(delegate_path, str) or not delegate_path.strip()):
+                raise PluginRuntimeContextError(
+                    f"Plugin runtime context delegate `{delegate_name}` path must be a non-empty string"
+                )
+            delegates[delegate_name] = PluginRuntimeTarget(delegate_profile, delegate_path)
+
+        context = cls(
             plugin_name=plugin_name,
             profile=profile,
             plugin_path=plugin_path,
+            delegates=delegates,
+            version=RUNTIME_CONTEXT_VERSION,
+        )
+        if expected_plugin is None or expected_plugin == plugin_name:
+            return context
+        target = delegates.get(expected_plugin)
+        if target is None:
+            raise PluginRuntimeContextError(f"Plugin runtime context is for `{plugin_name}`, not `{expected_plugin}`")
+        # A delegate receives only its own resolved profile/path. It cannot
+        # reuse sibling delegations or extend the chain transitively.
+        return cls(
+            plugin_name=expected_plugin,
+            profile=target.profile,
+            plugin_path=target.plugin_path,
             version=RUNTIME_CONTEXT_VERSION,
         )
 
@@ -201,11 +250,109 @@ def has_plugin_config_global(args: List[str]) -> bool:
 
 
 def load_runtime_context_from_env(*, expected_plugin: Optional[str] = None) -> Optional[PluginRuntimeContext]:
-    """Return the runtime context from this process, or ``None`` when absent."""
+    """Return the runtime context from this process, or ``None`` when absent.
+
+    Selecting a delegate narrows the inherited environment value to that
+    delegate before plugin code runs.  Any subprocess it starts therefore
+    cannot reuse the primary plugin's sibling delegates or extend the chain.
+    """
     value = os.environ.get(RUNTIME_CONTEXT_ENV)
     if value is None:
         return None
-    return PluginRuntimeContext.decode(value, expected_plugin=expected_plugin)
+    context = PluginRuntimeContext.decode(value, expected_plugin=expected_plugin)
+    if expected_plugin is not None:
+        os.environ[RUNTIME_CONTEXT_ENV] = context.encode()
+    return context
+
+
+def _resolve_profile_delegates(
+    agent_config: Any,
+    plugin_name: str,
+    profile: Dict[str, Any],
+) -> Dict[str, PluginRuntimeTarget]:
+    """Resolve manifest-declared, one-hop plugin profile references.
+
+    ``x-plugin-profile-ref`` lives on a top-level ``config_schema`` property.
+    The property's value in the current profile names the delegated plugin;
+    ``profile_field`` optionally names the sibling property containing its
+    profile name. ``default_profile: same-name`` falls back to the primary
+    profile's injected ``name``. Only these exact references are copied from
+    the authoritative AuthProvider AgentConfig.
+    """
+    from datus.plugins import store
+    from datus.plugins.registry import load_plugin_manifest
+
+    manifest = load_plugin_manifest(plugin_name)
+    schema = manifest.config_schema if manifest is not None else None
+    properties = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(properties, dict):
+        return {}
+
+    delegates: Dict[str, PluginRuntimeTarget] = {}
+    for plugin_field, property_schema in properties.items():
+        if not isinstance(property_schema, dict):
+            continue
+        reference = property_schema.get("x-plugin-profile-ref")
+        if reference is None:
+            continue
+        if not isinstance(reference, dict):
+            raise PluginRuntimeContextError(
+                f"Plugin `{plugin_name}` config_schema property `{plugin_field}` has an invalid "
+                "x-plugin-profile-ref declaration"
+            )
+
+        raw_delegate_name = profile.get(plugin_field)
+        if raw_delegate_name is None or str(raw_delegate_name).strip() == "":
+            continue
+        delegate_name = str(raw_delegate_name).strip()
+        if not store.is_valid_name(delegate_name) or delegate_name in store.RESERVED_PLUGIN_NAMES:
+            raise PluginRuntimeContextError(
+                f"Plugin `{plugin_name}` profile field `{plugin_field}` names invalid plugin `{delegate_name}`"
+            )
+        if delegate_name == plugin_name:
+            raise PluginRuntimeContextError(f"Plugin `{plugin_name}` cannot delegate its runtime profile to itself")
+        if hasattr(agent_config, "plugin_active") and not agent_config.plugin_active(delegate_name):
+            raise PluginRuntimeContextError(f"Delegated plugin `{delegate_name}` is not active for this project")
+
+        profile_field = reference.get("profile_field")
+        if profile_field is not None and (not isinstance(profile_field, str) or not profile_field.strip()):
+            raise PluginRuntimeContextError(
+                f"Plugin `{plugin_name}` profile reference for `{plugin_field}` has an invalid profile_field"
+            )
+        profile_field = profile_field.strip() if isinstance(profile_field, str) else None
+        default_profile = reference.get("default_profile", "plugin-default")
+        if default_profile not in {"plugin-default", "same-name"}:
+            raise PluginRuntimeContextError(
+                f"Plugin `{plugin_name}` profile reference for `{plugin_field}` has unsupported "
+                f"default_profile {default_profile!r}"
+            )
+
+        delegate_profile_name: Optional[str] = None
+        if profile_field:
+            raw_profile_name = profile.get(profile_field)
+            if raw_profile_name is not None and str(raw_profile_name).strip():
+                delegate_profile_name = str(raw_profile_name).strip()
+        if delegate_profile_name is None and default_profile == "same-name":
+            raw_primary_name = profile.get("name")
+            if raw_primary_name is None or not str(raw_primary_name).strip():
+                raise PluginRuntimeContextError(
+                    f"Plugin `{plugin_name}` profile needs a name to resolve same-name delegate `{delegate_name}`"
+                )
+            delegate_profile_name = str(raw_primary_name).strip()
+
+        delegate_profile = agent_config.get_plugin_profile(delegate_name, delegate_profile_name)
+        delegate_path = _resolve_plugin_path(agent_config, delegate_name)
+        target = PluginRuntimeTarget(
+            profile=dict(delegate_profile),
+            plugin_path=str(delegate_path) if delegate_path is not None else None,
+        )
+        previous = delegates.get(delegate_name)
+        if previous is not None and previous != target:
+            raise PluginRuntimeContextError(
+                f"Plugin `{plugin_name}` resolves conflicting profiles for delegate `{delegate_name}`"
+            )
+        delegates[delegate_name] = target
+    return delegates
 
 
 def prepare_plugin_invocation(command: str, agent_config: Any) -> Optional[PreparedPluginInvocation]:
@@ -286,10 +433,12 @@ def prepare_plugin_invocation(command: str, agent_config: Any) -> Optional[Prepa
 
     plugin_path = _resolve_plugin_path(agent_config, plugin_name)
     profile = agent_config.get_plugin_profile(plugin_name, profile_name)
+    delegates = _resolve_profile_delegates(agent_config, plugin_name, profile)
     runtime = PluginRuntimeContext(
         plugin_name=plugin_name,
         profile=profile,
         plugin_path=str(plugin_path) if plugin_path is not None else None,
+        delegates=delegates,
     )
     encoded = runtime.encode()
 
@@ -308,6 +457,11 @@ def prepare_plugin_invocation(command: str, agent_config: Any) -> Optional[Prepa
         + command[insert_at:]
     )
     read_dirs = [str(plugin_path)] if plugin_path is not None else []
+    read_dirs.extend(
+        target.plugin_path
+        for target in delegates.values()
+        if target.plugin_path is not None and target.plugin_path not in read_dirs
+    )
     return PreparedPluginInvocation(
         command=wrapped_command,
         env={RUNTIME_CONTEXT_ENV: encoded},
@@ -748,6 +902,7 @@ __all__ = [
     "PreparedPluginInvocation",
     "PluginRuntimeContext",
     "PluginRuntimeContextError",
+    "PluginRuntimeTarget",
     "RUNTIME_CONTEXT_ENV",
     "has_plugin_config_global",
     "load_runtime_context_from_env",

--- a/tests/unit_tests/cli/test_plugin_dispatch.py
+++ b/tests/unit_tests/cli/test_plugin_dispatch.py
@@ -4,13 +4,14 @@
 
 """Unit tests for ``datus.plugins`` dispatch + ``--profile``/``--config`` split."""
 
+import os
 from pathlib import Path
 from typing import Any, Optional
 
 from datus.cli import main as cli_main
 from datus.cli.main import _dispatch_plugin_command, _split_plugin_globals
 from datus.plugins.base import PluginManifest
-from datus.plugins.runtime_context import RUNTIME_CONTEXT_ENV, PluginRuntimeContext
+from datus.plugins.runtime_context import RUNTIME_CONTEXT_ENV, PluginRuntimeContext, PluginRuntimeTarget
 
 # ── _split_plugin_globals ────────────────────────────────────────────────────
 
@@ -107,6 +108,39 @@ def test_dispatch_calls_cli_with_resolved_profile(monkeypatch):
     assert _StubCli.last["profile"] == profile
     assert _StubCli.last["argv"] == ["dags", "list"]  # globals stripped
     assert stub_cfg.requested == {"name": "hello", "profile": "prod"}
+
+
+def test_dispatch_uses_inherited_delegate_without_loading_file_config(monkeypatch):
+    load_calls = []
+    _patch_dispatch(monkeypatch, profile_dict={"wrong": True}, load_calls=load_calls)
+    monkeypatch.setenv(
+        RUNTIME_CONTEXT_ENV,
+        PluginRuntimeContext(
+            plugin_name="k8s",
+            profile={"name": "dev", "provider": "eks"},
+            delegates={
+                "eks": PluginRuntimeTarget(
+                    profile={"name": "cluster-a", "region": "us-east-1"},
+                    plugin_path="/opt/plugins/eks",
+                )
+            },
+        ).encode(),
+    )
+    activated = []
+    monkeypatch.setattr("datus.plugins.store.activate_paths", lambda paths: activated.append(paths) or [])
+
+    rc = _dispatch_plugin_command(["eks", "--profile", "cluster-a", "kubernetes", "credential"])
+
+    assert rc == 7
+    assert load_calls == []
+    assert activated == [["/opt/plugins/eks"]]
+    assert _StubCli.last["profile"] == {"name": "cluster-a", "region": "us-east-1"}
+    assert _StubCli.last["argv"] == ["kubernetes", "credential"]
+    inherited = PluginRuntimeContext.decode(
+        os.environ[RUNTIME_CONTEXT_ENV],
+        expected_plugin="eks",
+    )
+    assert inherited.delegates == {}
 
 
 def test_dispatch_forwards_config_path(monkeypatch):

--- a/tests/unit_tests/plugins/test_manifest.py
+++ b/tests/unit_tests/plugins/test_manifest.py
@@ -131,6 +131,28 @@ def test_parse_manifest_full():
     assert manifest.config_schema["required"] == ["api_key"]
 
 
+def test_parse_manifest_preserves_plugin_profile_reference_extension():
+    reference = {"profile_field": "provider_profile", "default_profile": "same-name"}
+    manifest = parse_manifest(
+        {
+            "manifest_version": 1,
+            "config_schema": {
+                "type": "object",
+                "properties": {
+                    "provider": {
+                        "type": "string",
+                        "x-plugin-profile-ref": reference,
+                    }
+                },
+            },
+        },
+        "k8s",
+        PKG,
+    )
+
+    assert manifest.config_schema["properties"]["provider"]["x-plugin-profile-ref"] == reference
+
+
 def test_parse_manifest_bad_section_does_not_kill_others(caplog):
     """A malformed permissions block is dropped while cli stays usable."""
     data = {

--- a/tests/unit_tests/plugins/test_runtime_context.py
+++ b/tests/unit_tests/plugins/test_runtime_context.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from datus.plugins import runtime_context
+from datus.plugins.base import PluginManifest
 from datus.tools.func_tool.bash_tool import BashExecutionContext, BashTool
 
 _CTX = runtime_context.RUNTIME_CONTEXT_ENV
@@ -62,6 +63,58 @@ def test_context_rejects_wrong_plugin_and_malformed_value():
         runtime_context.PluginRuntimeContext.decode("v1.not-base64!")
 
 
+def test_context_selects_only_requested_delegate():
+    original = runtime_context.PluginRuntimeContext(
+        plugin_name="k8s",
+        profile={"name": "dev", "provider": "eks"},
+        delegates={
+            "eks": runtime_context.PluginRuntimeTarget(
+                profile={"name": "dev", "region": "us-east-1"},
+                plugin_path="/opt/plugins/eks",
+            )
+        },
+    )
+
+    selected = runtime_context.PluginRuntimeContext.decode(original.encode(), expected_plugin="eks")
+
+    assert selected == runtime_context.PluginRuntimeContext(
+        plugin_name="eks",
+        profile={"name": "dev", "region": "us-east-1"},
+        plugin_path="/opt/plugins/eks",
+    )
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="not `gke`"):
+        runtime_context.PluginRuntimeContext.decode(original.encode(), expected_plugin="gke")
+
+
+def test_loading_delegate_narrows_inherited_environment(monkeypatch):
+    original = runtime_context.PluginRuntimeContext(
+        plugin_name="k8s",
+        profile={"name": "dev"},
+        delegates={"eks": runtime_context.PluginRuntimeTarget(profile={"name": "dev"})},
+    )
+    monkeypatch.setenv(runtime_context.RUNTIME_CONTEXT_ENV, original.encode())
+
+    selected = runtime_context.load_runtime_context_from_env(expected_plugin="eks")
+
+    narrowed = runtime_context.PluginRuntimeContext(
+        plugin_name="eks",
+        profile={"name": "dev"},
+        plugin_path=None,
+    )
+    assert selected == narrowed
+    inherited = runtime_context.PluginRuntimeContext.decode(
+        os.environ[runtime_context.RUNTIME_CONTEXT_ENV],
+        expected_plugin="eks",
+    )
+    assert inherited == narrowed
+    assert inherited.delegates == {}
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="not `k8s`"):
+        runtime_context.PluginRuntimeContext.decode(
+            os.environ[runtime_context.RUNTIME_CONTEXT_ENV],
+            expected_plugin="k8s",
+        )
+
+
 def test_context_rejects_non_json_profile():
     with pytest.raises(runtime_context.PluginRuntimeContextError, match="not JSON-serializable"):
         runtime_context.PluginRuntimeContext("hello", {"bad": object()}).encode()
@@ -94,6 +147,103 @@ def test_prepare_plain_command_resolves_explicit_profile(monkeypatch, tmp_path):
     assert decoded.profile["token"] == "tenant-secret"
     assert runtime_context.RUNTIME_CONTEXT_ENV in prepared.command
     assert "tenant-secret" not in prepared.command
+
+
+@pytest.mark.parametrize(
+    "provider_profile,expected_profile",
+    [(None, "dev"), ("cluster-a", "cluster-a")],
+)
+def test_prepare_resolves_manifest_declared_provider_profile(
+    monkeypatch,
+    tmp_path,
+    provider_profile,
+    expected_profile,
+):
+    plugin_dirs = {name: tmp_path / name for name in ("k8s", "eks")}
+    for directory in plugin_dirs.values():
+        directory.mkdir()
+    schema = {
+        "type": "object",
+        "properties": {
+            "provider": {
+                "type": "string",
+                "x-plugin-profile-ref": {
+                    "profile_field": "provider_profile",
+                    "default_profile": "same-name",
+                },
+            }
+        },
+    }
+    manifest = PluginManifest(name="k8s", package_dir=plugin_dirs["k8s"], config_schema=schema)
+    monkeypatch.setattr("datus.plugins.registry.load_plugin_manifest", lambda name: manifest if name == "k8s" else None)
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dirs[name])
+
+    class Config:
+        plugins_enabled = True
+        plugin_paths = []
+
+        def __init__(self):
+            self.requested = []
+
+        def plugin_active(self, name):
+            return name in {"k8s", "eks"}
+
+        def get_plugin_profile(self, name, profile=None):
+            self.requested.append((name, profile))
+            if name == "k8s":
+                result = {"name": "dev", "provider": "eks", "namespace": "analytics"}
+                if provider_profile is not None:
+                    result["provider_profile"] = provider_profile
+                return result
+            return {"name": profile, "region": "us-east-1", "tenant_secret": "secret"}
+
+    config = Config()
+    prepared = runtime_context.prepare_plugin_invocation("datus k8s --profile dev get pods", config)
+
+    assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
+    assert config.requested == [("k8s", "dev"), ("eks", expected_profile)]
+    assert prepared.sandbox_read_dirs == [str(plugin_dirs["k8s"]), str(plugin_dirs["eks"])]
+    primary = runtime_context.PluginRuntimeContext.decode(prepared.env[_CTX], expected_plugin="k8s")
+    assert set(primary.delegates) == {"eks"}
+    delegate = runtime_context.PluginRuntimeContext.decode(prepared.env[_CTX], expected_plugin="eks")
+    assert delegate.profile == {
+        "name": expected_profile,
+        "region": "us-east-1",
+        "tenant_secret": "secret",
+    }
+
+
+def test_prepare_rejects_inactive_or_self_delegate(monkeypatch, tmp_path):
+    schema = {
+        "type": "object",
+        "properties": {
+            "provider": {
+                "type": "string",
+                "x-plugin-profile-ref": {"default_profile": "same-name"},
+            }
+        },
+    }
+    manifest = PluginManifest(name="k8s", package_dir=tmp_path, config_schema=schema)
+    monkeypatch.setattr("datus.plugins.registry.load_plugin_manifest", lambda name: manifest)
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: None)
+
+    class InactiveDelegateConfig(_Config):
+        def plugin_active(self, name):
+            return name == "k8s"
+
+    inactive = InactiveDelegateConfig(profile={"name": "dev", "provider": "eks"})
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="not active"):
+        runtime_context.prepare_plugin_invocation("datus k8s get pods", inactive)
+
+    class SelfConfig(_Config):
+        def plugin_active(self, name):
+            return True
+
+    with pytest.raises(runtime_context.PluginRuntimeContextError, match="cannot delegate.*itself"):
+        runtime_context.prepare_plugin_invocation(
+            "datus k8s get pods",
+            SelfConfig(profile={"name": "dev", "provider": "k8s"}),
+        )
 
 
 def test_prepare_pipeline_injects_only_datus_segment(monkeypatch, tmp_path):


### PR DESCRIPTION
## Why

Managed plugin subprocesses receive their configuration through the command-scoped `DATUS_PLUGIN_RUNTIME_CONTEXT` environment variable, which until now carried **only the invoked plugin's own resolved profile**.

That breaks plugin composition. When plugin A shells out to plugin B — for example a `k8s` plugin invoking a cloud credential plugin (`eks`) to obtain a cluster token — the second `datus <plugin>` process inherits no context it can use and falls back to local config-file resolution. In a multi-tenant API deployment that fallback path does not exist: the authoritative `AgentConfig` is supplied by an AuthProvider and lives only in the parent process, with no on-disk `agent.yml`.

The naive fix — shipping the whole `agent.plugins` section and letting each plugin pick what it needs — is not acceptable here. An environment variable is plaintext to every line of code in the process and to every subprocess it spawns; "the plugin only reads its own part" is a convention, not a boundary. It would also blow past the existing 64 KiB context ceiling in tenants with many plugins, and would leave `sandbox_read_dirs` uncomputable without a dependency declaration anyway.

## Solution

Add an explicit, manifest-declared **one-hop profile delegation**.

**Declaration.** A top-level `config_schema` property may carry the `x-plugin-profile-ref` extension. The property's value in the active profile names the delegated plugin; `profile_field` names the sibling property holding that plugin's profile name, and `default_profile: same-name` falls back to the primary profile's injected `name`:

```yaml
config_schema:
  properties:
    provider:
      type: string
      x-plugin-profile-ref:
        profile_field: provider_profile
        default_profile: same-name
```

No manifest-parsing change was required — `parse_manifest` already preserves unknown `x-` extension keys; a new test pins that contract.

**Resolution.** `prepare_plugin_invocation` calls the new `_resolve_profile_delegates`, which walks the declared references and resolves *only* those exact plugin/profile pairs from the authoritative `AgentConfig`. Each is validated: name legality, not a reserved name, not a self-reference, and `plugin_active` for the project. Conflicting resolutions for the same delegate fail closed. Resolved delegate directories are appended (deduplicated) to `sandbox_read_dirs`.

**Transport and narrowing.** Delegates travel as a new `delegates` map of `PluginRuntimeTarget` inside the same single environment variable. The security-relevant part is on the consuming side: `decode(..., expected_plugin=B)` now returns a context containing **only B's own profile and path, with an empty `delegates` map**, and `load_runtime_context_from_env` writes that narrowed value back to `os.environ` before any plugin code runs. Consequently a delegate cannot read the primary plugin's profile, cannot read sibling delegations, and cannot extend the chain transitively — the hop limit is enforced by the host, not by plugin cooperation.

Decoding is backward compatible: `delegates` defaults to `{}`, so contexts produced before this change still decode.

### Tradeoffs

- Plugin authors must declare composition in the manifest rather than discovering it at runtime. This is deliberate: the declaration is what makes the dependency statically auditable and what lets the sandbox read-dir set be computed ahead of execution.
- A runtime broker (child calls back to the parent for a named profile) would allow undeclared, policy-checked access, but requires an IPC channel, token lifecycle, and a parent-liveness assumption — disproportionate at this scale.

## Test Cases

All new coverage is unit-level, matching the existing tier for this module (no external services involved). Diff coverage: **83%**; test-quality audit: **P0=0, P1=0**.

`tests/unit_tests/plugins/test_runtime_context.py`
- `test_context_selects_only_requested_delegate` — selecting a delegate yields exactly that delegate's profile/path; an undeclared plugin still raises.
- `test_loading_delegate_narrows_inherited_environment` — asserts the rewritten `os.environ` value equals the narrowed context, has no delegates, and can no longer be decoded as the primary plugin.
- `test_prepare_resolves_manifest_declared_provider_profile` — parameterized over the `same-name` fallback and an explicit `provider_profile`; asserts the exact `get_plugin_profile` call sequence and the deduplicated `sandbox_read_dirs`.
- `test_prepare_rejects_inactive_or_self_delegate` — inactive delegate and self-delegation both fail closed.

`tests/unit_tests/plugins/test_manifest.py`
- `test_parse_manifest_preserves_plugin_profile_reference_extension` — the `x-plugin-profile-ref` extension survives manifest parsing.

`tests/unit_tests/cli/test_plugin_dispatch.py`
- `test_dispatch_uses_inherited_delegate_without_loading_file_config` — cross-component: dispatch resolves via the inherited delegate, loads **no** file config, activates the delegate's path, and leaves a narrowed environment behind.

### Pre-existing failures (not introduced here)

`ci/run-pr-tests.py datus/main` reports 88 failures locally. All 88 reproduce unchanged on `datus/main` (`c4d28c8cb`), verified by re-running the same targets on a clean checkout:
- 74 `tests/integration/*` failures (cli / doc_search / platform_doc / func_tools_db / mcp) caused by a local environment override;
- 14 `tests/unit_tests/*` OSI-authoring failures (`test_explorer_service.py`, `test_osi_authoring_templates.py`, `test_gen_semantic_model_agentic_node.py`) — baseline reports the identical `14 failed, 138 passed`.

None touch `datus/plugins/`. The 300 tests under `tests/unit_tests/plugins/` and `tests/unit_tests/cli/test_plugin_dispatch.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for plugin profiles to delegate to another plugin profile.
  * Delegated profiles can inherit configuration, use the referenced plugin’s path, and receive command-scoped settings.
  * Added safeguards to prevent nested or invalid delegation.
* **Documentation**
  * Expanded plugin manifest guidance with provider profile references, profile fields, and default-profile behavior.
* **Bug Fixes**
  * Improved delegated plugin dispatch so inherited configuration is used consistently without unnecessary file-based loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->