### PR TITLE
[BugFix] Read delegate manifests from selected plugin directories

### DIFF
--- a/datus/plugins/runtime_context.py
+++ b/datus/plugins/runtime_context.py
@@ -40,6 +40,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
 RUNTIME_CONTEXT_ENV = "DATUS_PLUGIN_RUNTIME_CONTEXT"
 RUNTIME_CONTEXT_VERSION = 1
 RUNTIME_CONTEXT_PREFIX = "v1."
@@ -265,10 +269,34 @@ def load_runtime_context_from_env(*, expected_plugin: Optional[str] = None) -> O
     return context
 
 
+def _load_manifest_for_invocation(plugin_name: str, plugin_path: Optional[Path]) -> Any:
+    """Read the manifest of the plugin copy this invocation will actually run.
+
+    ``plugin_path`` is the directory the normal store / ``agent.plugin_paths``
+    precedence already selected, so the manifest is read from there. Falling
+    back to the ``sys.path`` entry-point registry would be wrong in the two
+    deployments that matter most: a plugin mounted through
+    ``agent.plugin_paths`` (multi-tenant sandboxes) is not on the host
+    process's ``sys.path`` at all, and a host that never activated the managed
+    store sees a stale, empty registry. Both cases would silently yield "no
+    manifest" and drop every declared delegation.
+
+    ``plugin_path is None`` means the plugin lives in this interpreter's
+    site-packages, where the entry-point registry is the correct source.
+    """
+    from datus.plugins import store
+    from datus.plugins.registry import load_plugin_manifest
+
+    if plugin_path is None:
+        return load_plugin_manifest(plugin_name)
+    return store.manifest_for_dir(plugin_path, plugin_name)
+
+
 def _resolve_profile_delegates(
     agent_config: Any,
     plugin_name: str,
     profile: Dict[str, Any],
+    plugin_path: Optional[Path] = None,
 ) -> Dict[str, PluginRuntimeTarget]:
     """Resolve manifest-declared, one-hop plugin profile references.
 
@@ -280,10 +308,20 @@ def _resolve_profile_delegates(
     the authoritative AuthProvider AgentConfig.
     """
     from datus.plugins import store
-    from datus.plugins.registry import load_plugin_manifest
 
-    manifest = load_plugin_manifest(plugin_name)
-    schema = manifest.config_schema if manifest is not None else None
+    manifest = _load_manifest_for_invocation(plugin_name, plugin_path)
+    if manifest is None:
+        # Never silent: without a manifest no delegation can be declared, and
+        # the failure would otherwise only surface as the delegate subprocess
+        # rejecting its runtime context.
+        logger.warning(
+            "Plugin `%s` manifest could not be read from %s; any declared plugin profile "
+            "references are ignored for this invocation.",
+            plugin_name,
+            plugin_path or "the current Python environment",
+        )
+        return {}
+    schema = manifest.config_schema
     properties = schema.get("properties") if isinstance(schema, dict) else None
     if not isinstance(properties, dict):
         return {}
@@ -433,7 +471,7 @@ def prepare_plugin_invocation(command: str, agent_config: Any) -> Optional[Prepa
 
     plugin_path = _resolve_plugin_path(agent_config, plugin_name)
     profile = agent_config.get_plugin_profile(plugin_name, profile_name)
-    delegates = _resolve_profile_delegates(agent_config, plugin_name, profile)
+    delegates = _resolve_profile_delegates(agent_config, plugin_name, profile, plugin_path)
     runtime = PluginRuntimeContext(
         plugin_name=plugin_name,
         profile=profile,

--- a/datus/plugins/store.py
+++ b/datus/plugins/store.py
@@ -42,7 +42,7 @@ from email.parser import Parser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
-from datus.plugins.base import MANIFEST_FILENAME, read_manifest_file
+from datus.plugins.base import MANIFEST_FILENAME, PluginManifest, read_manifest_file
 from datus.plugins.registry import _SAFE_PLUGIN_NAME_RE, PLUGIN_ENTRY_POINT_GROUP, invalidate_plugin_cache
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -186,6 +186,54 @@ def plugin_name_for_dir(directory: Path) -> Optional[str]:
     except (OSError, configparser.Error):
         return None
     return next(iter(parser[PLUGIN_ENTRY_POINT_GROUP]), None)
+
+
+def _module_ref_for_dir(directory: Path) -> Optional[str]:
+    """Dotted package ref the plugin tree in ``directory`` registers, or ``None``."""
+    meta = read_meta(directory)
+    if meta is not None:
+        entry_point = meta.get("entry_point")
+        if isinstance(entry_point, str) and entry_point.strip():
+            module_ref, _, attr = entry_point.partition(":")
+            if not attr.strip() and module_ref.strip():
+                return module_ref.strip()
+    dist_info = _find_plugin_dist_info(directory)
+    if dist_info is None:
+        return None
+    parser = configparser.ConfigParser()
+    parser.optionxform = str
+    try:
+        parser.read_string((dist_info / "entry_points.txt").read_text(encoding="utf-8", errors="replace"))
+    except (OSError, configparser.Error):
+        return None
+    section = parser[PLUGIN_ENTRY_POINT_GROUP]
+    name = next(iter(section), None)
+    if name is None:
+        return None
+    module_ref, _, attr = section[name].strip().partition(":")
+    if attr.strip() or not module_ref.strip():
+        return None
+    return module_ref.strip()
+
+
+def manifest_for_dir(directory: Path, name: str) -> Optional["PluginManifest"]:
+    """Parse the manifest bundled in ONE plugin directory, without importing it.
+
+    Mirrors :func:`plugin_name_for_dir`, and exists because
+    :func:`datus.plugins.registry.load_plugin_manifest` resolves through
+    ``sys.path`` entry points: a plugin mounted via ``agent.plugin_paths`` (or
+    a managed store the host process never activated) is invisible to it even
+    though the directory was selected successfully. Callers that already know
+    which directory will execute must read the manifest from THAT directory,
+    so the schema they act on always belongs to the code that will run.
+
+    Returns ``None`` — never raises — when the tree declares no usable package
+    ref or bundles no valid manifest.
+    """
+    module_ref = _module_ref_for_dir(directory)
+    if module_ref is None:
+        return None
+    return read_manifest_file(directory.joinpath(*module_ref.split(".")), name)
 
 
 def iter_extra_plugin_dirs(extra_paths: Optional[List[str]]) -> List[tuple]:
@@ -430,6 +478,7 @@ __all__ = [
     "write_meta",
     "iter_installed",
     "plugin_name_for_dir",
+    "manifest_for_dir",
     "iter_extra_plugin_dirs",
     "introspect_target",
     "activate",

--- a/tests/unit_tests/plugins/test_runtime_context.py
+++ b/tests/unit_tests/plugins/test_runtime_context.py
@@ -9,6 +9,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+import yaml
 
 from datus.plugins import runtime_context
 from datus.plugins.base import PluginManifest
@@ -149,6 +150,40 @@ def test_prepare_plain_command_resolves_explicit_profile(monkeypatch, tmp_path):
     assert "tenant-secret" not in prepared.command
 
 
+def _write_plugin_tree(root, name, package, schema=None):
+    """Materialise a real ``pip install --target`` plugin tree under ``root``.
+
+    Mirrors the on-disk layout of both a managed install and an
+    ``agent.plugin_paths`` mount, so manifest discovery is exercised the way it
+    happens in a deployment instead of being stubbed out.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    dist_info = root / f"datus_{name}_plugin-0.1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "entry_points.txt").write_text(f"[datus.plugins]\n{name} = {package}\n", encoding="utf-8")
+    package_dir = root / package
+    package_dir.mkdir()
+    manifest = {"manifest_version": 1, "cli": f"{package}.cli:main"}
+    if schema is not None:
+        manifest["config_schema"] = schema
+    (package_dir / "datus-plugin.yml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    return root
+
+
+_PROVIDER_REF_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "provider": {
+            "type": "string",
+            "x-plugin-profile-ref": {
+                "profile_field": "provider_profile",
+                "default_profile": "same-name",
+            },
+        }
+    },
+}
+
+
 @pytest.mark.parametrize(
     "provider_profile,expected_profile",
     [(None, "dev"), ("cluster-a", "cluster-a")],
@@ -159,23 +194,18 @@ def test_prepare_resolves_manifest_declared_provider_profile(
     provider_profile,
     expected_profile,
 ):
-    plugin_dirs = {name: tmp_path / name for name in ("k8s", "eks")}
-    for directory in plugin_dirs.values():
-        directory.mkdir()
-    schema = {
-        "type": "object",
-        "properties": {
-            "provider": {
-                "type": "string",
-                "x-plugin-profile-ref": {
-                    "profile_field": "provider_profile",
-                    "default_profile": "same-name",
-                },
-            }
-        },
+    # Real trees on disk: the manifest must be found through the selected
+    # directory, never through this interpreter's entry points. A deployment
+    # that mounts plugins via ``agent.plugin_paths`` has no entry point for
+    # them at all, so a registry-based lookup silently drops every delegation.
+    plugin_dirs = {
+        "k8s": _write_plugin_tree(tmp_path / "k8s", "k8s", "datus_plugin_k8s", _PROVIDER_REF_SCHEMA),
+        "eks": _write_plugin_tree(tmp_path / "eks", "eks", "datus_plugin_eks"),
     }
-    manifest = PluginManifest(name="k8s", package_dir=plugin_dirs["k8s"], config_schema=schema)
-    monkeypatch.setattr("datus.plugins.registry.load_plugin_manifest", lambda name: manifest if name == "k8s" else None)
+    monkeypatch.setattr(
+        "datus.plugins.registry.load_plugin_manifest",
+        lambda name: pytest.fail(f"entry-point registry must not be consulted for {name!r}"),
+    )
     monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: plugin_dirs[name])
 
     class Config:
@@ -211,6 +241,54 @@ def test_prepare_resolves_manifest_declared_provider_profile(
         "region": "us-east-1",
         "tenant_secret": "secret",
     }
+
+
+def test_prepare_resolves_delegates_for_plugin_paths_mounted_plugins(monkeypatch, tmp_path):
+    """Delegation must survive a deployment with no entry points on ``sys.path``.
+
+    Multi-tenant sandboxes mount plugins through ``agent.plugin_paths`` under a
+    tenant directory and never create the managed store, so
+    ``importlib.metadata`` sees zero ``datus.plugins`` entry points. Only the
+    managed store is stubbed (to an empty dir, as in such a deployment); the
+    real ``iter_extra_plugin_dirs`` precedence and manifest discovery run.
+    """
+    monkeypatch.setattr("datus.plugins.store.plugins_root", lambda: tmp_path / "no-managed-store")
+    tenant = tmp_path / "tenants" / "acme" / "plugins"
+    k8s_dir = _write_plugin_tree(tenant / "datus-k8s-plugin" / "0.0.4", "k8s", "datus_plugin_k8s", _PROVIDER_REF_SCHEMA)
+    eks_dir = _write_plugin_tree(tenant / "datus-eks-plugin" / "0.0.1", "eks", "datus_plugin_eks")
+
+    class Config:
+        plugins_enabled = True
+        plugin_paths = [str(k8s_dir), str(eks_dir)]
+
+        def plugin_active(self, name):
+            return True
+
+        def get_plugin_profile(self, name, profile=None):
+            if name == "k8s":
+                return {"name": "default", "provider": "eks", "namespace": "acme"}
+            return {"name": profile, "region": "us-east-1", "tenant_secret": "acme-secret"}
+
+    prepared = runtime_context.prepare_plugin_invocation("datus k8s get pods", Config())
+
+    assert isinstance(prepared, runtime_context.PreparedPluginInvocation)
+    delegate = runtime_context.PluginRuntimeContext.decode(prepared.env[_CTX], expected_plugin="eks")
+    assert delegate.profile == {"name": "default", "region": "us-east-1", "tenant_secret": "acme-secret"}
+    assert prepared.sandbox_read_dirs == [str(k8s_dir), str(eks_dir)]
+
+
+def test_prepare_warns_when_manifest_is_unreadable(caplog, monkeypatch, tmp_path):
+    """A manifest that cannot be read must say so, not drop delegations silently."""
+    empty = tmp_path / "k8s"
+    empty.mkdir()
+    monkeypatch.setattr(runtime_context, "_resolve_plugin_path", lambda config, name: empty)
+
+    with caplog.at_level("WARNING"):
+        prepared = runtime_context.prepare_plugin_invocation("datus k8s get pods", _Config())
+
+    context = runtime_context.PluginRuntimeContext.decode(prepared.env[_CTX], expected_plugin="k8s")
+    assert context.delegates == {}
+    assert "manifest could not be read" in caplog.text
 
 
 def test_prepare_rejects_inactive_or_self_delegate(monkeypatch, tmp_path):

--- a/tests/unit_tests/plugins/test_store.py
+++ b/tests/unit_tests/plugins/test_store.py
@@ -253,6 +253,68 @@ def test_plugin_name_for_dir_none_when_entry_points_vanish(home, tmp_path, monke
     assert store.plugin_name_for_dir(target) is None
 
 
+def test_manifest_for_dir_reads_via_dist_info(home, tmp_path):
+    """A path-mounted tree resolves its manifest with no entry point on sys.path."""
+    target = _write_target(tmp_path / "ext", manifest="manifest_version: 1\ndescription: mounted\n")
+    manifest = store.manifest_for_dir(target, "demo")
+    assert (manifest.name, manifest.description) == ("demo", "mounted")
+    assert manifest.package_dir == target / "datus_demo_plugin"
+
+
+def test_manifest_for_dir_prefers_managed_meta_entry_point(home, tmp_path):
+    """A managed install records its entry point, so no dist-info scan is needed."""
+    target = _write_target(tmp_path / "ext", group=None)
+    store.write_meta(target, {"name": "demo", "entry_point": "datus_demo_plugin"})
+    manifest = store.manifest_for_dir(target, "demo")
+    assert manifest.name == "demo"
+    assert manifest.package_dir == target / "datus_demo_plugin"
+
+
+@pytest.mark.parametrize(
+    "meta,group",
+    [
+        # A legacy object-targeting entry point yields no importable package ref,
+        # in the recorded metadata and in the dist-info alike.
+        ({"name": "demo", "entry_point": "datus_demo_plugin:Plugin"}, None),
+        ({"name": "demo", "entry_point": "   "}, None),
+        (None, None),
+    ],
+)
+def test_manifest_for_dir_none_without_usable_package_ref(home, tmp_path, meta, group):
+    target = _write_target(tmp_path / "ext", group=group)
+    if meta is not None:
+        store.write_meta(target, meta)
+    assert store.manifest_for_dir(target, "demo") is None
+
+
+def test_manifest_for_dir_none_for_legacy_dist_info_entry(home, tmp_path):
+    target = _write_target(tmp_path / "ext", entry="datus_demo_plugin:Plugin")
+    assert store.manifest_for_dir(target, "demo") is None
+
+
+def test_manifest_for_dir_none_when_manifest_missing(home, tmp_path):
+    """The package ref resolves but the tree bundles no manifest."""
+    target = _write_target(tmp_path / "ext", manifest=None)
+    assert store.manifest_for_dir(target, "demo") is None
+
+
+def test_manifest_for_dir_none_when_entry_points_unreadable(home, tmp_path, monkeypatch):
+    target = _write_target(tmp_path / "ext")
+    dist_info = next(target.glob("*.dist-info"))
+    monkeypatch.setattr(store, "_find_plugin_dist_info", lambda d: dist_info)
+    (dist_info / "entry_points.txt").unlink()
+    assert store.manifest_for_dir(target, "demo") is None
+
+
+def test_manifest_for_dir_none_when_group_is_empty(home, tmp_path, monkeypatch):
+    """An empty ``datus.plugins`` group names no entry point to read."""
+    target = _write_target(tmp_path / "ext")
+    dist_info = next(target.glob("*.dist-info"))
+    (dist_info / "entry_points.txt").write_text("[datus.plugins]\n", encoding="utf-8")
+    monkeypatch.setattr(store, "_find_plugin_dist_info", lambda d: dist_info)
+    assert store.manifest_for_dir(target, "demo") is None
+
+
 def test_iter_extra_plugin_dirs_skips_bad_entries(home, tmp_path, caplog):
     first = _write_target(tmp_path / "one")
     _write_target(tmp_path / "two")  # same entry-point name → duplicate


### PR DESCRIPTION
## Summary

- Read a delegating plugin manifest from the exact managed-store or agent.plugin_paths directory selected for execution.
- Fall back to the installed entry-point registry only for site-packages plugins.
- Add safe manifest discovery for managed metadata and dist-info layouts.
- Preserve AuthProvider tenant isolation while allowing k8s to resolve its declared EKS profile delegate.

## Problem

The runtime delegate feature worked for installed entry points but silently found no config schema when tenant plugins were mounted only through agent.plugin_paths. The nested EKS command then inherited a k8s-only runtime context and failed with a plugin-context mismatch.

## Validation

- 207 targeted plugin runtime, store, manifest, and CLI tests passed.
- Existing untracked datus-plugin-flink directory was not included.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin manifests can now be resolved directly from selected plugin directories.
  * Plugins mounted through configured paths are supported during runtime delegation.
  * Added handling for managed installations and legacy plugin metadata.

* **Bug Fixes**
  * Prevented unnecessary registry lookups when a plugin directory is selected.
  * Missing or unreadable manifests now produce warnings and no delegates instead of causing failures.

* **Tests**
  * Expanded coverage for mounted plugins, manifest resolution, metadata variations, and unreadable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->