### PR TITLE
[BugFix] fix: reset subagent_status to SUCCESS on successful action after self-healing

### DIFF
--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -949,6 +949,7 @@ class SubAgentTaskTool:
                             final_output = action.output
                     elif action.status == ActionStatus.SUCCESS and action.output:
                         final_output = action.output
+                        subagent_status = ActionStatus.SUCCESS
             except Exception as e:
                 # Surface the failure as an envelope (not a re-raise) so the
                 # parent agent can resume the partial subagent session via


### PR DESCRIPTION
## Problem

When a sub-agent self-heals during execution — an intermediate tool call 
fails (e.g. SQL syntax error from `read_query`), the LLM fixes the issue, 
and a subsequent tool call succeeds — the `subagent_complete` action on 
the ActionBus carries `status=FAILED` even though the sub-agent ultimately 
succeeded.

## Root Cause

In `SubAgentTaskTool._execute_node()`, `subagent_status` is initialized to 
`SUCCESS`, downgraded to `FAILED` on any failed action, but never restored 
to `SUCCESS` when later actions succeed. The `elif` branch only updates 
`final_output`, not `subagent_status`.

## Impact

The `subagent_complete FAILED` action reaches the SSE converter, which 
checks `status == FAILED` before checking `action_type`, causing it to 
emit an error event instead of a normal subagent-complete summary event.

## Fix

One line: reset `subagent_status = ActionStatus.SUCCESS` in the success 
branch, mirroring the failure branch logic.



## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subagent tasks now accurately report a successful status when their output is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->