### PR TITLE
[Feature] Wire up the GaussDB adapter (datus-gaussdb)

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -160,6 +160,7 @@ jobs:
             --reinstall-package datus-doris \
             --reinstall-package datus-hologres \
             --reinstall-package datus-oracle \
+            --reinstall-package datus-gaussdb \
             --reinstall-package datus-storage-base \
             --reinstall-package datus-storage-postgresql \
             pytest-playwright \
@@ -183,6 +184,7 @@ jobs:
             ./external/datus-db-adapters/datus-greenplum \
             ./external/datus-db-adapters/datus-hive \
             ./external/datus-db-adapters/datus-spark \
+            ./external/datus-db-adapters/datus-gaussdb \
             ./external/datus-bi-adapters/datus-bi-core \
             ./external/datus-bi-adapters/datus-bi-superset \
             ./external/datus-bi-adapters/datus-bi-grafana \
@@ -315,6 +317,7 @@ jobs:
           echo "ADAPTERS_GP=1" >> $GITHUB_ENV
           echo "ADAPTERS_HIVE=1" >> $GITHUB_ENV
           echo "ADAPTERS_SPARK=1" >> $GITHUB_ENV
+          echo "ADAPTERS_GAUSSDB=1" >> $GITHUB_ENV
 
           # Use dedicated high host ports so nightly compose suites do not
           # collide with long-running services on the shared self-hosted runner.

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -353,6 +353,7 @@ flow_groups:
               - tests/integration/adapters/test_greenplum.py
               - tests/integration/adapters/test_hive.py
               - tests/integration/adapters/test_spark.py
+              - tests/integration/adapters/test_gaussdb.py
           weekly_benchmark:
             status: covered
             notes: Baisheng weekly benchmark runs Datus queries against StarRocks.

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -39,6 +39,7 @@ PACKAGE_NAMES = (
     "datus-greenplum",
     "datus-hive",
     "datus-spark",
+    "datus-gaussdb",
     "datus-bi-core",
     "datus-bi-superset",
     "datus-bi-grafana",

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -73,6 +73,7 @@ TRINO_COMPOSE="${TRINO_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-trino/docker-compose.y
 GREENPLUM_COMPOSE="${GREENPLUM_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-greenplum/docker-compose.yml}"
 HIVE_COMPOSE="${HIVE_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-hive/docker-compose.yml}"
 SPARK_COMPOSE="${SPARK_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-spark/docker-compose.yml}"
+GAUSSDB_COMPOSE="${GAUSSDB_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-gaussdb/docker-compose.yml}"
 SUPERSET_COMPOSE="${SUPERSET_COMPOSE:-${BI_ADAPTERS_ROOT}/datus-bi-superset/tests/integration/docker-compose.yml}"
 GRAFANA_COMPOSE="${GRAFANA_COMPOSE:-${BI_ADAPTERS_ROOT}/datus-bi-grafana/tests/integration/docker-compose.yml}"
 AIRFLOW_COMPOSE="${AIRFLOW_COMPOSE:-${SCHEDULER_ADAPTERS_ROOT}/datus-scheduler-airflow/tests/integration/docker-compose.yml}"
@@ -87,6 +88,7 @@ COMPOSE_FILES=(
   "$GREENPLUM_COMPOSE"
   "$HIVE_COMPOSE"
   "$SPARK_COMPOSE"
+  "$GAUSSDB_COMPOSE"
   "$SUPERSET_COMPOSE"
   "$GRAFANA_COMPOSE"
   "$AIRFLOW_COMPOSE"
@@ -105,6 +107,7 @@ COMPOSE_GROUPS=(
   "Greenplum Adapter Tests"
   "Hive Adapter Tests"
   "Spark Adapter Tests"
+  "GaussDB Adapter Tests"
 )
 
 DOCKER_GROUPS=(
@@ -489,6 +492,7 @@ compose_project_slug() {
     "Greenplum Adapter Tests") echo "greenplum" ;;
     "Hive Adapter Tests") echo "hive" ;;
     "Spark Adapter Tests") echo "spark" ;;
+    "GaussDB Adapter Tests") echo "gaussdb" ;;
     *)
       echo "$group_name" \
         | tr '[:upper:]' '[:lower:]' \
@@ -545,6 +549,7 @@ cleanup_all_compose() {
       "Greenplum Adapter Tests") compose_file="$GREENPLUM_COMPOSE" ;;
       "Hive Adapter Tests") compose_file="$HIVE_COMPOSE" ;;
       "Spark Adapter Tests") compose_file="$SPARK_COMPOSE" ;;
+      "GaussDB Adapter Tests") compose_file="$GAUSSDB_COMPOSE" ;;
       *) continue ;;
     esac
     if [ -f "$compose_file" ]; then
@@ -833,6 +838,7 @@ export ADAPTERS_TRINO="${ADAPTERS_TRINO:-1}"
 export ADAPTERS_GP="${ADAPTERS_GP:-1}"
 export ADAPTERS_HIVE="${ADAPTERS_HIVE:-1}"
 export ADAPTERS_SPARK="${ADAPTERS_SPARK:-1}"
+export ADAPTERS_GAUSSDB="${ADAPTERS_GAUSSDB:-1}"
 export ADAPTERS_METRICFLOW_DUCKDB="${ADAPTERS_METRICFLOW_DUCKDB:-1}"
 export ADAPTERS_METRICFLOW_MYSQL="${ADAPTERS_METRICFLOW_MYSQL:-1}"
 export ADAPTERS_METRICFLOW_PG="${ADAPTERS_METRICFLOW_PG:-1}"
@@ -1645,6 +1651,7 @@ NIGHTLY_DEDICATED_SUITE_DESELECTS=(
   --deselect tests/integration/adapters/test_greenplum.py
   --deselect tests/integration/adapters/test_hive.py
   --deselect tests/integration/adapters/test_spark.py
+  --deselect tests/integration/adapters/test_gaussdb.py
   --deselect tests/integration/adapters/test_semantic_metricflow_duckdb.py
   --deselect tests/integration/adapters/test_semantic_metricflow_mysql.py
   --deselect tests/integration/adapters/test_semantic_metricflow_postgresql.py
@@ -1671,6 +1678,7 @@ run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with
 run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Spark Adapter Tests" "$SPARK_COMPOSE" "spark-thrift:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_compose_suite "GaussDB Adapter Tests" "$GAUSSDB_COMPOSE" "gaussdb:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_gaussdb.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_logged "MetricFlow DuckDB Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_semantic_metricflow_duckdb.py --tb=short --verbose --timeout=300 --timeout-method=thread
 
 run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and provider_health" "${NIGHTLY_PYTEST_ROOTS[@]}" --tb=short --verbose --timeout=300 --timeout-method=thread --reruns 1 --reruns-delay 5

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -28,6 +28,7 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-greenplum": "datus-db-adapters/datus-greenplum",
     "datus-hive": "datus-db-adapters/datus-hive",
     "datus-spark": "datus-db-adapters/datus-spark",
+    "datus-gaussdb": "datus-db-adapters/datus-gaussdb",
     "datus-bi-core": "datus-bi-adapters/datus-bi-core",
     "datus-bi-superset": "datus-bi-adapters/datus-bi-superset",
     "datus-bi-grafana": "datus-bi-adapters/datus-bi-grafana",
@@ -71,6 +72,11 @@ DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
             "infer_transfer_type",
             "write_dataframe",
         ),
+    ),
+    "datus_gaussdb": DatabaseAdapterContract(
+        db_type="gaussdb",
+        parser_dialect="postgres",
+        required_hooks=("get_identifier_parser", "get_sql_generation_notes"),
     ),
 }
 

--- a/datus/cli/datasource_app.py
+++ b/datus/cli/datasource_app.py
@@ -45,6 +45,7 @@ INSTALLABLE_TYPES = (
     "clickhouse",
     "clickzetta",
     "doris",
+    "gaussdb",
     "greenplum",
     "hive",
     "hologres",

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -29,6 +29,7 @@ This design keeps the core package lightweight while allowing you to add support
 | Apache Doris | datus-doris | `pip install datus-doris` | Ready |
 | Hologres | datus-hologres | `pip install datus-hologres` | Ready |
 | Oracle | datus-oracle | `pip install datus-oracle` | Ready |
+| GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | Ready (Linux only) |
 
 ## Installation
 
@@ -76,6 +77,9 @@ pip install datus-hologres
 
 # Oracle
 pip install datus-oracle
+
+# GaussDB / openGauss (Linux only)
+pip install datus-gaussdb
 ```
 
 Once installed, Datus Agent will automatically detect and load the adapter.
@@ -291,6 +295,25 @@ oracle_data:
 Configure exactly one connection target: `service_name` (recommended), `sid`, or `dsn`. The service/PDB
 selects the connection target but is not part of an SQL object name; qualify objects as `SCHEMA.TABLE`.
 
+### GaussDB
+
+```yaml
+gaussdb_data:
+  type: gaussdb
+  host: localhost
+  port: 5432
+  username: datus
+  password: ${GAUSSDB_PASSWORD}
+  database: postgres
+  schema: public   # optional, default is public
+  driver: gaussdb  # optional, default is gaussdb; set to psycopg2 as an escape hatch
+```
+
+GaussDB and openGauss speak the PostgreSQL wire protocol. The default `gaussdb` driver is the official
+client and supports sha256, md5, and sm3 authentication; the `psycopg2` escape hatch only works against
+servers configured for md5. Both centralized and distributed deployments are supported, and the connector
+auto-detects the database's A / B / PG compatibility mode so generated SQL follows the right semantics.
+
 ### Multiple Database Entries
 
 ```yaml
@@ -397,6 +420,13 @@ All adapters support:
 - Schema-scoped metadata discovery through `ALL_*` dictionary views
 - Oracle-compatible profiling and bound-parameter data transfers
 
+#### GaussDB
+- PostgreSQL wire protocol (PostgreSQL-compatible SQL dialect)
+- sha256, md5, and sm3 authentication through the official `gaussdb` driver
+- A / B / PG compatibility-mode auto-detection, so SQL generation follows the server's semantics
+- Centralized and distributed deployments, with distribution-aware table DDL
+- Multi-schema datasource support
+
 ## Troubleshooting
 
 ### Adapter Not Found
@@ -430,6 +460,9 @@ Some adapters require additional system dependencies:
 - **Apache Doris**: Requires `datus-mysql` and `pymysql` (installed automatically)
 - **Hologres**: Requires `datus-postgresql` and `psycopg2-binary` (installed automatically)
 - **Oracle**: Requires `oracledb` (installed automatically; Thin mode needs no Oracle Client)
+- **GaussDB**: Requires `datus-postgresql` and the official `gaussdb` driver (installed automatically).
+  That driver binds a GaussDB-family libpq, which release wheels bundle for Linux; no build is published
+  for macOS, so run the adapter inside a Linux environment
 
 ## Architecture
 
@@ -445,7 +478,8 @@ datus-agent (Core)
     │   │   ├── datus-starrocks
     │   │   └── datus-doris
     │   ├── datus-postgresql
-    │   │   └── datus-hologres
+    │   │   ├── datus-hologres
+    │   │   └── datus-gaussdb
     │   ├── datus-hive
     │   ├── datus-spark
     │   ├── datus-clickhouse

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -29,6 +29,7 @@ Datus 使用模块化适配器架构，允许连接不同的数据库：
 | Apache Doris | datus-doris | `pip install datus-doris` | 可用 |
 | Hologres | datus-hologres | `pip install datus-hologres` | 可用 |
 | Oracle | datus-oracle | `pip install datus-oracle` | 可用 |
+| GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | 可用（仅 Linux） |
 
 ## 安装
 
@@ -73,6 +74,9 @@ pip install datus-hologres
 
 # Oracle
 pip install datus-oracle
+
+# GaussDB / openGauss（仅 Linux）
+pip install datus-gaussdb
 ```
 
 安装后，Datus Agent 会自动检测并加载适配器。
@@ -283,6 +287,24 @@ oracle_data:
 连接目标必须且只能配置一个：`service_name`（推荐）、`sid` 或 `dsn`。service/PDB 只用于选择连接目标，
 不属于 SQL 对象名；对象应使用 `SCHEMA.TABLE` 限定。
 
+### GaussDB
+
+```yaml
+gaussdb_data:
+  type: gaussdb
+  host: localhost
+  port: 5432
+  username: datus
+  password: ${GAUSSDB_PASSWORD}
+  database: postgres
+  schema: public   # 可选，默认为 public
+  driver: gaussdb  # 可选，默认为 gaussdb；可设为 psycopg2 作为兜底方案
+```
+
+GaussDB 与 openGauss 使用 PostgreSQL wire 协议。默认的 `gaussdb` 驱动为官方客户端，支持 sha256、md5
+和 sm3 认证；`psycopg2` 兜底方案仅适用于服务端配置为 md5 认证的场景。集中式与分布式部署均受支持，
+连接器会自动探测数据库的 A / B / PG 兼容模式，使生成的 SQL 遵循对应语义。
+
 ## 多数据库连接
 
 可以在 `agent.services.datasources` 下配置多个独立数据源连接：
@@ -384,6 +406,13 @@ agent:
 - 通过 `ALL_*` 数据字典视图发现 schema 范围内的元数据
 - Oracle 兼容的 profiling 和绑定参数数据传输
 
+#### GaussDB
+- PostgreSQL wire 协议（PostgreSQL 兼容 SQL 方言）
+- 通过官方 `gaussdb` 驱动支持 sha256、md5 和 sm3 认证
+- 自动探测 A / B / PG 兼容模式，使 SQL 生成遵循服务端语义
+- 同时支持集中式与分布式部署，并生成分布键感知的建表 DDL
+- 多 schema 数据源支持
+
 ## 故障排除
 
 ### 适配器未找到
@@ -416,6 +445,8 @@ pip install datus-mysql
 - **Apache Doris**：需要 `datus-mysql` 和 `pymysql`（自动安装）
 - **Hologres**：需要 `datus-postgresql` 和 `psycopg2-binary`（自动安装）
 - **Oracle**：需要 `oracledb`（自动安装；Thin 模式不需要 Oracle Client）
+- **GaussDB**：需要 `datus-postgresql` 和官方 `gaussdb` 驱动（自动安装）。该驱动依赖 GaussDB 系的
+  libpq，发布 wheel 中已内置 Linux 版本；官方未提供 macOS 版本，因此请在 Linux 环境中运行该适配器
 
 ## 架构
 
@@ -431,7 +462,8 @@ datus-agent (核心)
     │   │   ├── datus-starrocks
     │   │   └── datus-doris
     │   ├── datus-postgresql
-    │   │   └── datus-hologres
+    │   │   ├── datus-hologres
+    │   │   └── datus-gaussdb
     │   ├── datus-hive
     │   ├── datus-spark
     │   ├── datus-clickhouse

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -64,6 +64,7 @@ docker compose down -v
 | doris | `ADAPTERS_DORIS=1` | `DORIS_HOST/PORT/USER/PASSWORD/CATALOG/DATABASE` | `127.0.0.1:9030 root//internal/test` |
 | trino | `ADAPTERS_TRINO=1` | `TRINO_HOST/PORT/USER` | `localhost:8080 trino` (uses built-in `tpch.tiny`, no seeding) |
 | greenplum | `ADAPTERS_GP=1` | `GREENPLUM_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA` | `localhost:15432 gpadmin/pivotal/postgres/public` |
+| gaussdb | `ADAPTERS_GAUSSDB=1` | `GAUSSDB_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA` | `127.0.0.1:25434 datus/Datus@123/postgres/public` (Linux only) |
 | hive | `ADAPTERS_HIVE=1` | `HIVE_HOST/PORT/USERNAME/PASSWORD/DATABASE` | `localhost:10000 hive//default` |
 | spark | `ADAPTERS_SPARK=1` | `SPARK_HOST/PORT/USER/PASSWORD/DATABASE/AUTH_MECHANISM` | `localhost:10000 spark//default/NONE` |
 

--- a/tests/integration/adapters/test_gaussdb.py
+++ b/tests/integration/adapters/test_gaussdb.py
@@ -1,0 +1,176 @@
+"""
+Contract tests: GaussDB adapter via DBFuncTool.
+
+GaussDB / openGauss speaks the PostgreSQL wire protocol; the adapter
+`GaussDBConnector` inherits from `PostgreSQLConnector`. We still test it as a
+separate adapter to catch GaussDB-specific regressions (A/B/PG compatibility
+mode detection, distribution-aware DDL, official-driver connection handling).
+
+Opt-in (all required):
+  * install:    `uv pip install datus-gaussdb`
+  * start:      `cd datus-db-adapters/datus-gaussdb && docker compose up -d`
+  * env:         ADAPTERS_GAUSSDB=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  GAUSSDB_HOST=127.0.0.1  GAUSSDB_PORT=25434
+  GAUSSDB_USER=datus      GAUSSDB_PASSWORD=Datus@123
+  GAUSSDB_DATABASE=postgres  GAUSSDB_SCHEMA=public
+
+The official `gaussdb` driver binds a GaussDB-family libpq that is published for
+Linux only, so this suite runs on Linux (release wheels bundle that libpq).
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+from tests.nightly_requirements import import_required, require_opt_in_env
+
+require_opt_in_env("ADAPTERS_GAUSSDB", "tests/integration/adapters/README.md")
+
+datus_gaussdb = import_required(
+    "datus_gaussdb",
+    reason="datus-gaussdb not installed; run `uv pip install datus-gaussdb`",
+)
+
+GaussDBConfig = datus_gaussdb.GaussDBConfig
+GaussDBConnector = datus_gaussdb.GaussDBConnector
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+
+
+SCHEMA = os.getenv("GAUSSDB_SCHEMA", "public")
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+REGION_DDL = f"""
+CREATE TABLE "{SCHEMA}"."{REGION_TABLE}" (
+    r_regionkey INTEGER PRIMARY KEY,
+    r_name VARCHAR(25) NOT NULL,
+    r_comment VARCHAR(152)
+)
+"""
+NATION_DDL = f"""
+CREATE TABLE "{SCHEMA}"."{NATION_TABLE}" (
+    n_nationkey INTEGER PRIMARY KEY,
+    n_name VARCHAR(25) NOT NULL,
+    n_regionkey INTEGER NOT NULL,
+    n_comment VARCHAR(152)
+)
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def gaussdb_config() -> GaussDBConfig:
+    return GaussDBConfig(
+        host=os.getenv("GAUSSDB_HOST", "127.0.0.1"),
+        port=int(os.getenv("GAUSSDB_PORT", "25434")),
+        username=os.getenv("GAUSSDB_USER", "datus"),
+        password=os.getenv("GAUSSDB_PASSWORD", "Datus@123"),
+        database=os.getenv("GAUSSDB_DATABASE", "postgres"),
+        schema_name=SCHEMA,
+    )
+
+
+@pytest.fixture(scope="module")
+def gaussdb_connector(gaussdb_config: GaussDBConfig) -> Generator[GaussDBConnector, None, None]:
+    conn = GaussDBConnector(gaussdb_config)
+    try:
+        if not conn.test_connection():
+            pytest.fail(
+                "GaussDB container unreachable despite ADAPTERS_GAUSSDB=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-gaussdb?"
+            )
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(gaussdb_connector: GaussDBConnector) -> Generator[GaussDBConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = gaussdb_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    _exec(f'DROP TABLE IF EXISTS "{SCHEMA}"."{NATION_TABLE}" CASCADE')
+    _exec(f'DROP TABLE IF EXISTS "{SCHEMA}"."{REGION_TABLE}" CASCADE')
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    for row in REGION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f'INSERT INTO "{SCHEMA}"."{REGION_TABLE}" VALUES ({values})')
+    for row in NATION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f'INSERT INTO "{SCHEMA}"."{NATION_TABLE}" VALUES ({values})')
+
+    try:
+        yield gaussdb_connector
+    finally:
+        gaussdb_connector.execute({"sql_query": f'DROP TABLE IF EXISTS "{SCHEMA}"."{NATION_TABLE}" CASCADE'})
+        gaussdb_connector.execute({"sql_query": f'DROP TABLE IF EXISTS "{SCHEMA}"."{REGION_TABLE}" CASCADE'})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: GaussDBConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -56,7 +56,7 @@ def test_nightly_installs_storage_packages_from_latest_checkout():
 def test_nightly_installs_new_database_adapters_from_latest_checkout():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    for package_name in ("datus-doris", "datus-hologres", "datus-oracle"):
+    for package_name in ("datus-doris", "datus-hologres", "datus-oracle", "datus-gaussdb"):
         assert f"--reinstall-package {package_name}" in workflow
         assert f"./external/datus-db-adapters/{package_name}" in workflow
 
@@ -83,6 +83,17 @@ def test_nightly_runs_doris_agent_contract_from_checkout():
     assert 'wait_for_doris_client_readiness "${DORIS_READY_TIMEOUT:-600}"' in script
     assert 'wait_for_tcp_readiness "Doris"' not in script
     assert "tests/integration/adapters/test_doris.py" in script
+
+
+def test_nightly_runs_gaussdb_agent_contract_from_checkout():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'echo "ADAPTERS_GAUSSDB=1" >> $GITHUB_ENV' in workflow
+    assert 'GAUSSDB_COMPOSE="${GAUSSDB_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-gaussdb/docker-compose.yml}"' in script
+    assert 'run_compose_suite "GaussDB Adapter Tests" "$GAUSSDB_COMPOSE" "gaussdb:600"' in script
+    assert "tests/integration/adapters/test_gaussdb.py" in script
+    assert '"GaussDB Adapter Tests"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
 
 
 def test_doris_readiness_failure_is_logged_and_propagated(tmp_path):

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -44,7 +44,7 @@ def test_nightly_pytest_commands_set_explicit_test_layer():
         if " uv run pytest " in line and ("run_logged" in line or "run_compose_suite" in line)
     ]
 
-    assert len(pytest_command_lines) == 21
+    assert len(pytest_command_lines) == 22
     assert any("tests/integration/adapters/test_doris.py" in line for line in pytest_command_lines)
     for line in pytest_command_lines:
         expected_layer = "unit" if "Full Unit Tests" in line else "nightly"

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -15,6 +15,12 @@ verify_sources = importlib.util.module_from_spec(MODULE_SPEC)
 MODULE_SPEC.loader.exec_module(verify_sources)
 
 
+# Registration shape a healthy nightly checkout produces, per db_type.
+_PARSER_DIALECTS = {"hologres": "postgres", "gaussdb": "postgres", "oracle": "oracle"}
+_IDENTIFIER_PARSER_ADAPTERS = {"hologres", "gaussdb"}
+_SQL_NOTES_ADAPTERS = {"hologres", "gaussdb", "oracle"}
+
+
 class _FakeDistribution:
     def __init__(self, direct_url: str | None):
         self.direct_url = direct_url
@@ -67,6 +73,7 @@ def test_expected_sources_include_new_database_adapters():
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-doris"] == "datus-db-adapters/datus-doris"
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-hologres"] == "datus-db-adapters/datus-hologres"
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-oracle"] == "datus-db-adapters/datus-oracle"
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-gaussdb"] == "datus-db-adapters/datus-gaussdb"
 
 
 def test_expected_sources_include_dosi_semantic_adapter():
@@ -78,15 +85,16 @@ def test_expected_sources_include_dosi_semantic_adapter():
 def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
-        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
-        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
+        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
@@ -97,15 +105,16 @@ def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
 def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypatch):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda db_type: "oracle" if db_type == "oracle" else None,
-        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
-        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_parser_dialect=lambda db_type: None if db_type == "hologres" else _PARSER_DIALECTS.get(db_type),
+        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
@@ -129,9 +138,12 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
 def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, missing_hook: str, expected_error: str):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
+        get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
         get_identifier_parser=lambda db_type: (
-            None if db_type != "hologres" or missing_hook == "get_identifier_parser" else object()
+            None
+            if db_type not in _IDENTIFIER_PARSER_ADAPTERS
+            or (db_type == "hologres" and missing_hook == "get_identifier_parser")
+            else object()
         ),
         get_sql_generation_notes=lambda db_type: (
             None if db_type == "hologres" and missing_hook == "get_sql_generation_notes" else "notes"
@@ -142,6 +154,7 @@ def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, mi
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
@@ -152,15 +165,16 @@ def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, mi
 def test_verify_database_adapter_imports_requires_oracle_operations(monkeypatch):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
-        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
-        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
+        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda _db_type: None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
@@ -173,15 +187,16 @@ def test_verify_database_adapter_imports_requires_complete_oracle_operations(mon
     operations.render_count = None
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
-        get_parser_dialect=lambda db_type: {"hologres": "postgres", "oracle": "oracle"}.get(db_type),
-        get_identifier_parser=lambda db_type: object() if db_type == "hologres" else None,
-        get_sql_generation_notes=lambda db_type: "notes" if db_type in {"hologres", "oracle"} else None,
+        get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
+        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda db_type: operations if db_type == "oracle" else None,
     )
     modules = {
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)

--- a/tests/unit_tests/cli/test_datasource_commands.py
+++ b/tests/unit_tests/cli/test_datasource_commands.py
@@ -443,7 +443,7 @@ class TestDatasourceAppViews:
             assert ("sqlite", "sqlite", True) in app._db_types
 
     def test_new_database_adapters_are_installable(self):
-        assert {"doris", "hologres", "oracle"} <= set(INSTALLABLE_TYPES)
+        assert {"doris", "gaussdb", "hologres", "oracle"} <= set(INSTALLABLE_TYPES)
 
     def test_enter_config_form(self):
         cli = _make_cli()


### PR DESCRIPTION
## Why

Datus-ai/datus-db-adapters#96 adds `datus-gaussdb` — a GaussDB/openGauss adapter built on the official `gaussdb` driver (sha256/md5/sm3 auth works against GaussDB's default security settings, with wheels bundling the required GaussDB-family libpq). This PR wires it into the agent so the adapter is installable from the datasource CLI, protected by nightly, and documented.

## Solution

Mirrors the doris/hologres integration surface, verified spot by spot:

- `INSTALLABLE_TYPES` += `gaussdb` (datasource CLI offers `pip install datus-gaussdb`).
- Nightly: `ci/nightly_manifest.py` PACKAGE_NAMES; `ci/verify_nightly_adapter_sources.py` EXPECTED_LOCAL_PACKAGES + a `DatabaseAdapterContract` (db_type `gaussdb`, `parser_dialect="postgres"` — inherits the sqlglot parsing path and the pre-execution EXPLAIN row guard — plus the identifier-parser and sql-generation-notes hooks); `run-nightly.yml` and `ci/run-nightly-tests.sh` install lists.
- Docs (`docs/adapters/db_adapters.md` + `.zh.md`): support-table row, install note, datasource YAML example; documents A/B/PG compatibility-mode auto-detection, centralized + distributed support via catalog probing, the `driver: psycopg2` escape hatch, and the Linux-only runtime constraint of the official driver.
- Opt-in integration suite `tests/integration/adapters/test_gaussdb.py` (`ADAPTERS_GAUSSDB=1`, env-configurable endpoint matching the adapter's docker-compose), modeled on `test_greenplum.py` with plain CREATE TABLE DDL; registered in `tests/integration/adapters/README.md` and `ci/harness/coverage-map.yml`.

No changes needed in `DBType`, `DbConfig`, `db_manager`, or `sql_utils`: discovery, URI/context resolution, parsing, and prompt notes all flow through the adapter's registry hooks.

## Test Cases

- `uv run python ci/run-pr-tests.py upstream/main`: 215/215 passed (acceptance harness + impacted unit targets + coverage).
- `uv run python ci/audit_tests.py --diff-only upstream/main`: clean.
- Extended existing guards: `test_datasource_commands.py` (INSTALLABLE_TYPES membership), `test_verify_nightly_adapter_sources.py` + `test_nightly_checkout_contract.py` + `test_nightly_tracing_boundaries.py` (gaussdb pinned like doris/hologres).
- New opt-in integration suite exercises DBFuncTool end-to-end against a live openGauss container (metadata, query, and the adapter's compatibility-mode probe); runs in nightly once the adapter package is published/checked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GaussDB/openGauss as an installable datasource adapter.
  - Supports connection configuration, authentication, compatibility modes, and deployment options.
  - Provides table discovery, schema inspection, read-only queries, and safety checks for unsupported DML and multi-statement queries.
  - GaussDB support is available on Linux, using the official driver by default with an alternative driver option.

- **Documentation**
  - Added English and Chinese setup, configuration, compatibility, and architecture guidance.
  - Documented environment variables and default connection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->