### PR TITLE
[BugFix] Let a cancelled run stay cancelled while it waits in ask_user

### DIFF
--- a/datus/cli/execution_state.py
+++ b/datus/cli/execution_state.py
@@ -292,7 +292,11 @@ class InteractionBroker:
             Single-select answers have one element; multi-select may have more.
 
         Raises:
-            InteractionCancelled: If the broker is closed while waiting.
+            InteractionCancelled: The question itself was cancelled — the broker
+                was closed, or the user dismissed it (ESC submits ``[[""]]``).
+                Callers turn this into a tool-level "cancelled" result.
+            asyncio.CancelledError: The whole run is being cancelled. Propagates
+                untouched so the task actually dies; see the handler below.
         """
         if self._closed:
             raise InteractionCancelled("Broker is already closed")
@@ -353,7 +357,14 @@ class InteractionBroker:
         except asyncio.CancelledError:
             with self._lock:
                 self._pending.pop(action_id, None)
-            raise InteractionCancelled("Request cancelled")
+            # Re-raise, never downgrade to InteractionCancelled. Cancellation
+            # here means the *run* is being torn down (``/chat/stop`` cancels the
+            # task; a dropped SSE client cancels the generator), and swallowing
+            # CancelledError leaves that task alive: ``ask_user`` would catch the
+            # downgraded error, hand the model "User cancelled the question" as
+            # an ordinary tool result, and the LLM would carry on to its next
+            # action — after the caller was told the run had stopped.
+            raise
 
     async def fetch(self) -> AsyncGenerator[ActionHistory, None]:
         """Async generator that yields ActionHistory objects for interactions."""

--- a/datus/tools/func_tool/ask_user_tools.py
+++ b/datus/tools/func_tool/ask_user_tools.py
@@ -195,6 +195,10 @@ class AskUserTool:
             return FuncToolResult(success=1, result=result_json)
 
         except InteractionCancelled:
+            # Only the question was cancelled (ESC, or the broker closing). A
+            # cancelled *run* raises CancelledError, which is a BaseException and
+            # so passes through here untouched — deliberately, since turning it
+            # into a tool result would keep the run going after a /chat/stop.
             logger.info("AskUserTool: interaction cancelled by user")
             return FuncToolResult(success=0, error="User cancelled the question")
         except Exception as e:

--- a/tests/unit_tests/cli/test_execution_state.py
+++ b/tests/unit_tests/cli/test_execution_state.py
@@ -279,8 +279,12 @@ class TestInteractionBrokerRequest:
         assert success_action.output["user_choice"] == [["y"]]
 
     @pytest.mark.asyncio
-    async def test_request_cancelled_raises_interaction_cancelled(self):
-        """When the future is cancelled, request() raises InteractionCancelled."""
+    async def test_request_cancelled_propagates_cancelled_error(self):
+        """A cancelled run must stay cancelled: CancelledError, not InteractionCancelled.
+
+        Downgrading it let ``ask_user`` report an ordinary tool failure, so the
+        LLM kept going after ``/chat/stop`` said the run had ended.
+        """
         broker = InteractionBroker()
 
         async def do_request():
@@ -292,7 +296,25 @@ class TestInteractionBrokerRequest:
         # Cancel the task (which cancels the future inside request())
         task.cancel()
 
-        with pytest.raises((InteractionCancelled, asyncio.CancelledError)):
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert task.cancelled()
+        assert not broker.has_pending
+
+    @pytest.mark.asyncio
+    async def test_request_raises_interaction_cancelled_when_broker_closes(self):
+        """Closing the broker cancels the question only — that stays catchable."""
+        broker = InteractionBroker()
+
+        async def do_request():
+            return await broker.request([InteractionEvent(content="Pick one", choices={"a": "A"}, default_choice="a")])
+
+        task = asyncio.create_task(do_request())
+        await asyncio.sleep(0.05)
+
+        broker.close()
+
+        with pytest.raises(InteractionCancelled):
             await task
 
 


### PR DESCRIPTION
## The bug

`InteractionBroker.request` downgraded cancellation:

```python
except asyncio.CancelledError:
    self._pending.pop(action_id, None)
    raise InteractionCancelled("Request cancelled")   # execution_state.py:353
```

`InteractionCancelled` is an `Exception`, so `AskUserTool` caught it and returned `FuncToolResult(success=0, error="User cancelled the question")` — an ordinary tool result. The model read "the user cancelled" and went on to its next action. And because `CancelledError` was swallowed rather than re-raised, **the asyncio task was never actually cancelled**: the run keeps going after the caller has been told it stopped.

## Why it matters now

Both teardown paths of `POST /chat/stream` cancel the task: `/chat/stop`, and a dropped SSE client.

The Mission Orchestrator takes the first one *every time* a Project Agent asks the requester something. Its design is deliberate — a business user may answer two days later, so it posts the question as a card in the mission thread, calls `/chat/stop`, and parks the task in `wait_user`; the reply comes back later as a fresh turn. But the stop reported success while the run carried on:

- one more LLM call, paid for and thrown away;
- whatever tool the model picked next may have *executed* — writing files, running SQL — with side effects landing on the project while nobody read the stream;
- on long-lived deployments (BYOC pod / on-prem container) the run has no TTL, so it lingers holding its session until a restart.

## The fix

Re-raise. The pending interaction is still popped first, so nothing leaks in the broker.

`InteractionCancelled` keeps its narrower, useful meaning — *this question* was cancelled: the broker closed, or the user dismissed it (ESC submits `[[""]]`, which goes through `submit`, not through cancellation). Callers still turn that into a tool-level "cancelled" result, which is correct there.

`ask_user`'s `except Exception` cannot catch `CancelledError` (BaseException since 3.8), so nothing else had to change; the two docstrings now say which exception means what.

## Verification

The existing test accepted *either* exception:

```python
with pytest.raises((InteractionCancelled, asyncio.CancelledError)):
```

which is precisely why this went unnoticed. It now pins the run-teardown case (`CancelledError`, `task.cancelled()`, no pending left), and a second test covers the broker-close case still raising `InteractionCancelled`.

- `pytest tests/unit_tests/cli/test_execution_state.py tests/unit_tests/tools/func_tool/test_ask_user_tools.py`: 96 passed
- `pytest tests/unit_tests/cli tests/unit_tests/tools tests/unit_tests/api`: 8811 passed, 6 skipped, 1 xfailed
- `ruff format` / `ruff check`: clean

## Follow-ups (not here)

- Orchestrator side: a stop that does not land is now logged instead of swallowed — separate PR in Datus-mission-orchestrator.
- The real fix for the Mission case is for `ask_user` not to block at all under orchestrated dispatch: return "the question has been put to the requester" and end the turn from code rather than trusting the model to stop. This PR is its prerequisite — until cancellation works, that path has no safe fallback.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for interactive requests.
  * Run-level task cancellation now propagates correctly, while individual interaction cancellations continue to be reported separately.
  * Pending interactions are cleaned up when cancellation occurs.

* **Tests**
  * Added coverage distinguishing task cancellation from broker-initiated interaction cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->