### PR TITLE
[BugFix] Send text.format.name on Codex JSON-schema requests

### DIFF
--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -7,6 +7,7 @@
 import base64
 import json
 import os
+import re
 import time
 import uuid
 from contextlib import nullcontext
@@ -37,6 +38,26 @@ logger = get_logger(__name__)
 # Fallback values when providers.yml / OpenRouter cache do not cover a codex slug.
 _CODEX_DEFAULT_CONTEXT_LENGTH = 192000
 _CODEX_DEFAULT_MAX_TOKENS = 16384
+
+# The Responses API requires a ``name`` alongside a ``json_schema`` text format
+# and accepts only ``[a-zA-Z0-9_-]`` in it, capped at 64 characters.
+_SCHEMA_NAME_ALLOWED = re.compile(r"[^a-zA-Z0-9_-]")
+_SCHEMA_NAME_MAX_LENGTH = 64
+_SCHEMA_NAME_FALLBACK = "structured_response"
+
+
+def _json_schema_format_name(output_schema: Dict[str, Any], explicit: Optional[str] = None) -> str:
+    """Derive a Responses-API-legal ``text.format.name`` for a JSON schema.
+
+    Prefers an explicit caller-supplied name, then the schema's ``title``
+    (Pydantic's ``model_json_schema()`` always sets it to the model class
+    name), then a generic fallback. Illegal characters collapse to ``_``
+    because omitting the field — or sending an unsanitized one — makes the
+    provider reject the whole request with HTTP 400.
+    """
+    candidate = explicit or (output_schema.get("title") if isinstance(output_schema, dict) else None)
+    sanitized = _SCHEMA_NAME_ALLOWED.sub("_", str(candidate)).strip("_") if candidate else ""
+    return (sanitized or _SCHEMA_NAME_FALLBACK)[:_SCHEMA_NAME_MAX_LENGTH]
 
 
 def _agents_trace_baggage(agent_name: Optional[str]):
@@ -391,6 +412,10 @@ class CodexModel(LLMBaseModel):
             create_kwargs["text"] = {
                 "format": {
                     "type": "json_schema",
+                    # Required by the Responses API: without it every
+                    # schema-mode request fails with HTTP 400
+                    # "Missing required parameter: 'text.format.name'".
+                    "name": _json_schema_format_name(output_schema, kwargs.get("output_schema_name")),
                     "schema": output_schema,
                 }
             }

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -180,6 +180,92 @@ class TestCodexModelJsonOutput:
         call_kwargs = mock_client.responses.create.call_args[1]
         assert call_kwargs["text"]["format"]["type"] == "json_schema"
 
+    @pytest.mark.parametrize(
+        "schema_extra, explicit_name, expected_name",
+        [
+            # Pydantic's model_json_schema() always sets ``title``.
+            ({"title": "AutoReviewVerdict"}, None, "AutoReviewVerdict"),
+            # An explicit caller name wins over the schema title.
+            ({"title": "AutoReviewVerdict"}, "review_verdict", "review_verdict"),
+            # Illegal characters collapse; the API accepts only [a-zA-Z0-9_-].
+            ({"title": "My Model (v2).final"}, None, "My_Model__v2__final"),
+            # No title and no explicit name still yields a legal name.
+            ({}, None, "structured_response"),
+            # A title made entirely of illegal characters degrades to the fallback.
+            ({"title": "!!!"}, None, "structured_response"),
+        ],
+    )
+    @patch("datus.models.codex_model.OAuthManager")
+    def test_json_schema_format_always_carries_a_legal_name(
+        self, mock_oauth_cls, model_config, schema_extra, explicit_name, expected_name
+    ):
+        """The Responses API rejects a ``json_schema`` format without ``name``.
+
+        Omitting it fails the whole request with HTTP 400 "Missing required
+        parameter: 'text.format.name'", which silently disables every
+        structured-output caller (e.g. the bash/SQL permission auto reviewer).
+        """
+        import re
+
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth = MagicMock()
+        mock_oauth.get_access_token.return_value = "tok"
+        mock_oauth_cls.return_value = mock_oauth
+
+        model = CodexModel(model_config=model_config)
+        mock_client = MagicMock()
+        mock_client.responses.create.return_value = _mock_stream(json.dumps({"answer": 42}))
+        model._client = mock_client
+
+        schema = {"type": "object", "properties": {"answer": {"type": "integer"}}, **schema_extra}
+        kwargs = {"output_schema": schema}
+        if explicit_name is not None:
+            kwargs["output_schema_name"] = explicit_name
+
+        model.generate_with_json_output("test", **kwargs)
+
+        fmt = mock_client.responses.create.call_args[1]["text"]["format"]
+        assert fmt["name"] == expected_name
+        assert re.fullmatch(r"[a-zA-Z0-9_-]+", fmt["name"])
+        assert len(fmt["name"]) <= 64
+        assert fmt["schema"] == schema
+
+    @patch("datus.models.codex_model.OAuthManager")
+    def test_json_object_format_carries_no_schema_name(self, mock_oauth_cls, model_config):
+        """Without a schema the request stays in plain JSON-object mode."""
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth = MagicMock()
+        mock_oauth.get_access_token.return_value = "tok"
+        mock_oauth_cls.return_value = mock_oauth
+
+        model = CodexModel(model_config=model_config)
+        mock_client = MagicMock()
+        mock_client.responses.create.return_value = _mock_stream(json.dumps({"answer": 42}))
+        model._client = mock_client
+
+        model.generate_with_json_output("test")
+
+        assert mock_client.responses.create.call_args[1]["text"] == {"format": {"type": "json_object"}}
+
+    @patch("datus.models.codex_model.OAuthManager")
+    def test_long_schema_title_is_truncated_to_the_api_limit(self, mock_oauth_cls, model_config):
+        from datus.models.codex_model import CodexModel
+
+        mock_oauth = MagicMock()
+        mock_oauth.get_access_token.return_value = "tok"
+        mock_oauth_cls.return_value = mock_oauth
+
+        model = CodexModel(model_config=model_config)
+        mock_client = MagicMock()
+        mock_client.responses.create.return_value = _mock_stream(json.dumps({"answer": 42}))
+        model._client = mock_client
+
+        model.generate_with_json_output("test", output_schema={"type": "object", "title": "N" * 200})
+
+        assert mock_client.responses.create.call_args[1]["text"]["format"]["name"] == "N" * 64
+
 
 class TestCodexModelUtils:
     @patch("datus.models.codex_model.OAuthManager")

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -810,6 +810,25 @@ class TestDeepSeekHistorySanitization:
 class TestApplyAndRemoveSdkPatches:
     """Tests for apply_sdk_patches and remove_sdk_patches lifecycle."""
 
+    @pytest.fixture(autouse=True)
+    def unpatched_baseline(self):
+        """Start every lifecycle test from the un-patched state.
+
+        ``datus/models/__init__.py`` calls ``apply_sdk_patches()`` at import
+        time, so by the time any test runs ``litellm.completion`` is already
+        the patched wrapper and ``sdk_patches._original_*`` already hold the
+        true originals. Tests here capture ``litellm.completion`` as "the true
+        original" and re-apply, which only holds when nothing is patched yet.
+
+        Whether that was true used to depend on a sibling test having run its
+        ``remove_sdk_patches()`` cleanup first, so whichever test executed
+        first in a process failed. Normalizing here makes each test
+        independent of execution order and of the import-time patching.
+        """
+        remove_sdk_patches()
+        yield
+        remove_sdk_patches()
+
     def test_apply_and_remove_patches(self):
         """apply_sdk_patches and remove_sdk_patches complete without error."""
         # Apply patches


### PR DESCRIPTION
## Why

`CodexModel.generate_with_json_output` built the Responses API request with a `json_schema` text format that carried only `type` and `schema`. The API also requires `name`, so every schema-mode request failed:

```
Error code: 400 - {'error': {'message': "Missing required parameter: 'text.format.name'",
 'type': 'invalid_request_error', 'param': 'text.format.name',
 'code': 'missing_required_parameter'}}
```

Every structured-output caller on a Codex model was affected. The impact is easiest to see in the bash/SQL permission auto reviewer added in #1277: it fails closed on a model error, so under the `auto` profile every unresolved ASK degraded to a manual confirmation and non-interactive runs were denied outright. Observed in a real session as a repeating warning:

```
Auto review failed closed action=bash model=default: Codex generate_with_json_output failed:
Error code: 400 - Missing required parameter: 'text.format.name'
```

This PR also fixes an unrelated order dependency in `TestApplyAndRemoveSdkPatches`, which was failing CI here and on #1277.

## Solution

**1. Send `text.format.name` (`datus/models/codex_model.py`)**

The name is derived in this order:

1. an explicit `output_schema_name` kwarg, so callers can name the schema;
2. the schema's `title` — Pydantic's `model_json_schema()` always sets it to the model class name (`AutoReviewVerdict`);
3. a generic `structured_response` fallback.

The API accepts only `[a-zA-Z0-9_-]` and caps the field at 64 characters, so illegal characters collapse to `_` and the result is truncated. A title made entirely of illegal characters degrades to the fallback rather than producing an empty name, which would fail the same way the missing field did.

`strict: true` is deliberately not set. Strict mode requires `additionalProperties: false` and a fully-populated `required` list at every object level; turning it on globally would convert currently-working requests from other callers into 400s. It can be opted into later per caller if needed.

The no-schema path is unchanged and stays in plain `json_object` mode.

**2. Fix the sdk-patch test baseline (`tests/unit_tests/models/test_sdk_patches.py`)**

`datus/models/__init__.py` applies the SDK patches at import time, so `litellm.completion` is already the patched wrapper and `sdk_patches._original_*` already hold the true originals before any test runs. `TestApplyAndRemoveSdkPatches` captures `litellm.completion` as "the true original" and re-applies, which only holds from an un-patched baseline — and that baseline happened to exist only because a sibling test had run its `remove_sdk_patches()` cleanup first.

So whichever test in the class ran first in a process failed, deterministically rather than flakily: `test_apply_patches_idempotent` here, `test_remove_sdk_patches_restores_showwarning` on #1277. An autouse fixture now removes the patches before and after each test in the class. Test-only change; the end state the class already produced is unchanged.

## Test Cases

Unit tests only — this is a request-construction bug, fully observable at the `responses.create` boundary, and the existing Codex suite already mocks that client. No integration or nightly test is added because exercising it for real requires Codex OAuth credentials, which CI does not have.

Added to `tests/unit_tests/models/test_codex_model.py`:

- `test_json_schema_format_always_carries_a_legal_name` — parametrized over title-derived, explicit-name, illegal-character, no-title, and all-illegal-title cases; asserts the emitted name matches `^[a-zA-Z0-9_-]+$`, is within the 64-character limit, and that the schema is forwarded unchanged.
- `test_long_schema_title_is_truncated_to_the_api_limit`.
- `test_json_object_format_carries_no_schema_name` — pins that the schema-less path stays in `json_object` mode.

For the ordering fix, the existing lifecycle tests are the coverage: `test_apply_patches_idempotent` and `test_remove_sdk_patches_restores_showwarning` now pass when run alone, as a class, and as part of the full file — previously the first two combinations failed.

Verification: `ruff format`/`check` clean, `ci/audit_tests.py --diff-only` reports P0=0 P1=0, `ci/run-pr-tests.py` reports 1058/1058 passing with 100% diff coverage.

## Backport


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON schema responses now support a valid, automatically generated format name.
  * Names can be derived from a provided name or schema title, with fallback handling and length limits.
* **Bug Fixes**
  * Invalid characters in schema names are sanitized.
  * Plain JSON-object responses omit unnecessary schema naming when no schema is provided.
  * Supplied schemas remain unchanged when format names are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->