### PR TITLE
[BugFix] Fix /chat/history 500 caused by set-typed assistant fingerprint store

### DIFF
--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -279,7 +279,9 @@ class ChatService:
                         messages = msg["actions"]
                         assistant_response_seen = False
                         tool_result_seen = False
-                        seen_assistant_message_fingerprints: set[str] = set()
+                        # Maps fingerprint -> owning message_id; the helpers below
+                        # need the owner to tell a legitimate UPDATE from a repeat.
+                        seen_assistant_message_fingerprints: dict[str, str] = {}
                         for action in messages:
                             include_final_response = _should_include_final_response(action, assistant_response_seen)
                             sse_event = action_to_sse_event(

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -8,6 +8,7 @@ import pytest
 from datus.api.services.chat_service import ChatService
 from datus.api.services.chat_task_manager import ChatTaskManager
 from datus.models.session_manager import SessionManager
+from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.utils.exceptions import ErrorCode
 
 
@@ -207,6 +208,48 @@ class TestChatServiceGetHistory:
 
         result = chat_svc.get_history("empty-hist")
         assert result.success is True
+
+    def _assistant_response(self, text):
+        return ActionHistory(
+            action_id="a-" + text,
+            role=ActionRole.ASSISTANT,
+            action_type="response",
+            status=ActionStatus.SUCCESS,
+            output={"is_thinking": False, "response": text},
+        )
+
+    def _patch_messages(self, chat_svc, raw_messages):
+        fake_sm = MagicMock()
+        fake_sm.get_session_messages.return_value = raw_messages
+        return patch("datus.api.services.chat_service.SessionManager", return_value=fake_sm)
+
+    def test_get_history_renders_assistant_actions(self, chat_svc):
+        """Assistant actions convert to SSE payloads instead of erroring out."""
+        raw = [{"role": "assistant", "actions": [self._assistant_response("hello")]}]
+        with self._patch_messages(chat_svc, raw):
+            result = chat_svc.get_history("sid")
+
+        assert result.success is True
+        assert len(result.data.messages) == 1
+        assert result.data.messages[0].content[0].payload["content"] == "hello"
+
+    def test_get_history_dedupes_repeated_assistant_text(self, chat_svc):
+        """The fingerprint store is a dict of text -> owning message_id, not a set.
+
+        Passing a set made ``_should_skip_duplicate_assistant_message`` raise
+        ``'set' object has no attribute 'get'`` and failed the whole endpoint.
+        """
+        raw = [
+            {
+                "role": "assistant",
+                "actions": [self._assistant_response("same"), self._assistant_response("same")],
+            }
+        ]
+        with self._patch_messages(chat_svc, raw):
+            result = chat_svc.get_history("sid")
+
+        assert result.success is True
+        assert len(result.data.messages) == 1
 
 
 class TestChatServiceScopePropagation:

--- a/tests/unit_tests/api/services/test_chat_service.py
+++ b/tests/unit_tests/api/services/test_chat_service.py
@@ -1,6 +1,7 @@
 """Tests for datus.api.services.chat_service — chat session management."""
 
 import asyncio
+from contextlib import AbstractContextManager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -209,24 +210,24 @@ class TestChatServiceGetHistory:
         result = chat_svc.get_history("empty-hist")
         assert result.success is True
 
-    def _assistant_response(self, text):
+    def _assistant_response(self, action_id: str, text: str) -> ActionHistory:
         return ActionHistory(
-            action_id="a-" + text,
+            action_id=action_id,
             role=ActionRole.ASSISTANT,
             action_type="response",
             status=ActionStatus.SUCCESS,
             output={"is_thinking": False, "response": text},
         )
 
-    def _patch_messages(self, chat_svc, raw_messages):
+    def _patch_messages(self, raw_messages: list[dict]) -> AbstractContextManager[MagicMock]:
         fake_sm = MagicMock()
         fake_sm.get_session_messages.return_value = raw_messages
         return patch("datus.api.services.chat_service.SessionManager", return_value=fake_sm)
 
     def test_get_history_renders_assistant_actions(self, chat_svc):
         """Assistant actions convert to SSE payloads instead of erroring out."""
-        raw = [{"role": "assistant", "actions": [self._assistant_response("hello")]}]
-        with self._patch_messages(chat_svc, raw):
+        raw = [{"role": "assistant", "actions": [self._assistant_response("a1", "hello")]}]
+        with self._patch_messages(raw):
             result = chat_svc.get_history("sid")
 
         assert result.success is True
@@ -239,13 +240,14 @@ class TestChatServiceGetHistory:
         Passing a set made ``_should_skip_duplicate_assistant_message`` raise
         ``'set' object has no attribute 'get'`` and failed the whole endpoint.
         """
+        # Distinct action_ids so only the repeated text can drive the dedup.
         raw = [
             {
                 "role": "assistant",
-                "actions": [self._assistant_response("same"), self._assistant_response("same")],
+                "actions": [self._assistant_response("a1", "same"), self._assistant_response("a2", "same")],
             }
         ]
-        with self._patch_messages(chat_svc, raw):
+        with self._patch_messages(raw):
             result = chat_svc.get_history("sid")
 
         assert result.success is True


### PR DESCRIPTION
## Why

`GET /api/v1/chat/history` returns 500 for any session that has an assistant reply:

```json
{"success": false, "errorCode": "SESSION_HISTORY_ERROR",
 "errorMessage": "Failed to get session history: 'set' object has no attribute 'get'"}
```

Reproduced on dev (trace `691c9d05901d4c179af500afc3dc24bf`, pod `datus-backend-warm-pool-9jvht`, `chat_service.py:320`).

#1273 changed the assistant-dedup fingerprint store from `set[str]` to `dict[str, str]` (text -> owning message_id, so an UPDATE on the owning id is not mistaken for a repeat) and updated the `ChatTaskManager` caller. `ChatService.get_history` calls the same helpers but still seeded a `set()`, so the first assistant action hit `seen_fingerprints.get(...)` and raised `AttributeError`. The exception escaped to the outer handler and failed the whole endpoint — every session with an assistant message became unreadable.

## Solution

Seed `seen_assistant_message_fingerprints` as `dict[str, str]` in `get_history`, matching the helper contract and the `ChatTaskManager` caller. One-line type/initializer fix; dedup behaviour in history now matches streaming.

## Test Cases

Added to `tests/unit_tests/api/services/test_chat_service.py::TestChatServiceGetHistory`:

- `test_get_history_renders_assistant_actions` — an assistant action renders as an SSE markdown payload instead of erroring out (fails with `AttributeError` on the old code).
- `test_get_history_dedupes_repeated_assistant_text` — two identical assistant responses collapse to one message, pinning the dict-based dedup semantics.

Both fail before the fix and pass after. `ci/audit_tests.py --diff-only` reports P0=0/P1=0; impacted unit tests pass with 100% diff coverage.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate assistant messages being handled incorrectly in chat history.
  * Preserved legitimate message updates while filtering repeated content.
  * Prevented failures when displaying assistant action histories.

* **Tests**
  * Added regression coverage for duplicate-message handling and assistant action history rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate assistant messages being handled incorrectly in chat history.
  * Preserved legitimate message updates while filtering repeated content.
  * Prevented failures when displaying assistant action histories.

* **Tests**
  * Added regression coverage for duplicate-message handling and assistant action history rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->