### PR TITLE
[BugFix] Stabilize single-turn nightly SQL smoke

### DIFF
--- a/tests/integration/agent/test_chat_agentic.py
+++ b/tests/integration/agent/test_chat_agentic.py
@@ -101,7 +101,7 @@ class TestChatAgentic:
 
     def test_single_turn_chat(self, mock_args):
         """N5-01: Basic single-turn chat generates SQL and returns result."""
-        question = "List all schools in Fresno county"
+        question = "List 5 schools in Fresno county using a SQL query"
 
         with patch("datus.cli.repl.PromptSession.prompt") as mock_prompt:
             mock_prompt.side_effect = [question, EOFError]


### PR DESCRIPTION
## Summary

- bound the real-LLM single-turn chat smoke query to five Fresno schools
- keep the scenario focused on its asserted SQL execution behavior

## Why

In [nightly run 31638718174](https://github.com/Datus-ai/Datus-agent/actions/runs/31638718174), the unbounded prompt asked the model to list all 620 matching schools. The model reasonably attempted a file export through approval-gated bash; the test fixture rejected that approval, so the run ended without a chat response.

The test asserts SQL/query-tool use and a Fresno response, not exhaustive export behavior. A bounded SQL request removes that unrelated approval dependency.

The deterministic `/chat/history` regression from the same nightly run is already fixed by #1284. This PR was rebased onto that fix and drops its duplicate implementation and tests.

Related to #1283.

## Validation

- `uv run pytest -q tests/unit_tests/api/services/test_chat_service.py::TestChatServiceGetHistory` — 4 passed
- `uv run pytest --collect-only -q tests/integration/agent/test_chat_agentic.py::TestChatAgentic::test_single_turn_chat` — collected successfully
- Ruff check and format check passed for the changed file
- `ci/audit_tests.py` — P0: 0; two existing P1 weak-assert warnings
- full real-LLM execution requires the nightly environment

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
