### PR TITLE
[BugFix] Stop painting a white background behind TUI user blocks

### DIFF
--- a/datus/cli/cli_styles.py
+++ b/datus/cli/cli_styles.py
@@ -100,17 +100,20 @@ ACTION_ROLE_COLOR_NAMES: dict[str, str] = {
 }
 
 USER_SCROLLBACK_PROMPT = "> "
-USER_SCROLLBACK_BACKGROUND = "#eeeeee"
-USER_SCROLLBACK_PROMPT_STYLE = f"green bold on {USER_SCROLLBACK_BACKGROUND}"
-USER_SCROLLBACK_TEXT_STYLE = f"on {USER_SCROLLBACK_BACKGROUND}"
+USER_SCROLLBACK_PROMPT_STYLE = "green bold"
 USER_SCROLLBACK_BORDER_STYLE = "green"
 
 
 def render_user_scrollback_text(message: str, prompt_text: str = USER_SCROLLBACK_PROMPT) -> Panel:
-    """Render a user scrollback block — bordered panel with background fill.
+    """Render a user scrollback block — green rules, terminal-default fill.
 
-    The border and background give USER messages a strong visual identity
-    that separates them from neighbouring ASSISTANT markdown blocks.
+    The green rules and the green ``>`` prompt give USER messages their visual
+    identity; the block paints **no background**. A fixed background hue can
+    only ever suit one terminal theme — the TUI Console runs at
+    ``color_system="256"``, so a light fill lands on xterm 255 and shows as a
+    solid white slab on the dark schemes most SSH sessions use. Letting the
+    terminal background show through follows the same rule as the
+    ``completion-menu`` styles above.
 
     ``HORIZONTALS`` (top/bottom rules only, space side edges) instead of a
     fully-boxed style: the TUI's drag-copy extracts rendered characters, so
@@ -120,11 +123,10 @@ def render_user_scrollback_text(message: str, prompt_text: str = USER_SCROLLBACK
     """
     text = Text()
     text.append(prompt_text, style=USER_SCROLLBACK_PROMPT_STYLE)
-    text.append(message, style=USER_SCROLLBACK_TEXT_STYLE)
+    text.append(message)
     return Panel(
         text,
         border_style=USER_SCROLLBACK_BORDER_STYLE,
-        style=USER_SCROLLBACK_TEXT_STYLE,
         box=HORIZONTALS,
         padding=(0, 1),
         expand=True,

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -568,13 +568,15 @@ class TestRenderMainAction:
         panel = result[0]
         assert isinstance(panel, Panel)
         assert str(panel.border_style) == "green"
-        assert str(panel.style) == "on #eeeeee"
+        # No background fill: the block must inherit the terminal background so
+        # it reads correctly on both dark and light schemes.
+        assert str(panel.style) == "none"
         inner = panel.renderable
         assert isinstance(inner, Text)
         assert inner.plain.startswith("> ")
         assert "my question" in inner.plain
-        assert str(inner.spans[0].style) == "green bold on #eeeeee"
-        assert str(inner.spans[1].style) == "on #eeeeee"
+        assert str(inner.spans[0].style) == "green bold"
+        assert all("on " not in str(span.style) for span in inner.spans)
 
     def test_user_action_exec_message_is_suppressed_live(self):
         """During the live model turn, a marker-encoded manual-execution USER
@@ -830,13 +832,13 @@ class TestUtilityRenderables:
         panel = _renderer().render_user_header("What is revenue?")
         assert isinstance(panel, Panel)
         assert str(panel.border_style) == "green"
-        assert str(panel.style) == "on #eeeeee"
+        assert str(panel.style) == "none"
         inner = panel.renderable
         assert isinstance(inner, Text)
         assert inner.plain.startswith("> ")
         assert "What is revenue?" in inner.plain
-        assert str(inner.spans[0].style) == "green bold on #eeeeee"
-        assert str(inner.spans[1].style) == "on #eeeeee"
+        assert str(inner.spans[0].style) == "green bold"
+        assert all("on " not in str(span.style) for span in inner.spans)
 
     def test_user_header_exec_message_renders_styled_block(self):
         """On resume, a manual-execution record renders as its bash/sql block

--- a/tests/unit_tests/cli/test_cli_styles.py
+++ b/tests/unit_tests/cli/test_cli_styles.py
@@ -180,6 +180,27 @@ class TestRenderUserScrollbackText:
         selection.finish()
         assert extract_selection_text(buf, selection) == "  > hello world"
 
+    def test_paints_no_background(self):
+        """Contract: the USER block must not fill a background colour.
+
+        A fixed fill suits at most one terminal theme — the light hue this
+        block used to carry rendered as a solid white slab on the dark schemes
+        SSH sessions typically use. Rendering goes through the same
+        ``color_system="256"`` Console the TUI builds, so any background would
+        show up here as a ``48;5;N`` / ``4x`` SGR parameter.
+        """
+        import re
+
+        from datus.cli.cli_styles import render_user_scrollback_text
+
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=True, color_system="256", width=30)
+        console.print(render_user_scrollback_text("hello world"))
+
+        params = [p for seq in re.findall(r"\x1b\[([0-9;]*)m", buf.getvalue()) for p in seq.split(";") if p]
+        assert "48" not in params, f"background SGR emitted: {buf.getvalue()!r}"
+        assert not [p for p in params if p.isdigit() and (40 <= int(p) <= 47 or 100 <= int(p) <= 107)]
+
     def test_top_and_bottom_rules_remain(self):
         from datus.cli.cli_styles import render_user_scrollback_text
 


### PR DESCRIPTION
## Why

Running the Datus CLI over SSH on a Linux host renders the USER message block in the TUI scrollback as a solid white slab.

`render_user_scrollback_text()` filled its panel — and both text spans — with a hard-coded light hue (`USER_SCROLLBACK_BACKGROUND = "#eeeeee"`). The TUI's Rich Console is built with `color_system="256"` (`datus/cli/repl.py:723-729`), so that hue lands on xterm colour 255 and reads as white against the dark colour schemes most SSH sessions use. The block is the loudest element on screen instead of the quietest.

## Solution

Drop the background fill and let the terminal background show through:

- Remove `USER_SCROLLBACK_BACKGROUND` / `USER_SCROLLBACK_TEXT_STYLE`; the prompt keeps `green bold`, the message text carries no style.
- `render_user_scrollback_text()` no longer passes `style=` to the `Panel`.

The USER block keeps its visual identity through the green `HORIZONTALS` rules and the green `>` prompt, which read correctly on both dark and light themes. This follows the rule the `completion-menu` styles in the same module already document: `bg:default` blends into the terminal palette instead of fighting it. Any fixed hue can only ever suit one theme, so no replacement colour is introduced.

Considered and rejected: swapping in a dark fill (breaks light-theme users symmetrically) and adding a configurable/auto-detected theme option (terminal background detection is unreliable over SSH, and the plain block needs no configuration).

The bottom live input area is unaffected — it uses `class:input-area`, which is already an empty style.

## Test Cases

Unit tests only; this is a pure rendering change with no external dependencies.

- `tests/unit_tests/cli/test_cli_styles.py` — new `TestRenderUserScrollbackText::test_paints_no_background` renders through a Console configured exactly like the TUI's (`color_system="256"`) and asserts no background SGR parameter is emitted (`48`, `40-47`, `100-107`). This pins the contract that made the bug visible only on 256-colour terminals.
- `tests/unit_tests/cli/action_display/test_renderers.py` — `TestRenderMainAction::test_user_action` and `TestUtilityRenderables::test_user_header` previously asserted `panel.style == "on #eeeeee"`; both now assert no fill (`panel.style == "none"` and no span carrying an `on …` background).

Existing coverage that still passes unchanged: `test_copied_message_line_has_no_border_glyphs` (drag-copy extraction) and `test_top_and_bottom_rules_remain` (green rules).

Verification:

- `uv run pytest tests/unit_tests/cli/ -q` → 3858 passed, 1 skipped, 1 xfailed
- `uv run python ci/run-pr-tests.py datus/main` → diff coverage **100.00%**. One pre-existing local failure, `tests/integration/tools/test_mcp_acceptance.py::test_mcp_http_registration_read_only_call_and_error_envelope`, reproduces identically on a clean `datus/main` checkout and is unrelated to this change.
- `uv run python ci/audit_tests.py --repo-root . --diff-only datus/main` → **P0=0** (one pre-existing P1 `or_assert` at `test_renderers.py:990`, untouched by this PR)
- `uv run ruff format datus/ tests/ && uv run ruff check datus/ tests/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated user scrollback panels to use the terminal’s default background and text colors.
  - Applied green styling only to the prompt and panel border.
  - Preserved the existing bordered layout while improving compatibility with terminal themes.

- **Bug Fixes**
  - Removed unwanted background-color formatting from user message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->