### PR TITLE
[BugFix] tell the model when the rows it got are a sample

### DIFF
--- a/datus/api/models/visualization_models.py
+++ b/datus/api/models/visualization_models.py
@@ -18,6 +18,13 @@ class DataVisualizationRequest(BaseModel):
     """POST body for /api/v1/data_visualization."""
 
     csv_data: CsvData
+    total_rows: Optional[int] = Field(
+        None,
+        description=(
+            "Row count of the full result set when ``csv_data`` carries only a sample of it. "
+            "Omit when ``csv_data`` is the whole set."
+        ),
+    )
     chart_type: Optional[ChartType] = Field(None, description="Desired chart type; omit for auto-recommendation")
     sql: Optional[str] = Field(None, description="SQL query that produced the data (enables metadata extraction)")
     user_question: Optional[str] = Field(None, description="User's original question (improves insight quality)")

--- a/datus/api/routes/visualization_routes.py
+++ b/datus/api/routes/visualization_routes.py
@@ -35,6 +35,7 @@ async def data_visualization(
     result = await asyncio.to_thread(
         svc.visualization.generate,
         csv_data=request.csv_data,
+        total_rows=request.total_rows,
         chart_type=request.chart_type,
         sql=request.sql,
         user_question=request.user_question,

--- a/datus/api/services/visualization_service.py
+++ b/datus/api/services/visualization_service.py
@@ -65,12 +65,14 @@ class DataVisualizationService:
         sql: Optional[str],
         user_question: Optional[str],
         language: Optional[str],
+        total_rows: Optional[int] = None,
     ) -> str:
         """Compute a stable hash for the request payload."""
         payload = json.dumps(
             {
                 "columns": csv_data.columns,
                 "data": csv_data.data,
+                "total_rows": total_rows,
                 "chart_type": chart_type,
                 "sql": sql,
                 "user_question": user_question,
@@ -99,8 +101,12 @@ class DataVisualizationService:
         sql: Optional[str] = None,
         user_question: Optional[str] = None,
         language: Optional[str] = None,
+        total_rows: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Return a chart recommendation dict, using cache when available.
+
+        ``total_rows`` states how large the full result set is when ``csv_data``
+        is only a sample of it — the caller may cap the rows it uploads.
 
         The language is part of the cache key: the same dataset asked for in
         two languages must not share one cached answer. It has to be the
@@ -109,14 +115,14 @@ class DataVisualizationService:
         would serve the old answer after that default changes.
         """
         effective_language = language or getattr(self._agent_config, "language", None)
-        key = self._cache_key(csv_data, chart_type, sql, user_question, effective_language)
+        key = self._cache_key(csv_data, chart_type, sql, user_question, effective_language, total_rows)
 
         cached = self._cache.get(key)
         if cached is not None:
             self._cache.move_to_end(key)
             return cached
 
-        result = self._generate_uncached(csv_data, chart_type, sql, user_question, language)
+        result = self._generate_uncached(csv_data, chart_type, sql, user_question, language, total_rows)
         self._cache_set(key, result)
         return result
 
@@ -131,6 +137,7 @@ class DataVisualizationService:
         sql: Optional[str],
         user_question: Optional[str],
         language: Optional[str] = None,
+        total_rows: Optional[int] = None,
     ) -> Dict[str, Any]:
         # ── Build DataFrame ───────────────────────────────────────
         try:
@@ -163,9 +170,15 @@ class DataVisualizationService:
         try:
             viz_input = VisualizationInput(data=df)
             if has_context:
-                result = tool.execute_with_context(viz_input, sql=sql, user_question=user_question, language=language)
+                result = tool.execute_with_context(
+                    viz_input,
+                    sql=sql,
+                    user_question=user_question,
+                    language=language,
+                    total_rows=total_rows,
+                )
             else:
-                result = tool.execute(viz_input, language=language)
+                result = tool.execute(viz_input, language=language, total_rows=total_rows)
         except Exception as exc:
             logger.error(f"Visualization tool execution failed: {exc}")
             return {

--- a/datus/prompts/prompt_templates/visualization_system_1.0.j2
+++ b/datus/prompts/prompt_templates/visualization_system_1.0.j2
@@ -1,6 +1,9 @@
 You are a data visualization expert. Analyze the following dataset schema and preview:
 
 Columns & Types: {{ columns_info }}
+{% if sampling_note %}
+Sampling: {{ sampling_note }}
+{% endif %}
 Data Preview:
 {{ data_preview }}
 

--- a/datus/prompts/prompt_templates/visualization_with_context_1.0.j2
+++ b/datus/prompts/prompt_templates/visualization_with_context_1.0.j2
@@ -2,6 +2,10 @@ You are a data visualization and analysis expert. Analyze the following dataset 
 
 ## Dataset Schema
 Columns & Types: {{ columns_info }}
+{% if sampling_note %}
+## Sampling
+{{ sampling_note }}
+{% endif %}
 
 ## Data Preview
 {{ data_preview }}

--- a/datus/tools/llms_tools/visualization_tool.py
+++ b/datus/tools/llms_tools/visualization_tool.py
@@ -426,9 +426,10 @@ class VisualizationTool(BaseTool):
             return ""
 
         return (
-            f"The dataset below is the first {rows} rows of a {total_rows}-row result set. "
-            "The preview and the column cardinalities describe that sample only — state the "
-            "result size as the full total, and do not present sample extremes as global ones."
+            f"The dataset below is a {rows}-row sample of a {total_rows}-row result set. "
+            "Which rows were sampled is not stated. The preview and the column cardinalities "
+            "describe that sample only — state the result size as the full total, and do not "
+            "present sample extremes as global ones."
         )
 
     def _format_data_preview(self, df: pd.DataFrame) -> str:

--- a/datus/tools/llms_tools/visualization_tool.py
+++ b/datus/tools/llms_tools/visualization_tool.py
@@ -79,11 +79,17 @@ class VisualizationTool(BaseTool):
             logger.debug(f"Lazy visualization model resolution failed: {exc}")
             return None
 
-    def execute(self, input_data: VisualizationInput, language: Optional[str] = None) -> VisualizationOutput:
+    def execute(
+        self,
+        input_data: VisualizationInput,
+        language: Optional[str] = None,
+        total_rows: Optional[int] = None,
+    ) -> VisualizationOutput:
         """Generate visualization recommendation using LLM if available, otherwise heuristics.
 
         ``language`` pins the human-readable output (``reason``) to a language
         code; it falls back to ``agent_config.language`` when unset.
+        ``total_rows`` states the full result size when ``input_data`` is a sample.
         """
         if not isinstance(input_data, VisualizationInput):
             raise TypeError("VisualizationTool expects VisualizationInput as input data.")
@@ -104,7 +110,7 @@ class VisualizationTool(BaseTool):
         result = None
         if self.model:
             try:
-                result = self._llm_based_recommendation(dataframe, language=language)
+                result = self._llm_based_recommendation(dataframe, language=language, total_rows=total_rows)
             except Exception as exc:
                 logger.warning(f"LLM visualization recommendation failed, falling back to heuristics: {exc}")
 
@@ -119,6 +125,7 @@ class VisualizationTool(BaseTool):
         sql: Optional[str] = None,
         user_question: Optional[str] = None,
         language: Optional[str] = None,
+        total_rows: Optional[int] = None,
     ) -> VisualizationWithContextOutput:
         """Generate visualization with data context (showing, period, filters, insight).
 
@@ -127,7 +134,8 @@ class VisualizationTool(BaseTool):
 
         ``language`` pins the human-readable output (``reason``, ``filters``,
         ``insight``) to a language code; it falls back to
-        ``agent_config.language`` when unset.
+        ``agent_config.language`` when unset. ``total_rows`` states the full
+        result size when ``input_data`` is a sample.
         """
         if not isinstance(input_data, VisualizationInput):
             raise TypeError("VisualizationTool expects VisualizationInput as input data.")
@@ -160,7 +168,7 @@ class VisualizationTool(BaseTool):
         # Try context-aware LLM call
         if self.model:
             try:
-                result = self._llm_with_context(dataframe, sql, user_question, language=language)
+                result = self._llm_with_context(dataframe, sql, user_question, language=language, total_rows=total_rows)
                 if result is not None:
                     return result
             except Exception as exc:
@@ -186,6 +194,7 @@ class VisualizationTool(BaseTool):
         sql: Optional[str],
         user_question: Optional[str],
         language: Optional[str] = None,
+        total_rows: Optional[int] = None,
     ) -> Optional[VisualizationWithContextOutput]:
         """Single LLM call returning chart config + context metadata."""
         prompt = get_prompt_manager(agent_config=self.agent_config).render_template(
@@ -193,6 +202,7 @@ class VisualizationTool(BaseTool):
             version=self.prompt_version,
             columns_info=self._format_columns_info(df),
             data_preview=self._format_data_preview(df),
+            sampling_note=self._sampling_note(df, total_rows),
             sql=sql or "",
             user_question=user_question or "",
             language_directive=self._language_directive(language),
@@ -305,7 +315,7 @@ class VisualizationTool(BaseTool):
     # LLM recommendation
     # ------------------------------------------------------------------ #
     def _llm_based_recommendation(
-        self, df: pd.DataFrame, language: Optional[str] = None
+        self, df: pd.DataFrame, language: Optional[str] = None, total_rows: Optional[int] = None
     ) -> Optional[VisualizationOutput]:
         """Use LLM to recommend visualization configuration."""
         prompt = get_prompt_manager(agent_config=self.agent_config).render_template(
@@ -313,6 +323,7 @@ class VisualizationTool(BaseTool):
             version=self.prompt_version,
             columns_info=self._format_columns_info(df),
             data_preview=self._format_data_preview(df),
+            sampling_note=self._sampling_note(df, total_rows),
             language_directive=self._language_directive(language),
         )
 
@@ -402,6 +413,23 @@ class VisualizationTool(BaseTool):
             unique_count = df[column].nunique(dropna=True)
             info_parts.append(f"{column} ({dtype}, unique={unique_count})")
         return ", ".join(info_parts)
+
+    def _sampling_note(self, df: pd.DataFrame, total_rows: Optional[int]) -> str:
+        """Tell the model the rows it got are a sample, when the caller says so.
+
+        Both the preview and the per-column ``unique=`` counts are computed over
+        the rows we were handed, so a model told nothing would size the result
+        set by the sample and read its extremes as global ones.
+        """
+        rows = len(df)
+        if not total_rows or total_rows <= rows:
+            return ""
+
+        return (
+            f"The dataset below is the first {rows} rows of a {total_rows}-row result set. "
+            "The preview and the column cardinalities describe that sample only — state the "
+            "result size as the full total, and do not present sample extremes as global ones."
+        )
 
     def _format_data_preview(self, df: pd.DataFrame) -> str:
         preview_df = df.head(self.preview_rows).replace({np.nan: None})

--- a/tests/unit_tests/api/routes/test_visualization_routes.py
+++ b/tests/unit_tests/api/routes/test_visualization_routes.py
@@ -166,10 +166,12 @@ class TestServiceDelegation:
         valid_payload["sql"] = "SELECT date, sales FROM t"
         valid_payload["user_question"] = "Show me sales"
         valid_payload["language"] = "zh-CN"
+        valid_payload["total_rows"] = 1000
         client.post("/api/v1/data_visualization", json=valid_payload)
 
         kw = svc.visualization.generate.call_args.kwargs
         assert kw["chart_type"] == "Bar"
+        assert kw["total_rows"] == 1000
         assert kw["sql"] == "SELECT date, sales FROM t"
         assert kw["user_question"] == "Show me sales"
         assert kw["language"] == "zh-CN"
@@ -189,3 +191,4 @@ class TestServiceDelegation:
         assert kw["sql"] is None
         assert kw["user_question"] is None
         assert kw["language"] is None
+        assert kw["total_rows"] is None

--- a/tests/unit_tests/api/services/test_visualization_service.py
+++ b/tests/unit_tests/api/services/test_visualization_service.py
@@ -387,3 +387,42 @@ class TestResponseLanguage:
             svc.generate(csv_data)
 
         assert mock_cls.return_value.execute.call_args.kwargs["language"] is None
+
+
+class TestTotalRows:
+    """The row cap lives in the caller, so the full size has to travel separately."""
+
+    def test_forwarded_to_tool(self, mock_agent_config, csv_data):
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls, patch(_TOOL_PROMPT_PATH):
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data, total_rows=1000)
+
+        assert mock_cls.return_value.execute.call_args.kwargs["total_rows"] == 1000
+
+    def test_forwarded_to_tool_with_context(self, mock_agent_config, csv_data):
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls, patch(_TOOL_PROMPT_PATH):
+            mock_cls.return_value.execute_with_context.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data, sql="SELECT a", total_rows=1000)
+
+        assert mock_cls.return_value.execute_with_context.call_args.kwargs["total_rows"] == 1000
+
+    def test_different_total_rows_not_cached(self, mock_agent_config, csv_data):
+        """Same sample, different result size — the insight describes a different set."""
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data, total_rows=1000)
+            svc.generate(csv_data, total_rows=5000)
+
+        assert mock_cls.return_value.execute.call_count == 2
+
+    def test_same_total_rows_hits_cache(self, mock_agent_config, csv_data):
+        with patch(_LLM_PATH), patch(_VIZ_TOOL_PATH) as mock_cls:
+            mock_cls.return_value.execute.return_value = _mock_tool_result()
+            svc = DataVisualizationService(agent_config=mock_agent_config)
+            svc.generate(csv_data, total_rows=1000)
+            svc.generate(csv_data, total_rows=1000)
+
+        assert mock_cls.return_value.execute.call_count == 1

--- a/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
+++ b/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
@@ -635,7 +635,16 @@ class TestSamplingNote:
     def test_note_states_both_counts(self):
         tool = _make_tool()
         note = tool._sampling_note(self._df(), total_rows=1000)
-        assert "2" in note and "1000" in note
+        assert "2-row sample" in note
+        assert "1000-row result set" in note
+
+    def test_note_does_not_claim_which_rows_were_sampled(self):
+        """The tool is handed a row count, never which rows they are — saying
+        'the first N' would be a fact it cannot know, and one the model would
+        use (e.g. reading them as the earliest period)."""
+        tool = _make_tool()
+        note = tool._sampling_note(self._df(), total_rows=1000)
+        assert "first" not in note.lower()
 
     def test_no_note_without_total_rows(self):
         tool = _make_tool()

--- a/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
+++ b/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
@@ -623,3 +623,62 @@ class TestHeuristicLanguage:
         assert result.success is False
         assert not result.reason.isascii()
         assert result.error.isascii()
+
+
+class TestSamplingNote:
+    """``total_rows`` is how the caller says the rows it uploaded are a sample."""
+
+    @staticmethod
+    def _df():
+        return pd.DataFrame({"cat": ["a", "b"], "val": [1, 2]})
+
+    def test_note_states_both_counts(self):
+        tool = _make_tool()
+        note = tool._sampling_note(self._df(), total_rows=1000)
+        assert "2" in note and "1000" in note
+
+    def test_no_note_without_total_rows(self):
+        tool = _make_tool()
+        assert tool._sampling_note(self._df(), total_rows=None) == ""
+
+    def test_no_note_when_full_set_was_sent(self):
+        tool = _make_tool()
+        assert tool._sampling_note(self._df(), total_rows=2) == ""
+
+    def test_no_note_when_total_is_smaller_than_what_arrived(self):
+        """A total below the row count is a caller bug; claiming a sample would be worse."""
+        tool = _make_tool()
+        assert tool._sampling_note(self._df(), total_rows=1) == ""
+
+    def test_note_reaches_the_prompt(self):
+        mock_model = MagicMock()
+        mock_model.generate_with_json_output.return_value = {
+            "chart_type": "Bar Chart",
+            "x_col": "cat",
+            "y_cols": ["val"],
+            "reason": "compare",
+        }
+        tool = _make_tool(model=mock_model)
+
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "prompt"
+            tool.execute(_make_input(self._df()), total_rows=1000)
+
+        assert "1000" in mock_gpm.return_value.render_template.call_args.kwargs["sampling_note"]
+
+    def test_note_reaches_the_context_prompt(self):
+        mock_model = MagicMock()
+        mock_model.generate_with_json_output.return_value = {
+            "chart_type": "Bar Chart",
+            "x_col": "cat",
+            "y_cols": ["val"],
+            "reason": "compare",
+            "insight": "…",
+        }
+        tool = _make_tool(model=mock_model)
+
+        with patch("datus.tools.llms_tools.visualization_tool.get_prompt_manager") as mock_gpm:
+            mock_gpm.return_value.render_template.return_value = "prompt"
+            tool.execute_with_context(_make_input(self._df()), sql="SELECT 1", total_rows=1000)
+
+        assert "1000" in mock_gpm.return_value.render_template.call_args.kwargs["sampling_note"]


### PR DESCRIPTION
## Why

Callers cap how many rows they upload to `/api/v1/data_visualization`. A whole result set can be megabytes — Datus-saas [now sends the first 200 rows](https://github.com/Datus-ai/Datus-saas/pull/803) after a 1000-row preview overflowed its HTTP body limit.

Nothing in the request said the rows were a sample, and both prompt inputs are computed from whatever arrived:

- `data_preview` — the first `preview_rows` rows
- `columns_info` — per-column dtype **and `nunique`**, over the rows we were handed

So the insight would describe a 5000-row result set as if it were the 200 rows it saw: a sample maximum reported as the global one, cardinality understated, "N records" wrong.

## What

`DataVisualizationRequest.total_rows` (optional), threaded route → service → tool. When it exceeds the rows that arrived, the tool renders a sampling note into the prompt — stating both counts, and instructing the model to size the result by the stated total and not present sample extremes as global ones. Absent, equal, or smaller means the caller sent the whole set and no note is rendered; a smaller-than-actual total is a caller bug, and claiming a sample there would be worse than staying quiet.

Both templates get the note under `{% if sampling_note %}`, so the variable is optional and callers that don't pass it render exactly as before.

`total_rows` also joins `DataVisualizationService`'s cache key — the same 200-row sample drawn from a 1000-row and a 5000-row result must not share one cached insight.

## Compatibility

Additive and optional throughout: an older SaaS/backend that never sends `total_rows` produces byte-identical prompts. Datus-backend guards the reverse skew — it only passes the kwarg when the installed agent's `generate` accepts it.

## Test

`pytest tests/unit_tests/api tests/unit_tests/tools` — 200 passed, including 6 new `TestSamplingNote` cases (both counts stated, silent in each of the three no-sample cases, note reaches both the plain and the context prompt), 4 new `TestTotalRows` service cases (forwarded on both tool paths, busts the cache, hits the cache when unchanged), and the two route-delegation tests extended. `ruff format` / `ruff check` clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Visualization requests can now include the full result-set size when only a sample is provided.
  * Visualization guidance now clearly indicates when previews represent sampled data.
  * Sampling information is supported for both standard and context-aware visualizations.

* **Bug Fixes**
  * Visualization caching now distinguishes results generated from different full dataset sizes.

* **Tests**
  * Added coverage for sampling metadata, prompt behavior, request handling, and cache consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visualization requests can include the full result-set size when only a sample is provided.
  * Visualization guidance now indicates when previews represent sampled data.
  * Sampling information is supported for standard and context-aware visualizations.

* **Bug Fixes**
  * Visualization caching now distinguishes results generated from different full dataset sizes.

* **Tests**
  * Added coverage for sampling metadata, prompt behavior, request handling, and cache consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->