### PR TITLE
[BugFix] Switch nightly test config to the Dosi semantic adapter

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -102,7 +102,8 @@ jobs:
           digest="$(
             {
               for file in \
-                build_scripts/build_test_data.sh; do
+                build_scripts/build_test_data.sh \
+                tests/conf/agent.yml; do
                 if [ -f "$file" ]; then
                   sha256sum "$file"
                 fi

--- a/build_scripts/build_test_data.sh
+++ b/build_scripts/build_test_data.sh
@@ -47,8 +47,16 @@ validate_test_home() {
   exit 1
 }
 
+# The CLI exits 0 even when bootstrap reports {'status': 'failed', ...}, so a
+# broken component would only surface later as an empty dataset. Scan the
+# captured output for a failed Final Result and stop at the first bad step.
 run_bootstrap_kb() {
-  uv run datus-agent "$@"
+  local output
+  output="$(uv run datus-agent "$@" 2>&1 | tee /dev/stderr)"
+  if printf '%s' "$output" | grep -q "'status': 'failed'"; then
+    echo "bootstrap-kb reported a failed status: datus-agent $*" >&2
+    exit 1
+  fi
 }
 
 # Clean old data before creating a cacheable, deterministic fixture set.

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -232,7 +232,7 @@ agent:
         password: superset
         database: examples
     semantic_layer:
-      metricflow: {}
+      dosi: {}
     bi_platforms:
       superset:
         type: superset

--- a/tests/integration/agent/test_ask_metrics_agentic.py
+++ b/tests/integration/agent/test_ask_metrics_agentic.py
@@ -42,17 +42,17 @@ def ask_metrics_agent_config(nightly_agent_config):
     frpm semantic model, so ask_metrics has a real, queryable metric catalog.
 
     Function-scoped: mutating ``semantic_layer_configs`` here cannot leak into
-    other suites (nightly_agent_config is itself function-scoped)."""
+    other suites (nightly_agent_config is itself function-scoped).
+
+    The shared tests/conf/agent.yml now defaults to the Dosi adapter (semantic
+    authoring is Dosi-only), so this suite pins MetricFlow as the sole semantic
+    layer to keep covering the still-supported MetricFlow query-only path."""
     models_dir = str(FIXTURE_SEMANTIC_MODELS_DIR.resolve())
     assert (FIXTURE_SEMANTIC_MODELS_DIR / "frpm.yml").is_file(), (
         f"Missing committed fixture semantic model: {FIXTURE_SEMANTIC_MODELS_DIR / 'frpm.yml'}"
     )
 
-    configs = dict(nightly_agent_config.semantic_layer_configs)
-    metricflow_cfg = dict(configs.get("metricflow", {}))
-    metricflow_cfg["semantic_models_path"] = models_dir
-    configs["metricflow"] = metricflow_cfg
-    nightly_agent_config.semantic_layer_configs = configs
+    nightly_agent_config.semantic_layer_configs = {"metricflow": {"semantic_models_path": models_dir}}
     return nightly_agent_config
 
 


### PR DESCRIPTION
## Why

Nightly run [31837961352](https://github.com/Datus-ai/Datus-agent/actions/runs/31837961352) fails at **Build test data**: since semantic authoring became Dosi-only (#1287), `bootstrap-kb --components metrics` resolves the MetricFlow adapter from `tests/conf/agent.yml` and is rejected with the query-only migration error. `metrics.lance` is never populated, and the workflow's knowledge-base dataset check fails with `Knowledge base dataset is missing or empty after build: metrics.lance`.

Two latent gaps made this worse:

- The bootstrap CLI exits 0 even when the Final Result reports `status: failed`, so `build_test_data.sh` silently continued past the broken metrics step.
- The KB cache key does not hash `tests/conf/agent.yml`, so config changes would not invalidate a stale cached knowledge base.

## Solution

- `tests/conf/agent.yml`: switch `semantic_layer` from `metricflow` to `dosi` so the metrics bootstrap authors through the unified `semantic_modeling` workflow. The nightly CI already installs `datus-semantic-dosi` (both via the `ci` dependency group and the `external/datus-semantic-adapter` main checkout), so no install changes are needed.
- `test_ask_metrics_agentic.py`: pin MetricFlow as the sole semantic layer inside the suite fixture. This suite covers the still-supported MetricFlow query-only path and must not inherit the Dosi default (two configured layers without a `default` flag would raise).
- `build_test_data.sh`: fail at the first bootstrap step whose Final Result reports `status: failed` instead of surfacing the breakage later as an empty-dataset check.
- `run-nightly.yml`: include `tests/conf/agent.yml` in the KB cache key hash.

Verified locally against the real Dosi adapter (datus-semantic-adapter main + dosi-engine 0.1.4): the metrics bootstrap completes with `semantic_object_count=1, metrics_count=3, sql_entries_covered=3` and produces a non-empty `metrics.lance`.

## Test Cases

- Updated `tests/integration/agent/test_ask_metrics_agentic.py` fixture to pin the MetricFlow semantic layer explicitly.
- No new tests: the change is nightly build configuration/scripting; the existing nightly KB dataset check plus `tests/integration/agent/test_semantic_modeling_agentic.py` cover the Dosi authoring path.
- PR gates: `ci/run-pr-tests.py` 200 passed / 0 failed, diff coverage 100%; `ci/audit_tests.py --diff-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-data setup reliability by detecting bootstrap failures and stopping instead of continuing with incomplete data.
  * Updated semantic-layer test configuration to use the intended MetricFlow-based setup.

* **Chores**
  * Improved build-cache invalidation so changes to relevant test configuration or data-generation scripts trigger fresh test data creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->