### PR TITLE
[BugFix] Map unsupported datasource types to ANSI_SQL in OSI dialect prompt

### DIFF
--- a/datus/prompts/prompt_templates/_osi_dialect_map.j2
+++ b/datus/prompts/prompt_templates/_osi_dialect_map.j2
@@ -1,3 +1,16 @@
+{#- Map a Datus datasource type to a dialect the Dosi engine accepts.
+    The OSI Dialect enum admits one variant per warehouse the engine can
+    render (dosi-model spec.rs is the source of truth for this list); any
+    other type — sqlite, hive, spark, unknown — must be authored as ANSI_SQL
+    or the engine rejects the document with `unknown variant` at upsert time.
+    An enum addition missing here fails soft: ANSI_SQL always parses. -#}
 {% macro expression_dialect(datasource_type) -%}
-{{- (datasource_type | default('', true) | trim | upper) or 'ANSI_SQL' -}}
+{%- set engine_dialects = [
+  'ANSI_SQL', 'SNOWFLAKE', 'DATABRICKS',
+  'POSTGRESQL', 'GREENPLUM', 'HOLOGRES', 'GAUSSDB', 'ORACLE', 'MYSQL',
+  'DUCKDB', 'STARROCKS', 'DORIS', 'TIDB', 'TRINO', 'CLICKHOUSE',
+  'BIGQUERY', 'REDSHIFT',
+] -%}
+{%- set candidate = (datasource_type | default('', true) | trim | upper) -%}
+{{- candidate if candidate in engine_dialects else 'ANSI_SQL' -}}
 {%- endmacro %}

--- a/tests/conf/agent.yml
+++ b/tests/conf/agent.yml
@@ -5,6 +5,13 @@ agent:
   target: deepseek
   project_root: .datus_test_data/workspace
 
+  # Nightly agentic flows run non-interactively (execution_mode=workflow); an
+  # EXTERNAL filesystem path would otherwise raise PermissionDeniedException
+  # and abort the whole run. Strict mode turns those hits into a readable
+  # tool-failure payload so the agent can retarget inside the project root.
+  filesystem:
+    strict: true
+
   models:
     deepseek:
       type: deepseek

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -99,9 +99,14 @@ def test_metrics_template_osi_mode_allows_narrow_dataset_repairs():
         ("sqlite", "ANSI_SQL"),
         ("hive", "ANSI_SQL"),
         ("spark", "ANSI_SQL"),
+        # Normalization: surrounding whitespace and mixed case must not change
+        # the mapping outcome.
+        ("  duckdb  ", "DUCKDB"),
+        ("DuckDB", "DUCKDB"),
+        ("SQLite", "ANSI_SQL"),
     ],
 )
-def test_osi_mode_expression_dialect_derivation(template_name, datasource, expected_dialect):
+def test_osi_mode_expression_dialect_derivation(template_name: str, datasource: str, expected_dialect: str):
     # The OSI dialect label is the active datasource's own dialect when the
     # engine supports it, else the ANSI_SQL fallback.
     text = _render(template_name, "osi", datasource_dialect=datasource)
@@ -113,9 +118,11 @@ def test_osi_mode_expression_dialect_derivation(template_name, datasource, expec
     [
         ("duckdb", "DUCKDB"),
         ("sqlite", "ANSI_SQL"),
+        ("hive", "ANSI_SQL"),
+        ("spark", "ANSI_SQL"),
     ],
 )
-def test_semantic_modeling_template_maps_dialect_to_engine_enum(datasource_dialect, expected_dialect):
+def test_semantic_modeling_template_maps_dialect_to_engine_enum(datasource_dialect: str, expected_dialect: str):
     # The unified Dosi authoring template shares the same engine-enum mapping.
     pm = get_prompt_manager()
     text = pm.render_template(

--- a/tests/unit_tests/prompts/test_osi_authoring_templates.py
+++ b/tests/unit_tests/prompts/test_osi_authoring_templates.py
@@ -92,12 +92,40 @@ def test_metrics_template_osi_mode_allows_narrow_dataset_repairs():
         ("postgresql", "POSTGRESQL"),
         ("snowflake", "SNOWFLAKE"),
         ("databricks", "DATABRICKS"),
+        ("duckdb", "DUCKDB"),
+        # Types outside the Dosi engine's Dialect enum must map to ANSI_SQL:
+        # a blindly uppercased `SQLITE` is rejected by the engine parser with
+        # `unknown variant` at upsert time.
+        ("sqlite", "ANSI_SQL"),
+        ("hive", "ANSI_SQL"),
+        ("spark", "ANSI_SQL"),
     ],
 )
 def test_osi_mode_expression_dialect_derivation(template_name, datasource, expected_dialect):
-    # The OSI dialect label is the active datasource's own dialect (uppercased).
+    # The OSI dialect label is the active datasource's own dialect when the
+    # engine supports it, else the ANSI_SQL fallback.
     text = _render(template_name, "osi", datasource_dialect=datasource)
     assert f"OSI expression dialect for this run: `{expected_dialect}`" in text
+
+
+@pytest.mark.parametrize(
+    "datasource_dialect, expected_dialect",
+    [
+        ("duckdb", "DUCKDB"),
+        ("sqlite", "ANSI_SQL"),
+    ],
+)
+def test_semantic_modeling_template_maps_dialect_to_engine_enum(datasource_dialect, expected_dialect):
+    # The unified Dosi authoring template shares the same engine-enum mapping.
+    pm = get_prompt_manager()
+    text = pm.render_template(
+        template_name="semantic_modeling_system",
+        authoring_scope="full",
+        current_datasource="bird_school",
+        current_datasource_dialect=datasource_dialect,
+        **COMMON_VARS,
+    )
+    assert f"Dosi expression dialect: `{expected_dialect}`" in text
 
 
 @pytest.mark.parametrize("template_name", ["gen_semantic_model_system", "gen_metrics_system"])


### PR DESCRIPTION
## Why

Nightly run [31906306959](https://github.com/Datus-ai/Datus-agent/actions/runs/31906306959) still fails at **Build test data** after #1291. The fail-fast added there surfaced the real, two-layer defect in the Dosi metrics bootstrap on `bird_school` (sqlite):

1. **Deterministic root cause**: `_osi_dialect_map.j2` derives the OSI expression dialect by blindly uppercasing the datasource type, so the system prompt instructs the model to tag expressions with `SQLITE` — a variant the Dosi engine's `Dialect` enum deliberately does not define (`dosi-exec`: *"sqlite is a Datus built-in but not an osi dialect"*). Every authored document is rejected with `unknown variant \`SQLITE\`` at upsert time, and success then depends on the model guessing a valid dialect on retry.
2. **Fatal amplifier**: while investigating the rejection, the model sometimes greps outside the project root. In non-interactive workflow mode that raises `PermissionDeniedException` (`permission_hooks.py`), which nothing catches — the whole bootstrap aborts. The denial text (*"STOP retrying — choose a path inside the project root"*) is written for the model but never reaches it.

## Solution

- `_osi_dialect_map.j2`: pass through only dialects the engine enum accepts (source of truth: `dosi-model` `spec.rs`); everything else — sqlite, hive, spark, unknown — maps to `ANSI_SQL`, which always parses. An enum addition missing from the list fails soft to `ANSI_SQL`.
- `tests/conf/agent.yml`: enable `filesystem.strict` so an out-of-root filesystem hit returns the existing strict-mode tool-failure payload (naming the allowed roots) instead of an uncaught exception. Nightly agentic flows are non-interactive; a broker prompt can never be answered there.

Verified end to end against the real Dosi adapter (datus-semantic-adapter main + dosi-engine 0.1.4): the nightly metrics bootstrap command completes with `semantic_object_count=1, metrics_count=3` and zero `unknown variant` errors, producing a non-empty `metrics.lance`.

Known remaining risk (separate issue, not addressed here): an intermittent turn-repetition loop was observed once during verification — a single `inspect_semantic_sources`/`glob` tool round was re-emitted every turn until `Max turns (60) exceeded`, with the underlying `describe_table` executing exactly once. This predates this PR and matches previously observed Dosi-authoring variance.

## Test Cases

- Extended `tests/unit_tests/prompts/test_osi_authoring_templates.py`: dialect derivation now covers `duckdb` pass-through plus `sqlite`/`hive`/`spark` → `ANSI_SQL`, and a new test asserts the unified `semantic_modeling_system` template shares the same engine-enum mapping.
- PR gates: `ci/run-pr-tests.py` 200 passed / 0 failed, diff coverage 100%; `ci/audit_tests.py --diff-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL dialect handling by recognizing supported OSI engine dialects consistently across authoring templates.
  * Unsupported or missing dialect values now safely fall back to `ANSI_SQL`, providing more predictable query generation.
  * Added consistent dialect mapping for semantic modeling workflows, including SQLite, Hive, and Spark inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL dialect handling across authoring and semantic modeling workflows.
  * Supported dialect names are now normalized consistently, including mixed-case and whitespace variations.
  * Recognized dialects, including DuckDB, SQLite, Hive, and Spark, now map to the appropriate OSI engine dialect.
  * Unsupported or missing values now reliably fall back to `ANSI_SQL` for more predictable query generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->