### PR TITLE
[BugFix] Repair nightly tests broken by semantic-authoring consolidation; vendor GaussDB libpq

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -87,6 +87,18 @@ jobs:
           path: external/datus-storage-adapters
           persist-credentials: false
 
+      # Source checkouts of datus-gaussdb carry no vendored libpq (wheels get
+      # it at release-build time); without it the gaussdb driver binds the
+      # runner's vanilla PostgreSQL libpq and segfaults the pytest process.
+      # Restore the extracted libraries before `Install dependencies` packages
+      # the adapter, so a cache hit needs no rebuild or reinstall.
+      - name: Restore GaussDB vendored libpq cache
+        id: gaussdb-vendor-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: external/datus-db-adapters/datus-gaussdb/datus_gaussdb/_vendor/x86_64
+          key: gaussdb-vendor-${{ hashFiles('external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py') }}
+
       - name: Clean up stale temp files
         run: |
           echo "Cleaning stale pytest temp directories..."
@@ -243,6 +255,32 @@ jobs:
           fi
 
           docker compose version
+
+      # On cache miss the extraction needs Docker (it pulls the pinned
+      # openGauss image), so this runs after the Docker runtime check; the
+      # adapter was already installed without the libraries, so reinstall it.
+      - name: Vendor GaussDB client libpq
+        run: |
+          set -euo pipefail
+          vendor_dir="external/datus-db-adapters/datus-gaussdb/datus_gaussdb/_vendor/x86_64"
+          if [ ! -f "${vendor_dir}/libpq.so.5" ]; then
+            python3 external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py --arch x86_64
+            uv pip install --no-cache-dir --reinstall-package datus-gaussdb \
+              ./external/datus-db-adapters/datus-gaussdb
+          fi
+          for artifact in libpq.so.5 libssl.so.1.1 libcrypto.so.1.1; do
+            test -f "${vendor_dir}/${artifact}" || {
+              echo "::error::GaussDB vendored library missing after fetch: ${artifact}"
+              exit 1
+            }
+          done
+
+      - name: Save GaussDB vendored libpq cache
+        if: steps.gaussdb-vendor-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: external/datus-db-adapters/datus-gaussdb/datus_gaussdb/_vendor/x86_64
+          key: gaussdb-vendor-${{ hashFiles('external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py') }}
 
       - name: Setup config file
         run: |

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: external/datus-db-adapters/datus-gaussdb/datus_gaussdb/_vendor/x86_64
-          key: gaussdb-vendor-${{ hashFiles('external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py') }}
+          key: gaussdb-vendor-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py') }}
 
       - name: Clean up stale temp files
         run: |
@@ -260,10 +260,18 @@ jobs:
       # openGauss image), so this runs after the Docker runtime check; the
       # adapter was already installed without the libraries, so reinstall it.
       - name: Vendor GaussDB client libpq
+        id: gaussdb-vendor
         run: |
           set -euo pipefail
           vendor_dir="external/datus-db-adapters/datus-gaussdb/datus_gaussdb/_vendor/x86_64"
-          if [ ! -f "${vendor_dir}/libpq.so.5" ]; then
+          # Re-fetch when ANY required library is missing, not just libpq —
+          # a partial directory (e.g. an interrupted earlier run) must repair
+          # itself rather than fail the verification below.
+          need_fetch=0
+          for artifact in libpq.so.5 libssl.so.1.1 libcrypto.so.1.1; do
+            [ -f "${vendor_dir}/${artifact}" ] || need_fetch=1
+          done
+          if [ "$need_fetch" = "1" ]; then
             python3 external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py --arch x86_64
             uv pip install --no-cache-dir --reinstall-package datus-gaussdb \
               ./external/datus-db-adapters/datus-gaussdb
@@ -274,13 +282,16 @@ jobs:
               exit 1
             }
           done
+          echo "fetched=${need_fetch}" >> "$GITHUB_OUTPUT"
 
+      # Only a freshly fetched, fully verified set is saved; the verification
+      # step above already failed the job for anything incomplete.
       - name: Save GaussDB vendored libpq cache
-        if: steps.gaussdb-vendor-cache.outputs.cache-hit != 'true'
+        if: steps.gaussdb-vendor.outputs.fetched == '1' && steps.gaussdb-vendor-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: external/datus-db-adapters/datus-gaussdb/datus_gaussdb/_vendor/x86_64
-          key: gaussdb-vendor-${{ hashFiles('external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py') }}
+          key: gaussdb-vendor-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('external/datus-db-adapters/datus-gaussdb/scripts/fetch_vendor_libpq.py') }}
 
       - name: Setup config file
         run: |

--- a/tests/integration/agent/test_sql_summary_agentic.py
+++ b/tests/integration/agent/test_sql_summary_agentic.py
@@ -50,15 +50,18 @@ class TestSqlSummaryAgentic:
 
         logger.info(f"Node initialized with {len(node.tools)} tools: {tool_names}")
 
-    def test_interactive_mode_has_hooks(self, nightly_agent_config):
-        """N9-02: Interactive mode initializes hooks."""
+    def test_interactive_mode_initializes(self, nightly_agent_config):
+        """N9-02: Interactive mode builds the same tool surface as workflow mode."""
         node = SqlSummaryAgenticNode(
             node_name="gen_sql_summary",
             agent_config=nightly_agent_config,
             execution_mode="interactive",
         )
 
-        assert node.hooks is not None, "Interactive mode should have hooks"
+        assert node.execution_mode == "interactive"
+        tool_names = [tool.name for tool in node.tools]
+        assert "generate_sql_summary_id" in tool_names, f"Missing generate_sql_summary_id, got: {tool_names}"
+        assert "write_file" in tool_names, f"Missing write_file, got: {tool_names}"
 
     def test_template_context_preparation(self, nightly_agent_config):
         """N9-03: Template context includes tools and subject tree info."""

--- a/tests/integration/tools/test_bi_dashboard.py
+++ b/tests/integration/tools/test_bi_dashboard.py
@@ -474,7 +474,10 @@ class TestPartialIntegration:
                     if False:
                         yield  # pragma: no cover
 
-                async def _save_stub(_cfg, **_kwargs):
+                save_calls: list = []
+
+                async def _save_stub(_cfg, _sink=save_calls, **kwargs):
+                    _sink.append(kwargs)
                     if False:
                         yield  # pragma: no cover
 
@@ -495,6 +498,12 @@ class TestPartialIntegration:
                 assert any("Sub-Agent build successful" in (a.messages or "") for a in actions), (
                     f"Sub-agent build did not complete; got actions: {[a.messages for a in actions]}"
                 )
+                # The identifiers recorded by the unified semantic stage must
+                # reach the saved sub-agent's scoped context.
+                assert len(save_calls) == 1, f"expected one sub-agent save, got {len(save_calls)}"
+                scoped = save_calls[0]["scoped_context"]
+                assert scoped is not None and scoped.metrics, f"scoped context lost the metrics: {scoped}"
+                assert f"{platform}/test/layer0.metric_0" in scoped.metrics
 
                 logger.info(
                     "Partial integration test passed for %s — real Superset extraction: %d charts, "

--- a/tests/integration/tools/test_bi_dashboard.py
+++ b/tests/integration/tools/test_bi_dashboard.py
@@ -466,11 +466,10 @@ class TestPartialIntegration:
                         yield  # pragma: no cover
 
                 async def _sem_stub(_cfg, *, sqls, platform, dashboard_name, state):
+                    # The unified semantic-modeling stage owns metric authoring
+                    # (stream_bi_metrics was folded into it), so the stub also
+                    # records the generated metric identifiers.
                     state.semantic_ok = True
-                    if False:
-                        yield  # pragma: no cover
-
-                async def _metrics_stub(_cfg, *, sqls, platform, dashboard_name, state):
                     state.metrics.extend(f"{platform}/test/layer{i}.metric_{i}" for i in range(len(sqls)))
                     if False:
                         yield  # pragma: no cover
@@ -484,7 +483,6 @@ class TestPartialIntegration:
                     patch("datus.cli.bootstrap_bi_commands.stream_bi_metadata", side_effect=_meta_stub),
                     patch("datus.cli.bootstrap_bi_commands.stream_bi_reference_sql", side_effect=_ref_stub),
                     patch("datus.cli.bootstrap_bi_commands.stream_bi_semantic_model", side_effect=_sem_stub),
-                    patch("datus.cli.bootstrap_bi_commands.stream_bi_metrics", side_effect=_metrics_stub),
                     patch("datus.cli.bootstrap_bi_commands.stream_bi_save_subagents", side_effect=_save_stub),
                     patch("datus.cli.bootstrap_bi_commands.SubAgentManager"),
                     patch("datus.cli.bootstrap_bi_commands.configuration_manager"),

--- a/tests/unit_tests/configuration/test_configuration_load.py
+++ b/tests/unit_tests/configuration/test_configuration_load.py
@@ -43,7 +43,7 @@ def test_service_config_structure(agent_config: AgentConfig):
     assert "bird_school" in agent_config.services.datasources
     assert "snowflake" in agent_config.services.datasources
     assert "local_duckdb" in agent_config.services.datasources
-    assert "metricflow" in agent_config.services.semantic_layer
+    assert "dosi" in agent_config.services.semantic_layer
     assert "superset" in agent_config.services.bi_platforms
     assert "airflow_local" in agent_config.services.schedulers
 


### PR DESCRIPTION
## Why

Nightly run [31921897109](https://github.com/Datus-ai/Datus-agent/actions/runs/31921897109) shows the Build test data step now passes (#1291/#1292); the remaining failures in **Run nightly tests** split into two groups:

**1. Three nightly-marked tests left behind by recent merges** (nightly tests do not run in PR gates, so the breakage only appeared in the scheduled run):

- `test_service_config_structure` still asserted the MetricFlow semantic layer after #1291 switched `tests/conf/agent.yml` to Dosi.
- `test_interactive_mode_has_hooks` asserted generation hooks that #1289 removed (`SqlSummaryAgenticNode.hooks` is now always `None`).
- `test_bi_dashboard::test_workflow_without_llm` patched `bootstrap_bi_commands.stream_bi_metrics`, which #1287 folded into the unified `stream_bi_semantic_model` stage.

**2. The GaussDB group segfault that has ended every nightly with exit 139 since the group was added**: nightly installs `datus-gaussdb` from the git checkout, and source checkouts carry no vendored libpq (wheels get it at release-build time). `import_gaussdb()` falls back to system discovery, binds the runner's vanilla PostgreSQL libpq, and the first `PQconninfoParse` call segfaults the pytest process. Linux keeps the official libpq-bound driver by design (sm3 auth support), so nightly must provision the GaussDB libpq rather than switch drivers.

## Solution

Test repairs:

- Assert `dosi` in the semantic-layer config test.
- Repurpose the hooks test as an interactive-mode construction test over the tool surface (no tombstone assertion on the removed hooks).
- Drop the stale `stream_bi_metrics` patch; the semantic-model stub now records the generated metric identifiers itself.

GaussDB vendored libpq (`run-nightly.yml`):

- Cache-restore the extracted libraries into the checkout **before** `Install dependencies`, so a warm run packages them with no extra work.
- On a cache miss, run the adapter's own `scripts/fetch_vendor_libpq.py --arch x86_64` after the Docker runtime check (it extracts libpq from the pinned openGauss image plus checksum-pinned openEuler OpenSSL), reinstall `datus-gaussdb`, verify all three libraries exist, and save the cache keyed on the fetch script's hash.

Companion PR: [datus-db-adapters#101](https://github.com/Datus-ai/datus-db-adapters/pull/101) adds a `PQlibVersion()` probe so any future environment gap fails as a readable ImportError instead of SIGSEGV.

## Test Cases

- Updated the three tests above. `test_configuration_load.py` 14 passed locally; sql_summary construction tests 2 passed with a real config; `test_bi_dashboard` collects cleanly and its patch targets verified against the current module surface (full run needs the Superset stack).
- Workflow change validated by YAML parse; the extraction path itself is exercised on the first post-merge nightly (or a `workflow_dispatch` with `nightly_group_filter: GaussDB Adapter Tests`).
- PR gates: `ci/run-pr-tests.py` 221 passed / 0 failed, diff coverage 100%; `ci/audit_tests.py --diff-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated interactive-mode coverage for execution mode, SQL summaries, and file-writing tools.
  * Refined BI dashboard integration coverage for semantic modeling and metric generation.
  * Updated configuration validation for the `dosi` semantic-layer service.

* **Chores**
  * Improved nightly build reliability by caching and validating required database client libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
