### PR TITLE
[BugFix] Persist native Claude tool checkpoints

### DIFF
--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -769,10 +769,15 @@ class ClaudeModel(OpenAICompatibleModel):
                 if session is not None:
                     try:
                         prior_items = await session.get_items()
-                        if prior_items:
-                            messages.extend(prior_items)
                     except Exception as e:
                         logger.warning(f"Failed to load session history; starting fresh: {e}")
+                        prior_items = []
+                    if prior_items:
+                        messages.extend(prior_items)
+                        # Do not swallow a seal write failure. Continuing would
+                        # append the new user prompt after the durable
+                        # tool_result tail and corrupt replay role ordering.
+                        await self._seal_interrupted_native_history(session, messages)
                 # Anthropic ``text`` blocks must be a single string. The signature
                 # inherits ``prompt: Union[str, List[Dict[str, str]]]`` from the
                 # base class for legacy callers; defensively normalise list-shaped
@@ -784,15 +789,18 @@ class ClaudeModel(OpenAICompatibleModel):
                 }
                 # Index of this turn's first NEW message in ``messages`` (prior
                 # session history was just replayed above, so anything before
-                # this index is already persisted). The end-of-turn persistence
-                # stores ``messages[turn_start_index:]`` — the full structured
-                # delta including every ``tool_use`` / ``tool_result`` — instead
-                # of only the final text.
+                # this index is already persisted). ``persisted_message_index``
+                # advances after every complete model/tool round so a long native
+                # Claude run survives max-turn exhaustion, process interruption,
+                # or a later model failure without replaying duplicate rows.
                 turn_start_index = len(messages)
+                persisted_message_index = turn_start_index
                 messages.append(user_turn_message)
                 tool_call_cache = {}
                 sql_contexts = []
                 final_content = ""
+                last_assistant_text = ""
+                conversation_completed = False
                 # Guards the failure-path persistence below: the success path
                 # sets this once it has committed the turn, so the ``except``
                 # handler never double-writes a turn it already saved.
@@ -1022,6 +1030,15 @@ class ClaudeModel(OpenAICompatibleModel):
                     active_generation_span = None
 
                     message = response.content
+                    # Keep the fully rehydrated text from this model response.
+                    # Streaming ``thinking_delta.output.delta`` intentionally
+                    # remains one incremental fragment per event; this separate
+                    # snapshot is the source of truth when the last allowed turn
+                    # also contains tool_use blocks and the loop exhausts before
+                    # a normal text-only completion.
+                    last_assistant_text = "\n".join(
+                        block.text for block in message if block.type == "text" and block.text
+                    )
 
                     # Surface server-side tool calls (Anthropic web_search /
                     # web_fetch) as TOOL ActionHistory. The streaming path already
@@ -1092,7 +1109,8 @@ class ClaudeModel(OpenAICompatibleModel):
 
                     # If no tool calls, conversation is complete
                     if not any(block.type == "tool_use" for block in message):
-                        final_content = "\n".join([block.text for block in message if block.type == "text"])
+                        final_content = last_assistant_text
+                        conversation_completed = True
                         # Persist the final assistant message — including any
                         # sanitized ``server_tool_use`` / ``web_search_tool_result``
                         # blocks from a ``web_search``-only turn — before breaking.
@@ -1369,7 +1387,36 @@ class ClaudeModel(OpenAICompatibleModel):
                                 }
                             )
 
+                    # A native Claude "turn" is durable once every tool_use in
+                    # the assistant response has a corresponding tool_result.
+                    # Persist only the new suffix; persisting the whole in-memory
+                    # transcript here would duplicate prior checkpoints.  The
+                    # database may temporarily end in a tool_result while the run
+                    # is active. Graceful termination seals that tail below, and
+                    # the next invocation repairs it if the process dies between
+                    # these two points.
+                    persisted_message_index = await self._persist_native_message_delta(
+                        session,
+                        messages,
+                        persisted_message_index,
+                    )
+
                 logger.debug("Agent execution completed")
+                max_turns_exhausted = not conversation_completed
+                max_turns_notice = f"[Agent stopped after reaching max_turns={max_turns}; work may remain incomplete.]"
+                empty_completion_notice = "[Assistant completed without returning text.]"
+                if max_turns_exhausted:
+                    # Text accompanying the final tool_use was already emitted
+                    # through thinking_delta + its paired response action and is
+                    # checkpointed in ``messages``. Do not publish it again as a
+                    # final_response: the run is incomplete, and upper layers use
+                    # that wrapper as a de-dup/finalization boundary which can
+                    # otherwise suppress the live delta stream.
+                    # A tool-only response has no text/delta to preserve, so make
+                    # the stop explicit instead of returning a completely blank
+                    # assistant result. This notice is a final response, never a
+                    # fabricated model delta.
+                    final_content = "" if last_assistant_text else max_turns_notice
                 usage_info = self._build_native_usage_info(
                     requests=turn + 1,
                     cumulative_input_tokens=cumulative_input_tokens,
@@ -1396,49 +1443,39 @@ class ClaudeModel(OpenAICompatibleModel):
                 if action_history_manager is not None:
                     action_history_manager.add_action(final_action)
 
-                # Persist this turn into the session so the next turn replays it
-                # via ``session.get_items()``. Mirror what openai-agents Runner
-                # would do via SQLiteSession.add_items, but driven by us since
-                # the native Anthropic loop bypasses Runner.run.
-                #
-                # When the loop exits via ``max_turns`` exhaustion while still
-                # tool-calling, ``final_content`` stays "" — Anthropic rejects
-                # empty assistant text blocks on replay
-                # (``messages.{i}.content.{j}.text: text content blocks must be
-                # non-empty``), which would poison the session. Skip persistence
-                # in that case so the next turn starts from a clean slate.
-                if session is not None and final_content:
+                # A max-turn exit has no text-only completion, but the completed
+                # tool rounds (and any prose accompanying the final tool_use) are
+                # valuable history. Seal the persisted tool_result tail with a
+                # non-empty assistant message so the next user turn remains valid
+                # Anthropic replay input.
+                if max_turns_exhausted or not final_content:
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": max_turns_notice if max_turns_exhausted else empty_completion_notice,
+                                }
+                            ],
+                        }
+                    )
+
+                persisted_message_index = await self._persist_native_message_delta(
+                    session,
+                    messages,
+                    persisted_message_index,
+                )
+                turn_persisted = session is not None and persisted_message_index == len(messages)
+
+                if turn_persisted:
+                    # The native loop never calls Runner.run (which normally
+                    # drives ``store_run_usage``), so commit the durable usage
+                    # only after every message in this turn is safely stored.
                     try:
-                        # Persist the FULL structured turn — every assistant
-                        # ``tool_use`` block and its matching ``tool_result``
-                        # reply — not just ``final_content``. ``messages`` from
-                        # ``turn_start_index`` on is exactly the sequence
-                        # Anthropic accepted during the loop, so replaying it on
-                        # resume is safe and keeps the tool-calling history
-                        # intact. Storing only the final text previously dropped
-                        # every tool call/result, leaving resumed turns with
-                        # broken history (and tool calls leaking into text).
-                        turn_items = self._replay_safe_turn_items(
-                            messages[turn_start_index:], user_turn_message, final_content
-                        )
-                        await session.add_items(turn_items)
-                        turn_persisted = True
-                        # Persist the turn's token usage into the durable
-                        # ``turn_usage`` table. The native loop never calls
-                        # ``Runner.run`` (which is what normally triggers
-                        # ``store_run_usage``), so the CLI status bar's
-                        # cumulative total would stay at 0 without this. Must
-                        # run AFTER ``add_items`` so the SDK derives the right
-                        # ``user_turn_number`` from the freshly inserted rows.
                         await self._store_native_turn_usage(session, usage_info)
                     except Exception as e:
-                        logger.warning(f"Failed to persist session history for native Claude turn: {e}")
-                elif session is not None:
-                    logger.warning(
-                        "Skipping native Claude session persist: turn ended without final text "
-                        "(max_turns=%s exhausted while tool-calling).",
-                        max_turns,
-                    )
+                        logger.warning(f"Failed to persist usage for native Claude turn: {e}")
 
                 # Close out the composed hooks' lifecycle, completing parity with
                 # the SDK Runner path (current ``on_end`` implementations are
@@ -1465,6 +1502,58 @@ class ClaudeModel(OpenAICompatibleModel):
         finally:
             finish_native_span(active_tool_span, error=trace_failure)
             finish_native_span(active_generation_span, error=trace_failure)
+
+    @staticmethod
+    async def _persist_native_message_delta(
+        session: Any,
+        messages: List[Dict[str, Any]],
+        persisted_message_index: int,
+    ) -> int:
+        """Append the not-yet-persisted suffix of a native Claude run.
+
+        Returns the new durable boundary. A failed write leaves the boundary
+        unchanged so a later checkpoint retries the complete missing suffix.
+        """
+        if session is None or persisted_message_index >= len(messages):
+            return persisted_message_index
+        pending = messages[persisted_message_index:]
+        try:
+            await session.add_items(pending)
+        except Exception as exc:
+            logger.warning("Failed to checkpoint native Claude session history: %s", exc)
+            return persisted_message_index
+        return len(messages)
+
+    @staticmethod
+    async def _seal_interrupted_native_history(session: Any, messages: List[Dict[str, Any]]) -> None:
+        """Repair a prior hard-stop checkpoint that ends in tool_result.
+
+        A process can die after a complete tool round is checkpointed but before
+        the following model call or graceful max-turn seal. Appending a normal
+        user prompt to that tail would create consecutive user messages, so add
+        one replay-safe assistant marker before accepting the next turn.
+        """
+        if not messages:
+            return
+        last = messages[-1]
+        if not isinstance(last, dict):
+            return
+        content = last.get("content")
+        if last.get("role") != "user" or not isinstance(content, list) or not content:
+            return
+        if not all(isinstance(block, dict) and block.get("type") == "tool_result" for block in content):
+            return
+        marker = {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "[Previous agent run stopped after completing a tool round; continuing from checkpoint.]",
+                }
+            ],
+        }
+        await session.add_items([marker])
+        messages.append(marker)
 
     async def _persist_failed_turn(self, frame_locals: Dict[str, Any], error: Exception) -> None:
         """Best-effort save of an interrupted turn so the next turn isn't amnesiac.
@@ -1499,10 +1588,27 @@ class ClaudeModel(OpenAICompatibleModel):
             # message Anthropic will accept on replay.
             messages = frame_locals.get("messages")
             turn_start_index = frame_locals.get("turn_start_index")
+            persisted_message_index = frame_locals.get("persisted_message_index")
             if isinstance(messages, list) and isinstance(turn_start_index, int):
-                turn_items = self._replay_safe_turn_items(
-                    messages[turn_start_index:], user_turn_message, assistant_text
+                durable_boundary = (
+                    persisted_message_index if isinstance(persisted_message_index, int) else turn_start_index
                 )
+                if durable_boundary > turn_start_index:
+                    # Complete tool rounds before this boundary are already in
+                    # SQLite. Replay-sanitize only the missing suffix: a failure
+                    # can occur after the next model response appended a tool_use
+                    # but before its tool_result was recorded. The helper uses
+                    # ``user_turn_message`` as an empty-suffix fallback, so strip
+                    # that already-durable message back out before appending.
+                    turn_items = self._replay_safe_turn_items(
+                        messages[durable_boundary:], user_turn_message, assistant_text
+                    )
+                    if turn_items and turn_items[0] == user_turn_message:
+                        turn_items = turn_items[1:]
+                else:
+                    turn_items = self._replay_safe_turn_items(
+                        messages[turn_start_index:], user_turn_message, assistant_text
+                    )
             else:
                 turn_items = [
                     user_turn_message,

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -1528,6 +1528,21 @@ class SessionManager:
                         if role == "assistant":
                             # Assistant message - aggregate consecutive ones
                             content_array = message_json.get("content", [])
+                            had_prior_assistant_text = any(
+                                action.role == ActionRole.ASSISTANT for action in current_actions
+                            )
+                            assistant_message_text = "\n".join(
+                                str(item.get("text", ""))
+                                for item in content_array
+                                if isinstance(item, dict)
+                                and item.get("type") in ("output_text", "text")
+                                and item.get("text")
+                                and not (
+                                    had_prior_assistant_text
+                                    and str(item.get("text", "")).startswith("[Agent stopped after reaching max_turns=")
+                                )
+                            )
+                            assistant_text_recorded = False
 
                             for item in content_array:
                                 if not isinstance(item, dict):
@@ -1556,8 +1571,17 @@ class SessionManager:
                                             "created_at": created_at_iso,
                                         }
 
+                                    # This is an internal replay-safety marker,
+                                    # not model output. If the exhausted final
+                                    # turn also emitted text before tool_use, do
+                                    # not let the marker become the last assistant
+                                    # action and overwrite that real text on resume.
+                                    if not assistant_message_text or assistant_text_recorded:
+                                        continue
+                                    assistant_text_recorded = True
+
                                     # Add to progress
-                                    assistant_progress.append(f"💭Thinking: {text}")
+                                    assistant_progress.append(f"💭Thinking: {assistant_message_text}")
 
                                     # Create ActionHistory for thinking (use response_id from provider)
                                     response_id = message_json.get("provider_data", {}).get(
@@ -1566,10 +1590,10 @@ class SessionManager:
                                     thinking_action = ActionHistory(
                                         action_id=response_id,
                                         role=ActionRole.ASSISTANT,
-                                        messages=text,
+                                        messages=assistant_message_text,
                                         action_type="thinking",
                                         input=None,
-                                        output={"raw_output": text},
+                                        output={"raw_output": assistant_message_text},
                                         status=ActionStatus.SUCCESS,
                                         start_time=(
                                             datetime.fromisoformat(created_at) if created_at else datetime.now()

--- a/tests/unit_tests/models/test_builtin_web_tools.py
+++ b/tests/unit_tests/models/test_builtin_web_tools.py
@@ -417,6 +417,64 @@ async def test_persist_failed_turn_preserves_completed_tool_rounds():
 
 
 @pytest.mark.asyncio
+async def test_persist_failed_turn_after_checkpoint_only_appends_seal():
+    """Completed tool rounds already checkpointed mid-run must not be inserted
+    again when a later model call fails; only the missing assistant seal is new."""
+    from unittest.mock import AsyncMock
+
+    user = _user_msg()
+    messages = [user, _tool_use_msg("t1"), _tool_result_msg("t1")]
+    session = AsyncMock()
+    frame_locals = {
+        "session": session,
+        "turn_persisted": False,
+        "user_turn_message": user,
+        "final_content": "",
+        "messages": messages,
+        "turn_start_index": 0,
+        "persisted_message_index": len(messages),
+    }
+    fake_self = Mock()
+    fake_self._replay_safe_turn_items = ClaudeModel._replay_safe_turn_items
+    await ClaudeModel._persist_failed_turn(fake_self, frame_locals, RuntimeError("boom"))
+
+    session.add_items.assert_awaited_once()
+    items = session.add_items.await_args.args[0]
+    assert len(items) == 1
+    assert items[0]["role"] == "assistant"
+    assert "RuntimeError" in items[0]["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_persist_failed_turn_after_checkpoint_drops_dangling_tool_use():
+    """A model failure after emitting the next tool_use must not poison the DB
+    with a call that has no tool_result; persist only a replay-safe seal."""
+    from unittest.mock import AsyncMock
+
+    user = _user_msg()
+    completed = [user, _tool_use_msg("t1"), _tool_result_msg("t1")]
+    messages = [*completed, _tool_use_msg("t2")]
+    session = AsyncMock()
+    frame_locals = {
+        "session": session,
+        "turn_persisted": False,
+        "user_turn_message": user,
+        "final_content": "",
+        "messages": messages,
+        "turn_start_index": 0,
+        "persisted_message_index": len(completed),
+    }
+    fake_self = Mock()
+    fake_self._replay_safe_turn_items = ClaudeModel._replay_safe_turn_items
+    await ClaudeModel._persist_failed_turn(fake_self, frame_locals, RuntimeError("boom"))
+
+    items = session.add_items.await_args.args[0]
+    assert len(items) == 1
+    assert items[0]["role"] == "assistant"
+    assert all(block.get("type") != "tool_use" for block in items[0]["content"])
+
+
+@pytest.mark.asyncio
 async def test_persist_failed_turn_skips_when_already_persisted():
     """The success path already committed the turn; the failure path must not
     double-write."""
@@ -534,3 +592,63 @@ def test_replay_safe_turn_items_tolerates_non_list_assistant_content():
     final = {"role": "assistant", "content": "plain string reply"}
     items = ClaudeModel._replay_safe_turn_items([user, final], user, "fb")
     assert items == [user, final]
+
+
+@pytest.mark.asyncio
+async def test_persist_native_message_delta_advances_only_after_success():
+    """A failed checkpoint retains its boundary so the full missing suffix is
+    retried, while a successful retry advances to the end without duplicates."""
+    from unittest.mock import AsyncMock
+
+    messages = [_user_msg(), _tool_use_msg(), _tool_result_msg()]
+    session = AsyncMock()
+    session.add_items.side_effect = [RuntimeError("locked"), None]
+
+    boundary = await ClaudeModel._persist_native_message_delta(session, messages, 0)
+    assert boundary == 0
+    boundary = await ClaudeModel._persist_native_message_delta(session, messages, boundary)
+    assert boundary == len(messages)
+    assert session.add_items.await_args_list[0].args[0] == messages
+    assert session.add_items.await_args_list[1].args[0] == messages
+
+
+@pytest.mark.asyncio
+async def test_seal_interrupted_native_history_repairs_tool_result_tail():
+    """A hard-stop DB ending in tool_result receives one assistant marker before
+    a new user turn is appended, preserving Anthropic role alternation."""
+    from unittest.mock import AsyncMock
+
+    messages = [_user_msg(), _tool_use_msg(), _tool_result_msg()]
+    session = AsyncMock()
+    await ClaudeModel._seal_interrupted_native_history(session, messages)
+
+    session.add_items.assert_awaited_once()
+    marker = session.add_items.await_args.args[0][0]
+    assert marker["role"] == "assistant"
+    assert marker["content"][0]["text"].strip()
+    assert messages[-1] == marker
+
+
+@pytest.mark.asyncio
+async def test_native_checkpoint_and_recovery_seal_round_trip_real_sqlite(tmp_path):
+    """The checkpoint/recovery protocol must survive the real session schema,
+    not just the AsyncMock add_items contract used by the focused unit tests."""
+    from agents.extensions.memory import AdvancedSQLiteSession
+
+    session = AdvancedSQLiteSession(
+        session_id="chat_session_native_checkpoint",
+        db_path=str(tmp_path / "native_checkpoint.db"),
+        create_tables=True,
+    )
+    messages = [_user_msg(), _tool_use_msg("t1"), _tool_result_msg("t1")]
+
+    boundary = await ClaudeModel._persist_native_message_delta(session, messages, 0)
+    assert boundary == len(messages)
+    persisted = await session.get_items()
+    assert persisted == messages
+
+    await ClaudeModel._seal_interrupted_native_history(session, persisted)
+    recovered = await session.get_items()
+    assert recovered[:-1] == messages
+    assert recovered[-1]["role"] == "assistant"
+    assert recovered[-1]["content"][0]["text"].strip()

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -1373,11 +1373,11 @@ class TestGenerateWithMcpStream:
         assert session.add_items.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_session_skip_persist_when_final_content_empty(self):
+    async def test_session_checkpoints_and_seals_when_final_content_empty(self):
         """When ``max_turns`` is exhausted while still tool-calling, ``final_content``
-        stays empty. Persisting an empty assistant text block would be rejected by
-        Anthropic on replay (``text content blocks must be non-empty``), so the
-        guard must skip ``add_items`` entirely.
+        stays empty. Every completed tool round must already be durable, and the
+        run must append a non-empty assistant seal so the next user turn replays
+        with valid role alternation.
         """
         from datus.schemas.action_history import ActionHistoryManager
 
@@ -1418,9 +1418,107 @@ class TestGenerateWithMcpStream:
 
         # final_response still yielded so the caller gets a response.
         final = next(a for a in actions if a.action_type == "final_response")
+        assert "max_turns=2" in final.output["raw_output"]
+        # Two complete tool rounds checkpointed, followed by one assistant seal.
+        assert session.add_items.await_count == 3
+        persisted = [item for call in session.add_items.await_args_list for item in call.args[0]]
+        assert persisted[0]["role"] == "user"
+        assert (
+            sum(
+                block.get("type") == "tool_use"
+                for item in persisted
+                for block in item.get("content", [])
+                if isinstance(block, dict)
+            )
+            == 2
+        )
+        assert (
+            sum(
+                block.get("type") == "tool_result"
+                for item in persisted
+                for block in item.get("content", [])
+                if isinstance(block, dict)
+            )
+            == 2
+        )
+        assert persisted[-1]["role"] == "assistant"
+        assert "max_turns=2" in persisted[-1]["content"][0]["text"]
+        assert all(
+            block.get("text", "x") != ""
+            for item in persisted
+            for block in item.get("content", [])
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+
+    @pytest.mark.asyncio
+    async def test_max_turns_keeps_delta_fragments_out_of_final_response(self):
+        """A final response containing text plus tool_use is incomplete as an
+        agent run. Its model-authored text is streamed and persisted, while the
+        incomplete final_response stays empty. Each delta is one fragment."""
+        from datus.schemas.action_history import ActionHistoryManager
+
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+
+        text_start = MagicMock()
+        text_start.type = "text"
+        delta1 = MagicMock(type="text_delta", text="First fragment. ")
+        delta2 = MagicMock(type="text_delta", text="Second fragment.")
+        full_text = "First fragment. Second fragment."
+        final_msg = _make_response([_make_text_block(full_text), _make_tool_use_block()])
+        stream_manager = _FakeAsyncStreamManager(
+            [
+                _FakeStreamEvent("content_block_start", content_block=text_start),
+                _FakeStreamEvent("content_block_delta", delta=delta1),
+                _FakeStreamEvent("content_block_delta", delta=delta2),
+                _FakeStreamEvent("content_block_stop"),
+            ],
+            final_msg,
+        )
+        async_client = MagicMock()
+        async_client.messages.stream = MagicMock(return_value=stream_manager)
+        model.async_anthropic_client = async_client
+
+        func_tool = MagicMock()
+        func_tool.name = "read_query"
+        func_tool.description = ""
+        func_tool.params_json_schema = {"type": "object"}
+        func_tool.on_invoke_tool = AsyncMock(return_value="result")
+        session = MagicMock()
+        session.get_items = AsyncMock(return_value=[])
+        session.add_items = AsyncMock()
+
+        actions = []
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for action in model._generate_with_mcp_stream(
+                prompt="probe",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                max_turns=1,
+                func_tools=[func_tool],
+                action_history_manager=ActionHistoryManager(),
+                session=session,
+            ):
+                actions.append(action)
+
+        deltas = [action for action in actions if action.action_type == "thinking_delta"]
+        assert [action.output["delta"] for action in deltas] == ["First fragment. ", "Second fragment."]
+        final = next(action for action in actions if action.action_type == "final_response")
         assert final.output["raw_output"] == ""
-        # Critically: we must NOT have persisted an empty assistant text block.
-        session.add_items.assert_not_awaited()
+
+        persisted = [item for call in session.add_items.await_args_list for item in call.args[0]]
+        text_blocks = [
+            block["text"]
+            for item in persisted
+            if item.get("role") == "assistant"
+            for block in item.get("content", [])
+            if block.get("type") == "text"
+        ]
+        assert full_text in text_blocks
+        assert any("max_turns=1" in text for text in text_blocks)
 
     @pytest.mark.asyncio
     async def test_prompt_list_variant_is_normalized_to_string(self):
@@ -1627,10 +1725,10 @@ class TestNativeTokenUsageStreaming:
         assert usage.input_tokens_details.cached_tokens == 200
 
     @pytest.mark.asyncio
-    async def test_native_loop_skips_durable_usage_when_no_final_text(self):
+    async def test_native_loop_persists_durable_usage_after_max_turn_seal(self):
         """When the loop exhausts max_turns mid-tool-call (no final text), the
-        session is not persisted — and neither should the usage row be, to
-        avoid a turn_usage row with no matching message."""
+        checkpointed messages are sealed into a valid turn, so cumulative usage
+        should be committed against that durable user turn."""
         from datus.schemas.action_history import ActionHistoryManager
 
         cfg = _make_model_config(use_native_api=True)
@@ -1673,8 +1771,8 @@ class TestNativeTokenUsageStreaming:
             ):
                 pass
 
-        assert stored == [], "no durable usage row when the turn produced no final text"
-        session.add_items.assert_not_awaited()
+        assert len(stored) == 1
+        assert session.add_items.await_count == 3
 
 
 def _make_recorder_hooks():

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -1502,6 +1502,97 @@ class TestGetSessionMessages:
         assert complete.status == ActionStatus.SUCCESS
         assert complete.output == {"rows": 30000}
 
+    def test_native_max_turn_seal_does_not_hide_last_assistant_text(self, sm):
+        """The replay-only max-turn seal follows tool_result in SQLite, but
+        history rendering must keep the model's preceding complete text."""
+        session_id = f"test_native_max_turn_{uuid.uuid4().hex[:8]}"
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+        full_text = "First fragment. Second fragment."
+
+        rows = [
+            ({"role": "user", "content": [{"type": "text", "text": "probe"}]}, "2026-05-21T00:00:00"),
+            (
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": full_text},
+                        {"type": "tool_use", "id": "toolu_last", "name": "read_query", "input": {}},
+                    ],
+                },
+                "2026-05-21T00:00:01",
+            ),
+            (
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "tool_use_id": "toolu_last", "content": "result"}],
+                },
+                "2026-05-21T00:00:02",
+            ),
+            (
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "[Agent stopped after reaching max_turns=1; work may remain incomplete.]",
+                        }
+                    ],
+                },
+                "2026-05-21T00:00:03",
+            ),
+        ]
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (session_id,))
+            conn.executemany(
+                "INSERT INTO agent_messages (session_id, message_data, created_at) VALUES (?, ?, ?)",
+                [(session_id, json.dumps(data), timestamp) for data, timestamp in rows],
+            )
+            conn.commit()
+
+        assistant = next(message for message in sm.get_session_messages(session_id) if message["role"] == "assistant")
+        assert assistant["content"] == full_text
+        assert "max_turns" not in assistant["content"]
+
+    def test_native_resume_joins_all_text_blocks_from_last_assistant_message(self, sm):
+        """Anthropic may interleave multiple text blocks with tool_use blocks;
+        resume must reconstruct the entire assistant message, not its last block."""
+        import asyncio
+
+        session_id = f"test_native_multi_text_{uuid.uuid4().hex[:8]}"
+        session = sm.get_session(session_id)
+        asyncio.run(
+            session.add_items(
+                [
+                    {"role": "user", "content": [{"type": "text", "text": "probe"}]},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "First fragment."},
+                            {"type": "tool_use", "id": "toolu_multi", "name": "read_query", "input": {}},
+                            {"type": "text", "text": "Second fragment."},
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [{"type": "tool_result", "tool_use_id": "toolu_multi", "content": "result"}],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "[Agent stopped after reaching max_turns=1; work may remain incomplete.]",
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+
+        assistant = next(message for message in sm.get_session_messages(session_id) if message["role"] == "assistant")
+        assert assistant["content"] == "First fragment.\nSecond fragment."
+
     def test_native_server_web_tool_result_resume(self, sm):
         """A ``server_tool_use`` block plus inline ``web_search_tool_result`` in
         the same assistant message restore a tool call and its result."""


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

Native Claude sessions only persisted their structured tool history after a text-only completion. Runs that exhausted `max_turns`, failed after a completed tool round, or stopped between a `tool_result` checkpoint and the next model response could lose durable context or leave role ordering that Anthropic rejects on replay. Resume rendering could also let an internal stop marker hide the last model-authored text.

## Solution

Checkpoint each completed native Claude model/tool round as an append-only session delta and track the durable message boundary to avoid duplicate rows. Seal graceful max-turn and empty completions with non-empty replay-safe assistant markers, and repair a persisted `tool_result` tail before appending the next user turn. Failure recovery now sanitizes only the unpersisted suffix. Session rendering joins all assistant text blocks and suppresses internal max-turn seals when real assistant text is already available. Durable token usage is stored only after the complete message delta is committed.

## Test Cases

Added deterministic unit coverage for checkpoint retry boundaries, duplicate prevention, dangling `tool_use` removal, interrupted-history sealing, max-turn text/delta behavior, durable usage, multi-block assistant rendering, and a real `AdvancedSQLiteSession` checkpoint/recovery round trip. No integration or nightly tests were added because the behavior is fully exercised with mocked Anthropic streams and local SQLite without external credentials.

Validated with:

- `uv run ruff format datus/ tests/`
- `uv run ruff check --fix datus/ tests/`
- `uv run python ci/run-pr-tests.py datus/main` — 1060 passed, 95% diff coverage
- `uv run python ci/audit_tests.py --repo-root . --diff-only datus/main` — P0=0, P1=0

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation recovery after interrupted tool calls or failed turns.
  * Prevented duplicate messages and incomplete tool calls from appearing in saved conversations.
  * Preserved assistant responses during streaming and across multi-step tool interactions.
  * Improved session replay so assistant text remains complete and in the correct order.
  * Added clear recovery markers when conversations reach the maximum turn limit without a final response.
* **Tests**
  * Expanded coverage for persistence, recovery, streaming, and session replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->