### PR TITLE
[Enhancement] Document and validate GaussDB TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,19 @@ Per-node model assignment lets you use different providers for different workflo
 |----------|------|---------|
 | SQLite | `sqlite` | Built-in |
 | DuckDB | `duckdb` | Built-in |
-| PostgreSQL | `postgresql` | [`datus-postgresql`](https://github.com/Datus-ai/Datus-adapters) |
-| MySQL | `mysql` | [`datus-mysql`](https://github.com/Datus-ai/Datus-adapters) |
-| Snowflake | `snowflake` | [`datus-snowflake`](https://github.com/Datus-ai/Datus-adapters) |
-| StarRocks | `starrocks` | [`datus-starrocks`](https://github.com/Datus-ai/Datus-adapters) |
-| ClickHouse | `clickhouse` | [`datus-clickhouse`](https://github.com/Datus-ai/Datus-adapters) |
-| ClickZetta | `clickzetta` | [`datus-clickzetta`](https://github.com/Datus-ai/Datus-adapters) |
-| Hive | `hive` | [`datus-hive`](https://github.com/Datus-ai/Datus-adapters) |
-| Spark | `spark` | [`datus-spark`](https://github.com/Datus-ai/Datus-adapters) |
-| Trino | `trino` | [`datus-trino`](https://github.com/Datus-ai/Datus-adapters) |
+| PostgreSQL | `postgresql` | [`datus-postgresql`](https://github.com/Datus-ai/datus-db-adapters) |
+| MySQL | `mysql` | [`datus-mysql`](https://github.com/Datus-ai/datus-db-adapters) |
+| Snowflake | `snowflake` | [`datus-snowflake`](https://github.com/Datus-ai/datus-db-adapters) |
+| StarRocks | `starrocks` | [`datus-starrocks`](https://github.com/Datus-ai/datus-db-adapters) |
+| ClickHouse | `clickhouse` | [`datus-clickhouse`](https://github.com/Datus-ai/datus-db-adapters) |
+| ClickZetta | `clickzetta` | [`datus-clickzetta`](https://github.com/Datus-ai/datus-db-adapters) |
+| Hive | `hive` | [`datus-hive`](https://github.com/Datus-ai/datus-db-adapters) |
+| Spark | `spark` | [`datus-spark`](https://github.com/Datus-ai/datus-db-adapters) |
+| Trino | `trino` | [`datus-trino`](https://github.com/Datus-ai/datus-db-adapters) |
+| Apache Doris | `doris` | [`datus-doris`](https://github.com/Datus-ai/datus-db-adapters) |
+| Hologres | `hologres` | [`datus-hologres`](https://github.com/Datus-ai/datus-db-adapters) |
+| Oracle | `oracle` | [`datus-oracle`](https://github.com/Datus-ai/datus-db-adapters) |
+| GaussDB / openGauss | `gaussdb` | [`datus-gaussdb`](https://github.com/Datus-ai/datus-db-adapters) |
 
 See [Database Adapters documentation](https://docs.datus.ai/adapters/db_adapters/) for details.
 

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -25,6 +25,7 @@ NIGHTLY_TRACE_DIAGNOSTICS_FINALIZED=0
 test_exit_code=0
 last_command_exit_code=0
 NIGHTLY_GROUP_FILTER="${NIGHTLY_GROUP_FILTER:-}"
+GAUSSDB_TLS_HOST_DIR=""
 AGENT_TEST_CONFIG="${AGENT_TEST_CONFIG:-tests/conf/agent.yml}"
 DATUS_TEST_PROJECT_NAME="${DATUS_TEST_PROJECT_NAME:-datus_agent_nightly}"
 export DATUS_TEST_PROJECT_NAME
@@ -795,6 +796,14 @@ ensure_nightly_kb_data() {
   return 0
 }
 
+cleanup_gaussdb_tls_host_artifacts() {
+  if [ -n "$GAUSSDB_TLS_HOST_DIR" ] && [ -d "$GAUSSDB_TLS_HOST_DIR" ]; then
+    rm -f -- "$GAUSSDB_TLS_HOST_DIR/ca.crt"
+    rmdir "$GAUSSDB_TLS_HOST_DIR" 2>/dev/null || true
+  fi
+  GAUSSDB_TLS_HOST_DIR=""
+}
+
 cleanup_all() {
   set +e
   if [ "${NIGHTLY_SKIP_MANIFEST_FINALIZE:-0}" != "1" ]; then
@@ -805,6 +814,7 @@ cleanup_all() {
   fi
   restore_agent_test_config
   rm -f "$AGENT_TEST_CONFIG_BACKUP"
+  cleanup_gaussdb_tls_host_artifacts
   if validate_pytest_basetemp "$NIGHTLY_PYTEST_BASETEMP"; then
     rm -rf "$NIGHTLY_PYTEST_BASETEMP"
   fi
@@ -1474,6 +1484,33 @@ wait_for_compose_client_readiness() {
   esac
 }
 
+run_gaussdb_adapter_tests() {
+  local project_name
+  local tls_rootcert
+  local suite_status
+
+  project_name="$(compose_project_name "GaussDB Adapter Tests")"
+  cleanup_gaussdb_tls_host_artifacts
+  GAUSSDB_TLS_HOST_DIR="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-gaussdb-tls.XXXXXX")" || return 1
+  tls_rootcert="$GAUSSDB_TLS_HOST_DIR/ca.crt"
+
+  if ! compose_cmd "$project_name" "$GAUSSDB_COMPOSE" cp gaussdb:/gaussdb-tls/ca.crt "$tls_rootcert"; then
+    cleanup_gaussdb_tls_host_artifacts
+    return 1
+  fi
+
+  run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env \
+    DATUS_TEST_LAYER=nightly \
+    GAUSSDB_SSLMODE=verify-ca \
+    GAUSSDB_SSLROOTCERT="$tls_rootcert" \
+    uv run pytest -m nightly tests/integration/adapters/test_gaussdb.py \
+    --tb=short --verbose --timeout=300 --timeout-method=thread
+  suite_status=$?
+
+  cleanup_gaussdb_tls_host_artifacts
+  return "$suite_status"
+}
+
 run_compose_suite() {
   local group_name="$1"
   local compose_file="$2"
@@ -1677,7 +1714,7 @@ run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with
 run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Spark Adapter Tests" "$SPARK_COMPOSE" "spark-thrift:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_spark.py --tb=short --verbose --timeout=300 --timeout-method=thread
-run_compose_suite "GaussDB Adapter Tests" "$GAUSSDB_COMPOSE" "gaussdb:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_gaussdb.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_compose_suite "GaussDB Adapter Tests" "$GAUSSDB_COMPOSE" "gaussdb:600" -- run_gaussdb_adapter_tests
 run_logged "MetricFlow DuckDB Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_semantic_metricflow_duckdb.py --tb=short --verbose --timeout=300 --timeout-method=thread
 
 run_logged_warn_only "Provider Health Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and provider_health" "${NIGHTLY_PYTEST_ROOTS[@]}" --tb=short --verbose --timeout=300 --timeout-method=thread --reruns 1 --reruns-delay 5

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -29,7 +29,7 @@ This design keeps the core package lightweight while allowing you to add support
 | Apache Doris | datus-doris | `pip install datus-doris` | Ready |
 | Hologres | datus-hologres | `pip install datus-hologres` | Ready |
 | Oracle | datus-oracle | `pip install datus-oracle` | Ready |
-| GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | Ready (Linux only) |
+| GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | Ready (Linux and macOS) |
 
 ## Installation
 
@@ -78,7 +78,7 @@ pip install datus-hologres
 # Oracle
 pip install datus-oracle
 
-# GaussDB / openGauss (Linux only)
+# GaussDB / openGauss
 pip install datus-gaussdb
 ```
 
@@ -306,13 +306,33 @@ gaussdb_data:
   password: ${GAUSSDB_PASSWORD}
   database: postgres
   schema: public   # optional, default is public
-  driver: gaussdb  # optional, default is gaussdb; set to psycopg2 as an escape hatch
+  # driver: pg8000  # optional; omit to use gaussdb on Linux or pg8000 on macOS
+  sslmode: verify-ca
+  sslrootcert: /etc/datus/certs/gaussdb-ca.pem
 ```
 
-GaussDB and openGauss speak the PostgreSQL wire protocol. The default `gaussdb` driver is the official
-client and supports sha256, md5, and sm3 authentication; the `psycopg2` escape hatch only works against
-servers configured for md5. Both centralized and distributed deployments are supported, and the connector
-auto-detects the database's A / B / PG compatibility mode so generated SQL follows the right semantics.
+GaussDB and openGauss speak the PostgreSQL wire protocol. Choose the driver to match the platform and the
+server account's password authentication:
+
+| Driver | Platform | Authentication |
+|--------|----------|----------------|
+| `gaussdb` (Linux default) | Linux | sha256, md5, sm3 |
+| `pg8000` (macOS default) | Linux and macOS | sha256, md5 |
+| `psycopg2` | Linux and macOS | md5 only; escape hatch |
+
+All drivers support `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, and `verify-full`.
+For production, use `verify-ca` with `sslrootcert`: the connection is encrypted and the server certificate
+must chain to that CA. `verify-full` additionally verifies that the configured `host` matches the server
+certificate. `require` encrypts but does not authenticate the server; `prefer` permits an unencrypted
+fallback. If the server merely enables TLS, the client does not need a certificate. If it requires TLS,
+`prefer` normally negotiates TLS, but explicitly use `require` or either `verify-*` mode to prevent a
+plaintext fallback against a differently configured endpoint. Only `verify-ca` and `verify-full` need
+the server CA configured on the client. The `pg8000` path treats `allow` like `prefer` (TLS first), because
+its API cannot express libpq's plaintext-first retry order. The adapter currently supports one-way TLS,
+not mutual TLS (`sslcert`/`sslkey`).
+
+Both centralized and distributed deployments are supported. The connector auto-detects the database's
+A (Oracle), B (MySQL), or PG compatibility mode so generated SQL follows the server semantics.
 
 ### Multiple Database Entries
 
@@ -423,6 +443,8 @@ All adapters support:
 #### GaussDB
 - PostgreSQL wire protocol (PostgreSQL-compatible SQL dialect)
 - sha256, md5, and sm3 authentication through the official `gaussdb` driver
+- Pure-Python `pg8000` path with sha256/md5 authentication on Linux and macOS
+- TLS modes through `verify-full`, with `verify-ca` recommended for production
 - A / B / PG compatibility-mode auto-detection, so SQL generation follows the server's semantics
 - Centralized and distributed deployments, with distribution-aware table DDL
 - Multi-schema datasource support
@@ -460,9 +482,9 @@ Some adapters require additional system dependencies:
 - **Apache Doris**: Requires `datus-mysql` and `pymysql` (installed automatically)
 - **Hologres**: Requires `datus-postgresql` and `psycopg2-binary` (installed automatically)
 - **Oracle**: Requires `oracledb` (installed automatically; Thin mode needs no Oracle Client)
-- **GaussDB**: Requires `datus-postgresql` and the official `gaussdb` driver (installed automatically).
-  That driver binds a GaussDB-family libpq, which release wheels bundle for Linux; no build is published
-  for macOS, so run the adapter inside a Linux environment
+- **GaussDB**: Requires `datus-postgresql`; dependencies are installed automatically. Linux defaults to
+  the official `gaussdb` driver and the package wheel bundles its GaussDB-family libpq. macOS defaults to
+  the pure-Python `pg8000` driver because no compatible native libpq is published for Darwin.
 
 ## Architecture
 

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -320,16 +320,17 @@ server account's password authentication:
 | `pg8000` (macOS default) | Linux and macOS | sha256, md5 |
 | `psycopg2` | Linux and macOS | md5 only; escape hatch |
 
-All drivers support `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, and `verify-full`.
-For production, use `verify-ca` with `sslrootcert`: the connection is encrypted and the server certificate
-must chain to that CA. `verify-full` additionally verifies that the configured `host` matches the server
-certificate. `require` encrypts but does not authenticate the server; `prefer` permits an unencrypted
-fallback. If the server merely enables TLS, the client does not need a certificate. If it requires TLS,
-`prefer` normally negotiates TLS, but explicitly use `require` or either `verify-*` mode to prevent a
-plaintext fallback against a differently configured endpoint. Only `verify-ca` and `verify-full` need
-the server CA configured on the client. The `pg8000` path treats `allow` like `prefer` (TLS first), because
-its API cannot express libpq's plaintext-first retry order. The adapter currently supports one-way TLS,
-not mutual TLS (`sslcert`/`sslkey`).
+All drivers accept `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, and `verify-full`, but
+their retry behavior is not identical. For production, use `verify-ca` with `sslrootcert` as the baseline:
+the connection is encrypted and the server certificate must chain to that CA. When the configured `host`
+is guaranteed to match the server certificate, use `verify-full` for stricter hostname validation;
+otherwise keep `verify-ca`. `require` encrypts but does not authenticate the server; `prefer` permits an
+unencrypted fallback. If the server merely enables TLS, the client does not need a certificate. If it
+requires TLS, `prefer` normally negotiates TLS, but explicitly use `require` or either `verify-*` mode to
+prevent a plaintext fallback against a differently configured endpoint. Only `verify-ca` and `verify-full`
+need the server CA configured on the client. The `pg8000` path treats `allow` like `prefer` (TLS first),
+because its API cannot express libpq's plaintext-first retry order. The adapter currently supports one-way
+TLS, not mutual TLS (`sslcert`/`sslkey`).
 
 Both centralized and distributed deployments are supported. The connector auto-detects the database's
 A (Oracle), B (MySQL), or PG compatibility mode so generated SQL follows the server semantics.
@@ -444,7 +445,7 @@ All adapters support:
 - PostgreSQL wire protocol (PostgreSQL-compatible SQL dialect)
 - sha256, md5, and sm3 authentication through the official `gaussdb` driver
 - Pure-Python `pg8000` path with sha256/md5 authentication on Linux and macOS
-- TLS modes through `verify-full`, with `verify-ca` recommended for production
+- TLS modes through `verify-full`; `verify-ca` is the production baseline, and `verify-full` adds hostname validation
 - A / B / PG compatibility-mode auto-detection, so SQL generation follows the server's semantics
 - Centralized and distributed deployments, with distribution-aware table DDL
 - Multi-schema datasource support

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -29,7 +29,7 @@ Datus 使用模块化适配器架构，允许连接不同的数据库：
 | Apache Doris | datus-doris | `pip install datus-doris` | 可用 |
 | Hologres | datus-hologres | `pip install datus-hologres` | 可用 |
 | Oracle | datus-oracle | `pip install datus-oracle` | 可用 |
-| GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | 可用（仅 Linux） |
+| GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | 可用（Linux 和 macOS） |
 
 ## 安装
 
@@ -75,7 +75,7 @@ pip install datus-hologres
 # Oracle
 pip install datus-oracle
 
-# GaussDB / openGauss（仅 Linux）
+# GaussDB / openGauss
 pip install datus-gaussdb
 ```
 
@@ -298,12 +298,30 @@ gaussdb_data:
   password: ${GAUSSDB_PASSWORD}
   database: postgres
   schema: public   # 可选，默认为 public
-  driver: gaussdb  # 可选，默认为 gaussdb；可设为 psycopg2 作为兜底方案
+  # driver: pg8000  # 可选；省略时 Linux 默认 gaussdb，macOS 默认 pg8000
+  sslmode: verify-ca
+  sslrootcert: /etc/datus/certs/gaussdb-ca.pem
 ```
 
-GaussDB 与 openGauss 使用 PostgreSQL wire 协议。默认的 `gaussdb` 驱动为官方客户端，支持 sha256、md5
-和 sm3 认证；`psycopg2` 兜底方案仅适用于服务端配置为 md5 认证的场景。集中式与分布式部署均受支持，
-连接器会自动探测数据库的 A / B / PG 兼容模式，使生成的 SQL 遵循对应语义。
+GaussDB 与 openGauss 使用 PostgreSQL wire 协议。驱动应按运行平台和服务端账号的密码认证方式选择：
+
+| 驱动 | 平台 | 认证方式 |
+|------|------|----------|
+| `gaussdb`（Linux 默认） | Linux | sha256、md5、sm3 |
+| `pg8000`（macOS 默认） | Linux 和 macOS | sha256、md5 |
+| `psycopg2` | Linux 和 macOS | 仅 md5；作为兜底方案 |
+
+所有驱动都支持 `disable`、`allow`、`prefer`（默认）、`require`、`verify-ca` 和 `verify-full`。
+生产环境推荐同时配置 `verify-ca` 与 `sslrootcert`：连接会加密，并验证服务端证书是否由该 CA 签发。
+`verify-full` 还会验证配置的 `host` 是否与服务端证书匹配。`require` 只加密、不验证服务端身份；
+`prefer` 允许回退到非加密连接。服务端只是启用 TLS 时，客户端不需要自身证书；服务端强制 TLS 时，
+`prefer` 通常也会协商出 TLS，但应显式使用 `require` 或任一 `verify-*` 模式，避免客户端连接到配置不同的
+endpoint 时回退到明文。其中只有 `verify-ca` 和 `verify-full` 需要在客户端配置服务端 CA。`pg8000`
+会把 `allow` 按 `prefer` 处理（先尝试 TLS），因为其 API 无法表达 libpq 的明文优先重试顺序。当前适配器
+仅支持单向 TLS，不支持通过 `sslcert`/`sslkey` 配置双向 TLS。
+
+集中式与分布式部署均受支持。连接器会自动探测数据库的 A（Oracle）、B（MySQL）或 PG 兼容模式，
+使生成的 SQL 遵循对应语义。
 
 ## 多数据库连接
 
@@ -409,6 +427,8 @@ agent:
 #### GaussDB
 - PostgreSQL wire 协议（PostgreSQL 兼容 SQL 方言）
 - 通过官方 `gaussdb` 驱动支持 sha256、md5 和 sm3 认证
+- 通过纯 Python `pg8000` 驱动在 Linux 和 macOS 支持 sha256/md5 认证
+- 支持到 `verify-full` 的 TLS 模式，生产环境推荐 `verify-ca`
 - 自动探测 A / B / PG 兼容模式，使 SQL 生成遵循服务端语义
 - 同时支持集中式与分布式部署，并生成分布键感知的建表 DDL
 - 多 schema 数据源支持
@@ -445,8 +465,8 @@ pip install datus-mysql
 - **Apache Doris**：需要 `datus-mysql` 和 `pymysql`（自动安装）
 - **Hologres**：需要 `datus-postgresql` 和 `psycopg2-binary`（自动安装）
 - **Oracle**：需要 `oracledb`（自动安装；Thin 模式不需要 Oracle Client）
-- **GaussDB**：需要 `datus-postgresql` 和官方 `gaussdb` 驱动（自动安装）。该驱动依赖 GaussDB 系的
-  libpq，发布 wheel 中已内置 Linux 版本；官方未提供 macOS 版本，因此请在 Linux 环境中运行该适配器
+- **GaussDB**：需要 `datus-postgresql`，相关依赖会自动安装。Linux 默认使用官方 `gaussdb` 驱动，
+  发布 wheel 已内置其 GaussDB 系 libpq；macOS 没有兼容的原生 libpq，因此默认使用纯 Python `pg8000` 驱动。
 
 ## 架构
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -311,14 +311,15 @@ GaussDB 与 openGauss 使用 PostgreSQL wire 协议。驱动应按运行平台�
 | `pg8000`（macOS 默认） | Linux 和 macOS | sha256、md5 |
 | `psycopg2` | Linux 和 macOS | 仅 md5；作为兜底方案 |
 
-所有驱动都支持 `disable`、`allow`、`prefer`（默认）、`require`、`verify-ca` 和 `verify-full`。
-生产环境推荐同时配置 `verify-ca` 与 `sslrootcert`：连接会加密，并验证服务端证书是否由该 CA 签发。
-`verify-full` 还会验证配置的 `host` 是否与服务端证书匹配。`require` 只加密、不验证服务端身份；
-`prefer` 允许回退到非加密连接。服务端只是启用 TLS 时，客户端不需要自身证书；服务端强制 TLS 时，
-`prefer` 通常也会协商出 TLS，但应显式使用 `require` 或任一 `verify-*` 模式，避免客户端连接到配置不同的
-endpoint 时回退到明文。其中只有 `verify-ca` 和 `verify-full` 需要在客户端配置服务端 CA。`pg8000`
-会把 `allow` 按 `prefer` 处理（先尝试 TLS），因为其 API 无法表达 libpq 的明文优先重试顺序。当前适配器
-仅支持单向 TLS，不支持通过 `sslcert`/`sslkey` 配置双向 TLS。
+所有驱动都接受 `disable`、`allow`、`prefer`（默认）、`require`、`verify-ca` 和 `verify-full`，但重试行为
+并不完全相同。生产环境应以同时配置 `verify-ca` 与 `sslrootcert` 为基线：连接会加密，并验证服务端证书
+是否由该 CA 签发。当配置的 `host` 能保证与服务端证书匹配时，使用 `verify-full` 可进一步验证 hostname；
+否则继续使用 `verify-ca`。`require` 只加密、不验证服务端身份；`prefer` 允许回退到非加密连接。服务端
+只是启用 TLS 时，客户端不需要自身证书；服务端强制 TLS 时，`prefer` 通常也会协商出 TLS，但应显式使用
+`require` 或任一 `verify-*` 模式，避免客户端连接到配置不同的 endpoint 时回退到明文。其中只有
+`verify-ca` 和 `verify-full` 需要在客户端配置服务端 CA。`pg8000` 会把 `allow` 按 `prefer` 处理（先尝试
+TLS），因为其 API 无法表达 libpq 的明文优先重试顺序。当前适配器仅支持单向 TLS，不支持通过
+`sslcert`/`sslkey` 配置双向 TLS。
 
 集中式与分布式部署均受支持。连接器会自动探测数据库的 A（Oracle）、B（MySQL）或 PG 兼容模式，
 使生成的 SQL 遵循对应语义。
@@ -428,7 +429,7 @@ agent:
 - PostgreSQL wire 协议（PostgreSQL 兼容 SQL 方言）
 - 通过官方 `gaussdb` 驱动支持 sha256、md5 和 sm3 认证
 - 通过纯 Python `pg8000` 驱动在 Linux 和 macOS 支持 sha256/md5 认证
-- 支持到 `verify-full` 的 TLS 模式，生产环境推荐 `verify-ca`
+- 支持到 `verify-full` 的 TLS 模式；生产环境以 `verify-ca` 为基线，`verify-full` 可增加 hostname 验证
 - 自动探测 A / B / PG 兼容模式，使 SQL 生成遵循服务端语义
 - 同时支持集中式与分布式部署，并生成分布键感知的建表 DDL
 - 多 schema 数据源支持

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -173,6 +173,30 @@ my_hologres:
   sslmode: prefer               # Optional
 ```
 
+### GaussDB / openGauss
+
+```yaml
+my_gaussdb:
+  type: gaussdb
+  host: ${GAUSSDB_HOST}
+  port: 5432
+  username: ${GAUSSDB_USER}
+  password: ${GAUSSDB_PASSWORD}
+  database: postgres
+  schema: public
+  # driver: pg8000              # Optional; omit to use the platform default
+  sslmode: verify-ca             # Recommended for production
+  sslrootcert: /etc/datus/certs/gaussdb-ca.pem
+```
+
+Supported drivers are `gaussdb` (Linux; sha256/md5/sm3 authentication), `pg8000`
+(Linux/macOS; sha256/md5), and the md5-only `psycopg2` escape hatch. Supported TLS modes are
+`disable`, `allow`, `prefer` (default), `require`, `verify-ca`, and `verify-full`. Use
+`verify-ca` with the server CA in `sslrootcert` for production; use `verify-full` when the
+configured hostname also matches the certificate. The adapter supports one-way TLS, not client
+certificates for mutual TLS. See [Database Adapters](../adapters/db_adapters.md#gaussdb) for mode,
+platform, authentication, and A/B/PG compatibility details.
+
 ### Path Pattern (Multiple Files)
 
 Use glob patterns to auto-discover database files:
@@ -208,6 +232,7 @@ Supported patterns: `*.sqlite`, `**/*.sqlite`, `data/2024/*.db`
 - **MySQL/PostgreSQL**: `host`, `port`, `username`, `password`, `database`
 - **Apache Doris**: `catalog` (default `internal`)
 - **Hologres**: `schema`, `sslmode`; `access_key_id`/`access_key_secret` are accepted as aliases for `username`/`password`
+- **GaussDB/openGauss**: `schema`, `driver`, `sslmode`, `sslrootcert`
 
 ## Managing Databases
 

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -185,17 +185,18 @@ my_gaussdb:
   database: postgres
   schema: public
   # driver: pg8000              # Optional; omit to use the platform default
-  sslmode: verify-ca             # Recommended for production
+  sslmode: verify-ca             # Recommended production baseline
   sslrootcert: /etc/datus/certs/gaussdb-ca.pem
 ```
 
 Supported drivers are `gaussdb` (Linux; sha256/md5/sm3 authentication), `pg8000`
 (Linux/macOS; sha256/md5), and the md5-only `psycopg2` escape hatch. Supported TLS modes are
 `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, and `verify-full`. Use
-`verify-ca` with the server CA in `sslrootcert` for production; use `verify-full` when the
-configured hostname also matches the certificate. The adapter supports one-way TLS, not client
-certificates for mutual TLS. See [Database Adapters](../adapters/db_adapters.md#gaussdb) for mode,
-platform, authentication, and A/B/PG compatibility details.
+`verify-ca` with the server CA in `sslrootcert` as the production baseline. When the configured
+hostname is guaranteed to match the certificate, use `verify-full` for stricter hostname
+validation; otherwise keep `verify-ca`. The adapter supports one-way TLS, not client certificates
+for mutual TLS. See [Database Adapters](../adapters/db_adapters.md#gaussdb) for mode, platform,
+authentication, and A/B/PG compatibility details.
 
 ### Path Pattern (Multiple Files)
 

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -178,6 +178,28 @@ my_hologres:
   sslmode: prefer               # 可选
 ```
 
+### GaussDB / openGauss
+
+```yaml
+my_gaussdb:
+  type: gaussdb
+  host: ${GAUSSDB_HOST}
+  port: 5432
+  username: ${GAUSSDB_USER}
+  password: ${GAUSSDB_PASSWORD}
+  database: postgres
+  schema: public
+  # driver: pg8000              # 可选；省略时使用平台默认值
+  sslmode: verify-ca             # 生产环境推荐
+  sslrootcert: /etc/datus/certs/gaussdb-ca.pem
+```
+
+支持的驱动为 `gaussdb`（Linux；sha256/md5/sm3 认证）、`pg8000`（Linux/macOS；sha256/md5）和
+仅支持 md5 的 `psycopg2` 兜底方案。TLS 模式支持 `disable`、`allow`、`prefer`（默认）、`require`、
+`verify-ca` 和 `verify-full`。生产环境推荐 `verify-ca` 并通过 `sslrootcert` 提供服务端 CA；若配置的
+hostname 也与证书匹配，可使用 `verify-full`。当前仅支持单向 TLS，不支持客户端证书双向认证。
+模式、平台、认证方式及 A/B/PG 兼容模式详情见[数据库适配器](../adapters/db_adapters.md#gaussdb)。
+
 ### 路径模式（批量发现多个文件）
 
 使用 glob 模式自动发现数据库文件：
@@ -213,6 +235,7 @@ bird_benchmark:
 - **MySQL/PostgreSQL**：`host`、`port`、`username`、`password`、`database`
 - **Apache Doris**：`catalog`（默认为 `internal`）
 - **Hologres**：`schema`、`sslmode`；`access_key_id`/`access_key_secret` 可作为 `username`/`password` 的别名
+- **GaussDB/openGauss**：`schema`、`driver`、`sslmode`、`sslrootcert`
 
 ## 管理数据库
 

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -190,14 +190,15 @@ my_gaussdb:
   database: postgres
   schema: public
   # driver: pg8000              # 可选；省略时使用平台默认值
-  sslmode: verify-ca             # 生产环境推荐
+  sslmode: verify-ca             # 生产环境基线配置
   sslrootcert: /etc/datus/certs/gaussdb-ca.pem
 ```
 
 支持的驱动为 `gaussdb`（Linux；sha256/md5/sm3 认证）、`pg8000`（Linux/macOS；sha256/md5）和
 仅支持 md5 的 `psycopg2` 兜底方案。TLS 模式支持 `disable`、`allow`、`prefer`（默认）、`require`、
-`verify-ca` 和 `verify-full`。生产环境推荐 `verify-ca` 并通过 `sslrootcert` 提供服务端 CA；若配置的
-hostname 也与证书匹配，可使用 `verify-full`。当前仅支持单向 TLS，不支持客户端证书双向认证。
+`verify-ca` 和 `verify-full`。生产环境应以 `verify-ca` 配合 `sslrootcert` 提供服务端 CA 为基线；当配置的
+hostname 能保证与证书匹配时，使用 `verify-full` 可提供更严格的 hostname 验证，否则继续使用
+`verify-ca`。当前仅支持单向 TLS，不支持客户端证书双向认证。
 模式、平台、认证方式及 A/B/PG 兼容模式详情见[数据库适配器](../adapters/db_adapters.md#gaussdb)。
 
 ### 路径模式（批量发现多个文件）

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -64,7 +64,7 @@ docker compose down -v
 | doris | `ADAPTERS_DORIS=1` | `DORIS_HOST/PORT/USER/PASSWORD/CATALOG/DATABASE` | `127.0.0.1:9030 root//internal/test` |
 | trino | `ADAPTERS_TRINO=1` | `TRINO_HOST/PORT/USER` | `localhost:8080 trino` (uses built-in `tpch.tiny`, no seeding) |
 | greenplum | `ADAPTERS_GP=1` | `GREENPLUM_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA` | `localhost:15432 gpadmin/pivotal/postgres/public` |
-| gaussdb | `ADAPTERS_GAUSSDB=1` | `GAUSSDB_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA` | `127.0.0.1:25434 datus/Datus@123/postgres/public` (Linux only) |
+| gaussdb | `ADAPTERS_GAUSSDB=1` | `GAUSSDB_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA/DRIVER/SSLMODE/SSLROOTCERT` | `127.0.0.1:25434 datus/Datus@123/postgres/public`; `gaussdb` on Linux, `pg8000` on macOS |
 | hive | `ADAPTERS_HIVE=1` | `HIVE_HOST/PORT/USERNAME/PASSWORD/DATABASE` | `localhost:10000 hive//default` |
 | spark | `ADAPTERS_SPARK=1` | `SPARK_HOST/PORT/USER/PASSWORD/DATABASE/AUTH_MECHANISM` | `localhost:10000 spark//default/NONE` |
 

--- a/tests/integration/adapters/test_gaussdb.py
+++ b/tests/integration/adapters/test_gaussdb.py
@@ -15,14 +15,18 @@ Env overrides (defaults match the adapter's docker-compose.yml):
   GAUSSDB_HOST=127.0.0.1  GAUSSDB_PORT=25434
   GAUSSDB_USER=datus      GAUSSDB_PASSWORD=Datus@123
   GAUSSDB_DATABASE=postgres  GAUSSDB_SCHEMA=public
+  GAUSSDB_DRIVER=pg8000      GAUSSDB_SSLMODE=verify-ca
+  GAUSSDB_SSLROOTCERT=/path/to/gaussdb-ca.pem
 
 The official `gaussdb` driver binds a GaussDB-family libpq that is published for
-Linux only, so this suite runs on Linux (release wheels bundle that libpq).
+Linux only (release wheels bundle that libpq). macOS uses the pure-Python
+`pg8000` path by default.
 
 See `tests/integration/adapters/README.md`.
 """
 
 import os
+import sys
 from typing import Generator
 
 import pytest
@@ -92,6 +96,9 @@ def gaussdb_config() -> GaussDBConfig:
         password=os.getenv("GAUSSDB_PASSWORD", "Datus@123"),
         database=os.getenv("GAUSSDB_DATABASE", "postgres"),
         schema_name=SCHEMA,
+        driver=os.getenv("GAUSSDB_DRIVER") or ("pg8000" if sys.platform == "darwin" else "gaussdb"),
+        sslmode=os.getenv("GAUSSDB_SSLMODE", "prefer"),
+        sslrootcert=os.getenv("GAUSSDB_SSLROOTCERT") or None,
     )
 
 

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -16,6 +16,24 @@ def _nightly_script_text() -> str:
     return NIGHTLY_SCRIPT.read_text(encoding="utf-8")
 
 
+def _nightly_shell_commands() -> list[str]:
+    commands: list[str] = []
+    fragments: list[str] = []
+
+    for raw_line in _nightly_script_text().splitlines():
+        line = raw_line.strip()
+        continued = line.endswith("\\")
+        fragments.append(line[:-1].rstrip() if continued else line)
+        if continued:
+            continue
+
+        commands.append(" ".join(fragment for fragment in fragments if fragment))
+        fragments = []
+
+    assert not fragments
+    return commands
+
+
 def _pytest_script_line_containing(label: str) -> str:
     matches = [line for line in _nightly_script_text().splitlines() if label in line and " uv run pytest " in line]
     assert len(matches) == 1
@@ -38,17 +56,19 @@ def test_nightly_broad_suites_do_not_collect_unit_tests():
 
 
 def test_nightly_pytest_commands_set_explicit_test_layer():
-    pytest_command_lines = [
-        line
-        for line in _nightly_script_text().splitlines()
-        if " uv run pytest " in line and ("run_logged" in line or "run_compose_suite" in line)
+    pytest_commands = [
+        command
+        for command in _nightly_shell_commands()
+        if " uv run pytest " in command
+        and any(wrapper in command for wrapper in ("run_logged", "run_compose_suite", "run_with_agent_home"))
     ]
 
-    assert len(pytest_command_lines) == 22
-    assert any("tests/integration/adapters/test_doris.py" in line for line in pytest_command_lines)
-    for line in pytest_command_lines:
-        expected_layer = "unit" if "Full Unit Tests" in line else "nightly"
-        assert f"env DATUS_TEST_LAYER={expected_layer} uv run pytest" in line
+    assert len(pytest_commands) == 22
+    assert any("tests/integration/adapters/test_doris.py" in command for command in pytest_commands)
+    assert any("tests/integration/adapters/test_gaussdb.py" in command for command in pytest_commands)
+    for command in pytest_commands:
+        expected_layer = "unit" if "Full Unit Tests" in command else "nightly"
+        assert f"env DATUS_TEST_LAYER={expected_layer}" in command
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -551,6 +551,32 @@ class TestDbConfigToConnectionConfigAdapterBranch:
         assert result["private_key_file"] == "/tmp/rsa_key.p8"
         assert result["private_key_file_pwd"] == "1234"
 
+    def test_adapter_preserves_gaussdb_driver_and_tls_fields(self):
+        """GaussDB adapter options survive agent.yml parsing and manager conversion."""
+        from datus.configuration.agent_config import DbConfig
+
+        cfg = DbConfig.filter_kwargs(
+            DbConfig,
+            {
+                "type": "gaussdb",
+                "host": "gaussdb.example.com",
+                "port": "5432",
+                "username": "datus",
+                "password": "secret",
+                "database": "postgres",
+                "schema": "public",
+                "driver": "pg8000",
+                "sslmode": "verify-ca",
+                "sslrootcert": "/etc/datus/certs/gaussdb-ca.pem",
+            },
+        )
+
+        result = self._make_manager()._db_config_to_connection_config(cfg)
+
+        assert result["driver"] == "pg8000"
+        assert result["sslmode"] == "verify-ca"
+        assert result["sslrootcert"] == "/etc/datus/certs/gaussdb-ca.pem"
+
     def test_adapter_none_values_removed(self):
         """None-valued fields are excluded from the result dict."""
         mgr = self._make_manager()


### PR DESCRIPTION
## Summary

- preserve `driver`, `sslmode`, and `sslrootcert` from `agent.yml` through `DbConfig.extra` into the GaussDB adapter
- run the Agent-facing GaussDB nightly contract with the ephemeral CA from the adapter fixture and `sslmode=verify-ca`
- document the Linux/macOS driver matrix, authentication methods, A/B/PG compatibility modes, all TLS modes, production recommendations, and the one-way TLS boundary in English and Chinese
- update the top-level supported-database table and adapter repository links

## Why

GaussDB TLS options were accepted generically, but Agent did not have a regression test proving they survive configuration parsing and no Agent-facing real-TLS contract exercised certificate verification. The user documentation also did not explain when a client needs the server CA, how `require` differs from `verify-ca`, or which drivers work on each platform.

The nightly fixture now obtains a temporary CA from the disposable openGauss compose service, runs `DBFuncTool` through `verify-ca`, and cleans up both the host copy and Docker volume. No persistent Huawei Cloud instance is required.

## Dependency

- Requires Datus-ai/datus-db-adapters#102 to land first so the nightly checkout contains the TLS-enabled compose fixture and generated CA.

## Validation

- `uv run pytest tests/unit_tests/tools/db_tools/test_db_manager.py -q` — 70 passed
- focused `GaussDB Adapter Tests` nightly group — 5 passed with `verify-ca`
- direct Agent-facing `tests/integration/adapters/test_gaussdb.py` run — 5 passed
- `DOCS_LOCALE=en ... mkdocs build --strict` — passed
- `DOCS_LOCALE=zh ... mkdocs build --strict` — passed
- `uv run ruff check tests/integration/adapters/test_gaussdb.py tests/unit_tests/tools/db_tools/test_db_manager.py`
- `uv run ruff format --check tests/integration/adapters/test_gaussdb.py tests/unit_tests/tools/db_tools/test_db_manager.py`
- `bash -n ci/run-nightly-tests.sh`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
## Summary by CodeRabbit

* **New Features**
  * Added GaussDB/openGauss datasource support, including driver selection, TLS modes, CA certificates, and authentication guidance.
  * Added macOS support using the `pg8000` driver, alongside Linux driver options.
  * Added Oracle and GaussDB/openGauss entries to the supported database list.

* **Documentation**
  * Expanded English and Chinese setup guides with configuration examples, platform-specific behavior, and TLS instructions.

* **Bug Fixes**
  * Improved GaussDB TLS test handling and verified that connection security settings are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GaussDB/openGauss datasource support, including driver selection, TLS modes, CA certificates, and authentication guidance.
  * Added macOS support with the `pg8000` driver, alongside Linux driver options.
  * Added Oracle and GaussDB/openGauss to the supported database list.

* **Documentation**
  * Expanded English and Chinese guides with configuration examples, platform-specific behavior, and TLS instructions.

* **Bug Fixes**
  * Improved GaussDB TLS test handling and preserved connection security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->