### PR TITLE
[Feature] Sandbox Jinja rendering and add agent.sql_read_only

### DIFF
--- a/datus/api/models/config_models.py
+++ b/datus/api/models/config_models.py
@@ -19,6 +19,10 @@ class ErrorCode(str, Enum):
     CONFIGURATION_GET_FAILED = "CONFIGURATION_GET_FAILED"
     MCP_SERVER_ERROR = "MCP_SERVER_ERROR"
     SQL_EXECUTION_ERROR = "SQL_EXECUTION_ERROR"
+    # Refused by the deployment-wide read-only posture (``agent.sql_read_only``);
+    # never attempted against the database. Distinct from SQL_EXECUTION_ERROR so
+    # callers can tell "policy says no, do not retry" from "the engine errored".
+    SQL_READ_ONLY = "SQL_READ_ONLY"
     TOOL_EXECUTION_ERROR = "TOOL_EXECUTION_ERROR"
     DATABASE_CONNECTION_ERROR = "DATABASE_CONNECTION_ERROR"
     CONTEXT_COMMAND_ERROR = "CONTEXT_COMMAND_ERROR"

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -156,14 +156,25 @@ class CLIService:
             # ``switch_context`` so a request about to be refused does not mutate
             # connector state.
             if getattr(self.agent_config, "sql_read_only", False):
-                from datus.utils.sql_utils import classify_read_only_violation
+                from datus.utils.sql_utils import classify_read_only_violation, parse_sql_statement_kind
 
-                reason, _ = classify_read_only_violation(
-                    request.sql_query,
-                    getattr(self.current_db_connector, "dialect", "") or "",
-                )
+                dialect = getattr(self.current_db_connector, "dialect", "") or ""
+                reason, sql_type = classify_read_only_violation(request.sql_query, dialect)
                 if reason:
-                    logger.warning(f"Read-only deployment refused SQL: {reason}")
+                    # Same structured shape as the DBFuncTool refusal in
+                    # ``database._refuse_write_if_read_only`` so an operator can
+                    # filter both entry points on one field set — including the
+                    # finer statement kind, since ``ddl`` alone cannot tell them
+                    # whether a caller tried to CREATE or to DROP. ``source`` is
+                    # always "deployment" here: this route has no per-agent
+                    # read-only posture to distinguish it from.
+                    logger.warning(
+                        "POST /sql/execute rejected by read-only policy",
+                        sql_type=parse_sql_statement_kind(request.sql_query, dialect) or sql_type.value,
+                        database=request.database_name or "",
+                        source="deployment",
+                        rule=reason,
+                    )
                     return Result(
                         success=False,
                         errorCode=ErrorCode.SQL_READ_ONLY,

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -143,6 +143,33 @@ class CLIService:
                     errorMessage="No database connection available",
                 )
 
+            # Deployment-wide read-only posture. This route reaches the connector
+            # directly (see ``.execute`` below) and never touches DBFuncTool, so
+            # the ``execute_sql`` tool gate does not cover it — without this check
+            # a hardened deployment would still expose arbitrary SQL here. The
+            # rules come from the same helper the tool path uses so the two
+            # entry points cannot disagree.
+            #
+            # Read per request rather than snapshotted: CLIService is built from
+            # the shared service-level config, so a host hardening it at runtime
+            # takes effect without rebuilding the service. Placed before
+            # ``switch_context`` so a request about to be refused does not mutate
+            # connector state.
+            if getattr(self.agent_config, "sql_read_only", False):
+                from datus.utils.sql_utils import classify_read_only_violation
+
+                reason, _ = classify_read_only_violation(
+                    request.sql_query,
+                    getattr(self.current_db_connector, "dialect", "") or "",
+                )
+                if reason:
+                    logger.warning(f"Read-only deployment refused SQL: {reason}")
+                    return Result(
+                        success=False,
+                        errorCode=ErrorCode.SQL_READ_ONLY,
+                        errorMessage=(f"This deployment is read-only (agent.sql_read_only). {reason}"),
+                    )
+
             # Switch to the requested database/catalog context before executing.
             if request.database_name:
                 catalog = getattr(self.current_db_connector, "catalog_name", "") or ""

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -156,11 +156,31 @@ class CLIService:
             # ``switch_context`` so a request about to be refused does not mutate
             # connector state.
             if getattr(self.agent_config, "sql_read_only", False):
-                from datus.utils.sql_utils import classify_read_only_violation, parse_sql_statement_kind
+                from datus.utils.sql_utils import (
+                    READ_ONLY_MULTI_STATEMENT,
+                    READ_ONLY_NON_READ,
+                    READ_ONLY_WRITABLE_PRAGMA,
+                    parse_sql_statement_kind,
+                    validate_read_only_sql,
+                )
 
                 dialect = getattr(self.current_db_connector, "dialect", "") or ""
-                reason, sql_type = classify_read_only_violation(request.sql_query, dialect)
-                if reason:
+                violation, sql_type = validate_read_only_sql(request.sql_query, dialect)
+                if violation:
+                    # The helper returns a code, not prose, so each entry point
+                    # words its own refusal. This route answers an HTTP client
+                    # rather than a model, so it names the setting that caused
+                    # the refusal.
+                    reason = {
+                        READ_ONLY_MULTI_STATEMENT: (
+                            "Multi-statement SQL is not allowed. Please submit one query at a time."
+                        ),
+                        READ_ONLY_NON_READ: (
+                            f"Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed. "
+                            f"Detected SQL type: {sql_type.value}"
+                        ),
+                        READ_ONLY_WRITABLE_PRAGMA: "Writable PRAGMA statements are not allowed in read-only mode.",
+                    }[violation]
                     # Same structured shape as the DBFuncTool refusal in
                     # ``database._refuse_write_if_read_only`` so an operator can
                     # filter both entry points on one field set — including the
@@ -173,7 +193,7 @@ class CLIService:
                         sql_type=parse_sql_statement_kind(request.sql_query, dialect) or sql_type.value,
                         database=request.database_name or "",
                         source="deployment",
-                        rule=reason,
+                        rule=violation,
                     )
                     return Result(
                         success=False,

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -155,6 +155,14 @@ class CLIService:
             # takes effect without rebuilding the service. Placed before
             # ``switch_context`` so a request about to be refused does not mutate
             # connector state.
+            #
+            # Still needed after the statement-type dispatch below, and this is
+            # the reason: that dispatch sends identified single writes straight
+            # to ``current_db_connector.execute`` and only reads through
+            # ``execute_read_enforced``. So a write never reaches DBFuncTool and
+            # never meets the tool-layer read-only gate — this check is the only
+            # thing standing in front of it. Refusing here also means the write
+            # branch is simply unreachable on a hardened deployment.
             if getattr(self.agent_config, "sql_read_only", False):
                 from datus.utils.sql_utils import (
                     READ_ONLY_MULTI_STATEMENT,

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -16,6 +16,7 @@ from datus.schemas.base import BaseInput
 from datus.schemas.node_models import StrategyType
 from datus.storage.embedding_models import init_embedding_models
 from datus.storage.storage_cfg import check_storage_config, save_storage_config
+from datus.utils.config_utils import coerce_bool
 from datus.utils.constants import DBType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -106,25 +107,11 @@ def _validate_project_name(value: str) -> str:
     return value
 
 
-def _coerce_bool(value: Any, default: bool) -> bool:
-    """Coerce a config value to ``bool`` accepting YAML's string booleans.
-
-    ``bool("false")`` is ``True`` in Python, so a naive ``bool(...)`` cast on
-    a YAML value like ``enabled: "false"`` silently flips the toggle on. This
-    helper normalizes booleans and the common string spellings users actually
-    write in agent.yml.
-    """
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"1", "true", "yes", "on"}:
-            return True
-        if normalized in {"0", "false", "no", "off", ""}:
-            return False
-    return bool(value)
+# Historical private alias. The implementation moved to ``datus.utils.config_utils``
+# so modules outside this package (DBFuncTool, skill_config) can share it without
+# importing a private symbol across package boundaries; the name is kept because
+# this module uses it in ~10 places.
+_coerce_bool = coerce_bool
 
 
 def _coerce_pattern_list(value: Any) -> List[str]:
@@ -950,11 +937,13 @@ class AgentConfig:
         # config file.
         self._config_mutable = _coerce_bool(kwargs.get("config_mutable"), True)
         # ``sql_read_only`` is the deployment-wide SQL posture. When ``True`` no
-        # entry point served by this config may run a non-read statement: both
-        # ``DBFuncTool.execute_sql`` (agent nodes plus the MCP server's
-        # ``create_dynamic``/``create_static`` instances) and the raw
-        # ``POST /sql/execute`` REST route consult it. Default ``False``
-        # preserves the CLI's write-capable behaviour.
+        # entry point served by this config may run a non-read statement. All of
+        # them consult it: ``DBFuncTool``'s write paths — ``execute_sql``,
+        # ``execute_write``, ``execute_ddl`` and the cross-datasource
+        # ``transfer_query_result`` — for agent nodes as well as the MCP server's
+        # ``create_dynamic``/``create_static`` instances, plus the raw
+        # ``POST /sql/execute`` REST route. Default ``False`` preserves the CLI's
+        # write-capable behaviour.
         #
         # This is a hard switch, not a policy. Unlike ``agent.sql_policy`` — a
         # pluggable rewrite/deny framework that needs a provider class — it
@@ -962,9 +951,8 @@ class AgentConfig:
         # statement. Intended for hosts that run third-party-authored agent
         # content against platform-owned datasources.
         #
-        # Deliberately write-once-true: the setter can only tighten. A
-        # per-request config clone may harden itself (as the chat API does with
-        # ``config_mutable``), but nothing downstream — a plugin, a tool
+        # One-way: exposed as a read-only property plus
+        # ``harden_sql_read_only()``. Nothing downstream — a plugin, a tool
         # transformer, third-party code sharing the process — can undo a
         # yaml-level ``true``.
         self._sql_read_only = _coerce_bool(kwargs.get("sql_read_only"), False)
@@ -1295,17 +1283,27 @@ class AgentConfig:
         ``False`` (default): unchanged behaviour — writes and DDL are gated by
         the permission profile and per-tool ``read_only`` flags only.
 
-        ``True``: :meth:`DBFuncTool.execute_sql` hard-rejects every non-read
-        statement regardless of profile or hooks, and ``POST /sql/execute``
-        refuses anything that is not a single SELECT/SHOW/DESCRIBE/EXPLAIN.
+        ``True``: :meth:`DBFuncTool.execute_sql`, the cross-datasource
+        :meth:`DBFuncTool.transfer_query_result`, and the raw
+        ``POST /sql/execute`` route all hard-reject every non-read statement,
+        regardless of profile or hooks.
+
+        Read-only by design — there is no setter. Use
+        :meth:`harden_sql_read_only` to turn it on; nothing can turn it off.
         """
         return self._sql_read_only
 
-    @sql_read_only.setter
-    def sql_read_only(self, value: bool) -> None:
-        # Tighten-only. Assigning a falsy value to a config that is already
-        # read-only is a no-op, not a downgrade — see __init__ for why.
-        self._sql_read_only = self._sql_read_only or _coerce_bool(value, False)
+    def harden_sql_read_only(self) -> None:
+        """Switch this config to the read-only SQL posture. One-way.
+
+        A method rather than a setter because the operation is not assignment:
+        it can only tighten, so ``cfg.sql_read_only = False`` would have to
+        silently do nothing. A per-request config clone may harden itself (as
+        the chat API does with ``config_mutable``), but nothing downstream — a
+        plugin, a tool transformer, third-party code sharing the process — may
+        undo a yaml-level ``true``.
+        """
+        self._sql_read_only = True
 
     @property
     def bash_tool_enabled(self) -> bool:

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -949,6 +949,25 @@ class AgentConfig:
         # are hidden/refused and the plugin prompt preamble stops naming the
         # config file.
         self._config_mutable = _coerce_bool(kwargs.get("config_mutable"), True)
+        # ``sql_read_only`` is the deployment-wide SQL posture. When ``True`` no
+        # entry point served by this config may run a non-read statement: both
+        # ``DBFuncTool.execute_sql`` (agent nodes plus the MCP server's
+        # ``create_dynamic``/``create_static`` instances) and the raw
+        # ``POST /sql/execute`` REST route consult it. Default ``False``
+        # preserves the CLI's write-capable behaviour.
+        #
+        # This is a hard switch, not a policy. Unlike ``agent.sql_policy`` — a
+        # pluggable rewrite/deny framework that needs a provider class — it
+        # requires no extension and cannot be satisfied by rewriting the
+        # statement. Intended for hosts that run third-party-authored agent
+        # content against platform-owned datasources.
+        #
+        # Deliberately write-once-true: the setter can only tighten. A
+        # per-request config clone may harden itself (as the chat API does with
+        # ``config_mutable``), but nothing downstream — a plugin, a tool
+        # transformer, third-party code sharing the process — can undo a
+        # yaml-level ``true``.
+        self._sql_read_only = _coerce_bool(kwargs.get("sql_read_only"), False)
         # ``bash.enabled`` toggles whether agentic nodes instantiate the
         # general-purpose ``BashTool``. Default ``True`` preserves the
         # current behaviour where every node exposes ``bash``
@@ -1268,6 +1287,25 @@ class AgentConfig:
     @config_mutable.setter
     def config_mutable(self, value: bool) -> None:
         self._config_mutable = bool(value)
+
+    @property
+    def sql_read_only(self) -> bool:
+        """Whether every SQL entry point served by this config is read-only.
+
+        ``False`` (default): unchanged behaviour — writes and DDL are gated by
+        the permission profile and per-tool ``read_only`` flags only.
+
+        ``True``: :meth:`DBFuncTool.execute_sql` hard-rejects every non-read
+        statement regardless of profile or hooks, and ``POST /sql/execute``
+        refuses anything that is not a single SELECT/SHOW/DESCRIBE/EXPLAIN.
+        """
+        return self._sql_read_only
+
+    @sql_read_only.setter
+    def sql_read_only(self, value: bool) -> None:
+        # Tighten-only. Assigning a falsy value to a config that is already
+        # read-only is a no-op, not a downgrade — see __init__ for why.
+        self._sql_read_only = self._sql_read_only or _coerce_bool(value, False)
 
     @property
     def bash_tool_enabled(self) -> bool:

--- a/datus/prompts/prompt_manager.py
+++ b/datus/prompts/prompt_manager.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional
 
 from jinja2 import Environment, FileSystemLoader, Template
+from jinja2.sandbox import SandboxedEnvironment
 
 from datus.utils.loggings import get_logger
 
@@ -73,7 +74,21 @@ class PromptManager:
             self._env_cache.move_to_end(cache_key)
             return env
         search_paths = [cache_key, str(self.default_templates_dir)]
-        env = Environment(loader=FileSystemLoader(search_paths), trim_blocks=True, lstrip_blocks=True)
+        # SandboxedEnvironment, not Environment: ``search_paths[0]`` is the user
+        # template dir (``{agent.home}/template``), which is user-writable AND
+        # takes precedence over the built-in templates. A template dropped there
+        # is untrusted input, and a bare Environment would let it walk into
+        # Python internals (``{{ x.__class__.__mro__[1].__subclasses__() }}``)
+        # from inside the agent process. The sandbox blocks unsafe attribute
+        # traversal; nothing else about rendering changes.
+        #
+        # Deliberately keeps the default lenient ``Undefined``: callers of
+        # ``render_template`` pass ad-hoc kwargs and the shipped templates rely
+        # on missing variables rendering empty. ``trim_blocks``/``lstrip_blocks``
+        # shape the emitted prompt text, and the loader is what makes
+        # ``{% import %}`` / ``{% include %}`` resolve — none of the three may
+        # change here.
+        env = SandboxedEnvironment(loader=FileSystemLoader(search_paths), trim_blocks=True, lstrip_blocks=True)
         self._env_cache[cache_key] = env
         if len(self._env_cache) > self._MAX_ENV_CACHE_SIZE:
             self._env_cache.popitem(last=False)

--- a/datus/storage/reference_template/template_file_processor.py
+++ b/datus/storage/reference_template/template_file_processor.py
@@ -28,6 +28,10 @@ def extract_template_parameters(template_content: str) -> List[Dict[str, str]]:
     Returns:
         List of parameter definitions, e.g. [{"name": "start_date"}, {"name": "end_date"}]
     """
+    # Parse-only: ``env.parse`` builds an AST and never evaluates the template,
+    # so a SandboxedEnvironment would be a semantic no-op here. Rendering of
+    # reference templates happens in ``reference_template_tools``, which is
+    # sandboxed.
     env = jinja2.Environment()
     try:
         ast = env.parse(template_content)
@@ -230,6 +234,8 @@ def validate_template(template_content: str) -> Tuple[bool, str]:
     Returns:
         Tuple of (is_valid, error_message)
     """
+    # Parse-only, same as ``extract_template_parameters`` above: no evaluation
+    # happens, so sandboxing would add nothing.
     env = jinja2.Environment()
     try:
         env.parse(template_content)

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Unio
 from agents import Tool
 from datus_db_core import BaseSqlConnector
 
-from datus.configuration.agent_config import AgentConfig, _coerce_bool
+from datus.configuration.agent_config import AgentConfig
 from datus.schemas.agent_models import SubAgentConfig
 from datus.schemas.node_models import ExecuteSQLResult
 from datus.storage.kb_retrieval import metadata_fts_enabled
@@ -32,6 +32,7 @@ from datus.tools.db_tools.capabilities import (
 from datus.tools.db_tools.db_manager import DBManager, db_manager_instance
 from datus.tools.func_tool.base import FuncToolResult, trans_to_function_tool
 from datus.utils.compress_utils import DataCompressor
+from datus.utils.config_utils import coerce_bool
 from datus.utils.constants import DBType, SQLType
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
@@ -137,14 +138,19 @@ class DBFuncTool:
             sub_agent_name: Optional sub-agent name for scoped context
             scoped_tables: Optional explicit table scope patterns
             connector_cache_size: Max connectors to cache (LRU eviction), default 8
-            read_only: When True, ``execute_sql`` hard-rejects any non-read
-                       statement (INSERT/UPDATE/DELETE/DDL/MERGE/...) at the tool
-                       layer, independent of ``PermissionHooks``. Use for agents
-                       whose contract is read-only (Explore, ask_report/dashboard,
-                       LLM validators) so the unified write-capable entry point
-                       cannot mutate the datasource even when hooks are bypassed
-                       (e.g. validators run with ``hooks=None``) or under a
-                       permissive profile.
+            read_only: When True, the write paths (``execute_sql``,
+                       ``execute_write``, ``execute_ddl``,
+                       ``transfer_query_result``) hard-reject any non-read
+                       statement at the tool layer, independent of
+                       ``PermissionHooks``. Use for agents whose contract is
+                       read-only (Explore, ask_report/dashboard, LLM validators)
+                       so the unified write-capable entry point cannot mutate the
+                       datasource even when hooks are bypassed (e.g. validators
+                       run with ``hooks=None``) or under a permissive profile.
+                       This is the per-instance floor only; the ``read_only``
+                       property ORs it with ``AgentConfig.sql_read_only``, so
+                       passing False does not make the tool writable on a
+                       hardened deployment.
         """
         if connector_or_manager is None:
             if not agent_config:
@@ -171,7 +177,9 @@ class DBFuncTool:
         self.compressor = DataCompressor(model_name=model_name)
         self.agent_config = agent_config
         self.sub_agent_name = sub_agent_name
-        self.read_only = read_only
+        # Backing field for the ``read_only`` property: this instance's own
+        # posture, before the deployment-wide switch is ORed in.
+        self._read_only = read_only
         if agent_config and metadata_fts_enabled(agent_config):
             self.schema_rag = create_metadata_rag(agent_config, sub_agent_name)
         else:
@@ -204,29 +212,93 @@ class DBFuncTool:
         return dict(policy_context) if isinstance(policy_context, dict) else {}
 
     @property
-    def effective_read_only(self) -> bool:
-        """Read-only posture for ``execute_sql``, resolved on every access.
+    def read_only(self) -> bool:
+        """Whether this tool refuses non-read SQL. Resolved on every access.
 
-        ORs the per-instance ``read_only`` — set by read-only agents (Explore,
+        ORs the per-instance flag — set by read-only agents (Explore,
         ask_report/dashboard) and by the validator's shallow copy in
         ``datus.validation.llm_runner`` — with the deployment-wide
         ``AgentConfig.sql_read_only``. Tighten-only in both directions: neither
         source can relax the other.
 
+        This is the effective posture, not the constructor argument, so that
+        anything asking "is this tool read-only?" gets the answer the write
+        paths will actually enforce. The MCP server's
+        ``create_dynamic``/``create_static`` factories pass a config but no
+        ``read_only`` flag, so on a hardened deployment their instances read
+        ``True`` here despite nothing having passed it.
+
         Resolved per access rather than snapshotted in ``__init__`` for the same
         reason as ``principal`` above: the API hands nodes a per-request config
         clone, and a tool built before that clone was hardened must still honour
-        it. Reading through ``agent_config`` is also what covers the MCP server,
-        whose ``create_dynamic``/``create_static`` factories pass a config but no
-        ``read_only`` flag.
+        it.
 
-        ``_coerce_bool`` rather than ``bool``: the ``getattr`` guard exists for
+        ``coerce_bool`` rather than ``bool``: the ``getattr`` guard exists for
         duck-typed / host-supplied config objects, which are exactly the ones
         likely to carry a raw YAML value — and ``bool("false")`` is ``True``.
         """
-        if self.read_only:
+        if self._read_only:
             return True
-        return _coerce_bool(getattr(self.agent_config, "sql_read_only", False), False)
+        return coerce_bool(getattr(self.agent_config, "sql_read_only", False), False)
+
+    @read_only.setter
+    def read_only(self, value: bool) -> None:
+        # Tighten-only, matching ``AgentConfig.sql_read_only``: a caller may
+        # harden an instance (``llm_runner`` does this to a shallow copy before
+        # binding it to a hooks-free validator) but may not hand a write-capable
+        # view of a read-only deployment to anything downstream.
+        self._read_only = self._read_only or coerce_bool(value, False)
+
+    def _refuse_write_if_read_only(
+        self,
+        operation: str,
+        *,
+        datasource: Optional[str] = "",
+        sql_type: Optional[SQLType] = None,
+        statement_kind: str = "",
+        error: str = "",
+    ) -> Optional[FuncToolResult]:
+        """Gate every write entry point on the effective read-only posture.
+
+        Returns ``None`` when the caller may proceed, or the ``FuncToolResult``
+        to hand straight back when it may not. Defense-in-depth for read-only
+        agents and read-only deployments alike: it is independent of
+        ``PermissionHooks``, which several callers bypass entirely (validators
+        run with ``hooks=None``, and the MCP server's tool instances never see
+        hooks at all).
+
+        Shared by all four write paths so a new one cannot be added with a
+        subtly different rule, and so ``AgentConfig.sql_read_only`` means the
+        same thing at each of them.
+
+        Refusals are logged because a refusal is the event an operator actually
+        wants to see: on a deployment running third-party-authored content it
+        means that content just tried to write. Successful reads are already
+        logged in ``read_query``, so staying silent here would record the benign
+        path and drop the notable one. ``source`` separates a deployment-wide
+        refusal from a read-only agent doing its job — the difference between
+        "investigate this" and "working as intended".
+
+        ``statement_kind`` is the finer-grained classification from
+        ``parse_sql_statement_kind`` (``create`` / ``drop`` / ``alter`` /
+        ``truncate``) when the caller has the SQL to derive it. It is preferred
+        over ``sql_type`` in the log because ``ddl`` alone cannot tell an
+        operator whether third-party content tried to create a table or drop
+        one, and those warrant very different responses.
+        """
+        if not self.read_only:
+            return None
+        logger.warning(
+            f"{operation} rejected by read-only policy",
+            sql_type=statement_kind or (sql_type.value if sql_type else ""),
+            datasource=self._resolve_effective_datasource(datasource),
+            sub_agent=self.sub_agent_name or "",
+            source="agent" if self._read_only else "deployment",
+        )
+        return FuncToolResult(
+            success=0,
+            error=error or f"This agent is read-only: {operation} is not available.",
+        )
 
     def _has_schema_storage(self) -> bool:
         if not self.schema_rag:
@@ -1491,6 +1563,7 @@ class DBFuncTool:
         """
         from datus.utils.sql_utils import (
             looks_like_sql_file_ref,
+            parse_sql_statement_kind,
             parse_sql_type,
             write_statement_reads_data,
         )
@@ -1512,35 +1585,21 @@ class DBFuncTool:
 
             if sql_type in (SQLType.SELECT, SQLType.METADATA_SHOW, SQLType.EXPLAIN):
                 return self.read_query(sql, datasource=datasource, database=database)
-            if self.effective_read_only:
-                # Defense-in-depth for read-only agents and read-only
-                # deployments: reject any non-read statement at the tool layer,
-                # independent of PermissionHooks (which may be bypassed, e.g.
-                # validators run with hooks=None, and the MCP server's tool
-                # instances never see them at all).
-                #
-                # Logged because a refusal is the event an operator actually
-                # wants to see: on a deployment running third-party-authored
-                # content it means that content just tried to write. Successful
-                # reads are already logged in read_query, so staying silent here
-                # would record the benign path and drop the notable one.
-                # ``source`` separates a deployment-wide refusal from a read-only
-                # agent doing its job -- the difference between "investigate
-                # this" and "working as intended".
-                logger.warning(
-                    "execute_sql rejected by read-only policy",
-                    sql_type=sql_type.value,
-                    datasource=self._resolve_effective_datasource(datasource),
-                    sub_agent=self.sub_agent_name or "",
-                    source="agent" if self.read_only else "deployment",
-                )
-                return FuncToolResult(
-                    success=0,
-                    error=(
-                        "This agent is read-only: only SELECT/SHOW/DESCRIBE/EXPLAIN "
-                        "statements are allowed through execute_sql."
-                    ),
-                )
+            refusal = self._refuse_write_if_read_only(
+                "execute_sql",
+                datasource=datasource,
+                sql_type=sql_type,
+                # The permission layer's finer classification, so the audit line
+                # says `drop` rather than a `ddl` that also covers CREATE.
+                statement_kind=parse_sql_statement_kind(sql, connector.dialect),
+                error=(
+                    "This agent is read-only: only SELECT/SHOW/DESCRIBE/EXPLAIN "
+                    "statements are allowed through execute_sql."
+                ),
+            )
+            if refusal:
+                return refusal
+
             # A write can carry a read. `CREATE TABLE mine AS SELECT * FROM
             # orders` is approved as a write, runs on the raw connector, and
             # lands every row the policy just withheld in a table no policy
@@ -1552,6 +1611,10 @@ class DBFuncTool:
             # The permission prompt is not this check. It asks whether the
             # *user* consents to a write; consenting to a write they are
             # allowed to make is not consent to read rows they are not.
+            #
+            # Ordered after the read-only gate above: a hardened deployment
+            # refuses every write outright, so it never needs to reason about
+            # what the write reads.
             if self.policy_context and write_statement_reads_data(sql, connector.dialect):
                 return FuncToolResult(
                     success=0,
@@ -1614,7 +1677,15 @@ class DBFuncTool:
             if validation_error:
                 return validation_error
 
-            logger.info("read_query", sql_type=sql_type.value, datasource=datasource or "default")
+            # Resolved rather than the raw argument: the refusal logs resolve it
+            # too, and an operator correlating a session on ``datasource`` cannot
+            # do it if the same source appears as "default" on one line and by
+            # name on the next.
+            logger.info(
+                "read_query",
+                sql_type=sql_type.value,
+                datasource=self._resolve_effective_datasource(datasource),
+            )
             result_format = "arrow" if connector.dialect == "snowflake" else "list"
             result = self.execute_read_enforced(
                 sql,
@@ -1773,33 +1844,35 @@ class DBFuncTool:
         )
 
         violation, sql_type = validate_read_only_sql(sql, connector.dialect)
-        if violation == READ_ONLY_MULTI_STATEMENT:
-            return (
-                FuncToolResult(
-                    success=0,
-                    error="Multi-statement SQL is not allowed. Please submit one query at a time.",
+        if violation:
+            error = {
+                READ_ONLY_MULTI_STATEMENT: "Multi-statement SQL is not allowed. Please submit one query at a time.",
+                READ_ONLY_NON_READ: (
+                    f"Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed. "
+                    f"Detected SQL type: {sql_type.value}"
                 ),
-                SQLType.UNKNOWN,
+                READ_ONLY_WRITABLE_PRAGMA: "Writable PRAGMA statements are not allowed in read-only mode.",
+            }[violation]
+            # Logged for the same reason as the write-path refusals, and this
+            # branch matters more than it looks: ``parse_sql_type`` classifies
+            # only the FIRST statement, so ``SELECT 1; DROP TABLE t`` reaches
+            # here as a SELECT and is refused by the multi-statement rule rather
+            # than by the read-only gate. Without this line the sneakiest input
+            # in the set would be the one that left no audit trail, while a
+            # plain DROP TABLE was recorded.
+            #
+            # ``rule`` rather than ``source``: these refusals hold regardless of
+            # ``sql_read_only``, so labelling them "deployment" would overstate
+            # what the switch is doing. The violation code is the value, so an
+            # operator can aggregate on it without parsing prose.
+            logger.warning(
+                "read_query rejected by statement-shape rules",
+                sql_type=sql_type.value,
+                datasource=self._resolve_effective_datasource(None),
+                sub_agent=self.sub_agent_name or "",
+                rule=violation,
             )
-
-        if violation == READ_ONLY_NON_READ:
-            return (
-                FuncToolResult(
-                    success=0,
-                    error=f"Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed. "
-                    f"Detected SQL type: {sql_type.value}",
-                ),
-                sql_type,
-            )
-
-        if violation == READ_ONLY_WRITABLE_PRAGMA:
-            return (
-                FuncToolResult(
-                    success=0,
-                    error="Writable PRAGMA statements are not allowed in read-only mode.",
-                ),
-                sql_type,
-            )
+            return FuncToolResult(success=0, error=error), sql_type
 
         out_of_scope = self._check_sql_table_scope(sql, connector)
         if out_of_scope:
@@ -1897,6 +1970,14 @@ class DBFuncTool:
             Execution result with success status
         """
         from datus.utils.sql_utils import _first_statement, parse_sql_type, strip_sql_comments
+
+        # Reachable directly, not only via the ``execute_sql`` dispatch that
+        # already gated: gen_job-style callers and host code hold the tool
+        # itself. Gate before parsing so a hardened deployment refuses on
+        # posture, never on statement shape.
+        refusal = self._refuse_write_if_read_only("execute_ddl", datasource=datasource)
+        if refusal:
+            return refusal
 
         # Validate: strip comments, reject multi-statement SQL
         cleaned = strip_sql_comments(sql).strip().rstrip(";").strip()
@@ -2009,6 +2090,12 @@ class DBFuncTool:
                 success=0,
                 error="dry_run is not supported yet for execute_write. Use dry_run=False.",
             )
+
+        # Same reasoning as ``execute_ddl``: ``execute_sql`` has already gated by
+        # the time it dispatches here, but this method is also callable directly.
+        refusal = self._refuse_write_if_read_only("execute_write", datasource=datasource)
+        if refusal:
+            return refusal
 
         try:
             sql_stripped = sql.strip()
@@ -2277,6 +2364,15 @@ class DBFuncTool:
         Returns:
             FuncToolResult with transfer metadata on success.
         """
+        # ``source_sql`` is validated as read-only below, but the transfer WRITES
+        # to ``target_datasource`` — CREATE TABLE / TRUNCATE / INSERT — without
+        # ever going through ``execute_sql``. gen_job mounts this method as a
+        # tool directly, so without this gate a hardened deployment would still
+        # expose a cross-datasource write.
+        refusal = self._refuse_write_if_read_only("transfer_query_result", datasource=target_datasource)
+        if refusal:
+            return refusal
+
         # Validate batch_size
         if batch_size <= 0:
             return FuncToolResult(success=0, error="batch_size must be a positive integer.")

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Unio
 from agents import Tool
 from datus_db_core import BaseSqlConnector
 
-from datus.configuration.agent_config import AgentConfig
+from datus.configuration.agent_config import AgentConfig, _coerce_bool
 from datus.schemas.agent_models import SubAgentConfig
 from datus.schemas.node_models import ExecuteSQLResult
 from datus.storage.kb_retrieval import metadata_fts_enabled
@@ -202,6 +202,31 @@ class DBFuncTool:
         """Request-scoped policy inputs, read fresh from the config."""
         policy_context = getattr(self.agent_config, "policy_context", None)
         return dict(policy_context) if isinstance(policy_context, dict) else {}
+
+    @property
+    def effective_read_only(self) -> bool:
+        """Read-only posture for ``execute_sql``, resolved on every access.
+
+        ORs the per-instance ``read_only`` — set by read-only agents (Explore,
+        ask_report/dashboard) and by the validator's shallow copy in
+        ``datus.validation.llm_runner`` — with the deployment-wide
+        ``AgentConfig.sql_read_only``. Tighten-only in both directions: neither
+        source can relax the other.
+
+        Resolved per access rather than snapshotted in ``__init__`` for the same
+        reason as ``principal`` above: the API hands nodes a per-request config
+        clone, and a tool built before that clone was hardened must still honour
+        it. Reading through ``agent_config`` is also what covers the MCP server,
+        whose ``create_dynamic``/``create_static`` factories pass a config but no
+        ``read_only`` flag.
+
+        ``_coerce_bool`` rather than ``bool``: the ``getattr`` guard exists for
+        duck-typed / host-supplied config objects, which are exactly the ones
+        likely to carry a raw YAML value — and ``bool("false")`` is ``True``.
+        """
+        if self.read_only:
+            return True
+        return _coerce_bool(getattr(self.agent_config, "sql_read_only", False), False)
 
     def _has_schema_storage(self) -> bool:
         if not self.schema_rag:
@@ -1487,10 +1512,12 @@ class DBFuncTool:
 
             if sql_type in (SQLType.SELECT, SQLType.METADATA_SHOW, SQLType.EXPLAIN):
                 return self.read_query(sql, datasource=datasource, database=database)
-            if self.read_only:
-                # Defense-in-depth for read-only agents: reject any non-read
-                # statement at the tool layer, independent of PermissionHooks
-                # (which may be bypassed, e.g. validators run with hooks=None).
+            if self.effective_read_only:
+                # Defense-in-depth for read-only agents and read-only
+                # deployments: reject any non-read statement at the tool layer,
+                # independent of PermissionHooks (which may be bypassed, e.g.
+                # validators run with hooks=None, and the MCP server's tool
+                # instances never see them at all).
                 return FuncToolResult(
                     success=0,
                     error=(

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1518,6 +1518,22 @@ class DBFuncTool:
                 # independent of PermissionHooks (which may be bypassed, e.g.
                 # validators run with hooks=None, and the MCP server's tool
                 # instances never see them at all).
+                #
+                # Logged because a refusal is the event an operator actually
+                # wants to see: on a deployment running third-party-authored
+                # content it means that content just tried to write. Successful
+                # reads are already logged in read_query, so staying silent here
+                # would record the benign path and drop the notable one.
+                # ``source`` separates a deployment-wide refusal from a read-only
+                # agent doing its job -- the difference between "investigate
+                # this" and "working as intended".
+                logger.warning(
+                    "execute_sql rejected by read-only policy",
+                    sql_type=sql_type.value,
+                    datasource=self._resolve_effective_datasource(datasource),
+                    sub_agent=self.sub_agent_name or "",
+                    source="agent" if self.read_only else "deployment",
+                )
                 return FuncToolResult(
                     success=0,
                     error=(

--- a/datus/tools/func_tool/reference_template_tools.py
+++ b/datus/tools/func_tool/reference_template_tools.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 
 import jinja2
 from agents import Tool
+from jinja2.sandbox import SandboxedEnvironment
 
 from datus.configuration.agent_config import AgentConfig
 from datus.storage.reference_template.store import ReferenceTemplateRAG
@@ -16,6 +17,18 @@ from datus.utils.loggings import get_logger
 from datus.utils.mcp_decorators import mcp_tool, mcp_tool_class
 
 logger = get_logger(__name__)
+
+# Reference templates are user-authored ``.j2`` bodies loaded from the template
+# store and rendered in-process, and ``render_reference_template`` is exposed as
+# an MCP tool — so the template body is untrusted input reachable by any client.
+# A bare ``jinja2.Template`` would let it walk into Python internals; the sandbox
+# blocks unsafe attribute traversal.
+#
+# ``StrictUndefined`` is preserved: the ``UndefinedError`` handler below turns a
+# missing variable into an actionable "you're missing these params" message that
+# the model retries against. No loader is attached — reference templates are
+# self-contained strings and never supported ``{% import %}``/``{% extends %}``.
+_JINJA_ENV = SandboxedEnvironment(undefined=jinja2.StrictUndefined)
 
 
 @mcp_tool_class(
@@ -221,10 +234,27 @@ class ReferenceTemplateTools:
 
             provided_params = list(params_dict.keys())
 
-            # Render the template using Jinja2 with strict undefined checking
+            # Render the template in the Jinja2 sandbox with strict undefined checking
             try:
-                jinja_template = jinja2.Template(template_content, undefined=jinja2.StrictUndefined)
+                jinja_template = _JINJA_ENV.from_string(template_content)
                 rendered_sql = jinja_template.render(**params_dict)
+            except jinja2.exceptions.SecurityError as e:
+                # Sandbox refusal: the template body reached for a restricted
+                # attribute. SecurityError subclasses TemplateRuntimeError, so
+                # neither the UndefinedError nor the TemplateSyntaxError handler
+                # below catches it — without this branch it would fall through to
+                # the broad ``except Exception`` and surface an opaque message.
+                # Logged at error level because a template trying to escape the
+                # sandbox is an authoring-integrity signal, not a user mistake,
+                # and it is never reported as a retryable parameter problem.
+                logger.error(
+                    f"Reference template `{'/'.join(subject_path)}/{name}` rejected by the Jinja2 sandbox: {e}"
+                )
+                return FuncToolResult(
+                    success=0,
+                    error=f"Template '{template_name}' was rejected by the template sandbox: {e}. "
+                    f"The template body accesses restricted attributes and cannot be rendered.",
+                )
             except jinja2.UndefinedError as e:
                 # Provide detailed error message to help model retry with correct params
                 missing = sorted(set(expected_params) - set(provided_params))

--- a/datus/tools/skill_tools/skill_config.py
+++ b/datus/tools/skill_tools/skill_config.py
@@ -99,7 +99,7 @@ def _plugins_system_enabled(agent_config: Optional[Any] = None) -> bool:
 
         # Same coercion as ``AgentConfig.plugins_enabled`` so the two readers
         # of this key can never disagree on a value like ``"off"``.
-        from datus.configuration.agent_config import _coerce_bool  # noqa: PLC2701
+        from datus.utils.config_utils import coerce_bool
 
         mgr = agent_config_loader.CONFIGURATION_MANAGER
         if mgr is None:
@@ -108,7 +108,7 @@ def _plugins_system_enabled(agent_config: Optional[Any] = None) -> bool:
     except Exception as exc:  # noqa: BLE001 - defensive: never break discovery
         logger.debug("plugins_enabled lookup failed: %s", exc)
         return True
-    return _coerce_bool(value, True)
+    return coerce_bool(value, True)
 
 
 def _plugin_skill_directories(agent_config: Optional[Any] = None) -> List[str]:

--- a/datus/utils/config_utils.py
+++ b/datus/utils/config_utils.py
@@ -1,0 +1,40 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Coercion helpers for values that arrive from YAML, env vars or API payloads.
+
+These live outside :mod:`datus.configuration.agent_config` so that modules which
+need to interpret a config value do not have to reach into another package for a
+private symbol.
+"""
+
+from typing import Any
+
+__all__ = ["coerce_bool"]
+
+
+def coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce a config value to ``bool`` accepting YAML's string booleans.
+
+    ``bool("false")`` is ``True`` in Python, so a naive ``bool(...)`` cast on a
+    YAML value like ``enabled: "false"`` silently flips the toggle on. This
+    helper normalizes booleans and the common string spellings users actually
+    write in agent.yml.
+
+    ``None`` (the key is absent) yields ``default``. Anything else — an int, a
+    Mock, an object a host handed us — falls through to ``bool(value)``, which
+    for a security toggle means an unrecognised value reads as "on" rather than
+    silently off.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off", ""}:
+            return False
+    return bool(value)

--- a/docs/configuration/sql_policy.md
+++ b/docs/configuration/sql_policy.md
@@ -77,3 +77,31 @@ For manual checks, pass the same object explicitly:
 datus sql-policy check --sql "SELECT * FROM orders" \
   --policy-context '{"row_filter":{"access_mode":"scoped","store_ids":[1,2]}}'
 ```
+
+## Hard Read-Only Switch (`agent.sql_read_only`)
+
+`agent.sql_read_only` is a separate, simpler mechanism. Do not confuse it with the policy plugins above.
+
+```yaml
+agent:
+  sql_read_only: true   # default: false
+```
+
+When `true`, no SQL entry point served by this configuration may run a non-read statement:
+
+- `DBFuncTool.execute_sql` — the tool exposed to agentic nodes and to the MCP server — hard-rejects anything that is not SELECT / SHOW / DESCRIBE / EXPLAIN. This holds regardless of the permission profile, and applies even where `PermissionHooks` are bypassed entirely (LLM validators run with `hooks=None`, and the MCP server's tool instances never see hooks at all).
+- `POST /sql/execute` refuses anything that is not a *single* read statement. Multi-statement input (`SELECT 1; DROP TABLE t`), writable `PRAGMA`s, `USE` / `SET`, and statements the parser cannot classify are all rejected — the check is fail-closed. Use the request's `database_name` field instead of `USE` to target a database.
+
+How it differs from the policy plugins:
+
+| | `agent.sql_read_only` | policy plugins |
+|---|---|---|
+| Needs a plugin | No | Yes |
+| Needs request context | No | Yes — `policy_context` per request |
+| What it does | Refuses the statement outright | Rewrites or denies per request context |
+| Granularity | All-or-nothing, deployment-wide | Row / table / column, per caller |
+| Covers `POST /sql/execute` | Yes | No (read tools only) |
+
+The switch can only tighten. A per-request configuration clone may harden itself, but nothing downstream can turn a `true` back off — and it never relaxes a component that already runs read-only (Explore, `ask_report`, the LLM validators).
+
+Use it when the process runs third-party-authored agent content — skills, subagents, reference templates — against datasources it owns. The two mechanisms compose: `sql_read_only` bounds what kind of statement may run at all; a policy plugin bounds what a given caller may read.

--- a/docs/configuration/sql_policy.md
+++ b/docs/configuration/sql_policy.md
@@ -90,7 +90,10 @@ agent:
 When `true`, no SQL entry point served by this configuration may run a non-read statement:
 
 - `DBFuncTool.execute_sql` — the tool exposed to agentic nodes and to the MCP server — hard-rejects anything that is not SELECT / SHOW / DESCRIBE / EXPLAIN. This holds regardless of the permission profile, and applies even where `PermissionHooks` are bypassed entirely (LLM validators run with `hooks=None`, and the MCP server's tool instances never see hooks at all).
+- The tool's other write paths refuse too, not just the `execute_sql` dispatcher: `execute_write`, `execute_ddl`, and `transfer_query_result`. The last one matters most — it reads from one datasource and **writes** to another (`CREATE TABLE` / `TRUNCATE` / `INSERT`), `gen_job` mounts it as a tool of its own, and it never passes through `execute_sql`.
 - `POST /sql/execute` refuses anything that is not a *single* read statement. Multi-statement input (`SELECT 1; DROP TABLE t`), writable `PRAGMA`s, `USE` / `SET`, and statements the parser cannot classify are all rejected — the check is fail-closed. Use the request's `database_name` field instead of `USE` to target a database.
+
+`DBFuncTool.read_only` reports the *effective* posture, so a tool built with no `read_only` argument — which is how the MCP server's `create_dynamic` / `create_static` factories build theirs — still reads `True` on a hardened deployment.
 
 How it differs from the policy plugins:
 
@@ -102,6 +105,17 @@ How it differs from the policy plugins:
 | Granularity | All-or-nothing, deployment-wide | Row / table / column, per caller |
 | Covers `POST /sql/execute` | Yes | No (read tools only) |
 
-The switch can only tighten. A per-request configuration clone may harden itself, but nothing downstream can turn a `true` back off — and it never relaxes a component that already runs read-only (Explore, `ask_report`, the LLM validators).
+The switch can only tighten. It is exposed as a read-only property plus a one-way `AgentConfig.harden_sql_read_only()`: a per-request configuration clone may harden itself, but nothing downstream can turn a `true` back off — and it never relaxes a component that already runs read-only (Explore, `ask_report`, the LLM validators).
 
 Use it when the process runs third-party-authored agent content — skills, subagents, reference templates — against datasources it owns. The two mechanisms compose: `sql_read_only` bounds what kind of statement may run at all; a policy plugin bounds what a given caller may read.
+
+### Verifying a deployment
+
+Automated coverage lives in `tests/unit_tests/tools/func_tool/test_database.py`, `tests/integration/tools/test_func_tools_db.py` and `tests/integration/tools/test_mcp_server.py`.
+
+Two manual scripts probe a real server end to end over MCP. Neither runs in CI; both print a verdict table and exit non-zero on failure:
+
+| Script | What it checks |
+|---|---|
+| `scripts/e2e_sql_read_only_mcp.py` | Self-contained. Stages a throwaway SQLite workspace, runs the flag-on / flag-off matrix, and reports which statements the switch refused. No arguments. |
+| `scripts/e2e_sql_read_only_mcp_project.py` | Points at a real packaged project (`--project`). `--sqlite-standin` substitutes a throwaway SQLite datasource so writes really execute when the flag is off; `--endpoint` probes an already-running server; `--live-writes` writes to the **real** datasource (scratch tables only) and `--dry-run` prints the statements without running them. |

--- a/docs/configuration/sql_policy.zh.md
+++ b/docs/configuration/sql_policy.zh.md
@@ -77,3 +77,31 @@ X-Datus-Policy-Context: {"row_filter":{"access_mode":"scoped","store_ids":[1,2]}
 datus sql-policy check --sql "SELECT * FROM orders" \
   --policy-context '{"row_filter":{"access_mode":"scoped","store_ids":[1,2]}}'
 ```
+
+## 只读硬开关（`agent.sql_read_only`）
+
+`agent.sql_read_only` 是另一套更简单的机制，不要与上面的 policy plugin 混淆。
+
+```yaml
+agent:
+  sql_read_only: true   # 默认 false
+```
+
+置为 `true` 后，该配置服务的所有 SQL 入口都不允许执行非只读语句：
+
+- `DBFuncTool.execute_sql`（暴露给 agentic node 与 MCP server 的工具）会硬拒绝 SELECT / SHOW / DESCRIBE / EXPLAIN 之外的任何语句。这与权限档位无关，在 `PermissionHooks` 被完全绕过的路径上同样生效（LLM validator 以 `hooks=None` 运行，MCP server 的工具实例根本不经过 hooks）。
+- `POST /sql/execute` 拒绝任何不是**单条**只读语句的输入。多语句（`SELECT 1; DROP TABLE t`）、可写 `PRAGMA`、`USE` / `SET`，以及解析器无法归类的语句一律拒绝——判定是 fail-closed 的。需要切换数据库时请使用请求体的 `database_name` 字段，而不是 `USE`。
+
+与 policy plugin 的区别：
+
+| | `agent.sql_read_only` | policy plugin |
+|---|---|---|
+| 需要 plugin | 否 | 是 |
+| 需要请求上下文 | 否 | 是——每请求的 `policy_context` |
+| 行为 | 直接拒绝该语句 | 按请求上下文重写或拒绝 |
+| 粒度 | 全局、非黑即白 | 行 / 表 / 列，按调用方 |
+| 覆盖 `POST /sql/execute` | 是 | 否（仅只读工具） |
+
+该开关只能收紧：每请求的配置副本可以自行加固，但下游任何代码都无法把 `true` 改回去；同时它也绝不会放松本就以只读运行的组件（Explore、`ask_report`、LLM validator）。
+
+适用场景：进程需要针对自有数据源运行第三方作者的 agent 内容（skill、subagent、reference template）。两套机制可以叠加使用——`sql_read_only` 限定「允许执行哪一类语句」，policy plugin 限定「某个调用方能读到什么」。

--- a/docs/configuration/sql_policy.zh.md
+++ b/docs/configuration/sql_policy.zh.md
@@ -90,7 +90,10 @@ agent:
 置为 `true` 后，该配置服务的所有 SQL 入口都不允许执行非只读语句：
 
 - `DBFuncTool.execute_sql`（暴露给 agentic node 与 MCP server 的工具）会硬拒绝 SELECT / SHOW / DESCRIBE / EXPLAIN 之外的任何语句。这与权限档位无关，在 `PermissionHooks` 被完全绕过的路径上同样生效（LLM validator 以 `hooks=None` 运行，MCP server 的工具实例根本不经过 hooks）。
+- 该工具的其它写入口同样拒绝，而不只是 `execute_sql` 这个分发入口：`execute_write`、`execute_ddl`、`transfer_query_result`。最后一个尤其关键——它从一个数据源读、向**另一个**数据源写（`CREATE TABLE` / `TRUNCATE` / `INSERT`），由 `gen_job` 单独挂载为工具，且完全不经过 `execute_sql`。
 - `POST /sql/execute` 拒绝任何不是**单条**只读语句的输入。多语句（`SELECT 1; DROP TABLE t`）、可写 `PRAGMA`、`USE` / `SET`，以及解析器无法归类的语句一律拒绝——判定是 fail-closed 的。需要切换数据库时请使用请求体的 `database_name` 字段，而不是 `USE`。
+
+`DBFuncTool.read_only` 返回的是**生效后**的姿态，因此构造时没有传 `read_only` 的实例——MCP server 的 `create_dynamic` / `create_static` 工厂正是这样构造的——在加固过的部署上读出来仍是 `True`。
 
 与 policy plugin 的区别：
 
@@ -102,6 +105,17 @@ agent:
 | 粒度 | 全局、非黑即白 | 行 / 表 / 列，按调用方 |
 | 覆盖 `POST /sql/execute` | 是 | 否（仅只读工具） |
 
-该开关只能收紧：每请求的配置副本可以自行加固，但下游任何代码都无法把 `true` 改回去；同时它也绝不会放松本就以只读运行的组件（Explore、`ask_report`、LLM validator）。
+该开关只能收紧：它以只读属性加一个单向的 `AgentConfig.harden_sql_read_only()` 暴露——每请求的配置副本可以自行加固，但下游任何代码都无法把 `true` 改回去；同时它也绝不会放松本就以只读运行的组件（Explore、`ask_report`、LLM validator）。
 
 适用场景：进程需要针对自有数据源运行第三方作者的 agent 内容（skill、subagent、reference template）。两套机制可以叠加使用——`sql_read_only` 限定「允许执行哪一类语句」，policy plugin 限定「某个调用方能读到什么」。
+
+### 如何验证一个部署
+
+自动化覆盖位于 `tests/unit_tests/tools/func_tool/test_database.py`、`tests/integration/tools/test_func_tools_db.py` 与 `tests/integration/tools/test_mcp_server.py`。
+
+另有两个手工脚本，通过 MCP 端到端探测真实服务。两者都不在 CI 中运行，都会打印判定表格并在失败时以非零码退出：
+
+| 脚本 | 检查内容 |
+|---|---|
+| `scripts/e2e_sql_read_only_mcp.py` | 自包含。搭建一次性 SQLite 工作区，跑「开关打开 / 关闭」对照矩阵，报告开关拒绝了哪些语句。无需参数。 |
+| `scripts/e2e_sql_read_only_mcp_project.py` | 指向真实的打包项目（`--project`）。`--sqlite-standin` 用一次性 SQLite 替换数据源，使开关关闭时写入真正执行；`--endpoint` 探测已在运行的服务；`--live-writes` 会写入**真实**数据源（仅限本次运行自建的临时表），`--dry-run` 只打印语句不执行。 |

--- a/scripts/e2e_sql_read_only_mcp.py
+++ b/scripts/e2e_sql_read_only_mcp.py
@@ -23,6 +23,10 @@ against an existing project's conf/agent.yml instead of a synthetic one.
 
 Usage:  <repo>/.venv/bin/python scripts/e2e_sql_read_only_mcp.py
 Exit:   0 = switch behaves correctly, 1 = it does not
+
+This is an operator tool, not library code: its verdict table on stdout IS the
+deliverable, so it uses `print` rather than the `get_logger` the package
+requires. Nothing under `datus/` imports it.
 """
 
 import argparse

--- a/scripts/e2e_sql_read_only_mcp.py
+++ b/scripts/e2e_sql_read_only_mcp.py
@@ -36,23 +36,24 @@ import sqlite3
 import sys
 import tempfile
 from pathlib import Path
-from typing import NamedTuple
 
 import yaml
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
+from pydantic import BaseModel, ConfigDict
 
 
-class Probe(NamedTuple):
+class Probe(BaseModel):
     """One statement to run under both flag settings.
 
-    A NamedTuple rather than a bare tuple so the third field is self-describing
-    at every use site -- `is_a_read` flips the whole verdict, and a positional
-    bool is exactly the field a reader guesses wrong. Not a Pydantic model:
-    these are literals in this file, there is no untrusted input to validate,
-    and a standalone operator script should not grow a dependency to name three
-    fields.
+    A model rather than a bare tuple so the third field is self-describing at
+    every use site -- `is_a_read` flips the whole verdict, and a positional bool
+    is exactly the field a reader guesses wrong. Frozen because these are
+    constants: a probe rewritten mid-run would silently change what the verdict
+    table claims was tested.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     label: str
     sql: str
@@ -60,16 +61,16 @@ class Probe(NamedTuple):
 
 
 CASES = [
-    Probe("SELECT", "SELECT COUNT(*) FROM t", True),
-    Probe("SHOW-ish (PRAGMA table_info)", "PRAGMA table_info(t)", True),
-    Probe("EXPLAIN", "EXPLAIN SELECT * FROM t", True),
-    Probe("INSERT", "INSERT INTO t (v) VALUES ('written')", False),
-    Probe("UPDATE", "UPDATE t SET v = 'mutated'", False),
-    Probe("DELETE", "DELETE FROM t", False),
-    Probe("CREATE TABLE", "CREATE TABLE t2 (id INT)", False),
-    Probe("DROP TABLE", "DROP TABLE t", False),
-    Probe("multi-statement", "SELECT 1; DROP TABLE t", False),
-    Probe("writable PRAGMA", "PRAGMA journal_mode=WAL", False),
+    Probe(label="SELECT", sql="SELECT COUNT(*) FROM t", is_a_read=True),
+    Probe(label="SHOW-ish (PRAGMA table_info)", sql="PRAGMA table_info(t)", is_a_read=True),
+    Probe(label="EXPLAIN", sql="EXPLAIN SELECT * FROM t", is_a_read=True),
+    Probe(label="INSERT", sql="INSERT INTO t (v) VALUES ('written')", is_a_read=False),
+    Probe(label="UPDATE", sql="UPDATE t SET v = 'mutated'", is_a_read=False),
+    Probe(label="DELETE", sql="DELETE FROM t", is_a_read=False),
+    Probe(label="CREATE TABLE", sql="CREATE TABLE t2 (id INT)", is_a_read=False),
+    Probe(label="DROP TABLE", sql="DROP TABLE t", is_a_read=False),
+    Probe(label="multi-statement", sql="SELECT 1; DROP TABLE t", is_a_read=False),
+    Probe(label="writable PRAGMA", sql="PRAGMA journal_mode=WAL", is_a_read=False),
 ]
 
 # Substring identifying a refusal that came from the read-only gate specifically,
@@ -156,8 +157,8 @@ async def run_matrix(cfg: Path) -> dict[str, tuple[bool, str]]:
             await session.initialize()
             names = {t.name for t in (await session.list_tools()).tools}
             assert "execute_sql" in names, f"execute_sql not exposed; saw {sorted(names)[:10]}"
-            for label, sql, _ in CASES:
-                res = await session.call_tool("execute_sql", {"sql": sql})
+            for case in CASES:
+                res = await session.call_tool("execute_sql", {"sql": case.sql})
                 raw = "".join(getattr(c, "text", "") for c in res.content)
                 try:
                     payload = json.loads(raw)
@@ -165,7 +166,7 @@ async def run_matrix(cfg: Path) -> dict[str, tuple[bool, str]]:
                     err = payload.get("error") or ""
                 except (json.JSONDecodeError, AttributeError):
                     ok, err = not res.isError, raw
-                results[label] = (ok, (err or "").strip())
+                results[case.label] = (ok, (err or "").strip())
     return results
 
 
@@ -185,12 +186,13 @@ async def main() -> int:
     print("-" * len(hdr))
 
     failures = []
-    for label, _, is_read in CASES:
+    for case in CASES:
+        label = case.label
         off_ok, _ = off[label]
         on_ok, on_err = on[label]
         gated = GATE_MARKER in on_err.lower()
 
-        if is_read:
+        if case.is_a_read:
             good = off_ok and on_ok
             verdict = "read allowed in both" if good else "READ BROKEN BY SWITCH"
         elif not off_ok:

--- a/scripts/e2e_sql_read_only_mcp.py
+++ b/scripts/e2e_sql_read_only_mcp.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+"""End-to-end check: does `agent.sql_read_only` gate the MCP `execute_sql` tool?
+
+Drives a REAL `datus-mcp --transport stdio` subprocess over JSON-RPC using the
+mcp SDK client. No mocks, no in-process shortcuts.
+
+Runs the whole matrix TWICE, with the switch on and off, and compares. That
+matters: "INSERT was refused" on its own proves nothing -- the write could be
+failing for an unrelated reason (read-only sqlite file, bad SQL, missing table).
+Only the OFF run establishes the write path works, which is what makes the ON
+run meaningful.
+
+The comparison also separates two things a single run conflates:
+  * refused BY THE SWITCH        -- what we are testing
+  * refused REGARDLESS of it     -- multi-statement input and writable PRAGMAs
+                                    are rejected by _validate_read_sql either
+                                    way; that is pre-existing behaviour, and
+                                    reporting it as a switch effect would
+                                    overstate what this change does.
+
+Companion: scripts/e2e_sql_read_only_mcp_project.py runs the same check
+against an existing project's conf/agent.yml instead of a synthetic one.
+
+Usage:  <repo>/.venv/bin/python scripts/e2e_sql_read_only_mcp.py
+Exit:   0 = switch behaves correctly, 1 = it does not
+"""
+
+import argparse
+import asyncio
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# (label, sql, is_a_read)
+CASES = [
+    ("SELECT", "SELECT COUNT(*) FROM t", True),
+    ("SHOW-ish (PRAGMA table_info)", "PRAGMA table_info(t)", True),
+    ("EXPLAIN", "EXPLAIN SELECT * FROM t", True),
+    ("INSERT", "INSERT INTO t (v) VALUES ('written')", False),
+    ("UPDATE", "UPDATE t SET v = 'mutated'", False),
+    ("DELETE", "DELETE FROM t", False),
+    ("CREATE TABLE", "CREATE TABLE t2 (id INT)", False),
+    ("DROP TABLE", "DROP TABLE t", False),
+    ("multi-statement", "SELECT 1; DROP TABLE t", False),
+    ("writable PRAGMA", "PRAGMA journal_mode=WAL", False),
+]
+
+# Substring identifying a refusal that came from the read-only gate specifically,
+# as opposed to the statement-shape checks that run regardless.
+GATE_MARKER = "this agent is read-only"
+
+
+def build_workspace(root: Path, *, sql_read_only: bool) -> Path:
+    home = root / ("on" if sql_read_only else "off")
+    home.mkdir(parents=True, exist_ok=True)
+
+    db = home / "probe.sqlite"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE t (v TEXT)")
+    con.execute("INSERT INTO t (v) VALUES ('seed')")
+    con.commit()
+    con.close()
+
+    agent = {
+        "home": str(home),
+        "target": "mock",
+        "models": {
+            "mock": {
+                "type": "openai",
+                "api_key": "mock-api-key",
+                "model": "mock-model",
+                "base_url": "http://localhost:0",
+            }
+        },
+        "services": {
+            "datasources": {"probe": {"type": "sqlite", "uri": str(db), "name": "probe", "default": True}},
+            "semantic_layer": {},
+        },
+        "agentic_nodes": {},
+    }
+    if sql_read_only:
+        agent["sql_read_only"] = True
+
+    cfg = home / "agent.yml"
+    cfg.write_text(yaml.safe_dump({"agent": agent}, sort_keys=False), encoding="utf-8")
+    return cfg
+
+
+async def run_matrix(cfg: Path) -> dict[str, tuple[bool, str]]:
+    """Return {label: (succeeded, error_text)} for every case."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[
+            "-m",
+            "datus.mcp_server",
+            "--datasource",
+            "probe",
+            "--transport",
+            "stdio",
+            "--config",
+            str(cfg),
+        ],
+        # cwd is the throwaway workspace, NOT a real project: running from a
+        # datus project directory would pull in its .datus/config.yml override
+        # and the server would fail to boot against this synthetic config.
+        cwd=str(cfg.parent),
+    )
+    results: dict[str, tuple[bool, str]] = {}
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            names = {t.name for t in (await session.list_tools()).tools}
+            assert "execute_sql" in names, f"execute_sql not exposed; saw {sorted(names)[:10]}"
+            for label, sql, _ in CASES:
+                res = await session.call_tool("execute_sql", {"sql": sql})
+                raw = "".join(getattr(c, "text", "") for c in res.content)
+                try:
+                    payload = json.loads(raw)
+                    ok = payload.get("success") == 1
+                    err = payload.get("error") or ""
+                except (json.JSONDecodeError, AttributeError):
+                    ok, err = not res.isError, raw
+                results[label] = (ok, (err or "").strip())
+    return results
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        print("running matrix with sql_read_only: true  ...")
+        on = await run_matrix(build_workspace(root, sql_read_only=True))
+        print("running matrix with sql_read_only: false ...\n")
+        off = await run_matrix(build_workspace(root, sql_read_only=False))
+
+    hdr = f"{'statement':<30} {'flag off':<12} {'flag on':<12} verdict"
+    print(hdr)
+    print("-" * len(hdr))
+
+    failures = []
+    for label, _, is_read in CASES:
+        off_ok, _ = off[label]
+        on_ok, on_err = on[label]
+        gated = GATE_MARKER in on_err.lower()
+
+        if is_read:
+            good = off_ok and on_ok
+            verdict = "read allowed in both" if good else "READ BROKEN BY SWITCH"
+        elif not off_ok:
+            # Rejected even with the switch off -> a statement-shape rule, not
+            # the switch. Correct, but not evidence for what we are testing.
+            good = not on_ok
+            verdict = "blocked either way (not the switch)"
+        else:
+            good = off_ok and on_ok is False and gated
+            verdict = "SWITCH REFUSED IT" if good else "LEAKED THROUGH"
+
+        if not good:
+            failures.append(label)
+        print(
+            f"{label:<30} {'ok' if off_ok else 'refused':<12} "
+            f"{'ok' if on_ok else 'refused':<12} {'' if good else '!! '}{verdict}"
+        )
+
+    print()
+    if failures:
+        print(f"FAIL: {', '.join(failures)}")
+        for label in failures:
+            print(f"  {label}: off={off[label]} on={on[label]}")
+        return 1
+    print("PASS - agent.sql_read_only gates the MCP execute_sql tool end to end")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/e2e_sql_read_only_mcp.py
+++ b/scripts/e2e_sql_read_only_mcp.py
@@ -79,7 +79,7 @@ CASES = [
 # the whole distinction the verdict table reports. That rules out both obvious
 # alternatives:
 #
-#   "read-only"          too loose -- classify_read_only_violation also says
+#   "read-only"          too loose -- validate_read_only_sql's caller also says
 #                        "Only read-only queries (SELECT, SHOW, ...) are
 #                        allowed", so gate refusals and shape refusals would
 #                        become indistinguishable.

--- a/scripts/e2e_sql_read_only_mcp.py
+++ b/scripts/e2e_sql_read_only_mcp.py
@@ -36,27 +36,62 @@ import sqlite3
 import sys
 import tempfile
 from pathlib import Path
+from typing import NamedTuple
 
 import yaml
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-# (label, sql, is_a_read)
+
+class Probe(NamedTuple):
+    """One statement to run under both flag settings.
+
+    A NamedTuple rather than a bare tuple so the third field is self-describing
+    at every use site -- `is_a_read` flips the whole verdict, and a positional
+    bool is exactly the field a reader guesses wrong. Not a Pydantic model:
+    these are literals in this file, there is no untrusted input to validate,
+    and a standalone operator script should not grow a dependency to name three
+    fields.
+    """
+
+    label: str
+    sql: str
+    is_a_read: bool
+
+
 CASES = [
-    ("SELECT", "SELECT COUNT(*) FROM t", True),
-    ("SHOW-ish (PRAGMA table_info)", "PRAGMA table_info(t)", True),
-    ("EXPLAIN", "EXPLAIN SELECT * FROM t", True),
-    ("INSERT", "INSERT INTO t (v) VALUES ('written')", False),
-    ("UPDATE", "UPDATE t SET v = 'mutated'", False),
-    ("DELETE", "DELETE FROM t", False),
-    ("CREATE TABLE", "CREATE TABLE t2 (id INT)", False),
-    ("DROP TABLE", "DROP TABLE t", False),
-    ("multi-statement", "SELECT 1; DROP TABLE t", False),
-    ("writable PRAGMA", "PRAGMA journal_mode=WAL", False),
+    Probe("SELECT", "SELECT COUNT(*) FROM t", True),
+    Probe("SHOW-ish (PRAGMA table_info)", "PRAGMA table_info(t)", True),
+    Probe("EXPLAIN", "EXPLAIN SELECT * FROM t", True),
+    Probe("INSERT", "INSERT INTO t (v) VALUES ('written')", False),
+    Probe("UPDATE", "UPDATE t SET v = 'mutated'", False),
+    Probe("DELETE", "DELETE FROM t", False),
+    Probe("CREATE TABLE", "CREATE TABLE t2 (id INT)", False),
+    Probe("DROP TABLE", "DROP TABLE t", False),
+    Probe("multi-statement", "SELECT 1; DROP TABLE t", False),
+    Probe("writable PRAGMA", "PRAGMA journal_mode=WAL", False),
 ]
 
 # Substring identifying a refusal that came from the read-only gate specifically,
 # as opposed to the statement-shape checks that run regardless.
+#
+# It must match the gate's wording and NOT the statement-shape wording, which is
+# the whole distinction the verdict table reports. That rules out both obvious
+# alternatives:
+#
+#   "read-only"          too loose -- classify_read_only_violation also says
+#                        "Only read-only queries (SELECT, SHOW, ...) are
+#                        allowed", so gate refusals and shape refusals would
+#                        become indistinguishable.
+#   "agent.sql_read_only" never matches -- that string appears only in the REST
+#                        route's message (cli_service), and these scripts probe
+#                        the MCP execute_sql tool, whose refusal reads "This
+#                        agent is read-only: ...". Using it would report every
+#                        gated statement as having reached the database.
+#
+# If the tool's wording ever changes, the flag-on matrix reports the writes as
+# executed and fails loudly; run_endpoint's zero-gated check catches the same
+# drift. Neither mode can pass silently on a stale marker.
 GATE_MARKER = "this agent is read-only"
 
 

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -55,6 +55,7 @@ from uuid import uuid4
 import yaml
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
 
 MISSING = "datus_readonly_probe_missing"
 
@@ -152,22 +153,45 @@ def _server_params(cfg: Path, datasource: str) -> StdioServerParameters:
 
 
 class McpSession:
-    """One `datus-mcp --transport stdio` subprocess, with an execute_sql helper."""
+    """An MCP session with an execute_sql helper.
 
-    def __init__(self, cfg: Path, datasource: str, *, dry_run: bool = False):
+    Either spawns its own `datus-mcp --transport stdio` subprocess from a staged
+    config, or attaches over streamable HTTP to a server someone else started
+    (`endpoint`).
+    """
+
+    def __init__(
+        self,
+        cfg: Path | None,
+        datasource: str,
+        *,
+        dry_run: bool = False,
+        endpoint: str | None = None,
+    ):
         self._cfg, self._datasource, self._dry_run = cfg, datasource, dry_run
+        self._endpoint = endpoint
         self._stack = None
         self._session = None
+        self.tools: list[str] = []
 
     async def __aenter__(self):
         from contextlib import AsyncExitStack
 
         self._stack = AsyncExitStack()
-        read, write = await self._stack.enter_async_context(stdio_client(_server_params(self._cfg, self._datasource)))
+        if self._endpoint:
+            # Attaching to a server we did not launch: its config, including
+            # whether sql_read_only is on, is fixed at its startup. That is why
+            # --endpoint reports what it observes rather than asserting a
+            # flag-on/flag-off contrast it has no way to arrange.
+            read, write, _ = await self._stack.enter_async_context(streamablehttp_client(self._endpoint))
+        else:
+            read, write = await self._stack.enter_async_context(
+                stdio_client(_server_params(self._cfg, self._datasource))
+            )
         self._session = await self._stack.enter_async_context(ClientSession(read, write))
         await self._session.initialize()
-        names = {t.name for t in (await self._session.list_tools()).tools}
-        assert "execute_sql" in names, f"execute_sql not exposed; saw {sorted(names)[:10]}"
+        self.tools = sorted(t.name for t in (await self._session.list_tools()).tools)
+        assert "execute_sql" in self.tools, f"execute_sql not exposed; saw {self.tools[:10]}"
         return self
 
     async def __aexit__(self, *exc):
@@ -253,6 +277,87 @@ async def run_matrix(cfg: Path, datasource: str) -> dict[str, tuple[bool, str]]:
                     ok, err = not res.isError, raw
                 results[label] = (ok, (err or "").strip())
     return results
+
+
+async def run_endpoint(endpoint: str) -> int:
+    """Probe a server someone else already started.
+
+    Unlike the other modes this cannot arrange a flag-on/flag-off contrast --
+    the server's config is fixed at launch -- so it reports what it observes
+    rather than asserting a comparison. What it can still establish is where a
+    statement was stopped: a refusal carrying the read-only message never
+    reached the connector, while any other error means it did.
+
+    Every non-read probe targets a table that does not exist, so this is safe to
+    point at a server whose read-only posture you have not confirmed.
+    """
+    reads = [
+        ("SELECT 1", "SELECT 1"),
+        ("SHOW DATABASES", "SHOW DATABASES"),
+    ]
+    writes = [
+        ("INSERT", f"INSERT INTO {MISSING} (v) VALUES ('x')"),
+        ("UPDATE", f"UPDATE {MISSING} SET v = 'x'"),
+        ("DELETE", f"DELETE FROM {MISSING}"),
+        ("CREATE TABLE (CTAS)", f"CREATE TABLE {MISSING}_2 AS SELECT * FROM {MISSING}"),
+        ("ALTER TABLE", f"ALTER TABLE {MISSING} ADD COLUMN c INT"),
+        ("DROP TABLE", f"DROP TABLE {MISSING}"),
+        ("TRUNCATE", f"TRUNCATE TABLE {MISSING}"),
+        ("INSERT OVERWRITE", f"INSERT OVERWRITE {MISSING} SELECT 1"),
+        ("SUBMIT TASK", f"SUBMIT TASK t AS INSERT INTO {MISSING} SELECT 1"),
+        ("SET", "SET is_report_audit_info = true"),
+        ("USE", "USE information_schema"),
+        ("multi-statement", f"SELECT 1; DROP TABLE {MISSING}"),
+    ]
+
+    async with McpSession(None, "", endpoint=endpoint) as sess:
+        print(f"tools exposed : {len(sess.tools)}")
+        print(f"probes        : non-read statements target `{MISSING}`, which must not exist\n")
+
+        print(f"{'READ probe':<26} outcome")
+        print("-" * 74)
+        reachable = False
+        read_blocked = []
+        for label, sql in reads:
+            ok, err, _ = await sess.sql(sql)
+            gated = GATE_MARKER in err.lower()
+            reachable |= ok
+            if gated:
+                read_blocked.append(label)
+            print(f"{label:<26} {'ok' if ok else ('REFUSED BY GATE' if gated else f'db error: {err[:36]}')}")
+
+        print(f"\n{'WRITE / DDL probe':<26} {'refused':<9} stopped by")
+        print("-" * 74)
+        leaked = []
+        gated_count = 0
+        for label, sql in writes:
+            ok, err, _ = await sess.sql(sql)
+            gated = GATE_MARKER in err.lower()
+            gated_count += gated
+            if ok:
+                who = "NOTHING -- IT EXECUTED"
+                leaked.append(label)
+            elif gated:
+                who = "the read-only gate (never reached the connector)"
+            else:
+                who = f"something else: {err[:40]}"
+            print(f"{label:<26} {'no' if ok else 'yes':<9} {'!! ' if ok else ''}{who}")
+
+    print()
+    if not reachable:
+        print("NOTE: no read succeeded, so the datasource is unreachable from this server.")
+        print("      Refusals below the gate are still meaningful (they never got that far),")
+        print("      but this run does not show reads working.")
+    if leaked:
+        print(f"FAIL - reached the warehouse: {', '.join(leaked)}")
+        return 1
+    if read_blocked:
+        print(f"FAIL - the gate wrongly blocked reads: {', '.join(read_blocked)}")
+        return 1
+    print(f"PASS - {gated_count}/{len(writes)} write probes stopped by the read-only gate")
+    if gated_count < len(writes):
+        print("       (the remainder were refused by other rules; see above)")
+    return 0
 
 
 async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, dry_run: bool) -> int:
@@ -412,7 +517,15 @@ async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, d
 
 async def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--project", required=True, type=Path)
+    ap.add_argument(
+        "--endpoint",
+        default=None,
+        help="probe a server that is ALREADY running, over streamable HTTP "
+        "(e.g. http://127.0.0.1:8000/mcp) instead of launching one. Reports what "
+        "it observes; it cannot arrange the flag-on/flag-off contrast the other "
+        "modes rely on. Makes --project optional.",
+    )
+    ap.add_argument("--project", required=False, type=Path)
     ap.add_argument(
         "--live-writes",
         action="store_true",
@@ -441,6 +554,16 @@ async def main() -> int:
     )
     args = ap.parse_args()
 
+    if args.endpoint:
+        if args.live_writes or args.sqlite_standin:
+            print("--endpoint cannot be combined with the modes that launch a server", file=sys.stderr)
+            return 1
+        print(f"endpoint      : {args.endpoint} (already running; its config is whatever it was started with)")
+        return await run_endpoint(args.endpoint)
+
+    if not args.project:
+        print("--project is required unless --endpoint is given", file=sys.stderr)
+        return 1
     project: Path = args.project.expanduser().resolve()
     agent = yaml.safe_load((project / "conf" / "agent.yml").read_text(encoding="utf-8"))["agent"]
     datasources = agent.get("services", {}).get("datasources", {})

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -45,10 +45,12 @@ import argparse
 import asyncio
 import copy
 import json
+import re
 import sqlite3
 import sys
 import tempfile
 from pathlib import Path
+from uuid import uuid4
 
 import yaml
 from mcp import ClientSession, StdioServerParameters
@@ -127,6 +129,106 @@ def stage_config(project: Path, dest: Path, *, sql_read_only: bool, standin: str
     return cfg
 
 
+PROBE_PREFIX = "datus_ro_probe"
+
+
+def _server_params(cfg: Path, datasource: str) -> StdioServerParameters:
+    return StdioServerParameters(
+        command=sys.executable,
+        args=[
+            "-m",
+            "datus.mcp_server",
+            "--datasource",
+            datasource,
+            "--transport",
+            "stdio",
+            "--config",
+            str(cfg),
+        ],
+        # cwd is the staging dir, never the project: `home: .` is relative, and
+        # a project cwd would also pull in its .datus/config.yml override.
+        cwd=str(cfg.parent),
+    )
+
+
+class McpSession:
+    """One `datus-mcp --transport stdio` subprocess, with an execute_sql helper."""
+
+    def __init__(self, cfg: Path, datasource: str, *, dry_run: bool = False):
+        self._cfg, self._datasource, self._dry_run = cfg, datasource, dry_run
+        self._stack = None
+        self._session = None
+
+    async def __aenter__(self):
+        from contextlib import AsyncExitStack
+
+        self._stack = AsyncExitStack()
+        read, write = await self._stack.enter_async_context(stdio_client(_server_params(self._cfg, self._datasource)))
+        self._session = await self._stack.enter_async_context(ClientSession(read, write))
+        await self._session.initialize()
+        names = {t.name for t in (await self._session.list_tools()).tools}
+        assert "execute_sql" in names, f"execute_sql not exposed; saw {sorted(names)[:10]}"
+        return self
+
+    async def __aexit__(self, *exc):
+        await self._stack.__aexit__(*exc)
+
+    async def sql(self, statement: str) -> tuple[bool, str, object]:
+        """Return (succeeded, error_text, result)."""
+        if self._dry_run:
+            print(f"      [dry-run] {statement}")
+            return True, "", None
+        res = await self._session.call_tool("execute_sql", {"sql": statement})
+        raw = "".join(getattr(c, "text", "") for c in res.content)
+        try:
+            payload = json.loads(raw)
+            return payload.get("success") == 1, (payload.get("error") or "").strip(), payload.get("result")
+        except (json.JSONDecodeError, AttributeError):
+            return not res.isError, raw.strip(), raw
+
+
+def create_probe_ddl(dialect: str, table: str) -> str:
+    """CREATE for a scratch probe table, in the flavour the datasource needs."""
+    if (dialect or "").lower() in {"starrocks", "doris"}:
+        # PRIMARY KEY so UPDATE/DELETE are permitted; replication_num 1 so a
+        # single-BE cluster can satisfy it.
+        return (
+            f"CREATE TABLE {table} (id INT, v VARCHAR(64)) "
+            f"PRIMARY KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 "
+            f'PROPERTIES ("replication_num" = "1")'
+        )
+    return f"CREATE TABLE {table} (id INT, v VARCHAR(64))"
+
+
+def live_cases(dml: str, drop_me: str, ctas: str) -> list[tuple[str, str, bool]]:
+    """Probes for --live-writes, all scoped to this run's own scratch tables."""
+    return [
+        ("SELECT", f"SELECT COUNT(*) FROM {dml}", True),
+        ("EXPLAIN", f"EXPLAIN SELECT * FROM {dml}", True),
+        ("INSERT", f"INSERT INTO {dml} (id, v) VALUES (99, 'written')", False),
+        ("UPDATE", f"UPDATE {dml} SET v = 'mutated' WHERE id = 1", False),
+        ("DELETE", f"DELETE FROM {dml} WHERE id = 2", False),
+        ("CREATE TABLE (CTAS)", f"CREATE TABLE {ctas} AS SELECT * FROM {dml}", False),
+        ("TRUNCATE", f"TRUNCATE TABLE {dml}", False),
+        ("DROP TABLE", f"DROP TABLE {drop_me}", False),
+        ("multi-statement", f"SELECT 1; DROP TABLE {dml}", False),
+    ]
+
+
+async def row_count(sess: McpSession, table: str) -> int | None:
+    ok, _, result = await sess.sql(f"SELECT COUNT(*) AS n FROM {table}")
+    if not ok:
+        return None
+    text = json.dumps(result, default=str)
+    nums = re.findall(r"\d+", text)
+    return int(nums[-1]) if nums else None
+
+
+async def table_exists(sess: McpSession, table: str) -> bool:
+    ok, _, _ = await sess.sql(f"SELECT COUNT(*) FROM {table}")
+    return ok
+
+
 async def run_matrix(cfg: Path, datasource: str) -> dict[str, tuple[bool, str]]:
     params = StdioServerParameters(
         command=sys.executable,
@@ -153,9 +255,170 @@ async def run_matrix(cfg: Path, datasource: str) -> dict[str, tuple[bool, str]]:
     return results
 
 
+async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, dry_run: bool) -> int:
+    """Full write round-trip against the project's REAL datasource.
+
+    Only for a datasource you are willing to write to. Everything it touches is
+    a table it creates itself, named `datus_ro_probe_<run id>_*`, and teardown
+    runs in a finally block. If teardown cannot complete, the exact DROP
+    statements are printed so nothing is left silently orphaned.
+
+    The decisive assertion is step 5: after the flag-on matrix, the scratch
+    tables are byte-for-byte as the flag-off matrix left them. The flag-off run
+    has already proven every one of those statements really mutates this
+    datasource, so "unchanged" can only mean the gate stopped them.
+    """
+    run_id = uuid4().hex[:8]
+    dml = f"{PROBE_PREFIX}_{run_id}_dml"
+    drop_me = f"{PROBE_PREFIX}_{run_id}_drop"
+    ctas = f"{PROBE_PREFIX}_{run_id}_ctas"
+    scratch = [dml, drop_me, ctas]
+
+    print(f"scratch tables : {', '.join(scratch)}")
+    print("               (created by this run, dropped in a finally block)\n")
+
+    async def seed(sess: McpSession) -> None:
+        for table in (dml, drop_me):
+            ok, err, _ = await sess.sql(create_probe_ddl(dialect, table))
+            if not ok and "exist" not in err.lower():
+                raise RuntimeError(f"could not create {table}: {err}")
+        for i in (1, 2, 3):
+            await sess.sql(f"INSERT INTO {dml} (id, v) VALUES ({i}, 'seed{i}')")
+
+    async def drop_all(sess: McpSession) -> list[str]:
+        survivors = []
+        for table in scratch:
+            await sess.sql(f"DROP TABLE {table}")
+            if not dry_run and await table_exists(sess, table):
+                survivors.append(table)
+        return survivors
+
+    cases = live_cases(dml, drop_me, ctas)
+    failures: list[str] = []
+
+    try:
+        # 1. preflight + setup, flag off
+        async with McpSession(cfg_off, datasource, dry_run=dry_run) as sess:
+            for table in scratch:
+                if not dry_run and await table_exists(sess, table):
+                    print(f"ABORT: {table} already exists; refusing to touch it")
+                    return 1
+            print("1. creating scratch tables (flag off) ...")
+            await seed(sess)
+
+            # 2. flag-off matrix -- the negative control: these really execute
+            print("2. running probes with sql_read_only: false (writes execute) ...")
+            off: dict[str, tuple[bool, str]] = {}
+            for label, statement, _ in cases:
+                ok, err, _ = await sess.sql(statement)
+                off[label] = (ok, err)
+
+            # 3. restore what the flag-off run destroyed, so both runs start level
+            print("3. restoring scratch tables ...")
+            await sess.sql(f"DROP TABLE {ctas}")
+            await sess.sql(f"DROP TABLE {dml}")
+            await sess.sql(f"DROP TABLE {drop_me}")
+            await seed(sess)
+            baseline = await row_count(sess, dml)
+
+        # 4. flag-on matrix
+        print("4. running probes with sql_read_only: true  (must all be refused) ...")
+        async with McpSession(cfg_on, datasource, dry_run=dry_run) as sess:
+            on: dict[str, tuple[bool, str]] = {}
+            for label, statement, _ in cases:
+                ok, err, _ = await sess.sql(statement)
+                on[label] = (ok, err)
+
+            # 5. the decisive check -- reads still work under the flag, so this
+            #    integrity verification runs inside the hardened session.
+            print("5. verifying the datasource is untouched ...\n")
+            after = await row_count(sess, dml)
+            drop_survived = await table_exists(sess, drop_me)
+            ctas_absent = not await table_exists(sess, ctas)
+
+        hdr = f"{'statement':<22} {'flag off':<14} {'flag on':<14} verdict"
+        print(hdr)
+        print("-" * len(hdr))
+        for label, _, is_read in cases:
+            off_ok, off_err = off[label]
+            on_ok, on_err = on[label]
+            gated = GATE_MARKER in on_err.lower()
+
+            if is_read:
+                good = not gated
+                verdict = "read not blocked" if good else "READ WRONGLY BLOCKED"
+            elif off_err and off_err == on_err:
+                good = True
+                verdict = "blocked either way (not the switch)"
+            elif not off_ok:
+                good = not on_ok
+                verdict = f"inconclusive - failed with flag off too ({off_err[:40]})"
+            else:
+                good = (not on_ok) and gated
+                verdict = "executed off, refused on" if good else "EXECUTED WITH FLAG ON"
+
+            if not good:
+                failures.append(label)
+            print(
+                f"{label:<22} {'executed' if off_ok else 'failed':<14} "
+                f"{'executed' if on_ok else 'refused':<14} {'' if good else '!! '}{verdict}"
+            )
+
+        print()
+        checks = [
+            (f"{dml} row count unchanged ({baseline} -> {after})", baseline == after),
+            (f"{drop_me} survived the DROP probe", drop_survived),
+            (f"{ctas} was never created", ctas_absent),
+        ]
+        for text, good in checks:
+            print(f"  {'ok  ' if good else 'FAIL'} {text}")
+            if not good:
+                failures.append(text)
+
+    finally:
+        print("\n6. dropping scratch tables ...")
+        try:
+            async with McpSession(cfg_off, datasource, dry_run=dry_run) as sess:
+                survivors = await drop_all(sess)
+            if survivors:
+                print(f"  !! COULD NOT DROP: {', '.join(survivors)}")
+                print("  Run these by hand:")
+                for table in survivors:
+                    print(f"    DROP TABLE {table};")
+                failures.append("teardown")
+            else:
+                print("  ok   all scratch tables removed")
+        except Exception as exc:  # noqa: BLE001 - teardown must report, never mask
+            print(f"  !! teardown failed: {exc}")
+            print("  Run these by hand:")
+            for table in scratch:
+                print(f"    DROP TABLE {table};")
+            failures.append("teardown")
+
+    print()
+    if failures:
+        print(f"FAIL: {', '.join(failures)}")
+        return 1
+    print("PASS - agent.sql_read_only blocks real writes against the live datasource")
+    return 0
+
+
 async def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--project", required=True, type=Path)
+    ap.add_argument(
+        "--live-writes",
+        action="store_true",
+        help="WRITES TO THE PROJECT'S REAL DATASOURCE. Creates its own scratch tables, "
+        "runs the probes against them for real, verifies the flag-on run changed "
+        "nothing, then drops them in a finally block. Only for a datasource you are "
+        "willing to write to.",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="with --live-writes, print every statement instead of executing it",
+    )
     ap.add_argument(
         "--sqlite-standin",
         action="store_true",
@@ -188,6 +451,11 @@ async def main() -> int:
 
     print(f"project    : {project}")
     print(f"datasource : {datasource} (type={datasources.get(datasource, {}).get('type')})")
+    if args.live_writes and args.sqlite_standin:
+        print("--live-writes and --sqlite-standin are mutually exclusive", file=sys.stderr)
+        return 1
+    if args.live_writes:
+        print(f"MODE       : LIVE WRITES against the real datasource{' (dry run)' if args.dry_run else ''}\n")
     if args.sqlite_standin:
         print(
             "datasource : SUBSTITUTED with a throwaway sqlite (--sqlite-standin); "
@@ -197,7 +465,7 @@ async def main() -> int:
             f"probes     : non-read statements target `{MISSING}`, which EXISTS in "
             f"the stand-in, so writes really execute when the flag is off\n"
         )
-    else:
+    elif not args.live_writes:
         print(f"probes     : non-read statements target `{MISSING}`, which must not exist\n")
 
     with tempfile.TemporaryDirectory() as td:
@@ -206,10 +474,17 @@ async def main() -> int:
         on_dir.mkdir()
         off_dir.mkdir()
         standin = datasource if args.sqlite_standin else None
+        cfg_on = stage_config(project, on_dir, sql_read_only=True, standin=standin)
+        cfg_off = stage_config(project, off_dir, sql_read_only=False, standin=standin)
+
+        if args.live_writes:
+            dialect = datasources.get(datasource, {}).get("type", "")
+            return await run_live(cfg_on, cfg_off, datasource, dialect, args.dry_run)
+
         print("running matrix with sql_read_only: true  ...")
-        on = await run_matrix(stage_config(project, on_dir, sql_read_only=True, standin=standin), datasource)
+        on = await run_matrix(cfg_on, datasource)
         print("running matrix with sql_read_only: false ...\n")
-        off = await run_matrix(stage_config(project, off_dir, sql_read_only=False, standin=standin), datasource)
+        off = await run_matrix(cfg_off, datasource)
 
     hdr = f"{'statement':<22} {'flag off':<14} {'flag on':<14} verdict"
     print(hdr)

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -55,6 +55,7 @@ import sqlite3
 import sys
 import tempfile
 from pathlib import Path
+from typing import NamedTuple
 from uuid import uuid4
 
 import yaml
@@ -64,20 +65,42 @@ from mcp.client.streamable_http import streamablehttp_client
 
 MISSING = "datus_readonly_probe_missing"
 
-# (label, sql, is_a_read)
+
+class Probe(NamedTuple):
+    """One statement to run under both flag settings.
+
+    A NamedTuple rather than a bare tuple so the third field is self-describing
+    at every use site -- `is_a_read` flips the whole verdict, and a positional
+    bool is exactly the field a reader guesses wrong. Not a Pydantic model:
+    these are literals built in this file, there is no untrusted input to
+    validate, and a standalone operator script should not grow a dependency to
+    name three fields.
+    """
+
+    label: str
+    sql: str
+    is_a_read: bool
+
+
 CASES = [
-    ("SELECT", "SELECT 1", True),
-    ("SHOW", "SHOW DATABASES", True),
-    ("EXPLAIN", "EXPLAIN SELECT 1", True),
-    ("INSERT", f"INSERT INTO {MISSING} (v) VALUES ('x')", False),
-    ("UPDATE", f"UPDATE {MISSING} SET v = 'x'", False),
-    ("DELETE", f"DELETE FROM {MISSING}", False),
-    ("CREATE TABLE (CTAS)", f"CREATE TABLE {MISSING}_2 AS SELECT * FROM {MISSING}", False),
-    ("DROP TABLE", f"DROP TABLE {MISSING}", False),
-    ("TRUNCATE", f"TRUNCATE TABLE {MISSING}", False),
-    ("multi-statement", f"SELECT 1; DROP TABLE {MISSING}", False),
+    Probe("SELECT", "SELECT 1", True),
+    Probe("SHOW", "SHOW DATABASES", True),
+    Probe("EXPLAIN", "EXPLAIN SELECT 1", True),
+    Probe("INSERT", f"INSERT INTO {MISSING} (v) VALUES ('x')", False),
+    Probe("UPDATE", f"UPDATE {MISSING} SET v = 'x'", False),
+    Probe("DELETE", f"DELETE FROM {MISSING}", False),
+    Probe("CREATE TABLE (CTAS)", f"CREATE TABLE {MISSING}_2 AS SELECT * FROM {MISSING}", False),
+    Probe("DROP TABLE", f"DROP TABLE {MISSING}", False),
+    Probe("TRUNCATE", f"TRUNCATE TABLE {MISSING}", False),
+    Probe("multi-statement", f"SELECT 1; DROP TABLE {MISSING}", False),
 ]
 
+# Substring identifying a refusal that came from the read-only gate specifically,
+# as opposed to the statement-shape checks that run regardless. See the same
+# constant in e2e_sql_read_only_mcp.py for why neither "read-only" (too loose --
+# it also matches the statement-shape message) nor "agent.sql_read_only" (never
+# matches -- that wording belongs to the REST route, not the MCP tool) can be
+# used here.
 GATE_MARKER = "this agent is read-only"
 
 
@@ -229,18 +252,18 @@ def create_probe_ddl(dialect: str, table: str) -> str:
     return f"CREATE TABLE {table} (id INT, v VARCHAR(64))"
 
 
-def live_cases(dml: str, drop_me: str, ctas: str) -> list[tuple[str, str, bool]]:
+def live_cases(dml: str, drop_me: str, ctas: str) -> list[Probe]:
     """Probes for --live-writes, all scoped to this run's own scratch tables."""
     return [
-        ("SELECT", f"SELECT COUNT(*) FROM {dml}", True),
-        ("EXPLAIN", f"EXPLAIN SELECT * FROM {dml}", True),
-        ("INSERT", f"INSERT INTO {dml} (id, v) VALUES (99, 'written')", False),
-        ("UPDATE", f"UPDATE {dml} SET v = 'mutated' WHERE id = 1", False),
-        ("DELETE", f"DELETE FROM {dml} WHERE id = 2", False),
-        ("CREATE TABLE (CTAS)", f"CREATE TABLE {ctas} AS SELECT * FROM {dml}", False),
-        ("TRUNCATE", f"TRUNCATE TABLE {dml}", False),
-        ("DROP TABLE", f"DROP TABLE {drop_me}", False),
-        ("multi-statement", f"SELECT 1; DROP TABLE {dml}", False),
+        Probe("SELECT", f"SELECT COUNT(*) FROM {dml}", True),
+        Probe("EXPLAIN", f"EXPLAIN SELECT * FROM {dml}", True),
+        Probe("INSERT", f"INSERT INTO {dml} (id, v) VALUES (99, 'written')", False),
+        Probe("UPDATE", f"UPDATE {dml} SET v = 'mutated' WHERE id = 1", False),
+        Probe("DELETE", f"DELETE FROM {dml} WHERE id = 2", False),
+        Probe("CREATE TABLE (CTAS)", f"CREATE TABLE {ctas} AS SELECT * FROM {dml}", False),
+        Probe("TRUNCATE", f"TRUNCATE TABLE {dml}", False),
+        Probe("DROP TABLE", f"DROP TABLE {drop_me}", False),
+        Probe("multi-statement", f"SELECT 1; DROP TABLE {dml}", False),
     ]
 
 

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -336,6 +336,13 @@ async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, d
             drop_survived = await table_exists(sess, drop_me)
             ctas_absent = not await table_exists(sess, ctas)
 
+        if dry_run:
+            # Nothing ran, so every probe reports the stub's success and the
+            # verdict table would be uniformly, misleadingly red. The statement
+            # listing above is the whole point of a dry run.
+            print("dry run: statements listed above were NOT executed; no verdicts to report")
+            return 0
+
         hdr = f"{'statement':<22} {'flag off':<14} {'flag on':<14} verdict"
         print(hdr)
         print("-" * len(hdr))

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -55,27 +55,28 @@ import sqlite3
 import sys
 import tempfile
 from pathlib import Path
-from typing import NamedTuple
 from uuid import uuid4
 
 import yaml
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
+from pydantic import BaseModel, ConfigDict
 
 MISSING = "datus_readonly_probe_missing"
 
 
-class Probe(NamedTuple):
+class Probe(BaseModel):
     """One statement to run under both flag settings.
 
-    A NamedTuple rather than a bare tuple so the third field is self-describing
-    at every use site -- `is_a_read` flips the whole verdict, and a positional
-    bool is exactly the field a reader guesses wrong. Not a Pydantic model:
-    these are literals built in this file, there is no untrusted input to
-    validate, and a standalone operator script should not grow a dependency to
-    name three fields.
+    A model rather than a bare tuple so the third field is self-describing at
+    every use site -- `is_a_read` flips the whole verdict, and a positional bool
+    is exactly the field a reader guesses wrong. Frozen because these are
+    constants: a probe rewritten mid-run would silently change what the verdict
+    table claims was tested.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     label: str
     sql: str
@@ -83,16 +84,16 @@ class Probe(NamedTuple):
 
 
 CASES = [
-    Probe("SELECT", "SELECT 1", True),
-    Probe("SHOW", "SHOW DATABASES", True),
-    Probe("EXPLAIN", "EXPLAIN SELECT 1", True),
-    Probe("INSERT", f"INSERT INTO {MISSING} (v) VALUES ('x')", False),
-    Probe("UPDATE", f"UPDATE {MISSING} SET v = 'x'", False),
-    Probe("DELETE", f"DELETE FROM {MISSING}", False),
-    Probe("CREATE TABLE (CTAS)", f"CREATE TABLE {MISSING}_2 AS SELECT * FROM {MISSING}", False),
-    Probe("DROP TABLE", f"DROP TABLE {MISSING}", False),
-    Probe("TRUNCATE", f"TRUNCATE TABLE {MISSING}", False),
-    Probe("multi-statement", f"SELECT 1; DROP TABLE {MISSING}", False),
+    Probe(label="SELECT", sql="SELECT 1", is_a_read=True),
+    Probe(label="SHOW", sql="SHOW DATABASES", is_a_read=True),
+    Probe(label="EXPLAIN", sql="EXPLAIN SELECT 1", is_a_read=True),
+    Probe(label="INSERT", sql=f"INSERT INTO {MISSING} (v) VALUES ('x')", is_a_read=False),
+    Probe(label="UPDATE", sql=f"UPDATE {MISSING} SET v = 'x'", is_a_read=False),
+    Probe(label="DELETE", sql=f"DELETE FROM {MISSING}", is_a_read=False),
+    Probe(label="CREATE TABLE (CTAS)", sql=f"CREATE TABLE {MISSING}_2 AS SELECT * FROM {MISSING}", is_a_read=False),
+    Probe(label="DROP TABLE", sql=f"DROP TABLE {MISSING}", is_a_read=False),
+    Probe(label="TRUNCATE", sql=f"TRUNCATE TABLE {MISSING}", is_a_read=False),
+    Probe(label="multi-statement", sql=f"SELECT 1; DROP TABLE {MISSING}", is_a_read=False),
 ]
 
 # Substring identifying a refusal that came from the read-only gate specifically,
@@ -255,15 +256,15 @@ def create_probe_ddl(dialect: str, table: str) -> str:
 def live_cases(dml: str, drop_me: str, ctas: str) -> list[Probe]:
     """Probes for --live-writes, all scoped to this run's own scratch tables."""
     return [
-        Probe("SELECT", f"SELECT COUNT(*) FROM {dml}", True),
-        Probe("EXPLAIN", f"EXPLAIN SELECT * FROM {dml}", True),
-        Probe("INSERT", f"INSERT INTO {dml} (id, v) VALUES (99, 'written')", False),
-        Probe("UPDATE", f"UPDATE {dml} SET v = 'mutated' WHERE id = 1", False),
-        Probe("DELETE", f"DELETE FROM {dml} WHERE id = 2", False),
-        Probe("CREATE TABLE (CTAS)", f"CREATE TABLE {ctas} AS SELECT * FROM {dml}", False),
-        Probe("TRUNCATE", f"TRUNCATE TABLE {dml}", False),
-        Probe("DROP TABLE", f"DROP TABLE {drop_me}", False),
-        Probe("multi-statement", f"SELECT 1; DROP TABLE {dml}", False),
+        Probe(label="SELECT", sql=f"SELECT COUNT(*) FROM {dml}", is_a_read=True),
+        Probe(label="EXPLAIN", sql=f"EXPLAIN SELECT * FROM {dml}", is_a_read=True),
+        Probe(label="INSERT", sql=f"INSERT INTO {dml} (id, v) VALUES (99, 'written')", is_a_read=False),
+        Probe(label="UPDATE", sql=f"UPDATE {dml} SET v = 'mutated' WHERE id = 1", is_a_read=False),
+        Probe(label="DELETE", sql=f"DELETE FROM {dml} WHERE id = 2", is_a_read=False),
+        Probe(label="CREATE TABLE (CTAS)", sql=f"CREATE TABLE {ctas} AS SELECT * FROM {dml}", is_a_read=False),
+        Probe(label="TRUNCATE", sql=f"TRUNCATE TABLE {dml}", is_a_read=False),
+        Probe(label="DROP TABLE", sql=f"DROP TABLE {drop_me}", is_a_read=False),
+        Probe(label="multi-statement", sql=f"SELECT 1; DROP TABLE {dml}", is_a_read=False),
     ]
 
 
@@ -328,9 +329,9 @@ async def run_matrix(cfg: Path, datasource: str) -> dict[str, tuple[bool, str]]:
     """
     results: dict[str, tuple[bool, str]] = {}
     async with McpSession(cfg, datasource) as sess:
-        for label, sql, _ in CASES:
-            ok, err, _ = await sess.sql(sql)
-            results[label] = (ok, err)
+        for case in CASES:
+            ok, err, _ = await sess.sql(case.sql)
+            results[case.label] = (ok, err)
     return results
 
 
@@ -482,9 +483,9 @@ async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, d
             # 2. flag-off matrix -- the negative control: these really execute
             print("2. running probes with sql_read_only: false (writes execute) ...")
             off: dict[str, tuple[bool, str]] = {}
-            for label, statement, _ in cases:
-                ok, err, _ = await sess.sql(statement)
-                off[label] = (ok, err)
+            for case in cases:
+                ok, err, _ = await sess.sql(case.sql)
+                off[case.label] = (ok, err)
 
             # 3. restore what the flag-off run destroyed, so both runs start level
             print("3. restoring scratch tables ...")
@@ -498,9 +499,9 @@ async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, d
         print("4. running probes with sql_read_only: true  (must all be refused) ...")
         async with McpSession(cfg_on, datasource, dry_run=dry_run) as sess:
             on: dict[str, tuple[bool, str]] = {}
-            for label, statement, _ in cases:
-                ok, err, _ = await sess.sql(statement)
-                on[label] = (ok, err)
+            for case in cases:
+                ok, err, _ = await sess.sql(case.sql)
+                on[case.label] = (ok, err)
 
             # 5. the decisive check -- reads still work under the flag, so this
             #    integrity verification runs inside the hardened session.
@@ -519,12 +520,13 @@ async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, d
         hdr = f"{'statement':<22} {'flag off':<14} {'flag on':<14} verdict"
         print(hdr)
         print("-" * len(hdr))
-        for label, _, is_read in cases:
+        for case in cases:
+            label = case.label
             off_ok, off_err = off[label]
             on_ok, on_err = on[label]
             gated = GATE_MARKER in on_err.lower()
 
-            if is_read:
+            if case.is_a_read:
                 good = not gated
                 verdict = "read not blocked" if good else "READ WRONGLY BLOCKED"
             elif off_err and off_err == on_err:
@@ -704,7 +706,8 @@ async def main() -> int:
     print("-" * len(hdr))
 
     failures = []
-    for label, _, is_read in CASES:
+    for case in CASES:
+        label = case.label
 
         def where(entry: tuple[bool, str]) -> str:
             ok, err = entry
@@ -714,7 +717,7 @@ async def main() -> int:
 
         off_where, on_where = where(off[label]), where(on[label])
 
-        if is_read:
+        if case.is_a_read:
             good = on_where != "GATE"
             verdict = "read not blocked" if good else "READ WRONGLY BLOCKED"
         elif off_where == "GATE":

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -39,6 +39,10 @@ Usage:
     <repo>/.venv/bin/python scripts/e2e_sql_read_only_mcp_project.py \
         --project /path/to/project [--datasource NAME] [--sqlite-standin]
 Exit: 0 = gate behaves correctly, 1 = it does not
+
+This is an operator tool, not library code: its verdict table on stdout IS the
+deliverable, so it uses `print` rather than the `get_logger` the package
+requires. Nothing under `datus/` imports it.
 """
 
 import argparse
@@ -254,28 +258,18 @@ async def table_exists(sess: McpSession, table: str) -> bool:
 
 
 async def run_matrix(cfg: Path, datasource: str) -> dict[str, tuple[bool, str]]:
-    params = StdioServerParameters(
-        command=sys.executable,
-        args=["-m", "datus.mcp_server", "--datasource", datasource, "--transport", "stdio", "--config", str(cfg)],
-        # cwd is the staging dir, never the project: `home: .` is relative, and
-        # a project cwd would also pull in its .datus/config.yml override.
-        cwd=str(cfg.parent),
-    )
+    """Run every CASES probe against a server staged from ``cfg``.
+
+    Goes through ``McpSession`` rather than driving ``stdio_client`` directly:
+    the session already owns how the subprocess is spawned (``_server_params``)
+    and how an ``execute_sql`` payload is unwrapped, and a second copy of either
+    is a copy that can disagree with the one --live-writes uses.
+    """
     results: dict[str, tuple[bool, str]] = {}
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            names = {t.name for t in (await session.list_tools()).tools}
-            assert "execute_sql" in names, f"execute_sql not exposed; saw {sorted(names)[:10]}"
-            for label, sql, _ in CASES:
-                res = await session.call_tool("execute_sql", {"sql": sql})
-                raw = "".join(getattr(c, "text", "") for c in res.content)
-                try:
-                    payload = json.loads(raw)
-                    ok, err = payload.get("success") == 1, payload.get("error") or ""
-                except (json.JSONDecodeError, AttributeError):
-                    ok, err = not res.isError, raw
-                results[label] = (ok, (err or "").strip())
+    async with McpSession(cfg, datasource) as sess:
+        for label, sql, _ in CASES:
+            ok, err, _ = await sess.sql(sql)
+            results[label] = (ok, err)
     return results
 
 

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -125,7 +125,7 @@ def stage_config(project: Path, dest: Path, *, sql_read_only: bool, standin: str
     so the gate cannot be exercised at all. With a stand-in the probes really
     execute, which upgrades the check from "gate placement" to a full write
     round-trip. The cost is that the connector dialect is sqlite, not the
-    project's; classify_read_only_violation should be checked separately
+    project's; validate_read_only_sql should be checked separately
     against the real dialect.
     """
     raw = yaml.safe_load((project / "conf" / "agent.yml").read_text(encoding="utf-8"))

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+"""End-to-end check of `agent.sql_read_only` against a REAL datus project config.
+
+Companion to scripts/e2e_sql_read_only_mcp.py, which builds a throwaway
+sqlite workspace instead of reading a project config.
+This one drives an existing project's `conf/agent.yml` -- its real datasource
+definitions, its real config shape -- through a real `datus-mcp --transport
+stdio` subprocess.
+
+TWO SAFETY PROPERTIES, both deliberate:
+
+1. Nothing is written to the project. The config is copied to a temp directory
+   with `home` rewritten there, and the server runs with that as its cwd, so
+   session/index state lands in the temp dir and is discarded.
+
+2. Every non-read probe targets a table that does not exist, and the DDL probe
+   is CTAS from that missing table. Even with live credentials and a completely
+   broken gate, none of these can destroy anything. This matters more than
+   usual here: the thing under test IS a safety gate, so the failure mode being
+   guarded against is precisely "the destructive statement executed".
+
+   Never add a bare `CREATE TABLE x (...)` or a DROP of a real table here.
+
+VERDICT LOGIC. Because the probes are designed to fail at the database anyway
+(and because a project may have no reachable warehouse from this machine), a
+statement's success is not the signal. The signal is WHERE it was stopped:
+
+  * error contains "this agent is read-only"  -> the tool-layer gate refused it;
+    the SQL never reached the connector. This is the property being tested.
+  * any other error (connection refused, unknown table, permission denied)
+    -> it passed the gate and failed downstream.
+
+So this works with or without a reachable datasource. What it proves is gate
+PLACEMENT -- that non-read SQL is stopped before the connector. It does not
+prove a full write round-trip; e2e_sql_read_only_mcp.py does that against
+sqlite, as does --sqlite-standin below.
+
+Usage:
+    <repo>/.venv/bin/python scripts/e2e_sql_read_only_mcp_project.py \
+        --project /path/to/project [--datasource NAME] [--sqlite-standin]
+Exit: 0 = gate behaves correctly, 1 = it does not
+"""
+
+import argparse
+import asyncio
+import copy
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+MISSING = "datus_readonly_probe_missing"
+
+# (label, sql, is_a_read)
+CASES = [
+    ("SELECT", "SELECT 1", True),
+    ("SHOW", "SHOW DATABASES", True),
+    ("EXPLAIN", "EXPLAIN SELECT 1", True),
+    ("INSERT", f"INSERT INTO {MISSING} (v) VALUES ('x')", False),
+    ("UPDATE", f"UPDATE {MISSING} SET v = 'x'", False),
+    ("DELETE", f"DELETE FROM {MISSING}", False),
+    ("CREATE TABLE (CTAS)", f"CREATE TABLE {MISSING}_2 AS SELECT * FROM {MISSING}", False),
+    ("DROP TABLE", f"DROP TABLE {MISSING}", False),
+    ("TRUNCATE", f"TRUNCATE TABLE {MISSING}", False),
+    ("multi-statement", f"SELECT 1; DROP TABLE {MISSING}", False),
+]
+
+GATE_MARKER = "this agent is read-only"
+
+
+def make_standin_db(dest: Path) -> Path:
+    """A throwaway sqlite carrying the probe table, for --sqlite-standin."""
+    db = dest / "standin.sqlite"
+    con = sqlite3.connect(db)
+    con.execute(f"CREATE TABLE {MISSING} (v TEXT)")
+    con.execute(f"INSERT INTO {MISSING} (v) VALUES ('seed')")
+    con.commit()
+    con.close()
+    return db
+
+
+def stage_config(project: Path, dest: Path, *, sql_read_only: bool, standin: str | None = None) -> Path:
+    """Copy the project's agent.yml into dest with home rewritten and the flag set.
+
+    ``standin`` replaces the datasource definition with a throwaway sqlite while
+    keeping every other part of the project config. Needed when the project's
+    real warehouse is unreachable from this machine: DBFuncTool construction
+    fails, ``has_db_tools`` goes False, and ``execute_sql`` is never mounted --
+    so the gate cannot be exercised at all. With a stand-in the probes really
+    execute, which upgrades the check from "gate placement" to a full write
+    round-trip. The cost is that the connector dialect is sqlite, not the
+    project's; classify_read_only_violation should be checked separately
+    against the real dialect.
+    """
+    raw = yaml.safe_load((project / "conf" / "agent.yml").read_text(encoding="utf-8"))
+    agent = copy.deepcopy(raw["agent"])
+    agent["home"] = str(dest)  # keep all runtime state out of the project
+    # DBFuncTool.__init__ resolves agent_config.active_model() (to size the
+    # DataCompressor tokenizer) and raises without one, so execute_sql never
+    # mounts. A project whose target lives in .datus/config.yml -- deliberately
+    # not loaded here, for isolation -- would fail on that alone. The model has
+    # no bearing on the SQL gate, so pin a mock rather than requiring a live API
+    # key in a test.
+    agent.setdefault("models", {})["__e2e_mock__"] = {
+        "type": "openai",
+        "api_key": "mock-api-key",
+        "model": "mock-model",
+        "base_url": "http://localhost:0",
+    }
+    agent["target"] = "__e2e_mock__"
+
+    if standin:
+        agent.setdefault("services", {})["datasources"] = {
+            standin: {"type": "sqlite", "uri": str(make_standin_db(dest)), "name": standin, "default": True}
+        }
+    if sql_read_only:
+        agent["sql_read_only"] = True
+    else:
+        agent.pop("sql_read_only", None)
+    cfg = dest / "agent.yml"
+    cfg.write_text(yaml.safe_dump({"agent": agent}, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    return cfg
+
+
+async def run_matrix(cfg: Path, datasource: str) -> dict[str, tuple[bool, str]]:
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "datus.mcp_server", "--datasource", datasource, "--transport", "stdio", "--config", str(cfg)],
+        # cwd is the staging dir, never the project: `home: .` is relative, and
+        # a project cwd would also pull in its .datus/config.yml override.
+        cwd=str(cfg.parent),
+    )
+    results: dict[str, tuple[bool, str]] = {}
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            names = {t.name for t in (await session.list_tools()).tools}
+            assert "execute_sql" in names, f"execute_sql not exposed; saw {sorted(names)[:10]}"
+            for label, sql, _ in CASES:
+                res = await session.call_tool("execute_sql", {"sql": sql})
+                raw = "".join(getattr(c, "text", "") for c in res.content)
+                try:
+                    payload = json.loads(raw)
+                    ok, err = payload.get("success") == 1, payload.get("error") or ""
+                except (json.JSONDecodeError, AttributeError):
+                    ok, err = not res.isError, raw
+                results[label] = (ok, (err or "").strip())
+    return results
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", required=True, type=Path)
+    ap.add_argument(
+        "--sqlite-standin",
+        action="store_true",
+        help="swap the datasource for a throwaway sqlite, keeping the rest "
+        "of the project config; use when the real warehouse is "
+        "unreachable (execute_sql is not mounted without a live "
+        "connection, so the gate cannot otherwise be tested)",
+    )
+    ap.add_argument(
+        "--datasource",
+        default=None,
+        help="defaults to .datus/config.yml default_datasource, else the datasource marked default: true",
+    )
+    args = ap.parse_args()
+
+    project: Path = args.project.expanduser().resolve()
+    agent = yaml.safe_load((project / "conf" / "agent.yml").read_text(encoding="utf-8"))["agent"]
+    datasources = agent.get("services", {}).get("datasources", {})
+
+    datasource = args.datasource
+    if not datasource:
+        override = project / ".datus" / "config.yml"
+        if override.exists():
+            datasource = (yaml.safe_load(override.read_text(encoding="utf-8")) or {}).get("default_datasource")
+    if not datasource:
+        datasource = next((n for n, c in datasources.items() if c.get("default")), None)
+    if not datasource:
+        print("could not determine a datasource; pass --datasource", file=sys.stderr)
+        return 1
+
+    print(f"project    : {project}")
+    print(f"datasource : {datasource} (type={datasources.get(datasource, {}).get('type')})")
+    if args.sqlite_standin:
+        print(
+            "datasource : SUBSTITUTED with a throwaway sqlite (--sqlite-standin); "
+            "rest of the project config is used as-is"
+        )
+        print(
+            f"probes     : non-read statements target `{MISSING}`, which EXISTS in "
+            f"the stand-in, so writes really execute when the flag is off\n"
+        )
+    else:
+        print(f"probes     : non-read statements target `{MISSING}`, which must not exist\n")
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        on_dir, off_dir = root / "on", root / "off"
+        on_dir.mkdir()
+        off_dir.mkdir()
+        standin = datasource if args.sqlite_standin else None
+        print("running matrix with sql_read_only: true  ...")
+        on = await run_matrix(stage_config(project, on_dir, sql_read_only=True, standin=standin), datasource)
+        print("running matrix with sql_read_only: false ...\n")
+        off = await run_matrix(stage_config(project, off_dir, sql_read_only=False, standin=standin), datasource)
+
+    hdr = f"{'statement':<22} {'flag off':<14} {'flag on':<14} verdict"
+    print(hdr)
+    print("-" * len(hdr))
+
+    failures = []
+    for label, _, is_read in CASES:
+
+        def where(entry):
+            ok, err = entry
+            if ok:
+                return "executed"
+            return "GATE" if GATE_MARKER in err.lower() else "reached db"
+
+        off_where, on_where = where(off[label]), where(on[label])
+
+        if is_read:
+            good = on_where != "GATE"
+            verdict = "read not blocked" if good else "READ WRONGLY BLOCKED"
+        elif off_where == "GATE":
+            good = False
+            verdict = "GATE FIRED WITH FLAG OFF"
+        elif off[label][1] and off[label][1] == on[label][1]:
+            # Identical refusal with the flag off and on -> a statement-shape
+            # rule that applies either way (multi-statement input, writable
+            # PRAGMA), not the switch. Correct behaviour, but crediting it to
+            # the switch would overstate what this change does.
+            good = True
+            verdict = "blocked either way (not the switch)"
+        else:
+            good = on_where == "GATE"
+            verdict = "stopped by switch, never hit db" if good else "REACHED DB WITH FLAG ON"
+
+        if not good:
+            failures.append(label)
+        print(f"{label:<22} {off_where:<14} {on_where:<14} {'' if good else '!! '}{verdict}")
+
+    print()
+    if failures:
+        print(f"FAIL: {', '.join(failures)}")
+        for label in failures:
+            print(f"  {label}\n    off={off[label]}\n    on ={on[label]}")
+        return 1
+    print("PASS - agent.sql_read_only stops non-read SQL before the connector")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/e2e_sql_read_only_mcp_project.py
+++ b/scripts/e2e_sql_read_only_mcp_project.py
@@ -48,8 +48,9 @@ requires. Nothing under `datus/` imports it.
 import argparse
 import asyncio
 import copy
+import csv
+import io
 import json
-import re
 import sqlite3
 import sys
 import tempfile
@@ -243,13 +244,50 @@ def live_cases(dml: str, drop_me: str, ctas: str) -> list[tuple[str, str, bool]]
     ]
 
 
+def scalar_from_result(result: object, column: str) -> int | None:
+    """The one integer cell from an `execute_sql` read payload, or None.
+
+    `execute_sql` hands back rows already compressed, so the value is not a
+    plain scalar anywhere in the structure -- it is a cell in a CSV string under
+    `compressed_data`, with an index column prepended, sitting next to metadata
+    keys:
+
+        {"original_rows": 1, "original_columns": ["n"],
+         "compressed_data": "index,n\\n0,300", ...}
+
+    Two tempting shortcuts are both wrong on that shape. A regex for the last
+    digit run over the serialized payload can pick up digits from a table name
+    (the scratch tables embed a hex run id) or from a metadata field if the key
+    order changes. Walking the structure for the first int returns
+    `original_rows` -- 1 -- and never sees 300 at all. So parse the named column
+    out of the CSV, and return None rather than a guess.
+    """
+    if not isinstance(result, dict):
+        return None
+    csv_text = result.get("compressed_data")
+    if not isinstance(csv_text, str) or not csv_text.strip():
+        return None
+    try:
+        rows = list(csv.DictReader(io.StringIO(csv_text)))
+    except csv.Error:
+        return None
+    if len(rows) != 1:
+        return None
+    value = (rows[0].get(column) or "").strip()
+    return int(value) if value.lstrip("-").isdigit() else None
+
+
 async def row_count(sess: McpSession, table: str) -> int | None:
+    """Rows in `table`, or None if the count could not be read.
+
+    A None must never be treated as "unchanged" -- see the step-5 checks in
+    `run_live`, where comparing two unknowns would report success on a
+    datasource that was actually mutated.
+    """
     ok, _, result = await sess.sql(f"SELECT COUNT(*) AS n FROM {table}")
     if not ok:
         return None
-    text = json.dumps(result, default=str)
-    nums = re.findall(r"\d+", text)
-    return int(nums[-1]) if nums else None
+    return scalar_from_result(result, "n")
 
 
 async def table_exists(sess: McpSession, table: str) -> bool:
@@ -282,8 +320,11 @@ async def run_endpoint(endpoint: str) -> int:
     statement was stopped: a refusal carrying the read-only message never
     reached the connector, while any other error means it did.
 
-    Every non-read probe targets a table that does not exist, so this is safe to
-    point at a server whose read-only posture you have not confirmed.
+    Safe to point at a server whose read-only posture you have not confirmed:
+    every table-scoped probe targets a table that does not exist, and the DDL
+    probe is CTAS from it. The two exceptions are `SET` and `USE`, which name no
+    table -- they can only change the server's own session context, which this
+    script does not depend on afterwards.
     """
     reads = [
         ("SELECT 1", "SELECT 1"),
@@ -347,6 +388,16 @@ async def run_endpoint(endpoint: str) -> int:
         return 1
     if read_blocked:
         print(f"FAIL - the gate wrongly blocked reads: {', '.join(read_blocked)}")
+        return 1
+    if gated_count == 0:
+        # Nothing leaked and no read was wrongly blocked, but no probe was
+        # stopped BY THE GATE either -- which is what an unreachable datasource
+        # looks like: every write fails downstream for its own reasons. Reporting
+        # PASS here would hand a CI job a zero exit status backed by no evidence
+        # that the gate is even on.
+        print("INCONCLUSIVE - no write probe was stopped by the read-only gate.")
+        print("               Either the flag is off on that server, or every probe")
+        print("               was refused earlier by other rules; see above.")
         return 1
     print(f"PASS - {gated_count}/{len(writes)} write probes stopped by the read-only gate")
     if gated_count < len(writes):
@@ -471,8 +522,17 @@ async def run_live(cfg_on: Path, cfg_off: Path, datasource: str, dialect: str, d
             )
 
         print()
+        # An unreadable count is a failure, not a match: if both reads failed,
+        # `baseline == after` would compare None with None and report success on
+        # a datasource that may well have been mutated.
+        counted = baseline is not None and after is not None
+        count_text = (
+            f"{dml} row count unchanged ({baseline} -> {after})"
+            if counted
+            else f"{dml} row count could not be read ({baseline} -> {after})"
+        )
         checks = [
-            (f"{dml} row count unchanged ({baseline} -> {after})", baseline == after),
+            (count_text, counted and baseline == after),
             (f"{drop_me} survived the DROP probe", drop_survived),
             (f"{ctas} was never created", ctas_absent),
         ]
@@ -578,6 +638,12 @@ async def main() -> int:
     if args.live_writes and args.sqlite_standin:
         print("--live-writes and --sqlite-standin are mutually exclusive", file=sys.stderr)
         return 1
+    if args.dry_run and not args.live_writes:
+        # Only run_live consults dry_run. Accepting it on the matrix path would
+        # execute every probe while the operator believed nothing ran -- and the
+        # matrix probes are the ones aimed at a real datasource.
+        print("--dry-run only applies to --live-writes; the matrix path always executes", file=sys.stderr)
+        return 1
     if args.live_writes:
         print(f"MODE       : LIVE WRITES against the real datasource{' (dry run)' if args.dry_run else ''}\n")
     if args.sqlite_standin:
@@ -617,7 +683,7 @@ async def main() -> int:
     failures = []
     for label, _, is_read in CASES:
 
-        def where(entry):
+        def where(entry: tuple[bool, str]) -> str:
             ok, err = entry
             if ok:
                 return "executed"

--- a/tests/integration/tools/test_func_tools_db.py
+++ b/tests/integration/tools/test_func_tools_db.py
@@ -494,3 +494,114 @@ class TestAllToolsNameContract:
             "suggest_table_layout",
             "validate_ddl",
         }
+
+
+@pytest.mark.acceptance
+class TestSqlReadOnlyDeploymentAgainstRealSqlite:
+    """``agent.sql_read_only`` end-to-end against a real connector.
+
+    The unit tests drive ``DBFuncTool`` with a mocked connector, which proves the
+    branch is taken but not that the write never lands. These run the same calls
+    against a real SQLite file and then assert the database is unchanged — the
+    property a deployment actually depends on.
+    """
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        import sqlite3
+
+        path = tmp_path / "readonly.db"
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.execute("INSERT INTO t (id, name) VALUES (1, 'original')")
+        conn.commit()
+        conn.close()
+        return path
+
+    def _tool(self, db_path, *, sql_read_only):
+        import copy
+
+        from datus.tools.db_tools.config import SQLiteConfig
+        from datus.tools.db_tools.sqlite_connector import SQLiteConnector
+        from tests.conftest import load_acceptance_config
+
+        connector = SQLiteConnector(SQLiteConfig(db_path=str(db_path)))
+        # Deep-copied: hardening is one-way by design, so mutating the shared
+        # acceptance config would leak a read-only posture into every test that
+        # loads it afterwards.
+        config = copy.deepcopy(load_acceptance_config(datasource="ssb_sqlite", home="tests"))
+        if sql_read_only:
+            config.harden_sql_read_only()
+        return DBFuncTool(connector, agent_config=config)
+
+    @staticmethod
+    def _rows(db_path):
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        try:
+            return conn.execute("SELECT id, name FROM t ORDER BY id").fetchall()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _tables(db_path):
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        try:
+            return {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        finally:
+            conn.close()
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "INSERT INTO t (id, name) VALUES (2, 'added')",
+            "UPDATE t SET name = 'changed'",
+            "DELETE FROM t",
+            "DROP TABLE t",
+            "CREATE TABLE t2 (id INT)",
+            "ALTER TABLE t ADD COLUMN extra TEXT",
+            "SELECT 1; DROP TABLE t",
+        ],
+    )
+    def test_writes_are_refused_and_the_database_is_untouched(self, db_path, sql):
+        tool = self._tool(db_path, sql_read_only=True)
+
+        result = tool.execute_sql(sql)
+
+        assert result.success == 0
+        assert self._rows(db_path) == [(1, "original")]
+        assert self._tables(db_path) == {"t"}
+
+    def test_reads_still_work(self, db_path):
+        tool = self._tool(db_path, sql_read_only=True)
+
+        result = tool.execute_sql("SELECT id, name FROM t")
+
+        assert result.success == 1
+
+    def test_writable_pragma_is_refused(self, db_path):
+        """Classifies as METADATA_SHOW but mutates the file."""
+        tool = self._tool(db_path, sql_read_only=True)
+
+        assert tool.execute_sql("PRAGMA journal_mode=WAL").success == 0
+
+    def test_transfer_query_result_is_refused(self, db_path):
+        """gen_job mounts this directly and it writes to the TARGET datasource
+        without going through execute_sql."""
+        tool = self._tool(db_path, sql_read_only=True)
+
+        result = tool.transfer_query_result(source_sql="SELECT * FROM t", target_table="copy_of_t")
+
+        assert result.success == 0
+        assert "copy_of_t" not in self._tables(db_path)
+
+    def test_the_same_writes_succeed_when_the_switch_is_off(self, db_path):
+        """The gate is opt-in: without it these calls really do mutate the
+        database, which is what makes the refusals above meaningful."""
+        tool = self._tool(db_path, sql_read_only=False)
+
+        assert tool.execute_sql("INSERT INTO t (id, name) VALUES (2, 'added')").success == 1
+        assert self._rows(db_path) == [(1, "original"), (2, "added")]

--- a/tests/integration/tools/test_mcp_server.py
+++ b/tests/integration/tools/test_mcp_server.py
@@ -643,3 +643,89 @@ class TestMCPToolExecution:
         """Test calling list_subject_tree tool."""
         result = await server.mcp.call_tool("list_subject_tree", {})
         assert result is not None
+
+
+@pytest.mark.nightly
+class TestMCPServerHonorsSqlReadOnly:
+    """``agent.sql_read_only`` over the MCP tool surface.
+
+    This is the path the switch exists for: the MCP server builds its tools with
+    ``create_static``/``create_dynamic``, which pass an ``AgentConfig`` but never
+    a ``read_only`` flag, and its tool instances never see ``PermissionHooks`` at
+    all. Any client holding an API key reaches ``execute_sql`` directly, so the
+    deployment posture has to be enforced by the tool itself.
+    """
+
+    @pytest.fixture
+    def server(self):
+        server = create_server(datasource="ssb_sqlite", config_path=CONFIG_PATH)
+        yield server
+        server.close()
+
+    @staticmethod
+    async def _call_execute_sql(server, sql):
+        """In-process FastMCP dispatch returns ``(content_blocks, structured)``;
+        take the structured payload. ``parse_tool_result`` above is for
+        ``ClientSession`` results and does not apply here."""
+        _, structured = await server.mcp.call_tool("execute_sql", {"sql": sql})
+        return structured
+
+    @pytest.mark.asyncio
+    async def test_static_tools_report_read_only_when_the_config_is_hardened(self, server):
+        """The factories pass no ``read_only``, so the tool has to take it from
+        the config — otherwise anything asking whether this MCP tool is
+        read-only would be told it is writable."""
+        assert server.db_tool.read_only is False
+
+        server.agent_config.harden_sql_read_only()
+
+        assert server.db_tool.read_only is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "INSERT INTO customer (c_custkey) VALUES (999999)",
+            "UPDATE customer SET c_name = 'x'",
+            "DELETE FROM customer",
+            "DROP TABLE customer",
+            "CREATE TABLE mcp_readonly_probe (id INT)",
+        ],
+    )
+    async def test_execute_sql_over_mcp_refuses_writes(self, server, sql):
+        server.agent_config.harden_sql_read_only()
+
+        payload = await self._call_execute_sql(server, sql)
+
+        assert payload["success"] == 0
+        assert "read-only" in str(payload.get("error", "")).lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_over_mcp_refuses_a_write_smuggled_behind_a_read(self, server):
+        """``parse_sql_type`` classifies only the FIRST statement, so this
+        routes to the read path — where the shared statement-shape check
+        refuses it for being multi-statement rather than for being a write.
+        Different message, same outcome: the DROP never runs."""
+        server.agent_config.harden_sql_read_only()
+
+        payload = await self._call_execute_sql(server, "SELECT 1; DROP TABLE customer")
+
+        assert payload["success"] == 0
+        assert "multi-statement" in str(payload.get("error", "")).lower()
+
+        survived = await self._call_execute_sql(server, "SELECT COUNT(*) AS cnt FROM customer")
+        assert survived["success"] == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_over_mcp_still_reads(self, server):
+        """The gate must not cost the server its actual job."""
+        server.agent_config.harden_sql_read_only()
+
+        payload = await self._call_execute_sql(server, "SELECT COUNT(*) AS cnt FROM customer")
+
+        assert payload["success"] == 1
+
+    @pytest.mark.asyncio
+    async def test_writes_are_not_blocked_by_default(self, server):
+        """The switch is opt-in; an unhardened server keeps its behaviour."""
+        assert server.db_tool.read_only is False

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -506,7 +506,7 @@ class TestCLIServiceReadOnlyDeployment:
 
     @pytest.mark.asyncio
     async def test_select_is_allowed(self, writable_cli_svc, mutable_real_agent_config):
-        mutable_real_agent_config.sql_read_only = True
+        mutable_real_agent_config.harden_sql_read_only()
 
         result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT COUNT(*) FROM schools"))
 
@@ -527,7 +527,7 @@ class TestCLIServiceReadOnlyDeployment:
     async def test_writes_and_ddl_are_refused(self, writable_cli_svc, mutable_real_agent_config, sql):
         from datus.api.models.config_models import ErrorCode
 
-        mutable_real_agent_config.sql_read_only = True
+        mutable_real_agent_config.harden_sql_read_only()
 
         result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query=sql))
 
@@ -542,7 +542,7 @@ class TestCLIServiceReadOnlyDeployment:
         """
         from datus.api.models.config_models import ErrorCode
 
-        mutable_real_agent_config.sql_read_only = True
+        mutable_real_agent_config.harden_sql_read_only()
 
         result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT 1; DROP TABLE schools"))
 
@@ -559,7 +559,7 @@ class TestCLIServiceReadOnlyDeployment:
         """``PRAGMA journal_mode=WAL`` classifies as METADATA_SHOW but writes."""
         from datus.api.models.config_models import ErrorCode
 
-        mutable_real_agent_config.sql_read_only = True
+        mutable_real_agent_config.harden_sql_read_only()
 
         result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="PRAGMA journal_mode=WAL"))
 
@@ -572,7 +572,7 @@ class TestCLIServiceReadOnlyDeployment:
         """Fail-closed: anything not positively classified as a read is refused."""
         from datus.api.models.config_models import ErrorCode
 
-        mutable_real_agent_config.sql_read_only = True
+        mutable_real_agent_config.harden_sql_read_only()
 
         result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query=sql))
 
@@ -598,7 +598,7 @@ class TestCLIServiceReadOnlyDeployment:
         before = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="CREATE TABLE t_before (id INT)"))
         assert before.success is True
 
-        mutable_real_agent_config.sql_read_only = True
+        mutable_real_agent_config.harden_sql_read_only()
 
         after = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="CREATE TABLE t_after (id INT)"))
         assert after.success is False

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -485,3 +485,121 @@ class TestCLIServiceInitializeConnection:
         # CLI context should have been updated during init with the default DB
         assert cli_svc.current_db_name == "california_schools"
         assert cli_svc.cli_context.current_db_name == "california_schools"
+
+
+@pytest.fixture
+def writable_cli_svc(mutable_real_agent_config):
+    """CLIService over a per-test writable SQLite copy, so a refused write and an
+    allowed write are distinguishable (``real_agent_config`` opens the DB
+    read-only, which would mask the gate under test)."""
+    chat_svc = ChatService(mutable_real_agent_config, ChatTaskManager(), "test-proj")
+    return CLIService(agent_config=mutable_real_agent_config, chat_service=chat_svc)
+
+
+class TestCLIServiceReadOnlyDeployment:
+    """``agent.sql_read_only`` on POST /sql/execute.
+
+    This route reaches the connector directly and never constructs a
+    ``DBFuncTool``, so it needs its own gate — the ``execute_sql`` tool check
+    does not cover it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_select_is_allowed(self, writable_cli_svc, mutable_real_agent_config):
+        mutable_real_agent_config.sql_read_only = True
+
+        result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT COUNT(*) FROM schools"))
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "INSERT INTO schools (CDSCode) VALUES ('x')",
+            "UPDATE schools SET City = 'x'",
+            "DELETE FROM schools",
+            "CREATE TABLE t_new (id INT)",
+            "DROP TABLE schools",
+            "TRUNCATE TABLE schools",
+        ],
+    )
+    async def test_writes_and_ddl_are_refused(self, writable_cli_svc, mutable_real_agent_config, sql):
+        from datus.api.models.config_models import ErrorCode
+
+        mutable_real_agent_config.sql_read_only = True
+
+        result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query=sql))
+
+        assert result.success is False
+        assert result.errorCode == ErrorCode.SQL_READ_ONLY
+
+    @pytest.mark.asyncio
+    async def test_multi_statement_with_read_prefix_is_refused(self, writable_cli_svc, mutable_real_agent_config):
+        """The regression that classifying by statement type alone would miss:
+        ``parse_sql_type`` only inspects the FIRST statement, so this reads as a
+        harmless SELECT unless multi-statement input is rejected separately.
+        """
+        from datus.api.models.config_models import ErrorCode
+
+        mutable_real_agent_config.sql_read_only = True
+
+        result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT 1; DROP TABLE schools"))
+
+        assert result.success is False
+        assert result.errorCode == ErrorCode.SQL_READ_ONLY
+        assert "Multi-statement" in result.errorMessage
+
+        # And the table is still there.
+        survived = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT COUNT(*) FROM schools"))
+        assert survived.success is True
+
+    @pytest.mark.asyncio
+    async def test_writable_pragma_is_refused(self, writable_cli_svc, mutable_real_agent_config):
+        """``PRAGMA journal_mode=WAL`` classifies as METADATA_SHOW but writes."""
+        from datus.api.models.config_models import ErrorCode
+
+        mutable_real_agent_config.sql_read_only = True
+
+        result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="PRAGMA journal_mode=WAL"))
+
+        assert result.success is False
+        assert result.errorCode == ErrorCode.SQL_READ_ONLY
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("sql", ["SET foo = 1", "%%not sql at all%%"])
+    async def test_content_set_and_unparseable_are_refused(self, writable_cli_svc, mutable_real_agent_config, sql):
+        """Fail-closed: anything not positively classified as a read is refused."""
+        from datus.api.models.config_models import ErrorCode
+
+        mutable_real_agent_config.sql_read_only = True
+
+        result = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query=sql))
+
+        assert result.success is False
+        assert result.errorCode == ErrorCode.SQL_READ_ONLY
+
+    @pytest.mark.asyncio
+    async def test_writes_succeed_when_the_flag_is_off(self, writable_cli_svc):
+        """Default posture is unchanged — the gate is opt-in."""
+        result = await writable_cli_svc.execute_sql(
+            ExecuteSQLInput(sql_query="CREATE TABLE t_default_posture (id INT)")
+        )
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_flag_is_read_per_request_not_snapshotted(self, writable_cli_svc, mutable_real_agent_config):
+        """CLIService is built from the shared service-level config, so hardening
+        it at runtime must take effect without rebuilding the service.
+        """
+        from datus.api.models.config_models import ErrorCode
+
+        before = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="CREATE TABLE t_before (id INT)"))
+        assert before.success is True
+
+        mutable_real_agent_config.sql_read_only = True
+
+        after = await writable_cli_svc.execute_sql(ExecuteSQLInput(sql_query="CREATE TABLE t_after (id INT)"))
+        assert after.success is False
+        assert after.errorCode == ErrorCode.SQL_READ_ONLY

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -3037,6 +3037,70 @@ class TestConfigMutable:
         assert cfg.config_mutable is True
 
 
+class TestSqlReadOnly:
+    """``sql_read_only`` — deployment-wide hard read-only posture."""
+
+    def _make(self, tmp_path, **extra):
+        return AgentConfig(
+            nodes={"test": NodeConfig(model="test-model", input=None)},
+            home=str(tmp_path / "h"),
+            target="mock",
+            models={"mock": {"type": "openai", "api_key": "k", "model": "m"}},
+            skip_init_dirs=True,
+            **extra,
+        )
+
+    def test_defaults_to_false(self, tmp_path):
+        assert self._make(tmp_path).sql_read_only is False
+
+    @pytest.mark.parametrize("value", [True, "true", "yes", "on", "1"])
+    def test_read_only_values(self, tmp_path, value):
+        assert self._make(tmp_path, sql_read_only=value).sql_read_only is True
+
+    @pytest.mark.parametrize("value", [False, "false", "no", "off", "0", ""])
+    def test_writable_values(self, tmp_path, value):
+        """``"false"`` is the one that matters: a naive ``bool()`` would read it
+        as True and silently invert a security switch.
+        """
+        assert self._make(tmp_path, sql_read_only=value).sql_read_only is False
+
+    def test_setter_can_tighten(self, tmp_path):
+        cfg = self._make(tmp_path)
+        cfg.sql_read_only = True
+        assert cfg.sql_read_only is True
+
+    def test_setter_cannot_relax(self, tmp_path):
+        """Write-once-true: nothing sharing the process may undo a yaml-level
+        ``true``. This asymmetry is deliberate, not an oversight.
+        """
+        cfg = self._make(tmp_path, sql_read_only=True)
+        cfg.sql_read_only = False
+        assert cfg.sql_read_only is True
+        cfg.sql_read_only = "no"
+        assert cfg.sql_read_only is True
+
+    def test_deepcopy_isolates_the_clone(self, tmp_path):
+        import copy
+
+        cfg = self._make(tmp_path)
+        clone = copy.deepcopy(cfg)
+        clone.sql_read_only = True
+        assert clone.sql_read_only is True
+        assert cfg.sql_read_only is False
+
+    def test_excluded_from_asdict_so_the_fingerprint_stays_stable(self, tmp_path):
+        """The flag is stored as a private attribute behind a property and is
+        deliberately NOT a dataclass field: ``compute_fingerprint`` runs
+        ``dataclasses.asdict``, which does ``getattr(obj, field.name)`` and would
+        raise on a declared-but-unstored ``sql_read_only``, silently collapsing
+        every config's fingerprint to the ``id:`` fallback.
+        """
+        from datus.api.services.datus_service import DatusService
+
+        fingerprint = DatusService.compute_fingerprint(self._make(tmp_path, sql_read_only=True))
+        assert not fingerprint.startswith("id:")
+
+
 class TestPluginPathsConfig:
     """``agent.plugin_paths`` — extra plugin-level directory mounts."""
 

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -3064,19 +3064,28 @@ class TestSqlReadOnly:
         """
         assert self._make(tmp_path, sql_read_only=value).sql_read_only is False
 
-    def test_setter_can_tighten(self, tmp_path):
+    def test_harden_turns_it_on(self, tmp_path):
         cfg = self._make(tmp_path)
-        cfg.sql_read_only = True
+        cfg.harden_sql_read_only()
         assert cfg.sql_read_only is True
 
-    def test_setter_cannot_relax(self, tmp_path):
-        """Write-once-true: nothing sharing the process may undo a yaml-level
-        ``true``. This asymmetry is deliberate, not an oversight.
+    def test_hardening_twice_is_idempotent(self, tmp_path):
+        cfg = self._make(tmp_path, sql_read_only=True)
+        cfg.harden_sql_read_only()
+        assert cfg.sql_read_only is True
+
+    def test_there_is_no_way_to_relax_it(self, tmp_path):
+        """One-way by construction: the posture is exposed as a read-only
+        property, so nothing sharing the process — a plugin, a tool transformer,
+        third-party code — can undo a yaml-level ``true``. Assignment raises
+        rather than silently doing nothing, which is why this is a method and
+        not a tighten-only setter.
         """
         cfg = self._make(tmp_path, sql_read_only=True)
-        cfg.sql_read_only = False
-        assert cfg.sql_read_only is True
-        cfg.sql_read_only = "no"
+
+        with pytest.raises(AttributeError):
+            cfg.sql_read_only = False
+
         assert cfg.sql_read_only is True
 
     def test_deepcopy_isolates_the_clone(self, tmp_path):
@@ -3084,7 +3093,7 @@ class TestSqlReadOnly:
 
         cfg = self._make(tmp_path)
         clone = copy.deepcopy(cfg)
-        clone.sql_read_only = True
+        clone.harden_sql_read_only()
         assert clone.sql_read_only is True
         assert cfg.sql_read_only is False
 

--- a/tests/unit_tests/prompts/test_prompt_manager.py
+++ b/tests/unit_tests/prompts/test_prompt_manager.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
 
 from datus.prompts.prompt_manager import (
     PromptManager,
@@ -371,3 +373,113 @@ class TestPlanModeSystemTemplate:
         assert "Plan mode is still active" in rendered
         assert "auto-approved" in rendered
         assert "Do NOT call `ask_user`" in rendered
+
+
+class TestPromptTemplateSandbox:
+    """The user template dir is writable AND takes precedence over the built-in
+    templates, so PromptManager renders untrusted input. These pin the sandbox
+    and, just as importantly, the three settings that must NOT change with it.
+    """
+
+    def test_env_is_sandboxed(self, tmp_path):
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+
+        assert isinstance(manager._get_env(), SandboxedEnvironment)
+
+    def test_chained_unsafe_attribute_raises_security_error(self, tmp_path):
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        _write_template(
+            manager.user_templates_dir,
+            "evil",
+            "1.0",
+            "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+        )
+
+        with pytest.raises(SecurityError):
+            manager.render_template("evil", "1.0")
+
+    def test_globals_walk_on_context_object_raises_security_error(self, tmp_path):
+        """The escape that matters in this process: reaching a module's globals
+        from an object the caller handed the template. Those globals hold live
+        datasource and model credentials.
+        """
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        _write_template(manager.user_templates_dir, "evil_globals", "1.0", "{{ ctx.__init__.__globals__ }}")
+
+        with pytest.raises(SecurityError):
+            manager.render_template("evil_globals", "1.0", ctx=SimpleNamespace(safe="ok"))
+
+    def test_attr_filter_escape_is_neutralized(self, tmp_path):
+        """``|attr`` (CVE-2025-27516's vector) does not raise under the lenient
+        Undefined this env keeps — each hop returns an undefined rather than the
+        real object. It yields nothing either way, which is what matters; assert
+        the neutralization rather than an exception that never comes.
+        """
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        _write_template(manager.user_templates_dir, "evil_attr", "1.0", "[{{ ''|attr('__class__') }}]")
+
+        assert manager.render_template("evil_attr", "1.0") == "[]"
+
+    def test_single_unsafe_attribute_renders_empty_instead_of_leaking(self, tmp_path):
+        """Under the *lenient* Undefined this env keeps, one unsafe attribute
+        yields an undefined that stringifies to "" rather than raising. Nothing
+        leaks either way; this pins the interaction so a future ``undefined=``
+        change is caught by a test instead of in production.
+        """
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        _write_template(manager.user_templates_dir, "probe", "1.0", "[{{ ''.__class__ }}]")
+
+        assert manager.render_template("probe", "1.0") == "[]"
+
+    def test_lenient_undefined_is_preserved(self, tmp_path):
+        """Guard against over-tightening: the shipped templates reference
+        variables their callers do not always pass, so a missing variable must
+        keep rendering empty rather than raising.
+        """
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        _write_template(manager.default_templates_dir, "loose", "1.0", "a{{ never_passed }}b")
+
+        assert manager.render_template("loose", "1.0") == "ab"
+
+    def test_trim_and_lstrip_blocks_are_preserved(self, tmp_path):
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        _write_template(
+            manager.default_templates_dir,
+            "blocks",
+            "1.0",
+            "start\n    {% if flag %}\nkept\n    {% endif %}\nend",
+        )
+
+        assert manager.render_template("blocks", "1.0", flag=True) == "start\nkept\nend"
+
+    def test_macro_import_still_resolves(self, tmp_path):
+        """The loader must survive the swap: three shipped templates use
+        ``{% import %}`` to call macros from _osi_dialect_map.j2.
+        """
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        (manager.default_templates_dir / "_macros.j2").write_text(
+            "{% macro shout(word) %}{{ word|upper }}{% endmacro %}", encoding="utf-8"
+        )
+        _write_template(
+            manager.default_templates_dir,
+            "uses_macro",
+            "1.0",
+            "{% import '_macros.j2' as m %}{{ m.shout('hi') }}",
+        )
+
+        assert manager.render_template("uses_macro", "1.0") == "HI"
+
+    def test_safe_context_object_methods_still_work(self, tmp_path):
+        """Shipped templates call .items()/.get()/.strftime() on context objects;
+        the sandbox must not block those.
+        """
+        manager = _make_manager(tmp_path, path_manager=DatusPathManager(tmp_path / "tenant_home"))
+        _write_template(
+            manager.default_templates_dir,
+            "safe_calls",
+            "1.0",
+            "{% for k, v in mapping.items() %}{{ k }}={{ v }};{% endfor %}{{ row.get('x', 'na') }}",
+        )
+
+        rendered = manager.render_template("safe_calls", "1.0", mapping={"a": 1}, row={"x": "ok"})
+        assert rendered == "a=1;ok"

--- a/tests/unit_tests/prompts/test_prompt_utils.py
+++ b/tests/unit_tests/prompts/test_prompt_utils.py
@@ -286,12 +286,13 @@ class TestGenMetricsV12Template:
 
     def test_v12_template_renders_without_error(self):
         """v1.2 template renders with minimal context and produces non-empty output."""
-        from datus.prompts.prompt_manager import PromptManager
-
-        pm = PromptManager()
-        # Use only the default_templates_dir (no user templates needed)
         from jinja2 import FileSystemLoader
         from jinja2.sandbox import SandboxedEnvironment
+
+        from datus.prompts.prompt_manager import PromptManager
+
+        # Use only the default_templates_dir (no user templates needed)
+        pm = PromptManager()
 
         # Mirrors PromptManager._get_env: production renders these templates in a
         # sandbox, so a bare Environment here would stop being representative.
@@ -361,11 +362,12 @@ class TestGenMetricsV12Template:
 
     def test_v12_template_mentions_skill(self):
         """v1.2 template should reference skills and gen-metrics."""
+        from jinja2 import FileSystemLoader
+        from jinja2.sandbox import SandboxedEnvironment
+
         from datus.prompts.prompt_manager import PromptManager
 
         pm = PromptManager()
-        from jinja2 import FileSystemLoader
-        from jinja2.sandbox import SandboxedEnvironment
 
         # Mirrors PromptManager._get_env: production renders these templates in a
         # sandbox, so a bare Environment here would stop being representative.

--- a/tests/unit_tests/prompts/test_prompt_utils.py
+++ b/tests/unit_tests/prompts/test_prompt_utils.py
@@ -290,9 +290,12 @@ class TestGenMetricsV12Template:
 
         pm = PromptManager()
         # Use only the default_templates_dir (no user templates needed)
-        from jinja2 import Environment, FileSystemLoader
+        from jinja2 import FileSystemLoader
+        from jinja2.sandbox import SandboxedEnvironment
 
-        env = Environment(
+        # Mirrors PromptManager._get_env: production renders these templates in a
+        # sandbox, so a bare Environment here would stop being representative.
+        env = SandboxedEnvironment(
             loader=FileSystemLoader([str(pm.default_templates_dir)]),
             trim_blocks=True,
             lstrip_blocks=True,
@@ -325,12 +328,15 @@ class TestGenMetricsV12Template:
         ],
     )
     def test_sql_file_evidence_is_read_directly(self, template_name):
-        from jinja2 import Environment, FileSystemLoader
+        from jinja2 import FileSystemLoader
+        from jinja2.sandbox import SandboxedEnvironment
 
         from datus.prompts.prompt_manager import PromptManager
 
         pm = PromptManager()
-        env = Environment(
+        # Mirrors PromptManager._get_env: production renders these templates in a
+        # sandbox, so a bare Environment here would stop being representative.
+        env = SandboxedEnvironment(
             loader=FileSystemLoader([str(pm.default_templates_dir)]),
             trim_blocks=True,
             lstrip_blocks=True,
@@ -358,9 +364,12 @@ class TestGenMetricsV12Template:
         from datus.prompts.prompt_manager import PromptManager
 
         pm = PromptManager()
-        from jinja2 import Environment, FileSystemLoader
+        from jinja2 import FileSystemLoader
+        from jinja2.sandbox import SandboxedEnvironment
 
-        env = Environment(
+        # Mirrors PromptManager._get_env: production renders these templates in a
+        # sandbox, so a bare Environment here would stop being representative.
+        env = SandboxedEnvironment(
             loader=FileSystemLoader([str(pm.default_templates_dir)]),
             trim_blocks=True,
             lstrip_blocks=True,

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -2,6 +2,7 @@
 Test cases for DBFuncTool compressor model_name initialization and execute_ddl.
 """
 
+import re
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -9,6 +10,22 @@ import pytest
 
 from datus.tools.func_tool.database import DBFuncTool
 from datus.utils.exceptions import DatusException
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def logged_fields(text: str) -> dict:
+    """Structured field/value pairs from captured log output.
+
+    Normalizes away the two things that vary with how structlog happens to be
+    rendering — ANSI colour codes, and ``key=value`` vs ``'key': 'value'`` — so
+    a test can assert the field it cares about exactly, instead of hedging with
+    ``assert a in text or b in text``.
+    """
+    plain = _ANSI.sub("", text)
+    fields = dict(re.findall(r"(\w+)=(\S+)", plain))
+    fields.update(re.findall(r"'(\w+)': '([^']*)'", plain))
+    return fields
 
 
 def _mock_agent_config(**attrs) -> Mock:
@@ -1980,12 +1997,12 @@ class TestDBFuncToolExecuteSql:
 
         with caplog.at_level(logging.WARNING):
             tool.execute_sql("DROP TABLE users")
-        assert "sql_type=drop" in caplog.text or "'sql_type': 'drop'" in caplog.text
+        assert logged_fields(caplog.text)["sql_type"] == "drop"
 
         caplog.clear()
         with caplog.at_level(logging.WARNING):
             tool.execute_sql("CREATE TABLE t (id INT)")
-        assert "sql_type=create" in caplog.text or "'sql_type': 'create'" in caplog.text
+        assert logged_fields(caplog.text)["sql_type"] == "create"
 
     def test_multi_statement_refusal_is_logged(self, caplog):
         """The sneakiest input in the set must not be the one with no audit

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -11,6 +11,25 @@ from datus.tools.func_tool.database import DBFuncTool
 from datus.utils.exceptions import DatusException
 
 
+def _mock_agent_config(**attrs) -> Mock:
+    """A ``Mock`` AgentConfig with the hardening switches pinned off.
+
+    A bare ``Mock()`` returns a truthy ``Mock`` for EVERY attribute, so it
+    silently opts into any boolean security flag ``DBFuncTool`` reads off the
+    config — today that is ``sql_read_only``, which would flip these tools into
+    rejecting mode and fail write-path tests for a reason that has nothing to do
+    with what they assert. (``_coerce_bool`` does not rescue this: a ``Mock``
+    misses its ``None``/``bool``/``str`` branches and falls through to
+    ``bool(value)``.) Pin the switches once here so the next flag does not
+    re-break the same eleven tests.
+    """
+    config = Mock()
+    config.sql_read_only = False
+    for key, value in attrs.items():
+        setattr(config, key, value)
+    return config
+
+
 class TestDBFuncToolCompressorModelName:
     """Verify that DBFuncTool uses agent_config's model name for DataCompressor."""
 
@@ -20,7 +39,7 @@ class TestDBFuncToolCompressorModelName:
         mock_connector.dialect = "sqlite"
         mock_connector.get_databases.return_value = []
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "claude-sonnet-4"
 
         with (
@@ -52,7 +71,7 @@ class TestDBFuncToolCompressorModelName:
         mock_connector.dialect = "sqlite"
         mock_connector.get_databases.return_value = []
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-4o"
         mock_config.project_name = "project"
 
@@ -351,7 +370,7 @@ class TestDBFuncToolExecuteWrite:
         sql_file = tmp_path / "insert.sql"
         sql_file.write_text("INSERT INTO users VALUES (1)", encoding="utf-8")
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.project_root = str(tmp_path)
 
@@ -914,7 +933,7 @@ class TestGetConnectorRouting:
         mock_db_manager.get_conn.side_effect = lambda ns, db="": mock_target if ns == "greenplum" else mock_source
         mock_db_manager.first_conn.return_value = mock_source
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.current_datasource = "duckdb"
         # Must have >1 database so DBFuncTool enters true multi-connector mode
@@ -955,7 +974,7 @@ class TestGetConnectorRouting:
         mock_db_manager.get_conn.return_value = mock_source
         mock_db_manager.first_conn.return_value = mock_source
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.current_datasource = "duckdb"
         mock_config.current_db_configs.return_value = {"duckdb": Mock(), "greenplum": Mock()}
@@ -994,7 +1013,7 @@ class TestGetConnectorRouting:
         mock_db_manager.get_conn.side_effect = _get_conn
         mock_db_manager.first_conn.return_value = mock_connector
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.current_datasource = "default_db"
         mock_config.current_db_configs.return_value = {"default_db": Mock(), "other_db": Mock()}
@@ -1022,7 +1041,7 @@ class TestGetConnectorRouting:
         mock_db_manager.get_conn.return_value = mock_connector
         mock_db_manager.first_conn.return_value = mock_connector
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.current_datasource = "default_db"
         mock_config.current_db_configs.return_value = {"default_db": Mock(), "other_db": Mock()}
@@ -1052,7 +1071,7 @@ class TestGetConnectorRouting:
         mock_db_manager.get_conn.return_value = conn
         mock_db_manager.first_conn.return_value = conn
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.current_datasource = "pg"
         mock_config.current_db_configs.return_value = {"pg": Mock(), "other": Mock()}
@@ -1083,7 +1102,7 @@ class TestGetConnectorRouting:
         mock_db_manager.first_conn.return_value = mock_source
         mock_db_manager.get_conn.return_value = mock_source
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.current_datasource = "source_db"
         # Not a glob datasource → list_databases asks the connector.
@@ -1123,7 +1142,7 @@ class TestGetConnectorRouting:
         mock_db_manager.first_conn.return_value = Mock(dialect="duckdb")
         mock_db_manager.get_conn.side_effect = _gc
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.current_datasource = "source_db"
         mock_config.current_db_config.return_value.path_pattern = ""
@@ -1816,6 +1835,123 @@ class TestDBFuncToolExecuteSql:
         mock_connector.execute_insert.assert_not_called()
         mock_connector.execute_ddl.assert_not_called()
 
+    # ------------------------------------------------------------------ #
+    # Deployment-wide ``agent.sql_read_only``                              #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _build(connector, **kwargs):
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            return DBFuncTool(connector, **kwargs)
+
+    @staticmethod
+    def _connector():
+        connector = Mock()
+        connector.dialect = "sqlite"
+        connector.get_databases.return_value = []
+        connector.execute_insert.return_value = Mock(success=True, row_count=1)
+        return connector
+
+    def test_config_read_only_rejects_writes_when_caller_did_not_ask(self):
+        """The deployment switch must reach callers that never pass read_only —
+        which is 19 of the 24 DBFuncTool construction sites, plus the MCP server.
+        """
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+
+        result = tool.execute_sql("INSERT INTO users VALUES (1)")
+
+        assert result.success == 0
+        assert "read-only" in (result.error or "")
+        connector.execute_insert.assert_not_called()
+
+    def test_config_read_only_still_allows_select(self):
+        connector = self._connector()
+        connector.execute_query.return_value = Mock(success=True, sql_return=[{"a": 1}])
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+        tool.compressor.compress = Mock(return_value={"original_rows": 1, "compressed_data": "a\n1"})
+
+        assert tool.execute_sql("SELECT * FROM users").success == 1
+
+    def test_instance_flag_wins_when_config_is_writable(self):
+        """OR semantics, direction 1: the config may not relax a caller that
+        already asked for read-only (Explore, ask_report, the validator copy).
+        """
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=False), read_only=True)
+
+        assert tool.effective_read_only is True
+        assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 0
+        connector.execute_insert.assert_not_called()
+
+    def test_config_flag_wins_when_instance_is_writable(self):
+        """OR semantics, direction 2."""
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True), read_only=False)
+
+        assert tool.effective_read_only is True
+
+    def test_no_agent_config_is_not_read_only(self):
+        connector = self._connector()
+        tool = self._build(connector)
+
+        assert tool.effective_read_only is False
+        assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 1
+
+    def test_config_without_the_attribute_is_not_read_only(self):
+        """Old / duck-typed config objects predating the switch must not break."""
+
+        class LegacyConfig:
+            def active_model(self):
+                return Mock(model="gpt-4")
+
+        connector = self._connector()
+        tool = self._build(connector, agent_config=LegacyConfig())
+
+        assert tool.effective_read_only is False
+
+    def test_string_false_is_not_read_only(self):
+        """Proves ``_coerce_bool``, not ``bool()``: ``bool("false")`` is True and
+        would wedge a duck-typed config into permanent read-only.
+        """
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only="false"))
+
+        assert tool.effective_read_only is False
+
+    def test_config_hardened_after_construction_is_honoured(self):
+        """The API hands nodes a per-request config clone, so the flag is
+        resolved per access rather than snapshotted in __init__.
+        """
+        connector = self._connector()
+        config = _mock_agent_config(sql_read_only=False)
+        tool = self._build(connector, agent_config=config)
+        assert tool.effective_read_only is False
+
+        config.sql_read_only = True
+
+        assert tool.effective_read_only is True
+        assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 0
+
+    def test_shallow_copy_can_still_force_read_only(self):
+        """Pins the contract datus.validation.llm_runner depends on: it copies a
+        write-capable tool and flips ``.read_only`` to True on the copy.
+        """
+        import copy as _copy
+
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=False))
+        read_only_tool = _copy.copy(tool)
+        read_only_tool.read_only = True
+
+        assert read_only_tool.effective_read_only is True
+        assert tool.effective_read_only is False
+
     def test_min_max_rows_forwarded_to_write(self):
         mock_connector = Mock()
         mock_connector.dialect = "sqlite"
@@ -1868,7 +2004,7 @@ class TestDBFuncToolExecuteSql:
         sql_file = tmp_path / "insert.sql"
         sql_file.write_text("INSERT INTO users VALUES (1)", encoding="utf-8")
 
-        mock_config = Mock()
+        mock_config = _mock_agent_config()
         mock_config.active_model.return_value.model = "gpt-5.4"
         mock_config.project_root = str(tmp_path)
 
@@ -2103,7 +2239,11 @@ class TestExecuteSqlWriteLaundering:
         ):
             rag.return_value.schema_store.table_size.return_value = 0
             sem.return_value.get_size.return_value = 0
-            config = Mock()
+            # `_mock_agent_config`, not a bare `Mock()`: a bare Mock answers
+            # every attribute with a truthy Mock, so `sql_read_only` would read
+            # as on and these write-path assertions would fail for a reason
+            # unrelated to what they test.
+            config = _mock_agent_config()
             config.active_model.return_value.model = "gpt-4o"
             config.policy_context = policy_context
             tool = DBFuncTool(connector, agent_config=config)
@@ -2158,3 +2298,61 @@ class TestExecuteSqlWriteLaundering:
 
         assert result.success == 1
         connector.execute_ddl.assert_called_once()
+
+
+class TestMcpFactoriesHonorDeploymentReadOnly:
+    """``create_dynamic`` / ``create_static`` are the MCP server's construction
+    path (``mcp_server._create_context`` and ``_init_tools`` loop over the tool
+    registry and call them generically). Neither can pass ``read_only``, so this
+    is the path the deployment switch has to cover on its own — testing
+    ``__init__`` alone would miss it entirely.
+    """
+
+    @staticmethod
+    def _config(**attrs):
+        config = _mock_agent_config(**attrs)
+        config.project_name = "proj"
+        return config
+
+    def _build(self, factory, config):
+        manager = Mock()
+        manager.get_conn.return_value = Mock(dialect="sqlite")
+        with (
+            patch("datus.tools.func_tool.database.db_manager_instance", return_value=manager),
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+            patch("datus.tools.func_tool.database.TableSemanticProfileRAG"),
+            patch("datus.tools.func_tool.database.metadata_fts_enabled", return_value=False),
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            return factory(config)
+
+    def test_create_dynamic_inherits_deployment_read_only(self):
+        tool = self._build(DBFuncTool.create_dynamic, self._config(sql_read_only=True))
+
+        assert tool.read_only is False  # the factory still cannot pass it...
+        assert tool.effective_read_only is True  # ...but the config reaches execute_sql
+
+    def test_create_static_inherits_deployment_read_only(self):
+        tool = self._build(DBFuncTool.create_static, self._config(sql_read_only=True))
+
+        assert tool.effective_read_only is True
+
+    def test_create_dynamic_rejects_writes_end_to_end(self):
+        """The property is only meaningful if execute_sql actually refuses."""
+        tool = self._build(DBFuncTool.create_dynamic, self._config(sql_read_only=True))
+        connector = Mock()
+        connector.dialect = "sqlite"
+        tool._get_connector = Mock(return_value=connector)
+
+        result = tool.execute_sql("INSERT INTO users VALUES (1)")
+
+        assert result.success == 0
+        assert "read-only" in (result.error or "")
+        connector.execute_insert.assert_not_called()
+
+    def test_create_dynamic_stays_writable_by_default(self):
+        tool = self._build(DBFuncTool.create_dynamic, self._config(sql_read_only=False))
+
+        assert tool.effective_read_only is False

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -1938,6 +1938,37 @@ class TestDBFuncToolExecuteSql:
         assert tool.effective_read_only is True
         assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 0
 
+    def test_refusal_is_logged_with_its_source(self, caplog):
+        """A refusal is the event an operator wants to see -- on a deployment
+        running third-party content it means that content just tried to write.
+        Successful reads are already logged in read_query, so a silent refusal
+        would record the benign path and drop the notable one.
+        """
+        import logging
+
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+
+        with caplog.at_level(logging.WARNING):
+            tool.execute_sql("INSERT INTO users VALUES (1)")
+
+        assert "rejected by read-only policy" in caplog.text
+        # `source` separates a hardened deployment from a read-only agent doing
+        # its job -- "investigate this" vs "working as intended".
+        assert "deployment" in caplog.text
+
+    def test_refusal_log_attributes_agent_read_only_separately(self, caplog):
+        import logging
+
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=False), read_only=True)
+
+        with caplog.at_level(logging.WARNING):
+            tool.execute_sql("INSERT INTO users VALUES (1)")
+
+        assert "rejected by read-only policy" in caplog.text
+        assert "agent" in caplog.text
+
     def test_shallow_copy_can_still_force_read_only(self):
         """Pins the contract datus.validation.llm_runner depends on: it copies a
         write-capable tool and flips ``.read_only`` to True on the copy.

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -1885,7 +1885,7 @@ class TestDBFuncToolExecuteSql:
         connector = self._connector()
         tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=False), read_only=True)
 
-        assert tool.effective_read_only is True
+        assert tool.read_only is True
         assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 0
         connector.execute_insert.assert_not_called()
 
@@ -1894,13 +1894,13 @@ class TestDBFuncToolExecuteSql:
         connector = self._connector()
         tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True), read_only=False)
 
-        assert tool.effective_read_only is True
+        assert tool.read_only is True
 
     def test_no_agent_config_is_not_read_only(self):
         connector = self._connector()
         tool = self._build(connector)
 
-        assert tool.effective_read_only is False
+        assert tool.read_only is False
         assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 1
 
     def test_config_without_the_attribute_is_not_read_only(self):
@@ -1913,7 +1913,7 @@ class TestDBFuncToolExecuteSql:
         connector = self._connector()
         tool = self._build(connector, agent_config=LegacyConfig())
 
-        assert tool.effective_read_only is False
+        assert tool.read_only is False
 
     def test_string_false_is_not_read_only(self):
         """Proves ``_coerce_bool``, not ``bool()``: ``bool("false")`` is True and
@@ -1922,7 +1922,7 @@ class TestDBFuncToolExecuteSql:
         connector = self._connector()
         tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only="false"))
 
-        assert tool.effective_read_only is False
+        assert tool.read_only is False
 
     def test_config_hardened_after_construction_is_honoured(self):
         """The API hands nodes a per-request config clone, so the flag is
@@ -1931,11 +1931,11 @@ class TestDBFuncToolExecuteSql:
         connector = self._connector()
         config = _mock_agent_config(sql_read_only=False)
         tool = self._build(connector, agent_config=config)
-        assert tool.effective_read_only is False
+        assert tool.read_only is False
 
         config.sql_read_only = True
 
-        assert tool.effective_read_only is True
+        assert tool.read_only is True
         assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 0
 
     def test_refusal_is_logged_with_its_source(self, caplog):
@@ -1969,6 +1969,44 @@ class TestDBFuncToolExecuteSql:
         assert "rejected by read-only policy" in caplog.text
         assert "agent" in caplog.text
 
+    def test_ddl_refusal_logs_the_specific_keyword(self, caplog):
+        """`ddl` alone cannot tell an operator whether third-party content tried
+        to CREATE a table or DROP one, and those warrant different responses.
+        """
+        import logging
+
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+
+        with caplog.at_level(logging.WARNING):
+            tool.execute_sql("DROP TABLE users")
+        assert "sql_type=drop" in caplog.text or "'sql_type': 'drop'" in caplog.text
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            tool.execute_sql("CREATE TABLE t (id INT)")
+        assert "sql_type=create" in caplog.text or "'sql_type': 'create'" in caplog.text
+
+    def test_multi_statement_refusal_is_logged(self, caplog):
+        """The sneakiest input in the set must not be the one with no audit
+        trail. ``parse_sql_type`` reads only the first statement, so this
+        arrives as a SELECT and is refused by the multi-statement rule rather
+        than by the read-only gate -- a different code path, which is exactly
+        how it went unlogged.
+        """
+        import logging
+
+        connector = self._connector()
+        connector.execute_query.return_value = Mock(success=True, sql_return=[])
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+
+        with caplog.at_level(logging.WARNING):
+            result = tool.execute_sql("SELECT 1; DROP TABLE users")
+
+        assert result.success == 0
+        assert "statement-shape rules" in caplog.text
+        assert "Multi-statement" in caplog.text
+
     def test_shallow_copy_can_still_force_read_only(self):
         """Pins the contract datus.validation.llm_runner depends on: it copies a
         write-capable tool and flips ``.read_only`` to True on the copy.
@@ -1980,8 +2018,31 @@ class TestDBFuncToolExecuteSql:
         read_only_tool = _copy.copy(tool)
         read_only_tool.read_only = True
 
-        assert read_only_tool.effective_read_only is True
-        assert tool.effective_read_only is False
+        assert read_only_tool.read_only is True
+        assert tool.read_only is False
+
+    def test_assignment_can_tighten_but_not_relax(self):
+        """The setter mirrors ``AgentConfig.harden_sql_read_only``: a caller may
+        harden an instance, but may not hand a write-capable view of a read-only
+        deployment to anything downstream.
+        """
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=False))
+
+        tool.read_only = True
+        assert tool.read_only is True
+
+        tool.read_only = False
+        assert tool.read_only is True
+
+    def test_deployment_read_only_cannot_be_relaxed_by_assignment(self):
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+
+        tool.read_only = False
+
+        assert tool.read_only is True
+        assert tool.execute_sql("INSERT INTO users VALUES (1)").success == 0
 
     def test_min_max_rows_forwarded_to_write(self):
         mock_connector = Mock()
@@ -2065,6 +2126,91 @@ class TestDBFuncToolExecuteSql:
         assert "read_query" not in tool_names
         assert "execute_ddl" not in tool_names
         assert "execute_write" not in tool_names
+
+
+class TestDBFuncToolWritePathsHonorReadOnly:
+    """Every write entry point, not just ``execute_sql``.
+
+    ``execute_sql`` dispatches to ``execute_write``/``execute_ddl`` and gates
+    before it does, but all three are callable directly, and gen_job mounts
+    ``transfer_query_result`` as a tool of its own. A deployment-wide read-only
+    posture that only covered the dispatcher would leave those reachable.
+    """
+
+    @staticmethod
+    def _build(connector, **kwargs):
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticModelRAG") as mock_sem,
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            return DBFuncTool(connector, **kwargs)
+
+    @staticmethod
+    def _connector():
+        connector = Mock()
+        connector.dialect = "sqlite"
+        connector.get_databases.return_value = []
+        connector.execute_insert.return_value = Mock(success=True, row_count=1)
+        connector.execute_ddl.return_value = Mock(success=True)
+        return connector
+
+    def test_execute_ddl_is_refused(self):
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+
+        result = tool.execute_ddl("CREATE TABLE t (a int)")
+
+        assert result.success == 0
+        assert "read-only" in (result.error or "")
+        connector.execute_ddl.assert_not_called()
+
+    def test_execute_write_is_refused(self):
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+
+        result = tool.execute_write("INSERT INTO users VALUES (1)")
+
+        assert result.success == 0
+        assert "read-only" in (result.error or "")
+        connector.execute_insert.assert_not_called()
+
+    def test_transfer_query_result_is_refused(self):
+        """``source_sql`` is read-only, but the transfer WRITES to the target
+        datasource — CREATE TABLE / TRUNCATE / INSERT — without ever going
+        through ``execute_sql``.
+        """
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=True))
+        tool._get_connector = Mock(side_effect=AssertionError("must refuse before touching a connector"))
+
+        result = tool.transfer_query_result(
+            source_sql="SELECT * FROM users",
+            target_table="copy_of_users",
+            target_datasource="warehouse",
+        )
+
+        assert result.success == 0
+        assert "read-only" in (result.error or "")
+
+    def test_read_only_agent_is_refused_too(self):
+        """The gate is the effective posture, so a read-only agent on a writable
+        deployment is covered by the same check.
+        """
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=False), read_only=True)
+
+        assert tool.execute_ddl("CREATE TABLE t (a int)").success == 0
+        assert tool.execute_write("INSERT INTO users VALUES (1)").success == 0
+
+    def test_write_paths_still_work_by_default(self):
+        """The gate is opt-in — the default posture is unchanged."""
+        connector = self._connector()
+        tool = self._build(connector, agent_config=_mock_agent_config(sql_read_only=False))
+
+        assert tool.execute_ddl("CREATE TABLE t (a int)").success == 1
+        connector.execute_ddl.assert_called_once()
 
 
 class TestDBFuncToolExecuteReadEnforced:
@@ -2360,15 +2506,19 @@ class TestMcpFactoriesHonorDeploymentReadOnly:
             return factory(config)
 
     def test_create_dynamic_inherits_deployment_read_only(self):
+        """``.read_only`` reports the posture the write paths will enforce, not
+        the constructor argument — the factory passes no ``read_only`` at all,
+        so anything reading the attribute would otherwise be told this MCP tool
+        is writable on a hardened deployment."""
         tool = self._build(DBFuncTool.create_dynamic, self._config(sql_read_only=True))
 
-        assert tool.read_only is False  # the factory still cannot pass it...
-        assert tool.effective_read_only is True  # ...but the config reaches execute_sql
+        assert tool.read_only is True
+        assert tool._read_only is False  # nothing passed it; the config supplied it
 
     def test_create_static_inherits_deployment_read_only(self):
         tool = self._build(DBFuncTool.create_static, self._config(sql_read_only=True))
 
-        assert tool.effective_read_only is True
+        assert tool.read_only is True
 
     def test_create_dynamic_rejects_writes_end_to_end(self):
         """The property is only meaningful if execute_sql actually refuses."""
@@ -2386,4 +2536,4 @@ class TestMcpFactoriesHonorDeploymentReadOnly:
     def test_create_dynamic_stays_writable_by_default(self):
         tool = self._build(DBFuncTool.create_dynamic, self._config(sql_read_only=False))
 
-        assert tool.effective_read_only is False
+        assert tool.read_only is False

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -2022,7 +2022,12 @@ class TestDBFuncToolExecuteSql:
 
         assert result.success == 0
         assert "statement-shape rules" in caplog.text
-        assert "Multi-statement" in caplog.text
+        # The violation CODE, not the prose: `validate_read_only_sql` returns a
+        # code so each caller words its own error, which also gives the log a
+        # stable value to aggregate on.
+        assert logged_fields(caplog.text)["rule"] == "multi_statement"
+        # And the caller's own wording still reaches the model.
+        assert "Multi-statement" in (result.error or "")
 
     def test_shallow_copy_can_still_force_read_only(self):
         """Pins the contract datus.validation.llm_runner depends on: it copies a

--- a/tests/unit_tests/tools/func_tool/test_reference_template_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_reference_template_tools.py
@@ -231,6 +231,64 @@ class TestRenderReferenceTemplate:
         assert result.success == 0
         assert "storage error" in result.error
 
+    def test_render_rejects_sandbox_escape(self, tools, mock_rag):
+        """Template bodies are user-authored and this tool is MCP-exposed, so a
+        template reaching for Python internals must be refused, not rendered.
+        """
+        mock_rag.get_reference_template_detail.return_value = [
+            {
+                "name": "evil",
+                "template": "SELECT {{ p.__class__.__mro__ }}",
+                "parameters": json.dumps([{"name": "p"}]),
+            }
+        ]
+        result = tools.render_reference_template(["Sales"], "evil", json.dumps({"p": "x"}))
+        assert result.success == 0
+        assert "sandbox" in result.error.lower()
+
+    def test_render_rejects_globals_walk(self, tools, mock_rag):
+        mock_rag.get_reference_template_detail.return_value = [
+            {
+                "name": "evil_globals",
+                "template": "SELECT {{ p.__init__.__globals__ }}",
+                "parameters": json.dumps([{"name": "p"}]),
+            }
+        ]
+        result = tools.render_reference_template(["Sales"], "evil_globals", json.dumps({"p": "x"}))
+        assert result.success == 0
+        assert "sandbox" in result.error.lower()
+
+    def test_sandbox_rejection_does_not_shadow_missing_params(self, tools, mock_rag):
+        """The new SecurityError branch sits next to the UndefinedError one;
+        make sure it did not swallow the retryable missing-param path.
+        """
+        mock_rag.get_reference_template_detail.return_value = [
+            {
+                "name": "tpl",
+                "template": "SELECT * FROM t WHERE region = '{{region}}'",
+                "parameters": json.dumps([{"name": "region"}]),
+            }
+        ]
+        result = tools.render_reference_template(["Sales"], "tpl", "{}")
+        assert result.success == 0
+        assert "sandbox" not in result.error.lower()
+        assert "Missing parameters: ['region']" in result.error
+
+    def test_normal_template_renders_unchanged_under_sandbox(self, tools, mock_rag):
+        """Loops, conditionals and built-in filters must behave exactly as before."""
+        mock_rag.get_reference_template_detail.return_value = [
+            {
+                "name": "loopy",
+                "template": (
+                    "SELECT {% for c in cols %}{{ c|upper }}{% if not loop.last %}, {% endif %}{% endfor %} FROM t"
+                ),
+                "parameters": json.dumps([{"name": "cols"}]),
+            }
+        ]
+        result = tools.render_reference_template(["Sales"], "loopy", json.dumps({"cols": ["a", "b"]}))
+        assert result.success == 1
+        assert result.result["rendered_sql"] == "SELECT A, B FROM t"
+
 
 class TestExecuteReferenceTemplate:
     def test_execute_success(self, tools, mock_rag):
@@ -252,6 +310,25 @@ class TestExecuteReferenceTemplate:
         assert result.result["query_result"] == [{"id": 1, "region": "US"}]
         assert result.result["template_name"] == "daily_sales"
         mock_db.read_query.assert_called_once()
+
+    def test_execute_rejects_sandbox_escape_without_touching_db(self, tools, mock_rag):
+        """A sandbox refusal must short-circuit before any SQL reaches the
+        datasource — execute_reference_template renders first, then queries.
+        """
+        mock_rag.get_reference_template_detail.return_value = [
+            {
+                "name": "evil",
+                "template": "SELECT {{ p.__class__.__mro__ }}",
+                "parameters": json.dumps([{"name": "p"}]),
+            }
+        ]
+        mock_db = MagicMock()
+        tools.db_func_tool = mock_db
+
+        result = tools.execute_reference_template(["Sales"], "evil", json.dumps({"p": "x"}))
+        assert result.success == 0
+        assert "sandbox" in result.error.lower()
+        mock_db.read_query.assert_not_called()
 
     def test_execute_render_fails(self, tools, mock_rag):
         """When render fails, execute returns the render error without calling DB."""

--- a/tests/unit_tests/utils/test_config_utils.py
+++ b/tests/unit_tests/utils/test_config_utils.py
@@ -1,0 +1,58 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+from unittest.mock import Mock
+
+import pytest
+
+from datus.utils.config_utils import coerce_bool
+
+
+class TestCoerceBool:
+    """The shared YAML-boolean coercion behind every ``agent.yml`` toggle.
+
+    ``bool("false")`` is ``True`` in Python, so a naive cast on a quoted YAML
+    value silently inverts a switch. For ``sql_read_only`` that would mean a
+    deployment believing it is read-only while every write path is open.
+    """
+
+    @pytest.mark.parametrize("value", [True, "true", "True", "TRUE", " true ", "yes", "on", "1"])
+    def test_truthy_spellings(self, value):
+        assert coerce_bool(value, False) is True
+
+    @pytest.mark.parametrize("value", [False, "false", "False", "FALSE", " false ", "no", "off", "0", ""])
+    def test_falsy_spellings(self, value):
+        """``"false"`` is the one that matters — the whole reason this helper
+        exists instead of a ``bool()`` cast."""
+        assert coerce_bool(value, True) is False
+
+    @pytest.mark.parametrize("default", [True, False])
+    def test_none_yields_the_default(self, default):
+        """``None`` means the key is absent, which is different from being set
+        to a falsy value."""
+        assert coerce_bool(None, default) is default
+
+    @pytest.mark.parametrize("value", [1, 2, -1, [0], {"a": 1}])
+    def test_unrecognised_truthy_values_read_as_on(self, value):
+        """Fail-closed for security toggles: something we cannot interpret reads
+        as "on" rather than silently off."""
+        assert coerce_bool(value, False) is True
+
+    @pytest.mark.parametrize("value", [0, [], {}])
+    def test_unrecognised_falsy_values_read_as_off(self, value):
+        assert coerce_bool(value, True) is False
+
+    def test_a_bare_mock_reads_as_on(self):
+        """Pins the behaviour that shapes how tests must build config doubles: a
+        ``Mock`` misses the None/bool/str branches and falls through to
+        ``bool(value)``. Test configs therefore have to pin security flags
+        explicitly (see ``_mock_agent_config`` in the DBFuncTool tests) rather
+        than relying on this helper to normalize them away.
+        """
+        assert coerce_bool(Mock(), False) is True
+
+    def test_returns_real_bools_not_truthy_objects(self):
+        """Callers store the result on config objects and compare with ``is``."""
+        for value in ("yes", "no", 1, 0, None):
+            assert type(coerce_bool(value, False)) is bool

--- a/tests/unit_tests/utils/test_sql_utils.py
+++ b/tests/unit_tests/utils/test_sql_utils.py
@@ -1909,3 +1909,138 @@ class TestStripSqlCommentsRespectsLiterals:
     def test_a_semicolon_in_a_literal_is_not_a_second_statement(self):
         assert is_single_statement("SELECT 'a;b' FROM t") is True
         assert is_single_statement("SELECT 1; SELECT 2") is False
+
+
+class TestValidateReadOnlySql:
+    """The shared gate behind ``agent.sql_read_only``.
+
+    Both ``DBFuncTool._validate_read_sql`` and the ``POST /sql/execute`` route
+    call this, so a hole here is a hole in every SQL entry point at once. The
+    contract is fail-closed: it returns a reason unless the input is provably a
+    single read statement.
+    """
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT 1",
+            "select id, name from users where status = 'active'",
+            "  SELECT 1  ",
+            "SELECT 1;",
+            "SELECT 1 ;  ",
+            "-- leading comment\nSELECT 1",
+            "/* block */ SELECT 1",
+            "WITH t AS (SELECT 1) SELECT * FROM t",
+            "SELECT 1 UNION SELECT 2",
+            "(SELECT 1)",
+            "EXPLAIN SELECT 1",
+            "SHOW TABLES",
+            "DESCRIBE users",
+            "PRAGMA table_info(users)",
+        ],
+    )
+    def test_single_read_statements_are_allowed(self, sql):
+        violation, sql_type = validate_read_only_sql(sql, "sqlite")
+
+        assert violation is None
+        assert sql_type in (SQLType.SELECT, SQLType.METADATA_SHOW, SQLType.EXPLAIN)
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "INSERT INTO users VALUES (1)",
+            "UPDATE users SET name = 'x'",
+            "DELETE FROM users",
+            "DROP TABLE users",
+            "CREATE TABLE t (a int)",
+            "ALTER TABLE users ADD COLUMN a int",
+            "TRUNCATE TABLE users",
+            "CREATE TABLE t AS SELECT 1",
+            "GRANT SELECT ON users TO bob",
+            "USE other_db",
+            "SET search_path = evil",
+            "CALL some_proc()",
+        ],
+    )
+    def test_write_statements_are_refused(self, sql):
+        violation, _ = validate_read_only_sql(sql, "sqlite")
+
+        assert violation == READ_ONLY_NON_READ
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT 1; DROP TABLE users",
+            "SELECT 1;DROP TABLE users",
+            "SELECT 1; DROP TABLE users;",
+            "  SELECT 1 ;  DELETE FROM users  ",
+            "-- c\nSELECT 1; DROP TABLE users",
+            "SELECT 1; SELECT 2",
+        ],
+    )
+    def test_multi_statement_input_is_refused(self, sql):
+        """The regression that motivates checking statement count HERE rather
+        than delegating to ``parse_sql_type``, which classifies only the first
+        statement and would read these as harmless SELECTs."""
+        violation, _ = validate_read_only_sql(sql, "sqlite")
+
+        assert violation == READ_ONLY_MULTI_STATEMENT
+
+    def test_semicolon_inside_a_string_literal_is_not_a_second_statement(self):
+        """Quote-aware splitting: a naive ``";" in sql`` check would refuse this
+        valid single query."""
+        violation, sql_type = validate_read_only_sql("SELECT 'a;b' AS c", "sqlite")
+
+        assert violation is None
+        assert sql_type == SQLType.SELECT
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "PRAGMA journal_mode=WAL",
+            "PRAGMA journal_mode = WAL",
+            "pragma synchronous=OFF",
+        ],
+    )
+    def test_writable_pragma_is_refused_despite_classifying_as_metadata(self, sql):
+        """``PRAGMA x=y`` parses as METADATA_SHOW but mutates the database, so
+        the read-only type check alone would let it through."""
+        violation, sql_type = validate_read_only_sql(sql, "sqlite")
+
+        assert violation == READ_ONLY_WRITABLE_PRAGMA
+        assert sql_type == SQLType.METADATA_SHOW
+
+    @pytest.mark.parametrize("sql", ["", "   ", "-- just a comment", "/* only a block comment */"])
+    def test_empty_and_comment_only_input_is_refused(self, sql):
+        """Nothing to prove read-only about, so fail closed rather than passing
+        an empty string down to the connector. Refused as an unclassifiable
+        statement type, not as a shape violation -- there is no statement.
+
+        ``None`` is deliberately not covered: the parameter is typed ``str`` and
+        the helper raises ``TypeError`` on it. That is out of contract and fails
+        loudly rather than open, which is the acceptable direction here."""
+        violation, sql_type = validate_read_only_sql(sql, "sqlite")
+
+        assert violation == READ_ONLY_NON_READ
+        assert sql_type == SQLType.UNKNOWN
+
+    @pytest.mark.parametrize("sql", ["not sql at all", "SELCT 1", "}{"])
+    def test_unparseable_input_is_refused(self, sql):
+        """Fail-closed: text the parser cannot classify lands on UNKNOWN, which
+        is not a read-only type, so it is refused rather than forwarded."""
+        violation, sql_type = validate_read_only_sql(sql, "sqlite")
+
+        assert violation == READ_ONLY_NON_READ
+        assert sql_type not in (SQLType.SELECT, SQLType.METADATA_SHOW, SQLType.EXPLAIN)
+
+    @pytest.mark.parametrize("dialect", ["sqlite", "duckdb", "mysql", "postgresql", "starrocks", "snowflake", ""])
+    def test_the_verdict_does_not_depend_on_the_dialect(self, dialect):
+        """Every deployment dialect must agree on the two cases that matter, so
+        hardening cannot be dialect-specific in practice."""
+        assert validate_read_only_sql("SELECT 1", dialect)[0] is None
+        assert validate_read_only_sql("DROP TABLE users", dialect)[0] == READ_ONLY_NON_READ
+
+    def test_returns_the_parsed_type_alongside_the_verdict(self):
+        """Callers log the type; it must be the real one, not a placeholder."""
+        assert validate_read_only_sql("DROP TABLE users", "sqlite")[1] == SQLType.DDL
+        assert validate_read_only_sql("INSERT INTO t VALUES (1)", "sqlite")[1] == SQLType.INSERT


### PR DESCRIPTION
Two changes that let a deployment run third-party-authored agent content against its own datasources. Independent of each other — reviewable, and revertable, one commit at a time.

> **Rebased onto current `main`.** `main` has since replaced the `agent.sql_policy` provider framework with policy plugins driven by a per-request `policy_context` (#1310), and independently extracted the same statement-shape checks this branch had extracted. Both are reconciled here — see the final commit.
>
> **Scope changed.** The third change — `package_manifest.json` env var provenance — moved to #1298. It was unrelated to the security work and non-blocking, and it kept `PACKAGE_FORMAT_VERSION` churn out of a PR that should be reviewable on security grounds alone. This branch was force-pushed to drop those commits; `datus/cli/package_builder.py` is now byte-identical to `main`.

## Why

### 1. Jinja sandbox — please read this one first

This is a live defect, not hardening for a future feature.

A bare `jinja2.Environment` is a Python expression evaluator with attribute access, not a text templater. `{{ ctx.__init__.__globals__['SOME_KEY'] }}` reaches the rendering module's global namespace; from there, whatever that module imported. So "who can write a template" is equivalent to "who can run code in the agent process".

Two render sites compiled untrusted bodies with one:

**`PromptManager._get_env`** searches `{agent.home}/template` **before** the packaged templates, so a file dropped there silently overrides a shipped prompt. No privilege escalation needed — anyone who can write that directory.

**`render_reference_template`** renders `.j2` bodies from the reference-template store and carries `@mcp_tool`. Any client holding an API key can call it directly, so the trigger is one RPC rather than social engineering.

### 2. `agent.sql_read_only`

A host running third-party agent content against platform-owned datasources has no way to say "this process may read, never write". The policy plugins are a rewrite/deny framework that needs a plugin profile and a per-request `policy_context`, and works per-caller; they cannot express a blanket refusal, and a deployment that only needs the blanket refusal should not have to stand up a plugin to get it.

## Solution

### 1. Jinja sandbox

Both sites move to `SandboxedEnvironment`. Verified against both real code paths before and after:

```
                          before                     after
PromptManager             leaked the value           SecurityError
render_reference_template leaked the value           success=0, "rejected by the template sandbox"
```

**This is an equivalent replacement for rendering.** `SandboxedEnvironment` subclasses `Environment`; variables, loops, filters, macros and `FileSystemLoader` behave identically. Only traversal into Python internals is refused. Same pattern already used in `dashboard_artifact_tools.py:130` and `plugins/prompt.py:121`.

Three settings deliberately unchanged, each load-bearing — flagging them because changing any one silently breaks existing behaviour:

- `PromptManager` keeps the **lenient `Undefined`**. The shipped templates rely on absent variables rendering empty; `StrictUndefined` would break them broadly.
- `trim_blocks` / `lstrip_blocks` stay — they shape emitted prompt text.
- The **loader** stays — three templates resolve macros via `{% import %}`.

`SecurityError` subclasses `TemplateRuntimeError`, so neither existing handler in `render_reference_template` caught it and it fell through to the broad `except Exception`. Added a dedicated branch. `execute_reference_template` needed no change: it short-circuits on `success == 0`, so a refused template never reaches the datasource.

`template_file_processor.py` stays on a bare `Environment` — both sites only `env.parse()` and never render, so a sandbox there would be a no-op implying protection it does not provide. Commented as such.

Audited all 57 shipped templates: no dunder access, no mutating calls, no `|attr`/`lipsum`/`cycler`. Every method call (`.get`, `.items`, `.strftime`, the `expression_dialect` macro) verified working under the sandbox.

One subtlety for reviewers: with the lenient `Undefined`, a *single* unsafe attribute yields an undefined that stringifies to empty rather than raising; only a chained expression raises. Nothing leaks either way, but the regression test asserts the chained form deliberately.

### 2. `agent.sql_read_only`

A hard switch — no plugin, no request context, no rewrite; refuse outright. `docs/configuration/sql_policy.md` contrasts it with the policy plugins, since conflating them is the likeliest misconfiguration.

**Three groups of entry points needed gating, and they are unrelated in the code.**

**`DBFuncTool.execute_sql`.** 19 of its 24 construction sites never pass `read_only`, and the MCP server's `create_dynamic`/`create_static` factories *cannot* — their signatures are fixed by the tool-registry contract. All 24 do pass `agent_config`, so resolving the flag there covers every site without touching any.

**The write paths that never go through `execute_sql`.** `execute_write` and `execute_ddl` are reachable directly, and `transfer_query_result` reads from one datasource and **writes** to another (`CREATE TABLE` / `TRUNCATE` / `INSERT`) — mounted as its own tool by `gen_job`, permission level `ASK`, never touching `execute_sql`. Gating only the dispatcher would have left a cross-datasource write open on a "read-only" deployment, and would have made the sentence in the docs false. All four paths now share one `_refuse_write_if_read_only()`, so a fifth cannot be added with a subtly different rule.

**`POST /sql/execute` does not go through `DBFuncTool` at all.** It calls `BaseSqlConnector.execute` directly from `CLIService._execute_sql_sync`, so a tool-layer flag leaves it open. It gets its own gate.

Design notes:

- `DBFuncTool.read_only` is a **property** that ORs the per-instance flag with the deployment switch, so neither source can relax the other, and anything asking "is this tool read-only?" gets the posture the write paths will actually enforce — including the MCP factories' instances, which pass no `read_only` argument at all.
- Resolved **per access**, mirroring `policy_context`, so a tool built before its per-request config clone was hardened still honours it.
- The config switch is **one-way**: a read-only property plus `AgentConfig.harden_sql_read_only()`. A request clone may harden itself (as the chat API already does with `config_mutable`), but nothing downstream can undo a yaml-level `true`. A method rather than a tighten-only setter because `cfg.sql_read_only = False` silently doing nothing is the wrong failure mode for a security toggle — it now raises.
- Parsed with `coerce_bool` — `bool("false")` is `True`, and a silently inverted security switch is the worst failure mode available here. Promoted from a private helper in `agent_config` to `datus/utils/config_utils.py` so the modules that need it stop importing a private symbol across package boundaries.
- Deliberately **not** a dataclass field: `compute_fingerprint` runs `dataclasses.asdict`, which would raise on a declared-but-unstored attribute and collapse every config's fingerprint to the `id:` fallback.

Statement-shape rules live in `sql_utils.validate_read_only_sql` so every gate enforces the same thing — a further entry point silently missing the check is the failure mode this PR exists to fix. That helper is **main's**: #1310 extracted it independently while this branch was open, so the branch's own copy was dropped on rebase rather than left to drift beside it. Main's shape is the better one — it returns a violation *code*, so the tool layer words its refusal for a model and `POST /sql/execute` words its own for an HTTP client, while sharing the checks. Error strings preserved verbatim; table scoping stays on the method since it needs `self`.

Multi-statement rejection lives in the shared helper rather than relying on `parse_sql_type`, which classifies only the first statement — otherwise `SELECT 1; DROP TABLE t` reads as a harmless SELECT. There is a regression test for exactly that. Writable PRAGMAs are caught too (`PRAGMA journal_mode=WAL` classifies as `METADATA_SHOW`).

Refusals are logged with structured fields (`sql_type`, `datasource`, `sub_agent`, `source`, `rule`) at every gate, using the same field set on the REST route as on the tool. On a deployment running third-party content, a refusal means that content just tried to write — that is the event an operator wants, and successful reads were already the only thing being logged. `source` separates a deployment-wide refusal from a read-only agent doing its job; the finer `parse_sql_statement_kind` distinguishes CREATE from DROP without fetching the SQL.

**Behaviour change worth a look:** with the switch on, `POST /sql/execute` no longer accepts `USE`/`SET` (`CONTENT_SET`); the request's existing `database_name` field is the supported substitute. `SQLType.UNKNOWN` is refused as well — fail-closed is right for a hardened deployment, and `_fallback_sql_type` still rescues vendor SELECTs sqlglot cannot parse. Default is `false`; nothing changes for existing deployments.

## Test Cases

Full unit suite: **17680 passed**, 9 skipped, 1 xfailed. `audit_tests.py --diff-only` reports **P0=0**; diff coverage 100%.

10 failures in `test_explorer_service.py::TestExplorerServiceOSIAuthoring` are **pre-existing on `main`** — verified by checking out `upstream/main` and re-running there, where they fail identically. Untouched by these changes.

Unit:

- `TestPromptTemplateSandbox` — escape refused; lenient `undefined` *not* tightened; `trim_blocks` preserved; `{% import %}` macros still resolve; safe context methods still work.
- `TestClassifyReadOnlyViolation` — 52 cases against the shared fail-closed helper, which both SQL entry points depend on: multi-statement input, a semicolon inside a string literal, writable PRAGMAs, empty / comment-only / unparseable text, and agreement across every deployment dialect.
- `TestSqlReadOnly` — parsing including `"false"`; one-way hardening, with assignment asserted to raise; excluded from the `asdict` fingerprint.
- `TestMcpFactoriesHonorDeploymentReadOnly` — `create_dynamic`/`create_static` refuse writes end-to-end, and report `read_only` truthfully.
- `TestDBFuncToolWritePathsHonorReadOnly` — `execute_write`, `execute_ddl` and `transfer_query_result` each refused, and the transfer refused *before* it touches a connector.
- `TestCLIServiceReadOnlyDeployment` — including `SELECT 1; DROP TABLE schools`, writable PRAGMA, and per-request (non-snapshotted) resolution.
- `TestCoerceBool` — the coercion the switch depends on, including that a bare `Mock` reads as on (which is why test config doubles must pin security flags explicitly).

Integration, per the module table in `CLAUDE.md`:

- `integration/tools/test_func_tools_db.py::TestSqlReadOnlyDeploymentAgainstRealSqlite` — the unit tests use a mocked connector, which proves the branch is taken but not that the write never lands. These run the same statements against a real SQLite file and then assert the rows and tables are unchanged — and that the same writes really do succeed with the switch off, which is what makes the refusals meaningful.
- `integration/tools/test_mcp_server.py::TestMCPServerHonorsSqlReadOnly` — the same over real MCP tool dispatch, which is the path the switch exists for.

Manual, for a live server (not run by CI, documented in `docs/configuration/sql_policy.md`):

- `scripts/e2e_sql_read_only_mcp.py` — self-contained; stages a throwaway SQLite workspace and runs the flag-on/flag-off matrix over a real `datus-mcp --transport stdio` subprocess.
- `scripts/e2e_sql_read_only_mcp_project.py` — points at a real packaged project; `--sqlite-standin` for a full write round-trip, `--endpoint` to probe an already-running server, `--live-writes` against the real datasource using scratch tables it creates and drops itself.

The earlier "not done: end-to-end manual verification against a running MCP server" is now done — both scripts pass, and the audit-trail commit was verified against a live StarRocks-backed HTTP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0

