### PR TITLE
[BugFix] Gate visual HTML compile on an explicit switch, not filesystem_strict

### DIFF
--- a/datus/agent/node/gen_visual_dashboard_agentic_node.py
+++ b/datus/agent/node/gen_visual_dashboard_agentic_node.py
@@ -238,19 +238,13 @@ class GenVisualDashboardAgenticNode(
 
     # ----------------------------------------------------------- CLI compile
 
-    def _is_cli_mode(self) -> bool:
-        """CLI deployments compile a standalone HTML; API/SaaS deployments don't."""
-        if self.agent_config is None:
-            return True
-        deployment = getattr(self.agent_config, "deployment_mode", None) or getattr(self.agent_config, "run_mode", None)
-        if isinstance(deployment, str):
-            return deployment.lower() in {"", "cli", "interactive", "local"}
-        # If filesystem_strict is True the node is being driven by the API gateway;
-        # treat that as SaaS mode and skip the HTML compile.
-        return not bool(getattr(self.agent_config, "filesystem_strict", False))
-
     def _maybe_compile_html(self, dashboard_slug: str) -> Optional[str]:
-        if not self._is_cli_mode():
+        # ``compile_visual_html`` is set False by the API/gateway bootstraps,
+        # which render visual artifacts dynamically server-side. It is a
+        # behavior switch, not a deployment probe: safety flags such as
+        # ``filesystem_strict`` must never be read as a deployment signal
+        # (CLI and test configurations legitimately enable them too).
+        if self.agent_config is not None and not getattr(self.agent_config, "compile_visual_html", True):
             return None
         try:
             from datus.agent.node.visual_artifact.dashboard_html_renderer import render_dashboard_html

--- a/datus/agent/node/gen_visual_report_agentic_node.py
+++ b/datus/agent/node/gen_visual_report_agentic_node.py
@@ -204,19 +204,13 @@ class GenVisualReportAgenticNode(BaseVisualArtifactAgenticNode[GenVisualReportNo
 
     # ----------------------------------------------------------- CLI compile
 
-    def _is_cli_mode(self) -> bool:
-        """CLI deployments compile a standalone HTML; API/SaaS deployments don't."""
-        if self.agent_config is None:
-            return True
-        deployment = getattr(self.agent_config, "deployment_mode", None) or getattr(self.agent_config, "run_mode", None)
-        if isinstance(deployment, str):
-            return deployment.lower() in {"", "cli", "interactive", "local"}
-        # If filesystem_strict is True the node is being driven by the API gateway;
-        # treat that as SaaS mode and skip the HTML compile.
-        return not bool(getattr(self.agent_config, "filesystem_strict", False))
-
     def _maybe_compile_html(self, report_slug: str) -> Optional[str]:
-        if not self._is_cli_mode():
+        # ``compile_visual_html`` is set False by the API/gateway bootstraps,
+        # which render visual artifacts dynamically server-side. It is a
+        # behavior switch, not a deployment probe: safety flags such as
+        # ``filesystem_strict`` must never be read as a deployment signal
+        # (CLI and test configurations legitimately enable them too).
+        if self.agent_config is not None and not getattr(self.agent_config, "compile_visual_html", True):
             return None
         try:
             from datus.agent.node.visual_artifact.report_html_renderer import render_report_html

--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -367,6 +367,9 @@ class ChatTaskManager:
         # access, so force filesystem strict mode — every node constructed
         # below reads this flag via AgenticNode._resolve_filesystem_strict().
         agent_config.filesystem_strict = True
+        # API responses render dashboards/reports dynamically server-side
+        # (e.g. /dashboard/detail); never compile the CLI's standalone HTML.
+        agent_config.compile_visual_html = False
         # Multi-tenant API surface: the AgentConfig may be supplied by an
         # AuthProvider and the agent must never modify configuration. Hides
         # ``requires_mutable_config`` setup skills and switches the plugin

--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -916,6 +916,13 @@ class AgentConfig:
         # CLI, or direct assignment from API/gateway bootstraps.
         filesystem_raw = kwargs.get("filesystem") or {}
         self._filesystem_strict = bool(filesystem_raw.get("strict", False))
+        # ``compile_visual_html`` gates the visual nodes' standalone-HTML
+        # compile: CLI runs produce a local file the user opens, while API and
+        # gateway surfaces render dynamically server-side and set this False in
+        # their bootstraps. Deliberately NOT a YAML key — only entry-point code
+        # knows which surface is running, and a config-file toggle would let a
+        # stray setting silently drop the CLI's dashboard/report artifacts.
+        self.compile_visual_html = True
         # ``filesystem.allow_read`` / ``allow_write`` widen the fs tools beyond
         # the project root with explicitly configured absolute directories (the
         # filesystem counterpart of ``bash.sandbox.allow_*``). Needed whenever a

--- a/datus/gateway/main.py
+++ b/datus/gateway/main.py
@@ -105,6 +105,9 @@ def _run_gateway(args: argparse.Namespace) -> None:
     # file access. Force filesystem strict mode so nodes reject EXTERNAL
     # paths instead of hanging on a prompt.
     agent_config.filesystem_strict = True
+    # IM channels have no way to serve a local HTML artifact; visual nodes
+    # must not compile one.
+    agent_config.compile_visual_html = False
     # IM users must never be guided to edit the server's config file:
     # hide/refuse setup skills and use the read-only plugin prompt preamble.
     # (ChatTaskManager.start_chat re-asserts this on its per-request clone.)

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -468,10 +468,10 @@ class TestDashboardHtmlPathStreamMessage:
     def test_post_validate_hook_returns_none_in_non_cli_mode(self, real_agent_config, mock_llm_create):
         from datus.schemas.gen_visual_dashboard_models import GenVisualDashboardNodeResult
 
-        # filesystem_strict flips the node into SaaS/API mode — dashboards
+        # The API/gateway bootstraps disable the compile switch — dashboards
         # then render dynamically through the backend's /dashboard/detail
         # endpoint and never compile a standalone HTML.
-        real_agent_config.filesystem_strict = True
+        real_agent_config.compile_visual_html = False
         node = _make_node(real_agent_config)
         dashboard_slug = "path_msg_saas"
         self._seed_full_dashboard(Path(real_agent_config.project_root), dashboard_slug)
@@ -483,6 +483,25 @@ class TestDashboardHtmlPathStreamMessage:
         assert action is None
         assert result.html_path is None
         assert not (Path(real_agent_config.project_root) / "dashboards" / dashboard_slug / "index.html").exists()
+
+    def test_filesystem_strict_does_not_skip_cli_compile(self, real_agent_config, mock_llm_create):
+        from datus.schemas.gen_visual_dashboard_models import GenVisualDashboardNodeResult
+
+        # Regression: nightly enables agent.filesystem.strict as a safety
+        # switch; that must not be read as an API deployment and silently
+        # skip the compile (the dashboard_html_path action disappeared).
+        real_agent_config.filesystem_strict = True
+        node = _make_node(real_agent_config)
+        dashboard_slug = "path_msg_strict_cli"
+        dash_dir = self._seed_full_dashboard(Path(real_agent_config.project_root), dashboard_slug)
+        node._active_artifact_slug = dashboard_slug
+
+        result = GenVisualDashboardNodeResult(success=True)
+        action = node._post_validate_hook(dashboard_slug, result)
+
+        assert isinstance(action, ActionHistory)
+        assert action.action_type == "dashboard_html_path"
+        assert (dash_dir / "index.html").exists()
 
     def test_post_validate_hook_uses_node_config_overrides(self, real_agent_config, mock_llm_create):
         """``agentic_nodes.gen_visual_dashboard.{web_host,web_port,query_endpoint}``

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -370,9 +370,9 @@ class TestHtmlPathStreamMessage:
     def test_post_validate_hook_returns_none_in_non_cli_mode(self, real_agent_config, mock_llm_create):
         from datus.schemas.gen_visual_report_models import GenVisualReportNodeResult
 
-        # filesystem_strict flips the node into SaaS/API mode, which renders
+        # The API/gateway bootstraps disable the compile switch: SaaS renders
         # reports dynamically server-side and never compiles a standalone HTML.
-        real_agent_config.filesystem_strict = True
+        real_agent_config.compile_visual_html = False
         node = _make_node(real_agent_config)
         report_slug = "path_msg_saas"
         _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
@@ -384,6 +384,25 @@ class TestHtmlPathStreamMessage:
         assert action is None
         assert result.html_path is None
         assert not (Path(real_agent_config.project_root) / "reports" / report_slug / "index.html").exists()
+
+    def test_filesystem_strict_does_not_skip_cli_compile(self, real_agent_config, mock_llm_create):
+        from datus.schemas.gen_visual_report_models import GenVisualReportNodeResult
+
+        # Regression: nightly enables agent.filesystem.strict as a safety
+        # switch; that must not be read as an API deployment and silently
+        # skip the compile (the report_html_path action disappeared).
+        real_agent_config.filesystem_strict = True
+        node = _make_node(real_agent_config)
+        report_slug = "path_msg_strict_cli"
+        _seed_render_on_disk(Path(real_agent_config.project_root), report_slug)
+        node._active_artifact_slug = report_slug
+
+        result = GenVisualReportNodeResult(success=True)
+        action = node._post_validate_hook(report_slug, result)
+
+        assert action is not None
+        assert action.action_type == "report_html_path"
+        assert (Path(real_agent_config.project_root) / "reports" / report_slug / "index.html").exists()
 
 
 class _InlineThread:

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -1176,8 +1176,12 @@ class TestStartChat:
 
         assert captured["config"].config_mutable is False
         assert captured["config"].filesystem_strict is True
+        # API responses render visual artifacts dynamically server-side, so
+        # the per-request clone must switch off the CLI's standalone compile.
+        assert captured["config"].compile_visual_html is False
         # The shared config must not be mutated by the request.
         assert real_agent_config.config_mutable is True
+        assert real_agent_config.compile_visual_html is True
 
     async def test_start_chat_duplicate_session_raises(self, real_agent_config, mock_llm_create):
         """start_chat raises ValueError for duplicate session_id."""

--- a/tests/unit_tests/gateway/test_main.py
+++ b/tests/unit_tests/gateway/test_main.py
@@ -1,0 +1,64 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the gateway CLI entry point's config bootstrap."""
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datus.gateway import main as gateway_main
+
+
+def _args(**overrides) -> argparse.Namespace:
+    values = {"config": "", "datasource": "default", "host": "0.0.0.0", "port": 9000}
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+class TestRunGatewayBootstrap:
+    """_run_gateway must mark the loaded config for the IM surface."""
+
+    def _run(self, agent_config) -> MagicMock:
+        gateway_cls = MagicMock()
+        with (
+            patch("datus.configuration.agent_config_loader.load_agent_config", return_value=agent_config),
+            patch("datus.gateway.runtime.DatusGateway", gateway_cls),
+            patch.object(gateway_main.asyncio, "run"),
+        ):
+            gateway_main._run_gateway(_args())
+        return gateway_cls
+
+    def test_bootstrap_flags_are_forced_for_the_im_surface(self):
+        agent_config = SimpleNamespace(
+            filesystem_strict=False,
+            compile_visual_html=True,
+            config_mutable=True,
+            active_model=MagicMock(),
+            channels_config={"slack": {}},
+        )
+
+        gateway_cls = self._run(agent_config)
+
+        # No broker to confirm out-of-workspace access.
+        assert agent_config.filesystem_strict is True
+        # IM channels cannot serve a local HTML artifact.
+        assert agent_config.compile_visual_html is False
+        # IM users must never be guided to edit the server's config file.
+        assert agent_config.config_mutable is False
+        assert gateway_cls.call_args.kwargs["agent_config"] is agent_config
+
+    def test_missing_channels_config_exits(self):
+        agent_config = SimpleNamespace(
+            filesystem_strict=False,
+            compile_visual_html=True,
+            config_mutable=True,
+            active_model=MagicMock(),
+            channels_config={},
+        )
+
+        with pytest.raises(SystemExit):
+            self._run(agent_config)


### PR DESCRIPTION
## Why

Nightly run [31985725208](https://github.com/Datus-ai/Datus-agent/actions/runs/31985725208): the visual dashboard/report tests fail with `expected exactly one dashboard_html_path action, got 0` even though the agent completes the flow and `validate_render` passes.

Root cause: the visual nodes' `_is_cli_mode()` inferred the deployment surface from `filesystem_strict` — a **safety switch** that #1292 legitimately enabled for the nightly test config — and silently skipped the standalone-HTML compile. The `deployment_mode`/`run_mode` attributes the function consulted first have never been defined anywhere in the codebase (dead code since #764), so the strict-flag heuristic was the only live logic, and it silently drops artifacts for any CLI user who enables strict mode.

## Solution

Replace the deployment probe with an explicit behavior switch, matching how the codebase already handles surface-dependent behavior (`config_mutable`, `filesystem_strict` are behavior switches set by bootstraps, not identity probes):

- `AgentConfig.compile_visual_html` (default `True`) — deliberately **not** a YAML key: only entry-point code knows which surface is running, and a config-file toggle would let a stray setting silently drop the CLI's artifacts the same way strict did.
- The API per-request clone (`chat_task_manager`) and the gateway bootstrap set it `False`, alongside the other surface flags they already force. SaaS behavior is unchanged: those surfaces render visual artifacts dynamically server-side.
- Both visual nodes drop `_is_cli_mode()` entirely (dead `deployment_mode` probe included) and read the switch at the top of `_maybe_compile_html`.

Principle: safety flags are not deployment signals. Bootstraps translate surface identity into explicit behavior switches once; consumers read switches.

## Test Cases

- Both node suites: the SaaS case now sets `compile_visual_html = False`; new regression tests pin the nightly failure mode — `filesystem_strict = True` with the default switch must still compile (`dashboard_html_path` / `report_html_path` emitted, `index.html` on disk).
- `test_chat_task_manager`: the per-request clone asserts `compile_visual_html is False` while the shared config stays `True`.
- New `tests/unit_tests/gateway/test_main.py`: first coverage for the gateway bootstrap — asserts all three forced surface flags and the missing-channels exit.
- PR gates: 3581 passed / diff coverage 100% (the only local failures were a missing optional `datus_semantic_osi` package; the affected suite passes 72/72 once installed); `audit_tests` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
