### PR TITLE
[BugFix] Restate the response-language directive in the target language, key the prompt snapshot on it

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -33,7 +33,9 @@ from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.base import BaseInput, BaseResult
 from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.language_utils import ensure_native_directive as _ensure_native_directive
 from datus.utils.language_utils import resolve_language_name as _resolve_language_name
+from datus.utils.language_utils import resolve_native_directive as _resolve_native_directive
 from datus.utils.loggings import get_logger
 from datus.utils.message_utils import build_structured_content
 from datus.utils.node_utils import build_database_context
@@ -1055,8 +1057,11 @@ class AgenticNode(Node):
         node template, its version, and the active model (a model switch also
         resets the provider-side prefix cache, so rebuilding is free). The
         live per-turn datasource/dialect is injected in the user message
-        instead, so it deliberately does **not** appear here; date, language,
-        memory, and skills are frozen until the snapshot is rebuilt.
+        instead, so it deliberately does **not** appear here. ``language`` DOES
+        appear: it is a per-request field on the Chat API, so a user switching
+        the UI language mid-session must not keep replaying a snapshot that
+        pins the old one. Date, memory, and skills stay frozen until the
+        snapshot is rebuilt.
         """
         agent_config = getattr(self, "agent_config", None)
         version = prompt_version
@@ -1077,10 +1082,12 @@ class AgenticNode(Node):
                     model_id = f"{getattr(mc, 'type', '') or ''}:{getattr(mc, 'model', '') or ''}"
             except Exception:
                 model_id = ""
+        language = getattr(agent_config, "language", None) if agent_config is not None else None
         return {
             "node_name": self.get_node_name(),
             "prompt_version": str(version or ""),
             "model_name": model_id,
+            "language": str(language or "").strip(),
         }
 
     def _get_session_system_prompt(
@@ -1362,10 +1369,12 @@ class AgenticNode(Node):
                 version=None,
                 language_code=language_code,
                 language_name=_resolve_language_name(language_code),
+                native_directive=_resolve_native_directive(language_code),
             )
         except Exception as e:
             logger.warning(f"Failed to render response_language template: {e}")
             return base_prompt
+        language_section = _ensure_native_directive(language_section, language_code)
         if language_section and language_section.strip():
             base_prompt = base_prompt + "\n\n" + language_section
         return base_prompt

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -33,6 +33,7 @@ from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.base import BaseInput, BaseResult
 from datus.utils.exceptions import DatusException, ErrorCode
+from datus.utils.language_utils import build_fallback_directive as _build_fallback_directive
 from datus.utils.language_utils import ensure_native_directive as _ensure_native_directive
 from datus.utils.language_utils import resolve_language_name as _resolve_language_name
 from datus.utils.language_utils import resolve_native_directive as _resolve_native_directive
@@ -1372,8 +1373,12 @@ class AgenticNode(Node):
                 native_directive=_resolve_native_directive(language_code),
             )
         except Exception as e:
+            # Returning the prompt untouched would read as "no language pinned"
+            # and hand the turn back to the model's own choice — the very drift
+            # this directive exists to stop. Fall back like the other two call
+            # sites do.
             logger.warning(f"Failed to render response_language template: {e}")
-            return base_prompt
+            return base_prompt + "\n\n" + _build_fallback_directive(language_code)
         language_section = _ensure_native_directive(language_section, language_code)
         if language_section and language_section.strip():
             base_prompt = base_prompt + "\n\n" + language_section

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, ClassVar, Dict, Generic, 
 
 from pydantic import BaseModel
 
-from datus.agent.node.agentic_node import AgenticNode, _resolve_language_name
+from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.visual_artifact._visual_artifact_finalize import (
     finalize_stage_text,
     narrative_outputs_present,
@@ -44,6 +44,7 @@ from datus.agent.node.visual_artifact._visual_artifact_finalize import (
 )
 from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.utils.language_utils import build_fallback_directive
 
 if TYPE_CHECKING:
     from datus.agent.node.stream_run_context import StreamRunContext
@@ -456,8 +457,7 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         directive = self._inject_response_language("").strip()
         if directive:
             return directive
-        language_code = str(language_raw).strip()
-        return f"# Response Language\n- Use: {_resolve_language_name(language_code)} ({language_code})"
+        return build_fallback_directive(str(language_raw).strip())
 
     def _run_finalize(
         self,

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -444,12 +444,11 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         finalize prompt explicitly. Reuses the same rendered template rather
         than a second copy of the wording.
 
-        ``_inject_response_language`` swallows a template-render failure and
-        returns the prompt untouched, which here would read as "no language
-        pinned" and hand finalize the infer-from-the-user's-prompts branch —
-        wrong whenever the operator pinned a language the user does not write
-        in. Fall back to a minimal directive built from the same code/name pair
-        so a pinned language always survives.
+        ``_inject_response_language`` now falls back to a minimal directive of
+        its own on a render failure, so the branch below is belt-and-braces: an
+        empty return here would read as "no language pinned" and hand finalize
+        the infer-from-the-user's-prompts branch — wrong whenever the operator
+        pinned a language the user does not write in.
         """
         language_raw = getattr(self.agent_config, "language", None)
         if not language_raw or not str(language_raw).strip():

--- a/datus/prompts/prompt_templates/response_language_1.0.j2
+++ b/datus/prompts/prompt_templates/response_language_1.0.j2
@@ -1,4 +1,7 @@
 # Response Language
 - Use: {{ language_name }} ({{ language_code }})
+{% if native_directive %}
+- {{ native_directive }}
+{% endif %}
 - Apply to: replies, sub-agent prompts, file comments/prose, `ask_user` questions, and any human-readable text in generated artifacts
 - Exclude: code, SQL, identifiers, file paths, URLs, JSON keys

--- a/datus/tools/llms_tools/visualization_tool.py
+++ b/datus/tools/llms_tools/visualization_tool.py
@@ -24,7 +24,12 @@ from datus.prompts.prompt_manager import get_prompt_manager
 from datus.schemas.visualization import VisualizationInput, VisualizationOutput, VisualizationWithContextOutput
 from datus.tools.base import BaseTool
 from datus.tools.llms_tools.visualization_messages import empty_dataset_reason, reason_for_chart
-from datus.utils.language_utils import resolve_language_name
+from datus.utils.language_utils import (
+    build_fallback_directive,
+    ensure_native_directive,
+    resolve_language_name,
+    resolve_native_directive,
+)
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -275,19 +280,19 @@ class VisualizationTool(BaseTool):
         code = self._effective_language(language)
         if not code:
             return ""
-        language_name = resolve_language_name(code)
         try:
             section = get_prompt_manager(agent_config=self.agent_config).render_template(
                 "response_language",
                 version=None,
                 language_code=code,
-                language_name=language_name,
+                language_name=resolve_language_name(code),
+                native_directive=resolve_native_directive(code),
             )
         except Exception as exc:
             # A render failure must not silently drop a pinned language.
             logger.warning(f"Failed to render response_language template: {exc}")
-            return f"# Response Language\n- Use: {language_name} ({code})"
-        return section.strip() or f"# Response Language\n- Use: {language_name} ({code})"
+            return build_fallback_directive(code)
+        return ensure_native_directive(section.strip(), code) or build_fallback_directive(code)
 
     # ------------------------------------------------------------------ #
     # Data preparation

--- a/datus/utils/language_utils.py
+++ b/datus/utils/language_utils.py
@@ -26,6 +26,27 @@ LANGUAGE_NAME_MAP: Dict[str, str] = {
     "it": "Italian",
 }
 
+# The same directive restated *in the target language*. An English
+# meta-instruction ("Use: Chinese") sits at the end of an English system
+# prompt and then competes with dozens of turns of English schema/SQL tool
+# output; smaller models drift out of it — and CJK drift lands on a
+# neighbouring script (a Chinese session answered in Japanese) rather than on
+# English. A sentence written in the target language survives that far better.
+NATIVE_DIRECTIVE_MAP: Dict[str, str] = {
+    "en": "Always answer in English, no matter what language the context or tool output is in.",
+    "zh": "必须始终使用简体中文回复，无论上下文、表结构、SQL 或工具输出是什么语言。",
+    "zh-cn": "必须始终使用简体中文回复，无论上下文、表结构、SQL 或工具输出是什么语言。",
+    "zh-tw": "必須始終使用繁體中文回覆，無論上下文、表結構、SQL 或工具輸出是什麼語言。",
+    "ja": "文脈やツールの出力が何語であっても、必ず日本語で回答してください。",
+    "ko": "문맥이나 도구 출력이 어떤 언어이든 항상 한국어로 답변하세요.",
+    "es": "Responde siempre en español, sea cual sea el idioma del contexto o de la salida de las herramientas.",
+    "fr": "Réponds toujours en français, quelle que soit la langue du contexte ou des sorties d'outils.",
+    "de": "Antworte immer auf Deutsch, unabhängig von der Sprache des Kontexts oder der Tool-Ausgaben.",
+    "pt": "Responda sempre em português, seja qual for o idioma do contexto ou da saída das ferramentas.",
+    "ru": "Всегда отвечай на русском языке, независимо от языка контекста и вывода инструментов.",
+    "it": "Rispondi sempre in italiano, qualunque sia la lingua del contesto o dell'output degli strumenti.",
+}
+
 
 def resolve_language_name(code: Optional[str]) -> str:
     """Map a language code (e.g. ``"zh"``) to a human-readable name.
@@ -36,3 +57,43 @@ def resolve_language_name(code: Optional[str]) -> str:
     if not code:
         return "English"
     return LANGUAGE_NAME_MAP.get(code.strip().lower(), code)
+
+
+def resolve_native_directive(code: Optional[str]) -> str:
+    """Return the target-language instruction for ``code``, or ``""``.
+
+    Unknown codes have no translation to offer, so they fall back to the
+    English name line alone rather than to a wrong-language sentence.
+    """
+    if not code:
+        return ""
+    return NATIVE_DIRECTIVE_MAP.get(code.strip().lower(), "")
+
+
+def ensure_native_directive(section: str, code: Optional[str]) -> str:
+    """Append the native-language line when ``section`` is missing it.
+
+    ``DatusPathManager.ensure_templates`` copies the bundled templates into
+    ``~/.datus/template`` with ``replace=False``, and that copy wins over the
+    packaged one. Any home bootstrapped before this change therefore keeps
+    rendering the old name-only section forever, so the directive is restated
+    here rather than left to the template alone.
+    """
+    native = resolve_native_directive(code)
+    if not native or not section.strip() or native in section:
+        return section
+    return f"{section.rstrip()}\n- {native}"
+
+
+def build_fallback_directive(code: Optional[str]) -> str:
+    """Minimal ``# Response Language`` section built without the template.
+
+    Used by the callers that must not silently drop a pinned language when the
+    jinja render fails; keeps the same shape (and the native sentence) as
+    ``response_language_1.0.j2``.
+    """
+    lines = [f"# Response Language\n- Use: {resolve_language_name(code)} ({code})"]
+    native = resolve_native_directive(code)
+    if native:
+        lines.append(f"- {native}")
+    return "\n".join(lines)

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -88,6 +88,8 @@ agent:
 
 Built-in code → name mapping (injected into the system prompt): `en` → English, `zh` / `zh-cn` → Chinese, `zh-tw` → Traditional Chinese, `ja` → Japanese, `ko` → Korean, `es` → Spanish, `fr` → French, `de` → German, `pt` → Portuguese, `ru` → Russian, `it` → Italian. Unknown codes are used verbatim.
 
+For every mapped code the directive is also restated **in that language**, next to the English name line — a lone English meta-instruction competes with dozens of turns of English schema/SQL tool output, and smaller models drift out of it. Unknown codes keep the English line only.
+
 Chat API requests can override this per task by sending a `language` field in the request body (see [Chat API](../API/chat.md)). CLI usage inherits the yaml default.
 
 ### Models Configuration (Custom Entries) {#models-configuration}

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -25,6 +25,8 @@ agent:
 
 内置语言码映射：`en` → English、`zh` / `zh-cn` → Chinese、`zh-tw` → Traditional Chinese、`ja` → Japanese、`ko` → Korean、`es` → Spanish、`fr` → French、`de` → German、`pt` → Portuguese、`ru` → Russian、`it` → Italian。未知代码将原样注入 system prompt，方便扩展。
 
+对映射表内的语言码，除英文的名称行外还会用**该语言本身**再写一遍指令：单独一行英文元指令要和几十轮英文表结构 / SQL 工具输出竞争注意力，小模型容易漂移。未知代码仅保留英文行。
+
 Chat API 请求可通过请求体中的 `language` 字段按任务覆盖该默认值（详见 [Chat API](../API/chat.zh.md)）。CLI 无覆盖参数，直接沿用 yaml 中的默认。
 
 ### 模型提供方（models） {#models-configuration}

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -22,6 +22,7 @@ from datus.configuration.agent_config import AgentConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.base import BaseInput, BaseResult
 from datus.schemas.token_usage import TokenUsage
+from datus.utils.language_utils import NATIVE_DIRECTIVE_MAP
 
 _UNSET = object()
 
@@ -1839,12 +1840,16 @@ class TestInjectResponseLanguage:
         assert result.count("\n- Use:") == 1
         assert result.rstrip().endswith("JSON keys")
 
-    def test_render_failure_returns_base_unchanged(self):
+    def test_render_failure_still_pins_the_language(self):
+        """Dropping the directive on a render failure silently returns the turn
+        to the model's own language choice — what the directive exists to stop."""
         node = _make_node(agent_config=self._agent_config("zh"))
         with patch("datus.agent.node.agentic_node.get_prompt_manager") as mgr:
             mgr.return_value.render_template.side_effect = RuntimeError("boom")
             result = node._inject_response_language("BASE")
-        assert result == "BASE"
+        assert result.startswith("BASE\n\n# Response Language")
+        assert "Chinese (zh)" in result
+        assert result.endswith(NATIVE_DIRECTIVE_MAP["zh"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1825,6 +1825,20 @@ class TestInjectResponseLanguage:
         node = _make_node(agent_config=_Bare())
         assert node._inject_response_language("BASE") == "BASE"
 
+    def test_directive_is_restated_in_the_target_language(self):
+        """The English ``Use: Chinese`` line alone gets drowned out by dozens of
+        turns of English tool output; the native sentence is what actually holds
+        a small model in language."""
+        node = _make_node(agent_config=self._agent_config("zh"))
+        result = node._inject_response_language("BASE")
+        assert "简体中文" in result
+
+    def test_unknown_code_has_no_native_line(self):
+        node = _make_node(agent_config=self._agent_config("xx"))
+        result = node._inject_response_language("BASE")
+        assert result.count("\n- Use:") == 1
+        assert result.rstrip().endswith("JSON keys")
+
     def test_render_failure_returns_base_unchanged(self):
         node = _make_node(agent_config=self._agent_config("zh"))
         with patch("datus.agent.node.agentic_node.get_prompt_manager") as mgr:

--- a/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
@@ -9,7 +9,8 @@ Covers:
   node instances, rebuild on a meta change (model switch), no caching without a
   session id.
 - ``_system_prompt_snapshot_meta``: identity keys exclude per-turn live values
-  (datasource, profile, date, language).
+  (datasource, profile, date) but DO include the response language, which the
+  Chat API sets per request.
 - ``_build_datasource_reminder``: live per-turn datasource + dialect line for
   the user-message ``<system_reminder>`` envelope; never mentions the
   permission profile.
@@ -55,9 +56,10 @@ DELIVERABLE_TEMPLATES = [
 ]
 
 
-def _agent_config(*, current_datasource=None, services=None, model="gpt-4.1"):
+def _agent_config(*, current_datasource=None, services=None, model="gpt-4.1", language=None):
     return SimpleNamespace(
         prompt_version="1.2",
+        language=language,
         current_datasource=current_datasource,
         services=services,
         active_model=lambda: SimpleNamespace(type="openai", model=model),
@@ -190,6 +192,25 @@ class TestGetSessionSystemPrompt:
         assert node2.build_count == 0
         assert node2.lazy_mount_count == 1
 
+    def test_language_switch_rebuilds(self, session_manager):
+        """``language`` is a per-request Chat API field: a user switching the UI
+        language mid-session must not keep replaying the old directive."""
+        node = _SnapshotNode(session_manager, _agent_config(language="en"))
+        assert node._get_session_system_prompt(prompt_version="1.2") == "SYS#1"
+        node.agent_config = _agent_config(language="zh-CN")
+        assert node._get_session_system_prompt(prompt_version="1.2") == "SYS#2"
+        # The rebuilt snapshot replays for the new language.
+        assert node._get_session_system_prompt(prompt_version="1.2") == "SYS#2"
+        assert node.build_count == 2
+
+    def test_same_language_replays(self, session_manager):
+        """The common case — every request carries the same code — stays a hit."""
+        node = _SnapshotNode(session_manager, _agent_config(language="zh-CN"))
+        node._get_session_system_prompt(prompt_version="1.2")
+        node.agent_config = _agent_config(language="zh-CN")
+        node._get_session_system_prompt(prompt_version="1.2")
+        assert node.build_count == 1
+
     def test_node_model_override_switch_rebuilds(self, session_manager):
         """A node-level model override change must invalidate the snapshot."""
         node = _SnapshotNode(session_manager, _agent_config())
@@ -204,7 +225,12 @@ class TestSnapshotMeta:
     def test_meta_is_exactly_the_identity_keys(self, session_manager):
         node = _SnapshotNode(session_manager, _agent_config(current_datasource="main"))
         meta = node._system_prompt_snapshot_meta("1.2")
-        assert meta == {"node_name": "chat", "prompt_version": "1.2", "model_name": "openai:gpt-4.1"}
+        assert meta == {
+            "node_name": "chat",
+            "prompt_version": "1.2",
+            "model_name": "openai:gpt-4.1",
+            "language": "",
+        }
 
     def test_meta_falls_back_to_agent_config_version(self, session_manager):
         node = _SnapshotNode(session_manager, _agent_config())
@@ -220,6 +246,15 @@ class TestSnapshotMeta:
         node = _SnapshotNode(session_manager, cfg)
         meta = node._system_prompt_snapshot_meta("1.2")
         assert meta["model_name"] == ""
+
+    def test_meta_normalizes_language(self, session_manager):
+        """Unset and whitespace-only both collapse to the same identity, so a
+        blank per-request override never spuriously invalidates the snapshot."""
+        assert _SnapshotNode(session_manager, _agent_config())._system_prompt_snapshot_meta("1.2")["language"] == ""
+        node = _SnapshotNode(session_manager, _agent_config(language="  "))
+        assert node._system_prompt_snapshot_meta("1.2")["language"] == ""
+        node = _SnapshotNode(session_manager, _agent_config(language=" zh-CN "))
+        assert node._system_prompt_snapshot_meta("1.2")["language"] == "zh-CN"
 
     def test_meta_prefers_node_model_override(self, session_manager):
         """``node_config.model`` pins the effective model — it is the identity,

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -32,6 +32,7 @@ from datus.tools.func_tool import (
     DBFuncTool,
     SemanticTools,
 )
+from datus.utils.language_utils import NATIVE_DIRECTIVE_MAP
 from tests.unit_tests.mock_llm_model import (
     MockToolCall,
     build_tool_then_response,
@@ -752,7 +753,7 @@ class TestFinalizeLanguageDirective:
 
         directive = node._finalize_language_directive()
 
-        assert directive == "# Response Language\n- Use: Japanese (ja)"
+        assert directive == f"# Response Language\n- Use: Japanese (ja)\n- {NATIVE_DIRECTIVE_MAP['ja']}"
 
     def test_run_finalize_forwards_the_directive_to_the_llm(self, real_agent_config, mock_llm_create, tmp_path):
         """End-to-end through ``_run_finalize`` → ``run_finalize_analysis``:

--- a/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
+++ b/tests/unit_tests/tools/llms_tools/test_visualization_tool.py
@@ -12,6 +12,7 @@ import pytest
 
 from datus.schemas.visualization import VisualizationInput, VisualizationOutput
 from datus.tools.llms_tools.visualization_tool import VisualizationTool
+from datus.utils.language_utils import NATIVE_DIRECTIVE_MAP
 
 
 def _make_tool(model=None):
@@ -434,7 +435,10 @@ class TestLanguageDirective:
         kw = mock_gpm.return_value.render_template.call_args.kwargs
         assert kw["language_code"] == "zh"
         assert kw["language_name"] == "Chinese"
-        assert directive == "# Response Language\n- Use: Chinese (zh)"
+        assert kw["native_directive"] == NATIVE_DIRECTIVE_MAP["zh"]
+        # A home carrying a pre-upgrade template copy renders the name line
+        # only; the native sentence is restated on top of whatever came back.
+        assert directive == f"# Response Language\n- Use: Chinese (zh)\n- {NATIVE_DIRECTIVE_MAP['zh']}"
 
     def test_falls_back_to_agent_config_language(self):
         config = MagicMock()
@@ -477,7 +481,7 @@ class TestLanguageDirective:
             mock_gpm.return_value.render_template.side_effect = Exception("template missing")
             directive = tool._language_directive("zh")
 
-        assert directive == "# Response Language\n- Use: Chinese (zh)"
+        assert directive == f"# Response Language\n- Use: Chinese (zh)\n- {NATIVE_DIRECTIVE_MAP['zh']}"
 
     def test_empty_render_falls_back_to_minimal_directive(self):
         tool = _make_tool()
@@ -485,7 +489,7 @@ class TestLanguageDirective:
             mock_gpm.return_value.render_template.return_value = "   "
             directive = tool._language_directive("fr")
 
-        assert directive == "# Response Language\n- Use: French (fr)"
+        assert directive == f"# Response Language\n- Use: French (fr)\n- {NATIVE_DIRECTIVE_MAP['fr']}"
 
     def test_execute_passes_directive_into_prompt(self):
         mock_model = MagicMock()
@@ -504,7 +508,7 @@ class TestLanguageDirective:
 
         # The last render is the prompt itself; the directive render precedes it.
         prompt_call = mock_gpm.return_value.render_template.call_args_list[-1]
-        assert prompt_call.kwargs["language_directive"] == "directive"
+        assert prompt_call.kwargs["language_directive"] == f"directive\n- {NATIVE_DIRECTIVE_MAP['zh']}"
 
     def test_execute_with_context_passes_directive_into_prompt(self):
         mock_model = MagicMock()
@@ -525,7 +529,7 @@ class TestLanguageDirective:
             result = tool.execute_with_context(_make_input(df), sql="SELECT 1", language="zh")
 
         prompt_call = mock_gpm.return_value.render_template.call_args_list[-1]
-        assert prompt_call.kwargs["language_directive"] == "directive"
+        assert prompt_call.kwargs["language_directive"] == f"directive\n- {NATIVE_DIRECTIVE_MAP['zh']}"
         assert result.success is True
 
     def test_prompt_carries_empty_directive_when_unpinned(self):

--- a/tests/unit_tests/utils/test_language_utils.py
+++ b/tests/unit_tests/utils/test_language_utils.py
@@ -5,7 +5,14 @@
 
 import pytest
 
-from datus.utils.language_utils import LANGUAGE_NAME_MAP, resolve_language_name
+from datus.utils.language_utils import (
+    LANGUAGE_NAME_MAP,
+    NATIVE_DIRECTIVE_MAP,
+    build_fallback_directive,
+    ensure_native_directive,
+    resolve_language_name,
+    resolve_native_directive,
+)
 
 
 class TestResolveLanguageName:
@@ -32,3 +39,69 @@ class TestResolveLanguageName:
     @pytest.mark.parametrize("code", ["", None])
     def test_empty_defaults_to_english(self, code):
         assert resolve_language_name(code) == "English"
+
+
+class TestResolveNativeDirective:
+    def test_every_named_language_has_a_native_directive(self):
+        """A code the name map knows but the directive map doesn't would ship a
+        bare English meta-instruction — the exact weak form this map exists to
+        replace."""
+        assert set(LANGUAGE_NAME_MAP) == set(NATIVE_DIRECTIVE_MAP)
+
+    @pytest.mark.parametrize(
+        "code,fragment",
+        [
+            ("zh", "简体中文"),
+            ("zh-CN", "简体中文"),
+            ("zh-tw", "繁體中文"),
+            ("ja", "日本語"),
+            ("en", "in English"),
+        ],
+    )
+    def test_directive_is_written_in_the_target_language(self, code, fragment):
+        assert fragment in resolve_native_directive(code)
+
+    @pytest.mark.parametrize("code", ["xx-yy", "", None])
+    def test_unknown_or_empty_has_no_directive(self, code):
+        """No translation to offer — better a name-only line than a sentence in
+        the wrong language."""
+        assert resolve_native_directive(code) == ""
+
+
+class TestBuildFallbackDirective:
+    def test_includes_name_and_native_sentence(self):
+        out = build_fallback_directive("zh")
+        assert out.startswith("# Response Language")
+        assert "Chinese (zh)" in out
+        assert "简体中文" in out
+
+    def test_unknown_code_keeps_name_line_only(self):
+        out = build_fallback_directive("xx")
+        assert out == "# Response Language\n- Use: xx (xx)"
+
+
+class TestEnsureNativeDirective:
+    """A home bootstrapped before this change keeps serving the old
+    ``~/.datus/template`` copy (``ensure_templates`` uses ``replace=False``),
+    so the native line has to survive an outdated render.
+    """
+
+    OLD_SECTION = "# Response Language\n- Use: Chinese (zh)\n- Exclude: code, SQL"
+
+    def test_appends_to_a_stale_render(self):
+        out = ensure_native_directive(self.OLD_SECTION, "zh")
+        assert out.startswith(self.OLD_SECTION)
+        assert out.endswith(NATIVE_DIRECTIVE_MAP["zh"])
+
+    def test_does_not_duplicate_when_template_already_rendered_it(self):
+        section = f"{self.OLD_SECTION}\n- {NATIVE_DIRECTIVE_MAP['zh']}"
+        assert ensure_native_directive(section, "zh") == section
+
+    @pytest.mark.parametrize("code", ["xx-yy", "", None])
+    def test_untranslated_code_left_alone(self, code):
+        assert ensure_native_directive(self.OLD_SECTION, code) == self.OLD_SECTION
+
+    def test_empty_section_left_alone(self):
+        """An empty render means "no directive"; a bare native line without the
+        header would be worse than nothing."""
+        assert ensure_native_directive("", "zh") == ""


### PR DESCRIPTION
## Why

A user with the UI language set to Chinese occasionally got **Japanese** replies (model: `deepseek-v4-flash`).

The front end does send the language on every turn (`buildBaseChatRequest` → `language: 'zh-CN'`), and `chat_task_manager` does set it on the per-request config, so the directive was injected. The problem is how weak it is once injected:

- It is a **single English line** (`- Use: Chinese (zh-CN)`) at the very end of the system prompt, and nothing restates it per turn. After dozens of turns of English schema / SQL / tool output, small models drift out of it — and CJK drift lands on a *neighbouring script* (zh session answered in ja) rather than on English.
- `_system_prompt_snapshot_meta` did not include `language`. It is a **per-request** Chat API field, so a user switching the UI language mid-session kept replaying a snapshot pinned to the old language, forever.

## Solution

1. **Restate the directive in the target language.** `NATIVE_DIRECTIVE_MAP` in `datus/utils/language_utils.py` carries one sentence per mapped code (`zh` → 「必须始终使用简体中文回复，无论上下文、表结构、SQL 或工具输出是什么语言。」), rendered by `response_language_1.0.j2` next to the existing English name line. Unknown codes have no translation to offer and keep the English line only.

2. **Survive a stale user template.** `DatusPathManager.ensure_templates` copies the bundled templates into `~/.datus/template` with `replace=False`, and that copy takes precedence over the packaged one — so any home bootstrapped before this change would render the old name-only section forever and never get the fix. `ensure_native_directive()` re-appends the native line when the rendered section lacks it; it is idempotent (no-op when the template already produced it). The same helper backs the render-failure fallbacks in the visualization tool and visual-artifact finalize, which previously dropped the native line.

3. **Add `language` to the snapshot meta.** Normalized (`strip()`, unset/blank both → `\"\"`) so a blank per-request override never spuriously invalidates a snapshot. Old snapshots lack the key and rebuild once, which is free.

Scope note: this hardens the directive that already exists. Repeating it per turn in the user message (closest to the generation point, best anti-drift) is deliberately left out — it touches the per-turn envelope and belongs in its own change.

## Test Cases

Unit only — no LLM, no network:

- `tests/unit_tests/utils/test_language_utils.py` — every code in `LANGUAGE_NAME_MAP` has a native directive (a gap would silently ship the weak English-only form); each directive is written in its own language; unknown/empty codes yield none; `ensure_native_directive` appends to a stale render, does not duplicate, and leaves an empty section alone; `build_fallback_directive` shape.
- `tests/unit_tests/agent/node/test_agentic_node.py` — the injected block carries the native sentence for `zh`; an unmapped code gets the English line only.
- `tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py` — a language switch rebuilds the snapshot, the same code still replays, and meta normalization for unset / whitespace / padded values.
- Updated expectations in `test_visualization_tool.py` and `test_gen_visual_dashboard_agentic_node.py` for the fallback directives.

`pytest tests/unit_tests/agent/node/ tests/unit_tests/utils/ tests/unit_tests/tools/llms_tools/` → 1903 passed, 14 skipped. `ruff format` / `ruff check` clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Response-language instructions now include native-language guidance for supported languages.
  * Language directives are preserved when response templates are unavailable or fail to render.
  * Language-specific settings now affect prompt snapshots, ensuring changes are recognized correctly.

* **Documentation**
  * Updated English and Chinese configuration guidance to explain native-language directives and unknown-language behavior.

* **Bug Fixes**
  * Improved consistency of language instructions across generated responses and visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Response-language instructions now include native-language guidance for supported languages.
  * Language-specific settings now affect prompt snapshots, ensuring language changes are recognized correctly.

* **Bug Fixes**
  * Language directives are preserved when response templates are unavailable or fail to render.
  * Improved consistency of language instructions across generated responses and visualizations.

* **Documentation**
  * Updated English and Chinese configuration guidance to explain native-language directives and unknown-language behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->