### PR TITLE
[BugFix] List a schema-only dialect's catalog instead of returning nothing

### DIFF
--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -226,6 +226,56 @@ class DatasourceService:
             return [_listing_failed(connector.database_name, str(e))]
 
         db_infos: List[DatabaseInfo] = []
+
+        # 1b) A dialect with no database level (Oracle: schema is the only
+        # namespace) yields nothing above — its connector reports no database and
+        # its get_databases() is empty by design. Iterating that dropped the whole
+        # datasource out of the catalog while its tables were perfectly listable.
+        # Its schemas ARE the top level, so report them as the roots: a table then
+        # addresses as schema.table, which is exactly the identifier such a dialect
+        # accepts. Only when nothing else produced a root, so a dialect that does
+        # report a database keeps its existing shape.
+        if not db_names and has_schema and not supports_namespace("database", connector=connector, dialect=dialect):
+            try:
+                schemas = (
+                    [request.schema_name]
+                    if request.schema_name
+                    else connector.get_schemas(
+                        catalog_name=request.catalog_name,
+                        include_sys=request.include_sys_schemas,
+                    )
+                )
+            except Exception as e:
+                logger.warning("Failed to get schemas for schema-only dialect=%s: %s", dialect, e)
+                return [_listing_failed(connector.schema_name, str(e))]
+
+            for schema in schemas:
+                try:
+                    tables = connector.get_tables(catalog_name=catalog_name, schema_name=schema)
+                    tables.sort()
+                except Exception as e:
+                    logger.warning("Failed to get tables for schema=%s dialect=%s: %s", schema, dialect, e)
+                    db_infos.append(_listing_failed(schema, str(e)))
+                    continue
+
+                db_infos.append(
+                    DatabaseInfo(
+                        name=schema,
+                        uri=_get_uri(connector),
+                        type=dialect,
+                        current=(schema == connector.schema_name),
+                        catalog_name=catalog_name,
+                        # Already the root: nesting it under itself would render the
+                        # same name twice in a catalog tree.
+                        schema_name=None,
+                        connection_status="connected",
+                        tables_count=len(tables),
+                        last_accessed=now,
+                        tables=tables,
+                    )
+                )
+            return db_infos
+
         for db_name in db_names:
             if has_schema:
                 # 2) Resolve schemas for this db — a single failing db must not

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -175,17 +175,24 @@ class DatasourceService:
                 last_accessed=now,
             )
 
-        def _listing_failed(db_name: str, error: str, schema: Optional[str] = None) -> DatabaseInfo:
+        def _listing_failed(
+            db_name: str, error: str, schema: Optional[str] = None, *, current: Optional[bool] = None
+        ) -> DatabaseInfo:
             """The connection works but its objects could not be enumerated.
 
             Reporting this as ``disconnected`` used to hide the real cause and contradict
             the agent, which keeps querying the same database successfully.
+
+            ``current`` overrides the database comparison for a root that is not a
+            database: a schema-only dialect reports no ``database_name``, so the
+            default comparison would call its own default schema "not current" on
+            failure while the success path above calls it current.
             """
             return DatabaseInfo(
                 name=db_name,
                 uri=_get_uri(connector),
                 type=dialect,
-                current=(db_name == connector.database_name),
+                current=(db_name == connector.database_name) if current is None else current,
                 catalog_name=catalog_name,
                 schema_name=schema,
                 connection_status="connected",
@@ -247,7 +254,8 @@ class DatasourceService:
                 )
             except Exception as e:
                 logger.warning("Failed to get schemas for schema-only dialect=%s: %s", dialect, e)
-                return [_listing_failed(connector.schema_name, str(e))]
+                # The only root we can name here is the connector's own schema.
+                return [_listing_failed(connector.schema_name, str(e), current=True)]
 
             for schema in schemas:
                 try:
@@ -255,7 +263,7 @@ class DatasourceService:
                     tables.sort()
                 except Exception as e:
                     logger.warning("Failed to get tables for schema=%s dialect=%s: %s", schema, dialect, e)
-                    db_infos.append(_listing_failed(schema, str(e)))
+                    db_infos.append(_listing_failed(schema, str(e), current=(schema == connector.schema_name)))
                     continue
 
                 db_infos.append(

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from typing import NoReturn
+from typing import Iterator, NoReturn
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -924,7 +924,13 @@ class TestSchemaOnlyDialectCatalog:
     """
 
     @staticmethod
-    def _connector(schemas, tables, *, default_schema="APP", fail_on=None):
+    def _connector(
+        schemas: list[str],
+        tables: dict[str, list[str]],
+        *,
+        default_schema: str = "APP",
+        fail_on: str | None = None,
+    ) -> MagicMock:
         connector = MagicMock()
         connector.dialect = "oracle"
         connector.connection_string = "oracle+oracledb://user:pw@host:1521/?service_name=FREEPDB1"
@@ -935,7 +941,7 @@ class TestSchemaOnlyDialectCatalog:
         connector.get_databases.return_value = []
         connector.get_schemas.return_value = schemas
 
-        def _tables(catalog_name="", database_name="", schema_name=""):
+        def _tables(catalog_name: str = "", database_name: str = "", schema_name: str = "") -> list[str]:
             if fail_on and schema_name == fail_on:
                 raise RuntimeError("ORA-00942: table or view does not exist")
             return list(tables.get(schema_name, []))
@@ -945,7 +951,7 @@ class TestSchemaOnlyDialectCatalog:
 
     @staticmethod
     @contextmanager
-    def _namespaces(*supported):
+    def _namespaces(*supported: str) -> Iterator[None]:
         with patch(
             "datus.api.services.database_service.supports_namespace",
             side_effect=lambda namespace, **_: namespace in supported,
@@ -980,6 +986,30 @@ class TestSchemaOnlyDialectCatalog:
         assert infos[1].connection_status == "connected"
         assert "ORA-00942" in infos[1].error
         assert infos[1].tables_count is None
+
+    def test_a_failing_default_schema_still_reads_as_current(self, real_agent_config):
+        """The root is a schema here, so `current` cannot come from database_name."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = self._connector(["APP", "REPORTING"], {"REPORTING": ["KPI"]}, fail_on="APP")
+
+        with self._namespaces("schema"):
+            infos = svc._get_connection_info(connector, "oracle_ds", ListDatabasesInput())
+
+        failed = next(i for i in infos if i.name == "APP")
+        assert failed.error
+        assert failed.current is True
+        assert next(i for i in infos if i.name == "REPORTING").current is False
+
+    def test_unlistable_schemas_report_the_connector_schema_as_current(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = self._connector([], {})
+        connector.get_schemas.side_effect = RuntimeError("ORA-01031: insufficient privileges")
+
+        with self._namespaces("schema"):
+            infos = svc._get_connection_info(connector, "oracle_ds", ListDatabasesInput())
+
+        assert [(i.name, i.current) for i in infos] == [("APP", True)]
+        assert "ORA-01031" in infos[0].error
 
     def test_requested_schema_narrows_the_listing(self, real_agent_config):
         svc = DatasourceService(agent_config=real_agent_config)

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -913,3 +913,92 @@ class TestGetTablesColumns:
         result = svc.get_tables_columns(["schools", "frpm"])
         assert result.success is False
         assert result.errorCode == "INVALID_PARAMETERS"
+
+
+class TestSchemaOnlyDialectCatalog:
+    """A dialect whose only namespace is the schema (Oracle) must still list.
+
+    Such a connector reports no database and an empty ``get_databases()`` by
+    design, which used to leave ``databases: []`` — the datasource vanished from
+    the catalog while its tables were perfectly listable.
+    """
+
+    @staticmethod
+    def _connector(schemas, tables, *, default_schema="APP", fail_on=None):
+        connector = MagicMock()
+        connector.dialect = "oracle"
+        connector.connection_string = "oracle+oracledb://user:pw@host:1521/?service_name=FREEPDB1"
+        connector.database_name = ""
+        connector.schema_name = default_schema
+        connector.catalog_name = None
+        connector.test_connection.return_value = True
+        connector.get_databases.return_value = []
+        connector.get_schemas.return_value = schemas
+
+        def _tables(catalog_name="", database_name="", schema_name=""):
+            if fail_on and schema_name == fail_on:
+                raise RuntimeError("ORA-00942: table or view does not exist")
+            return list(tables.get(schema_name, []))
+
+        connector.get_tables.side_effect = _tables
+        return connector
+
+    @staticmethod
+    @contextmanager
+    def _namespaces(*supported):
+        with patch(
+            "datus.api.services.database_service.supports_namespace",
+            side_effect=lambda namespace, **_: namespace in supported,
+        ):
+            yield
+
+    def test_schemas_become_the_catalog_roots(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = self._connector(["APP", "REPORTING"], {"APP": ["ORDERS", "CUSTOMERS"], "REPORTING": ["KPI"]})
+
+        with self._namespaces("schema"):
+            infos = svc._get_connection_info(connector, "oracle_ds", ListDatabasesInput())
+
+        assert [i.name for i in infos] == ["APP", "REPORTING"]
+        # Already the root — nesting it under itself would print the name twice.
+        assert all(i.schema_name is None for i in infos)
+        assert infos[0].tables == ["CUSTOMERS", "ORDERS"]
+        assert infos[0].tables_count == 2
+        assert [i.current for i in infos] == [True, False]
+        assert all(i.connection_status == "connected" for i in infos)
+
+    def test_one_unreadable_schema_does_not_hide_the_others(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = self._connector(["APP", "LOCKED"], {"APP": ["ORDERS"]}, fail_on="LOCKED")
+
+        with self._namespaces("schema"):
+            infos = svc._get_connection_info(connector, "oracle_ds", ListDatabasesInput())
+
+        assert [i.name for i in infos] == ["APP", "LOCKED"]
+        assert infos[0].tables == ["ORDERS"]
+        # Reachable but unlistable: reported with its reason, not as disconnected.
+        assert infos[1].connection_status == "connected"
+        assert "ORA-00942" in infos[1].error
+        assert infos[1].tables_count is None
+
+    def test_requested_schema_narrows_the_listing(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = self._connector(["APP", "REPORTING"], {"REPORTING": ["KPI"]})
+
+        with self._namespaces("schema"):
+            infos = svc._get_connection_info(connector, "oracle_ds", ListDatabasesInput(schema_name="REPORTING"))
+
+        assert [i.name for i in infos] == ["REPORTING"]
+        connector.get_schemas.assert_not_called()
+
+    def test_dialect_with_a_database_level_keeps_the_nested_shape(self, real_agent_config):
+        """Regression: the fallback must not flatten PostgreSQL-shaped catalogs."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector = self._connector(["public"], {"public": ["orders"]}, default_schema="public")
+        connector.dialect = "postgresql"
+        connector.database_name = "shop"
+
+        with self._namespaces("database", "schema"):
+            infos = svc._get_connection_info(connector, "pg_ds", ListDatabasesInput())
+
+        assert [(i.name, i.schema_name) for i in infos] == [("shop", "public")]


### PR DESCRIPTION
## Symptom

Every Oracle datasource came back with an empty catalog:

```
GET /api/v1/catalog/list → 200 {"success":true,"data":{"databases":[]}}
```

The SaaS catalog panel therefore rendered "No tables yet" — while, in the same session and against the same connection, `list_tables` in chat answered correctly:

```
Call Tool list_tables → 2 tables
  DATUS_E2E.E2E_CUSTOMERS, DATUS_E2E.E2E_ORDERS
```

So the connection, the credentials and the metadata queries were all fine; only the listing endpoint produced nothing.

## Cause

`_get_connection_info` resolves what to iterate as **databases**:

```python
if request.database_name:                   db_names = [request.database_name]
elif connector.database_name:               db_names = [connector.database_name]
elif hasattr(connector, "get_databases"):   db_names = connector.get_databases(...)
else:                                       db_names = []
```

Oracle has no database level below the service, and its adapter says so on purpose:

- `OracleConfig` has no `database` field (it is only accepted as an alias for `service_name`), so `connector.database_name` is `''`.
- `OracleConnector.get_databases()` returns `[]` — *"Oracle has no database level below the service; namespace is schema-only."*

Both branches are empty, `db_names == []`, and the `for db_name in db_names:` loop never runs — the schema resolution and table enumeration nested inside it never get a chance. Reproduced directly against a live instance:

```
connector.database_name          : ''
connector.get_databases()        : []
connector.get_schemas()          : ['BAASSYS', 'DATUS_E2E', 'DBSFWUSER', ...]
connector.get_tables(DATUS_E2E)  : ['E2E_CUSTOMERS', 'E2E_ORDERS']
db_names it will iterate         : []  -> DatabaseInfo entries: 0
```

This is not Oracle-specific: any dialect whose only namespace is the schema falls through the same hole.

## Fix

When nothing else produced a root **and** the dialect declares no `database` namespace, report its **schemas as the roots**: `name=<schema>`, `schema_name=None`.

A table then addresses as `schema.table` — exactly the identifier such a dialect accepts, and the shape its own `parse_*_identifier` produces. That matters because the alternative fixes are worse: making the adapter return the service/PDB as a "database" would push `SERVICE.SCHEMA.TABLE` into consumers that build identifiers from this tree, which Oracle cannot resolve, and it is precisely why the adapter keeps `database_name` empty.

`schema_name` is left `None` because the entry is already the root; setting it too would render the same name twice in a catalog tree.

Both guards matter:
- **no roots yet** — a dialect that does report a database is untouched.
- **no `database` capability** — so this cannot flatten a PostgreSQL-shaped catalog.

Per-schema failures still degrade to that one schema (`connection_status: connected` plus the reason), rather than hiding its siblings.

## Verification

`tests/unit_tests/api/services/test_database_service.py` — **61 passed**. `ruff format --check` / `ruff check` clean.

Four new cases: schemas become the roots (names, `schema_name is None`, inlined sorted tables, `current` on the connector's own schema); one unreadable schema does not hide the others; `request.schema_name` narrows the listing without calling `get_schemas`; and a regression case pinning that a dialect **with** a database level keeps its nested `database > schema` shape.

End to end against a real Oracle 23ai container, through `build_database_entry` → `DBManager` → the real `OracleConnector`:

```
before: entries: 0
after : entries: 1
        name='DATUS_E2E' schema_name=None status=connected tables_count=2
        tables=['E2E_CUSTOMERS', 'E2E_ORDERS']
```

Found while verifying Oracle support end to end in Datus-saas (its data source, project and chat all worked; only this panel was empty).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Improved database browsing for systems organized by schemas rather than databases.
  * Schemas are now displayed as top-level entries with their tables listed in sorted order.
  * Schema-specific errors are shown while keeping the connection marked as available.
  * Existing schema filters, connection details, and database/schema hierarchies remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved database browsing for systems organized by schemas rather than databases.
  * Schemas are now displayed as top-level entries with their tables listed in sorted order.
  * Existing schema filters, connection details, and database/schema hierarchies remain supported.

* **Bug Fixes**
  * Schema-specific listing errors are isolated and displayed without preventing other schemas from loading.
  * Connections remain correctly marked as available when individual schema listings fail.
  * Current-schema status is now accurately reflected for schema-based catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->