### PR TITLE
[BugFix] Nightly: chmod 600 the GaussDB TLS root cert after docker cp

### DIFF
--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -1498,6 +1498,9 @@ run_gaussdb_adapter_tests() {
     cleanup_gaussdb_tls_host_artifacts
     return 1
   fi
+  # `docker compose cp` preserves the container file's mode (644); the GaussDB
+  # libpq refuses a root cert unless it is u=rw(600) or tighter.
+  chmod 600 "$tls_rootcert"
 
   run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env \
     DATUS_TEST_LAYER=nightly \


### PR DESCRIPTION
## Why

Nightly run [32086559973](https://github.com/Datus-ai/Datus-agent/actions/runs/32086559973): every GaussDB adapter test errors at connection setup with

```
OperationalError: connection failed: The ca file "...datus-agent-gaussdb-tls.d1PEL3/ca.crt"
permission should be u=rw(600) or less.
```

The TLS verification flow added in #1295 copies the CA certificate out of the openGauss container with `docker compose cp`, which preserves the container file's 644 mode. The GaussDB libpq enforces that a root cert must not be group/other-readable and refuses the connection outright, so all five tests error in the fixture. (The vendored-libpq path itself is healthy — this is a regular driver error, not the old segfault.)

## Solution

`chmod 600` the copied certificate before handing it to `GAUSSDB_SSLROOTCERT`. One line plus a comment in `run_gaussdb_adapter_tests`.

## Test Cases

No test change: this is a nightly-harness shell fix on the same surface as #1295, validated by `bash -n` and by the next scheduled nightly run's GaussDB group. The remaining failure in that run (Qwen model tests) is a Dashscope account-standing issue, tracked operationally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of nightly SSL test runs by securely setting TLS certificate permissions before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->