### PR TITLE
[Tool] Parallelize the PR acceptance suite and trim unused coverage reports

### DIFF
--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -158,15 +158,19 @@ def log(msg: str) -> None:
 TEST_CMD_TIMEOUT = int(os.environ.get("TEST_CMD_TIMEOUT", "3600"))
 
 
-def _resolve_impacted_unit_parallel_workers() -> str:
-    """Use half of the available CPUs unless the runner provides an override."""
+def _resolve_parallel_workers() -> str:
+    """Use half of the available CPUs unless the runner provides an override.
+
+    Shared by every parallel suite; the env var keeps its historical name so
+    existing runner overrides stay effective.
+    """
     configured = os.environ.get("IMPACTED_UNIT_PARALLEL_WORKERS")
     if configured:
         return configured
     return str(max(1, (os.cpu_count() or 1) // 2))
 
 
-IMPACTED_UNIT_PARALLEL_WORKERS = _resolve_impacted_unit_parallel_workers()
+PARALLEL_WORKERS = _resolve_parallel_workers()
 GIT_CMD_TIMEOUT = int(os.environ.get("GIT_CMD_TIMEOUT", "60"))
 DIFF_COVER_TIMEOUT = int(os.environ.get("DIFF_COVER_TIMEOUT", "300"))
 _COMPARE_BRANCH_CACHE: dict[str, str | None] = {}
@@ -346,6 +350,7 @@ def _build_pytest_command(
     emit_reports: bool = True,
     basetemp: str | None = None,
     parallel: bool = False,
+    dist: str | None = None,
 ) -> list[str]:
     cmd = [
         sys.executable,
@@ -360,10 +365,12 @@ def _build_pytest_command(
         cmd.extend(["-m", mark_expr])
 
     if parallel:
-        # Distribute the suite across a few pytest-xdist workers so the full unit
-        # run stays under TEST_CMD_TIMEOUT; pytest-cov merges per-worker data.
+        # Distribute the suite across pytest-xdist workers so the suites stay
+        # under TEST_CMD_TIMEOUT; pytest-cov merges per-worker data.
         # By default, use half of the available CPUs; runners may override this.
-        cmd.extend(["-n", IMPACTED_UNIT_PARALLEL_WORKERS])
+        cmd.extend(["-n", PARALLEL_WORKERS])
+        if dist:
+            cmd.extend(["--dist", dist])
 
     cmd.append("--cov=datus")
     if append:
@@ -403,6 +410,7 @@ def _run_pytest_suite(
     append: bool = False,
     emit_reports: bool = True,
     parallel: bool = False,
+    dist: str | None = None,
 ) -> int:
     """Run one pytest suite and stream logs to stdout and the CI log file."""
     basetemp = _suite_pytest_basetemp(suite_name)
@@ -415,6 +423,7 @@ def _run_pytest_suite(
         emit_reports=emit_reports,
         basetemp=basetemp,
         parallel=parallel,
+        dist=dist,
     )
     log(f"Running {suite_name}: {' '.join(cmd)}")
     log(f"{suite_name} pytest basetemp: {basetemp}")
@@ -726,6 +735,13 @@ def run_tests(base_ref: str = "") -> tuple[int, list[str]]:
                 suite_name="acceptance",
                 mark_expr=PR_HARNESS_MARK_EXPR,
                 emit_reports=not impacted_targets,
+                parallel=True,
+                # Per-file distribution: tests/integration/tools/test_func_tools_db.py
+                # opens the same on-disk DuckDB database from several test classes,
+                # and DuckDB allows only one process to hold the file lock. loadfile
+                # keeps every test of a file on one worker, so the lock is never
+                # contended across processes.
+                dist="loadfile",
             )
             exit_codes.append(acceptance_rc)
             junit_xml_paths.append(acceptance_xml)

--- a/ci/run-pr-tests.py
+++ b/ci/run-pr-tests.py
@@ -15,7 +15,6 @@ Outputs (written to GITHUB_OUTPUT if available, otherwise stdout):
 
 Generated files (all written to ci/ directory):
     ci/coverage.xml             - Cobertura coverage report
-    ci/htmlcov/                 - Full HTML coverage report
     ci/test-results.xml         - Combined JUnit test results
     ci/test-results-*.xml       - Per-suite JUnit results for acceptance / impacted unit suites
     ci/diff-cover.json          - Diff coverage data
@@ -377,13 +376,7 @@ def _build_pytest_command(
         cmd.append("--cov-append")
 
     if emit_reports:
-        cmd.extend(
-            [
-                f"--cov-report=xml:{DEFAULT_COVERAGE_XML}",
-                f"--cov-report=html:{DEFAULT_COVERAGE_HTML}",
-                "--cov-report=term-missing",
-            ]
-        )
+        cmd.append(f"--cov-report=xml:{DEFAULT_COVERAGE_XML}")
     else:
         cmd.append("--cov-report=")
 

--- a/tests/integration/storage/test_doc_search.py
+++ b/tests/integration/storage/test_doc_search.py
@@ -17,11 +17,11 @@ from lancedb.embeddings.base import TextEmbeddingFunction
 from lancedb.embeddings.registry import register
 
 from datus.configuration.agent_config import AgentConfig
-from datus.configuration.agent_config_loader import load_agent_config
 from datus.storage.document.schemas import PlatformDocChunk
 from datus.storage.document.store import document_store
 from datus.storage.embedding_models import EMBEDDING_MODELS, EmbeddingModel
 from datus.utils.loggings import get_logger
+from tests.conftest import load_acceptance_config
 
 logger = get_logger(__name__)
 
@@ -177,7 +177,7 @@ def _build_test_chunks() -> List[PlatformDocChunk]:
 
 @pytest.fixture
 def agent_config() -> AgentConfig:
-    return load_agent_config()
+    return load_acceptance_config()
 
 
 @pytest.mark.acceptance

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -264,22 +264,22 @@ def test_pr_harness_marker_expressions_route_component_tests():
         (8, "4"),
     ],
 )
-def test_impacted_unit_worker_default_uses_half_available_cpus(monkeypatch, cpu_count, expected_workers):
+def test_parallel_worker_default_uses_half_available_cpus(monkeypatch, cpu_count, expected_workers):
     monkeypatch.delenv("IMPACTED_UNIT_PARALLEL_WORKERS", raising=False)
     monkeypatch.setattr(run_pr_tests.os, "cpu_count", lambda: cpu_count)
 
-    assert run_pr_tests._resolve_impacted_unit_parallel_workers() == expected_workers
+    assert run_pr_tests._resolve_parallel_workers() == expected_workers
 
 
-def test_impacted_unit_worker_env_override_takes_precedence(monkeypatch):
+def test_parallel_worker_env_override_takes_precedence(monkeypatch):
     monkeypatch.setenv("IMPACTED_UNIT_PARALLEL_WORKERS", "6")
     monkeypatch.setattr(run_pr_tests.os, "cpu_count", lambda: 16)
 
-    assert run_pr_tests._resolve_impacted_unit_parallel_workers() == "6"
+    assert run_pr_tests._resolve_parallel_workers() == "6"
 
 
-def test_impacted_unit_suite_uses_configured_workers(tmp_path, monkeypatch):
-    monkeypatch.setattr(run_pr_tests, "IMPACTED_UNIT_PARALLEL_WORKERS", "4")
+def test_parallel_suite_uses_configured_workers(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "PARALLEL_WORKERS", "4")
     command = run_pr_tests._build_pytest_command(
         ["tests/unit_tests/"],
         str(tmp_path / "junit.xml"),
@@ -288,6 +288,59 @@ def test_impacted_unit_suite_uses_configured_workers(tmp_path, monkeypatch):
 
     worker_flag = command.index("-n")
     assert command[worker_flag : worker_flag + 2] == ["-n", "4"]
+    assert "--dist" not in command
+
+
+def test_parallel_suite_emits_dist_mode_after_workers(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "PARALLEL_WORKERS", "4")
+    command = run_pr_tests._build_pytest_command(
+        ["tests/unit_tests/"],
+        str(tmp_path / "junit.xml"),
+        parallel=True,
+        dist="loadfile",
+    )
+
+    worker_flag = command.index("-n")
+    assert command[worker_flag : worker_flag + 4] == ["-n", "4", "--dist", "loadfile"]
+
+
+def test_serial_suite_ignores_dist_mode(tmp_path):
+    command = run_pr_tests._build_pytest_command(
+        ["tests/unit_tests/"],
+        str(tmp_path / "junit.xml"),
+        parallel=False,
+        dist="loadfile",
+    )
+
+    assert "-n" not in command
+    assert "--dist" not in command
+
+
+def test_run_tests_runs_acceptance_parallel_with_per_file_distribution(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_pr_tests, "_reset_report_outputs", lambda: None)
+    monkeypatch.setattr(run_pr_tests, "DEFAULT_PYTEST_LOG", str(tmp_path / "pytest-coverage.txt"))
+    monkeypatch.setattr(run_pr_tests, "OUT_DIR", str(tmp_path))
+    monkeypatch.setattr(run_pr_tests, "DEFAULT_COVERAGE_DB", str(tmp_path / ".coverage"))
+    monkeypatch.setattr(run_pr_tests, "resolve_impacted_unit_tests", lambda base_ref: ["tests/unit_tests/"])
+    monkeypatch.setattr(run_pr_tests, "merge_junit_results", lambda junit_xml_paths: None)
+
+    suite_calls = []
+
+    def fake_suite(targets, junit_xml, log_file, **kwargs):
+        suite_calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(run_pr_tests, "_run_pytest_suite", fake_suite)
+
+    exit_code, _ = run_pr_tests.run_tests(base_ref="main")
+
+    assert exit_code == 0
+    acceptance_call = next(call for call in suite_calls if call["suite_name"] == "acceptance")
+    assert acceptance_call["parallel"] is True
+    assert acceptance_call["dist"] == "loadfile"
+    impacted_call = next(call for call in suite_calls if call["suite_name"] == "impacted unit tests")
+    assert impacted_call["parallel"] is True
+    assert impacted_call.get("dist") is None
 
 
 def test_resolve_explicit_compare_ref_prefers_origin_for_branch_name(monkeypatch):

--- a/tests/unit_tests/ci/test_run_pr_tests.py
+++ b/tests/unit_tests/ci/test_run_pr_tests.py
@@ -316,6 +316,27 @@ def test_serial_suite_ignores_dist_mode(tmp_path):
     assert "--dist" not in command
 
 
+def test_emit_reports_produces_only_cobertura_xml(tmp_path):
+    command = run_pr_tests._build_pytest_command(
+        ["tests/unit_tests/"],
+        str(tmp_path / "junit.xml"),
+    )
+
+    cov_reports = [arg for arg in command if arg.startswith("--cov-report")]
+    assert cov_reports == [f"--cov-report=xml:{run_pr_tests.DEFAULT_COVERAGE_XML}"]
+
+
+def test_suppressed_reports_disable_cov_output(tmp_path):
+    command = run_pr_tests._build_pytest_command(
+        ["tests/unit_tests/"],
+        str(tmp_path / "junit.xml"),
+        emit_reports=False,
+    )
+
+    cov_reports = [arg for arg in command if arg.startswith("--cov-report")]
+    assert cov_reports == ["--cov-report="]
+
+
 def test_run_tests_runs_acceptance_parallel_with_per_file_distribution(tmp_path, monkeypatch):
     monkeypatch.setattr(run_pr_tests, "_reset_report_outputs", lambda: None)
     monkeypatch.setattr(run_pr_tests, "DEFAULT_PYTEST_LOG", str(tmp_path / "pytest-coverage.txt"))


### PR DESCRIPTION
## Why

The run-coverage job spends most of its test time in the acceptance suite: 208 tests run serially for ~3 minutes on the self-hosted runner, while the impacted unit suite already runs under pytest-xdist with half the available CPUs. Additionally, every reporting run generates an HTML coverage report (`ci/htmlcov`) that is never uploaded or read by the workflow, and `term-missing` floods the job log with thousands of lines; only `coverage.xml` has consumers (the PR coverage comment and diff-cover).

## Solution

- Run the acceptance suite under pytest-xdist with the same worker count as the impacted suite (half the available CPUs, `IMPACTED_UNIT_PARALLEL_WORKERS` env override unchanged), using `--dist loadfile`. Per-file distribution is required: `tests/integration/tools/test_func_tools_db.py` opens the same on-disk DuckDB database from several test classes, and DuckDB allows only one process to hold the file lock — `load`/`loadscope` both trip it (3 failures reproduced locally), while `loadfile` keeps every test of a file on one worker so the lock is never contended across processes. The merge-queue harness works around the same constraint by keeping its integration targets serial.
- Rename `IMPACTED_UNIT_PARALLEL_WORKERS`/`_resolve_impacted_unit_parallel_workers` to `PARALLEL_WORKERS`/`_resolve_parallel_workers` since both suites now share them; the env var keeps its historical name so existing runner overrides stay effective.
- Emit only the Cobertura XML coverage report; drop `--cov-report=html` and `term-missing`. `DEFAULT_COVERAGE_HTML` stays in `_reset_report_outputs` so stale `htmlcov` directories left by older harness versions on persistent self-hosted workspaces are still cleaned up.

Expected effect on the coverage job: the acceptance pytest phase drops from ~178s to roughly a third of that (the largest file accounts for ~22% of suite execution time, so 4 workers keep good balance), plus report-generation savings and a much smaller streamed log.

## Test Cases

- `tests/unit_tests/ci/test_run_pr_tests.py`: renamed worker-resolution tests; new tests covering the `--dist` flag emission (parallel with/without dist, serial ignores dist), the acceptance/impacted wiring (`parallel=True, dist="loadfile"` for acceptance, no dist for impacted), and the cov-report contract (`emit_reports=True` yields only the Cobertura XML, `emit_reports=False` disables report output).
- Verified locally in a clean worktree: three consecutive parallel acceptance runs pass 208/208 with results identical to serial; overall coverage does not drop (25.79% parallel vs 25.36% serial); full `ci/run-pr-tests.py upstream/main` end-to-end run passes (417 tests, diff coverage 100%, `htmlcov` no longer generated); `ci/run-merge-queue-tests.py` rehearsal passes; `ci/audit_tests.py --diff-only` reports P0=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Testing**
  * Improved parallel test execution for faster and more reliable CI runs.
  * Acceptance tests now distribute work by file to avoid database locking issues.
  * Added support for optional pytest distribution modes and configurable worker counts.

* **Bug Fixes**
  * Coverage reporting now produces only the requested XML report when enabled and suppresses output when disabled.

* **Documentation**
  * Updated generated-files documentation to remove outdated coverage output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Improved parallel test execution for faster and more reliable CI runs.
  * Acceptance tests now distribute work by file to avoid database locking issues.
  * Added support for optional test distribution modes and configurable worker counts.

* **Bug Fixes**
  * Coverage reporting now produces only the requested XML report when enabled and suppresses output when disabled.

* **Documentation**
  * Updated generated-files documentation to remove outdated coverage output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->