### PR TITLE
[BugFix] Register the lance vector backend lazily to avoid importing lancedb

### DIFF
--- a/datus/storage/vector/__init__.py
+++ b/datus/storage/vector/__init__.py
@@ -4,13 +4,44 @@
 
 """Vector DB abstraction layer with pluggable backends."""
 
+from typing import Any
+
 from datus_storage_base.vector.base import BaseVectorBackend
 from datus_storage_base.vector.registry import VectorRegistry
 
-from datus.storage.vector.lance_backend import LanceVectorBackend
 
-# Register built-in LanceDB backend
-VectorRegistry.register("lance", LanceVectorBackend)
+class _LazyLanceVectorBackend(BaseVectorBackend):
+    """Registry placeholder that defers ``import lancedb`` to first use.
+
+    lancedb's native library is built for the x86-64-haswell baseline
+    (AVX2/FMA/F16C): on a CPU without those instructions the *import* itself
+    dies with SIGILL, which no try/except can catch because it is a signal,
+    not an exception. Deployments running another vector backend (pgvector)
+    must therefore never execute that import.
+
+    ``VectorRegistry.create_backend`` instantiates the registered class and
+    then calls ``initialize(config)`` on the result. Returning a foreign
+    instance from ``__new__`` makes Python skip this proxy's ``__init__``,
+    so the real backend is constructed and initialized exactly as before.
+    """
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> BaseVectorBackend:
+        from datus.storage.vector.lance_backend import LanceVectorBackend
+
+        return LanceVectorBackend(*args, **kwargs)
+
+
+def __getattr__(name: str) -> Any:
+    """Keep ``from datus.storage.vector import LanceVectorBackend`` lazy (PEP 562)."""
+    if name == "LanceVectorBackend":
+        from datus.storage.vector.lance_backend import LanceVectorBackend
+
+        return LanceVectorBackend
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# Register built-in LanceDB backend (constructing it imports lancedb, importing this module does not)
+VectorRegistry.register("lance", _LazyLanceVectorBackend)
 
 # Discover external adapters via entry points
 VectorRegistry.discover_adapters()

--- a/datus/storage/vector/__init__.py
+++ b/datus/storage/vector/__init__.py
@@ -23,6 +23,18 @@ class _LazyLanceVectorBackend(BaseVectorBackend):
     then calls ``initialize(config)`` on the result. Returning a foreign
     instance from ``__new__`` makes Python skip this proxy's ``__init__``,
     so the real backend is constructed and initialized exactly as before.
+
+    ``BaseVectorBackend``'s abstract methods are deliberately left
+    unimplemented. The abstractness check lives in ``object.__new__``, which
+    this ``__new__`` never reaches, so the proxy itself is never instantiated;
+    the base class is kept only so the registry still holds a
+    ``BaseVectorBackend`` subclass.
+
+    Consequence: ``VectorRegistry.get_backend_class("lance")`` returns this
+    proxy rather than ``LanceVectorBackend``. Calling it still yields a real,
+    usable backend — only ``issubclass``/``__name__`` inspection sees the
+    proxy. Returning the real class is impossible by construction: it would
+    require the very import this proxy exists to defer.
     """
 
     def __new__(cls, *args: Any, **kwargs: Any) -> BaseVectorBackend:

--- a/tests/unit_tests/storage/vector/test_init.py
+++ b/tests/unit_tests/storage/vector/test_init.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-"""Contract tests for ``datus.storage.vector`` package-level backend registration.
+"""Tests for ``datus/storage/vector/__init__.py`` -- backend registration contract.
 
 Protects the fix for issue #1308: importing ``datus.storage.vector`` must not
 import ``lancedb``. lancedb's wheel is built at the x86-64-haswell baseline

--- a/tests/unit_tests/storage/vector/test_init.py
+++ b/tests/unit_tests/storage/vector/test_init.py
@@ -47,14 +47,41 @@ _IMPORT_PROBE = textwrap.dedent(
 )
 
 
+# Bounds a hung probe so it fails loudly instead of hanging the job: the PR gate
+# (ci/run-pr-tests.py) passes no --timeout, so nothing else would stop it. The
+# probes measure ~1s; the bound is deliberately loose because the point is to
+# turn an unbounded hang into a diagnosable failure, not to police duration, and
+# a tight bound would flake under the parallel acceptance suite. Still an order
+# of magnitude below the merge queue's --timeout=120.
+_PROBE_TIMEOUT_SECONDS = 30
+
+
+def _decode(stream: bytes | str | None) -> str:
+    """Normalize captured output to text.
+
+    ``subprocess`` leaves the partial output on ``TimeoutExpired`` undecoded even
+    when the call passed ``text=True``, so the timeout path can hand us bytes.
+    """
+    if stream is None:
+        return ""
+    return stream.decode("utf-8", errors="replace") if isinstance(stream, bytes) else stream
+
+
 def _run_in_clean_interpreter(script: str) -> subprocess.CompletedProcess:
     """Run *script* in a fresh interpreter rooted at the repo."""
-    return subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=str(_REPO_ROOT),
-        capture_output=True,
-        text=True,
-    )
+    try:
+        return subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(
+            f"clean-interpreter probe exceeded {_PROBE_TIMEOUT_SECONDS}s\n"
+            f"script={script!r}\nstdout={_decode(exc.stdout)}\nstderr={_decode(exc.stderr)}"
+        )
 
 
 def _run_import_probe() -> dict[str, str]:

--- a/tests/unit_tests/storage/vector/test_init.py
+++ b/tests/unit_tests/storage/vector/test_init.py
@@ -22,7 +22,11 @@ import pytest
 
 import datus.storage.vector as vector_pkg
 from datus.storage.vector import VectorRegistry, _LazyLanceVectorBackend
-from datus.storage.vector.lance_backend import LanceVectorBackend
+
+# ``datus.storage.vector.lance_backend`` is deliberately NOT imported at module
+# level: it pulls in lancedb, and this module exists to certify that importing
+# the vector package does not. Tests that genuinely need the real backend import
+# it inside the test body and take the ``requires_lancedb`` fixture.
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
@@ -41,14 +45,19 @@ _IMPORT_PROBE = textwrap.dedent(
 )
 
 
-def _run_import_probe() -> dict[str, str]:
-    """Import the vector package in a fresh interpreter and report what it loaded."""
-    result = subprocess.run(
-        [sys.executable, "-c", _IMPORT_PROBE],
+def _run_in_clean_interpreter(script: str) -> subprocess.CompletedProcess:
+    """Run *script* in a fresh interpreter rooted at the repo."""
+    return subprocess.run(
+        [sys.executable, "-c", script],
         cwd=str(_REPO_ROOT),
         capture_output=True,
         text=True,
     )
+
+
+def _run_import_probe() -> dict[str, str]:
+    """Import the vector package in a fresh interpreter and report what it loaded."""
+    result = _run_in_clean_interpreter(_IMPORT_PROBE)
     assert result.returncode == 0, f"import probe failed:\nstdout={result.stdout}\nstderr={result.stderr}"
 
     # Ignore anything the interpreter or logging config may print around the markers.
@@ -64,6 +73,19 @@ def _run_import_probe() -> dict[str, str]:
 @pytest.fixture(scope="module")
 def import_probe() -> dict[str, str]:
     return _run_import_probe()
+
+
+@pytest.fixture(scope="module")
+def requires_lancedb() -> None:
+    """Skip when this host cannot import lancedb.
+
+    The probe has to run out-of-process: on a host without AVX2 the import dies
+    with SIGILL, which cannot be caught in-process — that is the failure mode
+    issue #1308 is about. A subprocess turns it into a return code.
+    """
+    result = _run_in_clean_interpreter("import lancedb")
+    if result.returncode != 0:
+        pytest.skip(f"lancedb is not importable on this host (rc={result.returncode})")
 
 
 class TestLazyLanceImport:
@@ -83,14 +105,16 @@ class TestLanceRegistration:
         assert VectorRegistry.is_registered("lance") is True
         assert "lance" in VectorRegistry.registered_types()
 
-    def test_create_backend_returns_initialized_lance_backend(self, tmp_path):
+    def test_create_backend_returns_initialized_lance_backend(self, requires_lancedb, tmp_path):
+        from datus.storage.vector.lance_backend import LanceVectorBackend
+
         backend = VectorRegistry.create_backend("lance", {"data_dir": str(tmp_path)})
 
         assert type(backend) is LanceVectorBackend
         # ``initialize(config)`` must have reached the real instance, not the proxy.
         assert backend._data_dir == str(tmp_path)
 
-    def test_created_backend_connects_to_a_project_directory(self, tmp_path):
+    def test_created_backend_connects_to_a_project_directory(self, requires_lancedb, tmp_path):
         backend = VectorRegistry.create_backend("lance", {"data_dir": str(tmp_path)})
 
         database = backend.connect("proj")
@@ -98,7 +122,9 @@ class TestLanceRegistration:
         assert database.table_names() == []
         assert (tmp_path / "proj" / "datus_db").is_dir()
 
-    def test_instantiating_the_proxy_yields_the_real_backend(self):
+    def test_instantiating_the_proxy_yields_the_real_backend(self, requires_lancedb):
+        from datus.storage.vector.lance_backend import LanceVectorBackend
+
         backend = _LazyLanceVectorBackend()
 
         assert type(backend) is LanceVectorBackend
@@ -108,7 +134,9 @@ class TestLanceRegistration:
 class TestModuleAttributeAccess:
     """PEP 562 ``__getattr__`` keeps the public ``__all__`` surface intact."""
 
-    def test_lance_vector_backend_attribute_resolves_to_the_real_class(self):
+    def test_lance_vector_backend_attribute_resolves_to_the_real_class(self, requires_lancedb):
+        from datus.storage.vector.lance_backend import LanceVectorBackend
+
         assert vector_pkg.LanceVectorBackend is LanceVectorBackend
 
     def test_lance_vector_backend_is_exported(self):

--- a/tests/unit_tests/storage/vector/test_init.py
+++ b/tests/unit_tests/storage/vector/test_init.py
@@ -21,12 +21,14 @@ from pathlib import Path
 import pytest
 
 import datus.storage.vector as vector_pkg
-from datus.storage.vector import VectorRegistry, _LazyLanceVectorBackend
+from datus.storage.vector import VectorRegistry
 
-# ``datus.storage.vector.lance_backend`` is deliberately NOT imported at module
-# level: it pulls in lancedb, and this module exists to certify that importing
-# the vector package does not. Tests that genuinely need the real backend import
-# it inside the test body and take the ``requires_lancedb`` fixture.
+# Nothing from this package beyond ``VectorRegistry`` is imported at module
+# level. ``lance_backend`` pulls in lancedb, and this module exists to certify
+# that importing the vector package does not; ``_LazyLanceVectorBackend`` is the
+# symbol under test, so importing it here would turn a red assertion into a
+# collection error when these tests are run against pre-fix code. Both are
+# imported inside the test bodies that need them.
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
@@ -123,6 +125,7 @@ class TestLanceRegistration:
         assert (tmp_path / "proj" / "datus_db").is_dir()
 
     def test_instantiating_the_proxy_yields_the_real_backend(self, requires_lancedb):
+        from datus.storage.vector import _LazyLanceVectorBackend
         from datus.storage.vector.lance_backend import LanceVectorBackend
 
         backend = _LazyLanceVectorBackend()

--- a/tests/unit_tests/storage/vector/test_vector_registry.py
+++ b/tests/unit_tests/storage/vector/test_vector_registry.py
@@ -1,0 +1,121 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Contract tests for ``datus.storage.vector`` package-level backend registration.
+
+Protects the fix for issue #1308: importing ``datus.storage.vector`` must not
+import ``lancedb``. lancedb's wheel is built at the x86-64-haswell baseline
+(AVX2/FMA/F16C), so on a CPU without those instructions the import itself dies
+with SIGILL — a signal, not an exception, which no ``try/except`` can contain.
+Deployments configured with a different vector backend (pgvector) crash-loop
+with exit code 132 if that import ever runs, so the absence of the import is an
+external contract, not an implementation detail.
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import datus.storage.vector as vector_pkg
+from datus.storage.vector import VectorRegistry, _LazyLanceVectorBackend
+from datus.storage.vector.lance_backend import LanceVectorBackend
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Runs in a clean interpreter: ``sys.modules`` is process-global and sibling
+# tests import lancedb directly, so the contract is unobservable in-process.
+_IMPORT_PROBE = textwrap.dedent(
+    """
+    import sys
+
+    import datus.storage.vector as vector_pkg
+
+    leaked = sorted(name for name in sys.modules if name == "lancedb" or name.startswith("lancedb."))
+    print("leaked=" + ",".join(leaked))
+    print("registered=" + ",".join(sorted(vector_pkg.VectorRegistry.registered_types())))
+    """
+)
+
+
+def _run_import_probe() -> dict[str, str]:
+    """Import the vector package in a fresh interpreter and report what it loaded."""
+    result = subprocess.run(
+        [sys.executable, "-c", _IMPORT_PROBE],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"import probe failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+
+    # Ignore anything the interpreter or logging config may print around the markers.
+    fields = {}
+    for line in result.stdout.splitlines():
+        for key in ("leaked", "registered"):
+            if line.startswith(f"{key}="):
+                fields[key] = line.split("=", 1)[1]
+    assert set(fields) == {"leaked", "registered"}, f"unexpected probe output: {result.stdout!r}"
+    return fields
+
+
+@pytest.fixture(scope="module")
+def import_probe() -> dict[str, str]:
+    return _run_import_probe()
+
+
+class TestLazyLanceImport:
+    """``import datus.storage.vector`` must not pull in lancedb (issue #1308)."""
+
+    def test_importing_package_does_not_import_lancedb(self, import_probe):
+        assert import_probe["leaked"] == ""
+
+    def test_lance_is_registered_without_importing_lancedb(self, import_probe):
+        assert "lance" in import_probe["registered"].split(",")
+
+
+class TestLanceRegistration:
+    """The lazy proxy must be indistinguishable from eager registration in use."""
+
+    def test_lance_backend_type_is_registered(self):
+        assert VectorRegistry.is_registered("lance") is True
+        assert "lance" in VectorRegistry.registered_types()
+
+    def test_create_backend_returns_initialized_lance_backend(self, tmp_path):
+        backend = VectorRegistry.create_backend("lance", {"data_dir": str(tmp_path)})
+
+        assert type(backend) is LanceVectorBackend
+        # ``initialize(config)`` must have reached the real instance, not the proxy.
+        assert backend._data_dir == str(tmp_path)
+
+    def test_created_backend_connects_to_a_project_directory(self, tmp_path):
+        backend = VectorRegistry.create_backend("lance", {"data_dir": str(tmp_path)})
+
+        database = backend.connect("proj")
+
+        assert database.table_names() == []
+        assert (tmp_path / "proj" / "datus_db").is_dir()
+
+    def test_instantiating_the_proxy_yields_the_real_backend(self):
+        backend = _LazyLanceVectorBackend()
+
+        assert type(backend) is LanceVectorBackend
+        assert not isinstance(backend, _LazyLanceVectorBackend)
+
+
+class TestModuleAttributeAccess:
+    """PEP 562 ``__getattr__`` keeps the public ``__all__`` surface intact."""
+
+    def test_lance_vector_backend_attribute_resolves_to_the_real_class(self):
+        assert vector_pkg.LanceVectorBackend is LanceVectorBackend
+
+    def test_lance_vector_backend_is_exported(self):
+        assert "LanceVectorBackend" in vector_pkg.__all__
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        missing_name = "does_not_exist"
+
+        with pytest.raises(AttributeError, match="has no attribute 'does_not_exist'"):
+            getattr(vector_pkg, missing_name)


### PR DESCRIPTION
## Why

Fixes #1308.

`datus/storage/vector/__init__.py` imported `lance_backend` — and therefore `lancedb` — at package-import time, purely to register the `"lance"` backend type.

lancedb's PyPI wheel is built at the `x86-64-haswell` baseline (AVX2 + FMA + F16C). On a host whose CPU model masks AVX2 (QEMU `kvm64`/`qemu64`, VMware EVC pinned pre-Haswell), `import lancedb` faults on an AVX2 instruction while loading `_lancedb.abi3.so`. Because SIGILL is a signal and not a Python exception, no `try/except ImportError`, feature flag or degradation path can contain it — the only fix is to never execute the import.

The observed impact on an on-prem Datus-backend deployment configured with `vector.type = postgresql` (pgvector; LanceDB never used): the process is stable under ordinary REST traffic, then dies with exit code **132** (128 + SIGILL) on the first AI/agent feature that touches the vector store, and crash-loops on every retry. The only import site is the lazy one in `datus/storage/backend_holder.py:get_vector_backend()`, which is why the crash lands there rather than at startup.

A wheel-level swap to `lancedb-compat` was evaluated in the backend image and deliberately rejected (single `manylinux_2_28_x86_64` wheel, no sdist, no release matching the pinned 0.34.0, and its `x86-64-v2` baseline still faults below Nehalem). See the issue for the full analysis.

## Solution

Register a `_LazyLanceVectorBackend` placeholder instead of the concrete class, so `import lancedb` moves from import time to construction time.

`VectorRegistry.create_backend` does `cls._backends[key]()` and then `.initialize(config)`. Returning a real `LanceVectorBackend` from the proxy's `__new__` means Python skips the proxy's `__init__` (the returned object is not an instance of the proxy class), so the real backend is constructed and receives `initialize()` exactly as today — lance deployments are behaviourally unchanged. Because `__new__` never calls `object.__new__`, `ABCMeta`'s abstract-method check never fires, so subclassing `BaseVectorBackend` without implementing its abstract methods is safe.

A PEP 562 module-level `__getattr__` keeps `from datus.storage.vector import LanceVectorBackend` working for the CLI, tests and external consumers, so the `__all__` surface is unchanged.

Verified against the reported code path — with `vector.type = postgresql`, `get_vector_backend()` no longer loads lancedb:

```
before:  import datus.storage.vector  ->  lancedb, lancedb._lancedb, lancedb.arrow, ... (whole native module tree)
after:   import datus.storage.vector  ->  nothing; "lance" still registered
```

`datus/storage/rdb/__init__.py` has the same eager shape but registers the stdlib-backed `SqliteRdbBackend` — no native library, no SIGILL risk — so it is left as is.

**Not included:** the issue's optional follow-up of moving `lancedb` to a `datus-agent[lance]` extra. `_DEFAULT_VECTOR = "lance"` in `tests/unit_tests/storage/_backend_discovery.py` makes the whole unit suite assume lancedb is installed, so that change needs its own CI / Dockerfile / docs pass and belongs in a separate PR.

## Test Cases

New `tests/unit_tests/storage/vector/test_init.py` (9 cases). The absence of the import is an external contract here — a pgvector deployment crash-loops if it ever returns — so per the repo's "no tombstone tests" rule this falls under the stated exception for *removed side effects with real regression risk*, and the module docstring names issue #1308 as the contract it protects.

**Red first** (per Testing Rules -> Bug-fix regression tests). Reverting `datus/storage/vector/__init__.py` to its pre-fix content and re-running the new module gives:

```
2 failed, 7 passed
E   AssertionError: assert 'lancedb,lanc...,lancedb.util' == ''
```

The failure is a real assertion on the property the fix establishes, not a collection error — nothing in the module is imported at module level that only exists after the fix, precisely so this verification stays meaningful. Restoring the file returns all 9 to green.

**Assert the property, not the instance**: the probe collects *every* module named `lancedb` or `lancedb.*` and asserts the set is empty, so the test stays red if the import returns under any other submodule spelling.

- **`TestLazyLanceImport`** — runs a probe in a clean interpreter (`sys.modules` is process-global and `test_lance_backend.py` imports lancedb directly, so the contract is unobservable in-process) and asserts that importing `datus.storage.vector` loads no `lancedb*` module while `"lance"` is still registered.
- **`TestLanceRegistration`** — `create_backend("lance", ...)` returns a real `LanceVectorBackend` whose `_data_dir` came from `initialize(config)` (proving `__new__` did not swallow initialization), `connect("proj")` still creates `{data_dir}/proj/datus_db` and lists tables, and instantiating the proxy directly yields the real class.
- **`TestModuleAttributeAccess`** — the PEP 562 hook resolves `LanceVectorBackend` to the real class, keeps it in `__all__`, and still raises `AttributeError` for unknown names.

**Runs without lancedb installed.** The module has no collection-time lancedb dependency: the four tests needing a real backend import it in the test body behind a `requires_lancedb` fixture that probes importability out-of-process — the only way to detect the SIGILL-on-import failure, since a signal cannot be caught in-process. On a host where lancedb is unimportable the module reports **5 passed, 4 skipped** instead of a collection error, so the tests proving this fix can actually run on the hardware the bug affects. Nothing is mocked: mocking the registry would remove the only evidence that the `__new__` proxy preserves `create_backend`'s `initialize()` contract, which is the entire risk this PR carries.

Existing coverage is the real regression net for the proxy: `tests/unit_tests/storage/vector/`, `test_backend_holder.py` and `test_registry_cache.py` (68 tests) drive the lance backend end to end through `create_backend` and all pass unchanged.

Gates run locally on the rebased branch: `ruff format` / `ruff check` clean, `ci/audit_tests.py --diff-only upstream/main` reports **P0=0 P1=0**, and `ci/run-pr-tests.py upstream/main` passes with **262 passed, 0 failed, diff coverage 100%**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved vector storage startup by loading LanceDB only when the Lance backend is needed.

* **Compatibility**
  * Existing Lance backend access and registration remain supported.
  * Unknown module attributes continue to return standard errors.

* **Testing**
  * Added coverage for lazy loading, backend creation and connection, public exports, and attribute access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
