### PR TITLE
[Doc] Expand the Apache Doris adapter section (EN + zh)

### DIFF
--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -252,13 +252,46 @@ doris_data:
   port: 9030
   username: root
   password: your_password
+  catalog: internal      # optional, default is internal
   database: your_database
-  catalog: internal  # optional, default is internal
+  charset: utf8mb4       # optional, default is utf8mb4
+  autocommit: true       # optional, default is true
+  timeout_seconds: 30    # optional, default is 30
 ```
 
-Doris speaks the MySQL protocol; `port` is the FE query port (default 9030). The built-in catalog is
-`internal`; external catalogs (for example, Hive Metastore catalogs) can be selected through the same
-`catalog` field.
+| Option | Default | Description |
+|--------|---------|-------------|
+| `host` | `127.0.0.1` | Frontend (FE) host |
+| `port` | `9030` | FE MySQL-protocol query port, not the FE HTTP port (8030) |
+| `username` | required | Doris user |
+| `password` | empty | Doris password |
+| `catalog` | `internal` | Catalog the connection starts in |
+| `database` | none | Database the connection starts in |
+| `charset` | `utf8mb4` | Connection character set |
+| `autocommit` | `true` | Autocommit mode |
+| `timeout_seconds` | `30` | Connection timeout |
+
+Doris speaks the MySQL protocol, so `port` is the FE query port (default 9030). Objects are addressed as
+`catalog.database.table`: Doris has no schema level between database and table, so leave `schema` unset
+and let `catalog` carry the extra level.
+
+`internal` is the built-in catalog holding Doris-managed tables. To start a connection on an external
+catalog — a Hive Metastore catalog, for example — name it in `catalog`:
+
+```yaml
+doris_hive:
+  type: doris
+  host: localhost
+  port: 9030
+  username: root
+  password: your_password
+  catalog: hive_catalog
+  database: warehouse
+```
+
+Within a session, `SWITCH <catalog>` changes the catalog and `USE [<catalog>.]<database>` changes the
+database. Switching catalogs clears the current database, because a database of that name usually does
+not exist under the new catalog; issue a `USE` afterwards to select one.
 
 ### Hologres
 
@@ -423,10 +456,15 @@ All adapters support:
 - HTTP/HTTPS connection with SSL support
 
 #### Apache Doris
-- MySQL protocol compatibility
-- Multi-catalog discovery and context switching (`catalog.database.table`)
-- Materialized view discovery and DDL retrieval
-- Catalog-aware metadata and sample-row retrieval
+- MySQL protocol compatibility on the FE query port
+- Multi-catalog support: `SHOW CATALOGS` discovery, plus `SWITCH <catalog>` and `USE [catalog.]database` context switching
+- Catalog-qualified `information_schema` reads, so metadata queries need no session-level catalog switch and stay thread-safe
+- Three-part identifiers (`catalog.database.table`) with backtick quoting; no schema level
+- Asynchronous materialized views discovered through `mv_infos()`, with DDL retrieval
+- Key-model-aware column metadata (Duplicate, Unique, and Aggregate key columns)
+- Catalog-aware sample-row retrieval, and list, CSV, Pandas, and Arrow result formats
+- A packaged `db-doris-sql` skill covering table models, distribution, materialized views, and Broker / Stream / Routine Load
+- Migration target support: table-layout suggestions, DDL validation, source-type mapping, and a dry-run `CREATE TABLE` against the cluster
 
 #### Hologres
 - PostgreSQL wire protocol (PostgreSQL-compatible SQL dialect)

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -289,6 +289,10 @@ doris_hive:
   database: warehouse
 ```
 
+The catalog has to exist in Doris already — Datus selects a catalog, it never creates one. Create it on
+the Doris side first (`CREATE CATALOG hive_catalog PROPERTIES (...)`, with the metastore URI and storage
+credentials the catalog type needs) and confirm it is listed by `SHOW CATALOGS`.
+
 Within a session, `SWITCH <catalog>` changes the catalog and `USE [<catalog>.]<database>` changes the
 database. Switching catalogs clears the current database, because a database of that name usually does
 not exist under the new catalog; issue a `USE` afterwards to select one.

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -467,7 +467,7 @@ All adapters support:
 - Asynchronous materialized views discovered through `mv_infos()`, with DDL retrieval
 - Key-model-aware column metadata (Duplicate, Unique, and Aggregate key columns)
 - Catalog-aware sample-row retrieval, and list, CSV, Pandas, and Arrow result formats
-- A packaged `db-doris-sql` skill covering table models, distribution, materialized views, and Broker / Stream / Routine Load
+- A packaged `db-doris-sql` skill covering table models, distribution, materialized views, and loading through Stream Load, Routine Load, or `INSERT INTO SELECT` over a TVF or catalog
 - Migration target support: table-layout suggestions, DDL validation, source-type mapping, and a dry-run `CREATE TABLE` against the cluster
 
 #### Hologres

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -282,6 +282,10 @@ doris_hive:
   database: warehouse
 ```
 
+该 catalog 必须已经存在于 Doris 中——Datus 只负责选择 catalog，不会创建 catalog。请先在 Doris 侧创建
+（`CREATE CATALOG hive_catalog PROPERTIES (...)`，并按 catalog 类型填入 metastore 地址和存储凭证），
+确认它出现在 `SHOW CATALOGS` 的结果中。
+
 在会话内，`SWITCH <catalog>` 用于切换 catalog，`USE [<catalog>.]<database>` 用于切换数据库。切换 catalog
 会清空当前数据库上下文——同名数据库通常并不存在于新的 catalog 中，切换后需要再执行一次 `USE`。
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -246,12 +246,44 @@ doris_data:
   port: 9030
   username: root
   password: your_password
+  catalog: internal      # 可选，默认为 internal
   database: your_database
-  catalog: internal  # 可选，默认为 internal
+  charset: utf8mb4       # 可选，默认为 utf8mb4
+  autocommit: true       # 可选，默认为 true
+  timeout_seconds: 30    # 可选，默认为 30
 ```
 
-Doris 使用 MySQL 协议，`port` 为 FE 查询端口（默认 9030）。内置 catalog 为 `internal`，外部
-catalog（例如 Hive Metastore catalog）可通过同一个 `catalog` 字段选择。
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `host` | `127.0.0.1` | FE 节点地址 |
+| `port` | `9030` | FE 的 MySQL 协议查询端口，不是 FE HTTP 端口（8030） |
+| `username` | 必填 | Doris 用户名 |
+| `password` | 空 | Doris 密码 |
+| `catalog` | `internal` | 连接建立时所在的 catalog |
+| `database` | 无 | 连接建立时所在的数据库 |
+| `charset` | `utf8mb4` | 连接字符集 |
+| `autocommit` | `true` | 自动提交模式 |
+| `timeout_seconds` | `30` | 连接超时时间（秒） |
+
+Doris 使用 MySQL 协议，`port` 为 FE 查询端口（默认 9030）。对象以 `catalog.database.table` 三段式命名：
+Doris 在数据库和表之间没有 schema 这一层，因此不要配置 `schema`，多出来的一层由 `catalog` 承担。
+
+`internal` 是存放 Doris 自管理表的内置 catalog。如果希望连接建立时就位于某个外部 catalog（例如 Hive
+Metastore catalog），直接在 `catalog` 中指定：
+
+```yaml
+doris_hive:
+  type: doris
+  host: localhost
+  port: 9030
+  username: root
+  password: your_password
+  catalog: hive_catalog
+  database: warehouse
+```
+
+在会话内，`SWITCH <catalog>` 用于切换 catalog，`USE [<catalog>.]<database>` 用于切换数据库。切换 catalog
+会清空当前数据库上下文——同名数据库通常并不存在于新的 catalog 中，切换后需要再执行一次 `USE`。
 
 ### Hologres
 
@@ -407,10 +439,15 @@ agent:
 - HTTP/HTTPS 连接及 SSL 支持
 
 #### Apache Doris
-- MySQL 协议兼容
-- 多 Catalog 发现与上下文切换（`catalog.database.table`）
-- 物化视图发现与 DDL 获取
-- Catalog 感知的元数据和样本数据获取
+- 通过 FE 查询端口兼容 MySQL 协议
+- 多 catalog 支持：`SHOW CATALOGS` 发现，以及 `SWITCH <catalog>`、`USE [catalog.]database` 上下文切换
+- 元数据读取使用 catalog 限定的 `information_schema`，无需切换会话级 catalog，且线程安全
+- `catalog.database.table` 三段式标识符，支持反引号引用；没有 schema 层
+- 通过 `mv_infos()` 发现异步物化视图，并获取其 DDL
+- 元数据区分 Doris 的三种 key 模型（Duplicate Key、Unique Key、Aggregate Key）的 key 列
+- Catalog 感知的样本数据获取，支持 list、CSV、Pandas、Arrow 结果格式
+- 内置 `db-doris-sql` Skill，覆盖表模型、分桶、物化视图以及 Broker / Stream / Routine Load
+- 支持作为迁移目标：表结构布局建议、DDL 校验、源类型映射，以及在集群上试运行 `CREATE TABLE`
 
 #### Hologres
 - PostgreSQL wire 协议（PostgreSQL 兼容 SQL 方言）

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -450,7 +450,7 @@ agent:
 - 通过 `mv_infos()` 发现异步物化视图，并获取其 DDL
 - 元数据区分 Doris 的三种 key 模型（Duplicate Key、Unique Key、Aggregate Key）的 key 列
 - Catalog 感知的样本数据获取，支持 list、CSV、Pandas、Arrow 结果格式
-- 内置 `db-doris-sql` Skill，覆盖表模型、分桶、物化视图以及 Broker / Stream / Routine Load
+- 内置 `db-doris-sql` Skill，覆盖表模型、分桶、物化视图，以及 Stream Load、Routine Load 和基于 TVF / catalog 的 `INSERT INTO SELECT` 数据导入
 - 支持作为迁移目标：表结构布局建议、DDL 校验、源类型映射，以及在集群上试运行 `CREATE TABLE`
 
 #### Hologres


### PR DESCRIPTION
## Why

The `Apache Doris` section of the database-adapters page carried one YAML block
and four feature bullets. That left most of what `datus-doris` actually does
undocumented:

- the connection accepts `charset`, `autocommit`, and `timeout_seconds`, none of
  which appeared in the example;
- Doris has no schema level between database and table, so the extra level is the
  catalog — the page never said so, and `schema` looks configurable by analogy
  with the other adapters;
- the page said external catalogs "can be selected through the same `catalog`
  field" without showing a datasource that does it;
- `SWITCH` / `USE` context switching, and the fact that switching catalogs clears
  the current database, were not mentioned at all;
- the packaged `db-doris-sql` skill and `MigrationTargetMixin` support were
  missing from the feature list, even though both ship in the adapter.

## Solution

Expand the Doris configuration section and feature list in both locales.

Configuration section:

- complete the YAML example with every `DorisConfig` field, and move `catalog`
  above `database` so it reads in catalog → database order;
- add an option table with the defaults taken from `datus_doris/config.py`,
  calling out that `port` is the FE MySQL-protocol query port (9030), not the FE
  HTTP port (8030);
- state that objects are addressed as `catalog.database.table` and that `schema`
  should be left unset;
- add a second datasource example that starts on an external (Hive Metastore)
  catalog;
- document in-session `SWITCH <catalog>` / `USE [<catalog>.]<database>`, and that
  a catalog switch clears the database context (matching `switch_catalog()` and
  `execute_content_set()` in the connector).

Feature list — 4 bullets to 9, covering catalog-qualified `information_schema`
reads, `mv_infos()` asynchronous materialized-view discovery (distinguished from
synchronous rollups), key-model-aware column metadata, list/CSV/Pandas/Arrow
result formats, the packaged `db-doris-sql` skill, and migration-target support.

No behavior change; docs only.

## Test Cases

Docs-only, so no integration or nightly cases. Verified with the same build the
`Deploy Docs` workflow runs, for both locales:

```bash
DOCS_LOCALE=en DOCS_SITE_URL=https://docs.datus.ai/dev/ \
  python ci/prepare_docs_build.py --base-config mkdocs.yml \
  --output-root "$BUILD/docs_build_en" --source-ref HEAD
DOCS_LOCALE=en DOCS_SITE_URL=https://docs.datus.ai/dev/ \
  mkdocs build --strict -f "$BUILD/docs_build_en/mkdocs.yml" --site-dir site-en

DOCS_LOCALE=zh DOCS_SITE_URL=https://docs.datus.ai/zh/dev/ \
  python ci/prepare_docs_build.py --base-config mkdocs.yml \
  --output-root "$BUILD/docs_build_zh" --source-ref HEAD
DOCS_LOCALE=zh DOCS_SITE_URL=https://docs.datus.ai/zh/dev/ \
  mkdocs build --strict -f "$BUILD/docs_build_zh/mkdocs.yml" --site-dir site-zh
```

Both pass, and the rendered `adapters/db_adapters/` page was checked in each
site output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ScBo62YVqa1ChpMvfWF6n

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [x] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Documentation**
  * Expanded Apache Doris connection documentation, including catalog settings, defaults, character sets, auto-commit, and connection timeouts.
  * Added guidance for external catalogs, catalog/database switching, and context clearing behavior.
  * Documented Doris metadata discovery, identifier handling, materialized views, key models, result formats, SQL skills, and migration support.
  * Updated both English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded Apache Doris connection configuration guidance, including catalog selection, defaults, character sets, auto-commit, and timeouts.
  - Documented catalog and database switching behavior, external catalog setup, and required catalog preparation in Doris.
  - Added coverage of catalog-aware metadata, identifier formats, materialized views, key models, result formats, SQL skills, and migration support.
  - Updated both English and Chinese documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->