### PR TITLE
[Tool] Audit vacuous string containments and codify bug-fix regression-test rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Must start with one of: `[BugFix]` `[Enhancement]` `[Feature]` `[Refactor]` `[UT
 
 1. **`## Why`** — problem solved; link issues if any
 2. **`## Solution`** — approach, key decisions, tradeoffs
-3. **`## Test Cases`** — added/changed integration/nightly tests; if none, justify
+3. **`## Test Cases`** — added/changed integration/nightly tests; if none, justify. `[BugFix]` PRs also state that the new tests fail on the pre-fix code (see **Bug-fix regression tests**)
 
 When using `gh pr create --body`, copy `.github/PULL_REQUEST_TEMPLATE.md` as the starting point. PRs with empty/missing sections must be revised before review.
 
@@ -162,6 +162,11 @@ Unit tests follow the mapping rule above. The table lists **additional** integra
 ### Test quality (beyond coverage)
 
 Beyond happy paths, exercise: **input format variants** (all valid shapes, not just the common one); **return-type contracts** (every branch returns the same structure); **cross-component contracts** (consume the producer's real output); **adversarial inputs** for regex/SQL/path sandboxes; **recursive/nested structures** at depth ≥ 3; **spec compliance** for standards (`.gitignore`, SQL dialects).
+
+### Bug-fix regression tests
+
+- **Red first**: the tests a `[BugFix]` PR adds must fail on the pre-fix code. Verify by running them with the source change reverted (`git stash push -- datus/` → run → `git stash pop`), and say so in `## Test Cases`.
+- **Assert the property, not the instance**: pin the invariant the bug violated, not the value the fix happens to produce — "no binary source type ever maps to VARBINARY", not "BYTEA maps to STRING" — so the test stays red when the bug returns under a different spelling.
 
 ### No tombstone tests when removing code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Beyond happy paths, exercise: **input format variants** (all valid shapes, not j
 
 ### Bug-fix regression tests
 
-- **Red first**: the tests a `[BugFix]` PR adds must fail on the pre-fix code. Verify by running them with the source change reverted (`git stash push -- datus/` → run → `git stash pop`), and say so in `## Test Cases`.
+- **Red first**: the tests a `[BugFix]` PR adds must fail on the pre-fix code. Verify by running them with the implementation change reverted — `git stash push -- <changed source paths>` → run → `git stash pop`, or a worktree at the pre-fix commit — and say so in `## Test Cases`.
 - **Assert the property, not the instance**: pin the invariant the bug violated, not the value the fix happens to produce — "no binary source type ever maps to VARBINARY", not "BYTEA maps to STRING" — so the test stays red when the bug returns under a different spelling.
 
 ### No tombstone tests when removing code

--- a/ci/audit_tests.py
+++ b/ci/audit_tests.py
@@ -107,6 +107,8 @@ RULE_TIERS: dict[str, set[str]] = {
     "try_except_skip": {"unit", "integration"},
     "weak_assert": {"unit", "integration"},
     "or_assert": {"unit", "integration"},
+    "regex_literal_containment": {"unit", "integration"},
+    "case_contradictory_containment": {"unit", "integration"},
     "lambda_throw": {"unit", "integration"},
     "duplicate_test_files": {"unit", "integration"},
     # Unit-tier-only (strict hermeticity).
@@ -353,7 +355,58 @@ class _AstChecker(ast.NodeVisitor):
                     suggestion="Assert the exact expected value, e.g. `== 'foo'` or `== 3`.",
                 )
             )
+        self._check_containment_compares(node)
         self.generic_visit(node)
+
+    def _check_containment_compares(self, node: ast.Assert) -> None:
+        """Flag string containments whose truth barely depends on the container.
+
+        Two semantically-vacuous shapes that are structurally normal asserts:
+        a `not in` needle written with regex alternation in mind (`"A|B|C"`
+        matches almost nothing as a literal), and a needle whose letter case
+        contradicts a `.upper()`/`.lower()` container (can never match).
+        """
+        for compare in ast.walk(node.test):
+            if not (isinstance(compare, ast.Compare) and len(compare.ops) == 1):
+                continue
+            op = compare.ops[0]
+            if not isinstance(op, (ast.In, ast.NotIn)):
+                continue
+            needle = compare.left
+            if not (isinstance(needle, ast.Constant) and isinstance(needle.value, str)):
+                continue
+            case_method = _case_contradicting_method(needle.value, compare.comparators[0])
+            if case_method is not None:
+                self._emit(
+                    Issue(
+                        file=self.path,
+                        line=compare.lineno,
+                        severity="P0",
+                        check="case_contradictory_containment",
+                        message=(
+                            f"Needle {needle.value!r} can never appear in a `.{case_method}()` result — "
+                            "the outcome is fixed before the code under test runs (Meszaros: Lying Test)"
+                        ),
+                        quote=self._quote(compare.lineno),
+                        suggestion=f"Match the needle's case to the `.{case_method}()` container, "
+                        "or drop the case conversion.",
+                    )
+                )
+            elif isinstance(op, ast.NotIn) and _is_pseudo_regex_literal(needle.value):
+                self._emit(
+                    Issue(
+                        file=self.path,
+                        line=compare.lineno,
+                        severity="P1",
+                        check="regex_literal_containment",
+                        message=(
+                            f"Needle {needle.value!r} reads like a regex alternation, but `not in` is literal "
+                            "substring containment — the assertion holds for almost any container"
+                        ),
+                        quote=self._quote(compare.lineno),
+                        suggestion="Split into one `assert marker not in ...` per alternative, or use re.search().",
+                    )
+                )
 
     # -- zero_assert_test / fixture / test function tracking
 
@@ -688,6 +741,44 @@ def _is_or_assert(expr: ast.AST) -> bool:
     if _is_tautological(expr):
         return False
     return all(isinstance(v, (ast.Compare, ast.Call)) for v in expr.values)
+
+
+# Explicit regex tokens that cannot occur in a sensible literal needle.
+_REGEX_TOKEN_RE = re.compile(r"\\[bBdDsSwW]|\(\?[:=!<]")
+# Word-ish segments joined by bare pipes: "S3|HDFS|BROKER". Legitimate pipes
+# come with spacing ("| col |", "a | b") or doubled ("a || b"), both excluded.
+_PSEUDO_ALTERNATION_RE = re.compile(r"[\w .()\-/]+(\|[\w .()\-/]+)+")
+
+
+def _is_pseudo_regex_literal(value: str) -> bool:
+    """True when a containment needle was probably written with regex semantics."""
+    if _REGEX_TOKEN_RE.search(value):
+        return True
+    if "\x08" in value:
+        # A regex \b typed in a non-raw string arrives here as a backspace
+        # control character; no legitimate containment needle carries one.
+        return True
+    if "|" not in value or "||" in value or " | " in value:
+        return False
+    return bool(_PSEUDO_ALTERNATION_RE.fullmatch(value))
+
+
+def _case_contradicting_method(needle: str, container: ast.AST) -> str | None:
+    """Return the case method when the needle can never appear in the container.
+
+    ``"broker load" not in notes.upper()``: the container never holds lowercase,
+    so the assertion is decided regardless of ``notes``.
+    """
+    if not (isinstance(container, ast.Call) and isinstance(container.func, ast.Attribute)):
+        return None
+    if container.args or container.keywords:
+        return None
+    method = container.func.attr
+    if method == "upper" and needle != needle.upper():
+        return method
+    if method in {"lower", "casefold"} and needle != needle.lower():
+        return method
+    return None
 
 
 _WEAK_NAMES = {"result", "output", "response", "ret", "data", "value", "x", "y", "obj"}

--- a/ci/audit_tests.py
+++ b/ci/audit_tests.py
@@ -743,8 +743,11 @@ def _is_or_assert(expr: ast.AST) -> bool:
     return all(isinstance(v, (ast.Compare, ast.Call)) for v in expr.values)
 
 
-# Explicit regex tokens that cannot occur in a sensible literal needle.
-_REGEX_TOKEN_RE = re.compile(r"\\[bBdDsSwW]|\(\?[:=!<]")
+# Regex escape and group tokens that suggest a needle was written as a pattern.
+_REGEX_ESCAPE_RE = re.compile(r"\\[bBdDsSwW]")
+_REGEX_GROUP_RE = re.compile(r"\(\?[:=!<]")
+# Windows drive-letter or UNC prefix — backslash sequences after these are paths.
+_WINDOWS_PATH_RE = re.compile(r"^(?:[A-Za-z]:[\\/]|\\\\)")
 # Word-ish segments joined by bare pipes: "S3|HDFS|BROKER". Legitimate pipes
 # come with spacing ("| col |", "a | b") or doubled ("a || b"), both excluded.
 _PSEUDO_ALTERNATION_RE = re.compile(r"[\w .()\-/]+(\|[\w .()\-/]+)+")
@@ -752,12 +755,19 @@ _PSEUDO_ALTERNATION_RE = re.compile(r"[\w .()\-/]+(\|[\w .()\-/]+)+")
 
 def _is_pseudo_regex_literal(value: str) -> bool:
     """True when a containment needle was probably written with regex semantics."""
-    if _REGEX_TOKEN_RE.search(value):
-        return True
     if "\x08" in value:
         # A regex \b typed in a non-raw string arrives here as a backspace
         # control character; no legitimate containment needle carries one.
         return True
+    if _REGEX_GROUP_RE.search(value):
+        return True
+    if not _WINDOWS_PATH_RE.match(value):
+        escapes = _REGEX_ESCAPE_RE.findall(value)
+        # A lone escape mid-string is indistinguishable from a Windows path
+        # fragment ("src\build"), so regex intent needs a boundary position
+        # or a second token.
+        if escapes and (len(escapes) >= 2 or _REGEX_ESCAPE_RE.match(value)):
+            return True
     if "|" not in value or "||" in value or " | " in value:
         return False
     return bool(_PSEUDO_ALTERNATION_RE.fullmatch(value))

--- a/tests/unit_tests/ci/test_audit_tests.py
+++ b/tests/unit_tests/ci/test_audit_tests.py
@@ -166,7 +166,63 @@ def test_no_word_boundary_needle():
 
         issues = audit_tests.scan_file(test_file, required_packages=set())
 
-        assert any(issue.check == "regex_literal_containment" for issue in issues)
+        flagged = [issue for issue in issues if issue.check == "regex_literal_containment"]
+        assert len(flagged) == 1
+        assert flagged[0].severity == "P1"
+        assert flagged[0].line == 4
+    finally:
+        audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_flags_multi_escape_and_group_regex_needles(tmp_path):
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_regex_shapes.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            r"""
+def test_regex_shaped_needles():
+    rendered = render()
+    assert r"DROP\s+TABLE\s+users" not in rendered
+    assert "suffix(?:_v2)" not in rendered
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        flagged = [issue for issue in issues if issue.check == "regex_literal_containment"]
+        assert [issue.line for issue in flagged] == [4, 5]
+        assert {issue.severity for issue in flagged} == {"P1"}
+    finally:
+        audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_does_not_flag_windows_path_needles(tmp_path):
+    """Backslash sequences in path literals are not regex intent."""
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_windows_paths.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            r"""
+def test_path_needles_are_literal():
+    output = render()
+    assert r"C:\build" not in output
+    assert r"D:/state\dump" not in output
+    assert r"\\server\share\logs" not in output
+    assert r"src\build" not in output
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        assert all(issue.check != "regex_literal_containment" for issue in issues)
     finally:
         audit_tests.configure_repo_root(original_root)
 

--- a/tests/unit_tests/ci/test_audit_tests.py
+++ b/tests/unit_tests/ci/test_audit_tests.py
@@ -119,3 +119,132 @@ def test_audit_does_not_flag_large_unit_test_file(tmp_path):
         assert all(issue.check != "file_size_budget" for issue in issues)
     finally:
         audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_flags_pseudo_regex_alternation_in_not_in(tmp_path):
+    """`"A|B|C" not in s` is literal containment, so it holds for almost any s."""
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_pseudo_regex.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """
+def test_markers_stay_out():
+    notes = load_notes()
+    assert "WITH S3|HDFS|BROKER" not in notes
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        flagged = [issue for issue in issues if issue.check == "regex_literal_containment"]
+        assert len(flagged) == 1
+        assert flagged[0].severity == "P1"
+        assert flagged[0].line == 4
+    finally:
+        audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_flags_explicit_regex_tokens_in_not_in(tmp_path):
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_regex_tokens.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            r"""
+def test_no_word_boundary_needle():
+    rendered = render()
+    assert "\bDROP\b" not in rendered
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        assert any(issue.check == "regex_literal_containment" for issue in issues)
+    finally:
+        audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_does_not_flag_legitimate_pipe_needles(tmp_path):
+    """Markdown tables, spaced pipes, SQL concat, and `in` direction stay clean."""
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_legit_pipes.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """
+def test_pipe_shapes_that_are_really_literals():
+    output = render()
+    assert "| Option |" not in output
+    assert "left | right" not in output
+    assert "a || b" not in output
+    assert "csv|field" in output
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        assert all(issue.check != "regex_literal_containment" for issue in issues)
+    finally:
+        audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_flags_case_contradictory_containment(tmp_path):
+    """A lowercase needle can never appear in an `.upper()` container."""
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_case_blind.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """
+def test_marker_stays_out():
+    notes = load_notes()
+    assert "broker load" not in notes.upper()
+    assert "LOAD LABEL" in notes.lower()
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        flagged = [issue for issue in issues if issue.check == "case_contradictory_containment"]
+        assert [issue.line for issue in flagged] == [4, 5]
+        assert {issue.severity for issue in flagged} == {"P0"}
+    finally:
+        audit_tests.configure_repo_root(original_root)
+
+
+def test_audit_does_not_flag_case_consistent_containment(tmp_path):
+    audit_tests = _load_audit_tests()
+    original_root = audit_tests.REPO_ROOT
+    try:
+        test_file = tmp_path / "tests" / "unit_tests" / "test_case_consistent.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """
+def test_marker_stays_out():
+    notes = load_notes()
+    assert "BROKER LOAD" not in notes.upper()
+    assert "load label" not in notes.lower()
+    assert "Broker Load" not in notes
+""",
+            encoding="utf-8",
+        )
+        audit_tests.configure_repo_root(tmp_path)
+
+        issues = audit_tests.scan_file(test_file, required_packages=set())
+
+        assert all(issue.check != "case_contradictory_containment" for issue in issues)
+    finally:
+        audit_tests.configure_repo_root(original_root)


### PR DESCRIPTION
## Why

Two assertion shapes are structurally normal but semantically vacuous, and the existing audit rules (`tautology`, `weak_assert`) cannot see them because they only inspect AST structure, not the semantics of the operands:

- `assert "WITH S3|HDFS|BROKER" not in notes` — written with regex alternation in mind, but `not in` is literal substring containment. The 19-character literal matches almost nothing, so the assertion passes whatever the file says: a test that provides coverage numbers and confidence while catching no regression.
- `assert "broker load" not in notes.upper()` — an `.upper()` result never contains lowercase, so the outcome is fixed before the code under test runs.

Separately, the repo had no stated convention that a bug fix's regression tests must be demonstrated to fail on the pre-fix code, or that they should pin the violated invariant rather than the fixed value — the two disciplines that make regression tests actually regression-proof.

## Solution

Two new audit rules in `ci/audit_tests.py`, both scoped to shapes with low false-positive risk:

- **`regex_literal_containment` (P1)** — fires on a `not in` needle that reads like a regex: bare pipes between word-ish segments (`S3|HDFS|BROKER`), explicit regex tokens (`\d`, `(?:`), or a `\b` typed in a non-raw string — which reaches the AST as a backspace control character, a form no legitimate needle carries. Markdown tables (`| col |`), spaced pipes, and SQL `||` are excluded, and the `in` direction is left alone because a pseudo-regex there fails loudly at authoring time.
- **`case_contradictory_containment` (P0)** — fires when the needle's letter case contradicts a `.upper()`/`.lower()`/`.casefold()` container, in either containment direction. The judgment is exact, so it lands as P0; a full-tree scan reports zero hits on the existing suite, so no `noqa` was needed.

CLAUDE.md gains the matching review-side conventions under **Testing Rules → Bug-fix regression tests**: a `[BugFix]` PR's new tests must be verified red on the pre-fix code and say so in `## Test Cases`, and regression tests assert the property, not the instance. The `## Test Cases` template requirement references the new section.

## Test Cases

- Five new unit tests in `tests/unit_tests/ci/test_audit_tests.py`: pseudo-alternation flagged at P1, explicit regex tokens flagged, legitimate pipe shapes and the `in` direction not flagged, case contradictions flagged at P0 on both `.upper()` and `.lower()`, case-consistent containments not flagged.
- Applying the new convention to itself: the three "flags" tests were verified red against the previous `ci/audit_tests.py` (via `git stash`) before the implementation was restored.
- `ci/audit_tests.py --all`: 609 files scanned, zero hits from the new rules on the existing suite, P0=0.
- `ci/run-pr-tests.py upstream/main`: 422 passed, diff coverage 100.00%.
- `ci/run-merge-queue-tests.py`: exit 0 (required because this touches a CI script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Added automated checks that identify invalid containment assertions, including regex-like patterns used as literal text.
  * Added detection for case-mismatched assertions that can never succeed after text normalization.
* **Bug Fixes**
  * Improved regression-test guidance to require newly added bug-fix tests to fail before the fix and verify expected invariants.
* **Tests**
  * Added coverage for valid and invalid pattern-based and case-sensitive containment checks, including severity and source-location reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks that identify likely incorrect containment assertions involving regex-like patterns and contradictory case transformations.
  * Improved detection accuracy for escaped patterns, grouped expressions, alternation, and Windows paths.

* **Bug Fixes**
  * Reduced false positives by distinguishing legitimate pipe-containing strings and Windows paths from regex intent.

* **Documentation**
  * Updated pull request guidance to require regression tests that fail before a bug fix and use invariant-based assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->