### PR TITLE
[Feature] Let the REST reads honour a request sub-agent scope

### DIFF
--- a/datus/api/auth/context.py
+++ b/datus/api/auth/context.py
@@ -31,7 +31,10 @@ class AppContext:
     # cached DatusService. The AuthProvider fills it from whatever transport
     # convention that host uses, so Agent needs no knowledge of the header.
     #
-    # Must be the ``agentic_nodes`` key, not an entry's ``id``: an ``id`` misses
-    # the lookup and degrades to no filter at all, returning 200 with
-    # unrestricted results. Providers resolve id -> key before setting this.
+    # Must be the ``agentic_nodes`` key, not an entry's ``id`` — only a key
+    # resolves to a scope. A value that resolves to nothing is refused with 400
+    # by ``deps.get_scoped_sub_agent`` before any scoped service is built, so a
+    # provider that sets an ``id`` here gets an error rather than an unfiltered
+    # read. Providers should still resolve id -> key so callers see a working
+    # request rather than a rejected one.
     sub_agent_name: Optional[str] = None

--- a/datus/api/auth/context.py
+++ b/datus/api/auth/context.py
@@ -18,9 +18,20 @@ class AppContext:
       ``get_datus_service`` loads it on demand.
     - ``policy_context``: request-scoped inputs consumed by active policy
       plugins. Authentication and authorization happen before this boundary.
+    - ``sub_agent_name``: which sub-agent's ``scoped_context`` bounds the
+      knowledge-base reads on this request; ``None`` means unscoped, which is
+      the single-tenant default.
     """
 
     user_id: Optional[str] = None
     project_id: Optional[str] = None
     config: Optional[AgentConfig] = None
     policy_context: Dict[str, Any] = field(default_factory=dict)
+    # Per request, because a hosting deployment serves many sub-agents from one
+    # cached DatusService. The AuthProvider fills it from whatever transport
+    # convention that host uses, so Agent needs no knowledge of the header.
+    #
+    # Must be the ``agentic_nodes`` key, not an entry's ``id``: an ``id`` misses
+    # the lookup and degrades to no filter at all, returning 200 with
+    # unrestricted results. Providers resolve id -> key before setting this.
+    sub_agent_name: Optional[str] = None

--- a/datus/api/deps.py
+++ b/datus/api/deps.py
@@ -106,3 +106,34 @@ def get_app_context(request: Request) -> AppContext:
 
 ServiceDep = Annotated[DatusService, Depends(get_datus_service)]
 AppContextDep = Annotated[AppContext, Depends(get_app_context)]
+
+
+def get_scoped_sub_agent(request: Request, svc: ServiceDep) -> Optional[str]:
+    """The request's sub-agent name, validated against the configuration.
+
+    Returns ``None`` for an unscoped request — the single-tenant default.
+
+    A name that is not a configured ``agentic_nodes`` key is refused with 400
+    rather than passed on, because a service built from an unrecognised name has
+    no scope filter at all: the read would succeed and return everything. That
+    turns a caller's identifier mistake into a scope bypass. Rejecting here
+    stops it before any route body runs, so nothing unscoped is ever built or
+    cached.
+
+    Taking ``svc`` as a dependency rather than reading ``request.state`` also
+    fixes the ordering hazard by construction: FastAPI resolves ``ServiceDep``
+    first because this depends on it, so a route can declare its parameters in
+    any order.
+    """
+    sub_agent_name = get_app_context(request).sub_agent_name
+    if sub_agent_name is None:
+        return None
+    if not svc.has_sub_agent(sub_agent_name):
+        # Deliberately does not name the configured sub-agents: on a deployment
+        # that publishes one of them to a consumer, listing the rest is its own
+        # disclosure.
+        raise HTTPException(status_code=400, detail=f"Unknown sub-agent: {sub_agent_name}")
+    return sub_agent_name
+
+
+SubAgentDep = Annotated[Optional[str], Depends(get_scoped_sub_agent)]

--- a/datus/api/routes/explorer_routes.py
+++ b/datus/api/routes/explorer_routes.py
@@ -4,7 +4,7 @@ API routes for Explorer endpoints.
 
 from fastapi import APIRouter
 
-from datus.api.deps import AppContextDep, ServiceDep
+from datus.api.deps import ServiceDep, SubAgentDep
 from datus.api.models.base_models import Result
 from datus.api.models.explorer_models import (
     CreateDirectoryInput,
@@ -36,10 +36,10 @@ router = APIRouter(prefix="/api/v1", tags=["explorer"])
 )
 async def get_subject_list(
     svc: ServiceDep,
-    ctx: AppContextDep,
+    sub_agent: SubAgentDep,
 ) -> Result[SubjectListData]:
     """Get subject tree."""
-    return await svc.explorer_for(ctx.sub_agent_name).get_subject_list()
+    return await svc.explorer_for(sub_agent).get_subject_list()
 
 
 @router.post(
@@ -93,10 +93,10 @@ async def delete_subject(
 async def get_metric(
     request: SubjectPathInput,
     svc: ServiceDep,
-    ctx: AppContextDep,
+    sub_agent: SubAgentDep,
 ) -> Result[MetricInfo]:
     """Get metric info."""
-    return await svc.explorer_for(ctx.sub_agent_name).get_metric(request.subject_path)
+    return await svc.explorer_for(sub_agent).get_metric(request.subject_path)
 
 
 @router.post(
@@ -108,10 +108,10 @@ async def get_metric(
 async def get_metric_dimensions(
     request: SubjectPathInput,
     svc: ServiceDep,
-    ctx: AppContextDep,
+    sub_agent: SubAgentDep,
 ) -> Result[MetricDimensionsData]:
     """List a metric's queryable dimensions."""
-    return await svc.explorer_for(ctx.sub_agent_name).get_metric_dimensions(request)
+    return await svc.explorer_for(sub_agent).get_metric_dimensions(request)
 
 
 @router.post(
@@ -123,10 +123,10 @@ async def get_metric_dimensions(
 async def preview_metric(
     request: MetricPreviewInput,
     svc: ServiceDep,
-    ctx: AppContextDep,
+    sub_agent: SubAgentDep,
 ) -> Result[MetricPreviewData]:
     """Compile a saved metric to SQL for preview."""
-    return await svc.explorer_for(ctx.sub_agent_name).preview_metric(request)
+    return await svc.explorer_for(sub_agent).preview_metric(request)
 
 
 @router.post(
@@ -138,10 +138,10 @@ async def preview_metric(
 async def get_reference_sql(
     request: SubjectPathInput,
     svc: ServiceDep,
-    ctx: AppContextDep,
+    sub_agent: SubAgentDep,
 ) -> Result[ReferenceSQLInfo]:
     """Get reference SQL."""
-    return await svc.explorer_for(ctx.sub_agent_name).get_reference_sql(request.subject_path)
+    return await svc.explorer_for(sub_agent).get_reference_sql(request.subject_path)
 
 
 @router.post(

--- a/datus/api/routes/explorer_routes.py
+++ b/datus/api/routes/explorer_routes.py
@@ -4,7 +4,7 @@ API routes for Explorer endpoints.
 
 from fastapi import APIRouter
 
-from datus.api.deps import ServiceDep
+from datus.api.deps import AppContextDep, ServiceDep
 from datus.api.models.base_models import Result
 from datus.api.models.explorer_models import (
     CreateDirectoryInput,
@@ -36,9 +36,10 @@ router = APIRouter(prefix="/api/v1", tags=["explorer"])
 )
 async def get_subject_list(
     svc: ServiceDep,
+    ctx: AppContextDep,
 ) -> Result[SubjectListData]:
     """Get subject tree."""
-    return await svc.explorer.get_subject_list()
+    return await svc.explorer_for(ctx.sub_agent_name).get_subject_list()
 
 
 @router.post(
@@ -92,9 +93,10 @@ async def delete_subject(
 async def get_metric(
     request: SubjectPathInput,
     svc: ServiceDep,
+    ctx: AppContextDep,
 ) -> Result[MetricInfo]:
     """Get metric info."""
-    return await svc.explorer.get_metric(request.subject_path)
+    return await svc.explorer_for(ctx.sub_agent_name).get_metric(request.subject_path)
 
 
 @router.post(
@@ -106,9 +108,10 @@ async def get_metric(
 async def get_metric_dimensions(
     request: SubjectPathInput,
     svc: ServiceDep,
+    ctx: AppContextDep,
 ) -> Result[MetricDimensionsData]:
     """List a metric's queryable dimensions."""
-    return await svc.explorer.get_metric_dimensions(request)
+    return await svc.explorer_for(ctx.sub_agent_name).get_metric_dimensions(request)
 
 
 @router.post(
@@ -120,9 +123,10 @@ async def get_metric_dimensions(
 async def preview_metric(
     request: MetricPreviewInput,
     svc: ServiceDep,
+    ctx: AppContextDep,
 ) -> Result[MetricPreviewData]:
     """Compile a saved metric to SQL for preview."""
-    return await svc.explorer.preview_metric(request)
+    return await svc.explorer_for(ctx.sub_agent_name).preview_metric(request)
 
 
 @router.post(
@@ -134,9 +138,10 @@ async def preview_metric(
 async def get_reference_sql(
     request: SubjectPathInput,
     svc: ServiceDep,
+    ctx: AppContextDep,
 ) -> Result[ReferenceSQLInfo]:
     """Get reference SQL."""
-    return await svc.explorer.get_reference_sql(request.subject_path)
+    return await svc.explorer_for(ctx.sub_agent_name).get_reference_sql(request.subject_path)
 
 
 @router.post(

--- a/datus/api/routes/tool_routes.py
+++ b/datus/api/routes/tool_routes.py
@@ -4,7 +4,7 @@ from typing import Annotated, Dict, Optional
 
 from fastapi import APIRouter, Body, Path
 
-from datus.api.deps import AppContextDep, ServiceDep
+from datus.api.deps import ServiceDep, SubAgentDep
 from datus.api.models.base_models import Result
 from datus.tools.func_tool.base import FuncToolResult
 
@@ -20,15 +20,14 @@ router = APIRouter(prefix="/api/v1/tools", tags=["tools"])
 def execute_tool(
     tool_name: Annotated[str, Path(description="Name of the tool to execute")],
     svc: ServiceDep,
-    ctx: AppContextDep,
+    sub_agent: SubAgentDep,
     params: Annotated[Optional[Dict], Body()] = None,
 ) -> Result[FuncToolResult]:
     """Execute a tool by name, scoped to the request's sub-agent if it has one.
 
-    ``ServiceDep`` must stay declared before ``AppContextDep``: the context is
-    published on ``request.state`` while the service dependency resolves, so the
-    reverse order trips the assertion in ``get_app_context``.
+    ``SubAgentDep`` has already rejected a name that matches no configured
+    sub-agent, so this only ever sees a real scope or ``None``.
     """
     if params is None:
         params = {}
-    return svc.tool_for(ctx.sub_agent_name).execute(tool_name, params)
+    return svc.tool_for(sub_agent).execute(tool_name, params)

--- a/datus/api/routes/tool_routes.py
+++ b/datus/api/routes/tool_routes.py
@@ -4,7 +4,7 @@ from typing import Annotated, Dict, Optional
 
 from fastapi import APIRouter, Body, Path
 
-from datus.api.deps import ServiceDep
+from datus.api.deps import AppContextDep, ServiceDep
 from datus.api.models.base_models import Result
 from datus.tools.func_tool.base import FuncToolResult
 
@@ -20,9 +20,15 @@ router = APIRouter(prefix="/api/v1/tools", tags=["tools"])
 def execute_tool(
     tool_name: Annotated[str, Path(description="Name of the tool to execute")],
     svc: ServiceDep,
+    ctx: AppContextDep,
     params: Annotated[Optional[Dict], Body()] = None,
 ) -> Result[FuncToolResult]:
-    """Execute a tool by name."""
+    """Execute a tool by name, scoped to the request's sub-agent if it has one.
+
+    ``ServiceDep`` must stay declared before ``AppContextDep``: the context is
+    published on ``request.state`` while the service dependency resolves, so the
+    reverse order trips the assertion in ``get_app_context``.
+    """
     if params is None:
         params = {}
-    return svc.tool.execute(tool_name, params)
+    return svc.tool_for(ctx.sub_agent_name).execute(tool_name, params)

--- a/datus/api/services/datus_service.py
+++ b/datus/api/services/datus_service.py
@@ -7,7 +7,7 @@ and a project-scoped ChatTaskManager into a single cached instance.
 import dataclasses
 import hashlib
 import json
-from typing import Any
+from typing import Any, Dict, Optional
 
 from datus.configuration.agent_config import AgentConfig
 from datus.utils.loggings import get_logger
@@ -71,11 +71,14 @@ class DatusService:
         self._chat = None
         self._cli = None
         self._datasource = None
-        self._explorer = None
+        # Keyed by sub-agent name, not a single slot: these two services carry a
+        # scope filter, and DatusServiceCache keys only on project, so one slot
+        # would serve the first caller's scope to every later sub-agent.
+        self._explorers: Dict[Optional[str], Any] = {}
         self._mcp = None
         self._kb = None
         self._visualization = None
-        self._tool = None
+        self._tools: Dict[Optional[str], Any] = {}
         self._success_story = None
         self._dashboard = None
         self._report = None
@@ -160,13 +163,26 @@ class DatusService:
             self._datasource = DatasourceService(agent_config=self._agent_config)
         return self._datasource
 
-    @property
-    def explorer(self):
-        if self._explorer is None:
+    def explorer_for(self, sub_agent_name: Optional[str] = None):
+        """ExplorerService scoped to ``sub_agent_name`` (``None`` = unscoped).
+
+        One instance per name. A single lazy slot would be worse than the
+        unscoped status quo: the first request's sub-agent would be cached and
+        every later request, whatever sub-agent it named, would silently read
+        through that scope. Wrong results, no error.
+        """
+        if sub_agent_name not in self._explorers:
             from datus.api.services.explorer_service import ExplorerService
 
-            self._explorer = ExplorerService(agent_config=self._agent_config)
-        return self._explorer
+            self._explorers[sub_agent_name] = ExplorerService(
+                agent_config=self._agent_config, sub_agent_name=sub_agent_name
+            )
+        return self._explorers[sub_agent_name]
+
+    @property
+    def explorer(self):
+        """The unscoped ExplorerService. Kept so existing callers are unchanged."""
+        return self.explorer_for(None)
 
     @property
     def mcp(self):
@@ -184,13 +200,21 @@ class DatusService:
             self._kb = KbService(agent_config=self._agent_config)
         return self._kb
 
-    @property
-    def tool(self):
-        if self._tool is None:
+    def tool_for(self, sub_agent_name: Optional[str] = None):
+        """ToolService scoped to ``sub_agent_name`` (``None`` = unscoped).
+
+        Per-name for the same reason as :meth:`explorer_for`.
+        """
+        if sub_agent_name not in self._tools:
             from datus.api.services.tool_service import ToolService
 
-            self._tool = ToolService(agent_config=self._agent_config)
-        return self._tool
+            self._tools[sub_agent_name] = ToolService(agent_config=self._agent_config, sub_agent_name=sub_agent_name)
+        return self._tools[sub_agent_name]
+
+    @property
+    def tool(self):
+        """The unscoped ToolService. Kept so existing callers are unchanged."""
+        return self.tool_for(None)
 
     @property
     def success_story(self):

--- a/datus/api/services/datus_service.py
+++ b/datus/api/services/datus_service.py
@@ -7,10 +7,18 @@ and a project-scoped ChatTaskManager into a single cached instance.
 import dataclasses
 import hashlib
 import json
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from datus.configuration.agent_config import AgentConfig
+from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    # Import-time only: these modules import back into the service layer, and
+    # the accessors below import them lazily inside the function body to keep
+    # that cycle from forming at runtime.
+    from datus.api.services.explorer_service import ExplorerService
+    from datus.api.services.tool_service import ToolService
 
 logger = get_logger(__name__)
 
@@ -74,11 +82,11 @@ class DatusService:
         # Keyed by sub-agent name, not a single slot: these two services carry a
         # scope filter, and DatusServiceCache keys only on project, so one slot
         # would serve the first caller's scope to every later sub-agent.
-        self._explorers: Dict[Optional[str], Any] = {}
+        self._explorers: Dict[Optional[str], "ExplorerService"] = {}
         self._mcp = None
         self._kb = None
         self._visualization = None
-        self._tools: Dict[Optional[str], Any] = {}
+        self._tools: Dict[Optional[str], "ToolService"] = {}
         self._success_story = None
         self._dashboard = None
         self._report = None
@@ -163,14 +171,49 @@ class DatusService:
             self._datasource = DatasourceService(agent_config=self._agent_config)
         return self._datasource
 
-    def explorer_for(self, sub_agent_name: Optional[str] = None):
+    def has_sub_agent(self, sub_agent_name: str) -> bool:
+        """Whether ``sub_agent_name`` is a configured ``agentic_nodes`` key.
+
+        The key, not an entry's ``id``. ``AgentConfig.sub_agent_config`` looks up
+        that mapping directly, so only a key resolves to a scope.
+        """
+        nodes = getattr(self._agent_config, "agentic_nodes", None) or {}
+        return sub_agent_name in nodes
+
+    def _require_known_sub_agent(self, sub_agent_name: Optional[str]) -> None:
+        """Refuse a name that resolves to no scope.
+
+        ``None`` is not a name — it means "unscoped", the single-tenant default.
+        Any other value must be a configured key, because an unrecognised one
+        would build a service whose scope filter is ``None``: a successful,
+        completely unfiltered read. That turns a caller's identifier mistake —
+        passing an ``id`` instead of a key, a typo, a name left over from a
+        rename — into a scope bypass, which is the exact failure this scoping
+        exists to prevent. Fail closed instead.
+
+        The message deliberately does not list the configured sub-agents: on a
+        deployment that publishes one sub-agent to a consumer, enumerating the
+        others is a disclosure in its own right.
+        """
+        if sub_agent_name is None or self.has_sub_agent(sub_agent_name):
+            return
+        raise DatusException(
+            code=ErrorCode.COMMON_UNSUPPORTED,
+            message_args={"your_value": sub_agent_name, "field_name": "sub_agent_name"},
+        )
+
+    def explorer_for(self, sub_agent_name: Optional[str] = None) -> "ExplorerService":
         """ExplorerService scoped to ``sub_agent_name`` (``None`` = unscoped).
 
         One instance per name. A single lazy slot would be worse than the
         unscoped status quo: the first request's sub-agent would be cached and
         every later request, whatever sub-agent it named, would silently read
         through that scope. Wrong results, no error.
+
+        An unknown name raises and is never cached — see
+        :meth:`_require_known_sub_agent`.
         """
+        self._require_known_sub_agent(sub_agent_name)
         if sub_agent_name not in self._explorers:
             from datus.api.services.explorer_service import ExplorerService
 
@@ -180,7 +223,7 @@ class DatusService:
         return self._explorers[sub_agent_name]
 
     @property
-    def explorer(self):
+    def explorer(self) -> "ExplorerService":
         """The unscoped ExplorerService. Kept so existing callers are unchanged."""
         return self.explorer_for(None)
 
@@ -200,11 +243,13 @@ class DatusService:
             self._kb = KbService(agent_config=self._agent_config)
         return self._kb
 
-    def tool_for(self, sub_agent_name: Optional[str] = None):
+    def tool_for(self, sub_agent_name: Optional[str] = None) -> "ToolService":
         """ToolService scoped to ``sub_agent_name`` (``None`` = unscoped).
 
-        Per-name for the same reason as :meth:`explorer_for`.
+        Per-name, and unknown names refused, for the same reasons as
+        :meth:`explorer_for`.
         """
+        self._require_known_sub_agent(sub_agent_name)
         if sub_agent_name not in self._tools:
             from datus.api.services.tool_service import ToolService
 
@@ -212,7 +257,7 @@ class DatusService:
         return self._tools[sub_agent_name]
 
     @property
-    def tool(self):
+    def tool(self) -> "ToolService":
         """The unscoped ToolService. Kept so existing callers are unchanged."""
         return self.tool_for(None)
 

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -4,7 +4,7 @@ Explorer service for catalog and subject tree management.
 
 import asyncio
 import os
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from datus.api.models.base_models import Result
 from datus.api.models.explorer_models import (
@@ -27,6 +27,9 @@ from datus.api.models.explorer_models import (
 )
 from datus.utils.loggings import get_logger
 
+if TYPE_CHECKING:
+    from datus.configuration.agent_config import AgentConfig
+
 logger = get_logger(__name__)
 
 
@@ -37,7 +40,7 @@ class ExplorerService:
     directories, metrics, and reference SQL.
     """
 
-    def __init__(self, agent_config, sub_agent_name: Optional[str] = None):
+    def __init__(self, agent_config: "AgentConfig", sub_agent_name: Optional[str] = None) -> None:
         """Initialize ExplorerService.
 
         Args:

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -37,13 +37,23 @@ class ExplorerService:
     directories, metrics, and reference SQL.
     """
 
-    def __init__(self, agent_config):
+    def __init__(self, agent_config, sub_agent_name: Optional[str] = None):
         """Initialize ExplorerService.
 
         Args:
             agent_config: Agent configuration object
+            sub_agent_name: Restrict the knowledge-base reads to this sub-agent's
+                ``scoped_context``. ``None`` (the default) reads everything,
+                which is the existing single-tenant behaviour.
+
+                Must be the ``agentic_nodes`` key, never an entry's ``id``:
+                ``AgentConfig.sub_agent_config`` is a plain lookup on that
+                mapping, so an ``id`` misses, yields ``{}``, and the scope
+                filter degrades to "no filter" — unrestricted results with a
+                200, not an error. Callers resolve id -> key before this point.
         """
         self.agent_config = agent_config
+        self.sub_agent_name = sub_agent_name
         self.datasource_id = str(agent_config.current_datasource or "").strip()
         logger.info("ExplorerService initialized")
 
@@ -60,9 +70,12 @@ class ExplorerService:
         from datus.storage.registry import get_subject_tree_store
         from datus.storage.semantic_model.store import SemanticModelRAG
 
-        self.metric_rag = MetricRAG(agent_config, datasource_id=self.datasource_id)
-        self.reference_sql_rag = ReferenceSqlRAG(agent_config, datasource_id=self.datasource_id)
-        self.semantic_model_rag = SemanticModelRAG(agent_config, datasource_id=self.datasource_id)
+        # ``sub_agent_name`` is the second positional parameter of all three;
+        # passing datasource_id by keyword alone silently skipped it, which is
+        # why these reads were unscoped no matter what the caller asked for.
+        self.metric_rag = MetricRAG(agent_config, sub_agent_name, datasource_id=self.datasource_id)
+        self.reference_sql_rag = ReferenceSqlRAG(agent_config, sub_agent_name, datasource_id=self.datasource_id)
+        self.semantic_model_rag = SemanticModelRAG(agent_config, sub_agent_name, datasource_id=self.datasource_id)
         self.subject_tree_store = get_subject_tree_store(
             project=agent_config.project_name,
             datasource_id=self.datasource_id,
@@ -298,10 +311,14 @@ class ExplorerService:
                 If successful, error_message is None
                 If failed, semantic_file_path is empty string
         """
-        from datus.storage.semantic_model.store import SemanticModelRAG
-
         try:
-            semantic_rag = SemanticModelRAG(self.agent_config, datasource_id=self.datasource_id)
+            # Reuse the instance built in __init__ rather than constructing a
+            # fresh one: a local build would drop ``sub_agent_name`` and hand
+            # back semantic models from outside the sub-agent's scope, which is
+            # exactly the leak this scoping exists to close.
+            semantic_rag = self.semantic_model_rag
+            if semantic_rag is None:
+                return "", "No datasource is selected; select a datasource first"
             current_db_config = self.agent_config.current_db_config()
 
             # Use provided params or fall back to current DB config

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -103,10 +103,41 @@ class ExplorerService:
         from datus.tools.func_tool.semantic_tools import SemanticTools
 
         try:
-            return SemanticTools(self.agent_config).adapter
+            return SemanticTools(self.agent_config, self.sub_agent_name).adapter
         except Exception as e:  # noqa: BLE001 - adapter is optional; fall back to KB
             logger.warning(f"Semantic adapter unavailable: {e}")
             return None
+
+    def _metric_is_in_scope(self, subject_path: List[str]) -> bool:
+        """Whether this service's sub-agent may see the metric at ``subject_path``.
+
+        Unscoped services see everything, so this is only a real check when a
+        sub-agent is set.
+
+        Needed because the semantic adapter reads the YAML source of truth,
+        which knows nothing about ``scoped_context``. Handing it a metric name
+        straight from the request would answer with a metric the caller is not
+        scoped to, even though the KB row for it is filtered out everywhere
+        else. Resolve the name through the scoped ``MetricRAG`` first, so the
+        adapter is only ever asked about metrics the caller may see.
+        """
+        if not self.sub_agent_name:
+            return True
+        if not subject_path or self.subject_tree_store is None or self.metric_rag is None:
+            return False
+        parent_path = subject_path[:-1]
+        metric_name = subject_path[-1]
+        if not parent_path:
+            return False
+        parent_node = self.subject_tree_store.get_node_by_path(parent_path)
+        if not parent_node:
+            return False
+        rows = self.metric_rag.storage.list_entries(
+            parent_node["node_id"],
+            name=metric_name,
+            extra_conditions=self.metric_rag._sub_agent_conditions(),
+        )
+        return bool(rows)
 
     def _semantic_mutation_rejection(self) -> Optional["Result[dict]"]:
         """Reject semantic writes for legacy query-only projects."""
@@ -390,7 +421,13 @@ class ExplorerService:
                     # Then, add metrics as children if they exist
                     if node_id:
                         try:
-                            metrics = self.metric_rag.storage.list_entries(node_id)
+                            # Scoped: `list_entries` applies no sub-agent filter
+                            # of its own, so reading it bare would list every
+                            # metric under the node regardless of the caller's
+                            # scope -- on the very route this scoping exists for.
+                            metrics = self.metric_rag.storage.list_entries(
+                                node_id, extra_conditions=self.metric_rag._sub_agent_conditions()
+                            )
                             for metric in metrics:
                                 metric_name = metric.get("name", "")
                                 if metric_name:
@@ -406,7 +443,9 @@ class ExplorerService:
 
                         # Add reference SQLs as children if they exist
                         try:
-                            ref_sqls = self.reference_sql_rag.reference_sql_storage.list_entries(node_id)
+                            ref_sqls = self.reference_sql_rag.reference_sql_storage.list_entries(
+                                node_id, extra_conditions=self.reference_sql_rag._sub_agent_conditions()
+                            )
                             for ref_sql in ref_sqls:
                                 sql_name = ref_sql.get("name", "")
                                 if sql_name:
@@ -419,6 +458,18 @@ class ExplorerService:
                                     child_nodes.append(sql_node)
                         except Exception as ex:
                             logger.debug(f"No reference SQL found for node {node_id}: {ex}")
+
+                    # A scoped caller should not learn the shape of the tree
+                    # outside its scope. Once the entry lists above are filtered,
+                    # a directory with no surviving children holds nothing this
+                    # caller may see, so listing its name would leak the
+                    # taxonomy of another sub-agent's knowledge base.
+                    #
+                    # Only when scoped: unscoped callers are the project's own
+                    # owners, and empty directories are real structure they
+                    # created and expect to see.
+                    if self.sub_agent_name and not child_nodes:
+                        continue
 
                     # Create directory SubjectNode
                     subject_node = SubjectNode(
@@ -770,6 +821,13 @@ class ExplorerService:
                     errorMessage="Subject path cannot be empty",
                 )
 
+            if not self._metric_is_in_scope(request.subject_path):
+                return Result[MetricDimensionsData](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage=f"Metric not found: {'/'.join(request.subject_path)}",
+                )
+
             metric_name = request.subject_path[-1]
 
             from datus.tools.func_tool.semantic_tools import (
@@ -778,8 +836,11 @@ class ExplorerService:
             )
 
             runtime_db_context = self._semantic_runtime_db_context(request)
+            # `sub_agent_name` is the second POSITIONAL parameter here too, so
+            # the keyword-only call skipped it and built an unscoped instance.
             tools = SemanticTools(
                 self.agent_config,
+                self.sub_agent_name,
                 runtime_db_context_provider=lambda: runtime_db_context,
             )
             adapter = tools.adapter
@@ -840,13 +901,23 @@ class ExplorerService:
                     errorMessage="Subject path cannot be empty",
                 )
 
+            if not self._metric_is_in_scope(request.subject_path):
+                return Result[MetricPreviewData](
+                    success=False,
+                    errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
+                    errorMessage=f"Metric not found: {'/'.join(request.subject_path)}",
+                )
+
             metric_name = request.subject_path[-1]
 
             from datus.tools.func_tool.semantic_tools import SemanticTools
 
             runtime_db_context = self._semantic_runtime_db_context(request)
+            # `sub_agent_name` is the second POSITIONAL parameter here too, so
+            # the keyword-only call skipped it and built an unscoped instance.
             tools = SemanticTools(
                 self.agent_config,
+                self.sub_agent_name,
                 runtime_db_context_provider=lambda: runtime_db_context,
             )
             if tools.adapter is None:
@@ -980,7 +1051,12 @@ class ExplorerService:
                 )
 
             # Get reference SQL entries
-            sql_entries = self.reference_sql_rag.reference_sql_storage.list_entries(node_id, name=sql_name)
+            # Scoped, for the same reason as get_subject_list: without the
+            # sub-agent conditions this returns the SQL body of any reference
+            # SQL the caller can name, in or out of scope.
+            sql_entries = self.reference_sql_rag.reference_sql_storage.list_entries(
+                node_id, name=sql_name, extra_conditions=self.reference_sql_rag._sub_agent_conditions()
+            )
 
             if not sql_entries or len(sql_entries) == 0:
                 return Result[ReferenceSQLInfo](

--- a/datus/api/services/tool_service.py
+++ b/datus/api/services/tool_service.py
@@ -26,7 +26,7 @@ class ToolService:
         "search_semantic_objects",
     }
 
-    def __init__(self, agent_config: AgentConfig, sub_agent_name: Optional[str] = None):
+    def __init__(self, agent_config: AgentConfig, sub_agent_name: Optional[str] = None) -> None:
         """Build the tool registry, optionally scoped to one sub-agent.
 
         ``sub_agent_name`` must be the ``agentic_nodes`` key, never a config

--- a/datus/api/services/tool_service.py
+++ b/datus/api/services/tool_service.py
@@ -1,7 +1,7 @@
 """Service for direct tool dispatch via tool name."""
 
 import inspect
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 from datus.api.models.base_models import Result
 from datus.api.models.config_models import ErrorCode
@@ -26,11 +26,20 @@ class ToolService:
         "search_semantic_objects",
     }
 
-    def __init__(self, agent_config: AgentConfig):
+    def __init__(self, agent_config: AgentConfig, sub_agent_name: Optional[str] = None):
+        """Build the tool registry, optionally scoped to one sub-agent.
+
+        ``sub_agent_name`` must be the ``agentic_nodes`` key, never a config
+        entry's ``id``: ``AgentConfig.sub_agent_config`` is a plain lookup on
+        that mapping, so an ``id`` misses, yields ``{}``, and the scope filter
+        silently degrades to "no filter" — a 200 with unrestricted results
+        rather than an error. Callers resolve id -> key before getting here.
+        """
         self._agent_config = agent_config
+        self._sub_agent_name = sub_agent_name
         self.context_warning = ""
         try:
-            self._context_search_tools = ContextSearchTools(agent_config)
+            self._context_search_tools = ContextSearchTools(agent_config, sub_agent_name=sub_agent_name)
         except Exception as exc:
             self._context_search_tools = None
             self.context_warning = format_context_degraded_warning(exc)

--- a/datus/storage/subject_tree/store.py
+++ b/datus/storage/subject_tree/store.py
@@ -1227,7 +1227,11 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         return True
 
     def list_entries(
-        self, node_id: int, name: Optional[str] = None, limit: Optional[int] = None
+        self,
+        node_id: int,
+        name: Optional[str] = None,
+        limit: Optional[int] = None,
+        extra_conditions: Optional[List] = None,
     ) -> List[Dict[str, Any]]:
         """Get storage entries by subject node ID and entry name.
 
@@ -1239,6 +1243,10 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
             node_id: Subject node ID (parent node in the subject tree)
             name: Entry name (e.g., metric name or SQL name)
             limit: Maximum number of results to return (default: None)
+            extra_conditions: Additional filter conditions, ANDed with the rest.
+                Callers reading on behalf of a scoped sub-agent must pass that
+                RAG's ``_sub_agent_conditions()``; this method applies no scope
+                of its own, so omitting them returns every entry under the node.
 
         Returns:
             List of entries matching the criteria, enriched with subject_path
@@ -1267,6 +1275,9 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
 
             if name:
                 conditions.append(eq(NAME_COLUMN_NAME, name))
+
+            if extra_conditions:
+                conditions.extend(extra_conditions)
 
             where_clause = None if len(conditions) == 0 else and_(*conditions)
             # Execute search

--- a/datus/storage/subject_tree/store.py
+++ b/datus/storage/subject_tree/store.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import pyarrow as pa
-from datus_storage_base.conditions import and_, in_, like
+from datus_storage_base.conditions import Node, and_, in_, like
 from datus_storage_base.rdb.base import ColumnDef, IndexDef, TableDefinition, UniqueViolationError, WhereOp
 
 from datus.storage import BaseEmbeddingStore
@@ -1231,7 +1231,7 @@ class BaseSubjectEmbeddingStore(BaseEmbeddingStore):
         node_id: int,
         name: Optional[str] = None,
         limit: Optional[int] = None,
-        extra_conditions: Optional[List] = None,
+        extra_conditions: Optional[List[Node]] = None,
     ) -> List[Dict[str, Any]]:
         """Get storage entries by subject node ID and entry name.
 

--- a/tests/unit_tests/api/routes/test_tool_routes.py
+++ b/tests/unit_tests/api/routes/test_tool_routes.py
@@ -2,18 +2,23 @@
 
 from unittest.mock import MagicMock
 
+from datus.api.auth.context import AppContext
 from datus.api.models.base_models import Result
 from datus.api.routes.tool_routes import execute_tool
 from datus.tools.func_tool.base import FuncToolResult
 
 
 def _mock_svc(execute_return=None):
-    """Build a mock DatusService with tool service."""
+    """Build a mock DatusService whose tool_for() returns a stub tool service."""
     svc = MagicMock()
     if execute_return is None:
         execute_return = Result(success=True, data=FuncToolResult(success=1, result=[]))
-    svc.tool.execute.return_value = execute_return
+    svc.tool_for.return_value.execute.return_value = execute_return
     return svc
+
+
+def _ctx(sub_agent_name=None):
+    return AppContext(sub_agent_name=sub_agent_name)
 
 
 class TestExecuteToolRoute:
@@ -22,9 +27,9 @@ class TestExecuteToolRoute:
     def test_search_metrics_with_body(self):
         """POST /tools/search_metrics with body calls tool service."""
         svc = _mock_svc()
-        result = execute_tool("search_metrics", svc, {"query_text": "revenue"})
+        result = execute_tool("search_metrics", svc, _ctx(), {"query_text": "revenue"})
         assert result.success is True
-        svc.tool.execute.assert_called_once_with("search_metrics", {"query_text": "revenue"})
+        svc.tool_for.return_value.execute.assert_called_once_with("search_metrics", {"query_text": "revenue"})
 
     def test_unknown_tool_returns_result(self):
         """POST /tools/unknown_tool returns error result from service."""
@@ -34,20 +39,38 @@ class TestExecuteToolRoute:
             errorMessage="Tool 'unknown_tool' not found.",
         )
         svc = _mock_svc(execute_return=error_result)
-        result = execute_tool("unknown_tool", svc, {})
+        result = execute_tool("unknown_tool", svc, _ctx(), {})
         assert result.success is False
-        svc.tool.execute.assert_called_once_with("unknown_tool", {})
+        svc.tool_for.return_value.execute.assert_called_once_with("unknown_tool", {})
 
     def test_list_subject_tree_empty_body(self):
         """POST /tools/list_subject_tree with empty body passes empty dict."""
         svc = _mock_svc()
-        result = execute_tool("list_subject_tree", svc, None)
+        result = execute_tool("list_subject_tree", svc, _ctx(), None)
         assert result.success is True
-        svc.tool.execute.assert_called_once_with("list_subject_tree", {})
+        svc.tool_for.return_value.execute.assert_called_once_with("list_subject_tree", {})
 
     def test_passes_params_through(self):
         """Body params are passed directly to tool service."""
         svc = _mock_svc()
         params = {"query_text": "test", "top_n": 3, "subject_path": ["Finance"]}
-        execute_tool("search_metrics", svc, params)
-        svc.tool.execute.assert_called_once_with("search_metrics", params)
+        execute_tool("search_metrics", svc, _ctx(), params)
+        svc.tool_for.return_value.execute.assert_called_once_with("search_metrics", params)
+
+    def test_unscoped_request_asks_for_the_unscoped_service(self):
+        """No sub-agent on the context means the same unscoped service as before."""
+        svc = _mock_svc()
+
+        execute_tool("search_metrics", svc, _ctx(), {})
+
+        svc.tool_for.assert_called_once_with(None)
+
+    def test_request_sub_agent_selects_the_scoped_service(self):
+        """The whole point: the request's sub-agent decides which scope the tool
+        reads through. Passing it to `tool_for` is what keeps a consumer of one
+        published sub-agent from searching another one's knowledge base."""
+        svc = _mock_svc()
+
+        execute_tool("search_metrics", svc, _ctx("revenue_analyst"), {})
+
+        svc.tool_for.assert_called_once_with("revenue_analyst")

--- a/tests/unit_tests/api/routes/test_tool_routes.py
+++ b/tests/unit_tests/api/routes/test_tool_routes.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock
 
-from datus.api.auth.context import AppContext
 from datus.api.models.base_models import Result
 from datus.api.routes.tool_routes import execute_tool
 from datus.tools.func_tool.base import FuncToolResult
@@ -17,17 +16,13 @@ def _mock_svc(execute_return=None):
     return svc
 
 
-def _ctx(sub_agent_name=None):
-    return AppContext(sub_agent_name=sub_agent_name)
-
-
 class TestExecuteToolRoute:
     """Tests for POST /api/v1/tools/{tool_name}."""
 
     def test_search_metrics_with_body(self):
         """POST /tools/search_metrics with body calls tool service."""
         svc = _mock_svc()
-        result = execute_tool("search_metrics", svc, _ctx(), {"query_text": "revenue"})
+        result = execute_tool("search_metrics", svc, None, {"query_text": "revenue"})
         assert result.success is True
         svc.tool_for.return_value.execute.assert_called_once_with("search_metrics", {"query_text": "revenue"})
 
@@ -39,14 +34,14 @@ class TestExecuteToolRoute:
             errorMessage="Tool 'unknown_tool' not found.",
         )
         svc = _mock_svc(execute_return=error_result)
-        result = execute_tool("unknown_tool", svc, _ctx(), {})
+        result = execute_tool("unknown_tool", svc, None, {})
         assert result.success is False
         svc.tool_for.return_value.execute.assert_called_once_with("unknown_tool", {})
 
     def test_list_subject_tree_empty_body(self):
         """POST /tools/list_subject_tree with empty body passes empty dict."""
         svc = _mock_svc()
-        result = execute_tool("list_subject_tree", svc, _ctx(), None)
+        result = execute_tool("list_subject_tree", svc, None, None)
         assert result.success is True
         svc.tool_for.return_value.execute.assert_called_once_with("list_subject_tree", {})
 
@@ -54,23 +49,26 @@ class TestExecuteToolRoute:
         """Body params are passed directly to tool service."""
         svc = _mock_svc()
         params = {"query_text": "test", "top_n": 3, "subject_path": ["Finance"]}
-        execute_tool("search_metrics", svc, _ctx(), params)
+        execute_tool("search_metrics", svc, None, params)
         svc.tool_for.return_value.execute.assert_called_once_with("search_metrics", params)
 
     def test_unscoped_request_asks_for_the_unscoped_service(self):
-        """No sub-agent on the context means the same unscoped service as before."""
+        """No sub-agent on the request means the same unscoped service as before."""
         svc = _mock_svc()
 
-        execute_tool("search_metrics", svc, _ctx(), {})
+        execute_tool("search_metrics", svc, None, {})
 
         svc.tool_for.assert_called_once_with(None)
 
     def test_request_sub_agent_selects_the_scoped_service(self):
         """The whole point: the request's sub-agent decides which scope the tool
         reads through. Passing it to `tool_for` is what keeps a consumer of one
-        published sub-agent from searching another one's knowledge base."""
+        published sub-agent from searching another one's knowledge base.
+
+        `SubAgentDep` has already validated the name by this point, so the route
+        never has to consider an unknown one."""
         svc = _mock_svc()
 
-        execute_tool("search_metrics", svc, _ctx("revenue_analyst"), {})
+        execute_tool("search_metrics", svc, "revenue_analyst", {})
 
         svc.tool_for.assert_called_once_with("revenue_analyst")

--- a/tests/unit_tests/api/services/test_datus_service.py
+++ b/tests/unit_tests/api/services/test_datus_service.py
@@ -10,6 +10,7 @@ from datus.api.services.datus_service import DatusService
 from datus.api.services.explorer_service import ExplorerService
 from datus.api.services.kb_service import KbService
 from datus.api.services.mcp_service import MCPService
+from datus.utils.exceptions import DatusException
 
 
 class TestDatusServiceInit:
@@ -318,13 +319,51 @@ class TestSubAgentScopedServices:
         assert analyst is not None and auditor is not None
         assert str(analyst) != str(auditor)
 
-    def test_an_unknown_name_fails_open_not_closed(self, real_agent_config):
-        """Documents the sharp edge the callers must respect: `sub_agent_config`
-        is a plain dict lookup, so a name that is not an `agentic_nodes` key —
-        an entry's `id`, say — yields {} and the filter degrades to None. That
-        is 200-with-everything, not an error, which is why the id -> key
-        resolution has to happen before this boundary.
+    def test_an_unknown_name_is_refused(self, real_agent_config):
+        """The failure mode this must never have: `sub_agent_config` is a plain
+        dict lookup, so a name that is not an `agentic_nodes` key — an entry's
+        `id`, a typo, a name left over from a rename — resolves to {} and the
+        filter degrades to None. Building that service would answer 200 with
+        everything, turning an identifier mistake into a scope bypass. Fail
+        closed.
         """
         svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
 
-        assert svc.explorer_for("no_such_sub_agent").semantic_model_rag._sub_agent_filter is None
+        with pytest.raises(DatusException) as excinfo:
+            svc.explorer_for("no_such_sub_agent")
+
+        assert "no_such_sub_agent" in str(excinfo.value)
+
+    def test_an_unknown_name_is_refused_for_tools_too(self, real_agent_config):
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        with pytest.raises(DatusException):
+            svc.tool_for("no_such_sub_agent")
+
+    def test_a_refused_name_is_not_cached(self, real_agent_config):
+        """A rejected name must leave no slot behind — otherwise a later lookup
+        could find a service that was never supposed to exist."""
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        with pytest.raises(DatusException):
+            svc.explorer_for("no_such_sub_agent")
+
+        assert "no_such_sub_agent" not in svc._explorers
+
+    def test_the_error_does_not_enumerate_other_sub_agents(self, real_agent_config):
+        """On a deployment that publishes one sub-agent to a consumer, naming
+        the others in an error is a disclosure in its own right."""
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        with pytest.raises(DatusException) as excinfo:
+            svc.explorer_for("no_such_sub_agent")
+
+        message = str(excinfo.value)
+        assert "analyst" not in message
+        assert "auditor" not in message
+
+    def test_has_sub_agent_distinguishes_configured_names(self, real_agent_config):
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        assert svc.has_sub_agent("analyst") is True
+        assert svc.has_sub_agent("no_such_sub_agent") is False

--- a/tests/unit_tests/api/services/test_datus_service.py
+++ b/tests/unit_tests/api/services/test_datus_service.py
@@ -44,14 +44,17 @@ class TestDatusServiceInit:
         assert svc.task_manager._default_interactive is True
 
     def test_lazy_slots_are_none_on_init(self, real_agent_config):
-        """All lazy service slots are None after construction."""
+        """All lazy service slots are unpopulated after construction."""
         svc = DatusService(agent_config=real_agent_config, project_id="p1")
         assert svc._chat is None
         assert svc._cli is None
         assert svc._datasource is None
-        assert svc._explorer is None
         assert svc._mcp is None
         assert svc._kb is None
+        # Explorer and tool are keyed by sub-agent name rather than held in a
+        # single slot, so "not yet built" is an empty mapping.
+        assert svc._explorers == {}
+        assert svc._tools == {}
 
 
 class TestDatusServiceLazyProperties:
@@ -213,3 +216,115 @@ class TestFingerprintPluginState:
 
         assert first == second
         assert not first.startswith("id:")
+
+
+class TestSubAgentScopedServices:
+    """Explorer/Tool services keyed by sub-agent.
+
+    These two services carry a knowledge-base scope filter, but
+    ``DatusServiceCache`` keys only on project. A single lazy slot would cache
+    the first request's sub-agent and serve its scope to every later one — not
+    "too wide" like the unscoped default, but *wrong*, and silently so.
+    """
+
+    @staticmethod
+    def _with_sub_agents(agent_config):
+        """Give the config two sub-agents with disjoint scopes.
+
+        ``tables`` rather than ``metrics``: a metrics/sqls scope resolves its
+        paths against the subject tree, so it yields no filter on an empty test
+        KB. ``tables`` goes through ``build_table_filter``, which needs no
+        stored data — the point here is the plumbing, not the resolver.
+        """
+        agent_config.agentic_nodes = {
+            **(agent_config.agentic_nodes or {}),
+            "analyst": {"scoped_context": {"tables": "finance.revenue"}},
+            "auditor": {"scoped_context": {"tables": "finance.audit"}},
+        }
+        return agent_config
+
+    def test_default_explorer_is_unscoped(self, real_agent_config):
+        """The property keeps today's behaviour: no name, no filter."""
+        svc = DatusService(agent_config=real_agent_config, project_id="p1")
+
+        assert svc.explorer.sub_agent_name is None
+        assert svc.explorer.metric_rag.sub_agent_name is None
+
+    def test_default_tool_is_unscoped(self, real_agent_config):
+        svc = DatusService(agent_config=real_agent_config, project_id="p1")
+
+        assert svc.tool._sub_agent_name is None
+
+    def test_property_and_explicit_none_are_the_same_instance(self, real_agent_config):
+        """`.explorer` is exactly `explorer_for(None)`, so the 14 existing call
+        sites keep hitting one cached instance instead of rebuilding per call."""
+        svc = DatusService(agent_config=real_agent_config, project_id="p1")
+
+        assert svc.explorer is svc.explorer_for(None)
+        assert svc.tool is svc.tool_for(None)
+
+    def test_same_sub_agent_is_cached(self, real_agent_config):
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        assert svc.explorer_for("analyst") is svc.explorer_for("analyst")
+        assert svc.tool_for("analyst") is svc.tool_for("analyst")
+
+    def test_different_sub_agents_get_different_instances(self, real_agent_config):
+        """The regression a single slot would cause: one sub-agent's scope
+        answering another sub-agent's request."""
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        assert svc.explorer_for("analyst") is not svc.explorer_for("auditor")
+        assert svc.tool_for("analyst") is not svc.tool_for("auditor")
+
+    def test_scoped_explorer_is_not_the_unscoped_one(self, real_agent_config):
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        assert svc.explorer_for("analyst") is not svc.explorer
+
+    def test_named_sub_agent_reaches_the_rag_layer(self, real_agent_config):
+        """All three RAGs take `sub_agent_name` as their SECOND POSITIONAL
+        argument. Passing only `datasource_id=` by keyword skipped it, which is
+        why these reads were unscoped no matter what the caller asked.
+
+        `MetricRAG` is the one that keeps the name as an attribute; the other
+        two only use it to build their filter, which the next test covers."""
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        explorer = svc.explorer_for("analyst")
+
+        assert explorer.sub_agent_name == "analyst"
+        assert explorer.metric_rag.sub_agent_name == "analyst"
+
+    def test_a_scope_filter_is_actually_built(self, real_agent_config):
+        """Was permanently None before: `_build_sub_agent_filter` returns None
+        for a falsy name, so an unnamed service could never filter anything."""
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        assert svc.explorer.semantic_model_rag._sub_agent_filter is None
+
+        scoped = str(svc.explorer_for("analyst").semantic_model_rag._sub_agent_filter)
+        # The filter names the sub-agent's own tables, not merely "something".
+        assert "finance" in scoped and "revenue" in scoped
+
+    def test_two_sub_agents_get_different_filters(self, real_agent_config):
+        """Distinct scopes must produce distinct filters — equal filters would
+        mean the second service was handed the first one's scope."""
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        analyst = svc.explorer_for("analyst").semantic_model_rag._sub_agent_filter
+        auditor = svc.explorer_for("auditor").semantic_model_rag._sub_agent_filter
+
+        assert analyst is not None and auditor is not None
+        assert str(analyst) != str(auditor)
+
+    def test_an_unknown_name_fails_open_not_closed(self, real_agent_config):
+        """Documents the sharp edge the callers must respect: `sub_agent_config`
+        is a plain dict lookup, so a name that is not an `agentic_nodes` key —
+        an entry's `id`, say — yields {} and the filter degrades to None. That
+        is 200-with-everything, not an error, which is why the id -> key
+        resolution has to happen before this boundary.
+        """
+        svc = DatusService(agent_config=self._with_sub_agents(real_agent_config), project_id="p1")
+
+        assert svc.explorer_for("no_such_sub_agent").semantic_model_rag._sub_agent_filter is None

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -1286,3 +1286,53 @@ class TestExplorerServiceOSIAuthoring:
         )
         assert result.success is True, result.errorMessage
         assert kb_deleted["called"] is True  # stale KB row cleaned up
+
+
+class TestExplorerServiceSubAgentScope:
+    """`sub_agent_name` is the second POSITIONAL parameter of all three RAGs.
+
+    Constructing them with `datasource_id=` by keyword alone silently skipped
+    it, so these reads were unscoped whatever the caller asked for.
+    """
+
+    def test_defaults_to_unscoped(self, real_agent_config):
+        svc = ExplorerService(agent_config=real_agent_config)
+
+        assert svc.sub_agent_name is None
+        assert svc.metric_rag.sub_agent_name is None
+        assert svc.semantic_model_rag._sub_agent_filter is None
+
+    def test_name_reaches_every_rag(self, real_agent_config):
+        real_agent_config.agentic_nodes = {
+            **(real_agent_config.agentic_nodes or {}),
+            "analyst": {"scoped_context": {"tables": "finance.revenue"}},
+        }
+
+        svc = ExplorerService(agent_config=real_agent_config, sub_agent_name="analyst")
+
+        assert svc.sub_agent_name == "analyst"
+        assert svc.metric_rag.sub_agent_name == "analyst"
+
+        scoped = str(svc.semantic_model_rag._sub_agent_filter)
+        assert "finance" in scoped and "revenue" in scoped
+
+    def test_semantic_file_path_reuses_the_scoped_rag(self, real_agent_config):
+        """`_get_semantic_file_path` used to build its own
+        `SemanticModelRAG` inline, which dropped the scope and would have handed
+        back semantic models from outside the sub-agent's tables. It must go
+        through the instance built in __init__.
+        """
+        real_agent_config.agentic_nodes = {
+            **(real_agent_config.agentic_nodes or {}),
+            "analyst": {"scoped_context": {"tables": "finance.revenue"}},
+        }
+        svc = ExplorerService(agent_config=real_agent_config, sub_agent_name="analyst")
+        svc.semantic_model_rag = MagicMock()
+        svc.semantic_model_rag.get_semantic_model.return_value = []
+
+        path, error = svc._get_semantic_file_path(None, None, None, "orders")
+
+        assert path == ""
+        assert error == "No semantic model found for provided parameters"
+        # The scoped instance was consulted — not a fresh unscoped one.
+        svc.semantic_model_rag.get_semantic_model.assert_called_once()

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -8,6 +8,7 @@ from datus.api.models.explorer_models import (
     CreateDirectoryInput,
     DeleteSubjectInput,
     EditSemanticModelInput,
+    MetricPreviewInput,
     ReferenceSQLInput,
     RenameSubjectInput,
     SubjectListData,
@@ -1336,3 +1337,164 @@ class TestExplorerServiceSubAgentScope:
         assert error == "No semantic model found for provided parameters"
         # The scoped instance was consulted — not a fresh unscoped one.
         svc.semantic_model_rag.get_semantic_model.assert_called_once()
+
+
+class TestExplorerServiceScopedReads:
+    """The reads must carry the scope down to storage, not just hold a name.
+
+    `SubjectTreeStore.list_entries` applies no sub-agent filter of its own, so a
+    bare call returns every entry under the node. Two of the routes this service
+    scopes — `get_subject_list` and `get_reference_sql` — used to call it that
+    way, which meant a scoped caller still received out-of-scope metric names,
+    reference-SQL names, and reference-SQL bodies.
+    """
+
+    @staticmethod
+    def _scoped_service(real_agent_config):
+        real_agent_config.agentic_nodes = {
+            **(real_agent_config.agentic_nodes or {}),
+            "analyst": {"scoped_context": {"tables": "finance.revenue", "metrics": "Finance.Revenue"}},
+        }
+        return ExplorerService(agent_config=real_agent_config, sub_agent_name="analyst")
+
+    @pytest.mark.asyncio
+    async def test_subject_list_passes_scope_to_metric_storage(self, real_agent_config):
+        svc = self._scoped_service(real_agent_config)
+        svc.subject_tree_store = MagicMock()
+        svc.subject_tree_store.get_tree_structure.return_value = {
+            "Finance": {"node_id": 1, "children": {}},
+        }
+        svc.metric_rag.storage = MagicMock()
+        svc.metric_rag.storage.list_entries.return_value = [{"name": "revenue"}]
+        svc.reference_sql_rag.reference_sql_storage = MagicMock()
+        svc.reference_sql_rag.reference_sql_storage.list_entries.return_value = []
+
+        await svc.get_subject_list()
+
+        conditions = svc.metric_rag.storage.list_entries.call_args.kwargs["extra_conditions"]
+        assert conditions == svc.metric_rag._sub_agent_conditions()
+
+    @pytest.mark.asyncio
+    async def test_subject_list_passes_scope_to_reference_sql_storage(self, real_agent_config):
+        svc = self._scoped_service(real_agent_config)
+        svc.subject_tree_store = MagicMock()
+        svc.subject_tree_store.get_tree_structure.return_value = {
+            "Finance": {"node_id": 1, "children": {}},
+        }
+        svc.metric_rag.storage = MagicMock()
+        svc.metric_rag.storage.list_entries.return_value = []
+        svc.reference_sql_rag.reference_sql_storage = MagicMock()
+        svc.reference_sql_rag.reference_sql_storage.list_entries.return_value = [{"name": "daily"}]
+
+        await svc.get_subject_list()
+
+        conditions = svc.reference_sql_rag.reference_sql_storage.list_entries.call_args.kwargs["extra_conditions"]
+        assert conditions == svc.reference_sql_rag._sub_agent_conditions()
+
+    @pytest.mark.asyncio
+    async def test_subject_list_drops_directories_emptied_by_the_scope(self, real_agent_config):
+        """A directory whose entries were all filtered out holds nothing this
+        caller may see, so naming it would leak another sub-agent's taxonomy."""
+        svc = self._scoped_service(real_agent_config)
+        svc.subject_tree_store = MagicMock()
+        svc.subject_tree_store.get_tree_structure.return_value = {
+            "OtherTeam": {"node_id": 2, "children": {}},
+        }
+        svc.metric_rag.storage = MagicMock()
+        svc.metric_rag.storage.list_entries.return_value = []
+        svc.reference_sql_rag.reference_sql_storage = MagicMock()
+        svc.reference_sql_rag.reference_sql_storage.list_entries.return_value = []
+
+        result = await svc.get_subject_list()
+
+        assert result.data.subjects == []
+
+    @pytest.mark.asyncio
+    async def test_unscoped_subject_list_keeps_empty_directories(self, real_agent_config):
+        """An unscoped caller owns the project: an empty directory is real
+        structure they created, not something to hide."""
+        svc = ExplorerService(agent_config=real_agent_config)
+        svc.subject_tree_store = MagicMock()
+        svc.subject_tree_store.get_tree_structure.return_value = {
+            "Empty": {"node_id": 3, "children": {}},
+        }
+        svc.metric_rag.storage = MagicMock()
+        svc.metric_rag.storage.list_entries.return_value = []
+        svc.reference_sql_rag.reference_sql_storage = MagicMock()
+        svc.reference_sql_rag.reference_sql_storage.list_entries.return_value = []
+
+        result = await svc.get_subject_list()
+
+        assert [node.name for node in result.data.subjects] == ["Empty"]
+
+    @pytest.mark.asyncio
+    async def test_get_reference_sql_passes_scope_to_storage(self, real_agent_config):
+        svc = self._scoped_service(real_agent_config)
+        svc.subject_tree_store = MagicMock()
+        svc.subject_tree_store.get_node_by_path.return_value = {"node_id": 1}
+        svc.reference_sql_rag.reference_sql_storage = MagicMock()
+        svc.reference_sql_rag.reference_sql_storage.list_entries.return_value = []
+
+        await svc.get_reference_sql(["Finance", "daily"])
+
+        conditions = svc.reference_sql_rag.reference_sql_storage.list_entries.call_args.kwargs["extra_conditions"]
+        assert conditions == svc.reference_sql_rag._sub_agent_conditions()
+
+
+class TestExplorerServiceSemanticScope:
+    """The semantic adapter reads the YAML source of truth, which knows nothing
+    about `scoped_context`. The metric name has to be resolved through the
+    scoped `MetricRAG` before the adapter is asked about it."""
+
+    @staticmethod
+    def _scoped_service(real_agent_config):
+        real_agent_config.agentic_nodes = {
+            **(real_agent_config.agentic_nodes or {}),
+            "analyst": {"scoped_context": {"tables": "finance.revenue"}},
+        }
+        return ExplorerService(agent_config=real_agent_config, sub_agent_name="analyst")
+
+    def test_unscoped_service_admits_every_metric(self, real_agent_config):
+        svc = ExplorerService(agent_config=real_agent_config)
+
+        assert svc._metric_is_in_scope(["Finance", "revenue"]) is True
+
+    def test_out_of_scope_metric_is_rejected(self, real_agent_config):
+        svc = self._scoped_service(real_agent_config)
+        svc.subject_tree_store = MagicMock()
+        svc.subject_tree_store.get_node_by_path.return_value = {"node_id": 1}
+        svc.metric_rag.storage = MagicMock()
+        svc.metric_rag.storage.list_entries.return_value = []  # filtered out by the scope
+
+        assert svc._metric_is_in_scope(["OtherTeam", "secret_metric"]) is False
+
+    def test_in_scope_metric_is_admitted(self, real_agent_config):
+        svc = self._scoped_service(real_agent_config)
+        svc.subject_tree_store = MagicMock()
+        svc.subject_tree_store.get_node_by_path.return_value = {"node_id": 1}
+        svc.metric_rag.storage = MagicMock()
+        svc.metric_rag.storage.list_entries.return_value = [{"name": "revenue"}]
+
+        assert svc._metric_is_in_scope(["Finance", "revenue"]) is True
+
+    @pytest.mark.asyncio
+    async def test_preview_metric_refuses_an_out_of_scope_metric(self, real_agent_config):
+        """And refuses before reaching the adapter — the adapter would happily
+        compile a metric this caller may not see."""
+        svc = self._scoped_service(real_agent_config)
+        svc._metric_is_in_scope = MagicMock(return_value=False)
+
+        result = await svc.preview_metric(MetricPreviewInput(subject_path=["OtherTeam", "secret_metric"]))
+
+        assert result.success is False
+        assert "secret_metric" in result.errorMessage
+
+    @pytest.mark.asyncio
+    async def test_get_metric_dimensions_refuses_an_out_of_scope_metric(self, real_agent_config):
+        svc = self._scoped_service(real_agent_config)
+        svc._metric_is_in_scope = MagicMock(return_value=False)
+
+        result = await svc.get_metric_dimensions(SubjectPathInput(subject_path=["OtherTeam", "secret_metric"]))
+
+        assert result.success is False
+        assert "secret_metric" in result.errorMessage

--- a/tests/unit_tests/api/services/test_tool_service.py
+++ b/tests/unit_tests/api/services/test_tool_service.py
@@ -142,3 +142,29 @@ class TestToolServiceExecute:
         assert result.success is True
         assert result.data.success == 1
         assert result.data.result == {"key": "value"}
+
+
+class TestToolServiceSubAgentScope:
+    """`ContextSearchTools` has always accepted `sub_agent_name`; `ToolService`
+    just never passed it, so every REST tool call read the whole knowledge base
+    regardless of which sub-agent the caller was scoped to."""
+
+    def test_defaults_to_unscoped(self, mock_agent_config):
+        service = ToolService(mock_agent_config)
+
+        assert service._sub_agent_name is None
+
+    def test_forwards_the_name_to_context_search_tools(self, mock_agent_config):
+        with patch("datus.api.services.tool_service.ContextSearchTools") as mock_tools:
+            service = ToolService(mock_agent_config, sub_agent_name="analyst")
+
+        assert service._sub_agent_name == "analyst"
+        assert mock_tools.call_args.kwargs["sub_agent_name"] == "analyst"
+
+    def test_unscoped_construction_passes_none_explicitly(self, mock_agent_config):
+        """Passing None is the same call shape, so there is no second code path
+        for the default case to drift down."""
+        with patch("datus.api.services.tool_service.ContextSearchTools") as mock_tools:
+            ToolService(mock_agent_config)
+
+        assert mock_tools.call_args.kwargs["sub_agent_name"] is None

--- a/tests/unit_tests/api/test_deps.py
+++ b/tests/unit_tests/api/test_deps.py
@@ -245,3 +245,59 @@ class TestGetDatusService:
             assert "Failed to load agent config" in str(e)
         finally:
             await cache.shutdown()
+
+
+class TestGetScopedSubAgent:
+    """The gate that keeps an unrecognised sub-agent name from becoming an
+    unscoped read.
+
+    A service built from a name that matches no `agentic_nodes` key has no
+    scope filter at all, so the request would succeed and return everything.
+    Rejecting here — before any route body runs — means nothing unscoped is
+    built or cached from a caller's identifier mistake.
+    """
+
+    @staticmethod
+    def _request(sub_agent_name):
+        request = MagicMock()
+        request.state.app_context = AppContext(sub_agent_name=sub_agent_name)
+        return request
+
+    @staticmethod
+    def _svc(known=("analyst",)):
+        svc = MagicMock()
+        svc.has_sub_agent.side_effect = lambda name: name in known
+        return svc
+
+    def test_unscoped_request_passes_through(self):
+        """No name is not an unknown name — it is the single-tenant default."""
+        svc = self._svc()
+
+        assert deps.get_scoped_sub_agent(self._request(None), svc) is None
+        svc.has_sub_agent.assert_not_called()
+
+    def test_known_name_is_returned(self):
+        assert deps.get_scoped_sub_agent(self._request("analyst"), self._svc()) == "analyst"
+
+    def test_unknown_name_is_rejected_with_400(self):
+        with pytest.raises(HTTPException) as excinfo:
+            deps.get_scoped_sub_agent(self._request("no_such_sub_agent"), self._svc())
+
+        assert excinfo.value.status_code == 400
+
+    def test_rejection_names_the_offending_value(self):
+        """The caller needs to know which identifier was wrong."""
+        with pytest.raises(HTTPException) as excinfo:
+            deps.get_scoped_sub_agent(self._request("typo_analyst"), self._svc())
+
+        assert "typo_analyst" in str(excinfo.value.detail)
+
+    def test_rejection_does_not_enumerate_configured_sub_agents(self):
+        """Listing the other sub-agents to a consumer scoped to one of them is a
+        disclosure in its own right."""
+        with pytest.raises(HTTPException) as excinfo:
+            deps.get_scoped_sub_agent(self._request("nope"), self._svc(known=("analyst", "auditor")))
+
+        detail = str(excinfo.value.detail)
+        assert "analyst" not in detail
+        assert "auditor" not in detail


### PR DESCRIPTION
## Why

`_build_sub_agent_filter` opens with:

```python
if not sub_agent_name:
    return None          # no name, no filter
```

In Studio that is correct. The caller owns the project, and a sub-agent's
`scoped_context` is the material an agent draws on — not a boundary around a
person.

Where an agent's knowledge base is published to consumers it *is* a boundary,
and two REST surfaces could not honour it, because the services behind them did
not accept a sub-agent name at all:

```python
# tool_service.py — ContextSearchTools has always taken sub_agent_name; nobody passed it
self._context_search_tools = ContextSearchTools(agent_config)

# explorer_service.py — sub_agent_name is the SECOND POSITIONAL parameter of all three RAGs,
# so passing datasource_id by keyword silently skipped it
self.metric_rag = MetricRAG(agent_config, datasource_id=self.datasource_id)
```

So `POST /tools/search_metrics` and the explorer reads returned everything in
the knowledge base, regardless of which sub-agent the request belonged to.
`/chat/stream` and the MCP server were already scoped — `create_dynamic`
takes the name — so these two were the gap.

## Solution

**Per-name service slots, not just a new constructor argument.** This is the
part worth reviewing. `DatusServiceCache` keys on project alone, and both
services are lazily cached in a single slot. Adding a parameter without also
splitting the cache would have made things *worse* than the unscoped status
quo: the first request's sub-agent gets cached, and every later request —
whatever sub-agent it names — reads through that scope. Wrong results, no
error.

```python
def explorer_for(self, sub_agent_name: Optional[str] = None):
    if sub_agent_name not in self._explorers:
        self._explorers[sub_agent_name] = ExplorerService(...)
    return self._explorers[sub_agent_name]

@property
def explorer(self):
    return self.explorer_for(None)
```

Keeping the properties as `*_for(None)` means the 14 existing call sites are
untouched and **Studio sees no behaviour change** — the default is exactly
today's unscoped read.

**`AppContext` carries the name** because it is built per request while the
service is cached across many. The auth provider fills it from whatever
transport convention the host uses, so Agent needs no knowledge of any
particular header.

Six scope-sensitive read routes take the name from there. The eight authoring
routes (create/edit/delete) are deliberately left alone — scoping writes is a
separate question with different failure modes.

Two sharp edges found while implementing:

- **`_get_semantic_file_path` built its own `SemanticModelRAG` inline.** Left
  alone it would have kept returning semantic models from outside the
  sub-agent's tables while everything around it was scoped. It now reuses the
  instance from `__init__`.
- **`sub_agent_config` is a plain `agentic_nodes.get(name)`.** A name that is
  not a key — an entry's `id`, say — yields `{}`, and the filter degrades to
  `None`: HTTP 200 with unrestricted results, no error. `/chat/stream` avoids
  this because `_create_node` resolves id -> key first; this path has no such
  step, so **callers must pass the canonical key**. Documented at each boundary
  and pinned by a test that asserts the fail-open behaviour deliberately rather
  than hiding it.

## Test Cases

Unit tests, mirroring the changed modules:

- `test_datus_service.py::TestSubAgentScopedServices` — the cache split, which
  is where the real risk is: same name returns one cached instance, different
  names return different ones, `.explorer` is exactly `explorer_for(None)`, and
  two sub-agents with disjoint scopes produce *different* filters (equal ones
  would mean the second service got the first one's scope). Also asserts a
  filter is actually built where it was permanently `None` before, and that an
  unknown name fails open.
- `test_explorer_service.py::TestExplorerServiceSubAgentScope` — the name
  reaches the RAG layer, and `_get_semantic_file_path` goes through the scoped
  instance.
- `test_tool_service.py::TestToolServiceSubAgentScope` — the name is forwarded
  to `ContextSearchTools`, including that the unscoped case passes `None`
  through the same call shape rather than down a second code path.
- `test_tool_routes.py` — the route passes the request's sub-agent to
  `tool_for`, and passes `None` when the request has none.

Filter assertions check the rendered filter names the sub-agent's own tables,
not merely that it is non-`None`.

No integration or nightly tests: the change is service wiring plus a dataclass
field, fully reachable from the unit tier.

**Pre-existing failures, unrelated to this PR:** 15 tests fail on `main`
itself (10 in `test_explorer_service.py::TestExplorerServiceOSIAuthoring`, 5 in
`test_semantic_modeling_agentic_node.py`). Verified by stashing this branch and
re-running both files at `upstream/main`, where they fail identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Explorer and tool operations now respect the active sub-agent context.
  * Knowledge-base searches are scoped to the selected sub-agent when applicable.
  * Services are cached independently for each sub-agent, improving context isolation.
* **Bug Fixes**
  * Semantic model lookups now consistently reuse the correctly scoped context.
  * Missing data-source scenarios return an appropriate error instead of failing unexpectedly.
* **Tests**
  * Added coverage for scoped and unscoped service behavior, isolation, caching, and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explorer and tool operations now respect the selected sub-agent context.
  * Knowledge-base searches, metrics, semantic models, and tool results are scoped appropriately.
  * Service results remain isolated and efficiently reused per sub-agent.
* **Bug Fixes**
  * Invalid sub-agent selections are rejected before requests run.
  * Out-of-scope metrics and data sources are no longer exposed.
  * Missing data sources now return clearer errors.
* **Tests**
  * Added comprehensive coverage for scoping, isolation, validation, caching, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->