### PR TITLE
[Enhancement] Exempt fd duplication and /dev/null targets from the bash redirection ceiling

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -128,7 +128,12 @@ agent:
   #   # order: deny (also matches wrapped commands like ``xargs rm``) →
   #   # safety ceiling (bash -c / sudo / $() / redirection / background & /
   #   # loops & subshells never auto-allow statically) → ask → allow →
-  #   # default (ask). A command chained with ``|``, ``&&``, ``||`` or ``;`` is
+  #   # default (ask). Two redirections are exempt from that ceiling because
+  #   # they name no path and so cannot do anything the argv could not:
+  #   # file-descriptor duplication (``2>&1``, ``>&2``, ``<&0``) and a
+  #   # ``/dev/null`` target (``2>/dev/null``, ``&>/dev/null``). Any other
+  #   # redirection still requires confirmation. A command chained with
+  #   # ``|``, ``&&``, ``||`` or ``;`` is
   #   # judged per sub-command: it auto-runs only if every sub-command is
   #   # allowed, and any denied sub-command blocks the whole chain. A
   #   # safety-ceiling ASK is still eligible for ``auto_review`` above, which

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -624,7 +624,10 @@ def _split_top_level(command: str, *, chain: bool) -> Optional[List[str]]:
                 continue
             elif c == "&":
                 if nxt != "&":
-                    if nxt == ">" or _last_nonspace(buf) in "<>":
+                    # Tuple membership, not ``in "<>"``: ``_last_nonspace``
+                    # returns "" for a leading `&` and "" is a substring of
+                    # every string, which would read `& ls` as a redirection.
+                    if nxt == ">" or _last_nonspace(buf) in ("<", ">"):
                         # The `&` belongs to a redirection, not to job control:
                         # `2>&1`, `>&2`, `<&0` (preceded by the operator) or
                         # `&>file` (followed by it). Keep it in the segment and

--- a/datus/tools/permission/bash_rules.py
+++ b/datus/tools/permission/bash_rules.py
@@ -32,6 +32,9 @@ name EVERY sub-command that needs approval instead of one representative.
 Shell constructs that segmentation cannot model still hit the safety ceiling
 as a whole: ``$()``, backticks, ``${}``, redirection, background ``&``,
 ``|&``, newlines, subshells/braces and compound keywords (``for``/``if``/…).
+Two redirections are exempt because they name no path and so cannot do
+anything the argv could not: fd duplication (``2>&1``, ``>&2``, ``<&0``) and a
+``/dev/null`` target (see ``_BENIGN_REDIRECTION_RE``).
 
 The safety ceiling is a *static* verdict, not a final one: under a profile with
 ``permissions.auto_review`` enabled the shared reviewer in ``auto_reviewer.py``
@@ -91,6 +94,55 @@ logger = get_logger(__name__)
 # function with only ``split_pipeline`` in front of it.
 _SHELL_METACHARS_RE = re.compile(r"[;&<>`\n]|\$\(|\$\{|\|\||&&")
 
+# Redirections that cannot express anything the argv already can't, and so are
+# exempt from the redirection safety ceiling **in the permission layer only**:
+#
+#   * file-descriptor duplication / closing — ``2>&1``, ``>&2``, ``<&0``,
+#     ``2>&-``. These rewire the command's own streams. No path is named, so
+#     nothing can be written anywhere, and no new command can be introduced.
+#   * a ``/dev/null`` target — ``>/dev/null``, ``2>>/dev/null``,
+#     ``&>/dev/null``. The write goes to the null device by definition.
+#
+# ``2>&1`` and ``2>/dev/null`` are among the most common shell idioms there
+# are; forcing a confirmation prompt for them trains users to click through
+# prompts, which costs more safety than the ceiling buys. Every other
+# redirection stays on the ceiling: ``> file`` names an arbitrary path, so an
+# allow rule matched on argv (``ls:*`` says nothing about where output lands)
+# cannot vouch for it.
+#
+# Scope is deliberate. This is applied by ``_evaluate_single_command`` and
+# nowhere else: ``contains_shell_metachars`` itself is unchanged because
+# ``BashTool._segment_allowed`` shares it as the execution-layer whitelist for
+# skills — a separate trust boundary that must keep rejecting every
+# redirection outright.
+_BENIGN_REDIRECTION_RE = re.compile(
+    # 2>&1, >&2, <&0, 2>&-
+    r"\d*[<>]&(?:\d+|-)"
+    # >/dev/null, 2>/dev/null, >>/dev/null, &>/dev/null, &>>/dev/null.
+    # The target must end the token: without the lookahead, ``> /dev/nullx``
+    # would match its ``/dev/null`` prefix and leave a stray ``x`` behind,
+    # exempting a write to a real file.
+    r"|(?:\d*>{1,2}|&>{1,2})\s*/dev/null(?=\s|$)"
+)
+
+
+def _without_benign_redirections(text: str) -> str:
+    """Blank out the redirections listed in ``_BENIGN_REDIRECTION_RE``.
+
+    Substitutes a space rather than an empty string so stripping cannot fuse
+    two tokens into one (``a 2>&1b`` must not become ``a b``).
+    """
+    return _BENIGN_REDIRECTION_RE.sub(" ", text)
+
+
+def _last_nonspace(chars: List[str]) -> str:
+    """Last non-whitespace character accumulated so far, or ``""``."""
+    for ch in reversed(chars):
+        if not ch.isspace():
+            return ch
+    return ""
+
+
 # Shell keywords and grouping constructs. Segmentation splits on operators but
 # does not model compound commands, so ``for f in *; do rm $f; done`` arrives
 # here as three fragments (``for f in *``, ``do rm $f``, ``done``) that must
@@ -128,6 +180,11 @@ def contains_shell_metachars(text: str) -> bool:
     metacharacter is treated just as conservatively as an unquoted one.
     Shared by ``evaluate_bash_command`` (→ forced ASK) and
     ``BashTool._segment_allowed`` (→ reject).
+
+    Deliberately knows nothing about ``_BENIGN_REDIRECTION_RE``: the
+    permission layer strips those forms from its own input before calling this,
+    while the execution-layer whitelist keeps rejecting every redirection. Add
+    the exemption at the call site, never here.
     """
     return bool(_SHELL_METACHARS_RE.search(text))
 
@@ -567,6 +624,18 @@ def _split_top_level(command: str, *, chain: bool) -> Optional[List[str]]:
                 continue
             elif c == "&":
                 if nxt != "&":
+                    if nxt == ">" or _last_nonspace(buf) in "<>":
+                        # The `&` belongs to a redirection, not to job control:
+                        # `2>&1`, `>&2`, `<&0` (preceded by the operator) or
+                        # `&>file` (followed by it). Keep it in the segment and
+                        # let the redirection ceiling judge the whole form —
+                        # bailing here would send `ls 2>&1 | head` to the
+                        # ceiling as one opaque string and hide `head` from the
+                        # per-sub-command prompt. A genuine trailing `&`
+                        # (`sleep 5 &`) still returns None below.
+                        buf.append(c)
+                        i += 1
+                        continue
                     # A lone `&` backgrounds the command — not a sequencer.
                     return None
                 step = 2
@@ -614,9 +683,14 @@ def split_command_chain(command: str) -> Optional[List[str]]:
     background ``&``, an empty segment (``ls &&``, ``;;``, ``| ls``) or
     unbalanced quotes.
 
+    An ``&`` that belongs to a redirection (``2>&1``, ``>&2``, ``<&0``,
+    ``&>file``) is not a background operator and does not stop segmentation;
+    ``sleep 5 &`` still does.
+
     Note that ``None`` is not the only path to the safety ceiling: a segment
-    that still carries ``$()``, backticks, redirection or a newline is caught
-    per-segment by :func:`contains_shell_metachars`.
+    that still carries ``$()``, backticks, a newline or a redirection other
+    than the benign forms in ``_BENIGN_REDIRECTION_RE`` is caught per-segment
+    by :func:`contains_shell_metachars`.
     """
     return _split_top_level(command, chain=True)
 
@@ -707,7 +781,12 @@ def _evaluate_single_command(command: str, rules: BashCommandRules) -> BashRuleD
             bucket=session_bucket_for(argv, None),
             safety_forced=True,
         )
-    if contains_shell_metachars(command):
+    # ``2>&1`` / ``2>/dev/null`` and friends are dropped before the check —
+    # see ``_BENIGN_REDIRECTION_RE`` for which forms and why. Ordering matters:
+    # the wrapper and inline-code ceilings above already fired, so a command
+    # that reaches here cannot smuggle a second command past this exemption
+    # (``sh -c "... 2>&1"`` is stopped by the wrapper rule).
+    if contains_shell_metachars(_without_benign_redirections(command)):
         return BashRuleDecision(
             level=PermissionLevel.ASK,
             source=BashDecisionSource.SAFETY,

--- a/tests/unit_tests/tools/permission/test_bash_rules.py
+++ b/tests/unit_tests/tools/permission/test_bash_rules.py
@@ -18,8 +18,11 @@ from datus.tools.permission.bash_rules import (
     BashCommandRules,
     BashDecisionSource,
     command_matches_pattern,
+    contains_shell_metachars,
     evaluate_bash_command,
     session_bucket_for,
+    split_command_chain,
+    split_pipeline,
 )
 from datus.tools.permission.permission_config import PermissionLevel
 
@@ -243,6 +246,150 @@ class TestSafetyCeiling:
     def test_plain_command_is_not_safety_forced(self):
         decision = evaluate_bash_command("cargo build", BashCommandRules())
         assert decision.safety_forced is False
+
+
+class TestBenignRedirectionExemption:
+    """``2>&1`` and a ``/dev/null`` target do not force a confirmation.
+
+    Neither form can express anything the argv already can't: fd duplication
+    rewires the command's own streams and names no path, and a ``/dev/null``
+    target discards by definition. They are also two of the most common shell
+    idioms there are, so prompting for them trains users to click through
+    prompts. Every other redirection still hits the ceiling because it names a
+    path an argv-matched allow rule cannot vouch for.
+    """
+
+    RULES = BashCommandRules(allow=["ls:*", "cat:*", "head:*", "grep:*", "echo:*"])
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls -la 2>&1",
+            "ls -la 1>&2",
+            "ls -la >&2",
+            "cat f <&0",
+            "ls -la 2>&-",
+            "ls -la 2>/dev/null",
+            "ls -la > /dev/null",
+            "ls -la >> /dev/null",
+            "ls -la 2>> /dev/null",
+            "ls -la &>/dev/null",
+            "ls -la &>> /dev/null",
+        ],
+    )
+    def test_benign_redirection_auto_allows(self, command):
+        decision = evaluate_bash_command(command, self.RULES)
+        assert decision.level == PermissionLevel.ALLOW
+        assert decision.safety_forced is False
+
+    def test_exempt_redirection_inside_a_chain_is_judged_per_sub_command(self):
+        """The motivating case. Bailing out of segmentation on the ``&`` of
+        ``2>&1`` sent the whole string to the ceiling and hid ``head`` from the
+        per-sub-command prompt."""
+        assert split_command_chain("ls -la /tmp 2>&1 | head -20") == ["ls -la /tmp 2>&1", "head -20"]
+
+        decision = evaluate_bash_command("ls -la /tmp 2>&1 | head -20", self.RULES)
+        assert decision.level == PermissionLevel.ALLOW
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "ls > out.txt",  # names an arbitrary path
+            "ls >> out.txt",
+            "ls 2> err.txt",
+            "ls &> out.txt",  # both streams, still an arbitrary path
+            "ls < in.txt",  # input redirection is not exempt
+            "ls > /dev/nullx",  # near-miss on the device name
+            "ls > /dev/stdout",  # only /dev/null is exempt
+        ],
+    )
+    def test_other_redirections_still_force_ask(self, command):
+        decision = evaluate_bash_command(command, self.RULES)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.SAFETY
+        assert decision.safety_forced is True
+
+    @pytest.mark.parametrize("command", ["ls &", "sleep 5 &", "ls 2>&1 &", "ls & rm x"])
+    def test_background_ampersand_is_not_mistaken_for_a_redirection(self, command):
+        """The exemption keys on the ``&`` sitting next to ``<``/``>``; a
+        trailing job-control ``&`` must still stop segmentation."""
+        assert split_command_chain(command) is None
+
+        decision = evaluate_bash_command(command, self.RULES)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.safety_forced is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo $(id) 2>/dev/null",
+            "echo `whoami` 2>&1",
+            "ls\nrm x 2>&1",
+        ],
+    )
+    def test_exemption_does_not_rescue_other_metacharacters(self, command):
+        """Stripping the redirection must not strip anything else with it."""
+        decision = evaluate_bash_command(command, self.RULES)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.SAFETY
+        assert decision.safety_forced is True
+
+    def test_exempt_redirection_does_not_change_a_chain_verdict(self):
+        """A non-allow-listed sub-command still blocks the chain, and the
+        redirection changes nothing about it: the redirected and bare forms of
+        the same chain must be judged identically."""
+        redirected = evaluate_bash_command("ls; rm x 2>/dev/null", self.RULES)
+        bare = evaluate_bash_command("ls; rm x", self.RULES)
+
+        assert redirected.level == PermissionLevel.ASK
+        assert redirected.level == bare.level
+        assert redirected.source == bare.source
+        assert redirected.safety_forced == bare.safety_forced
+
+    def test_wrapper_ceiling_still_beats_the_exemption(self):
+        """Ordering guard: the wrapper rule fires before the redirection check,
+        so a shell wrapper cannot smuggle a command past the exemption."""
+        rules = BashCommandRules(allow=["sh:*", "ls:*"])
+        decision = evaluate_bash_command('sh -c "rm -rf / 2>&1"', rules)
+        assert decision.level == PermissionLevel.ASK
+        assert decision.source == BashDecisionSource.SAFETY
+        assert decision.safety_forced is True
+
+    def test_deny_rule_still_beats_the_exemption(self):
+        rules = BashCommandRules(allow=["ls:*"], deny=["ls:/secret*"])
+        decision = evaluate_bash_command("ls /secret 2>/dev/null", rules)
+        assert decision.level == PermissionLevel.DENY
+
+    def test_dangerous_command_is_unaffected_by_its_redirection(self):
+        """``rm -rf /`` was never safety-forced — no metacharacters. Adding
+        ``2>/dev/null`` used to force it, which made the redirection look like
+        the dangerous part. Both forms now agree; neither auto-allows."""
+        rules = BashCommandRules(allow=["ls:*"])
+        bare = evaluate_bash_command("rm -rf /", rules)
+        redirected = evaluate_bash_command("rm -rf / 2>/dev/null", rules)
+
+        assert bare.level == PermissionLevel.ASK
+        assert redirected.level == PermissionLevel.ASK
+        assert redirected.safety_forced == bare.safety_forced
+
+    def test_anchored_allow_rule_does_not_match_the_redirection_token(self):
+        """Known limitation, pinned deliberately: ``shlex`` keeps ``2>&1`` as an
+        argv token, so an exact (unglobbed) allow rule no longer matches. The
+        command is an ordinary ASK, not a safety-forced one."""
+        rules = BashCommandRules(allow=["git status"])
+        decision = evaluate_bash_command("git status 2>&1", rules)
+
+        assert decision.level == PermissionLevel.ASK
+        assert decision.safety_forced is False
+        assert evaluate_bash_command("git status", rules).level == PermissionLevel.ALLOW
+
+    def test_execution_layer_whitelist_still_rejects_every_redirection(self):
+        """The exemption is permission-layer only. ``BashTool`` shares
+        ``contains_shell_metachars`` as the skills whitelist — a separate trust
+        boundary that must keep rejecting redirection outright."""
+        assert contains_shell_metachars("ls -la 2>&1") is True
+        assert contains_shell_metachars("ls -la 2>/dev/null") is True
+        assert split_pipeline("ls 2>&1") == ["ls 2>&1"]
 
 
 class TestSessionBuckets:

--- a/tests/unit_tests/tools/permission/test_bash_rules.py
+++ b/tests/unit_tests/tools/permission/test_bash_rules.py
@@ -309,6 +309,16 @@ class TestBenignRedirectionExemption:
         assert decision.source == BashDecisionSource.SAFETY
         assert decision.safety_forced is True
 
+    @pytest.mark.parametrize("command", ["& ls", "  & ls"])
+    def test_leading_ampersand_is_not_mistaken_for_a_redirection(self, command):
+        """There is no preceding operator, so segmentation must still bail.
+
+        Regression: the check was written ``_last_nonspace(buf) in "<>"``, and
+        ``"" in "<>"`` is True in Python — an empty string is a substring of
+        every string — so a leading ``&`` read as a redirection.
+        """
+        assert split_command_chain(command) is None
+
     @pytest.mark.parametrize("command", ["ls &", "sleep 5 &", "ls 2>&1 &", "ls & rm x"])
     def test_background_ampersand_is_not_mistaken_for_a_redirection(self, command):
         """The exemption keys on the ``&`` sitting next to ``<``/``>``; a


### PR DESCRIPTION
## Why

`2>&1` and `2>/dev/null` are among the most common shell idioms there are, and both were forcing a confirmation prompt.

The motivating case, observed in the real CLI with every sub-command allow-listed (`ls:*`, `head:*`):

```
⏺ 🔧 bash("ls -la /tmp/openclaw 2>&1 | head -20")
  └─ AI review ? unavailable · user approved
```

Two independent ceilings fired on it:

1. `split_command_chain` returned `None` — the `&` of `2>&1` is indistinguishable from a background-job `&` to the splitter, so the whole chain went to the safety ceiling as one opaque string. That also hid `head -20` from the per-sub-command prompt that #1311 had just added.
2. Even with segmentation fixed, `contains_shell_metachars` matched the `>` and forced ASK.

Neither form can express anything the argv already can't. Fd duplication (`2>&1`, `>&2`, `<&0`, `2>&-`) rewires the command's own streams and names no path — nothing can be written anywhere and no new command can be introduced. A `/dev/null` target discards by definition. Prompting for them teaches users to click through prompts, which costs more safety than the ceiling buys.

## Solution

Exempt exactly those two forms, at two call sites:

- **`_split_top_level(chain=True)`** no longer treats an `&` adjacent to a redirection operator as job control (`2>&1`, `>&2`, `<&0` by the preceding `<`/`>`; `&>file` by the following `>`). A genuine trailing `&` — `sleep 5 &`, `ls 2>&1 &` — still stops segmentation.
- **`_evaluate_single_command`** strips the exempt forms (`_BENIGN_REDIRECTION_RE`) before the metacharacter check.

Everything else keeps its ceiling: `> file` names a path an argv-matched allow rule cannot vouch for (`ls:*` says nothing about where output lands). Input redirection, `&> file`, and near-misses like `> /dev/nullx` are unchanged.

### Key decisions

**Scope is permission-layer only.** `contains_shell_metachars` is untouched, because `BashTool._segment_allowed` shares it as the execution-layer whitelist for skills — a separate trust boundary that must keep rejecting every redirection outright. The exemption lives at the call site; a test pins that the exec layer still rejects `2>&1`. Adding it to the shared helper would silently widen the skills whitelist.

**Ordering already protects it.** Deny rules, the wrapper ceiling and the inline-code ceiling all run *before* the redirection check, so `sh -c "rm -rf / 2>&1"` is still stopped by the wrapper rule. Both are pinned by tests.

**The `/dev/null` match is anchored.** Without the trailing lookahead, `> /dev/nullx` matched its `/dev/null` prefix and left a stray `x` behind — exempting a write to a real file. Caught by the test that asserts near-misses still ask.

### Behaviour changes worth calling out

- `rm -rf / 2>/dev/null` drops from a safety-forced ASK to an ordinary ASK — which is what bare `rm -rf /` always was (no metacharacters). The redirection was never the dangerous part, and having the redirected form look *more* suspicious than the bare one was the inconsistency. Neither auto-allows.
- **Known limitation, pinned deliberately:** `shlex` keeps `2>&1` as an argv token, so an exact (unglobbed) allow rule such as `git status` no longer matches `git status 2>&1` — that command is an ordinary ASK rather than a safety-forced one. Prefix rules (`git status:*`), which is what the profiles use, match fine. Stripping the token from argv would fix it but would make rule matching stop reflecting the real argv (`echo "2>&1"` genuinely passes an argument), so it is left alone.

### Second commit

`940e8493` fixes a latent bug introduced by the first: the fd-duplication check was written `_last_nonspace(buf) in "<>"`, and `"" in "<>"` is True in Python — an empty string is a substring of every string — so a leading `&` (`& ls`) read as a redirection. The outcome stayed a safety-forced ASK because the `&` still trips the metacharacter check, but the intent was violated. Found because `_last_nonspace`'s `return ""` was the single uncovered line in the diff-coverage report.

## Test Cases

No integration/nightly tests: this is pure static rule evaluation with no LLM, database or network involvement, and it is fully coverable at the unit tier.

`tests/unit_tests/tools/permission/test_bash_rules.py` — `TestBenignRedirectionExemption`:

- 11 exempt forms auto-allow (`2>&1`, `1>&2`, `>&2`, `<&0`, `2>&-`, and `/dev/null` as `>`, `>>`, `2>`, `2>>`, `&>`, `&>>`)
- the motivating chain segments into `["ls -la /tmp 2>&1", "head -20"]` and auto-allows
- 7 non-exempt redirections still force ASK, including `&> out.txt`, `< in.txt`, `> /dev/nullx` and `> /dev/stdout`
- background `&` still stops segmentation (`ls &`, `sleep 5 &`, `ls 2>&1 &`, `ls & rm x`), plus a regression for the leading-`&` substring bug
- stripping does not rescue other metacharacters (`$()`, backticks, newline)
- wrapper ceiling and deny rules still beat the exemption
- `rm -rf /` and `rm -rf / 2>/dev/null` are judged identically
- the anchored-allow-rule limitation is asserted rather than left implicit
- the execution-layer whitelist still rejects every redirection

### Verification

- `tests/unit_tests/tools/permission/` + `test_bash_tool.py`: **705 passed**
- `tests/unit_tests/tools/` + `tests/unit_tests/cli/`: **7609 passed, 8 skipped, 1 xfailed**
- `ci/run-pr-tests.py datus/main`: impacted unit tests exit 0, **diff coverage 100%**
- `ci/audit_tests.py --diff-only datus/main`: **P0=0, P1=0**
- `ruff format --check` / `ruff check`: clean

The harness also reports 6 failed / 68 errors in `tests/integration/cli/test_cli_commands.py` and `test_platform_doc_acceptance.py`. These are a local-environment issue, not this change — they reproduce identically on a clean `datus/main` checkout (a local `.datus/config.yml` sets `default_datasource: california_schools`, which the test config rejects).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benign shell redirections, such as file-descriptor duplication and `/dev/null` redirects, no longer require safety confirmation.
  * Other redirections continue to require confirmation.
  * Command chains now evaluate redirection-related operators correctly.

* **Bug Fixes**
  * Preserved existing protections for dangerous commands, metacharacters, deny rules, and execution-level restrictions.

* **Documentation**
  * Clarified which redirection patterns are exempt from safety prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->