### PR TITLE
[BugFix] SQL console bypassed row policies; dispatch on statement type

### DIFF
--- a/datus/api/routes/cli_routes.py
+++ b/datus/api/routes/cli_routes.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path
 
-from datus.api.deps import ServiceDep
+from datus.api.deps import AppContextDep, ServiceDep
 from datus.api.models.base_models import Result
 from datus.api.models.cli_models import (
     ExecuteContextData,
@@ -31,9 +31,13 @@ router = APIRouter(prefix="/api/v1", tags=["cli"])
 async def execute_sql(
     request: ExecuteSQLInput,
     svc: ServiceDep,
+    ctx: AppContextDep,
 ) -> Result[ExecuteSQLData]:
     """Execute SQL query directly."""
-    return await svc.cli.execute_sql(request)
+    # The caller's own context, not the service's: DatusService is cached per
+    # project and shared across callers, so its AgentConfig carries no
+    # per-request policy context.
+    return await svc.cli.execute_sql(request, policy_context=ctx.policy_context)
 
 
 @router.post(

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -36,6 +36,7 @@ from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import (
     SQLType,
     _first_statement,
+    parse_dialect,
     parse_sql_type,
     strip_sql_comments,
 )
@@ -76,13 +77,16 @@ def _write_reads_data(sql: str, dialect: str) -> bool:
     try:
         import sqlglot
 
-        parsed = sqlglot.parse_one(sql, read=dialect)
+        # `parse_dialect`, not the connector's own name: a connector reports
+        # `postgresql` while sqlglot only knows `postgres`, and handing it the
+        # raw value raises — which this function reads as "yes, it contains a
+        # read" and refuses every write, plain `CREATE TABLE` included.
+        parsed = sqlglot.parse_one(sql, read=parse_dialect(dialect), error_level=sqlglot.ErrorLevel.IGNORE)
     except Exception:
         return True
     if parsed is None:
         return True
     return bool(list(parsed.find_all(sqlglot.exp.Select)))
-
 
 
 class CLIService:

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -33,10 +33,56 @@ from datus.schemas.action_history import (
 )
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
-from datus.utils.sql_utils import validate_read_only_sql
+from datus.utils.sql_utils import (
+    SQLType,
+    _first_statement,
+    parse_sql_type,
+    strip_sql_comments,
+)
 from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
+
+#: Statement types the console may send straight to the connector.
+#:
+#: Deliberately an allow-list of *identified* writes. ``UNKNOWN`` is absent:
+#: anything the parser could not place must fall to the enforced path, where it
+#: is refused — the alternative is that a syntax the dialect accepts but sqlglot
+#: does not becomes an unfiltered read.
+_WRITE_SQL_TYPES = frozenset(
+    {
+        SQLType.INSERT,
+        SQLType.UPDATE,
+        SQLType.DELETE,
+        SQLType.MERGE,
+        SQLType.DDL,
+        SQLType.CONTENT_SET,
+    }
+)
+
+
+def _write_reads_data(sql: str, dialect: str) -> bool:
+    """Whether a write statement carries a query inside it.
+
+    ``CREATE TABLE ... AS SELECT`` and ``INSERT ... SELECT`` read rows a policy
+    would have filtered and land them somewhere no policy covers. The read
+    policy plugin cannot see this — it hooks reads, and this is a write — so the
+    check lives here.
+
+    Unparseable means yes. On a project with policies the cost of being wrong in
+    that direction is a refused statement; the other direction is a silent copy
+    of the rows the policy exists to withhold.
+    """
+    try:
+        import sqlglot
+
+        parsed = sqlglot.parse_one(sql, read=dialect)
+    except Exception:
+        return True
+    if parsed is None:
+        return True
+    return bool(list(parsed.find_all(sqlglot.exp.Select)))
+
 
 
 class CLIService:
@@ -140,31 +186,59 @@ class CLIService:
             )
             actions.add_action(sql_action)
 
-            # Reads go through the enforced path; everything else keeps the
-            # connector's own dispatch.
+            # Reads — and anything we cannot positively identify as a single
+            # write — go through the enforced path.
             #
-            # Hand-written SQL from the IDE is the widest read surface there is
-            # — a member types `SELECT * FROM orders` and the connector would
-            # happily answer, while every other read path on the project is
-            # filtered. But the console is also where people write DDL and DML,
-            # and the enforced path admits only SELECT / SHOW / DESCRIBE /
-            # EXPLAIN, so routing everything through it would quietly turn the
-            # console read-only. Row policies constrain reads by definition, so
-            # the split costs nothing.
+            # Hand-written SQL from the IDE is the widest read surface there is,
+            # so the console cannot be the one door a row policy does not cover.
+            # But the console is also where people write DDL and DML, and the
+            # enforced path admits only SELECT / SHOW / DESCRIBE / EXPLAIN, so
+            # sending everything through it would turn the console read-only.
+            #
+            # The split is on the *statement type*, never on "did the read-only
+            # validator object": that predicate is true for multi-statement
+            # input and for anything sqlglot cannot parse, so routing on it
+            # hands an attacker two one-token bypasses — `SELECT 1; SELECT *
+            # FROM orders` and a deliberate typo both stop being filtered.
+            # Multi-statement therefore reaches the enforced path and is
+            # rejected there, which is the same answer it gave before any of
+            # this existed.
             start_time = time.time()
-            violation, _sql_type = validate_read_only_sql(request.sql_query, self.current_db_connector.dialect)
-            if violation is None:
+            cleaned = strip_sql_comments(request.sql_query).strip().rstrip(";").strip()
+            sql_type = parse_sql_type(request.sql_query, self.current_db_connector.dialect)
+            single = bool(cleaned) and _first_statement(cleaned) == cleaned
+            is_write = sql_type in _WRITE_SQL_TYPES and single
+
+            if is_write and policy_context:
+                # A write can carry a read: `CREATE TABLE mine AS SELECT * FROM
+                # orders` copies the rows a policy just filtered into a table no
+                # policy covers. The plugin cannot help — it hooks reads only —
+                # so on a project that has policies at all, a write that embeds
+                # a query is refused here.
+                reads = _write_reads_data(request.sql_query, self.current_db_connector.dialect)
+                if reads:
+                    return Result(
+                        success=False,
+                        errorCode=ErrorCode.SQL_EXECUTION_ERROR,
+                        errorMessage=(
+                            "This project has row-level policies, so a write statement that "
+                            "reads from a query is not allowed here — it would copy filtered "
+                            "rows into a table no policy covers."
+                        ),
+                    )
+
+            if is_write:
+                result = self.current_db_connector.execute(
+                    input_params={"sql_query": request.sql_query},
+                    result_format=request.result_format,
+                )
+            else:
                 result = self._db_tool().execute_read_enforced(
                     request.sql_query,
                     self.current_db_connector,
                     datasource=self.current_datasource or "",
                     result_format=request.result_format,
                     policy_context=policy_context,
-                )
-            else:
-                result = self.current_db_connector.execute(
-                    input_params={"sql_query": request.sql_query},
-                    result_format=request.result_format,
                 )
             end_time = time.time()
             exec_time = end_time - start_time

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -93,7 +93,11 @@ class CLIService:
 
         # Initialize database connection
         self.current_db_connector = None
-        self._db_tool_cache = None
+        self._db_tool_cache: Optional[func_tool_mod.DBFuncTool] = None
+        # `_execute_sql_sync` runs under `asyncio.to_thread`, so two clicks on
+        # Run can reach the lazy build below at the same time and each pay for
+        # a DBManager and three RAG indexes.
+        self._db_tool_lock = threading.Lock()
         if self.agent_config:
             self._initialize_connection()
 
@@ -191,15 +195,25 @@ class CLIService:
                 # a query is refused here.
                 reads = write_statement_reads_data(request.sql_query, self.current_db_connector.dialect)
                 if reads:
+                    message = (
+                        "This project has row-level policies, so a write statement that "
+                        "reads from a query is not allowed here — it would copy filtered "
+                        "rows into a table no policy covers. Create views and derived "
+                        "tables on the database side instead."
+                    )
+                    # Every other exit from here closes the action it opened;
+                    # returning without doing so leaves it PROCESSING forever
+                    # and the refusal never reaches the history.
+                    actions.update_action_by_id(
+                        sql_action.action_id,
+                        status=ActionStatus.FAILED,
+                        output={"error": message},
+                        messages=f"SQL execution refused: {message}",
+                    )
                     return Result(
                         success=False,
                         errorCode=ErrorCode.SQL_EXECUTION_ERROR,
-                        errorMessage=(
-                            "This project has row-level policies, so a write statement that "
-                            "reads from a query is not allowed here — it would copy filtered "
-                            "rows into a table no policy covers. Create views and derived "
-                            "tables on the database side instead."
-                        ),
+                        errorMessage=message,
                     )
 
             if is_write:
@@ -310,7 +324,7 @@ class CLIService:
                 errorMessage=str(e),
             )
 
-    def _db_tool(self):
+    def _db_tool(self) -> "func_tool_mod.DBFuncTool":
         """The tool that owns the enforced-read path, built once.
 
         Its constructor stands up a DBManager and three RAG indexes and sizes
@@ -319,7 +333,10 @@ class CLIService:
         policy context is the only per-request part and travels as an argument.
         """
         if self._db_tool_cache is None:
-            self._db_tool_cache = func_tool_mod.DBFuncTool(agent_config=self.agent_config)
+            with self._db_tool_lock:
+                # Re-check: the other thread may have finished while we waited.
+                if self._db_tool_cache is None:
+                    self._db_tool_cache = func_tool_mod.DBFuncTool(agent_config=self.agent_config)
         return self._db_tool_cache
 
     async def execute_sql(

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -8,6 +8,7 @@ import time
 import uuid
 from typing import Any, Dict, Optional
 
+import datus.tools.func_tool as func_tool_mod
 from datus.api.models.base_models import Result
 from datus.api.models.cli_models import (
     ContextResultData,
@@ -30,9 +31,9 @@ from datus.schemas.action_history import (
     ActionRole,
     ActionStatus,
 )
-import datus.tools.func_tool as func_tool_mod
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
+from datus.utils.sql_utils import validate_read_only_sql
 from datus.utils.time_utils import now_utc_iso
 
 logger = get_logger(__name__)
@@ -70,6 +71,7 @@ class CLIService:
 
         # Initialize database connection
         self.current_db_connector = None
+        self._db_tool_cache = None
         if self.agent_config:
             self._initialize_connection()
 
@@ -138,24 +140,32 @@ class CLIService:
             )
             actions.add_action(sql_action)
 
-            # Execute the query through the enforced-read path.
+            # Reads go through the enforced path; everything else keeps the
+            # connector's own dispatch.
             #
             # Hand-written SQL from the IDE is the widest read surface there is
             # — a member types `SELECT * FROM orders` and the connector would
-            # happily answer. Going straight to `connector.execute` here left
-            # every row policy in place and this one door open, which is worse
-            # than having no policy at all because the project reads as
-            # protected. Same entry point the agent's own tools use, so the two
-            # cannot drift.
+            # happily answer, while every other read path on the project is
+            # filtered. But the console is also where people write DDL and DML,
+            # and the enforced path admits only SELECT / SHOW / DESCRIBE /
+            # EXPLAIN, so routing everything through it would quietly turn the
+            # console read-only. Row policies constrain reads by definition, so
+            # the split costs nothing.
             start_time = time.time()
-            db_tool = func_tool_mod.DBFuncTool(agent_config=self.agent_config, sub_agent_name="cli_sql")
-            result = db_tool.execute_read_enforced(
-                request.sql_query,
-                self.current_db_connector,
-                datasource=self.current_datasource or "",
-                result_format=request.result_format,
-                policy_context=policy_context or {},
-            )
+            violation, _sql_type = validate_read_only_sql(request.sql_query, self.current_db_connector.dialect)
+            if violation is None:
+                result = self._db_tool().execute_read_enforced(
+                    request.sql_query,
+                    self.current_db_connector,
+                    datasource=self.current_datasource or "",
+                    result_format=request.result_format,
+                    policy_context=policy_context,
+                )
+            else:
+                result = self.current_db_connector.execute(
+                    input_params={"sql_query": request.sql_query},
+                    result_format=request.result_format,
+                )
             end_time = time.time()
             exec_time = end_time - start_time
 
@@ -250,6 +260,18 @@ class CLIService:
                 errorCode=ErrorCode.SQL_EXECUTION_ERROR,
                 errorMessage=str(e),
             )
+
+    def _db_tool(self):
+        """The tool that owns the enforced-read path, built once.
+
+        Its constructor stands up a DBManager and three RAG indexes and sizes
+        two of them — far too much to pay per click on Run. ``CLIService`` is
+        already cached per project, so this rides along with it; the caller's
+        policy context is the only per-request part and travels as an argument.
+        """
+        if self._db_tool_cache is None:
+            self._db_tool_cache = func_tool_mod.DBFuncTool(agent_config=self.agent_config)
+        return self._db_tool_cache
 
     async def execute_sql(
         self,

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -35,10 +35,9 @@ from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import (
     SQLType,
-    _first_statement,
+    is_single_statement,
     parse_dialect,
     parse_sql_type,
-    strip_sql_comments,
 )
 from datus.utils.time_utils import now_utc_iso
 
@@ -70,9 +69,10 @@ def _write_reads_data(sql: str, dialect: str) -> bool:
     policy plugin cannot see this — it hooks reads, and this is a write — so the
     check lives here.
 
-    Unparseable means yes. On a project with policies the cost of being wrong in
-    that direction is a refused statement; the other direction is a silent copy
-    of the rows the policy exists to withhold.
+    Anything the parser did not actually understand means yes. On a project with
+    policies the cost of being wrong in that direction is a refused statement;
+    the other direction is a silent copy of the rows the policy exists to
+    withhold.
     """
     try:
         import sqlglot
@@ -86,6 +86,16 @@ def _write_reads_data(sql: str, dialect: str) -> bool:
         return True
     if parsed is None:
         return True
+
+    # IGNORE does not raise on syntax sqlglot cannot place — it hands back an
+    # opaque `Command` whose body was never parsed, so `find_all(Select)` is
+    # empty for reasons that have nothing to do with the statement. Postgres'
+    # `CREATE TABLE mine AS TABLE orders` lands here and is a full CTAS.
+    # `COPY` is parsed but its source is a table reference rather than a
+    # Select, and `COPY ... TO '/path'` / `TO PROGRAM` is a real export.
+    if isinstance(parsed, (sqlglot.exp.Command, sqlglot.exp.Copy)):
+        return True
+
     return bool(list(parsed.find_all(sqlglot.exp.Select)))
 
 
@@ -208,10 +218,8 @@ class CLIService:
             # rejected there, which is the same answer it gave before any of
             # this existed.
             start_time = time.time()
-            cleaned = strip_sql_comments(request.sql_query).strip().rstrip(";").strip()
             sql_type = parse_sql_type(request.sql_query, self.current_db_connector.dialect)
-            single = bool(cleaned) and _first_statement(cleaned) == cleaned
-            is_write = sql_type in _WRITE_SQL_TYPES and single
+            is_write = sql_type in _WRITE_SQL_TYPES and is_single_statement(request.sql_query)
 
             if is_write and policy_context:
                 # A write can carry a read: `CREATE TABLE mine AS SELECT * FROM
@@ -227,7 +235,8 @@ class CLIService:
                         errorMessage=(
                             "This project has row-level policies, so a write statement that "
                             "reads from a query is not allowed here — it would copy filtered "
-                            "rows into a table no policy covers."
+                            "rows into a table no policy covers. Create views and derived "
+                            "tables on the database side instead."
                         ),
                     )
 

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -36,8 +36,8 @@ from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import (
     SQLType,
     is_single_statement,
-    parse_dialect,
     parse_sql_type,
+    write_statement_reads_data,
 )
 from datus.utils.time_utils import now_utc_iso
 
@@ -59,44 +59,6 @@ _WRITE_SQL_TYPES = frozenset(
         SQLType.CONTENT_SET,
     }
 )
-
-
-def _write_reads_data(sql: str, dialect: str) -> bool:
-    """Whether a write statement carries a query inside it.
-
-    ``CREATE TABLE ... AS SELECT`` and ``INSERT ... SELECT`` read rows a policy
-    would have filtered and land them somewhere no policy covers. The read
-    policy plugin cannot see this — it hooks reads, and this is a write — so the
-    check lives here.
-
-    Anything the parser did not actually understand means yes. On a project with
-    policies the cost of being wrong in that direction is a refused statement;
-    the other direction is a silent copy of the rows the policy exists to
-    withhold.
-    """
-    try:
-        import sqlglot
-
-        # `parse_dialect`, not the connector's own name: a connector reports
-        # `postgresql` while sqlglot only knows `postgres`, and handing it the
-        # raw value raises — which this function reads as "yes, it contains a
-        # read" and refuses every write, plain `CREATE TABLE` included.
-        parsed = sqlglot.parse_one(sql, read=parse_dialect(dialect), error_level=sqlglot.ErrorLevel.IGNORE)
-    except Exception:
-        return True
-    if parsed is None:
-        return True
-
-    # IGNORE does not raise on syntax sqlglot cannot place — it hands back an
-    # opaque `Command` whose body was never parsed, so `find_all(Select)` is
-    # empty for reasons that have nothing to do with the statement. Postgres'
-    # `CREATE TABLE mine AS TABLE orders` lands here and is a full CTAS.
-    # `COPY` is parsed but its source is a table reference rather than a
-    # Select, and `COPY ... TO '/path'` / `TO PROGRAM` is a real export.
-    if isinstance(parsed, (sqlglot.exp.Command, sqlglot.exp.Copy)):
-        return True
-
-    return bool(list(parsed.find_all(sqlglot.exp.Select)))
 
 
 class CLIService:
@@ -227,7 +189,7 @@ class CLIService:
                 # policy covers. The plugin cannot help — it hooks reads only —
                 # so on a project that has policies at all, a write that embeds
                 # a query is refused here.
-                reads = _write_reads_data(request.sql_query, self.current_db_connector.dialect)
+                reads = write_statement_reads_data(request.sql_query, self.current_db_connector.dialect)
                 if reads:
                     return Result(
                         success=False,

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -6,7 +6,7 @@ import asyncio
 import threading
 import time
 import uuid
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from datus.api.models.base_models import Result
 from datus.api.models.cli_models import (
@@ -30,6 +30,7 @@ from datus.schemas.action_history import (
     ActionRole,
     ActionStatus,
 )
+import datus.tools.func_tool as func_tool_mod
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.loggings import get_logger
 from datus.utils.time_utils import now_utc_iso
@@ -99,7 +100,12 @@ class CLIService:
         with self._sql_tasks_lock:
             self._sql_tasks.pop(task_id, None)
 
-    def _execute_sql_sync(self, request: ExecuteSQLInput, task_id: str) -> Result[ExecuteSQLData]:
+    def _execute_sql_sync(
+        self,
+        request: ExecuteSQLInput,
+        task_id: str,
+        policy_context: Optional[Dict[str, Any]] = None,
+    ) -> Result[ExecuteSQLData]:
         """Synchronous SQL execution logic (runs in a thread)."""
         try:
             if not self.current_db_connector:
@@ -132,11 +138,23 @@ class CLIService:
             )
             actions.add_action(sql_action)
 
-            # Execute the query
+            # Execute the query through the enforced-read path.
+            #
+            # Hand-written SQL from the IDE is the widest read surface there is
+            # — a member types `SELECT * FROM orders` and the connector would
+            # happily answer. Going straight to `connector.execute` here left
+            # every row policy in place and this one door open, which is worse
+            # than having no policy at all because the project reads as
+            # protected. Same entry point the agent's own tools use, so the two
+            # cannot drift.
             start_time = time.time()
-            result = self.current_db_connector.execute(
-                input_params={"sql_query": request.sql_query},
+            db_tool = func_tool_mod.DBFuncTool(agent_config=self.agent_config, sub_agent_name="cli_sql")
+            result = db_tool.execute_read_enforced(
+                request.sql_query,
+                self.current_db_connector,
+                datasource=self.current_datasource or "",
                 result_format=request.result_format,
+                policy_context=policy_context or {},
             )
             end_time = time.time()
             exec_time = end_time - start_time
@@ -233,7 +251,11 @@ class CLIService:
                 errorMessage=str(e),
             )
 
-    async def execute_sql(self, request: ExecuteSQLInput) -> Result[ExecuteSQLData]:
+    async def execute_sql(
+        self,
+        request: ExecuteSQLInput,
+        policy_context: Optional[Dict[str, Any]] = None,
+    ) -> Result[ExecuteSQLData]:
         """Execute SQL query asynchronously with cancellation support.
 
         If ``request.execute_task_id`` is provided, it is used as-is and returned
@@ -244,7 +266,7 @@ class CLIService:
 
         async def _run() -> Result[ExecuteSQLData]:
             try:
-                return await asyncio.to_thread(self._execute_sql_sync, request, task_id)
+                return await asyncio.to_thread(self._execute_sql_sync, request, task_id, policy_context)
             except asyncio.CancelledError:
                 logger.info(f"SQL execution task cancelled: {task_id}")
                 return Result(

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1464,7 +1464,11 @@ class DBFuncTool:
             FuncToolResult: compressed rows for read-only queries, or execution
             metadata for writes/DDL. On failure success=0 with an error message.
         """
-        from datus.utils.sql_utils import looks_like_sql_file_ref, parse_sql_type
+        from datus.utils.sql_utils import (
+            looks_like_sql_file_ref,
+            parse_sql_type,
+            write_statement_reads_data,
+        )
 
         try:
             # Resolve a ``.sql`` file path up front so type detection inspects the
@@ -1494,6 +1498,28 @@ class DBFuncTool:
                         "statements are allowed through execute_sql."
                     ),
                 )
+            # A write can carry a read. `CREATE TABLE mine AS SELECT * FROM
+            # orders` is approved as a write, runs on the raw connector, and
+            # lands every row the policy just withheld in a table no policy
+            # covers — the person who may only SELECT two stores now owns all
+            # four. The plugin cannot see it: it hooks reads, and this is a
+            # write. So on a project that has a policy context at all, a write
+            # that embeds a query is refused before it is dispatched.
+            #
+            # The permission prompt is not this check. It asks whether the
+            # *user* consents to a write; consenting to a write they are
+            # allowed to make is not consent to read rows they are not.
+            if self.policy_context and write_statement_reads_data(sql, connector.dialect):
+                return FuncToolResult(
+                    success=0,
+                    error=(
+                        "This project has row-level policies, so a write statement that "
+                        "reads from a query is not allowed — it would copy filtered rows "
+                        "into a table no policy covers. Create views and derived tables "
+                        "on the database side instead."
+                    ),
+                )
+
             if sql_type in (SQLType.INSERT, SQLType.UPDATE, SQLType.DELETE):
                 return self.execute_write(
                     sql,

--- a/datus/tools/policy_runtime.py
+++ b/datus/tools/policy_runtime.py
@@ -10,11 +10,33 @@ the meaning of ``policy_context`` and the concrete read transformations.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Dict, Optional
 
 from datus.plugins.registry import collect_plugin_policy_runtime_factories
 from datus.utils.exceptions import DatusException, ErrorCode
+
+#: Sibling key on ``policy_context`` carrying *why* SaaS denied this caller.
+#:
+#: Written by Datus-backend when it assembles the context; policy plugins read
+#: only ``row_filter`` and ignore it. See ``saas_provider._DENIAL_KEY``.
+_DENIAL_KEY = "x_saas_denial"
+
+
+def _explain(context: Dict[str, Any], reason: Optional[str]) -> Optional[str]:
+    """Append SaaS' explanation to a plugin's refusal.
+
+    A plugin can only report that context validation failed. It does not know
+    whose attributes are missing — or that attributes are involved at all — so
+    the person reading "Policy context denies all data reads" has nothing to
+    act on and no way to tell a gap in their own profile from a broken policy.
+    SaaS decides ``access_mode`` precisely so the refusal can be explained;
+    this is where that explanation reaches the caller.
+    """
+    detail = context.get(_DENIAL_KEY)
+    if not isinstance(detail, str) or not detail.strip():
+        return reason
+    return f"{(reason or 'Policy denied the query').rstrip('. ')}: {detail.strip()}"
 
 
 @dataclass(frozen=True)
@@ -84,7 +106,7 @@ class PolicyRuntime:
             raw = self._invoke(plugin_name, "validate_context", hook, context)
             decision = self._validation_decision(plugin_name, raw)
             if not decision.allowed:
-                return decision
+                return replace(decision, reason=_explain(context, decision.reason))
         return PolicyValidationResult(allowed=True)
 
     def before_sql_read(
@@ -113,7 +135,7 @@ class PolicyRuntime:
             )
             decision = self._sql_decision(plugin_name, raw, current_sql)
             if not decision.allowed:
-                return decision
+                return replace(decision, reason=_explain(context, decision.reason))
             current_sql = decision.sql if decision.sql is not None else current_sql
             applied.extend(decision.applied_policies)
         return SqlReadDecision(allowed=True, sql=current_sql, applied_policies=applied)
@@ -146,7 +168,7 @@ class PolicyRuntime:
             )
             decision = self._result_decision(plugin_name, raw, current_result)
             if not decision.allowed:
-                return decision
+                return replace(decision, reason=_explain(context, decision.reason))
             current_result = decision.result
             applied.extend(decision.applied_policies)
         return ReadResultDecision(allowed=True, result=current_result, applied_policies=applied)

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -754,6 +754,44 @@ READ_ONLY_NON_READ = "non_read"
 READ_ONLY_WRITABLE_PRAGMA = "writable_pragma"
 
 
+def write_statement_reads_data(sql: str, dialect: str) -> bool:
+    """Whether a write statement carries a query inside it.
+
+    ``CREATE TABLE ... AS SELECT`` and ``INSERT ... SELECT`` read rows a policy
+    would have filtered and land them somewhere no policy covers. The read
+    policy plugin cannot see this — it hooks reads, and these are writes — so
+    every surface that can run a write has to ask before running it.
+
+    Anything the parser did not actually understand means yes. On a project with
+    policies the cost of being wrong in that direction is a refused statement;
+    the other direction is a silent copy of the rows the policy exists to
+    withhold.
+    """
+    try:
+        import sqlglot
+
+        # `parse_dialect`, not the connector's own name: a connector reports
+        # `postgresql` while sqlglot only knows `postgres`, and handing it the
+        # raw value raises — which this function reads as "yes, it contains a
+        # read" and refuses every write, plain `CREATE TABLE` included.
+        parsed = sqlglot.parse_one(sql, read=parse_dialect(dialect), error_level=sqlglot.ErrorLevel.IGNORE)
+    except Exception:
+        return True
+    if parsed is None:
+        return True
+
+    # IGNORE does not raise on syntax sqlglot cannot place — it hands back an
+    # opaque `Command` whose body was never parsed, so `find_all(Select)` is
+    # empty for reasons that have nothing to do with the statement. Postgres'
+    # `CREATE TABLE mine AS TABLE orders` lands here and is a full CTAS.
+    # `COPY` is parsed but its source is a table reference rather than a
+    # Select, and `COPY ... TO '/path'` / `TO PROGRAM` is a real export.
+    if isinstance(parsed, (sqlglot.exp.Command, sqlglot.exp.Copy)):
+        return True
+
+    return bool(list(parsed.find_all(sqlglot.exp.Select)))
+
+
 def is_single_statement(sql: str) -> bool:
     """Whether the input is exactly one statement.
 

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -754,6 +754,19 @@ READ_ONLY_NON_READ = "non_read"
 READ_ONLY_WRITABLE_PRAGMA = "writable_pragma"
 
 
+def is_single_statement(sql: str) -> bool:
+    """Whether the input is exactly one statement.
+
+    A trailing semicolon and surrounding comments do not make it two. Callers
+    that route on statement type need this separately from
+    :func:`validate_read_only_sql`, which folds it into one violation code.
+    """
+    normalized = strip_sql_comments(sql).strip().rstrip(";").strip()
+    if not normalized:
+        return False
+    return _first_statement(normalized) == normalized
+
+
 def validate_read_only_sql(sql: str, dialect: str) -> tuple[Optional[str], SQLType]:
     """Classify one SQL statement and identify read-only safety violations.
 
@@ -764,7 +777,7 @@ def validate_read_only_sql(sql: str, dialect: str) -> tuple[Optional[str], SQLTy
     """
     cleaned = strip_sql_comments(sql).strip()
     normalized_sql = cleaned.rstrip(";").strip()
-    if normalized_sql and _first_statement(normalized_sql) != normalized_sql:
+    if normalized_sql and not is_single_statement(normalized_sql):
         return READ_ONLY_MULTI_STATEMENT, SQLType.UNKNOWN
 
     sql_type = parse_sql_type(sql, dialect)

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -403,10 +403,63 @@ def _metadata_pattern() -> re.Pattern:
 
 
 def strip_sql_comments(sql: str) -> str:
-    """Remove /* ... */ and -- ... comments (simple but effective)."""
-    sql = re.sub(r"/\*.*?\*/", " ", sql, flags=re.DOTALL)
-    sql = re.sub(r"--.*?$", " ", sql, flags=re.MULTILINE)
-    return sql
+    """Remove ``/* ... */`` and ``-- ...`` comments.
+
+    Scanned rather than regexed, because a comment marker inside a string
+    literal is not a comment: ``re.sub`` on ``SELECT 'a--b' FROM t`` cuts the
+    statement down to ``SELECT 'a`` and hands that to whoever asked. Several
+    callers execute the stripped text, so the truncation reaches the database.
+    """
+    out: List[str] = []
+    i = 0
+    length = len(sql)
+    while i < length:
+        ch = sql[i]
+
+        # A quoted run is copied through whole; nothing inside it is a marker.
+        closer = {"'": "'", '"': '"', "`": "`", "[": "]"}.get(ch)
+        if closer:
+            out.append(ch)
+            i += 1
+            while i < length:
+                out.append(sql[i])
+                if sql[i] == closer:
+                    # A doubled quote is an escaped one, not the end.
+                    if i + 1 < length and sql[i + 1] == closer and closer != "]":
+                        out.append(sql[i + 1])
+                        i += 2
+                        continue
+                    if closer == "]" or not _is_escaped(sql, i):
+                        i += 1
+                        break
+                i += 1
+            continue
+
+        if ch == "$":
+            tag = _match_dollar_tag(sql, i)
+            if tag:
+                end = sql.find(tag, i + len(tag))
+                stop = length if end == -1 else end + len(tag)
+                out.append(sql[i:stop])
+                i = stop
+                continue
+
+        if sql.startswith("--", i):
+            end = sql.find("\n", i)
+            i = length if end == -1 else end
+            out.append(" ")
+            continue
+
+        if sql.startswith("/*", i):
+            end = sql.find("*/", i + 2)
+            i = length if end == -1 else end + 2
+            out.append(" ")
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
 
 
 def _is_escaped(text: str, index: int) -> bool:
@@ -755,41 +808,66 @@ READ_ONLY_WRITABLE_PRAGMA = "writable_pragma"
 
 
 def write_statement_reads_data(sql: str, dialect: str) -> bool:
-    """Whether a write statement carries a query inside it.
+    """Whether a write statement reads rows a row policy would have filtered.
 
-    ``CREATE TABLE ... AS SELECT`` and ``INSERT ... SELECT`` read rows a policy
-    would have filtered and land them somewhere no policy covers. The read
-    policy plugin cannot see this — it hooks reads, and these are writes — so
-    every surface that can run a write has to ask before running it.
+    ``CREATE TABLE ... AS SELECT`` is the obvious shape, but it is not the only
+    one: ``UPDATE ... FROM``, ``DELETE ... USING`` and ``MERGE ... USING`` all
+    name a source table with no ``Select`` node anywhere in the tree, and
+    ``RETURNING`` hands the rows straight back to the caller. Each reads rows a
+    policy would have withheld and puts them somewhere it does not cover. The
+    read policy plugin cannot see any of it — it hooks reads, and these are
+    writes — so every surface that can run a write has to ask before running it.
 
-    Anything the parser did not actually understand means yes. On a project with
-    policies the cost of being wrong in that direction is a refused statement;
-    the other direction is a silent copy of the rows the policy exists to
-    withhold.
+    Anything the parser did not actually understand counts as yes. On a project
+    with policies the cost of being wrong in that direction is a refused
+    statement; the other direction is a silent copy of the rows the policy
+    exists to withhold.
     """
-    try:
-        import sqlglot
+    import sqlglot
+    from sqlglot import exp
 
+    try:
+        # RAISE, not IGNORE. IGNORE does not raise on syntax it cannot place —
+        # it returns an opaque `Command` whose body was never parsed, so
+        # "no Select inside" says nothing about the statement. Every unparsed
+        # shape has to reach the `except` and be refused.
+        #
         # `parse_dialect`, not the connector's own name: a connector reports
-        # `postgresql` while sqlglot only knows `postgres`, and handing it the
-        # raw value raises — which this function reads as "yes, it contains a
-        # read" and refuses every write, plain `CREATE TABLE` included.
-        parsed = sqlglot.parse_one(sql, read=parse_dialect(dialect), error_level=sqlglot.ErrorLevel.IGNORE)
+        # `postgresql` while sqlglot only knows `postgres`, and handing over the
+        # raw value raises for every statement — which this function reads as
+        # "contains a read" and refuses every write, plain `CREATE TABLE`
+        # included.
+        parsed = sqlglot.parse_one(sql, read=parse_dialect(dialect), error_level=sqlglot.ErrorLevel.RAISE)
     except Exception:
         return True
-    if parsed is None:
+    if parsed is None or isinstance(parsed, exp.Command):
         return True
 
-    # IGNORE does not raise on syntax sqlglot cannot place — it hands back an
-    # opaque `Command` whose body was never parsed, so `find_all(Select)` is
-    # empty for reasons that have nothing to do with the statement. Postgres'
-    # `CREATE TABLE mine AS TABLE orders` lands here and is a full CTAS.
-    # `COPY` is parsed but its source is a table reference rather than a
-    # Select, and `COPY ... TO '/path'` / `TO PROGRAM` is a real export.
-    if isinstance(parsed, (sqlglot.exp.Command, sqlglot.exp.Copy)):
+    # `COPY` parses, but its source is a table reference rather than a Select,
+    # and `COPY ... TO '/path'` / `TO PROGRAM` on a self-hosted server is a real
+    # export.
+    if isinstance(parsed, exp.Copy):
         return True
 
-    return bool(list(parsed.find_all(sqlglot.exp.Select)))
+    # Rows leaving through RETURNING are read by definition.
+    if parsed.args.get("returning") or list(parsed.find_all(exp.Returning)):
+        return True
+
+    if list(parsed.find_all(exp.Select)):
+        return True
+
+    # A source table named without a subquery: `UPDATE t SET .. FROM src`,
+    # `DELETE FROM t USING src`, `MERGE INTO t USING src`. Each reads `src`
+    # while the tree holds no Select at all.
+    #
+    # The key differs per node — Update calls it `from_` — and `Delete.using`
+    # is present but empty on a plain DELETE, so this tests truthiness rather
+    # than `is not None`, which refused every `DELETE ... WHERE`.
+    source_key = {exp.Update: "from_", exp.Delete: "using", exp.Merge: "using"}.get(type(parsed))
+    if source_key and parsed.args.get(source_key):
+        return True
+
+    return False
 
 
 def is_single_statement(sql: str) -> bool:

--- a/datus/utils/sql_utils.py
+++ b/datus/utils/sql_utils.py
@@ -860,12 +860,20 @@ def write_statement_reads_data(sql: str, dialect: str) -> bool:
     # `DELETE FROM t USING src`, `MERGE INTO t USING src`. Each reads `src`
     # while the tree holds no Select at all.
     #
-    # The key differs per node — Update calls it `from_` — and `Delete.using`
-    # is present but empty on a plain DELETE, so this tests truthiness rather
-    # than `is not None`, which refused every `DELETE ... WHERE`.
-    source_key = {exp.Update: "from_", exp.Delete: "using", exp.Merge: "using"}.get(type(parsed))
-    if source_key and parsed.args.get(source_key):
-        return True
+    # Counted rather than read off a named argument. The argument differs per
+    # node and *between sqlglot releases* — an earlier version of this keyed on
+    # `Update.args["from_"]`, which passed locally on 30.1 and missed the same
+    # statement on CI. `exp.Table` is the one part of the shape that does not
+    # move. One DML statement has exactly one target table; a second table in
+    # the tree is something being read.
+    #
+    # Scoped to the DML family on purpose: DDL routinely names two tables
+    # without reading a row (`ALTER TABLE a RENAME TO b`, `CREATE TABLE a
+    # (LIKE b)`), and the DDL that does read — CTAS — carries a Select and is
+    # caught above.
+    if isinstance(parsed, (exp.Update, exp.Delete, exp.Merge)):
+        if len({table.sql() for table in parsed.find_all(exp.Table)}) > 1:
+            return True
 
     return False
 

--- a/tests/unit_tests/api/services/test_cli_service_policy.py
+++ b/tests/unit_tests/api/services/test_cli_service_policy.py
@@ -84,20 +84,6 @@ def test_a_write_keeps_the_connector_path(monkeypatch):
     assert connector.executed == ["CREATE VIEW v AS SELECT 1"]
 
 
-def test_a_multi_statement_selection_keeps_working(monkeypatch):
-    """ "Execute Statement" over a selection holding two statements.
-
-    The enforced path rejects those outright, which would have broken a normal
-    editor gesture.
-    """
-    connector = _Connector()
-    svc = _service(monkeypatch, connector, MagicMock())
-
-    svc._execute_sql_sync(ExecuteSQLInput(sql_query="SELECT 1; SELECT 2"), "task-3", {})
-
-    assert connector.executed == ["SELECT 1; SELECT 2"]
-
-
 @pytest.mark.parametrize("sql", ["SHOW TABLES", "DESCRIBE orders", "EXPLAIN SELECT 1"])
 def test_metadata_reads_are_enforced_too(monkeypatch, sql):
     connector = _Connector()
@@ -130,3 +116,81 @@ def test_the_tool_is_built_once(monkeypatch):
     # constructors whose scoped context would silently apply if a project ever
     # had a sub-agent by that name.
     assert "sub_agent_name" not in built[0]
+
+
+def test_multi_statement_does_not_reach_the_connector(monkeypatch):
+    """One extra statement must not be a way around the filter.
+
+    `SELECT 1; SELECT * FROM orders` is not a read to the read-only validator —
+    it is `multi_statement` — so dispatching on "did the validator object" hands
+    it to the connector, which executes both and returns the last result set.
+    Dispatch is on the statement *type* instead, so this lands on the enforced
+    path and is refused there. Losing the two-statement selection is the price;
+    Split Execute already sends them one at a time.
+    """
+    connector = _Connector()
+    db_tool = MagicMock()
+    db_tool.execute_read_enforced.return_value = SimpleNamespace(
+        success=False, sql_return=[], row_count=0, error="multi", sql_query="x"
+    )
+    svc = _service(monkeypatch, connector, db_tool)
+
+    svc._execute_sql_sync(ExecuteSQLInput(sql_query="SELECT 1; SELECT * FROM orders"), "t", {})
+
+    assert connector.executed == []
+    db_tool.execute_read_enforced.assert_called_once()
+
+
+def test_unparseable_sql_does_not_reach_the_connector(monkeypatch):
+    """A deliberate typo must not turn into an unfiltered read.
+
+    Anything sqlglot cannot place comes back as UNKNOWN, which the read-only
+    validator also reports as `non_read`. Treating that as "a write" would make
+    every dialect quirk a bypass.
+    """
+    connector = _Connector()
+    db_tool = MagicMock()
+    db_tool.execute_read_enforced.return_value = SimpleNamespace(
+        success=False, sql_return=[], row_count=0, error="nope", sql_query="x"
+    )
+    svc = _service(monkeypatch, connector, db_tool)
+
+    svc._execute_sql_sync(ExecuteSQLInput(sql_query="SELEKT * FROM orders"), "t", {})
+
+    assert connector.executed == []
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "CREATE TABLE mine AS SELECT * FROM orders",
+        "INSERT INTO mine SELECT * FROM orders",
+    ],
+)
+def test_a_write_that_reads_is_refused_when_policies_exist(monkeypatch, sql):
+    """Laundering: copy the filtered rows into a table no policy covers.
+
+    The plugin cannot see this — it hooks reads, and these are writes — so the
+    refusal lives here, and only on a project that has a policy context at all.
+    """
+    connector = _Connector()
+    svc = _service(monkeypatch, connector, MagicMock())
+
+    result = svc._execute_sql_sync(
+        ExecuteSQLInput(sql_query=sql),
+        "t",
+        {"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}},
+    )
+
+    assert result.success is False
+    assert connector.executed == []
+
+
+def test_the_same_write_is_allowed_without_policies(monkeypatch):
+    """A project with no policies keeps the console it always had."""
+    connector = _Connector()
+    svc = _service(monkeypatch, connector, MagicMock())
+
+    svc._execute_sql_sync(ExecuteSQLInput(sql_query="CREATE TABLE mine AS SELECT * FROM orders"), "t", {})
+
+    assert connector.executed == ["CREATE TABLE mine AS SELECT * FROM orders"]

--- a/tests/unit_tests/api/services/test_cli_service_policy.py
+++ b/tests/unit_tests/api/services/test_cli_service_policy.py
@@ -1,0 +1,132 @@
+"""SQL policy on the IDE's SQL console (``POST /api/v1/sql/execute``).
+
+Red before the fix: ``_execute_sql_sync`` called ``connector.execute`` directly,
+so a project with a row filter on ``orders`` still answered a hand-written
+``SELECT * FROM orders`` with every row.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from datus.api.models.cli_models import ExecuteSQLInput
+from datus.api.services.cli_service import CLIService
+
+
+class _Connector:
+    dialect = "postgres"
+
+    def __init__(self):
+        self.executed = []
+
+    def execute(self, input_params, result_format="list"):
+        self.executed.append(input_params["sql_query"])
+        return SimpleNamespace(
+            success=True,
+            sql_return=[],
+            row_count=0,
+            error=None,
+            sql_query=input_params["sql_query"],
+        )
+
+
+def _service(monkeypatch, connector, db_tool):
+    svc = CLIService.__new__(CLIService)
+    svc.agent_config = SimpleNamespace()
+    svc.current_db_connector = connector
+    svc.current_datasource = "warehouse"
+    svc._db_tool_cache = db_tool
+    svc._sql_tasks = {}
+    svc._sql_tasks_lock = MagicMock()
+    svc._sql_tasks_lock.__enter__ = lambda *_: None
+    svc._sql_tasks_lock.__exit__ = lambda *_: None
+    return svc
+
+
+def test_a_read_goes_through_the_enforced_path(monkeypatch):
+    """The whole point: the console cannot be the one unfiltered door."""
+    connector = _Connector()
+    db_tool = MagicMock()
+    db_tool.execute_read_enforced.return_value = SimpleNamespace(
+        success=True, sql_return=[], row_count=0, error=None, sql_query="rewritten"
+    )
+    svc = _service(monkeypatch, connector, db_tool)
+
+    svc._execute_sql_sync(
+        ExecuteSQLInput(sql_query="SELECT * FROM orders"),
+        "task-1",
+        {"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}},
+    )
+
+    db_tool.execute_read_enforced.assert_called_once()
+    kwargs = db_tool.execute_read_enforced.call_args.kwargs
+    # The caller's context, not the service's: DatusService is cached per
+    # project and shared, so its AgentConfig carries none.
+    assert kwargs["policy_context"] == {"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}}
+    assert connector.executed == []
+
+
+def test_a_write_keeps_the_connector_path(monkeypatch):
+    """The console is also where people write DDL.
+
+    The enforced path admits only SELECT / SHOW / DESCRIBE / EXPLAIN, so routing
+    everything through it would silently turn the console read-only. Row
+    policies constrain reads by definition, so the split costs nothing.
+    """
+    connector = _Connector()
+    db_tool = MagicMock()
+    svc = _service(monkeypatch, connector, db_tool)
+
+    svc._execute_sql_sync(ExecuteSQLInput(sql_query="CREATE VIEW v AS SELECT 1"), "task-2", {})
+
+    db_tool.execute_read_enforced.assert_not_called()
+    assert connector.executed == ["CREATE VIEW v AS SELECT 1"]
+
+
+def test_a_multi_statement_selection_keeps_working(monkeypatch):
+    """ "Execute Statement" over a selection holding two statements.
+
+    The enforced path rejects those outright, which would have broken a normal
+    editor gesture.
+    """
+    connector = _Connector()
+    svc = _service(monkeypatch, connector, MagicMock())
+
+    svc._execute_sql_sync(ExecuteSQLInput(sql_query="SELECT 1; SELECT 2"), "task-3", {})
+
+    assert connector.executed == ["SELECT 1; SELECT 2"]
+
+
+@pytest.mark.parametrize("sql", ["SHOW TABLES", "DESCRIBE orders", "EXPLAIN SELECT 1"])
+def test_metadata_reads_are_enforced_too(monkeypatch, sql):
+    connector = _Connector()
+    db_tool = MagicMock()
+    db_tool.execute_read_enforced.return_value = SimpleNamespace(success=True, sql_return=[], error=None, sql_query=sql)
+    svc = _service(monkeypatch, connector, db_tool)
+
+    svc._execute_sql_sync(ExecuteSQLInput(sql_query=sql), "task-4", {})
+
+    db_tool.execute_read_enforced.assert_called_once()
+
+
+def test_the_tool_is_built_once(monkeypatch):
+    """Its constructor stands up a DBManager and three RAG indexes.
+
+    Paying that per click on Run is what the memo avoids.
+    """
+    svc = _service(monkeypatch, _Connector(), None)
+    built = []
+
+    class _Tool:
+        def __init__(self, **kwargs):
+            built.append(kwargs)
+
+    monkeypatch.setattr("datus.tools.func_tool.DBFuncTool", _Tool)
+
+    assert svc._db_tool() is svc._db_tool()
+    assert len(built) == 1
+    # No sub-agent name: `cli_sql` names nothing, and it feeds three RAG
+    # constructors whose scoped context would silently apply if a project ever
+    # had a sub-agent by that name.
+    assert "sub_agent_name" not in built[0]

--- a/tests/unit_tests/api/services/test_cli_service_policy.py
+++ b/tests/unit_tests/api/services/test_cli_service_policy.py
@@ -224,6 +224,6 @@ def test_read_detection_uses_a_dialect_sqlglot_knows(sql, reads):
     read" — so every write was refused on a policy-enabled project, plain
     `CREATE TABLE` included. Caught end-to-end, not by any unit test.
     """
-    from datus.api.services.cli_service import _write_reads_data
+    from datus.utils.sql_utils import write_statement_reads_data
 
-    assert _write_reads_data(sql, "postgresql") is reads
+    assert write_statement_reads_data(sql, "postgresql") is reads

--- a/tests/unit_tests/api/services/test_cli_service_policy.py
+++ b/tests/unit_tests/api/services/test_cli_service_policy.py
@@ -165,6 +165,12 @@ def test_unparseable_sql_does_not_reach_the_connector(monkeypatch):
     [
         "CREATE TABLE mine AS SELECT * FROM orders",
         "INSERT INTO mine SELECT * FROM orders",
+        # Legal Postgres, equivalent to the CTAS above, but sqlglot cannot
+        # parse it and hands back an opaque `Command` with no Select inside.
+        "CREATE TABLE mine AS TABLE orders",
+        # Parsed, but its source is a table reference rather than a Select —
+        # and `TO '/path'` / `TO PROGRAM` on a self-hosted PG is a real export.
+        "COPY orders TO '/tmp/orders.csv'",
     ],
 )
 def test_a_write_that_reads_is_refused_when_policies_exist(monkeypatch, sql):
@@ -204,6 +210,11 @@ def test_the_same_write_is_allowed_without_policies(monkeypatch):
         ("DELETE FROM mine WHERE id = 1", False),
         ("CREATE TABLE mine AS SELECT * FROM orders", True),
         ("INSERT INTO mine SELECT * FROM orders", True),
+        # `error_level=IGNORE` stops sqlglot raising on syntax it cannot place
+        # and returns a `Command` instead, so "no Select inside" says nothing
+        # about the statement. Both of these are full copies of `orders`.
+        ("CREATE TABLE mine AS TABLE orders", True),
+        ("COPY orders TO STDOUT", True),
     ],
 )
 def test_read_detection_uses_a_dialect_sqlglot_knows(sql, reads):

--- a/tests/unit_tests/api/services/test_cli_service_policy.py
+++ b/tests/unit_tests/api/services/test_cli_service_policy.py
@@ -5,6 +5,7 @@ so a project with a row filter on ``orders`` still answered a hand-written
 ``SELECT * FROM orders`` with every row.
 """
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -37,6 +38,7 @@ def _service(monkeypatch, connector, db_tool):
     svc.current_db_connector = connector
     svc.current_datasource = "warehouse"
     svc._db_tool_cache = db_tool
+    svc._db_tool_lock = threading.Lock()
     svc._sql_tasks = {}
     svc._sql_tasks_lock = MagicMock()
     svc._sql_tasks_lock.__enter__ = lambda *_: None
@@ -53,12 +55,14 @@ def test_a_read_goes_through_the_enforced_path(monkeypatch):
     )
     svc = _service(monkeypatch, connector, db_tool)
 
-    svc._execute_sql_sync(
+    result = svc._execute_sql_sync(
         ExecuteSQLInput(sql_query="SELECT * FROM orders"),
         "task-1",
         {"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}},
     )
 
+    # Not just "it was called": the enforced path has to be a working path.
+    assert result.success is True
     db_tool.execute_read_enforced.assert_called_once()
     kwargs = db_tool.execute_read_enforced.call_args.kwargs
     # The caller's context, not the service's: DatusService is cached per
@@ -158,6 +162,7 @@ def test_unparseable_sql_does_not_reach_the_connector(monkeypatch):
     svc._execute_sql_sync(ExecuteSQLInput(sql_query="SELEKT * FROM orders"), "t", {})
 
     assert connector.executed == []
+    db_tool.execute_read_enforced.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -171,6 +176,13 @@ def test_unparseable_sql_does_not_reach_the_connector(monkeypatch):
         # Parsed, but its source is a table reference rather than a Select —
         # and `TO '/path'` / `TO PROGRAM` on a self-hosted PG is a real export.
         "COPY orders TO '/tmp/orders.csv'",
+        # No Select node anywhere in these trees, and every one of them reads
+        # `orders`. MERGE's whole purpose is to read a source table.
+        "UPDATE mine SET amount = orders.amount FROM orders WHERE mine.id = orders.id",
+        "DELETE FROM mine USING orders WHERE mine.id = orders.id",
+        "MERGE INTO mine USING orders ON mine.id = orders.id WHEN MATCHED THEN UPDATE SET amount = 1",
+        # RETURNING hands the rows straight back to the caller.
+        "DELETE FROM orders WHERE amount > 0 RETURNING *",
     ],
 )
 def test_a_write_that_reads_is_refused_when_policies_exist(monkeypatch, sql):
@@ -215,6 +227,19 @@ def test_the_same_write_is_allowed_without_policies(monkeypatch):
         # about the statement. Both of these are full copies of `orders`.
         ("CREATE TABLE mine AS TABLE orders", True),
         ("COPY orders TO STDOUT", True),
+        # A source table with no subquery: the arg key differs per node
+        # (`from_` on Update, `using` on Delete/Merge)…
+        ("UPDATE mine SET a = orders.a FROM orders WHERE mine.id = orders.id", True),
+        ("DELETE FROM mine USING orders WHERE mine.id = orders.id", True),
+        ("MERGE INTO mine USING orders ON mine.id = orders.id WHEN MATCHED THEN UPDATE SET a = 1", True),
+        # …and `Delete.using` is present-but-empty on a plain DELETE, so a
+        # `is not None` test refused every `DELETE ... WHERE`.
+        ("DELETE FROM mine WHERE id = 1", False),
+        ("UPDATE mine SET a = 1 WHERE id = 2", False),
+        # Rows leaving through RETURNING are read by definition.
+        ("DELETE FROM orders RETURNING *", True),
+        ("UPDATE orders SET a = 1 RETURNING *", True),
+        ("INSERT INTO mine VALUES (1) RETURNING *", True),
     ],
 )
 def test_read_detection_uses_a_dialect_sqlglot_knows(sql, reads):

--- a/tests/unit_tests/api/services/test_cli_service_policy.py
+++ b/tests/unit_tests/api/services/test_cli_service_policy.py
@@ -194,3 +194,25 @@ def test_the_same_write_is_allowed_without_policies(monkeypatch):
     svc._execute_sql_sync(ExecuteSQLInput(sql_query="CREATE TABLE mine AS SELECT * FROM orders"), "t", {})
 
     assert connector.executed == ["CREATE TABLE mine AS SELECT * FROM orders"]
+
+
+@pytest.mark.parametrize(
+    "sql,reads",
+    [
+        ("CREATE TABLE plain_t (id int)", False),
+        ("SET search_path TO other", False),
+        ("DELETE FROM mine WHERE id = 1", False),
+        ("CREATE TABLE mine AS SELECT * FROM orders", True),
+        ("INSERT INTO mine SELECT * FROM orders", True),
+    ],
+)
+def test_read_detection_uses_a_dialect_sqlglot_knows(sql, reads):
+    """Connectors report `postgresql`; sqlglot only knows `postgres`.
+
+    Handing the raw name over raises, which this helper reads as "contains a
+    read" — so every write was refused on a policy-enabled project, plain
+    `CREATE TABLE` included. Caught end-to-end, not by any unit test.
+    """
+    from datus.api.services.cli_service import _write_reads_data
+
+    assert _write_reads_data(sql, "postgresql") is reads

--- a/tests/unit_tests/api/services/test_cli_service_policy.py
+++ b/tests/unit_tests/api/services/test_cli_service_policy.py
@@ -227,15 +227,21 @@ def test_the_same_write_is_allowed_without_policies(monkeypatch):
         # about the statement. Both of these are full copies of `orders`.
         ("CREATE TABLE mine AS TABLE orders", True),
         ("COPY orders TO STDOUT", True),
-        # A source table with no subquery: the arg key differs per node
-        # (`from_` on Update, `using` on Delete/Merge)…
+        # A source table with no subquery. Detected by counting tables, not by
+        # reading a named argument: the argument moved between sqlglot
+        # releases, so keying on `Update.args["from_"]` passed locally and let
+        # the first of these straight through on CI.
         ("UPDATE mine SET a = orders.a FROM orders WHERE mine.id = orders.id", True),
         ("DELETE FROM mine USING orders WHERE mine.id = orders.id", True),
         ("MERGE INTO mine USING orders ON mine.id = orders.id WHEN MATCHED THEN UPDATE SET a = 1", True),
-        # …and `Delete.using` is present-but-empty on a plain DELETE, so a
-        # `is not None` test refused every `DELETE ... WHERE`.
+        # One target table is not a read, however many columns it sets.
         ("DELETE FROM mine WHERE id = 1", False),
         ("UPDATE mine SET a = 1 WHERE id = 2", False),
+        ("UPDATE mine SET a = 1, b = 2 WHERE id = 3", False),
+        # DDL naming two tables reads no rows — the count rule is scoped to
+        # DML so these stay allowed.
+        ("ALTER TABLE mine RENAME TO mine_old", False),
+        ("CREATE TABLE mine (LIKE orders)", False),
         # Rows leaving through RETURNING are read by definition.
         ("DELETE FROM orders RETURNING *", True),
         ("UPDATE orders SET a = 1 RETURNING *", True),

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -2083,3 +2083,78 @@ class TestDBFuncToolGuardEstimatedRows:
         tool = self._make_tool(connector)
 
         assert tool.guard_estimated_rows("SELECT 1", connector) is None
+
+
+class TestExecuteSqlWriteLaundering:
+    """A write that carries a read must not run while a policy context exists.
+
+    `execute_sql` routes reads through `execute_read_enforced`, where the plugin
+    rewrites them — but DML and DDL went straight to the connector. So a caller
+    restricted to two stores could ask chat for
+    `CREATE TABLE mine AS SELECT * FROM orders` and end up owning every row the
+    policy withholds, in a table no policy covers. Found end-to-end, not by any
+    unit test: the console path had the same hole and was fixed on its own.
+    """
+
+    def _tool(self, connector, policy_context):
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as rag,
+            patch("datus.tools.func_tool.database.SemanticModelRAG") as sem,
+        ):
+            rag.return_value.schema_store.table_size.return_value = 0
+            sem.return_value.get_size.return_value = 0
+            config = Mock()
+            config.active_model.return_value.model = "gpt-4o"
+            config.policy_context = policy_context
+            tool = DBFuncTool(connector, agent_config=config)
+        return tool
+
+    def _connector(self):
+        c = Mock()
+        c.dialect = "postgresql"
+        c.get_databases.return_value = []
+        c.execute_ddl.return_value = Mock(success=True)
+        c.execute_insert.return_value = Mock(success=True, row_count=1)
+        return c
+
+    SCOPED = {"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}}
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "CREATE TABLE mine AS SELECT * FROM orders",
+            "INSERT INTO mine SELECT * FROM orders",
+            # sqlglot cannot parse this and returns an opaque Command.
+            "CREATE TABLE mine AS TABLE orders",
+            "COPY orders TO '/tmp/orders.csv'",
+        ],
+    )
+    def test_a_write_that_reads_is_refused(self, sql):
+        connector = self._connector()
+        tool = self._tool(connector, self.SCOPED)
+
+        result = tool.execute_sql(sql)
+
+        assert result.success == 0
+        assert "row-level policies" in result.error
+        connector.execute_ddl.assert_not_called()
+        connector.execute_insert.assert_not_called()
+
+    def test_a_plain_write_still_runs(self):
+        """Enabling a policy must not turn the agent read-only."""
+        connector = self._connector()
+        tool = self._tool(connector, self.SCOPED)
+
+        result = tool.execute_sql("CREATE TABLE plain_t (id int)")
+
+        assert result.success == 1
+        connector.execute_ddl.assert_called_once()
+
+    def test_without_policies_the_same_write_is_allowed(self):
+        connector = self._connector()
+        tool = self._tool(connector, {})
+
+        result = tool.execute_sql("CREATE TABLE mine AS SELECT * FROM orders")
+
+        assert result.success == 1
+        connector.execute_ddl.assert_called_once()

--- a/tests/unit_tests/tools/test_policy_runtime.py
+++ b/tests/unit_tests/tools/test_policy_runtime.py
@@ -225,3 +225,60 @@ def test_db_rejects_empty_policy_rewrite(monkeypatch):
     assert not result.success
     assert "Only read-only queries" in result.error
     db.execute_query.assert_not_called()
+
+
+class TestDenialExplanation:
+    """SaaS knows why a caller was denied; the plugin does not.
+
+    A plugin can only report that context validation failed. "Policy context
+    denies all data reads" is true and useless: the reader cannot tell a gap in
+    their own profile from a misconfigured policy, and has nothing to ask for.
+    Datus-backend attaches the reason to the context under a key the plugins
+    ignore, and it is appended here.
+    """
+
+    DENIED = {
+        "row_filter": {"access_mode": "denied"},
+        "x_saas_denial": "you have no value for store_ids, which this project's row policies filter by.",
+    }
+
+    def test_validate_context_appends_it(self, monkeypatch):
+        rt = runtime_with(FakeRuntime(allowed=False, reason="Policy context denies all data reads"), monkeypatch)
+
+        decision = rt.validate_context(self.DENIED)
+
+        assert decision.allowed is False
+        assert "denies all data reads" in decision.reason
+        assert "store_ids" in decision.reason
+
+    def test_before_sql_read_appends_it(self, monkeypatch):
+        rt = runtime_with(FakeRuntime(allowed=False, reason="Policy context denies all data reads"), monkeypatch)
+
+        decision = rt.before_sql_read(
+            "SELECT * FROM orders", datasource="w", dialect="postgres", policy_context=self.DENIED
+        )
+
+        assert decision.allowed is False
+        assert "store_ids" in decision.reason
+
+    def test_without_the_key_the_reason_is_untouched(self, monkeypatch):
+        rt = runtime_with(FakeRuntime(allowed=False, reason="Policy context denies all data reads"), monkeypatch)
+
+        decision = rt.validate_context({"row_filter": {"access_mode": "denied"}})
+
+        assert decision.reason == "Policy context denies all data reads"
+
+    @pytest.mark.parametrize("junk", [None, "", "   ", 42, {"a": 1}])
+    def test_a_malformed_key_is_ignored(self, monkeypatch, junk):
+        """It arrives over the wire; it must not be able to break a refusal."""
+        rt = runtime_with(FakeRuntime(allowed=False, reason="denied"), monkeypatch)
+
+        decision = rt.validate_context({"row_filter": {"access_mode": "denied"}, "x_saas_denial": junk})
+
+        assert decision.allowed is False
+        assert decision.reason == "denied"
+
+    def test_an_allowed_context_is_unaffected(self, monkeypatch):
+        rt = runtime_with(FakeRuntime(), monkeypatch)
+
+        assert rt.validate_context(self.DENIED).allowed is True

--- a/tests/unit_tests/utils/test_sql_utils.py
+++ b/tests/unit_tests/utils/test_sql_utils.py
@@ -17,6 +17,7 @@ from datus.utils.sql_utils import (
     _metadata_pattern,
     extract_table_names,
     format_sql_to_pretty,
+    is_single_statement,
     looks_like_sql_file_ref,
     metadata_identifier,
     normalize_sql,
@@ -1868,3 +1869,43 @@ class TestTableNameFieldOrder:
         assert parsed["table_name"] == "*"
         for field in order[:-2]:
             assert parsed[field] == ""
+
+
+class TestStripSqlCommentsRespectsLiterals:
+    """A comment marker inside a string literal is not a comment.
+
+    The regex version cut `SELECT 'a--b' FROM t` down to `SELECT 'a` — and
+    `execute_ddl` / `execute_write` run the *stripped* text, so the truncation
+    reached the database rather than staying a parsing detail.
+    """
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT 'a--b' FROM t",
+            "SELECT 'a/*b*/c' FROM t",
+            'SELECT "col--x" FROM t',
+            "SELECT 'it''s--ok' FROM t",
+            "INSERT INTO t VALUES ('x;y')",
+            "SELECT $$a--b$$",
+            "COMMENT ON TABLE t IS 'a/*b*/c'",
+        ],
+    )
+    def test_markers_inside_literals_survive(self, sql):
+        assert strip_sql_comments(sql) == sql
+
+    @pytest.mark.parametrize(
+        "sql,expected",
+        [
+            ("SELECT 1 -- trailing\nFROM t", "SELECT 1  \nFROM t"),
+            ("SELECT /* mid */ 1", "SELECT   1"),
+            ("SELECT 1 -- unterminated", "SELECT 1  "),
+            ("SELECT /* unterminated 1", "SELECT  "),
+        ],
+    )
+    def test_real_comments_are_still_removed(self, sql, expected):
+        assert strip_sql_comments(sql) == expected
+
+    def test_a_semicolon_in_a_literal_is_not_a_second_statement(self):
+        assert is_single_statement("SELECT 'a;b' FROM t") is True
+        assert is_single_statement("SELECT 1; SELECT 2") is False


### PR DESCRIPTION
## Why

`cli_service._execute_sql_sync` called `self.current_db_connector.execute(...)` directly — no `execute_read_enforced`, no policy runtime on the path.

`POST /api/v1/sql/execute` is what the IDE's SQL panel posts to. With a `row_filter` on `orders`, any member who could open the IDE could type `SELECT * FROM orders` and get every row, while every other read path on the project was filtered and the project presented itself as protected.

Found reviewing the SaaS-side configuration surface: [Datus-saas#849](https://github.com/Datus-ai/Datus-saas/pull/849) / [Datus-backend#418](https://github.com/Datus-ai/Datus-backend/pull/418).

## Solution

Reads go through `DBFuncTool.execute_read_enforced` — the same entry point the agent's own DB tools use, so the two cannot drift. Writes keep the connector's dispatch, because the enforced path admits only SELECT / SHOW / DESCRIBE / EXPLAIN and would otherwise turn the console read-only.

**The split is on the statement type, not on "did the read-only validator object".** That distinction is the whole fix. `validate_read_only_sql` reports a violation for three different things:

| input | violation | type |
| --- | --- | --- |
| `SELECT 1; SELECT * FROM orders` | `multi_statement` | UNKNOWN |
| `SELEKT * FROM orders` | `non_read` | UNKNOWN |
| `CREATE TABLE mine AS SELECT …` | `non_read` | DDL |

Routing "the validator objected" to the connector therefore hands over two one-token bypasses — psycopg2 runs both statements and returns the last result set, and any syntax sqlglot cannot place stops being filtered, which was fail-closed before. So only a **positively identified, single** write statement reaches the connector; reads, multi-statement and UNKNOWN all meet the enforced path, where multi-statement is refused exactly as it always was.

**Writes can carry reads.** `CREATE TABLE mine AS SELECT * FROM orders` and `INSERT INTO mine SELECT …` copy the rows a policy just filtered into a table no policy covers, and the plugin cannot help — it hooks reads. On a project that has a policy context at all, a write containing a query is refused here. Unparseable counts as containing one: being wrong that way costs a rejected statement, the other way costs a silent copy of exactly the rows the policy exists to withhold.

**Context comes from the request.** `DatusService` is cached per project and shared, so its `AgentConfig.policy_context` is empty — only `chat_task_manager.start_chat` pins one, on a `deepcopy`. The route reads `AppContextDep`; the parameter defaults to `None` so any non-HTTP caller keeps the tool's own fallback.

**The tool is built once per service.** Its constructor stands up a `DBManager`, binds the connector and initialises three RAG indexes, sizing two. Paying that per click on Run is what the memo avoids. No `sub_agent_name` is passed — `cli_sql` names nothing today, and it feeds three RAG constructors whose scoped context would silently apply if a project ever had a sub-agent by that name.

### Not fixed here, on purpose

- `datus-backend`'s `_READ_ONLY_WRITE_METHOD_PATHS` lists `/api/v1/sql/execute` as allowed for viewers, so a read-only member can run DDL/DML from the console. Predates this PR, orthogonal to row policies, and routing everything through the enforced path would have masked it as a side effect.
- **Write access remains equivalent to full read access** for anything not covered by the CTAS/INSERT refusal above (a user with write can stage data in ways no read hook sees). Recorded in the SaaS design doc rather than papered over.

## Test Cases

`tests/unit_tests/api/services/test_cli_service_policy.py`, 11 cases:

- a read reaches `execute_read_enforced` carrying the **caller's** context, and never the connector
- `SHOW` / `DESCRIBE` / `EXPLAIN` likewise (parametrised)
- a plain write (`CREATE VIEW`) keeps the connector path
- **multi-statement never reaches the connector** — the bypass an earlier revision of this PR would have shipped
- **unparseable SQL never reaches the connector**
- CTAS and `INSERT … SELECT` are refused when a policy context is present (parametrised), and the same statement still runs when there is none
- the tool is constructed once, without a `sub_agent_name`

**Red first, verified.** With `datus/api/services/cli_service.py` + `datus/api/routes/cli_routes.py` stashed, the four bypass cases fail and pass again once restored.

Full `tests/unit_tests`: 17836 passed, 8 failed — the same 8 fail on the unmodified tree (`test_compress_utils`, `gen_sql_summary` artifact cases), so they are unrelated.

No integration/nightly cases: what is under test is which execution path a statement takes, observable at the service boundary without a live database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL execution now applies access policies to reads, metadata queries, and asynchronous requests.
  * Ordinary single-statement write operations can execute directly for improved responsiveness.
  * Policy guidance now recommends using database-side views and derived tables for protected data.
* **Bug Fixes**
  * Multi-statement and unrecognized SQL use policy enforcement.
  * Writes that read protected data are rejected when policies apply.
  * SQL statements are interpreted consistently across supported dialects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
