### PR TITLE
[BugFix] Route scoped table matching through the active connector

### DIFF
--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -579,6 +579,7 @@ class DBFuncTool:
             return None
         dialect = getattr(self._primary_connector, "dialect", "") or ""
         parsed = parse_table_name_parts(token, dialect)
+        parsed = self._normalize_parsed_namespaces(parsed, self._primary_connector, dialect)
         if not parsed.get("table_name"):
             return None
         values = {
@@ -588,6 +589,22 @@ class DBFuncTool:
             "table": parsed.get("table_name", ""),
         }
         return ScopedTablePattern(raw=token, **values)
+
+    @staticmethod
+    def _normalize_parsed_namespaces(
+        parsed: Dict[str, str], connector: BaseSqlConnector, dialect: str
+    ) -> Dict[str, str]:
+        """Align generic parser output with the connector's namespace model."""
+        if (
+            parsed.get("schema_name")
+            and not parsed.get("database_name")
+            and supports_namespace("database", connector=connector, dialect=dialect)
+            and not supports_namespace("schema", connector=connector, dialect=dialect)
+        ):
+            parsed = dict(parsed)
+            parsed["database_name"] = parsed["schema_name"]
+            parsed["schema_name"] = ""
+        return parsed
 
     def _get_semantic_model(
         self, catalog: str = "", database: str = "", schema: str = "", table_name: str = ""
@@ -879,18 +896,7 @@ class DBFuncTool:
         )
         dialect = getattr(routed_connector, "dialect", "") or ""
         parsed = parse_table_name_parts(raw_name, dialect)
-        # Some database-only adapters (notably Hive) advertise capabilities on
-        # the connector while the generic parser lacks matching registry
-        # metadata. It then right-aligns ``database.table`` as ``schema.table``.
-        # Move that namespace back so the connector default cannot override it.
-        if (
-            parsed.get("schema_name")
-            and not parsed.get("database_name")
-            and supports_namespace("database", connector=routed_connector, dialect=dialect)
-            and not supports_namespace("schema", connector=routed_connector, dialect=dialect)
-        ):
-            parsed["database_name"] = parsed["schema_name"]
-            parsed["schema_name"] = ""
+        parsed = self._normalize_parsed_namespaces(parsed, routed_connector, dialect)
         for field, parsed_field in (
             ("catalog", "catalog_name"),
             ("database", "database_name"),

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -879,6 +879,18 @@ class DBFuncTool:
         )
         dialect = getattr(routed_connector, "dialect", "") or ""
         parsed = parse_table_name_parts(raw_name, dialect)
+        # Some database-only adapters (notably Hive) advertise capabilities on
+        # the connector while the generic parser lacks matching registry
+        # metadata. It then right-aligns ``database.table`` as ``schema.table``.
+        # Move that namespace back so the connector default cannot override it.
+        if (
+            parsed.get("schema_name")
+            and not parsed.get("database_name")
+            and supports_namespace("database", connector=routed_connector, dialect=dialect)
+            and not supports_namespace("schema", connector=routed_connector, dialect=dialect)
+        ):
+            parsed["database_name"] = parsed["schema_name"]
+            parsed["schema_name"] = ""
         for field, parsed_field in (
             ("catalog", "catalog_name"),
             ("database", "database_name"),

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -573,13 +573,16 @@ class DBFuncTool:
         except Exception:
             return None
 
-    def _parse_scope_token(self, token: str) -> Optional[ScopedTablePattern]:
+    def _parse_scope_token(
+        self, token: str, connector: Optional[BaseSqlConnector] = None
+    ) -> Optional[ScopedTablePattern]:
         token = (token or "").strip()
         if not token:
             return None
-        dialect = getattr(self._primary_connector, "dialect", "") or ""
+        routed_connector = connector or self._primary_connector
+        dialect = getattr(routed_connector, "dialect", "") or ""
         parsed = parse_table_name_parts(token, dialect)
-        parsed = self._normalize_parsed_namespaces(parsed, self._primary_connector, dialect)
+        parsed = self._normalize_parsed_namespaces(parsed, routed_connector, dialect)
         if not parsed.get("table_name"):
             return None
         values = {
@@ -907,10 +910,17 @@ class DBFuncTool:
                 setattr(coordinate, field, self._normalize_identifier_part(parsed[parsed_field]))
         return coordinate
 
-    def _table_matches_scope(self, coordinate: TableCoordinate) -> bool:
+    def _table_matches_scope(self, coordinate: TableCoordinate, connector: Optional[BaseSqlConnector] = None) -> bool:
         if not self._scoped_patterns:
             return True
-        return any(pattern.matches(coordinate) for pattern in self._scoped_patterns)
+        patterns = self._scoped_patterns
+        if connector is not None:
+            patterns = []
+            for pattern in self._scoped_patterns:
+                routed_pattern = self._parse_scope_token(pattern.raw, connector)
+                if routed_pattern is not None:
+                    patterns.append(routed_pattern)
+        return any(pattern.matches(coordinate) for pattern in patterns)
 
     def _filter_table_entries(
         self,
@@ -932,7 +942,7 @@ class DBFuncTool:
                 schema=schema,
                 connector=connector,
             )
-            if self._table_matches_scope(coordinate):
+            if self._table_matches_scope(coordinate, connector=connector):
                 filtered.append(entry)
         return filtered
 
@@ -992,7 +1002,7 @@ class DBFuncTool:
         out_of_scope: List[str] = []
         for name in table_names:
             coordinate = self._build_table_coordinate(raw_name=name, connector=routed_connector)
-            if not self._table_matches_scope(coordinate):
+            if not self._table_matches_scope(coordinate, connector=routed_connector):
                 out_of_scope.append(name)
         return out_of_scope
 
@@ -1403,7 +1413,7 @@ class DBFuncTool:
                 connector=connector,
             )
 
-            if not self._table_matches_scope(coordinate):
+            if not self._table_matches_scope(coordinate, connector=connector):
                 error_msg = f"Table '{table_name}' is outside the scoped context."
                 logger.warning(error_msg)
                 return FuncToolResult(
@@ -1943,7 +1953,7 @@ class DBFuncTool:
                 schema=schema_name,
                 connector=connector,
             )
-            if not self._table_matches_scope(coordinate):
+            if not self._table_matches_scope(coordinate, connector=connector):
                 return FuncToolResult(
                     success=0,
                     error=f"Table '{table_name}' is outside the scoped context.",

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -155,6 +155,26 @@ class TestDBFuncToolTableCoordinates:
 
         assert (coordinate.database, coordinate.schema, coordinate.table) == expected
 
+    def test_database_only_scope_rejects_another_database(self):
+        class Connector:
+            dialect = "hive"
+
+            @staticmethod
+            def get_effective_capabilities():
+                return {"database"}
+
+        connector = Connector()
+        tool = object.__new__(DBFuncTool)
+        tool._primary_connector = connector
+        tool._field_order = ["database", "table"]
+        pattern = tool._parse_scope_token("dwd.*")
+        tool._scoped_patterns = [pattern]
+
+        assert pattern.database == "dwd"
+        assert pattern.schema == ""
+        assert tool._table_matches_scope(tool._build_table_coordinate("dwd.events", connector=connector))
+        assert not tool._table_matches_scope(tool._build_table_coordinate("other.events", connector=connector))
+
 
 class TestDBFuncToolExecuteDDL:
     """Tests for DBFuncTool.execute_ddl method."""

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -107,6 +107,55 @@ class TestDBFuncToolCompressorModelName:
         assert tool._table_semantic_profiles is None
 
 
+class TestDBFuncToolTableCoordinates:
+    @pytest.mark.parametrize(
+        ("capabilities", "field_order", "raw_name", "defaults", "expected"),
+        [
+            (
+                {"database"},
+                ["database", "table"],
+                "dwd.dwd_dim_user_a_day",
+                {"database": "ods"},
+                ("dwd", "", "dwd_dim_user_a_day"),
+            ),
+            (
+                {"schema"},
+                ["schema", "table"],
+                "analytics.events",
+                {"schema": "public"},
+                ("", "analytics", "events"),
+            ),
+            (
+                {"database", "schema"},
+                ["database", "schema", "table"],
+                "warehouse.analytics.events",
+                {"database": "default", "schema": "public"},
+                ("warehouse", "analytics", "events"),
+            ),
+            (
+                {"database"},
+                ["database", "table"],
+                "events",
+                {"database": "ods"},
+                ("ods", "", "events"),
+            ),
+        ],
+    )
+    def test_qualified_names_follow_connector_namespaces(self, capabilities, field_order, raw_name, defaults, expected):
+        class Connector:
+            dialect = "hive"
+
+            def get_effective_capabilities(self):
+                return capabilities
+
+        connector = Connector()
+        tool = object.__new__(DBFuncTool)
+        tool._field_order = field_order
+        coordinate = tool._build_table_coordinate(raw_name, connector=connector, **defaults)
+
+        assert (coordinate.database, coordinate.schema, coordinate.table) == expected
+
+
 class TestDBFuncToolExecuteDDL:
     """Tests for DBFuncTool.execute_ddl method."""
 

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -141,11 +141,18 @@ class TestDBFuncToolTableCoordinates:
             ),
         ],
     )
-    def test_qualified_names_follow_connector_namespaces(self, capabilities, field_order, raw_name, defaults, expected):
+    def test_qualified_names_follow_connector_namespaces(
+        self,
+        capabilities: set[str],
+        field_order: list[str],
+        raw_name: str,
+        defaults: dict[str, str],
+        expected: tuple[str, str, str],
+    ) -> None:
         class Connector:
-            dialect = "hive"
+            dialect: str = "hive"
 
-            def get_effective_capabilities(self):
+            def get_effective_capabilities(self) -> set[str]:
                 return capabilities
 
         connector = Connector()
@@ -155,12 +162,12 @@ class TestDBFuncToolTableCoordinates:
 
         assert (coordinate.database, coordinate.schema, coordinate.table) == expected
 
-    def test_database_only_scope_rejects_another_database(self):
+    def test_database_only_scope_rejects_another_database(self) -> None:
         class Connector:
-            dialect = "hive"
+            dialect: str = "hive"
 
             @staticmethod
-            def get_effective_capabilities():
+            def get_effective_capabilities() -> set[str]:
                 return {"database"}
 
         connector = Connector()
@@ -172,8 +179,36 @@ class TestDBFuncToolTableCoordinates:
 
         assert pattern.database == "dwd"
         assert pattern.schema == ""
-        assert tool._table_matches_scope(tool._build_table_coordinate("dwd.events", connector=connector))
-        assert not tool._table_matches_scope(tool._build_table_coordinate("other.events", connector=connector))
+        assert tool._table_matches_scope(
+            tool._build_table_coordinate("dwd.events", connector=connector), connector=connector
+        )
+        assert not tool._table_matches_scope(
+            tool._build_table_coordinate("other.events", connector=connector), connector=connector
+        )
+
+    def test_scope_uses_routed_connector_namespaces(self) -> None:
+        class SchemaConnector:
+            dialect: str = "postgres"
+
+            @staticmethod
+            def get_effective_capabilities() -> set[str]:
+                return {"schema"}
+
+        class DatabaseConnector:
+            dialect: str = "hive"
+
+            @staticmethod
+            def get_effective_capabilities() -> set[str]:
+                return {"database"}
+
+        tool = object.__new__(DBFuncTool)
+        tool._primary_connector = SchemaConnector()
+        tool._field_order = ["schema", "table"]
+        tool._scoped_patterns = [tool._parse_scope_token("dwd.*")]
+        routed_connector = DatabaseConnector()
+        coordinate = tool._build_table_coordinate("other.events", connector=routed_connector)
+
+        assert not tool._table_matches_scope(coordinate, connector=routed_connector)
 
 
 class TestDBFuncToolExecuteDDL:


### PR DESCRIPTION
## Why

Scoped table patterns are parsed against the primary connector, while table coordinates can be parsed with the connector routed for each request. In a multi-connector deployment, the same namespace token can therefore be interpreted differently by the scope and by the coordinate being checked.

Related to #1317. Depends on Datus-ai/datus-db-adapters#111 for the Hive root-cause fix.

## Current patch

This Draft routes table-level scope-pattern parsing through the active connector so the pattern and coordinate can use the same connector capabilities.

It does not change the Hive adapter's declared capabilities and does not fix #1317 by itself. Review also identified remaining work before this generic change could be merge-ready: database/schema-level scope checks still use primary-connector patterns, the routing test needs a production-realistic behavior failure on the base revision, and routed-pattern caching and fail-closed diagnostics need a bounded design.

## Validation recorded for this branch

- `python -m pytest tests/unit_tests/tools/func_tool/test_database.py -q`: 165 passed.
- `python -m pytest tests/integration/tools/test_mcp_server.py -q`: 52 passed.
- `ruff format --check` and `ruff check` for both changed files: passed.
- `python ci/audit_tests.py --repo-root . --diff-only upstream/main`: P0=0, P1=0.
- `tests/integration/tools/test_func_tools_db.py`: 38 passed with 3 missing-local-datasource setup errors, identical on the base and patched snapshots.

These checks establish repository compatibility but do not establish that the current Draft fixes the published Hive path. The full Windows run recorded 1937 passed and 7 skipped; remaining baseline failures/errors involved Windows symlink privileges, WSL/bash path translation, local encoding/fixtures, and concurrent LanceDB temporary writes.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0