### PR TITLE
[BugFix] Stop the bang-node warm-up from clobbering a running chat session

### DIFF
--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -13,6 +13,7 @@ import json
 import platform
 import re
 import subprocess
+import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
@@ -117,6 +118,15 @@ class ChatCommands:
         # Chat state management - unified node management
         self.current_node: ChatAgenticNode | None = None  # Can be ChatAgenticNode or GenSQLAgenticNode
         self.current_subagent_name: str | None = None  # Track current subagent name
+        # Serializes every ``current_node`` check-create-publish sequence.
+        # ``DatusCLI._warm_bang_node`` builds the default node from the
+        # background init thread while the input thread may start a chat turn,
+        # and node construction takes long enough (tool setup, skill/web/MCP
+        # mounting) for both to observe ``current_node is None`` and each
+        # publish its own node — the later writer then orphans the session the
+        # running turn is streaming into. Reentrant so a holder can call the
+        # nested node helpers.
+        self._node_lock = threading.RLock()
         self.chat_history = []
         self.last_actions = []
         self.all_turn_actions: List[Tuple[str, List[ActionHistory]]] = []
@@ -148,6 +158,19 @@ class ChatCommands:
             if hasattr(self.current_node, "active_database"):
                 self.current_node.active_database = getattr(self.cli.cli_context, "current_db_name", "") or ""
             self.current_node.setup_tools()
+
+    @contextmanager
+    def node_transaction(self):
+        """Hold the node lock across a check-create-publish of ``current_node``.
+
+        Every caller that decides whether to build a node and then publishes
+        the result must run inside this block, so a concurrent builder either
+        waits and reuses the published node or observes the decision that won.
+        Callers outside this module (the web executor) use it too — the lock
+        itself stays private.
+        """
+        with self._node_lock:
+            yield
 
     def _should_create_new_node(self, subagent_name: str = None) -> bool:
         """Determine if a new node should be created."""
@@ -261,26 +284,36 @@ class ChatCommands:
         ``self.current_node``, so ``!`` autocomplete lists the complete tool set
         and never observes a half-mounted node. Returns ``None`` when node
         construction fails.
+
+        Runs under :meth:`node_transaction` because this is the one caller that
+        builds a node nobody asked for yet: a chat turn starting concurrently
+        must never have its own node replaced by this warm-up. The publish is
+        therefore also re-checked — a turn that won the race keeps its node and
+        the warm one is dropped.
         """
-        if self.current_node is not None:
+        with self.node_transaction():
+            if self.current_node is not None:
+                return self.current_node
+            try:
+                node = self._create_new_node(None)
+                if hasattr(node, "active_database"):
+                    node.active_database = getattr(self.cli.cli_context, "current_db_name", "") or ""
+                if hasattr(node, "setup_tools"):
+                    node.setup_tools()
+                # Mount the tools that are otherwise injected lazily during a turn
+                # (skill / bash / memory / web) so the ``!`` list is complete.
+                if hasattr(node, "_ensure_lazy_tools_mounted"):
+                    node._ensure_lazy_tools_mounted()
+                if self.current_node is not None:
+                    logger.debug("Bang-node warm dropped: a chat turn published its own node first")
+                    return self.current_node
+                self.current_subagent_name = None
+                self.current_node = node
+            except Exception as exc:  # noqa: BLE001 - never crash the REPL on a ! call
+                logger.error(f"Failed to create chat node for '!' tool execution: {exc}", exc_info=True)
+                self.current_node = None
+                return None
             return self.current_node
-        try:
-            node = self._create_new_node(None)
-            if hasattr(node, "active_database"):
-                node.active_database = getattr(self.cli.cli_context, "current_db_name", "") or ""
-            if hasattr(node, "setup_tools"):
-                node.setup_tools()
-            # Mount the tools that are otherwise injected lazily during a turn
-            # (skill / bash / memory / web) so the ``!`` list is complete.
-            if hasattr(node, "_ensure_lazy_tools_mounted"):
-                node._ensure_lazy_tools_mounted()
-            self.current_subagent_name = None
-            self.current_node = node
-        except Exception as exc:  # noqa: BLE001 - never crash the REPL on a ! call
-            logger.error(f"Failed to create chat node for '!' tool execution: {exc}", exc_info=True)
-            self.current_node = None
-            return None
-        return self.current_node
 
     def create_node_input(
         self,
@@ -478,43 +511,49 @@ class ChatCommands:
                     message = self._render_agent_dispatch_hint(message, at_agent)
 
             if interactive:
-                # Decision logic: determine if we need to create a new node
-                need_new_node = self._should_create_new_node(subagent_name)
-                is_switch = self._is_agent_switch(subagent_name)
+                # The decision and the publish share one lock hold: a
+                # background ``!`` warm-up must not slip a node in between
+                # ``_should_create_new_node`` and the assignment below, nor
+                # replace this turn's node once it is published.
+                with self.node_transaction():
+                    # Decision logic: determine if we need to create a new node
+                    need_new_node = self._should_create_new_node(subagent_name)
+                    is_switch = self._is_agent_switch(subagent_name)
 
-                # Get or create node
-                if need_new_node:
-                    # Copy session when switching agents to preserve conversation
-                    # while keeping the session_id prefix consistent with the new
-                    # node type. The copy runs *before* construction so the new
-                    # node opens the cloned .db directly — no post-construct mutation.
-                    from datus.agent.node.node_factory import resolve_node_name
+                    # Get or create node
+                    if need_new_node:
+                        # Copy session when switching agents to preserve conversation
+                        # while keeping the session_id prefix consistent with the new
+                        # node type. The copy runs *before* construction so the new
+                        # node opens the cloned .db directly — no post-construct mutation.
+                        from datus.agent.node.node_factory import resolve_node_name
 
-                    prev_session_id = None
-                    prev_node_name = None
-                    new_session_id: Optional[str] = None
-                    if is_switch and self.current_node:
-                        prev_session_id = getattr(self.current_node, "session_id", None)
-                        prev_node_name = self.current_node.get_node_name()
-                    if prev_session_id:
-                        new_session_id = self._copy_session_for_switch(
-                            prev_session_id, resolve_node_name(subagent_name)
-                        )
-                    self.current_node = self._create_new_node(subagent_name, session_id=new_session_id)
-                    if prev_node_name:
-                        # Pass the previous node's name explicitly so downstream
-                        # nodes (e.g. feedback) can route memory to the caller
-                        # without having to parse the session id prefix.
-                        self.current_node.caller_node_name = prev_node_name
-                    self.current_subagent_name = subagent_name if subagent_name else None
-                    if not is_switch:
-                        self.all_turn_actions = []
+                        prev_session_id = None
+                        prev_node_name = None
+                        new_session_id: Optional[str] = None
+                        if is_switch and self.current_node:
+                            prev_session_id = getattr(self.current_node, "session_id", None)
+                            prev_node_name = self.current_node.get_node_name()
+                        if prev_session_id:
+                            new_session_id = self._copy_session_for_switch(
+                                prev_session_id, resolve_node_name(subagent_name)
+                            )
+                        self.current_node = self._create_new_node(subagent_name, session_id=new_session_id)
+                        if prev_node_name:
+                            # Pass the previous node's name explicitly so downstream
+                            # nodes (e.g. feedback) can route memory to the caller
+                            # without having to parse the session id prefix.
+                            self.current_node.caller_node_name = prev_node_name
+                        self.current_subagent_name = subagent_name if subagent_name else None
+                        if not is_switch:
+                            self.all_turn_actions = []
 
-                current_node = self.current_node
+                    current_node = self.current_node
             else:
                 # Non-interactive: always create a new node
-                self.current_node = self._create_new_node(None)
-                current_node = self.current_node
+                with self.node_transaction():
+                    self.current_node = self._create_new_node(None)
+                    current_node = self.current_node
 
             # Ensure the node has a pending-input queue so the TUI Enter
             # handler, the API ``/insert`` route, and the model layer's
@@ -1508,19 +1547,20 @@ class ChatCommands:
         self.console.clear()
 
         # Clear current session
-        if self.current_node:
-            try:
-                self.current_node.delete_session()
-                self.console.print("[green]Console and current session cleared.[/]")
-            except Exception as e:
-                logger.error(f"Error deleting session: {e}")
+        with self.node_transaction():
+            if self.current_node:
+                try:
+                    self.current_node.delete_session()
+                    self.console.print("[green]Console and current session cleared.[/]")
+                except Exception as e:
+                    logger.error(f"Error deleting session: {e}")
+                    self.console.print("[green]Console cleared. Next chat will create a new session.[/]")
+            else:
                 self.console.print("[green]Console cleared. Next chat will create a new session.[/]")
-        else:
-            self.console.print("[green]Console cleared. Next chat will create a new session.[/]")
 
-        # Reset all node references
-        self.current_node = None
-        self.all_turn_actions = []
+            # Reset all node references
+            self.current_node = None
+            self.all_turn_actions = []
 
     def cmd_chat_info(self, args: str):
         """Display information about the current session."""
@@ -1854,11 +1894,12 @@ class ChatCommands:
             # Pass session_id at construction so ``AgenticNode.__init__`` can
             # rehydrate persisted plan-mode state (and the todolist disk-load
             # path) before the first turn — see ``restore_plan_mode_state``.
-            new_node = self._create_new_node(subagent_name, session_id=target_session_id)
+            with self.node_transaction():
+                new_node = self._create_new_node(subagent_name, session_id=target_session_id)
 
-            # Update state
-            self.current_node = new_node
-            self.current_subagent_name = subagent_name
+                # Update state
+                self.current_node = new_node
+                self.current_subagent_name = subagent_name
 
             # Mirror restored plan-mode flag back to the REPL toggle so the
             # bottom status bar reflects what the node believes (PLAN vs CHAT).
@@ -1964,9 +2005,10 @@ class ChatCommands:
             if turn_num == 1:
                 # First turn selected — no prior messages, create a fresh session
                 node_name = self._extract_node_type_from_session_id(source_session_id)
-                new_node = self._create_new_node(node_name if node_name != "chat" else None)
-                self.current_node = new_node
-                self.current_subagent_name = node_name if node_name != "chat" else None
+                with self.node_transaction():
+                    new_node = self._create_new_node(node_name if node_name != "chat" else None)
+                    self.current_node = new_node
+                    self.current_subagent_name = node_name if node_name != "chat" else None
                 self.chat_history = []
                 self.all_turn_actions = []
                 self.last_actions = []
@@ -1985,10 +2027,11 @@ class ChatCommands:
             node_name = self._extract_node_type_from_session_id(new_session_id)
             subagent_name = node_name if node_name != "chat" else None
 
-            new_node = self._create_new_node(subagent_name, session_id=new_session_id)
+            with self.node_transaction():
+                new_node = self._create_new_node(subagent_name, session_id=new_session_id)
 
-            self.current_node = new_node
-            self.current_subagent_name = subagent_name
+                self.current_node = new_node
+                self.current_subagent_name = subagent_name
             if hasattr(self.cli, "plan_mode_active"):
                 self.cli.plan_mode_active = bool(getattr(new_node, "plan_mode_active", False))
 

--- a/datus/cli/chat_commands.py
+++ b/datus/cli/chat_commands.py
@@ -14,6 +14,7 @@ import platform
 import re
 import subprocess
 import threading
+from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
@@ -160,7 +161,7 @@ class ChatCommands:
             self.current_node.setup_tools()
 
     @contextmanager
-    def node_transaction(self):
+    def node_transaction(self) -> Iterator[None]:
         """Hold the node lock across a check-create-publish of ``current_node``.
 
         Every caller that decides whether to build a node and then publishes
@@ -268,6 +269,21 @@ class ChatCommands:
         except Exception:  # noqa: BLE001
             pass
 
+    def get_or_create_node(self, subagent_name: Optional[str] = None) -> "AgenticNode":
+        """Return the active node, publishing a new one under the node lock if needed.
+
+        The plain check-create-publish, for callers that do not carry the
+        interactive chat path's agent-switch handling (session copy,
+        ``caller_node_name``, turn-action reset). Owning the transaction here
+        keeps :attr:`_node_lock` and the node-creation internals inside this
+        class instead of being reassembled by callers in other modules.
+        """
+        with self.node_transaction():
+            if self._should_create_new_node(subagent_name):
+                self.current_node = self._create_new_node(subagent_name)
+                self.current_subagent_name = subagent_name if subagent_name else None
+            return self.current_node
+
     def ensure_node_for_bang(self) -> Optional["AgenticNode"]:
         """Return the current chat node, lazily creating a default one if needed.
 
@@ -311,8 +327,11 @@ class ChatCommands:
                 self.current_node = node
             except Exception as exc:  # noqa: BLE001 - never crash the REPL on a ! call
                 logger.error(f"Failed to create chat node for '!' tool execution: {exc}", exc_info=True)
-                self.current_node = None
-                return None
+                # ``current_node`` was ``None`` on entry, so a non-None value here
+                # was published by a reentrant caller inside the build. Clearing
+                # it would orphan that node's session — the very failure this
+                # method's re-check exists to prevent.
+                return self.current_node
             return self.current_node
 
     def create_node_input(
@@ -1551,12 +1570,12 @@ class ChatCommands:
             if self.current_node:
                 try:
                     self.current_node.delete_session()
-                    self.console.print("[green]Console and current session cleared.[/]")
+                    print_success(self.console, "Console and current session cleared.")
                 except Exception as e:
                     logger.error(f"Error deleting session: {e}")
-                    self.console.print("[green]Console cleared. Next chat will create a new session.[/]")
+                    print_success(self.console, "Console cleared. Next chat will create a new session.")
             else:
-                self.console.print("[green]Console cleared. Next chat will create a new session.[/]")
+                print_success(self.console, "Console cleared. Next chat will create a new session.")
 
             # Reset all node references
             self.current_node = None

--- a/datus/cli/web/chat_executor.py
+++ b/datus/cli/web/chat_executor.py
@@ -41,16 +41,19 @@ class ChatExecutor:
             # @Agent yet).
             at_tables, at_metrics, at_sqls, _at_agent = cli.at_completer.parse_at_context(user_message)
 
-            # Reuse chat_commands node management
-            need_new_node = cli.chat_commands._should_create_new_node(current_subagent)
+            # Reuse chat_commands node management. The decision and the publish
+            # share one lock hold so a concurrent background node warm-up
+            # cannot replace the node this turn is about to stream into.
+            with cli.chat_commands.node_transaction():
+                need_new_node = cli.chat_commands._should_create_new_node(current_subagent)
 
-            # Disable compact in web mode to avoid blocking
-            if need_new_node:
-                current_node = cli.chat_commands._create_new_node(current_subagent)
-                cli.chat_commands.current_node = current_node
-                cli.chat_commands.current_subagent_name = current_subagent if current_subagent else None
-            else:
-                current_node = cli.chat_commands.current_node
+                # Disable compact in web mode to avoid blocking
+                if need_new_node:
+                    current_node = cli.chat_commands._create_new_node(current_subagent)
+                    cli.chat_commands.current_node = current_node
+                    cli.chat_commands.current_subagent_name = current_subagent if current_subagent else None
+                else:
+                    current_node = cli.chat_commands.current_node
 
             # Create input using shared method from chat_commands
             node_input, _ = cli.chat_commands.create_node_input(

--- a/datus/cli/web/chat_executor.py
+++ b/datus/cli/web/chat_executor.py
@@ -44,16 +44,7 @@ class ChatExecutor:
             # Reuse chat_commands node management. The decision and the publish
             # share one lock hold so a concurrent background node warm-up
             # cannot replace the node this turn is about to stream into.
-            with cli.chat_commands.node_transaction():
-                need_new_node = cli.chat_commands._should_create_new_node(current_subagent)
-
-                # Disable compact in web mode to avoid blocking
-                if need_new_node:
-                    current_node = cli.chat_commands._create_new_node(current_subagent)
-                    cli.chat_commands.current_node = current_node
-                    cli.chat_commands.current_subagent_name = current_subagent if current_subagent else None
-                else:
-                    current_node = cli.chat_commands.current_node
+            current_node = cli.chat_commands.get_or_create_node(current_subagent)
 
             # Create input using shared method from chat_commands
             node_input, _ = cli.chat_commands.create_node_input(

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -323,6 +323,50 @@ class TestShouldCreateNewNode:
         assert cmds.current_subagent_name == "gen_sql"
 
 
+class TestGetOrCreateNode:
+    """The public check-create-publish shared by the web executor."""
+
+    def test_creates_and_publishes_when_no_node_exists(self, real_agent_config, mock_llm_create):
+        cmds = _make_chat_commands(real_agent_config)
+        node = cmds.get_or_create_node()
+        assert node.id == "chat_cli"
+        assert cmds.current_node is node
+        assert cmds.current_subagent_name is None
+
+    def test_reuses_published_node(self, real_agent_config, mock_llm_create):
+        cmds = _make_chat_commands(real_agent_config)
+        first = cmds.get_or_create_node()
+        assert cmds.get_or_create_node() is first
+
+    def test_switching_subagent_publishes_new_node_and_name(self, real_agent_config, mock_llm_create):
+        cmds = _make_chat_commands(real_agent_config)
+        regular = cmds.get_or_create_node()
+        switched = cmds.get_or_create_node("gen_sql")
+        assert switched is not regular
+        assert cmds.current_node is switched
+        assert cmds.current_subagent_name == "gen_sql"
+
+    def test_publish_happens_under_the_node_lock(self, real_agent_config, mock_llm_create):
+        """The decision and the assignment share one lock hold.
+
+        A warm-up observing an unlocked gap between them could publish its own
+        node over the one this call is about to return.
+        """
+        cmds = _make_chat_commands(real_agent_config)
+        held = []
+
+        def _record_lock_state(*args, **kwargs):
+            # ``RLock`` is reentrant, so a same-thread acquire always succeeds;
+            # the owner check is what proves the section is held.
+            held.append(cmds._node_lock._is_owned())
+            return MagicMock(name="node")
+
+        with patch.object(cmds, "_create_new_node", side_effect=_record_lock_state):
+            cmds.get_or_create_node()
+
+        assert held == [True]
+
+
 # ===========================================================================
 # TestExtractNodeTypeFromSessionId
 # ===========================================================================
@@ -4398,23 +4442,57 @@ class TestEnsureNodeForBang:
         cmds = _make_chat_commands(real_agent_config)
         start = threading.Barrier(2)
         turn_node_used = []
+        errors = []
 
         def _run_turn():
-            start.wait(timeout=5)
-            with cmds.node_transaction():
-                if cmds._should_create_new_node(None):
-                    cmds.current_node = cmds._create_new_node(None)
-                turn_node_used.append(cmds.current_node)
+            try:
+                start.wait(timeout=1)
+                with cmds.node_transaction():
+                    if cmds._should_create_new_node(None):
+                        cmds.current_node = cmds._create_new_node(None)
+                    turn_node_used.append(cmds.current_node)
+            except Exception as exc:  # noqa: BLE001 - surfaced by the assert below
+                errors.append(("turn", exc))
 
         def _run_warm_up():
-            start.wait(timeout=5)
-            cmds.ensure_node_for_bang()
+            try:
+                start.wait(timeout=1)
+                cmds.ensure_node_for_bang()
+            except Exception as exc:  # noqa: BLE001 - surfaced by the assert below
+                errors.append(("warm-up", exc))
 
         threads = [threading.Thread(target=_run_turn), threading.Thread(target=_run_warm_up)]
         for thread in threads:
             thread.start()
         for thread in threads:
-            thread.join(timeout=30)
+            thread.join(timeout=2)
 
         assert not any(thread.is_alive() for thread in threads), "node_transaction deadlocked"
+        assert not errors, f"worker threads raised: {errors}"
+        assert turn_node_used, "the turn thread never published a node"
         assert cmds.current_node is turn_node_used[0]
+
+    def test_construction_failure_keeps_a_node_published_mid_build(self, real_agent_config, mock_llm_create):
+        """A node published inside the build survives a later failure.
+
+        The warm-up owns ``current_node`` only when it published it itself.
+        Clearing the attribute on any failure would discard a node a reentrant
+        caller installed while the build was running, orphaning its session.
+        """
+        cmds = _make_chat_commands(real_agent_config)
+        published_node = MagicMock(name="published_node")
+        warm_node = MagicMock(name="warm_node")
+
+        def _publish_then_fail():
+            # Stands in for a reentrant caller publishing its own node while
+            # this warm-up is still mounting tools, followed by a later step
+            # of the build raising.
+            cmds.current_node = published_node
+            raise RuntimeError("boom")
+
+        warm_node.setup_tools.side_effect = _publish_then_fail
+
+        with patch.object(cmds, "_create_new_node", return_value=warm_node):
+            assert cmds.ensure_node_for_bang() is published_node
+
+        assert cmds.current_node is published_node

--- a/tests/unit_tests/cli/test_chat_commands.py
+++ b/tests/unit_tests/cli/test_chat_commands.py
@@ -4362,3 +4362,59 @@ class TestEnsureNodeForBang:
         with patch.object(cmds, "_create_new_node", side_effect=RuntimeError("boom")):
             assert cmds.ensure_node_for_bang() is None
         assert cmds.current_node is None
+
+    def test_warm_up_keeps_node_published_while_it_was_building(self, real_agent_config, mock_llm_create):
+        """A turn that publishes mid-warm-up owns ``current_node`` afterwards.
+
+        The warm-up (background init thread) and a chat turn (input thread) can
+        both observe ``current_node is None``; node construction is slow enough
+        that the warm-up finishes last and used to overwrite the node the turn
+        was already streaming into, orphaning its session — the running turn's
+        actions then belonged to a node nobody could reach.
+        """
+        cmds = _make_chat_commands(real_agent_config)
+        turn_node = MagicMock(name="turn_node")
+        warm_node = MagicMock(name="warm_node")
+
+        def _publish_turn_node_mid_build(*args, **kwargs):
+            # Stands in for a chat turn winning the race while this warm-up is
+            # still mounting tools on its own node.
+            cmds.current_node = turn_node
+            return warm_node
+
+        with patch.object(cmds, "_create_new_node", side_effect=_publish_turn_node_mid_build):
+            assert cmds.ensure_node_for_bang() is turn_node
+
+        assert cmds.current_node is turn_node
+
+    def test_concurrent_warm_up_and_turn_agree_on_one_node(self, real_agent_config, mock_llm_create):
+        """Whoever wins, the node the turn uses is the one left published.
+
+        Exercises the real threading shape: background warm-up against an input
+        thread running the same check-create-publish the chat path does.
+        """
+        import threading
+
+        cmds = _make_chat_commands(real_agent_config)
+        start = threading.Barrier(2)
+        turn_node_used = []
+
+        def _run_turn():
+            start.wait(timeout=5)
+            with cmds.node_transaction():
+                if cmds._should_create_new_node(None):
+                    cmds.current_node = cmds._create_new_node(None)
+                turn_node_used.append(cmds.current_node)
+
+        def _run_warm_up():
+            start.wait(timeout=5)
+            cmds.ensure_node_for_bang()
+
+        threads = [threading.Thread(target=_run_turn), threading.Thread(target=_run_warm_up)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        assert not any(thread.is_alive() for thread in threads), "node_transaction deadlocked"
+        assert cmds.current_node is turn_node_used[0]

--- a/tests/unit_tests/cli/web/test_chat_executor.py
+++ b/tests/unit_tests/cli/web/test_chat_executor.py
@@ -161,8 +161,7 @@ class TestChatExecutorStream:
         node = _FakeNode()
         cli = MagicMock()
         cli.at_completer.parse_at_context.return_value = ([], [], [], None)
-        cli.chat_commands._should_create_new_node.return_value = True
-        cli.chat_commands._create_new_node.return_value = node
+        cli.chat_commands.get_or_create_node.return_value = node
         cli.chat_commands.create_node_input.return_value = ({"q": "x"}, None)
         cli.actions = []
 
@@ -191,8 +190,7 @@ class TestChatExecutorStream:
         node = _FakeNode()
         cli = MagicMock()
         cli.at_completer.parse_at_context.return_value = ([], [], [], None)
-        cli.chat_commands._should_create_new_node.return_value = False
-        cli.chat_commands.current_node = node
+        cli.chat_commands.get_or_create_node.return_value = node
         cli.chat_commands.create_node_input.return_value = ({"q": "x"}, None)
         cli.actions = []
 
@@ -223,8 +221,7 @@ class TestChatExecutorStream:
         node = _FakeNode()
         cli = MagicMock()
         cli.at_completer.parse_at_context.return_value = ([], [], [], None)
-        cli.chat_commands._should_create_new_node.return_value = True
-        cli.chat_commands._create_new_node.return_value = node
+        cli.chat_commands.get_or_create_node.return_value = node
         cli.chat_commands.create_node_input.return_value = ({"q": "x"}, None)
         cli.actions = []
 


### PR DESCRIPTION
## Why

`DatusCLI._warm_bang_node` builds the default chat node on the background init thread so `!<tool>` autocomplete has a tool list before the first turn. `ChatCommands.ensure_node_for_bang` checked `current_node is None` at entry but published its node several hundred milliseconds later — after `setup_tools` and `_ensure_lazy_tools_mounted` (skill / web / MCP) finished. A chat turn starting inside that window created and published its own node, and the warm-up then overwrote it.

The running turn kept streaming into a node nobody could reach: its session was orphaned, so the next turn continued from an empty session and `.chat_info` reported 0 actions.

Nightly run [32523139245](https://github.com/Datus-ai/Datus-agent/actions/runs/32523139245) caught it — `test_streaming_response` read `action_count == 0` from session `chat_session_0945e75a`, which never executed a turn, while the executed session `chat_session_58ed458d` held the full action list. The log shows the fingerprint of two concurrent node builds: `Web tools injected into node 'chat'` twice within the same second, the second one landing after the turn had already started.

The race dates back to #1186 (2026-07-22); neither `_background_init_agent` nor `ensure_node_for_bang` has been touched since, so which side wins is decided by a few tens of milliseconds of runner timing. On 8/20 the turn won and the suite was green; on 8/21 the warm-up won and all three attempts (initial + 2 reruns) failed identically.

## Solution

Serialize every `current_node` check-create-publish behind a reentrant lock, exposed as `ChatCommands.node_transaction()` so `datus/cli/web/chat_executor.py` (which had the same check-then-set) can share it without the lock leaving the class.

- The warm-up holds the lock across its whole build and **re-checks before publishing**, dropping its own node when a turn won the race.
- The chat turn, `/clear`, `/resume` and `/rewind` paths take the same lock around their decision and assignment.

Ordering is now irrelevant: whichever side arrives first publishes, and the other reuses that node or steps aside.

`agent_ready` is deliberately left where it is. Moving it past the warm-up would make an exception in any intervening step latch "initialization failed" — a contract `test_background_init_keeps_agent_ready_after_preload_failure` already pins — and with the lock in place the ordering no longer matters.

## Test Cases

Both added to `tests/unit_tests/cli/test_chat_commands.py::TestEnsureNodeForBang`:

- `test_warm_up_keeps_node_published_while_it_was_building` — publishes a turn's node mid-build and asserts the warm-up keeps it. **Verified red on the pre-fix code**: with the two source files stashed (`git stash push -- datus/cli/chat_commands.py datus/cli/web/chat_executor.py`) it fails with `assert <warm_node> is <turn_node>`, the exact production symptom; green after restoring the fix.
- `test_concurrent_warm_up_and_turn_agree_on_one_node` — runs both paths on real threads off a `threading.Barrier` and asserts the node the turn used is the one left published, with a deadlock guard on the join.

No nightly test is added: `tests/integration/agent/test_chat_agentic.py::TestChatAgentic::test_streaming_response` already asserts this invariant end-to-end — it is the test that caught the bug.

Gates run locally on this branch:

- `uv run python ci/run-pr-tests.py upstream/main` — 4113 passed, 1 skipped, 0 failed; diff coverage **92%**
- `uv run python ci/audit_tests.py --repo-root . --diff-only upstream/main` — **P0=0, P1=0**
- `uv run ruff format --check` / `ruff check` — clean

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat reliability when multiple operations occur at the same time.
  * Prevented concurrent chat turns, warm-ups, clears, resumes, and rewinds from overwriting each other’s state.
  * Ensured an active chat node remains selected throughout a streaming response.
  * Prevented deadlocks and stale-node replacement during concurrent chat initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat reliability when multiple operations occur at the same time.
  * Prevented concurrent chat turns, warm-ups, clears, resumes, and rewinds from overwriting each other’s state.
  * Ensured an active chat node remains selected throughout a streaming response.
  * Prevented deadlocks and stale-node replacement during concurrent chat initialization.
  * Preserved newly available chat nodes when warm-up encounters an error.
* **Style**
  * Improved success feedback after clearing a chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->