### PR TITLE
[BugFix] Cap litellm below the httpx pin so pip stops backtracking into wheel-less sdists

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ pip install datus-agent
 datus
 ```
 
+`uv` resolves this dependency set in seconds and is the recommended alternative — `pip` can spend several minutes backtracking through `litellm` releases when installing versions up to 0.3.9:
+
+```bash
+pip install uv
+uv pip install datus-agent --system
+```
+
 After the REPL starts, run `/model` to configure an LLM, `/datasource` to add a datasource, and (optionally) `/init` to generate `AGENTS.md` for the current project. For detailed guidance, see the [Quickstart Guide](https://docs.datus.ai/getting_started/Quickstart/).
 
 ### Four Ways to Use Datus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,12 @@ dependencies = [
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",
-    "litellm>=1.67.4.post1,<2",
+    # Upper bound tracks the ``httpx[socks]==0.27.2`` pin above: litellm 1.83.1+ requires
+    # ``httpx==0.28.1`` / ``httpx>=0.28``, so nothing above 1.83.0 can ever be selected.
+    # Without the bound, pip backtracks from the newest release through ~90 versions and
+    # source-builds the 1.92-1.95 sdists, which ship no macOS or Windows wheels — minutes
+    # stuck on "Preparing metadata". Lift this bound only together with the httpx pin.
+    "litellm>=1.67.4.post1,<1.83.1",
     "pydantic>=2.11.7,<3.0",
     "lancedb==0.34.0",
     # This library is required by lancedb

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,8 @@ openinference-instrumentation-openai-agents>=1.0.0
 opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp>=1.20.0
-litellm>=1.67.4.post1,<2
+# Keep in sync with pyproject.toml: the upper bound tracks the httpx pin above.
+litellm>=1.67.4.post1,<1.83.1
 pydantic>=2.11.7,<3.0
 pyarrow<19.0.0
 rich==14.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -790,7 +790,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.47.6" },
     { name = "jsonschema", specifier = ">=4.17,<5" },
     { name = "lancedb", specifier = "==0.34.0" },
-    { name = "litellm", specifier = ">=1.67.4.post1,<2" },
+    { name = "litellm", specifier = ">=1.67.4.post1,<1.83.1" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "mcp", specifier = ">=1.11.0" },


### PR DESCRIPTION
## Why

Fixes #1326.

`pip install datus-agent` spends minutes stuck on `Preparing metadata (pyproject.toml)`. The reported root cause (`openai`/`pydantic`/`anthropic` pins blocking newer litellm) is not what happens — those are all satisfied by litellm 1.84+. The actual blocker is the `httpx[socks]==0.27.2` pin:

| litellm | httpx requirement | compatible with our pin |
|---|---|---|
| 1.83.0 | `httpx>=0.23.0` | yes |
| 1.83.1 - 1.83.14 | `httpx==0.28.1` | no |
| 1.84.0+ | `httpx<1.0,>=0.28.0` | no |

So 1.83.0 is the highest release that can ever be selected, but `litellm<2` never told pip that. pip discovered it by backtracking from the newest release down through 94 candidates — and litellm switched to compiled platform wheels at 1.92.0, where several releases ship no wheel for the installing platform:

| litellm | wheels published |
|---|---|
| 1.92.0, 1.92.1, 1.93.0 | linux only |
| 1.93.1, 1.94.0, 1.94.1, 1.95.0 | linux + windows, **no macOS** |

Every miss falls back to a ~16 MB sdist and a local metadata build.

This is not Windows-specific — reproduced on macOS 15 / Python 3.12.10 / pip 26.2.1 with `pip install --dry-run datus-agent==0.3.9`: **94 litellm candidates, 7 sdist metadata builds, 70 s**, finally selecting litellm 1.83.0.

Two reasons it went unnoticed: the published-package smoke test in `publish-release.yml` runs on `ubuntu-latest`, the one platform with a manylinux wheel at every step; and `install.sh` already uses uv, so only the README's manual `pip install` path is affected — which is the only path Windows users have, since the installer is a bash script.

## Solution

Cap the bound at the point the httpx pin actually allows: `litellm>=1.67.4.post1,<1.83.1`, with a comment tying the two together so nobody lifts one without the other. Same change mirrored into `requirements.txt`, and `uv.lock`'s specifier record refreshed (the locked version stays **1.81.10** — it already satisfies the new bound, so the CI and dev environments are byte-for-byte unchanged).

Verified end-to-end by building a wheel from this branch and resolving it in a clean venv:

| | before (PyPI 0.3.9) | after (this branch) |
|---|---|---|
| litellm candidates | 94 | **2** |
| sdist metadata builds | 7 | **0** |
| resolved litellm | 1.83.0 | 1.83.0 |

Identical resolution result, just without the search. `uv lock --locked` and `uv sync --locked --group ci` both pass, resolving 262 packages to the same `litellm==1.81.10` + `httpx==0.27.2`.

README also now points at uv for the manual install path, which helps anyone installing 0.3.9 or earlier (where the backtracking is baked into the published metadata).

Deliberately left out of this PR:

- **Lifting the `httpx[socks]==0.27.2` pin.** It has been there since the initial commit with no recorded reason, and nothing else needs it — `openai` wants `>=0.23,<1`, `anthropic` `>=0.25,<1`, `mcp` `>=0.27`. Lifting it would unlock litellm up to 1.91.5 (still pure-Python wheels), but needs its own validation of httpx 0.28's breaking changes plus a full test run. Note a bound would still be required afterwards: litellm 1.92+ declares `requires-python <3.15`, which conflicts with our open-ended `requires-python = ">=3.12"`.
- **Bumping the locked litellm from 1.81.10 to 1.83.0.** Worth doing — pip users get 1.83.0 while CI tests 1.81.10 — but it is a version bump that should go through nightly on its own.
- **Extending the release smoke matrix to macOS/Windows.** That ubuntu-only smoke test is exactly the blind spot here, but adding runners is a CI cost decision.

## Test Cases

No automated test. This is a packaging-metadata change with no runtime behaviour to exercise: the resolved dependency set is unchanged (litellm 1.81.10, httpx 0.27.2), so every existing test would pass identically before and after — a test asserting the new bound would only restate the diff.

The regression it prevents lives in pip's resolver, not in our code, and can only be observed against a published artifact. It was verified manually as described above (94 → 2 candidates, 7 → 0 sdist builds) by building a wheel from this branch and resolving it in a clean Python 3.12 venv on macOS.

A dependency-constraint guard test was considered — asserting that while httpx excludes 0.28.1 the litellm bound must exclude 1.83.1 — and dropped as restating metadata rather than protecting behaviour.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `uv` as an alternative installation method.
  - Included commands for installing `uv` and the application.

- **Chores**
  - Updated the supported LiteLLM version range for improved compatibility with the pinned HTTP client dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->