### PR TITLE
[BugFix] Bound the /table/columns prefetch so it cannot starve the datasource

### DIFF
--- a/datus/api/services/chat_service.py
+++ b/datus/api/services/chat_service.py
@@ -34,6 +34,7 @@ from datus.api.services.chat_task_manager import (
 from datus.configuration.agent_config import AgentConfig
 from datus.models.session_manager import SessionManager, session_matches_agent
 from datus.schemas.action_history import ActionRole, ActionStatus
+from datus.utils.config_utils import coerce_positive_int
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.time_utils import now_utc_iso
@@ -46,22 +47,6 @@ logger = get_logger(__name__)
 # request path — clients that omit ``limit`` entirely — stays bounded.
 _DEFAULT_SESSION_PAGE_SIZE = 50
 _DEFAULT_MAX_SESSION_PAGE_SIZE = 200
-
-
-def _positive_int(raw: Any, fallback: int) -> int:
-    """Coerce a config value or caller-supplied page size to a positive int.
-
-    Both operator YAML and direct (non-HTTP) callers are untrusted here: a
-    missing key, ``null``, a non-numeric string, or a non-positive number all
-    fall back to *fallback* rather than producing an empty or reversed page.
-    ``OverflowError`` is caught alongside the usual pair because YAML ``.inf``
-    parses to float infinity, which ``int()`` refuses to convert.
-    """
-    try:
-        value = int(raw)
-    except (TypeError, ValueError, OverflowError):
-        return fallback
-    return value if value > 0 else fallback
 
 
 class ChatService:
@@ -159,16 +144,16 @@ class ChatService:
         """
         try:
             api_config = getattr(self.agent_config, "api_config", {}) or {}
-            max_page_size = _positive_int(api_config.get("max_session_page_size"), _DEFAULT_MAX_SESSION_PAGE_SIZE)
+            max_page_size = coerce_positive_int(api_config.get("max_session_page_size"), _DEFAULT_MAX_SESSION_PAGE_SIZE)
             default_page_size = min(
-                _positive_int(api_config.get("default_session_page_size"), _DEFAULT_SESSION_PAGE_SIZE),
+                coerce_positive_int(api_config.get("default_session_page_size"), _DEFAULT_SESSION_PAGE_SIZE),
                 max_page_size,
             )
             # A non-positive ``limit`` is treated as unspecified rather than
             # passed through: the route pins ``ge=1``, but a direct caller
             # passing -1 would otherwise slice ``all_ids[offset:-1]`` and
             # enrich nearly every session — the exact cost this bounds.
-            page_size = min(_positive_int(limit, default_page_size), max_page_size)
+            page_size = min(coerce_positive_int(limit, default_page_size), max_page_size)
             # Likewise the route pins ``ge=0``; clamp again for non-HTTP callers,
             # since a negative offset would silently slice from the tail.
             offset = max(offset, 0)

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -40,6 +40,7 @@ from datus.storage.semantic_model.artifact_file import (
 )
 from datus.tools.db_tools.capabilities import supports_namespace
 from datus.tools.db_tools.db_manager import DBManager
+from datus.utils.config_utils import coerce_positive_int, coerce_positive_seconds
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_table_name_parts
 from datus.utils.text_utils import redact_uri
@@ -61,20 +62,6 @@ _DEFAULT_PREFETCH_BUDGET_SECONDS = 3.0
 def _brief_columns(columns: list[ColumnInfo]) -> list[TableColumnBrief]:
     """Slim the prefetch payload: no default_value, which no client reads."""
     return [TableColumnBrief(name=c.name, type=c.type, nullable=c.nullable, pk=c.pk) for c in columns]
-
-
-def _positive_number(raw: Any, fallback: float) -> float:
-    """Coerce an operator-supplied bound to a positive number.
-
-    Operator YAML is untrusted here: a missing key, ``null``, a non-numeric
-    string, or a non-positive number all fall back rather than raise, since a
-    typo in agent.yml must not take the endpoint down.
-    """
-    try:
-        value = float(raw)
-    except (TypeError, ValueError):
-        return fallback
-    return value if value > 0 else fallback
 
 
 class DatasourceService:
@@ -594,7 +581,7 @@ class DatasourceService:
         what it still needs — one table at a time, via /table/detail.
         """
         api_config = getattr(self.agent_config, "api_config", {}) or {}
-        max_tables = int(_positive_number(api_config.get("max_prefetch_tables"), _DEFAULT_MAX_PREFETCH_TABLES))
+        max_tables = coerce_positive_int(api_config.get("max_prefetch_tables"), _DEFAULT_MAX_PREFETCH_TABLES)
         if len(tables) > max_tables:
             return Result(
                 success=False,
@@ -626,7 +613,9 @@ class DatasourceService:
             return Result(success=True, data=GetTablesColumnsData(tables=results))
 
         try:
-            budget = _positive_number(api_config.get("prefetch_budget_seconds"), _DEFAULT_PREFETCH_BUDGET_SECONDS)
+            budget = coerce_positive_seconds(
+                api_config.get("prefetch_budget_seconds"), _DEFAULT_PREFETCH_BUDGET_SECONDS
+            )
             deadline = time.monotonic() + budget
             for index, full_path in enumerate(pending):
                 if time.monotonic() >= deadline:

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -5,6 +5,7 @@ Service for handling Database Management operations.
 import asyncio
 import stat
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -50,6 +51,30 @@ _NO_SCHEMA_TYPES = {"sqlite", "duckdb", "mysql"}
 # Default cap on tables per /table/columns batch; override with
 # ``api.max_prefetch_tables`` in agent.yml.
 _DEFAULT_MAX_PREFETCH_TABLES = 500
+# Wall-clock a single /table/columns batch may spend resolving uncached tables
+# before it returns what it has; override with ``api.prefetch_budget_seconds``.
+# A batch walks tables one at a time behind the connector lock, so on a slow
+# source an unbounded one holds a to_thread worker for minutes.
+_DEFAULT_PREFETCH_BUDGET_SECONDS = 3.0
+
+
+def _brief_columns(columns: list[ColumnInfo]) -> list[TableColumnBrief]:
+    """Slim the prefetch payload: no default_value, which no client reads."""
+    return [TableColumnBrief(name=c.name, type=c.type, nullable=c.nullable, pk=c.pk) for c in columns]
+
+
+def _positive_number(raw: Any, fallback: float) -> float:
+    """Coerce an operator-supplied bound to a positive number.
+
+    Operator YAML is untrusted here: a missing key, ``null``, a non-numeric
+    string, or a non-positive number all fall back rather than raise, since a
+    typo in agent.yml must not take the endpoint down.
+    """
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return fallback
+    return value if value > 0 else fallback
 
 
 class DatasourceService:
@@ -75,6 +100,11 @@ class DatasourceService:
         # asyncio.to_thread detail/batch requests.
         self._columns_cache: dict[str, list[ColumnInfo]] = {}
         self._schema_lock = threading.Lock()
+        # Only one prefetch batch resolves uncached tables at a time. Several in
+        # parallel cannot go any faster — they serialize on _schema_lock anyway —
+        # they just each pin a to_thread worker while queuing, which is what
+        # starves interactive metadata reads.
+        self._prefetch_gate = threading.BoundedSemaphore(1)
         self._initialize_connection()
 
     def _active_semantic_adapter(self) -> str:
@@ -420,6 +450,29 @@ class DatasourceService:
                 errorMessage=str(e),
             )
 
+    def _resolve_table_identity(self, full_path: str) -> tuple[str, str, str, str]:
+        """Resolve a dotted reference to (catalog, database, schema, table).
+
+        Connector defaults fill in whatever the caller left out. For StarRocks
+        that is catalog.database.table, with no schema level.
+        """
+        name_parts = parse_table_name_parts(full_path, self.current_db_connector.get_type())
+        catalog_name = name_parts["catalog_name"] or getattr(self.current_db_connector, "catalog_name", "")
+        database_name = (
+            name_parts["database_name"] or self.current_db_name or getattr(self.current_db_connector, "database", "")
+        )
+        schema_name = name_parts["schema_name"] or getattr(self.current_db_connector, "schema_name", "")
+        return catalog_name, database_name, schema_name, name_parts["table_name"]
+
+    def _cached_columns(self, full_path: str) -> Optional[list[ColumnInfo]]:
+        """Columns already in the cache for this reference, without touching the source."""
+        try:
+            catalog_name, database_name, schema_name, table_name = self._resolve_table_identity(full_path)
+        except Exception:
+            # Unparseable name — let the per-table path report it.
+            return None
+        return self._columns_cache.get(f"{catalog_name}.{database_name}.{schema_name}.{table_name}")
+
     def get_table_schema(self, full_path: str) -> Result[GetTableDetailData]:
         """
         Get table schema details.
@@ -438,21 +491,8 @@ class DatasourceService:
                     errorMessage="No database connection",
                 )
 
-            # Get table schema
-            name_parts = parse_table_name_parts(full_path, self.current_db_connector.get_type())
-
             try:
-                # For StarRocks: catalog.database.table (no schema level)
-                # Use current database if not specified
-                catalog_name = name_parts["catalog_name"] or getattr(self.current_db_connector, "catalog_name", "")
-                database_name = (
-                    name_parts["database_name"]
-                    or self.current_db_name
-                    or getattr(self.current_db_connector, "database", "")
-                )
-                schema_name = name_parts["schema_name"] or getattr(self.current_db_connector, "schema_name", "")
-                table_name = name_parts["table_name"]
-
+                catalog_name, database_name, schema_name, table_name = self._resolve_table_identity(full_path)
                 cache_key = f"{catalog_name}.{database_name}.{schema_name}.{table_name}"
 
                 def _detail(cols: list[ColumnInfo]) -> Result[GetTableDetailData]:
@@ -535,12 +575,26 @@ class DatasourceService:
         """Batch-fetch columns for multiple tables (autocomplete prefetch).
 
         Reuses get_table_schema (and its column cache) per table. Tables that
-        fail to resolve are omitted rather than failing the whole batch. The
-        request is capped at ``api.max_prefetch_tables`` (agent.yml) to bound
-        per-request datasource work.
+        fail to resolve are omitted rather than failing the whole batch.
+
+        Prefetch is a convenience, so it yields rather than competes. Three
+        bounds keep one caller from monopolising the datasource, because the
+        columns of N tables cost N serial round-trips behind the connector lock —
+        on a slow source (Oracle listing every schema) that is minutes of held
+        lock and a to_thread worker, and everything else needing table metadata,
+        interactive reads included, waits behind it:
+
+        - the request size is capped at ``api.max_prefetch_tables``;
+        - only one batch resolves uncached tables at a time, and a second does
+          not queue — it returns what the cache already holds;
+        - a batch stops once ``api.prefetch_budget_seconds`` is spent.
+
+        Under the last two, tables are left out of the response. That is the
+        contract a table failing to resolve already has, so a client re-asks for
+        what it still needs — one table at a time, via /table/detail.
         """
         api_config = getattr(self.agent_config, "api_config", {}) or {}
-        max_tables = int(api_config.get("max_prefetch_tables", _DEFAULT_MAX_PREFETCH_TABLES))
+        max_tables = int(_positive_number(api_config.get("max_prefetch_tables"), _DEFAULT_MAX_PREFETCH_TABLES))
         if len(tables) > max_tables:
             return Result(
                 success=False,
@@ -549,14 +603,47 @@ class DatasourceService:
             )
 
         results: list[TableColumns] = []
+        pending: list[str] = []
         for full_path in tables:
-            detail = self.get_table_schema(full_path)
-            if detail.success and detail.data is not None:
-                columns = [
-                    TableColumnBrief(name=c.name, type=c.type, nullable=c.nullable, pk=c.pk)
-                    for c in detail.data.table.columns
-                ]
-                results.append(TableColumns(table=full_path, columns=columns))
+            cached = self._cached_columns(full_path)
+            if cached is None:
+                pending.append(full_path)
+            else:
+                results.append(TableColumns(table=full_path, columns=_brief_columns(cached)))
+
+        # Cache hits cost nothing, so they are served regardless of the bounds
+        # below — and a fully-warm batch never even takes the gate.
+        if not pending:
+            return Result(success=True, data=GetTablesColumnsData(tables=results))
+
+        if not self._prefetch_gate.acquire(blocking=False):
+            logger.info(
+                "Prefetch already in flight; serving %d cached of %d tables and omitting %d",
+                len(results),
+                len(tables),
+                len(pending),
+            )
+            return Result(success=True, data=GetTablesColumnsData(tables=results))
+
+        try:
+            budget = _positive_number(api_config.get("prefetch_budget_seconds"), _DEFAULT_PREFETCH_BUDGET_SECONDS)
+            deadline = time.monotonic() + budget
+            for index, full_path in enumerate(pending):
+                if time.monotonic() >= deadline:
+                    logger.info(
+                        "Prefetch budget of %.1fs spent after %d tables; omitting the remaining %d",
+                        budget,
+                        index,
+                        len(pending) - index,
+                    )
+                    break
+
+                detail = self.get_table_schema(full_path)
+                if detail.success and detail.data is not None:
+                    results.append(TableColumns(table=full_path, columns=_brief_columns(detail.data.table.columns)))
+        finally:
+            self._prefetch_gate.release()
+
         return Result(success=True, data=GetTablesColumnsData(tables=results))
 
     def _semantic_models_root(self) -> Optional[Path]:

--- a/datus/utils/config_utils.py
+++ b/datus/utils/config_utils.py
@@ -9,9 +9,10 @@ need to interpret a config value do not have to reach into another package for a
 private symbol.
 """
 
+import math
 from typing import Any
 
-__all__ = ["coerce_bool"]
+__all__ = ["coerce_bool", "coerce_positive_int", "coerce_positive_seconds"]
 
 
 def coerce_bool(value: Any, default: bool) -> bool:
@@ -38,3 +39,40 @@ def coerce_bool(value: Any, default: bool) -> bool:
         if normalized in {"0", "false", "no", "off", ""}:
             return False
     return bool(value)
+
+
+def coerce_positive_int(value: Any, default: int) -> int:
+    """Coerce a config value or caller-supplied count to a positive ``int``.
+
+    Both operator YAML and direct (non-HTTP) callers are untrusted here: a
+    missing key, ``null``, a non-numeric string, or a non-positive number all
+    yield *default* rather than a bound that breaks the caller.
+
+    ``OverflowError`` is caught alongside the usual pair because YAML ``.inf``
+    parses to float infinity, which ``int()`` refuses to convert — and ``.inf``
+    is what an operator writes when they mean "no limit". A fractional value
+    (``0.5``) truncates to ``0`` and so falls back too, rather than becoming a
+    bound that rejects everything.
+    """
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return coerced if coerced > 0 else default
+
+
+def coerce_positive_seconds(value: Any, default: float) -> float:
+    """Coerce a config value to a positive, finite number of seconds.
+
+    Like :func:`coerce_positive_int` but keeping fractions, since sub-second
+    budgets are meaningful. Infinity is rejected rather than honoured: it passes
+    a bare ``> 0`` test and would silently turn a deadline into no deadline —
+    the opposite of what a timeout is for.
+    """
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    if coerced > 0 and math.isfinite(coerced):
+        return coerced
+    return default

--- a/datus/utils/config_utils.py
+++ b/datus/utils/config_utils.py
@@ -48,12 +48,24 @@ def coerce_positive_int(value: Any, default: int) -> int:
     missing key, ``null``, a non-numeric string, or a non-positive number all
     yield *default* rather than a bound that breaks the caller.
 
-    ``OverflowError`` is caught alongside the usual pair because YAML ``.inf``
-    parses to float infinity, which ``int()`` refuses to convert — and ``.inf``
-    is what an operator writes when they mean "no limit". A fractional value
-    (``0.5``) truncates to ``0`` and so falls back too, rather than becoming a
-    bound that rejects everything.
+    Two things Python would coerce silently are treated as typos instead:
+
+    - ``bool`` is an ``int`` subclass, and YAML reads ``true`` / ``yes`` / ``on``
+      as ``True``, so ``int()`` would turn a mistyped toggle into a bound of 1 —
+      a bound that looks deliberate and quietly rejects almost everything.
+    - YAML ``.inf`` — what an operator writes for "no limit" — is a float
+      infinity that ``int()`` refuses to convert, raising ``OverflowError``.
+
+    A fractional number does still truncate (``3.5`` yields 3, ``0.5`` yields 0
+    and so falls back for being non-positive). That is deliberate: callers pass
+    request-supplied page sizes through here too, where truncating still bounds
+    the request, whereas falling back would hand back a *larger* default than
+    was asked for. A caller that must reject a fractional bound outright should
+    check before calling.
     """
+    # Checked before int(), which accepts bool via the int subclass.
+    if isinstance(value, bool):
+        return default
     try:
         coerced = int(value)
     except (TypeError, ValueError, OverflowError):
@@ -67,8 +79,11 @@ def coerce_positive_seconds(value: Any, default: float) -> float:
     Like :func:`coerce_positive_int` but keeping fractions, since sub-second
     budgets are meaningful. Infinity is rejected rather than honoured: it passes
     a bare ``> 0`` test and would silently turn a deadline into no deadline —
-    the opposite of what a timeout is for.
+    the opposite of what a timeout is for. ``bool`` is rejected for the same
+    reason it is there: YAML ``true`` would otherwise buy a 1-second budget.
     """
+    if isinstance(value, bool):
+        return default
     try:
         coerced = float(value)
     except (TypeError, ValueError, OverflowError):

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -925,17 +925,22 @@ class TestGetTablesColumns:
             -5,
             float("inf"),  # YAML `.inf` — what an operator writes for "no limit"
             "inf",
-            0.5,  # would truncate to a limit of 0 and reject every batch
+            0.5,  # truncates to 0, so falls back for being non-positive
+            True,  # YAML `true`/`yes`/`on`; bool is an int subclass, so -> 1
         ],
-        ids=["text", "null", "zero", "negative", "inf", "inf-text", "fraction"],
+        ids=["text", "null", "zero", "negative", "inf", "inf-text", "fraction", "yaml-true"],
     )
     def test_a_bad_limit_falls_back_instead_of_breaking(self, real_agent_config, limit):
-        """A typo in agent.yml must not take the endpoint down."""
+        """A typo in agent.yml must not take the endpoint down.
+
+        Two tables on purpose: several of these values coerce to a bound of 1,
+        which a single-table batch could not tell apart from the real default.
+        """
         svc = DatasourceService(agent_config=real_agent_config)
         svc.agent_config.api_config = {"max_prefetch_tables": limit}
-        result = svc.get_tables_columns(["schools"])
+        result = svc.get_tables_columns(["schools", "frpm"])
         assert result.success is True
-        assert [t.table for t in result.data.tables] == ["schools"]
+        assert [t.table for t in result.data.tables] == ["schools", "frpm"]
 
     @pytest.mark.parametrize(
         "budget",
@@ -981,11 +986,16 @@ class TestGetTablesColumnsBounds:
 
     def test_stops_once_the_budget_is_spent(self, real_agent_config):
         svc = DatasourceService(agent_config=real_agent_config)
-        svc.agent_config.api_config = {"prefetch_budget_seconds": 1e-9}
+        svc.agent_config.api_config = {"prefetch_budget_seconds": 5}
         spy = MagicMock(wraps=svc.current_db_connector.get_schema)
         svc.current_db_connector.get_schema = spy
 
-        result = svc.get_tables_columns(["schools", "frpm"])
+        # A fake clock rather than a tiny budget: a real one relies on two
+        # consecutive monotonic() readings differing, which they do not on a
+        # platform whose clock resolution is coarse (~15.6ms on Windows).
+        clock = chain([0.0], repeat(1e9))
+        with _fake_monotonic(lambda: next(clock)):
+            result = svc.get_tables_columns(["schools", "frpm"])
 
         # An exhausted budget omits tables rather than failing the batch.
         assert result.success is True
@@ -995,9 +1005,12 @@ class TestGetTablesColumnsBounds:
     def test_omitted_tables_stay_fetchable(self, real_agent_config):
         """What a bound leaves out, the client can still ask for one at a time."""
         svc = DatasourceService(agent_config=real_agent_config)
-        svc.agent_config.api_config = {"prefetch_budget_seconds": 1e-9}
+        svc.agent_config.api_config = {"prefetch_budget_seconds": 5}
 
-        assert svc.get_tables_columns(["schools"]).data.tables == []
+        clock = chain([0.0], repeat(1e9))
+        with _fake_monotonic(lambda: next(clock)):
+            assert svc.get_tables_columns(["schools"]).data.tables == []
+
         detail = svc.get_table_schema("schools")
 
         assert detail.success is True

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -3,6 +3,7 @@
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from itertools import chain, repeat
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterator, NoReturn
@@ -17,6 +18,7 @@ from datus.api.models.table_models import (
     ValidateSemanticModelData,
     ValidateSemanticModelInput,
 )
+from datus.api.services import database_service
 from datus.api.services.database_service import DatasourceService
 from datus.storage.semantic_model.artifact_file import artifact_revision, semantic_artifact_lock
 from datus.tools.db_tools.db_manager import DBManager
@@ -914,13 +916,59 @@ class TestGetTablesColumns:
         assert result.success is False
         assert result.errorCode == "INVALID_PARAMETERS"
 
-    def test_a_bad_limit_falls_back_instead_of_raising(self, real_agent_config):
+    @pytest.mark.parametrize(
+        "limit",
+        [
+            "not-a-number",
+            None,
+            0,
+            -5,
+            float("inf"),  # YAML `.inf` — what an operator writes for "no limit"
+            "inf",
+            0.5,  # would truncate to a limit of 0 and reject every batch
+        ],
+        ids=["text", "null", "zero", "negative", "inf", "inf-text", "fraction"],
+    )
+    def test_a_bad_limit_falls_back_instead_of_breaking(self, real_agent_config, limit):
         """A typo in agent.yml must not take the endpoint down."""
         svc = DatasourceService(agent_config=real_agent_config)
-        svc.agent_config.api_config = {"max_prefetch_tables": "not-a-number"}
+        svc.agent_config.api_config = {"max_prefetch_tables": limit}
         result = svc.get_tables_columns(["schools"])
         assert result.success is True
         assert [t.table for t in result.data.tables] == ["schools"]
+
+    @pytest.mark.parametrize(
+        "budget",
+        [float("inf"), "inf", "not-a-number", None, 0, -1],
+        ids=["inf", "inf-text", "text", "null", "zero", "negative"],
+    )
+    def test_a_bad_budget_falls_back_to_a_real_deadline(self, real_agent_config, budget):
+        """Infinity is the dangerous one: it passes `> 0` and removes the deadline."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.agent_config.api_config = {"prefetch_budget_seconds": budget}
+
+        # The default budget is finite, so a clock jump past it stops the batch.
+        clock = chain([0.0], repeat(1e9))
+        with _fake_monotonic(lambda: next(clock)):
+            result = svc.get_tables_columns(["schools"])
+
+        assert result.success is True
+        assert result.data.tables == []
+
+
+@contextmanager
+def _fake_monotonic(reading) -> Iterator[None]:
+    """Drive database_service's clock without touching the stdlib one.
+
+    The module does ``import time``, so ``database_service.time`` *is* the
+    stdlib module — patching ``...database_service.time.monotonic`` swaps it
+    process-wide, and every other caller in the window (another thread, a
+    library timer) then reads the fake. Rebinding the module-level name instead
+    keeps the fake local to this module.
+    """
+    stand_in = SimpleNamespace(monotonic=reading)
+    with patch.object(database_service, "time", stand_in):
+        yield
 
 
 class TestGetTablesColumnsBounds:
@@ -960,8 +1008,11 @@ class TestGetTablesColumnsBounds:
         svc = DatasourceService(agent_config=real_agent_config)
         svc.agent_config.api_config = {"prefetch_budget_seconds": 5}
         # deadline = 0 + 5; then: first check 1 (under), second check 99 (over).
-        clock = iter([0.0, 1.0, 99.0])
-        with patch("datus.api.services.database_service.time.monotonic", lambda: next(clock)):
+        # Trailing repeat so an extra reading — another thread, or a future
+        # version of the method taking one more — degrades the assertion rather
+        # than raising StopIteration from inside the code under test.
+        clock = chain([0.0, 1.0], repeat(99.0))
+        with _fake_monotonic(lambda: next(clock)):
             result = svc.get_tables_columns(["schools", "frpm"])
 
         assert result.success is True

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -914,6 +914,108 @@ class TestGetTablesColumns:
         assert result.success is False
         assert result.errorCode == "INVALID_PARAMETERS"
 
+    def test_a_bad_limit_falls_back_instead_of_raising(self, real_agent_config):
+        """A typo in agent.yml must not take the endpoint down."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.agent_config.api_config = {"max_prefetch_tables": "not-a-number"}
+        result = svc.get_tables_columns(["schools"])
+        assert result.success is True
+        assert [t.table for t in result.data.tables] == ["schools"]
+
+
+class TestGetTablesColumnsBounds:
+    """A prefetch batch must yield to the rest of the service, not compete.
+
+    Columns cost one serial round-trip per table behind the connector lock, so
+    an unbounded batch on a slow source holds that lock — and a to_thread
+    worker — for minutes, starving interactive metadata reads.
+    """
+
+    def test_stops_once_the_budget_is_spent(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.agent_config.api_config = {"prefetch_budget_seconds": 1e-9}
+        spy = MagicMock(wraps=svc.current_db_connector.get_schema)
+        svc.current_db_connector.get_schema = spy
+
+        result = svc.get_tables_columns(["schools", "frpm"])
+
+        # An exhausted budget omits tables rather than failing the batch.
+        assert result.success is True
+        assert result.data.tables == []
+        assert spy.call_count == 0
+
+    def test_omitted_tables_stay_fetchable(self, real_agent_config):
+        """What a bound leaves out, the client can still ask for one at a time."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.agent_config.api_config = {"prefetch_budget_seconds": 1e-9}
+
+        assert svc.get_tables_columns(["schools"]).data.tables == []
+        detail = svc.get_table_schema("schools")
+
+        assert detail.success is True
+        assert detail.data.table.columns
+
+    def test_budget_spent_mid_batch_returns_the_partial_result(self, real_agent_config):
+        """The clock runs out after the first table; the second is omitted."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.agent_config.api_config = {"prefetch_budget_seconds": 5}
+        # deadline = 0 + 5; then: first check 1 (under), second check 99 (over).
+        clock = iter([0.0, 1.0, 99.0])
+        with patch("datus.api.services.database_service.time.monotonic", lambda: next(clock)):
+            result = svc.get_tables_columns(["schools", "frpm"])
+
+        assert result.success is True
+        assert [t.table for t in result.data.tables] == ["schools"]
+
+    def test_a_second_batch_does_not_queue_behind_the_first(self, real_agent_config):
+        """A batch that cannot take the gate returns instead of pinning a worker."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        spy = MagicMock(wraps=svc.current_db_connector.get_schema)
+        svc.current_db_connector.get_schema = spy
+
+        svc._prefetch_gate.acquire()
+        try:
+            result = svc.get_tables_columns(["schools"])
+        finally:
+            svc._prefetch_gate.release()
+
+        assert result.success is True
+        assert result.data.tables == []
+        assert spy.call_count == 0
+
+    def test_cache_hits_are_served_while_the_gate_is_held(self, real_agent_config):
+        """Warm tables cost nothing, so no bound should withhold them."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.get_tables_columns(["schools"])
+
+        svc._prefetch_gate.acquire()
+        try:
+            result = svc.get_tables_columns(["schools", "frpm"])
+        finally:
+            svc._prefetch_gate.release()
+
+        # schools is cached; frpm would need the source, so it is omitted.
+        assert [t.table for t in result.data.tables] == ["schools"]
+        assert result.data.tables[0].columns
+
+    def test_the_gate_is_released_for_the_next_batch(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+
+        first = svc.get_tables_columns(["schools"])
+        second = svc.get_tables_columns(["frpm"])
+
+        assert [t.table for t in first.data.tables] == ["schools"]
+        assert [t.table for t in second.data.tables] == ["frpm"]
+
+    def test_the_gate_is_released_when_a_table_blows_up(self, real_agent_config):
+        """An exception mid-batch must not leave the gate held forever."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        with patch.object(svc, "get_table_schema", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                svc.get_tables_columns(["schools"])
+
+        assert svc.get_tables_columns(["schools"]).data.tables
+
 
 class TestSchemaOnlyDialectCatalog:
     """A dialect whose only namespace is the schema (Oracle) must still list.

--- a/tests/unit_tests/utils/test_config_utils.py
+++ b/tests/unit_tests/utils/test_config_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from datus.utils.config_utils import coerce_bool
+from datus.utils.config_utils import coerce_bool, coerce_positive_int, coerce_positive_seconds
 
 
 class TestCoerceBool:
@@ -56,3 +56,75 @@ class TestCoerceBool:
         """Callers store the result on config objects and compare with ``is``."""
         for value in ("yes", "no", 1, 0, None):
             assert type(coerce_bool(value, False)) is bool
+
+
+class TestCoercePositiveInt:
+    """Bounds read from ``agent.yml``, where a typo must not become a tiny bound.
+
+    An absent bound is obvious; a bound of 1 looks deliberate and quietly
+    rejects almost everything. These are the coercions Python would perform
+    silently to get there.
+    """
+
+    @pytest.mark.parametrize("value", [20, 20.0, "20", " 20 "])
+    def test_accepts_a_whole_number_however_written(self, value):
+        assert coerce_positive_int(value, 500) == 20
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_a_yaml_boolean_is_a_typo_not_a_bound_of_one(self, value):
+        """``bool`` is an ``int`` subclass and YAML reads ``true``/``yes``/``on``
+        as ``True``, so ``int()`` would hand back a bound of 1."""
+        assert coerce_positive_int(value, 500) == 500
+
+    @pytest.mark.parametrize(("value", "expected"), [(3.5, 3), (1.9, 1), (20.5, 20)])
+    def test_a_fractional_number_truncates(self, value, expected):
+        """Deliberate: request-supplied page sizes come through here, and
+        truncating still bounds the request where falling back would hand back a
+        larger default than was asked for. Callers needing a whole number must
+        check before calling."""
+        assert coerce_positive_int(value, 500) == expected
+
+    @pytest.mark.parametrize("value", [0.5, -0.5])
+    def test_a_fraction_below_one_falls_back_for_being_non_positive(self, value):
+        assert coerce_positive_int(value, 500) == 500
+
+    @pytest.mark.parametrize("value", [float("inf"), float("-inf"), "inf", ".inf"])
+    def test_infinity_falls_back(self, value):
+        """YAML ``.inf`` is what an operator writes for "no limit"; ``int()``
+        raises ``OverflowError`` on it rather than converting."""
+        assert coerce_positive_int(value, 500) == 500
+
+    @pytest.mark.parametrize("value", [float("nan"), None, "abc", "", [], {"a": 1}, Mock()])
+    def test_uninterpretable_values_fall_back(self, value):
+        assert coerce_positive_int(value, 500) == 500
+
+    @pytest.mark.parametrize("value", [0, -1, -500])
+    def test_non_positive_values_fall_back(self, value):
+        assert coerce_positive_int(value, 500) == 500
+
+    def test_returns_a_real_int(self):
+        assert type(coerce_positive_int(20.0, 500)) is int
+
+
+class TestCoercePositiveSeconds:
+    """A timeout budget. Unlike a count it keeps fractions, since sub-second
+    budgets are meaningful — but it must never resolve to *no* deadline."""
+
+    @pytest.mark.parametrize("value", [0.5, 1.9, 3, "2.5"])
+    def test_keeps_fractions(self, value):
+        assert coerce_positive_seconds(value, 3.0) == float(value)
+
+    @pytest.mark.parametrize("value", [float("inf"), "inf", ".inf"])
+    def test_infinity_is_rejected_not_honoured(self, value):
+        """It passes a bare ``> 0`` and would turn a deadline into no deadline —
+        the opposite of what a timeout is for."""
+        assert coerce_positive_seconds(value, 3.0) == 3.0
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_a_yaml_boolean_falls_back(self, value):
+        """``true`` would otherwise buy a 1-second budget."""
+        assert coerce_positive_seconds(value, 3.0) == 3.0
+
+    @pytest.mark.parametrize("value", [float("nan"), None, "abc", 0, -1, []])
+    def test_uninterpretable_or_non_positive_values_fall_back(self, value):
+        assert coerce_positive_seconds(value, 3.0) == 3.0


### PR DESCRIPTION
## Problem

A customer on-prem deployment (Oracle) reported the whole app hanging for about a minute after entering a project. The frontend was firing a catalog-wide column warm-up — six parallel `POST /table/columns` of 200 tables each (fixed on the SaaS side in Datus-ai/Datus-saas#856) — but the reason it took the *service* down rather than just being slow is here.

`get_tables_columns` resolves its tables serially, and each `get_table_schema` takes the single per-connector `_schema_lock` while holding an `asyncio.to_thread` worker:

```python
for full_path in tables:
    detail = self.get_table_schema(full_path)   # N serial round-trips, N lock acquisitions
```

So N tables cost N round-trips. On a slow source that is minutes of held lock and a pinned worker, and **everything else needing table metadata queues behind it** — interactive `/table/detail`, the agent's schema linking during chat. Six such batches in parallel could not go any faster (they serialize on the lock regardless) but each pinned a worker while waiting.

## Fix

Prefetch is a convenience, so it should yield rather than compete. Two bounds on top of the existing size cap:

- **One batch at a time**, and a second **does not queue** — it returns what the cache already holds. Queuing is the part that pins a worker, and a queued batch could not go faster anyway.
- **A time budget** (`api.prefetch_budget_seconds`, default 3s). The batch stops when it is spent.

Both leave tables out of the response, which is exactly the contract a table that fails to resolve already has — so a client re-asks for what it still needs, one table at a time, via `/table/detail`. The matching SaaS change evicts omitted tables so its on-demand path retries them.

**Cache hits are served regardless of either bound**, and a fully-warm batch never takes the gate at all — the common steady-state case stays free.

Worst case for one request goes from unbounded (~50s+ observed on Oracle) to the budget plus one table round-trip — the budget is only checked between tables, and a single `get_table_schema` (including its wait on the connector lock) has no timeout of its own. At the ~0.25s/table observed on Oracle that is ~3.25s. At most one batch touches the source at any moment.

Two smaller things in the same area:
- `max_prefetch_tables` no longer raises out of `int()` on a non-numeric `agent.yml` value; a typo falls back to the default instead of taking the endpoint down.
- Table-identity resolution is factored out of `get_table_schema` into `_resolve_table_identity` / `_cached_columns`, so the batch can test the cache without touching the connector.

## Known limits — this is not blanket rate limiting

Three boundaries a reader should not assume are covered. Each is a deliberate
follow-up, not an oversight:

**A single round-trip is still unbounded.** The budget is only evaluated at the
top of the loop, and `get_table_schema` holds `_schema_lock` across
`connector.get_schema()` with no timeout of its own. If one wide table's
`ALL_TAB_COLUMNS` query takes 60s, the batch holds the lock and a to_thread
worker for those 60s and interactive `/table/detail` queues behind it. This
change moves the ceiling from N×T to budget+T, not to budget. A real fix means
a timeout on `get_schema`, or taking the lock with `acquire(timeout=)`.

**The gate is per-project, so it does not defend across projects.**
`DatasourceService` is cached per project and `DBManager` is not a singleton
(`db_manager.py:193` — `_conn_dict` is an instance field), so M active projects
have M independent gates, locks and connectors. On-prem all projects share one
container, so six IDEs open at once means six parallel batches, each pinning a
worker from the shared `min(32, cpu+4)` pool and all hitting the same Oracle.
Smaller than the original blast radius, not gone. Fixing it means lifting the
gate to module scope, or a registry keyed by datasource URI — keyed, because a
module-level gate would serialize projects on unrelated datasources.

**An over-limit batch is rejected whole, which is inconsistent with the other
two bounds.** A spent budget and a busy gate both return `success=True` with a
partial result; only the size cap returns `INVALID_PARAMETERS`, which the SaaS
http client throws on. So an operator who tunes `max_prefetch_tables` below the
client's fixed 50 gets batches that always fail, and a client that releases the
names on failure re-sends the same doomed request on the next keystroke —
nothing ever warms. `tables[:max_tables]` with the remainder reported as omitted
would make all three bounds the same shape. Not done here because it changes a
documented response for the endpoint and the test that pins it; worth its own
change.

## What this does *not* fix

The real cost is that columns are fetched one table per round-trip. Every dialect could do this in a single metadata query (`ALL_TAB_COLUMNS`, `information_schema.columns`), but `get_schema` is a per-table interface on `BaseSqlConnector` in `datus_db_core`, and the dialect connectors live outside this repo. That is the actual fix and it belongs in a separate change; this PR only stops one caller from monopolising the datasource in the meantime.

## Test

New `TestGetTablesColumnsBounds` — 7 cases: budget exhausted before the first table (asserts the connector is never called), omitted tables still fetchable per-table afterwards, budget spent mid-batch returns the partial result, a second batch returning instead of queuing, cache hits served while the gate is held, gate released for the next batch, gate released when a table raises. Plus one for the non-numeric limit falling back.

- `tests/unit_tests/api/services/test_database_service.py` — 71 passed.
- `tests/unit_tests/api` — 1352 passed; the 10 failures + 2 errors in `test_explorer_service.py` / `test_metric_hooks.py` are pre-existing (identical on a clean `main`).
- `ruff format` + `ruff check` clean.

## Related

- Datus-ai/Datus-saas#856 — removes the catalog-wide warm-up that triggered this and batches the per-document prefetch.
- A Datus-backend submodule bump follows once this merges.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

* **Improvements**
  * Added safer and more predictable database column loading with configurable request limits and time budgets.
  * Cached results are returned immediately without additional throttling.
  * Partial results remain available when processing limits are reached.
  * Individual table details can still be retrieved when batch loading is incomplete.
  * Improved handling of invalid settings, concurrent requests, and temporary failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added safer, more predictable database column loading with configurable request limits and time budgets.
  * Cached results are returned immediately without additional throttling.
  * Partial results remain available when processing limits are reached.
  * Individual table details can still be retrieved when batch loading is incomplete.
  * Improved handling of invalid settings, concurrent requests, and temporary failures.
  * Standardized validation for session paging and duration settings, including fractional and infinite values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
