### PR TITLE
[Doc] Add airflow/mwaa/s3 plugin docs (EN + zh)

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -921,6 +921,9 @@ flow_groups:
         quality_sensitive: false
         docs:
           - docs/plugin/introduction.md
+          - docs/plugin/airflow.md
+          - docs/plugin/mwaa.md
+          - docs/plugin/s3.md
         entrypoints:
           - "CLI: datus <plugin> subcommand dispatch"
           - Plugin profile resolution and project pins

--- a/docs/plugin/airflow.md
+++ b/docs/plugin/airflow.md
@@ -1,0 +1,153 @@
+# Airflow Plugin
+
+The Airflow plugin (`datus-airflow-plugin`) connects the Datus agent to a
+remote Apache Airflow 2.x or 3.x deployment through Airflow's stable REST API.
+Nothing Airflow-related is installed where Datus runs. Once a profile is
+configured, the agent can inspect, trigger, and troubleshoot DAGs, manage
+variables, connections, and pools, and export or deploy DAG source code — all
+driven by natural-language requests in the chat.
+
+## Installation
+
+```bash
+datus plugin install datus-airflow-plugin
+```
+
+Requires datus-agent >= 0.3.8. After installation the bundled skills appear in
+`/skill list`, and the agent discovers the plugin and its configured
+environments when a session starts. See [Plugins](introduction.md) for other
+install sources and profile management.
+
+## Skills
+
+| Skill | Purpose |
+|---|---|
+| `airflow` | Day-to-day operations against a configured Airflow environment |
+| `airflow-setup` | Create an environment profile through a guided conversation |
+| `airflow-dag-export` | Export or deploy DAG source with an explicitly confirmed scope |
+
+### airflow
+
+The core operations skill. With it the agent can:
+
+- list and inspect DAGs, runs, task states, and task logs;
+- trigger a DAG run — optionally waiting for the result — and clear failed
+  runs or tasks for a retry;
+- pause and unpause DAGs and check import errors after a deployment;
+- manage instance-wide variables, connections, and pools;
+- create and monitor backfills and read server version and health (assets and
+  the backfill API require Airflow 3).
+
+A profile can carry scope guardrails: `dag_id_prefix` restricts every
+DAG-scoped action to matching DAG ids, and `allow_commands` restricts the
+available command groups. The agent sees these limits in its context and works
+inside them instead of discovering them by failing. They guard against
+mistakes; they are not a security boundary — tenant isolation still belongs on
+the Airflow server.
+
+### airflow-setup
+
+Configuration by conversation. Ask the agent to set up the plugin and the
+skill collects the Airflow web server URL, the auth method (a static API
+token, or a username and password), and optional settings such as a
+`dags_folder` deployment URI or the scope guardrails above. Secrets are always
+written as `${ENV_VAR}` references, never literals, and the skill verifies the
+new profile with a cheap read-only call before finishing. A resulting profile
+looks like this:
+
+```yaml
+agent:
+  plugins:
+    airflow:
+      prod:
+        default: true
+        api_base_url: https://airflow.example.com/api/v1  # /api/v1 = Airflow 2, /api/v2 = Airflow 3
+        username: admin
+        password: ${AIRFLOW_PASSWORD}
+        dags_folder: s3://my-bucket/dags/  # optional deployment URI;
+                                           # storage credentials belong to the s3 plugin
+```
+
+### airflow-dag-export
+
+A confirmation-gated workflow for exporting, backing up, migrating, or
+deploying DAG source:
+
+1. **Discover** — the live Airflow API is the only source of truth. The skill
+   lists the active DAG set and fetches each Python file through the API; it
+   never scans the `dags_folder` storage behind the scheduler.
+2. **Propose and refine** — it presents a complete proposal: environment,
+   selected DAGs, files, destination, and transfer method. You adjust the
+   scope in natural language — by DAG id, glob or regex, owner, tag, paused
+   state, source keyword, or referenced connection id — and it recomputes the
+   proposal after every change.
+3. **Confirm and write** — nothing is written to the destination until you
+   confirm the exact current proposal. The export ships with a
+   `dag-export-manifest.json` recording every DAG, file, and checksum, and
+   never contains credentials.
+4. **Upload** — the destination URI selects the transfer: local paths are
+   copied directly, `s3://` goes through the [S3 plugin](s3.md), `gs://` and
+   `abfs://` through the GCS and ADLS plugins. The Airflow plugin itself
+   contains no object-storage client.
+
+## Using with the Agent
+
+Some example requests, once a profile exists:
+
+- **"Which DAGs failed last night in prod?"** — the agent lists recent failed
+  runs, drills into task states, and pulls the failing task's logs.
+- **"Trigger sales_daily and wait for it to finish."** — the agent asks for
+  confirmation, starts the run, and polls until it succeeds or fails.
+- **"Clear the failed tasks of yesterday's sales_daily run and retry them."**
+- **"Backfill sales_daily for the first week of January — dry-run first."**
+- **"Set up the airflow plugin for our staging cluster."** — runs
+  `airflow-setup`.
+
+Commands the agent runs go through the Datus
+[permission system](introduction.md#permissions): read-only operations run
+without confirmation; routine reversible ones (pausing, clearing runs, setting
+variables) ask once under the `normal` mode; anything that starts a run,
+deletes an object, imports files in bulk, or touches connection secrets always
+asks first.
+
+## Orchestrating Workflows
+
+### Deploy DAGs through the S3 plugin
+
+When the scheduler syncs its DAGs from object storage — the usual production
+setup — pair this plugin with the [S3 plugin](s3.md):
+
+1. Point the profile's `dags_folder` at the bucket the scheduler reads, e.g.
+   `s3://my-bucket/dags/`. Storage credentials live in the S3 plugin's own
+   profile; the Airflow plugin never receives them.
+2. Ask the agent to deploy. It uploads the DAG file through the S3 plugin,
+   then polls the DAG list and import errors through the Airflow API until
+   the new DAG is parsed.
+3. Continue in the same conversation: trigger the DAG and watch the run.
+
+A single end-to-end request works too:
+
+```text
+Create dags/hello_world.py with one task that prints the run date, upload it
+to the Airflow DAG root with the s3 plugin, verify the DAG appears, trigger
+it, and wait for completion.
+```
+
+The same pairing runs in reverse for backup and migration — "export all
+active prod DAGs to s3://backup/airflow/2026-08-24/" drives
+`airflow-dag-export` with the S3 plugin as the transfer layer.
+
+### Airflow on Amazon MWAA
+
+For Airflow hosted on Amazon MWAA, the [MWAA plugin](mwaa.md) manages the
+environment itself — login links, tokens, environment details — and this
+plugin can be pointed at the environment's web server for the fine-grained,
+permission-classified DAG operations described above.
+
+## Related Docs
+
+- [Plugins](introduction.md) — install sources, profiles, activation, and permissions
+- [S3 plugin](s3.md) — the transfer layer behind `s3://` DAG deployment
+- [MWAA plugin](mwaa.md) — Amazon-managed Airflow environments
+- [Data Engineering Quickstart](../getting_started/data_engineering_quickstart.md) — an end-to-end pipeline that publishes a daily Airflow DAG
+- [Skills](../skills/introduction.md) — how skills are discovered and loaded

--- a/docs/plugin/airflow.zh.md
+++ b/docs/plugin/airflow.zh.md
@@ -1,0 +1,133 @@
+# Airflow 插件
+
+Airflow 插件（`datus-airflow-plugin`）通过 Airflow 的稳定 REST API，把 Datus agent
+连接到远端的 Apache Airflow 2.x 或 3.x 部署，Datus 所在机器不需要安装任何 Airflow
+组件。配置好 profile 之后，你就可以在对话里用自然语言让 agent 查看、触发和排查
+DAG，管理 variables、connections 和 pools，以及导出或部署 DAG 源码。
+
+## 安装
+
+```bash
+datus plugin install datus-airflow-plugin
+```
+
+要求 datus-agent >= 0.3.8。安装完成后，自带的 skills 会出现在 `/skill list` 中，
+会话开始时 agent 会自动发现插件及其已配置的环境。其他安装来源和 profile 管理方式
+见[插件](introduction.zh.md)。
+
+## Skills
+
+| Skill | 作用 |
+|---|---|
+| `airflow` | 对已配置的 Airflow 环境做日常操作 |
+| `airflow-setup` | 通过对话引导创建环境 profile |
+| `airflow-dag-export` | 在明确确认范围后导出或部署 DAG 源码 |
+
+### airflow
+
+核心操作 skill。借助它，agent 可以：
+
+- 列出并查看 DAG、运行记录、任务状态和任务日志；
+- 触发 DAG 运行（可以等待运行结束），清理失败的运行或任务以便重跑；
+- 暂停和恢复 DAG，在部署后检查 import 错误；
+- 管理实例级的 variables、connections 和 pools；
+- 创建和跟踪 backfill，读取服务端版本与健康状态（assets 和 backfill API 需要
+  Airflow 3）。
+
+Profile 可以设置作用域护栏：`dag_id_prefix` 把所有针对 DAG 的操作限制在匹配前缀的
+DAG 上，`allow_commands` 限制可用的命令组。这些限制会出现在 agent 的上下文里，
+agent 会主动遵守，而不是靠失败来试探边界。它们用来防止误操作，不是安全边界——
+真正的租户隔离仍然要靠 Airflow 服务端。
+
+### airflow-setup
+
+用对话完成配置。让 agent 帮你配置插件，这个 skill 会收集 Airflow Web 服务器地址、
+认证方式（静态 API token，或用户名加密码），以及 `dags_folder` 部署 URI、上述作用域
+护栏等可选项。密钥一律写成 `${ENV_VAR}` 引用，绝不写明文；写好后 skill 会用一次
+只读调用验证 profile 可用。生成的 profile 形如：
+
+```yaml
+agent:
+  plugins:
+    airflow:
+      prod:
+        default: true
+        api_base_url: https://airflow.example.com/api/v1  # /api/v1 对应 Airflow 2，/api/v2 对应 Airflow 3
+        username: admin
+        password: ${AIRFLOW_PASSWORD}
+        dags_folder: s3://my-bucket/dags/  # 可选的部署 URI；
+                                           # 存储凭据属于 s3 插件，不写在这里
+```
+
+### airflow-dag-export
+
+一个必须经过明确确认的工作流，用于导出、备份、迁移或部署 DAG 源码：
+
+1. **发现** —— 以线上 Airflow API 为唯一权威来源。skill 通过 API 列出活跃 DAG
+   集合，逐个获取 Python 源码，绝不去扫描调度器背后的 `dags_folder` 存储。
+2. **提议与调整** —— 给出一份完整方案：环境、选中的 DAG、文件、目的地和传输
+   方式。你可以用自然语言调整范围——按 DAG id、通配或正则、owner、tag、暂停
+   状态、源码关键字或引用的 connection id 过滤——每次调整后它都会重新计算并
+   展示方案。
+3. **确认后写入** —— 在你确认当前这份方案之前，不会向目的地写任何东西。导出
+   结果附带 `dag-export-manifest.json`，记录每个 DAG、文件和校验和，绝不包含
+   凭据。
+4. **上传** —— 由目的地 URI 决定传输方式：本地路径直接复制，`s3://` 走
+   [S3 插件](s3.zh.md)，`gs://` 和 `abfs://` 分别走 GCS 和 ADLS 插件。Airflow
+   插件自身不含任何对象存储客户端。
+
+## 在 agent 中使用
+
+配置好 profile 后，可以这样提出请求：
+
+- **「prod 里昨晚哪些 DAG 失败了？」** —— agent 会列出最近失败的运行，逐层查看
+  任务状态，并调出失败任务的日志。
+- **「触发 sales_daily，等它跑完告诉我结果。」** —— agent 先请求确认，然后启动
+  运行并轮询到成功或失败。
+- **「把昨天 sales_daily 那次运行里失败的任务清掉重跑。」**
+- **「给 sales_daily 补跑一月第一周的数据，先 dry-run。」**
+- **「帮我给 staging 集群配置 airflow 插件。」** —— 触发 `airflow-setup`。
+
+Agent 执行的命令都经过 Datus [权限系统](introduction.zh.md#permissions)：只读操作
+直接执行；常规可逆操作（暂停、清理运行、设置 variable）在 `normal` 模式下需要
+确认一次；启动运行、删除对象、批量导入、涉及 connection 密钥的操作任何模式下都
+必须先确认。
+
+## 编排工作流
+
+### 用 S3 插件部署 DAG
+
+当调度器从对象存储同步 DAG（生产环境的常见做法）时，把本插件和
+[S3 插件](s3.zh.md)配合使用：
+
+1. 把 profile 的 `dags_folder` 指向调度器读取的桶，例如
+   `s3://my-bucket/dags/`。存储凭据配置在 S3 插件自己的 profile 里，Airflow
+   插件不会接触它们。
+2. 让 agent 部署。它会通过 S3 插件上传 DAG 文件，然后通过 Airflow API 轮询
+   DAG 列表和 import 错误，直到新 DAG 被解析成功。
+3. 在同一段对话里继续：触发 DAG，跟踪运行结果。
+
+也可以一句话交代整个流程：
+
+```text
+创建 dags/hello_world.py，里面一个任务打印运行日期；用 s3 插件把它上传到
+Airflow 的 DAG 根目录，确认 DAG 出现后触发它，并等待运行完成。
+```
+
+同样的组合反过来就是备份和迁移——「把 prod 的所有活跃 DAG 导出到
+s3://backup/airflow/2026-08-24/」会驱动 `airflow-dag-export`，由 S3 插件承担
+传输。
+
+### 托管在 Amazon MWAA 上的 Airflow
+
+如果 Airflow 托管在 Amazon MWAA 上，[MWAA 插件](mwaa.zh.md)负责环境本身——登录
+链接、令牌、环境详情——再把本插件指向该环境的 Web 服务器，就能获得上面这套
+细粒度、带权限分级的 DAG 操作能力。
+
+## 相关文档
+
+- [插件](introduction.zh.md) —— 安装来源、profile、项目启用与权限
+- [S3 插件](s3.zh.md) —— `s3://` DAG 部署背后的传输层
+- [MWAA 插件](mwaa.zh.md) —— Amazon 托管的 Airflow 环境
+- [数据工程快速开始](../getting_started/data_engineering_quickstart.zh.md) —— 包含发布每日 Airflow DAG 的端到端流水线
+- [Skills](../skills/introduction.zh.md) —— skills 的发现和加载方式

--- a/docs/plugin/introduction.md
+++ b/docs/plugin/introduction.md
@@ -278,5 +278,7 @@ and tool safeguards. The default is `true`.
 
 ## Next steps
 
+- Browse the plugin guides: [Airflow](airflow.md), [MWAA](mwaa.md), and
+  [S3](s3.md).
 - [Develop a plugin](development.md) with the `datus-plugin-development` skill.
 - Learn how [skills](../skills/introduction.md) are discovered and used.

--- a/docs/plugin/introduction.zh.md
+++ b/docs/plugin/introduction.zh.md
@@ -183,7 +183,7 @@ datus plugin disable internal-admin
 在不允许 agent 修改 `agent.yml` 的托管环境中，对应的 setup skill 不会显示。此时需要由
 管理员完成配置。
 
-## 权限
+## 权限 {#permissions}
 
 Agent 运行的插件命令会经过 Datus 权限系统。插件可以将自己的命令标记为：
 
@@ -255,5 +255,6 @@ agent:
 
 ## 下一步
 
+- 阅读插件指南：[Airflow](airflow.zh.md)、[MWAA](mwaa.zh.md) 和 [S3](s3.zh.md)。
 - 使用 `datus-plugin-development` skill [开发插件](development.zh.md)。
 - 了解 [skills](../skills/introduction.zh.md) 的发现和使用方式。

--- a/docs/plugin/mwaa.md
+++ b/docs/plugin/mwaa.md
@@ -1,0 +1,129 @@
+# MWAA Plugin
+
+The MWAA plugin (`datus-mwaa-plugin`) connects the Datus agent to Amazon
+Managed Workflows for Apache Airflow. It works at the environment level:
+inspecting MWAA environments, minting Airflow UI login links and CLI tokens,
+listing the DAGs an environment currently runs and reading their source, and
+passing Airflow CLI commands through MWAA's REST endpoint. Creating, updating,
+or deleting environments is out of scope.
+
+## Installation
+
+```bash
+datus plugin install datus-mwaa-plugin
+```
+
+Requires datus-agent >= 0.3.8. AWS credentials resolve through the standard
+boto3 chain, or through the profile fields collected by `mwaa-setup` below.
+See [Plugins](introduction.md) for other install sources and profile
+management.
+
+## Skills
+
+| Skill | Purpose |
+|---|---|
+| `mwaa` | Inspect environments, mint tokens, read current DAGs and their source |
+| `mwaa-setup` | Create a profile (region, credentials, default environment) |
+| `mwaa-dag-export` | Export the environment's DAG source with an explicitly confirmed scope |
+
+### mwaa
+
+With this skill the agent can:
+
+- list MWAA environments and describe one — the details include the Airflow
+  version, status, web server URL, and the S3 bucket and DAG path the
+  environment reads;
+- mint a one-time Airflow UI login URL, or a CLI token together with the web
+  server hostname;
+- list the DAGs the environment currently runs and read a DAG's source. Both
+  go through a short-lived MWAA web session straight to the environment's
+  Airflow REST API — the S3 bucket is never read;
+- run an Airflow CLI command over MWAA's REST endpoint. This is an opaque
+  passthrough — the wrapped command could be destructive — so the agent
+  always asks for confirmation first, and MWAA does not support every Airflow
+  subcommand there. For day-to-day DAG operations prefer the
+  [Airflow plugin](airflow.md) pointed at the environment.
+
+### mwaa-setup
+
+Ask the agent to set up the plugin and the skill collects the AWS region, the
+credential source (the default AWS chain, a named profile, keys as
+`${ENV_VAR}` references, or a role to assume), and an optional default
+environment name, then verifies the profile by listing environments. The IAM
+principal needs `airflow:ListEnvironments`, `airflow:GetEnvironment`,
+`airflow:CreateWebLoginToken`, and `airflow:CreateCliToken`. A resulting
+profile looks like this:
+
+```yaml
+agent:
+  plugins:
+    mwaa:
+      prod:
+        default: true
+        region: us-east-1
+        environment: prod-airflow  # optional default environment
+        # credentials: standard AWS chain, or profile / keys / role_arn
+```
+
+### mwaa-dag-export
+
+The MWAA counterpart of the Airflow plugin's export workflow, with the same
+guarantees: the environment's Airflow API is the only source of truth (the
+skill never enumerates the MWAA S3 DAG prefix), the scope is adjustable in
+natural language and recomputed after every change, nothing is written or
+uploaded before you confirm the exact proposal, and the export carries a
+checksummed `dag-export-manifest.json` that never contains credentials or
+tokens. Uploads route by destination URI — `s3://` goes through the
+[S3 plugin](s3.md).
+
+## Using with the Agent
+
+Some example requests, once a profile exists:
+
+- **"Give me a login link for the prod MWAA UI."** — a one-time web-login URL.
+- **"Which DAGs run in the prod environment? Show me sales_daily's source."**
+- **"Describe the analytics-airflow environment — which bucket does it read
+  DAGs from?"**
+- **"Set up the mwaa plugin for us-east-1."** — runs `mwaa-setup`.
+
+These inspection operations run without confirmation. Only the Airflow CLI
+passthrough always asks first, because its payload is opaque to the
+[permission system](introduction.md#permissions).
+
+## Orchestrating Workflows
+
+### Fine-grained DAG operations through the Airflow plugin
+
+MWAA manages the environment; the [Airflow plugin](airflow.md) manages the
+DAGs. For triggering, pausing, clearing, log reading, and the rest of its
+permission-classified operation set, configure an Airflow-plugin profile
+against the MWAA environment's web server — this plugin supplies the hostname
+and token. Ask the agent to wire the two together:
+
+```text
+Point the airflow plugin at the prod MWAA environment, then trigger
+sales_daily and wait for the run.
+```
+
+### Deploy DAGs through the S3 plugin
+
+An MWAA environment reads its DAGs from the S3 bucket and prefix shown in its
+environment details. The MWAA plugin contains no S3 transfer, so deployment
+is a combination: the agent uploads the file through the [S3 plugin](s3.md),
+then verifies through this plugin that the DAG appears:
+
+```text
+Upload dags/sales_daily.py to the prod MWAA environment's DAG folder and
+confirm the DAG shows up.
+```
+
+In the other direction, "export every DAG of the prod MWAA environment to
+s3://backup/mwaa/2026-08-24/" runs `mwaa-dag-export` — the source always
+comes through the Airflow API, and the upload goes through the S3 plugin.
+
+## Related Docs
+
+- [Plugins](introduction.md) — install sources, profiles, activation, and permissions
+- [Airflow plugin](airflow.md) — fine-grained DAG operations for the same environment
+- [S3 plugin](s3.md) — DAG uploads into the environment's bucket
+- [Skills](../skills/introduction.md) — how skills are discovered and loaded

--- a/docs/plugin/mwaa.zh.md
+++ b/docs/plugin/mwaa.zh.md
@@ -1,0 +1,108 @@
+# MWAA 插件
+
+MWAA 插件（`datus-mwaa-plugin`）把 Datus agent 连接到 Amazon Managed Workflows
+for Apache Airflow。它工作在环境层面：查看 MWAA 环境、签发 Airflow UI 登录链接和
+CLI 令牌、列出环境当前运行的 DAG 并读取源码，以及把 Airflow CLI 命令透传给 MWAA
+的 REST 端点。创建、修改或删除环境不在其范围内。
+
+## 安装
+
+```bash
+datus plugin install datus-mwaa-plugin
+```
+
+要求 datus-agent >= 0.3.8。AWS 凭据按标准 boto3 链解析，也可以通过下面
+`mwaa-setup` 收集的 profile 字段提供。其他安装来源和 profile 管理方式见
+[插件](introduction.zh.md)。
+
+## Skills
+
+| Skill | 作用 |
+|---|---|
+| `mwaa` | 查看环境、签发令牌、读取当前 DAG 及其源码 |
+| `mwaa-setup` | 创建 profile（区域、凭据、默认环境） |
+| `mwaa-dag-export` | 在明确确认范围后导出环境的 DAG 源码 |
+
+### mwaa
+
+借助这个 skill，agent 可以：
+
+- 列出 MWAA 环境并查看详情——包括 Airflow 版本、状态、Web 服务器地址，以及环境
+  读取 DAG 的 S3 桶和路径；
+- 签发一次性的 Airflow UI 登录链接，或 CLI 令牌加 Web 服务器主机名；
+- 列出环境当前运行的 DAG 并读取某个 DAG 的源码。两者都通过短时 MWAA Web 会话
+  直接调用环境的 Airflow REST API——从不读取 S3 桶；
+- 通过 MWAA 的 REST 端点执行 Airflow CLI 命令。这是不透明的透传——被包裹的命令
+  可能有破坏性——因此 agent 总是先请求确认，而且 MWAA 并不支持所有 Airflow
+  子命令。日常 DAG 操作建议改用指向该环境的 [Airflow 插件](airflow.zh.md)。
+
+### mwaa-setup
+
+让 agent 帮你配置插件，这个 skill 会收集 AWS 区域、凭据来源（默认 AWS 链、命名
+profile、以 `${ENV_VAR}` 引用的密钥，或要 assume 的角色），以及可选的默认环境名，
+然后通过列出环境来验证 profile。IAM 主体需要 `airflow:ListEnvironments`、
+`airflow:GetEnvironment`、`airflow:CreateWebLoginToken` 和
+`airflow:CreateCliToken` 四项权限。生成的 profile 形如：
+
+```yaml
+agent:
+  plugins:
+    mwaa:
+      prod:
+        default: true
+        region: us-east-1
+        environment: prod-airflow  # 可选的默认环境
+        # 凭据：标准 AWS 链，或 profile / 密钥 / role_arn
+```
+
+### mwaa-dag-export
+
+Airflow 插件导出工作流的 MWAA 对应版本，保证完全一致：以环境的 Airflow API 为
+唯一权威来源（skill 绝不枚举 MWAA 的 S3 DAG 前缀），范围可用自然语言反复调整、
+每次调整后重新计算，在你确认当前方案之前不写入、不上传，导出结果附带含校验和的
+`dag-export-manifest.json`，绝不包含凭据或令牌。上传按目的地 URI 路由——
+`s3://` 走 [S3 插件](s3.zh.md)。
+
+## 在 agent 中使用
+
+配置好 profile 后，可以这样提出请求：
+
+- **「给我一个 prod MWAA UI 的登录链接。」** —— 返回一次性 web-login URL。
+- **「prod 环境现在跑着哪些 DAG？把 sales_daily 的源码给我看看。」**
+- **「看下 analytics-airflow 这个环境的详情——它从哪个桶读 DAG？」**
+- **「帮我在 us-east-1 配置 mwaa 插件。」** —— 触发 `mwaa-setup`。
+
+以上查看类操作都不需要确认；只有 Airflow CLI 透传总是先确认，因为它的内容对
+[权限系统](introduction.zh.md#permissions)来说是不透明的。
+
+## 编排工作流
+
+### 用 Airflow 插件做细粒度 DAG 操作
+
+MWAA 插件管环境，[Airflow 插件](airflow.zh.md)管 DAG。触发、暂停、清理、看日志
+这些带权限分级的操作，应该给 Airflow 插件配置一个指向 MWAA 环境 Web 服务器的
+profile——主机名和令牌由本插件提供。直接让 agent 把两者接起来：
+
+```text
+把 airflow 插件指向 prod MWAA 环境，然后触发 sales_daily 并等待运行结束。
+```
+
+### 用 S3 插件部署 DAG
+
+MWAA 环境从环境详情里显示的 S3 桶和前缀读取 DAG。MWAA 插件不含 S3 传输能力，
+所以部署是一个组合动作：agent 先通过 [S3 插件](s3.zh.md)上传文件，再通过本插件
+验证 DAG 出现：
+
+```text
+把 dags/sales_daily.py 上传到 prod MWAA 环境的 DAG 目录，并确认 DAG 已经出现。
+```
+
+反过来，「把 prod MWAA 环境的所有 DAG 导出到 s3://backup/mwaa/2026-08-24/」会
+运行 `mwaa-dag-export`——源码始终来自 Airflow API，上传由 S3 插件完成。
+
+## 相关文档
+
+- [插件](introduction.zh.md) —— 安装来源、profile、项目启用与权限
+- [Airflow 插件](airflow.zh.md) —— 对同一环境做细粒度 DAG 操作
+- [S3 插件](s3.zh.md) —— 向环境的桶上传 DAG
+- [Skills](../skills/introduction.zh.md) —— skills 的发现和加载方式

--- a/docs/plugin/s3.md
+++ b/docs/plugin/s3.md
@@ -1,0 +1,119 @@
+# S3 Plugin
+
+The S3 plugin (`datus-s3-plugin`) lets the Datus agent browse, query, and move
+object-storage data. It speaks to Amazon S3 and to S3-compatible stores such
+as MinIO and Alibaba Cloud OSS, and it is the transfer layer other plugins
+rely on when a workflow reads from or writes to an `s3://` URI — deploying
+Airflow DAGs, for example.
+
+## Installation
+
+```bash
+datus plugin install datus-s3-plugin
+```
+
+Requires datus-agent >= 0.3.8. See [Plugins](introduction.md) for other
+install sources and profile management.
+
+## Skills
+
+| Skill | Purpose |
+|---|---|
+| `s3` | Browse, read, query, and move objects |
+| `s3-setup` | Create a profile (region, credentials, default bucket, compatibility mode) |
+
+### s3
+
+With this skill the agent can:
+
+- **browse and read** — list buckets and prefixes, show object metadata,
+  print an object's contents or first lines, and mint presigned URLs (a
+  presigned PUT URL grants write access and is treated like a credential);
+- **query in place** — run S3 Select SQL against a single CSV, JSON, or
+  Parquet object without downloading it, e.g. counting rows per group
+  straight off the bucket;
+- **move data** — upload and download files, sync a directory (only new and
+  changed files are transferred), move objects, and delete them;
+- **publish artifacts safely** — the skill encodes upload hygiene: verify an
+  upload by reading its metadata back, publish each build under a versioned
+  key instead of overwriting a mutable one, and never let credentials end up
+  inside uploaded files.
+
+Writes use SSE-KMS when the profile sets `kms_key_id`. In `aliyun-oss`
+compatibility mode, S3 Select and SSE-KMS are rejected explicitly.
+
+### s3-setup
+
+Ask the agent to set up the plugin and the skill collects the region, the
+credential source (the default AWS chain, a named profile, keys as
+`${ENV_VAR}` references, or a role to assume), an optional default bucket for
+bare keys, and an optional SSE-KMS key, then verifies the profile with a
+read-only listing. MinIO needs only an `endpoint_url`; Alibaba OSS uses the
+dedicated compatibility fields. A resulting profile looks like this:
+
+```yaml
+agent:
+  plugins:
+    s3:
+      prod:
+        default: true
+        region: us-east-1
+        bucket: my-data-lake  # optional default bucket
+        # credentials: standard AWS chain, or profile / keys / role_arn
+      minio-local:
+        endpoint_url: http://minio:9000
+        access_key_id: ${MINIO_ACCESS_KEY}
+        secret_access_key: ${MINIO_SECRET_KEY}
+```
+
+The IAM principal needs at least `s3:ListBucket` and `s3:GetObject`; add
+`s3:PutObject` for uploads and `s3:DeleteObject` for deletes.
+
+## Using with the Agent
+
+Some example requests, once a profile exists:
+
+- **"What's in s3://my-lake/events/?"** — lists the prefix.
+- **"Show me the first ten rows of s3://my-lake/events/day.csv."**
+- **"How many events per region are in that file?"** — an S3 Select query;
+  nothing is downloaded.
+- **"Sync ./artifacts to s3://my-lake/artifacts/v1/ and verify the upload."**
+- **"Set up the s3 plugin against our MinIO."** — runs `s3-setup`.
+
+Under the [permission system](introduction.md#permissions), reads, queries,
+and presigning run without confirmation; uploads, syncs, and moves ask once
+under the `normal` mode; deletes always ask.
+
+## Orchestrating Workflows
+
+### The transfer layer for DAG deployment
+
+The [Airflow](airflow.md) and [MWAA](mwaa.md) plugins contain no
+object-storage client on purpose. Whenever a DAG deployment, export, backup,
+or migration targets an `s3://` URI, the agent routes the transfer through
+this plugin:
+
+- **Deploy** — "deploy dags/sales_daily.py to prod Airflow": the agent
+  uploads through this plugin into the scheduler's `dags_folder` (or an MWAA
+  environment's DAG prefix), then verifies through the scheduler-side plugin
+  that the DAG parses.
+- **Back up** — "export all active prod DAGs to s3://backup/airflow/": the
+  Airflow or MWAA export skill collects the sources through the scheduler's
+  API and hands this plugin the upload.
+
+Credentials stay separated: this plugin owns the storage credentials, the
+scheduler plugins own the Airflow credentials, and neither sees the other's.
+
+### Publish pipeline artifacts
+
+The same pattern serves anything a pipeline consumes from object storage —
+job JARs, rendered configs, exported query results. Ask the agent to publish
+a directory under a versioned prefix: it syncs only what changed, then reads
+the uploads back to verify them.
+
+## Related Docs
+
+- [Plugins](introduction.md) — install sources, profiles, activation, and permissions
+- [Airflow plugin](airflow.md) — DAG deployment on self-managed Airflow
+- [MWAA plugin](mwaa.md) — DAG deployment on Amazon MWAA
+- [Skills](../skills/introduction.md) — how skills are discovered and loaded

--- a/docs/plugin/s3.md
+++ b/docs/plugin/s3.md
@@ -42,6 +42,11 @@ With this skill the agent can:
 Writes use SSE-KMS when the profile sets `kms_key_id`. In `aliyun-oss`
 compatibility mode, S3 Select and SSE-KMS are rejected explicitly.
 
+Note that AWS no longer offers S3 Select to new customers: only accounts that
+were using it before July 25, 2024 can still call it. Newer accounts should
+query through Amazon Athena or download the object and filter locally
+instead. MinIO continues to support the S3 Select API.
+
 ### s3-setup
 
 Ask the agent to set up the plugin and the skill collects the region, the
@@ -66,8 +71,10 @@ agent:
         secret_access_key: ${MINIO_SECRET_KEY}
 ```
 
-The IAM principal needs at least `s3:ListBucket` and `s3:GetObject`; add
-`s3:PutObject` for uploads and `s3:DeleteObject` for deletes.
+The IAM principal needs at least `s3:ListBucket` and `s3:GetObject`; listing
+the account's buckets additionally needs `s3:ListAllMyBuckets` (its
+`Resource` must be `"*"`). Add `s3:PutObject` for uploads and
+`s3:DeleteObject` for deletes.
 
 ## Using with the Agent
 

--- a/docs/plugin/s3.zh.md
+++ b/docs/plugin/s3.zh.md
@@ -1,0 +1,105 @@
+# S3 插件
+
+S3 插件（`datus-s3-plugin`）让 Datus agent 能够浏览、查询和搬运对象存储数据。
+它既支持 Amazon S3，也支持 MinIO、阿里云 OSS 等 S3 兼容存储；当工作流需要读写
+`s3://` URI 时（比如部署 Airflow DAG），其他插件都依赖它承担传输。
+
+## 安装
+
+```bash
+datus plugin install datus-s3-plugin
+```
+
+要求 datus-agent >= 0.3.8。其他安装来源和 profile 管理方式见
+[插件](introduction.zh.md)。
+
+## Skills
+
+| Skill | 作用 |
+|---|---|
+| `s3` | 浏览、读取、查询和搬运对象 |
+| `s3-setup` | 创建 profile（区域、凭据、默认桶、兼容模式） |
+
+### s3
+
+借助这个 skill，agent 可以：
+
+- **浏览和读取** —— 列出桶和前缀、查看对象元数据、打印对象内容或前几行、生成
+  预签名 URL（预签名的 PUT URL 等于写权限，会被当作凭据对待）；
+- **就地查询** —— 用 S3 Select SQL 直接查询单个 CSV、JSON 或 Parquet 对象，
+  不需要下载，比如直接在桶上按分组数行数；
+- **搬运数据** —— 上传下载文件、同步目录（只传输新增和变化的文件）、移动对象、
+  删除对象；
+- **安全发布产物** —— skill 内置了上传规范：上传后读回元数据做验证，每个构建
+  发布到带版本号的 key 而不是覆盖可变 key，绝不把凭据留在上传的文件里。
+
+Profile 设置了 `kms_key_id` 时，写入使用 SSE-KMS 加密。`aliyun-oss` 兼容模式下，
+S3 Select 和 SSE-KMS 会被明确拒绝。
+
+### s3-setup
+
+让 agent 帮你配置插件，这个 skill 会收集区域、凭据来源（默认 AWS 链、命名
+profile、以 `${ENV_VAR}` 引用的密钥，或要 assume 的角色）、供裸 key 使用的可选
+默认桶，以及可选的 SSE-KMS 密钥，然后用一次只读列表验证 profile。MinIO 只需要
+`endpoint_url`；阿里云 OSS 使用专门的兼容字段。生成的 profile 形如：
+
+```yaml
+agent:
+  plugins:
+    s3:
+      prod:
+        default: true
+        region: us-east-1
+        bucket: my-data-lake  # 可选的默认桶
+        # 凭据：标准 AWS 链，或 profile / 密钥 / role_arn
+      minio-local:
+        endpoint_url: http://minio:9000
+        access_key_id: ${MINIO_ACCESS_KEY}
+        secret_access_key: ${MINIO_SECRET_KEY}
+```
+
+IAM 主体至少需要 `s3:ListBucket` 和 `s3:GetObject`；上传需要 `s3:PutObject`，
+删除需要 `s3:DeleteObject`。
+
+## 在 agent 中使用
+
+配置好 profile 后，可以这样提出请求：
+
+- **「s3://my-lake/events/ 里有什么？」** —— 列出该前缀下的对象。
+- **「把 s3://my-lake/events/day.csv 的前十行给我看看。」**
+- **「这个文件里每个 region 各有多少条记录？」** —— 一次 S3 Select 查询，
+  什么都不用下载。
+- **「把 ./artifacts 同步到 s3://my-lake/artifacts/v1/ 并验证上传结果。」**
+- **「帮我把 s3 插件配到我们的 MinIO 上。」** —— 触发 `s3-setup`。
+
+在[权限系统](introduction.zh.md#permissions)下，读取、查询和预签名不需要确认；
+上传、同步和移动在 `normal` 模式下确认一次；删除任何时候都要确认。
+
+## 编排工作流
+
+### DAG 部署的传输层
+
+[Airflow](airflow.zh.md) 和 [MWAA](mwaa.zh.md) 插件刻意不含对象存储客户端。
+只要 DAG 的部署、导出、备份或迁移涉及 `s3://` URI，agent 就会把传输交给本插件：
+
+- **部署** —— 「把 dags/sales_daily.py 部署到 prod Airflow」：agent 通过本插件
+  把文件上传到调度器的 `dags_folder`（或 MWAA 环境的 DAG 前缀），再通过调度器
+  侧的插件验证 DAG 解析成功。
+- **备份** —— 「把 prod 的所有活跃 DAG 导出到 s3://backup/airflow/」：Airflow
+  或 MWAA 的导出 skill 通过调度器的 API 收集源码，把上传交给本插件。
+
+凭据彼此隔离：本插件持有存储凭据，调度器插件持有 Airflow 凭据，双方都看不到
+对方的。
+
+### 发布流水线产物
+
+同样的模式适用于流水线从对象存储消费的一切东西——作业 JAR、渲染好的配置、导出
+的查询结果。让 agent 把目录发布到带版本号的前缀下：它只同步有变化的文件，然后
+读回上传结果做验证。
+
+## 相关文档
+
+- [插件](introduction.zh.md) —— 安装来源、profile、项目启用与权限
+- [Airflow 插件](airflow.zh.md) —— 自建 Airflow 上的 DAG 部署
+- [MWAA 插件](mwaa.zh.md) —— Amazon MWAA 上的 DAG 部署
+- [Skills](../skills/introduction.zh.md) —— skills 的发现和加载方式

--- a/docs/plugin/s3.zh.md
+++ b/docs/plugin/s3.zh.md
@@ -36,6 +36,10 @@ datus plugin install datus-s3-plugin
 Profile 设置了 `kms_key_id` 时，写入使用 SSE-KMS 加密。`aliyun-oss` 兼容模式下，
 S3 Select 和 SSE-KMS 会被明确拒绝。
 
+注意：AWS 已不再向新客户开放 S3 Select，只有 2024 年 7 月 25 日之前用过它的
+账号可以继续调用。新账号建议改用 Amazon Athena 查询，或下载对象后在本地过滤；
+MinIO 仍然支持 S3 Select API。
+
 ### s3-setup
 
 让 agent 帮你配置插件，这个 skill 会收集区域、凭据来源（默认 AWS 链、命名
@@ -58,7 +62,8 @@ agent:
         secret_access_key: ${MINIO_SECRET_KEY}
 ```
 
-IAM 主体至少需要 `s3:ListBucket` 和 `s3:GetObject`；上传需要 `s3:PutObject`，
+IAM 主体至少需要 `s3:ListBucket` 和 `s3:GetObject`；列出账号下的所有桶还需要
+`s3:ListAllMyBuckets`（其 `Resource` 必须是 `"*"`）。上传需要 `s3:PutObject`，
 删除需要 `s3:DeleteObject`。
 
 ## 在 agent 中使用

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,9 @@ nav:
     - Plugin:
       - Introduction: plugin/introduction.md
       - Development: plugin/development.md
+      - Airflow: plugin/airflow.md
+      - MWAA: plugin/mwaa.md
+      - S3: plugin/s3.md
     - Chatbot: web_chatbot/introduction.md
     - IM Gateway:
       - Introduction: gateway/introduction.md
@@ -201,6 +204,9 @@ plugins:
             Auto Memory: 自动记忆
             Plugin: 插件
             Development: 开发指南
+            Airflow: Airflow
+            MWAA: MWAA
+            S3: S3
             Develop: 开发
             Observability: 可观测性
             VSCode Extension: VSCode 插件


### PR DESCRIPTION
## Why

The docs site has no per-plugin pages: `docs/plugin/` only covers the plugin system itself (introduction + development), while the airflow/mwaa/s3 plugins are documented solely by CLI-focused READMEs in the Datus-Plugins repo. Users working through the agent had nowhere to learn what these plugins can do, how to trigger their skills with natural language, or how the plugins compose.

## Solution

- Add `docs/plugin/{airflow,mwaa,s3}.md` (+ `.zh.md` full translations), the first per-plugin pages on the site. Each follows the same skill-centric structure: installation (pip), bundled skills (what each skill does and its safety rules, e.g. the confirmation-gated `airflow-dag-export` workflow), natural-language usage examples with the agent, and cross-plugin workflow orchestration. No CLI subcommand tutorials by design.
- Document how the plugins compose and cross-link them: DAG deployment routes uploads through the s3 plugin (the airflow plugin deliberately has no storage client and no `dags deploy` command); MWAA manages the environment while the airflow plugin handles fine-grained, permission-classified DAG operations; the s3 page describes its role as the shared transfer layer.
- Register the three pages in the mkdocs nav (+ zh `nav_translations`), link them from the plugin introduction's Next steps, and give the zh introduction's permission section an explicit `{#permissions}` anchor so the new pages' permission links resolve on the Chinese site.
- All skill behaviour descriptions were verified against the current plugin sources (SKILL.md files, manifests, and the e2e workflow prompts in Datus-Plugins); known README inaccuracies (e.g. the wrong `pip install datus-aws-plugins` line in the mwaa README) were not carried over.

## Test Cases

Doc-only change; no integration/nightly tests added. Verified with the same gates as the docs deploy workflow: `mkdocs build --strict` passes for both the en and zh locales, and the three pages render with working cross-links in both builds. `ci/audit_tests.py --diff-only` reports nothing to scan.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Airflow, MWAA, and S3 plugin guides in English and Chinese.
  * Documented installation, configuration, permissions, supported workflows, integrations, and usage examples.
  * Added plugin guide links to the introduction pages.
  * Added the new guides to the documentation navigation in both languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Airflow, MWAA, and S3 plugin guides in English and Chinese.
  * Documented installation, configuration, permissions, supported workflows, integrations, and usage examples.
  * Added guidance for DAG deployment, storage transfers, credential handling, and security behavior.
  * Documented S3 Select availability and alternative filtering options.
  * Added plugin guide links to the introduction pages.
  * Added the new guides to the documentation navigation in both languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->