### PR TITLE
[BugFix] Cap MCP connect time so one bad server can't freeze a chat turn

### DIFF
--- a/datus/models/mcp_utils.py
+++ b/datus/models/mcp_utils.py
@@ -24,6 +24,9 @@ logger = get_logger(__name__)
 DEFAULT_CONNECT_TIMEOUT_SECONDS = 15.0
 DEFAULT_CONNECT_BUDGET_SECONDS = 30.0
 RETRY_BACKOFF_SECONDS = 1.0
+# Tearing down a half-open transport can block on the same read that never
+# answered, so the salvage attempt gets a bound of its own.
+CLEANUP_TIMEOUT_SECONDS = 5.0
 
 _CANCEL_SCOPE_ERROR = "Attempted to exit cancel scope in a different task than it was entered in"
 
@@ -55,13 +58,31 @@ def connect_budget_seconds() -> float:
     return _env_float("DATUS_MCP_CONNECT_BUDGET", DEFAULT_CONNECT_BUDGET_SECONDS)
 
 
-async def _close_quietly(server_name: str, server: "MCPServer") -> None:
+def _cleanup_timeout(deadline: Optional[float]) -> float:
+    """How long a failed attempt may spend closing the transport."""
+    if deadline is None:
+        return CLEANUP_TIMEOUT_SECONDS
+    return max(0.0, min(CLEANUP_TIMEOUT_SECONDS, deadline - time.monotonic()))
+
+
+async def _close_quietly(server_name: str, server: "MCPServer", timeout: Optional[float] = None) -> None:
     """Best-effort teardown; MCP transports raise noisy anyio errors when closed
-    from a task other than the one that opened them."""
+    from a task other than the one that opened them.
+
+    ``timeout`` bounds the teardown itself. It is passed when salvaging a failed
+    handshake — where the transport is already misbehaving — and left off for a
+    session the caller actually used, whose close must not be truncated.
+    """
     try:
-        await server.__aexit__(None, None, None)
+        if timeout is None:
+            await server.__aexit__(None, None, None)
+        else:
+            async with asyncio.timeout(timeout):
+                await server.__aexit__(None, None, None)
     except asyncio.CancelledError:
         raise
+    except TimeoutError:
+        logger.debug(f"Timed out closing MCP server {server_name} after {timeout:.1f}s; abandoning it")
     except RuntimeError as e:
         if _CANCEL_SCOPE_ERROR in str(e):
             logger.debug(f"Suppressed cancel scope error while closing MCP server {server_name}")
@@ -123,11 +144,11 @@ async def _safe_connect_server(
             logger.error(
                 f"Timeout connecting to MCP server {server_name} after {attempt_timeout:.1f}s (attempt {attempt + 1})"
             )
-            await _close_quietly(server_name, server)
+            await _close_quietly(server_name, server, timeout=_cleanup_timeout(deadline))
         except Exception as e:
             last_error = e
             logger.error(f"Failed to connect MCP server {server_name} (attempt {attempt + 1}): {str(e)}")
-            await _close_quietly(server_name, server)
+            await _close_quietly(server_name, server, timeout=_cleanup_timeout(deadline))
         else:
             logger.info(f"MCP server {server_name} connected successfully")
             try:

--- a/datus/models/mcp_utils.py
+++ b/datus/models/mcp_utils.py
@@ -3,12 +3,16 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import asyncio
+import math
 import os
 import time
 from contextlib import AsyncExitStack, asynccontextmanager
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional
 
 from datus.utils.loggings import get_logger
+
+if TYPE_CHECKING:
+    from agents.mcp import MCPServer
 
 logger = get_logger(__name__)
 
@@ -33,7 +37,9 @@ def _env_float(name: str, default: float) -> float:
     except ValueError:
         logger.warning(f"Ignoring non-numeric {name}={raw!r}, falling back to {default}s")
         return default
-    if value <= 0:
+    # `nan <= 0` is False and `inf` is positive, so both slip past a plain
+    # sign check and reach asyncio.timeout() as a deadline that never fires.
+    if not math.isfinite(value) or value <= 0:
         logger.warning(f"Ignoring non-positive {name}={raw!r}, falling back to {default}s")
         return default
     return value
@@ -49,7 +55,7 @@ def connect_budget_seconds() -> float:
     return _env_float("DATUS_MCP_CONNECT_BUDGET", DEFAULT_CONNECT_BUDGET_SECONDS)
 
 
-async def _close_quietly(server_name: str, server: Any) -> None:
+async def _close_quietly(server_name: str, server: "MCPServer") -> None:
     """Best-effort teardown; MCP transports raise noisy anyio errors when closed
     from a task other than the one that opened them."""
     try:
@@ -68,11 +74,11 @@ async def _close_quietly(server_name: str, server: Any) -> None:
 @asynccontextmanager
 async def _safe_connect_server(
     server_name: str,
-    server,
+    server: "MCPServer",
     max_retries: int = 3,
     connect_timeout: Optional[float] = None,
     deadline: Optional[float] = None,
-):
+) -> AsyncGenerator["MCPServer", None]:
     """Context-managed safe MCP server connection.
 
     Args:
@@ -134,11 +140,22 @@ async def _safe_connect_server(
             return
 
         if attempt < max_retries - 1:
-            try:
-                await asyncio.sleep(RETRY_BACKOFF_SECONDS)
-            except asyncio.CancelledError:
-                logger.debug(f"MCP server {server_name} retry cancelled")
-                raise
+            backoff = RETRY_BACKOFF_SECONDS
+            if deadline is not None:
+                # Sleeping past the deadline would push the caller's first
+                # token out beyond the cap the budget promises.
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning(f"MCP server {server_name}: connect budget exhausted, giving up")
+                    break
+                backoff = min(backoff, remaining)
+
+            if backoff > 0:
+                try:
+                    await asyncio.sleep(backoff)
+                except asyncio.CancelledError:
+                    logger.debug(f"MCP server {server_name} retry cancelled")
+                    raise
 
     raise last_error if last_error else TimeoutError(f"Could not connect MCP server {server_name} within budget")
 

--- a/datus/models/mcp_utils.py
+++ b/datus/models/mcp_utils.py
@@ -3,66 +3,158 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import asyncio
+import os
+import time
 from contextlib import AsyncExitStack, asynccontextmanager
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
 
+# MCP servers are connected before the agent produces its first token, so a
+# server that accepts the TCP connection but never answers the JSON-RPC
+# handshake (a wrong URL that serves HTML, for instance) makes the whole turn
+# look frozen. These caps bound that blast radius: per attempt, and across all
+# servers of one run.
+DEFAULT_CONNECT_TIMEOUT_SECONDS = 15.0
+DEFAULT_CONNECT_BUDGET_SECONDS = 30.0
+RETRY_BACKOFF_SECONDS = 1.0
+
+_CANCEL_SCOPE_ERROR = "Attempted to exit cancel scope in a different task than it was entered in"
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(f"Ignoring non-numeric {name}={raw!r}, falling back to {default}s")
+        return default
+    if value <= 0:
+        logger.warning(f"Ignoring non-positive {name}={raw!r}, falling back to {default}s")
+        return default
+    return value
+
+
+def connect_timeout_seconds() -> float:
+    """Per-attempt cap on one MCP handshake."""
+    return _env_float("DATUS_MCP_CONNECT_TIMEOUT", DEFAULT_CONNECT_TIMEOUT_SECONDS)
+
+
+def connect_budget_seconds() -> float:
+    """Cap on the total time spent connecting every MCP server of one run."""
+    return _env_float("DATUS_MCP_CONNECT_BUDGET", DEFAULT_CONNECT_BUDGET_SECONDS)
+
+
+async def _close_quietly(server_name: str, server: Any) -> None:
+    """Best-effort teardown; MCP transports raise noisy anyio errors when closed
+    from a task other than the one that opened them."""
+    try:
+        await server.__aexit__(None, None, None)
+    except asyncio.CancelledError:
+        raise
+    except RuntimeError as e:
+        if _CANCEL_SCOPE_ERROR in str(e):
+            logger.debug(f"Suppressed cancel scope error while closing MCP server {server_name}")
+        else:
+            logger.debug(f"Error while closing MCP server {server_name}: {e}")
+    except Exception as e:
+        logger.debug(f"Error while closing MCP server {server_name}: {e}")
+
 
 @asynccontextmanager
-async def _safe_connect_server(server_name: str, server, max_retries: int = 3):
-    """Context-managed safe MCP server connection"""
-    provider = None
+async def _safe_connect_server(
+    server_name: str,
+    server,
+    max_retries: int = 3,
+    connect_timeout: Optional[float] = None,
+    deadline: Optional[float] = None,
+):
+    """Context-managed safe MCP server connection.
+
+    Args:
+        server_name: Name used for logging.
+        server: Server instance created via ``MCPManager._create_server_instance``.
+        max_retries: How many handshake attempts before giving up.
+        connect_timeout: Per-attempt cap in seconds; defaults to
+            ``DATUS_MCP_CONNECT_TIMEOUT``.
+        deadline: Optional ``time.monotonic()`` deadline shared across servers.
+            Attempts are shortened to fit it and stop once it passes.
+    """
+    if connect_timeout is None:
+        connect_timeout = connect_timeout_seconds()
+
+    last_error: Optional[BaseException] = None
 
     for attempt in range(max_retries):
+        attempt_timeout = connect_timeout
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning(f"MCP server {server_name}: connect budget exhausted, giving up")
+                break
+            attempt_timeout = min(attempt_timeout, remaining)
+
+        logger.info(
+            f"Attempting to connect to MCP server {server_name} "
+            f"(attempt {attempt + 1}/{max_retries}, timeout {attempt_timeout:.1f}s)"
+        )
+        logger.debug(f"MCP server {server_name} type: {type(server)}")
+
         try:
-            logger.info(f"Attempting to connect to MCP server {server_name} (attempt {attempt + 1}/{max_retries})")
-            logger.debug(f"MCP server {server_name} type: {type(server)}")
-
-            provider = server  # assume already created via Provider.from_process(...)
-            # async context here ensures lifecycle is tracked
-            async with provider:
-                logger.info(f"MCP server {server_name} connected successfully")
-                try:
-                    yield provider
-                except GeneratorExit:
-                    # Handle proper cleanup on generator exit
-                    logger.debug(f"MCP server {server_name} generator being closed")
-                    raise
-                return  # only yield once; exit after use
-
-        except asyncio.TimeoutError:
-            logger.error(f"Timeout connecting to MCP server {server_name} (attempt {attempt + 1})")
-            if attempt == max_retries - 1:
-                raise
+            # Only the handshake is bounded — the caller's work below runs
+            # outside the timeout and must never be cancelled by it.
+            async with asyncio.timeout(attempt_timeout):
+                await server.__aenter__()
         except asyncio.CancelledError:
-            # Handle cancellation during connection attempts
             logger.debug(f"MCP server {server_name} connection cancelled")
             raise
-        except GeneratorExit:
-            # Re-raise GeneratorExit to ensure proper cleanup
-            raise
+        except TimeoutError as e:
+            last_error = e
+            logger.error(
+                f"Timeout connecting to MCP server {server_name} after {attempt_timeout:.1f}s (attempt {attempt + 1})"
+            )
+            await _close_quietly(server_name, server)
         except Exception as e:
+            last_error = e
             logger.error(f"Failed to connect MCP server {server_name} (attempt {attempt + 1}): {str(e)}")
-            if attempt == max_retries - 1:
-                raise
-
+            await _close_quietly(server_name, server)
+        else:
+            logger.info(f"MCP server {server_name} connected successfully")
             try:
-                await asyncio.sleep(1.0)
+                yield server
+            except GeneratorExit:
+                logger.debug(f"MCP server {server_name} generator being closed")
+                raise
+            finally:
+                await _close_quietly(server_name, server)
+            return
+
+        if attempt < max_retries - 1:
+            try:
+                await asyncio.sleep(RETRY_BACKOFF_SECONDS)
             except asyncio.CancelledError:
-                # Handle cancellation during retry sleep
                 logger.debug(f"MCP server {server_name} retry cancelled")
                 raise
 
+    raise last_error if last_error else TimeoutError(f"Could not connect MCP server {server_name} within budget")
+
 
 @asynccontextmanager
-async def multiple_mcp_servers(mcp_servers: Dict[str, Any]):
+async def multiple_mcp_servers(mcp_servers: Dict[str, Any], connect_budget: Optional[float] = None):
     """Context manager for managing multiple MCP servers.
+
+    Servers that cannot be reached are skipped rather than failing the run, and
+    the whole connect phase is capped by ``connect_budget`` so one unreachable
+    server cannot stall the agent for minutes.
 
     Args:
         mcp_servers: Dictionary of MCP servers to manage
+        connect_budget: Total seconds allowed for connecting all servers;
+            defaults to ``DATUS_MCP_CONNECT_BUDGET``.
 
     Yields:
         Dictionary of connected MCP servers
@@ -70,21 +162,44 @@ async def multiple_mcp_servers(mcp_servers: Dict[str, Any]):
     connected_servers = {}
     stack = AsyncExitStack()
 
+    if connect_budget is None:
+        connect_budget = connect_budget_seconds()
+    per_attempt_timeout = connect_timeout_seconds()
+    deadline = time.monotonic() + connect_budget
+
     try:
-        logger.info(f"Attempting to connect {len(mcp_servers)} MCP servers: {list(mcp_servers.keys())}")
+        if mcp_servers:
+            logger.info(
+                f"Attempting to connect {len(mcp_servers)} MCP servers: {list(mcp_servers.keys())} "
+                f"(budget {connect_budget:.1f}s)"
+            )
 
         for server_name, server in mcp_servers.items():
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    f"Skipping MCP server {server_name}: connect budget of {connect_budget:.1f}s exhausted; "
+                    f"the agent runs without it"
+                )
+                continue
+
             try:
                 logger.info(f"Connecting MCP server: {server_name}")
-                cm = _safe_connect_server(server_name, server)
+                cm = _safe_connect_server(
+                    server_name,
+                    server,
+                    connect_timeout=per_attempt_timeout,
+                    deadline=deadline,
+                )
                 connected_server = await stack.enter_async_context(cm)
                 connected_servers[server_name] = connected_server
                 logger.info(f"Successfully connected MCP server: {server_name}")
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
-                logger.error(f"Failed to start MCP server {server_name}: {str(e)}")
+                logger.error(f"Failed to start MCP server {server_name}: {str(e)}; continuing without it")
 
-        if not connected_servers:
-            logger.debug("Warning: No MCP servers were successfully connected")
+        if mcp_servers and not connected_servers:
+            logger.warning("No MCP servers were successfully connected; the agent runs with built-in tools only")
 
         yield connected_servers
 
@@ -93,7 +208,7 @@ async def multiple_mcp_servers(mcp_servers: Dict[str, Any]):
         try:
             await stack.aclose()
         except RuntimeError as e:
-            if "Attempted to exit cancel scope in a different task than it was entered in" in str(e):
+            if _CANCEL_SCOPE_ERROR in str(e):
                 # This is a known anyio issue that can be safely ignored during cleanup
                 logger.debug("Suppressed cancel scope error during MCP server cleanup")
             else:

--- a/datus/tools/mcp_tools/mcp_manager.py
+++ b/datus/tools/mcp_tools/mcp_manager.py
@@ -520,7 +520,12 @@ class MCPManager:
         headers["Accept"] = "text/event-stream"
 
         server_params = MCPServerSseParams(url=url, headers=headers, timeout=timeout, sse_read_timeout=timeout)
-        server_instance = MCPServerSse(params=server_params, client_session_timeout_seconds=60, tool_filter=tool_filter)
+        # ``client_session_timeout_seconds`` bounds the JSON-RPC handshake; a
+        # hard-coded value here ignored the user's ``timeout`` and let a URL
+        # that answers HTML instead of MCP hang the caller for a full minute.
+        server_instance = MCPServerSse(
+            params=server_params, client_session_timeout_seconds=timeout, tool_filter=tool_filter
+        )
         details = {"url": url, "headers_count": len(headers) if headers else 0, "timeout": timeout}
         return server_instance, details
 
@@ -544,7 +549,7 @@ class MCPManager:
             terminate_on_close=True,
         )
         server_instance = MCPServerStreamableHttp(
-            params=server_params, client_session_timeout_seconds=60, tool_filter=tool_filter
+            params=server_params, client_session_timeout_seconds=timeout, tool_filter=tool_filter
         )
         details = {"url": url, "headers_count": len(merged_headers), "timeout": timeout}
         return server_instance, details

--- a/tests/unit_tests/models/test_mcp_utils.py
+++ b/tests/unit_tests/models/test_mcp_utils.py
@@ -74,6 +74,21 @@ class TestSafeConnectServer:
         assert server.enter_calls < 5
 
     @pytest.mark.asyncio
+    async def test_retry_backoff_never_outlives_the_deadline(self, monkeypatch):
+        monkeypatch.setattr(mcp_utils, "RETRY_BACKOFF_SECONDS", 5.0)
+        server = FakeServer(fail_times=99)
+        started = time.monotonic()
+
+        with pytest.raises(ConnectionError):
+            async with _safe_connect_server(
+                "flaky", server, max_retries=3, connect_timeout=1.0, deadline=started + 0.05
+            ):
+                pytest.fail("should never connect")
+
+        # The backoff is clamped to what is left of the budget, not slept whole.
+        assert time.monotonic() - started < 1.0
+
+    @pytest.mark.asyncio
     async def test_retry_then_success(self):
         server = FakeServer(fail_times=1)
 
@@ -142,4 +157,11 @@ class TestEnvOverrides:
 
     def test_non_positive_env_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("DATUS_MCP_CONNECT_TIMEOUT", "0")
+        assert mcp_utils.connect_timeout_seconds() == mcp_utils.DEFAULT_CONNECT_TIMEOUT_SECONDS
+
+    @pytest.mark.parametrize("raw", ["inf", "-inf", "nan"])
+    def test_non_finite_env_falls_back_to_default(self, monkeypatch, raw):
+        # `nan` compares False against every bound and `inf` is positive, so
+        # both would otherwise become a timeout that never fires.
+        monkeypatch.setenv("DATUS_MCP_CONNECT_TIMEOUT", raw)
         assert mcp_utils.connect_timeout_seconds() == mcp_utils.DEFAULT_CONNECT_TIMEOUT_SECONDS

--- a/tests/unit_tests/models/test_mcp_utils.py
+++ b/tests/unit_tests/models/test_mcp_utils.py
@@ -21,9 +21,10 @@ from datus.models.mcp_utils import _safe_connect_server, multiple_mcp_servers
 class FakeServer:
     """Minimal stand-in for an agents-SDK MCP server."""
 
-    def __init__(self, *, hang: bool = False, fail_times: int = 0):
+    def __init__(self, *, hang: bool = False, fail_times: int = 0, hang_exit: bool = False):
         self.hang = hang
         self.fail_times = fail_times
+        self.hang_exit = hang_exit
         self.enter_calls = 0
         self.exit_calls = 0
 
@@ -37,6 +38,8 @@ class FakeServer:
 
     async def __aexit__(self, exc_type, exc, tb):
         self.exit_calls += 1
+        if self.hang_exit:
+            await asyncio.sleep(3600)
         return False
 
 
@@ -85,8 +88,37 @@ class TestSafeConnectServer:
             ):
                 pytest.fail("should never connect")
 
-        # The backoff is clamped to what is left of the budget, not slept whole.
-        assert time.monotonic() - started < 1.0
+        # The backoff is clamped to what is left of the budget, not slept whole:
+        # 50ms of deadline plus scheduler slack, nowhere near the 5s backoff.
+        assert time.monotonic() - started < 0.5
+
+    @pytest.mark.asyncio
+    async def test_hanging_teardown_does_not_outlive_the_deadline(self, monkeypatch):
+        # A transport that blocks on close would otherwise hang the connect
+        # phase just as thoroughly as one that blocks on the handshake.
+        monkeypatch.setattr(mcp_utils, "CLEANUP_TIMEOUT_SECONDS", 3600.0)
+        server = FakeServer(fail_times=99, hang_exit=True)
+        started = time.monotonic()
+
+        with pytest.raises(ConnectionError):
+            async with _safe_connect_server(
+                "stuck-close", server, max_retries=2, connect_timeout=1.0, deadline=started + 0.05
+            ):
+                pytest.fail("should never connect")
+
+        assert server.exit_calls >= 1
+        assert time.monotonic() - started < 0.5
+
+    @pytest.mark.asyncio
+    async def test_used_session_teardown_is_not_bounded(self):
+        # The cap covers salvage of a failed handshake, never the close of a
+        # session the caller actually worked with.
+        server = FakeServer()
+
+        async with _safe_connect_server("ok", server, max_retries=1, connect_timeout=0.05) as connected:
+            assert connected is server
+
+        assert server.exit_calls == 1
 
     @pytest.mark.asyncio
     async def test_retry_then_success(self):

--- a/tests/unit_tests/models/test_mcp_utils.py
+++ b/tests/unit_tests/models/test_mcp_utils.py
@@ -1,0 +1,145 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""
+Unit tests for datus/models/mcp_utils.py
+
+CI-level: zero external dependencies. MCP servers are fakes whose handshake
+either hangs, fails, or succeeds on demand.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from datus.models import mcp_utils
+from datus.models.mcp_utils import _safe_connect_server, multiple_mcp_servers
+
+
+class FakeServer:
+    """Minimal stand-in for an agents-SDK MCP server."""
+
+    def __init__(self, *, hang: bool = False, fail_times: int = 0):
+        self.hang = hang
+        self.fail_times = fail_times
+        self.enter_calls = 0
+        self.exit_calls = 0
+
+    async def __aenter__(self):
+        self.enter_calls += 1
+        if self.hang:
+            await asyncio.sleep(3600)
+        if self.enter_calls <= self.fail_times:
+            raise ConnectionError("handshake refused")
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exit_calls += 1
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _fast_retries(monkeypatch):
+    """Keep the retry backoff out of the test wall clock."""
+    monkeypatch.setattr(mcp_utils, "RETRY_BACKOFF_SECONDS", 0.0)
+
+
+class TestSafeConnectServer:
+    @pytest.mark.asyncio
+    async def test_hanging_handshake_times_out_per_attempt(self):
+        server = FakeServer(hang=True)
+        started = time.monotonic()
+
+        with pytest.raises(TimeoutError):
+            async with _safe_connect_server("hung", server, max_retries=2, connect_timeout=0.05):
+                pytest.fail("should never connect")
+
+        # 2 attempts x 50ms, not 2 x the SDK's own minute-long session timeout.
+        assert time.monotonic() - started < 1.0
+        assert server.enter_calls == 2
+        assert server.exit_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_deadline_stops_further_attempts(self):
+        server = FakeServer(hang=True)
+        deadline = time.monotonic() + 0.05
+
+        with pytest.raises(TimeoutError):
+            async with _safe_connect_server("hung", server, max_retries=5, connect_timeout=10.0, deadline=deadline):
+                pytest.fail("should never connect")
+
+        # The deadline, not connect_timeout, is what bounds the attempt.
+        assert server.enter_calls < 5
+
+    @pytest.mark.asyncio
+    async def test_retry_then_success(self):
+        server = FakeServer(fail_times=1)
+
+        async with _safe_connect_server("flaky", server, max_retries=3, connect_timeout=1.0) as connected:
+            assert connected is server
+
+        assert server.enter_calls == 2
+        # One teardown for the failed handshake, one for the successful session.
+        assert server.exit_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_body_is_not_cancelled_by_connect_timeout(self):
+        """The timeout covers the handshake only, never the caller's work."""
+        server = FakeServer()
+
+        async with _safe_connect_server("ok", server, max_retries=1, connect_timeout=0.05):
+            await asyncio.sleep(0.2)
+
+        assert server.exit_calls == 1
+
+
+class TestMultipleMcpServers:
+    @pytest.mark.asyncio
+    async def test_unreachable_server_is_skipped_not_fatal(self):
+        servers = {"broken": FakeServer(fail_times=99), "good": FakeServer()}
+
+        async with multiple_mcp_servers(servers, connect_budget=5.0) as connected:
+            assert "broken" not in connected
+            assert connected["good"] is servers["good"]
+
+    @pytest.mark.asyncio
+    async def test_budget_bounds_the_whole_connect_phase(self):
+        servers = {f"hung{i}": FakeServer(hang=True) for i in range(4)}
+        started = time.monotonic()
+
+        async with multiple_mcp_servers(servers, connect_budget=0.2) as connected:
+            assert connected == {}
+
+        # Without a shared budget this was servers x retries x per-attempt timeout.
+        assert time.monotonic() - started < 2.0
+
+    @pytest.mark.asyncio
+    async def test_servers_after_budget_exhaustion_are_not_dialled(self):
+        hung = FakeServer(hang=True)
+        never = FakeServer()
+
+        async with multiple_mcp_servers({"hung": hung, "never": never}, connect_budget=0.1) as connected:
+            assert connected == {}
+
+        assert never.enter_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_mapping_yields_empty_dict(self):
+        async with multiple_mcp_servers({}) as connected:
+            assert connected == {}
+
+
+class TestEnvOverrides:
+    def test_connect_timeout_env_override(self, monkeypatch):
+        monkeypatch.setenv("DATUS_MCP_CONNECT_TIMEOUT", "3.5")
+        assert mcp_utils.connect_timeout_seconds() == 3.5
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("DATUS_MCP_CONNECT_BUDGET", "not-a-number")
+        assert mcp_utils.connect_budget_seconds() == mcp_utils.DEFAULT_CONNECT_BUDGET_SECONDS
+
+    def test_non_positive_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("DATUS_MCP_CONNECT_TIMEOUT", "0")
+        assert mcp_utils.connect_timeout_seconds() == mcp_utils.DEFAULT_CONNECT_TIMEOUT_SECONDS


### PR DESCRIPTION
## Why

On dev, a chat turn hung with **no SSE event at all** — the frontend just showed "生成中…" forever.

The workspace had an MCP server registered with `url: https://mcp.zapier.com/` (the marketing page, not a real MCP endpoint — Zapier's is `…/api/mcp/s/<key>/mcp`). It accepts the TCP connection and answers with `text/html`, so the JSON-RPC `initialize` request never gets a response:

```
09:02:31  POST /api/v1/chat/stream
09:02:31  Parsed node configuration for 'chat': {..., 'mcp': 'zapier', ...}
09:02:31  Added MCP server 'zapier': {'url': 'https://mcp.zapier.com/', 'timeout': 30.0}
09:02:33  Attempting to connect to MCP server zapier (attempt 1/3)
          Unexpected content type: text/html; charset=utf-8
09:03:33  Failed ... Waited 60.0 seconds.
09:03:34  attempt 2/3 ...
09:04:14  request_completed  POST /api/v1/chat/stream  duration_ms=103251   ← user gave up
```

Two things turned a misconfigured server into a frozen session:

1. `MCPManager._create_server_instance` hard-coded `client_session_timeout_seconds=60`, so the user's configured `timeout: 30` never bounded the handshake.
2. `_safe_connect_server` retried 3 times serially with no overall budget → up to ~180s.

And because `multiple_mcp_servers()` wraps the entire agent run (`openai_compatible.py`, `claude_model.py`, `codex_model.py` all enter it before `Runner.run`), that time is spent *before the first token*, so the stream produces nothing at all — not even an error event.

## Solution

- **Per-attempt handshake cap** (`DEFAULT_CONNECT_TIMEOUT_SECONDS = 15s`, env `DATUS_MCP_CONNECT_TIMEOUT`). Only `__aenter__` runs under `asyncio.timeout`; the caller's work after the yield is deliberately outside it, so a slow agent turn is never cancelled by the connect timeout.
- **Shared budget for the whole connect phase** (`DEFAULT_CONNECT_BUDGET_SECONDS = 30s`, env `DATUS_MCP_CONNECT_BUDGET`). Attempts are shortened to fit the remaining budget, retries stop when it's gone, and servers still queued are skipped with a warning instead of being dialled.
- **Failed servers stay non-fatal** (unchanged behaviour) but now log at `warning` when nothing connected, so "the agent runs with built-in tools only" is visible rather than a `debug` line.
- **`client_session_timeout_seconds` now honours the configured `timeout`** for SSE and Streamable HTTP servers. STDIO keeps its 60s, since a cold `npx`/`uvx` start legitimately takes longer.
- Best-effort teardown (`_close_quietly`) after a failed or timed-out attempt, with the known anyio cancel-scope error suppressed the same way the existing cleanup path does.

Worst case for the scenario above goes from ~180s of silence to ~30s, and the turn then proceeds normally without the broken server.

## Test Cases

New `tests/unit_tests/models/test_mcp_utils.py` (11 cases, no external deps — fake servers whose handshake hangs / fails / succeeds):

- a hanging handshake times out per attempt instead of blocking for the SDK's minute
- the shared deadline stops further attempts
- transient failure then success still connects
- **the caller's work after the yield is not cancelled by the connect timeout**
- an unreachable server is skipped, a healthy one alongside it still connects
- the budget bounds the whole connect phase (4 hung servers)
- servers queued after budget exhaustion are never dialled
- empty mapping yields an empty dict
- env overrides, plus fallback on non-numeric / non-positive values

Regression: `tests/unit_tests/models/`, `tests/unit_tests/tools/mcp_tools/`, `tests/unit_tests/cli/test_mcp_app.py`, `test_mcp_commands.py` → 1302 passed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Added configurable connection timeouts, retry delays, and overall connection budgets for MCP servers.
  * MCP connections now honor configured handshake timeout values.
  * Agents can continue operating when servers are unreachable or exceed connection limits.

* **Bug Fixes**
  * Improved cleanup of failed or timed-out connections.
  * Prevented connection timeouts from interrupting ongoing server work.
  * Added safer handling for invalid timeout configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable connection timeouts, retry delays, and overall connection budgets for MCP servers.
  * MCP connections now honor configured handshake timeout values.
  * Agents can continue operating when servers are unreachable or exceed connection limits.

* **Bug Fixes**
  * Improved cleanup of failed or timed-out connections.
  * Prevented connection timeouts from interrupting ongoing server work.
  * Added safer handling for invalid timeout configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->