### PR TITLE
[Others] Pin datus-semantic-dosi to a released version, not a commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,9 +215,9 @@ dev = [
 ]
 ci = [
     "datus-storage-postgresql>=0.1.5",
-    # The current PyPI release predates the authoring-spec API used here.
-    # Use the merged adapter source until the next adapter package is released.
-    "datus-semantic-dosi @ https://github.com/Datus-ai/datus-semantic-adapter/archive/04b260bddee5ddbb296aff3e1652181b13c9af19.tar.gz#subdirectory=datus-semantic-dosi ; platform_machine == 'x86_64' and sys_platform == 'linux'",
+    # dosi-engine publishes manylinux wheels only, so the marker keeps a macOS
+    # checkout resolvable; that platform builds the engine from source instead.
+    "datus-semantic-dosi>=0.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ci = [
-    { name = "datus-semantic-dosi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/Datus-ai/datus-semantic-adapter/archive/04b260bddee5ddbb296aff3e1652181b13c9af19.tar.gz", subdirectory = "datus-semantic-dosi" },
+    { name = "datus-semantic-dosi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=0.1.6" },
     { name = "datus-storage-postgresql", specifier = ">=0.1.5" },
 ]
 dev = [
@@ -749,27 +749,19 @@ wheels = [
 
 [[package]]
 name = "datus-semantic-dosi"
-version = "0.1.1"
-source = { url = "https://github.com/Datus-ai/datus-semantic-adapter/archive/04b260bddee5ddbb296aff3e1652181b13c9af19.tar.gz", subdirectory = "datus-semantic-dosi" }
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datus-semantic-core", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "dosi-engine", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "pydantic", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "pyyaml", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "datus-semantic-core" },
+    { name = "dosi-engine" },
+    { name = "duckdb" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
 ]
-sdist = { hash = "sha256:15b44b45de856cdb0d35fb201308a55207bef37e298502b1a7515fcd37762f3d" }
-
-[package.metadata]
-requires-dist = [
-    { name = "datus-semantic-core", specifier = ">=0.2.3" },
-    { name = "dosi-engine", specifier = ">=0.1.3" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/b7/60/ae3f1fd838fd84170e3991e0843a18cab7a33752846881f82bec2798abed/datus_semantic_dosi-0.1.6.tar.gz", hash = "sha256:5d35b14232dc5f3b20d8c5695925a684ec534ccb9801cd14e3e6345dd78b9d27", size = 50259, upload-time = "2026-08-24T13:29:42.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/14/e473cf29f39449449fc4ee272acc8a0aa1ccaa8aa5f09c97dc60ab84abc6/datus_semantic_dosi-0.1.6-py3-none-any.whl", hash = "sha256:d58387316d03e5c580ddab5b05e606cf8605eed267ffbc69cbce1809e18efce2", size = 40846, upload-time = "2026-08-24T13:29:42.073Z" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "datus-storage-base"
@@ -3403,8 +3395,8 @@ name = "secretstorage"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/9f/11ef35cf1027c1339552ea7bfe6aaa74a8516d8b5caf6e7d338daf54fd80/secretstorage-3.4.0.tar.gz", hash = "sha256:c46e216d6815aff8a8a18706a2fbfd8d53fcbb0dce99301881687a1b0289ef7c", size = 19748, upload-time = "2025-09-09T16:42:13.859Z" }
 wheels = [


### PR DESCRIPTION
## Why

The `ci` dependency group pointed `datus-semantic-dosi` at a `datus-semantic-adapter` merge commit:

```toml
"datus-semantic-dosi @ https://github.com/Datus-ai/datus-semantic-adapter/archive/04b260bd....tar.gz#subdirectory=datus-semantic-dosi ; ..."
```

The comment above it explains the pin as temporary — "the current PyPI release predates the authoring-spec API used here". That is no longer true: the pinned commit is `04b260bd` (2026-08-13, version 0.1.1), and 0.1.5 shipped on 2026-08-18 with that API. The pin now tracks a commit nothing else references, four releases behind.

## Solution

Replace the URL with an ordinary specifier, `datus-semantic-dosi>=0.1.5`, and drop the stale comment.

The platform marker stays, with a comment explaining what it is actually for: `dosi-engine` publishes `manylinux_2_28` wheels and no sdist, so an unmarked dependency makes a macOS checkout unresolvable. That platform builds the engine from source instead.

**This does not change what CI tests.** Both `run-ut-and-coverage.yml` and `run-nightly.yml` check out the adapter repository at `main` and reinstall `datus-semantic-dosi` from that source immediately after `uv sync`:

```yaml
uv sync --locked --group ci
uv pip install --no-cache-dir \
  --reinstall-package datus-semantic-dosi \
  ./external/datus-semantic-adapter/datus-semantic-dosi
```

So the locked version has never been the one under test. It only decides what a plain `uv sync` produces for a developer.

## Test Cases

No tests added or changed — this is a dependency declaration, and no test asserts on it.

Verified instead by resolution and by running the suite against the version this now selects:

- `uv lock --check` passes; the lockfile diff touches only `datus-semantic-dosi` (URL source → registry 0.1.5, plus its new `duckdb` transitive dependency) and stays at format `revision = 3`
- `uv sync --locked --group ci --python-platform x86_64-manylinux_2_28 --dry-run` resolves and selects 0.1.5, so CI's platform is unaffected
- `uv sync --locked --group ci --dry-run` on macOS resolves, confirming the marker still keeps that platform installable
- full unit suite against `datus-semantic-dosi==0.1.5`: **18109 passed, 0 failed**

## Related

`datus-semantic-adapter` PR #88 fixes recursive model discovery in this same package. Once it releases, this specifier picks it up without another edit — which is the point of moving off a commit pin.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Chores**
  * Updated the CI environment to use the published `datus-semantic-dosi` package version 0.1.5 or later on x86_64 Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI dependency to use the published package version.
  * Retained compatibility for x86_64 Linux environments.
  * Added documentation about macOS source-build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->