### PR TITLE
[BugFix] Serialise the uploads catalog read so parallel tool calls stop being refused

### DIFF
--- a/datus/tools/db_tools/data_file_loader.py
+++ b/datus/tools/db_tools/data_file_loader.py
@@ -761,7 +761,11 @@ def _annotate_text_dates(connection: Any, table: str, profile: List[Dict[str, An
         if not non_null or unparsed:
             continue
         target = "TIMESTAMP" if with_clock else "DATE"
-        by_name[name]["cast_hint"] = f"text {target.lower()}s: CAST({name} AS {target}) to use date functions"
+        # Quoted unconditionally, like ``example_sql`` does: the hint exists to be
+        # copied into a query, and a spreadsheet header with a space in it (or a
+        # dash, or a reserved word) makes the bare form a parser error.
+        expression = f"CAST({quote_identifier(name)} AS {target})"
+        by_name[name]["cast_hint"] = f"text {target.lower()}s: {expression} to use date functions"
 
 
 def preview_view(connection: Any, table: str, limit: int = PREVIEW_ROW_LIMIT) -> Tuple[List[str], List[List[Any]]]:

--- a/datus/tools/db_tools/data_file_loader.py
+++ b/datus/tools/db_tools/data_file_loader.py
@@ -704,7 +704,64 @@ def summarize_view(connection: Any, table: str) -> List[Dict[str, Any]]:
     for row in cursor.fetchall():
         record = dict(zip(names, row))
         profile.append({key: _jsonable(value) for key, value in record.items() if key in keep})
+    _annotate_text_dates(connection, table, profile)
     return profile
+
+
+def _annotate_text_dates(connection: Any, table: str, profile: List[Dict[str, Any]]) -> None:
+    """Mark VARCHAR columns that hold nothing but dates, with the cast to use.
+
+    A spreadsheet column of dates typed as text stays VARCHAR: ``read_xlsx``
+    converts a real date *cell* by its number format, but text is text. Every
+    date function then fails to bind — ``strftime(order_date, '%Y-%m')`` reports
+    a candidate-function error naming types, not the fix — and the model burns a
+    round trip per attempt working out that a cast was needed.
+
+    The cast is *verified*, not guessed from the column name or from SUMMARIZE's
+    min/max: those are the lexical extremes, so a mixed column can show ISO ends
+    and non-date values in between, and a hint that NULLs rows is worse than no
+    hint. Only a column where every value parses gets annotated.
+
+    Deliberately a hint and not a cast baked into the view: DuckDB re-expands a
+    view's ``SELECT *`` per query, which is what makes a column added to the file
+    later show up without reloading. Freezing an explicit projection to carry
+    casts would trade that away, and it would buy little — TRY_CAST accepts only
+    ISO-ish text (``8/31/2017`` and ``20170701`` both fail), which is exactly the
+    text that already sorts and compares correctly as-is.
+    """
+    candidates = [
+        column["column_name"] for column in profile if str(column.get("column_type", "")).upper() == "VARCHAR"
+    ]
+    if not candidates:
+        return
+
+    selects = []
+    for index, name in enumerate(candidates):
+        quoted = quote_identifier(name)
+        selects.append(f"count({quoted}) AS n{index}")
+        selects.append(
+            f"count(*) FILTER (WHERE {quoted} IS NOT NULL AND TRY_CAST({quoted} AS TIMESTAMP) IS NULL) AS bad{index}"
+        )
+        selects.append(
+            f"count(*) FILTER (WHERE TRY_CAST({quoted} AS TIMESTAMP)::TIME <> TIME '00:00:00') AS clock{index}"
+        )
+    try:
+        row = connection.execute(f"SELECT {', '.join(selects)} FROM {quote_identifier(table)}").fetchone()
+    except Exception as exc:
+        # A profile without hints is still a usable profile, so this stays
+        # advisory: never fail a load over it.
+        logger.debug("Could not probe %s for text date columns: %s", table, exc)
+        return
+    if row is None:
+        return
+
+    by_name = {column["column_name"]: column for column in profile}
+    for index, name in enumerate(candidates):
+        non_null, unparsed, with_clock = row[index * 3], row[index * 3 + 1], row[index * 3 + 2]
+        if not non_null or unparsed:
+            continue
+        target = "TIMESTAMP" if with_clock else "DATE"
+        by_name[name]["cast_hint"] = f"text {target.lower()}s: CAST({name} AS {target}) to use date functions"
 
 
 def preview_view(connection: Any, table: str, limit: int = PREVIEW_ROW_LIMIT) -> Tuple[List[str], List[List[Any]]]:
@@ -759,16 +816,21 @@ def ownership_tag(rel_path: str, sheet: Optional[str]) -> str:
 
 
 def registered_objects(connection: Any) -> Dict[str, Optional[str]]:
-    """Every name in the catalog mapped to its ownership comment (``None`` if unset)."""
-    try:
-        rows = connection.execute(
-            "SELECT view_name, comment FROM duckdb_views() WHERE database_name != 'system' "
-            "UNION ALL "
-            "SELECT table_name, comment FROM duckdb_tables() WHERE database_name != 'system'"
-        ).fetchall()
-    except Exception as exc:  # pragma: no cover - fresh/empty catalog
-        logger.debug("Could not enumerate uploads catalog: %s", exc)
-        return {}
+    """Every name in the catalog mapped to its ownership comment (``None`` if unset).
+
+    Failures propagate. An empty catalog is a legitimate answer that this
+    returns as ``{}`` — a fresh database answers both queries with zero rows,
+    no error — so swallowing an exception into the same ``{}`` erases the only
+    difference that matters to the caller. The SQL guard reads "no names" as
+    "no table reference can be authorised" and refuses the query, which turns
+    an unreadable catalog into a confident, wrong, and very actionable-looking
+    "that table is not registered" about a table that is registered.
+    """
+    rows = connection.execute(
+        "SELECT view_name, comment FROM duckdb_views() WHERE database_name != 'system' "
+        "UNION ALL "
+        "SELECT table_name, comment FROM duckdb_tables() WHERE database_name != 'system'"
+    ).fetchall()
     return {row[0]: row[1] for row in rows}
 
 

--- a/datus/tools/db_tools/data_file_loader.py
+++ b/datus/tools/db_tools/data_file_loader.py
@@ -681,6 +681,15 @@ def convert_legacy_xls(path: Path, cache_dir: Path, sheet: Optional[str] = None)
 # ------------------------------------------------------------------ profiling
 
 
+_DATE_PROBE_BATCH = 40
+"""Columns per text-date probe statement.
+
+The probe's cost is quadratic in expressions per statement, not in total work:
+1600 columns cost 23.8s as one statement and 0.57s in batches of 40 (DuckDB
+1.5.2). 40 columns is 160 aggregates, measured at ~0.01s.
+"""
+
+
 def summarize_view(connection: Any, table: str) -> List[Dict[str, Any]]:
     """Per-column profile via DuckDB's ``SUMMARIZE``.
 
@@ -728,6 +737,21 @@ def _annotate_text_dates(connection: Any, table: str, profile: List[Dict[str, An
     casts would trade that away, and it would buy little — TRY_CAST accepts only
     ISO-ish text (``8/31/2017`` and ``20170701`` both fail), which is exactly the
     text that already sorts and compares correctly as-is.
+
+    Validity is tested against DATE, and TIMESTAMP is only *offered*. The two are
+    not ordered the way they look: trailing whitespace after a bare date makes
+    the TIMESTAMP cast NULL while the DATE cast still succeeds (DuckDB 1.5.2 —
+    ``TRY_CAST('2017-07-01 ' AS TIMESTAMP)`` is NULL, ``AS DATE`` is not), and
+    space-padded dates are ordinary in text cells and aligned CSV exports. Using
+    TIMESTAMP as the gate silently withheld the hint from exactly those columns.
+
+    Probed in batches because the cost is quadratic in the number of expressions
+    per statement, and this runs inside ``exclusive_connection`` — the lock every
+    concurrent ``execute_sql`` on the uploads catalog contends for. Measured on
+    DuckDB 1.5.2 with a 1600-column view: 23.8s as one statement, 0.57s in
+    batches of 40. Wide exports reach four-digit column counts and xlsx allows
+    16384, so an unbatched probe would block every parallel tool call for the
+    duration.
     """
     candidates = [
         column["column_name"] for column in profile if str(column.get("column_type", "")).upper() == "VARCHAR"
@@ -735,37 +759,48 @@ def _annotate_text_dates(connection: Any, table: str, profile: List[Dict[str, An
     if not candidates:
         return
 
-    selects = []
-    for index, name in enumerate(candidates):
-        quoted = quote_identifier(name)
-        selects.append(f"count({quoted}) AS n{index}")
-        selects.append(
-            f"count(*) FILTER (WHERE {quoted} IS NOT NULL AND TRY_CAST({quoted} AS TIMESTAMP) IS NULL) AS bad{index}"
-        )
-        selects.append(
-            f"count(*) FILTER (WHERE TRY_CAST({quoted} AS TIMESTAMP)::TIME <> TIME '00:00:00') AS clock{index}"
-        )
-    try:
-        row = connection.execute(f"SELECT {', '.join(selects)} FROM {quote_identifier(table)}").fetchone()
-    except Exception as exc:
-        # A profile without hints is still a usable profile, so this stays
-        # advisory: never fail a load over it.
-        logger.debug("Could not probe %s for text date columns: %s", table, exc)
-        return
-    if row is None:
-        return
-
     by_name = {column["column_name"]: column for column in profile}
-    for index, name in enumerate(candidates):
-        non_null, unparsed, with_clock = row[index * 3], row[index * 3 + 1], row[index * 3 + 2]
-        if not non_null or unparsed:
-            continue
-        target = "TIMESTAMP" if with_clock else "DATE"
-        # Quoted unconditionally, like ``example_sql`` does: the hint exists to be
-        # copied into a query, and a spreadsheet header with a space in it (or a
-        # dash, or a reserved word) makes the bare form a parser error.
-        expression = f"CAST({quote_identifier(name)} AS {target})"
-        by_name[name]["cast_hint"] = f"text {target.lower()}s: {expression} to use date functions"
+    quoted_table = quote_identifier(table)
+    for start in range(0, len(candidates), _DATE_PROBE_BATCH):
+        batch = candidates[start : start + _DATE_PROBE_BATCH]
+        selects = []
+        for index, name in enumerate(batch):
+            quoted = quote_identifier(name)
+            selects.append(f"count({quoted}) AS n{index}")
+            selects.append(
+                f"count(*) FILTER (WHERE {quoted} IS NOT NULL AND TRY_CAST({quoted} AS DATE) IS NULL) AS bad_date{index}"
+            )
+            selects.append(
+                f"count(*) FILTER (WHERE {quoted} IS NOT NULL AND TRY_CAST({quoted} AS TIMESTAMP) IS NULL) "
+                f"AS bad_stamp{index}"
+            )
+            selects.append(
+                f"count(*) FILTER (WHERE TRY_CAST({quoted} AS TIMESTAMP)::TIME <> TIME '00:00:00') AS clock{index}"
+            )
+        try:
+            row = connection.execute(f"SELECT {', '.join(selects)} FROM {quoted_table}").fetchone()
+        except Exception as exc:
+            # A profile without hints is still a usable profile, so this stays
+            # advisory: never fail a load over it.
+            logger.debug("Could not probe %s for text date columns: %s", table, exc)
+            return
+        if row is None:
+            return
+
+        for index, name in enumerate(batch):
+            non_null, unparsed, unparsed_stamp, with_clock = row[index * 4 : index * 4 + 4]
+            if not non_null or unparsed:
+                continue
+            # A clock only earns the TIMESTAMP cast if *every* value survives it:
+            # a column mixing timed values with space-padded bare dates would
+            # otherwise be handed a cast that NULLs the padded ones. DATE is valid
+            # for all of them, and losing a time is better than losing a row.
+            target = "TIMESTAMP" if with_clock and not unparsed_stamp else "DATE"
+            # Quoted unconditionally, like ``example_sql`` does: the hint exists to be
+            # copied into a query, and a spreadsheet header with a space in it (or a
+            # dash, or a reserved word) makes the bare form a parser error.
+            expression = f"CAST({quote_identifier(name)} AS {target})"
+            by_name[name]["cast_hint"] = f"text {target.lower()}s: {expression} to use date functions"
 
 
 def preview_view(connection: Any, table: str, limit: int = PREVIEW_ROW_LIMIT) -> Tuple[List[str], List[List[Any]]]:

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1707,7 +1707,10 @@ class DBFuncTool:
         connector = self._get_connector(LOCAL_FILES_DATASOURCE, "")
         exclusive = getattr(connector, "exclusive_connection", None)
         if exclusive is None:
-            raise RuntimeError(f"Datasource '{LOCAL_FILES_DATASOURCE}' is not a DuckDB datasource")
+            raise DatusException(
+                ErrorCode.COMMON_VALIDATION_FAILED,
+                message=f"Datasource '{LOCAL_FILES_DATASOURCE}' is not a DuckDB datasource",
+            )
         with exclusive() as connection:
             return registered_objects(connection)
 

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1674,7 +1674,7 @@ class DBFuncTool:
             )
 
         try:
-            registered = list(registered_objects(self._uploads_connection()))
+            registered = list(self._registered_uploads())
         except Exception as exc:
             # No catalog reading means no way to authorise a reference, and this
             # gate is the boundary — so refuse rather than skip it.
@@ -1692,14 +1692,24 @@ class DBFuncTool:
             )
         return None
 
-    def _uploads_connection(self):
-        """Raw connection to the uploads catalog, for authorising a query."""
+    def _registered_uploads(self) -> Dict[str, Optional[str]]:
+        """Names the uploads catalog holds, read while holding the connector lock.
+
+        The read has to happen *inside* ``exclusive_connection``. Handing the
+        connection out and querying it afterwards races every other caller on
+        the same connector, and an LLM emitting parallel tool calls makes that
+        the normal case, not a corner: ``DuckDBPyConnection`` is not thread-safe,
+        so concurrent ``execute`` either returns another statement's rows or
+        segfaults the process. Returning the wrong rows is the worse outcome —
+        a short read looks like an empty catalog, which this gate then reports
+        as "table is not registered" about a table that is registered.
+        """
         connector = self._get_connector(LOCAL_FILES_DATASOURCE, "")
         exclusive = getattr(connector, "exclusive_connection", None)
         if exclusive is None:
             raise RuntimeError(f"Datasource '{LOCAL_FILES_DATASOURCE}' is not a DuckDB datasource")
         with exclusive() as connection:
-            return connection
+            return registered_objects(connection)
 
     def _resolve_data_file(self, path: str):
         """Classify a user-supplied data-file path against the filesystem policy.
@@ -1852,6 +1862,16 @@ class DBFuncTool:
                         f"so uploaded files cannot be registered in this deployment."
                     ),
                 )
+
+            # The tool schema types this as an integer, so a model with nothing to
+            # say sends 0 rather than omitting the key — the same way it sends ""
+            # for sheet and encoding, and observed in real traffic. Rows are
+            # 1-based, so 0 can only mean "unspecified"; taken literally it fails
+            # every sheet with "header_row must be 1 or greater" and the file
+            # reads as unloadable. A negative value is a real mistake and still
+            # reports as one.
+            if header_row == 0:
+                header_row = None
 
             with exclusive() as connection:
                 if inspect_only:

--- a/tests/unit_tests/tools/db_tools/test_data_file_loader.py
+++ b/tests/unit_tests/tools/db_tools/test_data_file_loader.py
@@ -700,11 +700,11 @@ class TestTextDateHints:
     def test_all_iso_dates_are_flagged_for_a_date_cast(self, connection):
         column = self._profile(connection, ["2017-07-01", "2017-08-31"])
         assert column["column_type"] == "VARCHAR"
-        assert column["cast_hint"] == "text dates: CAST(d AS DATE) to use date functions"
+        assert column["cast_hint"] == 'text dates: CAST("d" AS DATE) to use date functions'
 
     def test_a_clock_component_asks_for_a_timestamp_cast(self, connection):
         column = self._profile(connection, ["2017-07-01 09:30:00", "2017-07-02 00:00:00"])
-        assert column["cast_hint"] == "text timestamps: CAST(d AS TIMESTAMP) to use date functions"
+        assert column["cast_hint"] == 'text timestamps: CAST("d" AS TIMESTAMP) to use date functions'
 
     def test_nulls_do_not_block_the_hint(self, connection):
         column = self._profile(connection, ["2017-07-01", None, "2017-08-31"])
@@ -729,6 +729,17 @@ class TestTextDateHints:
         column = self._profile(connection, ["2017-07-01"], literal_type="DATE")
         assert column["column_type"] == "DATE"
         assert "cast_hint" not in column
+
+    def test_the_hint_is_runnable_for_a_header_with_a_space(self, connection):
+        """The hint exists to be copied into a query, and spreadsheet headers have
+        spaces in them. Unquoted, ``CAST(order date AS DATE)`` is a parser error."""
+        connection.execute("""CREATE VIEW v AS SELECT * FROM (VALUES ('2017-07-01')) t("order date")""")
+        hint = {column["column_name"]: column for column in summarize_view(connection, "v")}["order date"]["cast_hint"]
+
+        expression = hint.split(": ", 1)[1].rsplit(" to use", 1)[0]
+        assert expression == 'CAST("order date" AS DATE)'
+        # Runs, rather than merely looking quoted.
+        assert connection.execute(f"SELECT strftime({expression}, '%Y-%m') FROM v").fetchone()[0] == "2017-07"
 
     def test_a_bare_year_is_not_a_date(self, connection):
         """``TRY_CAST('2017' AS DATE)`` is NULL, so a year column stays un-hinted."""

--- a/tests/unit_tests/tools/db_tools/test_data_file_loader.py
+++ b/tests/unit_tests/tools/db_tools/test_data_file_loader.py
@@ -741,6 +741,40 @@ class TestTextDateHints:
         # Runs, rather than merely looking quoted.
         assert connection.execute(f"SELECT strftime({expression}, '%Y-%m') FROM v").fetchone()[0] == "2017-07"
 
+    def test_space_padded_dates_still_get_the_hint(self, connection):
+        """Validity is tested against DATE, not TIMESTAMP — they are not ordered
+        the way they look. ``TRY_CAST('2017-07-01 ' AS TIMESTAMP)`` is NULL while
+        ``AS DATE`` is not, so gating on TIMESTAMP withheld the hint from exactly
+        the space-padded text that turns up in cells and aligned CSV exports."""
+        column = self._profile(connection, ["  2017-07-01  ", "2017-08-31 "])
+
+        assert column["cast_hint"] == 'text dates: CAST("d" AS DATE) to use date functions'
+
+    def test_a_clock_mixed_with_padded_dates_falls_back_to_date(self, connection):
+        """TIMESTAMP would NULL the padded rows; DATE is valid for every row.
+        Losing a time beats losing a row."""
+        column = self._profile(connection, ["2017-07-01 09:30:00", "2017-07-02 "])
+
+        assert "AS DATE)" in column["cast_hint"]
+
+    def test_hints_survive_the_probe_batch_boundary(self, connection):
+        """The probe runs in batches, so the row-offset arithmetic restarts per
+        batch. A column past the first boundary must still be annotated, and
+        annotated with *its own* result."""
+        from datus.tools.db_tools.data_file_loader import _DATE_PROBE_BATCH
+
+        width = _DATE_PROBE_BATCH * 2 + 3
+        # Every column is a date except one placed past the first boundary.
+        odd_one = _DATE_PROBE_BATCH + 5
+        values = [f"'not-a-date{i}' AS c{i}" if i == odd_one else f"'2017-07-01' AS c{i}" for i in range(width)]
+        connection.execute(f"CREATE VIEW wide AS SELECT {', '.join(values)} FROM range(3)")
+
+        profile = {column["column_name"]: column for column in summarize_view(connection, "wide")}
+
+        assert len(profile) == width
+        assert "cast_hint" not in profile[f"c{odd_one}"]
+        assert all("cast_hint" in profile[f"c{i}"] for i in range(width) if i != odd_one)
+
     def test_a_bare_year_is_not_a_date(self, connection):
         """``TRY_CAST('2017' AS DATE)`` is NULL, so a year column stays un-hinted."""
         column = self._profile(connection, ["2017", "2018"])

--- a/tests/unit_tests/tools/db_tools/test_data_file_loader.py
+++ b/tests/unit_tests/tools/db_tools/test_data_file_loader.py
@@ -31,6 +31,7 @@ from datus.tools.db_tools.data_file_loader import (
     ownership_tag,
     registered_objects,
     sanitize_identifier,
+    summarize_view,
     unresolved_table_references,
 )
 
@@ -658,3 +659,78 @@ class TestCsvEncoding:
 
     def test_an_unreadable_file_does_not_raise(self, tmp_path):
         assert detect_csv_encoding(tmp_path / "absent.csv") == "utf-8"
+
+
+# ------------------------------------------------------------------- catalog
+
+
+class TestRegisteredObjects:
+    def test_empty_catalog_is_an_empty_mapping(self, connection):
+        assert registered_objects(connection) == {}
+
+    def test_a_failed_read_is_not_an_empty_catalog(self):
+        """The two must not collapse into the same value.
+
+        Callers treat "no names" as "nothing is registered": the SQL guard turns
+        it into a refusal naming the table the model just registered. Swallowing
+        the error made an unreadable catalog indistinguishable from an empty one,
+        which sent the model re-registering and re-querying in a loop.
+        """
+
+        class Broken:
+            def execute(self, *_args, **_kwargs):
+                raise RuntimeError("Connection Error: connection has been closed")
+
+        with pytest.raises(RuntimeError):
+            registered_objects(Broken())
+
+
+# ----------------------------------------------------------- text date hints
+
+
+class TestTextDateHints:
+    """A spreadsheet's dates typed as text stay VARCHAR, and every date function
+    then fails to bind. The profile says which cast to use, verified per column."""
+
+    def _profile(self, connection, values, *, literal_type="VARCHAR"):
+        rows = ", ".join("(NULL)" if value is None else f"('{value}')" for value in values)
+        connection.execute(f"CREATE VIEW v AS SELECT CAST(d AS {literal_type}) AS d FROM (VALUES {rows}) t(d)")
+        return {column["column_name"]: column for column in summarize_view(connection, "v")}["d"]
+
+    def test_all_iso_dates_are_flagged_for_a_date_cast(self, connection):
+        column = self._profile(connection, ["2017-07-01", "2017-08-31"])
+        assert column["column_type"] == "VARCHAR"
+        assert column["cast_hint"] == "text dates: CAST(d AS DATE) to use date functions"
+
+    def test_a_clock_component_asks_for_a_timestamp_cast(self, connection):
+        column = self._profile(connection, ["2017-07-01 09:30:00", "2017-07-02 00:00:00"])
+        assert column["cast_hint"] == "text timestamps: CAST(d AS TIMESTAMP) to use date functions"
+
+    def test_nulls_do_not_block_the_hint(self, connection):
+        column = self._profile(connection, ["2017-07-01", None, "2017-08-31"])
+        assert "cast_hint" in column
+
+    def test_one_unparseable_value_withholds_the_hint(self, connection):
+        """SUMMARIZE reports the *lexical* min/max, so a mixed column can show ISO
+        ends. A hint whose cast NULLs rows is worse than no hint, so the check is
+        every value, not the extremes."""
+        column = self._profile(connection, ["2017-07-01", "n/a", "2017-08-31"])
+        assert "cast_hint" not in column
+
+    def test_ordinary_text_is_not_flagged(self, connection):
+        column = self._profile(connection, ["Brooklyn", "Philadelphia"])
+        assert "cast_hint" not in column
+
+    def test_an_all_null_column_is_not_flagged(self, connection):
+        column = self._profile(connection, [None, None])
+        assert "cast_hint" not in column
+
+    def test_a_column_already_typed_as_a_date_gets_no_hint(self, connection):
+        column = self._profile(connection, ["2017-07-01"], literal_type="DATE")
+        assert column["column_type"] == "DATE"
+        assert "cast_hint" not in column
+
+    def test_a_bare_year_is_not_a_date(self, connection):
+        """``TRY_CAST('2017' AS DATE)`` is NULL, so a year column stays un-hinted."""
+        column = self._profile(connection, ["2017", "2018"])
+        assert "cast_hint" not in column

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -2818,6 +2818,83 @@ class TestUploadsCatalogSqlGuard:
         # Rejected before touching the database at all.
         connector.execute_query.assert_not_called()
 
+    def test_catalog_is_read_while_the_connector_lock_is_held(self):
+        """The whole read, not just the handle, has to be inside the lock.
+
+        Regression: the guard took the connection out of ``exclusive_connection``
+        and queried it afterwards. ``DuckDBPyConnection`` is not thread-safe, and
+        an LLM emitting parallel tool calls makes concurrent reads the normal
+        case — observed in a real session as batches of N parallel ``execute_sql``
+        where exactly N-1 were refused as "not a table registered" for a table
+        that was registered, and under sustained load as a segfault.
+        """
+        import contextlib
+
+        from datus.tools.db_tools.db_manager import DBManager
+
+        held = []
+        # Recorded rather than asserted inside the mock: the guard wraps the read
+        # in ``except Exception``, so an assert raised in here would be swallowed
+        # and the test would pass against the very bug it exists to catch.
+        locked_during_read = []
+        catalog = Mock()
+
+        def execute(*args, **kwargs):
+            locked_during_read.append(bool(held))
+            result = Mock()
+            result.fetchall.return_value = [("jeffshop_q3", None)]
+            return result
+
+        catalog.execute.side_effect = execute
+
+        @contextlib.contextmanager
+        def exclusive():
+            held.append(True)
+            try:
+                yield catalog
+            finally:
+                held.pop()
+
+        connector = Mock()
+        connector.dialect = "duckdb"
+        connector.get_databases.return_value = []
+        connector.exclusive_connection = exclusive
+        manager = Mock(spec=DBManager)
+        manager.get_conn.return_value = connector
+        config = _mock_agent_config()
+        config.current_datasource = "local_files"
+        config.current_db_configs.return_value = {"local_files": Mock(type="duckdb")}
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticDatasetRAG") as mock_sem,
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            tool = DBFuncTool(manager, agent_config=config)
+
+        result = tool.execute_sql("SELECT * FROM jeffshop_q3", datasource="local_files")
+
+        assert locked_during_read, "the guard never read the catalog"
+        assert all(locked_during_read), "catalog read happened outside exclusive_connection()"
+        assert "not a table registered" not in (result.error or "")
+
+    def test_unreadable_catalog_is_not_reported_as_an_unregistered_table(self):
+        """A failed catalog read must not read as "your table does not exist".
+
+        The two are opposite instructions to the model: one says retry, the other
+        says the registration it just did was a no-op — so it re-registers, re-lists,
+        and re-runs the same query. Distinguishable only if the read is allowed to
+        fail rather than returning an empty catalog.
+        """
+        tool, _ = self._make_tool()
+        tool._get_connector = Mock(side_effect=RuntimeError("database is locked"))
+
+        result = tool.execute_sql("SELECT * FROM jeffshop_q3", datasource="local_files")
+
+        assert result.success == 0
+        assert "unavailable" in result.error
+        assert "not a table registered" not in result.error
+
     def test_allows_ordinary_reads_of_registered_tables(self):
         """Asserting only "no rejection message" would also pass if the query
         never ran, so check it reached the connector."""
@@ -3096,3 +3173,67 @@ class TestFilesystemRootPlumbing:
                     line = text.count("\n", 0, match.start()) + 1
                     offenders.append(f"{path.name}:{line}")
         assert offenders == [], f"DBFuncTool built without filesystem_root: {offenders}"
+
+
+class TestHeaderRowNormalisation:
+    """``header_row`` is the one optional the tool schema types as a number, so
+    the "unspecified" value a model sends is 0 rather than an omitted key."""
+
+    def _tool(self):
+        import contextlib
+
+        from datus.tools.db_tools.db_manager import DBManager
+
+        connector = Mock()
+        connector.dialect = "duckdb"
+        connector.db_path = "/tmp/local_files.duckdb"
+        connector.get_databases.return_value = []
+        connector.exclusive_connection = lambda: contextlib.nullcontext(Mock())
+        manager = Mock(spec=DBManager)
+        manager.get_conn.return_value = connector
+        config = _mock_agent_config()
+        config._client_source = "web"
+        config.current_datasource = "local_files"
+        config.current_db_configs.return_value = {"local_files": Mock(type="duckdb")}
+        with (
+            patch("datus.tools.func_tool.database.SchemaWithValueRAG") as mock_rag,
+            patch("datus.tools.func_tool.database.SemanticDatasetRAG") as mock_sem,
+        ):
+            mock_rag.return_value.schema_store.table_size.return_value = 0
+            mock_sem.return_value.get_size.return_value = 0
+            return DBFuncTool(manager, agent_config=config)
+
+    def _capture(self, tmp_path, **kwargs):
+        from types import SimpleNamespace
+
+        tool = self._tool()
+        book = tmp_path / "book.xlsx"
+        book.write_bytes(b"")
+        tool._resolve_data_file = lambda path: SimpleNamespace(resolved=book, display=path)
+        captured = {}
+
+        def load_file(*_args, **call_kwargs):
+            captured.update(call_kwargs)
+            return [], []
+
+        with (
+            patch("datus.tools.func_tool.database.load_file", side_effect=load_file),
+            patch("datus.tools.func_tool.database.registered_objects", return_value={}),
+        ):
+            tool.load_file_as_table(path="book.xlsx", **kwargs)
+        return captured
+
+    def test_zero_means_unspecified(self, tmp_path):
+        """Rows are 1-based, so 0 taken literally fails every sheet with
+        "header_row must be 1 or greater" and the whole file reads as unloadable.
+        Observed in real traffic: the session's inspect call carried
+        ``header_row: 0``, where it happened to be ignored."""
+        assert self._capture(tmp_path, header_row=0)["header_row"] is None
+
+    def test_a_real_header_row_is_passed_through(self, tmp_path):
+        assert self._capture(tmp_path, header_row=3)["header_row"] == 3
+
+    def test_a_negative_row_is_still_a_mistake(self, tmp_path):
+        """Not folded into "unspecified": nothing sends -1 by accident, and
+        silently auto-detecting would hide a caller bug."""
+        assert self._capture(tmp_path, header_row=-1)["header_row"] == -1


### PR DESCRIPTION
## What went wrong

A dev session analysing an uploaded workbook had **8 of its 10 `execute_sql` calls refused**:

```
jeffshop_q3_2017_q3 is not a table registered on the 'local_files' datasource
```

The table *was* registered, and the same session queried it successfully seconds later. The trace makes the cause unambiguous:

| batch | parallel calls | refused | succeeded |
|---|---|---|---|
| 09:15:36 | 5 | 4 | 1 |
| 09:15:48 | 4 | 3 | 1 |
| 09:15:59 | **1** | 0 | 1 |
| 09:16:05 | 2 | 1 | 1 |
| 09:16:27 | 2 | 1 | 1 |
| 09:16:17 / 09:16:33 | **1** | 0 | 1 |

Every single-call batch passed; every batch of N parallel calls had exactly N-1 refusals, timestamps 1ms apart. Nothing to do with the table, the SQL, or the catalog.

## Cause

`_reject_unsafe_uploads_sql` authorises a query by reading the catalog. It took the connection out of `exclusive_connection` and queried it **after the lock was released**:

```python
with exclusive() as connection:
    return connection          # lock released here
...
registered = list(registered_objects(self._uploads_connection()))   # runs unlocked
```

`DuckDBPyConnection` is not thread-safe, and an LLM emitting parallel tool calls makes concurrent reads the normal case. A 5-thread reproduction against the real connector:

| | result |
|---|---|
| unlocked (this bug) | **SIGSEGV** under sustained load; 4-of-5 refused otherwise |
| locked (this PR) | 300/300 pass over 60 rounds |

The session was lucky to get wrong answers rather than a dead SSE stream.

## Fixes

**1. The read happens inside the lock.** `_uploads_connection` is replaced by `_registered_uploads`, which never hands the connection out.

**2. A failed catalog read no longer masquerades as "not registered."** `registered_objects` swallowed every exception into `{}` — which is also what a legitimately empty catalog returns. The guard reads "no names" as "no reference can be authorised", so an unreadable catalog produced the opposite instruction to the model: it re-registered the file, re-listed the catalog, and re-ran the same query. Failures now propagate to the existing *catalog is unavailable* branch.

**3. `header_row=0` means unspecified.** It previously failed every sheet with `header_row must be 1 or greater`, so the whole file read as unloadable. The tool schema types this optional as a number, so a model with nothing to say sends `0` rather than omitting the key — this session did exactly that on its inspect call, where it happened to be ignored. Negative values are still reported as mistakes.

**4. Text dates carry the cast to use.** `strftime(order_date, '%Y-%m')` also failed to bind in that session: a spreadsheet's dates typed as text stay VARCHAR. The per-column profile now says `text dates: CAST(order_date AS DATE) to use date functions`, verified per column — only a column where *every* value parses is annotated, because SUMMARIZE reports the lexical min/max and a mixed column can show ISO ends.

This is a hint, not a cast baked into the view, for two measured reasons:
- DuckDB **re-expands a view's `SELECT *` per query** — a column added to the file later shows up without reloading. Freezing an explicit projection to carry casts would trade that away.
- It would buy little: `TRY_CAST` accepts only ISO-ish text (`8/31/2017` and `20170701` both return NULL), which is exactly the text that already sorts and compares correctly as-is.

## Verification

- The concurrency regression test **fails on the old code and passes on the new** — checked both ways. It records the lock state and asserts outside the mock, because the guard wraps the read in `except Exception` and an assert raised inside would be swallowed, letting the test pass against the very bug it exists to catch.
- `tests/unit_tests/tools/` — 3952 passed. The one failure (`test_semantic_modeling_stamps_query_source_with_runtime_dosi_version`) is pre-existing and reproduces with these changes stashed.
- Affected suites on this branch: **389 passed**, integration tier included.
- End-to-end against the real workbook: `order_date` flagged, dimension columns correctly not flagged, and the SQL that failed in production now returns `[('2017-07', 8974.0), ('2017-08', 10492.0)]`.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

- **New Features**
  - Added advisory date and timestamp conversion hints when text columns contain date-like values, including columns with nulls.
  - Treats a header row value of `0` as unspecified during file loading.

- **Bug Fixes**
  - Improved upload validation by safely checking registered files while maintaining connection consistency.
  - Catalog access errors are now reported clearly instead of appearing as missing tables.
  - Profiling continues successfully when date-detection checks cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->