### PR TITLE
[Feature] Address table metadata and SQL execution per datasource

### DIFF
--- a/conf/agent.yml.example
+++ b/conf/agent.yml.example
@@ -503,6 +503,25 @@ agent:
       - ~/.datus/skills
       - ./skills
 
+  api:
+    # Bounds on the HTTP API's datasource access. All three exist because a
+    # single metadata or SQL round-trip can run for seconds on a real warehouse,
+    # and these requests run on a shared thread pool.
+    #
+    # How long POST /sql/execute waits for its datasource's connector before
+    # giving up with DATASOURCE_BUSY. The connector is shared per datasource and
+    # carries mutable database context, so statements on one datasource run one
+    # at a time; without a bound, a queue would pin worker threads that every
+    # other request needs too. Nothing is executed on timeout, so even a write
+    # is safe to retry.
+    sql_queue_budget_seconds: 30
+    # Largest batch POST /table/columns will accept (autocomplete prefetch).
+    max_prefetch_tables: 500
+    # How long one prefetch batch may spend resolving uncached tables before it
+    # returns what it has. Tables it did not reach are simply omitted, and the
+    # client re-asks per table.
+    prefetch_budget_seconds: 3
+
   autocomplete:
     # After switching / adding / editing a datasource, refresh the LanceDB
     # schema index in the background so @Table completion reflects new

--- a/datus/api/models/agent_models.py
+++ b/datus/api/models/agent_models.py
@@ -31,6 +31,16 @@ class CreateAgentInput(BaseModel):
 
     name: str = Field(..., min_length=1, description="Agent name (unique within workspace)")
     datasource_id: str = Field(default="", description="Datasource ID this agent is bound to")
+    # Same binding by namespace name instead of id. A web client picking the
+    # datasource out of the catalog tree only ever sees the namespace name, and
+    # `catalogs` below is scoped to it — the ids live on the saas side.
+    datasource_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Datasource namespace name this agent is bound to, resolved against the project's "
+            "bindings. Ignored when `datasource_id` is given; both omitted means the project's primary."
+        ),
+    )
     type: str = Field(
         default="gen_sql", description="Node class: gen_sql / gen_report / ask_report / ask_dashboard / ..."
     )
@@ -171,6 +181,15 @@ class EditAgentInput(BaseModel):
     catalogs: Optional[List[str]] = Field(
         default=None,
         description="Catalog access patterns (e.g., 'production_db.*', 'production_db.public.*')",
+    )
+    # `catalogs` above is matched against exactly one datasource, so re-pointing
+    # the agent at another one has to travel with the patterns that describe it.
+    datasource_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Datasource namespace name to re-bind this agent to, resolved against the project's "
+            "bindings. Omit to leave the binding untouched."
+        ),
     )
     subjects: Optional[List[str]] = Field(
         default=None, description="Subject access patterns (e.g., 'Finance.Revenue.*')"

--- a/datus/api/models/cli_models.py
+++ b/datus/api/models/cli_models.py
@@ -15,6 +15,7 @@ class ExecuteSQLInput(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
+                "datasource": "prod_warehouse",
                 "database_name": "sales_db",
                 "sql_query": "SELECT * FROM users WHERE status = 'active'",
                 "result_format": "csv",
@@ -24,6 +25,11 @@ class ExecuteSQLInput(BaseModel):
         }
     )
 
+    # Which connection profile to run against. A project can bind several, and
+    # the dotted table names in the SQL carry no datasource level — so the
+    # editor tab's datasource has to travel with the statement or it silently
+    # runs on the project's default warehouse instead.
+    datasource: Optional[str] = Field(None, description="Datasource to execute against; null means the current one")
     database_name: Optional[str] = Field(None, description="Database name")
     sql_query: str = Field(..., description="SQL query to execute")
     result_format: str = Field("arrow", description="Result format (arrow, csv, json)")
@@ -72,6 +78,7 @@ class ExecuteContextInput(BaseModel):
         json_schema_extra={
             "example": {
                 "context_type": "tables",
+                "datasource": "prod_warehouse",
                 "database_name": "sales_db",
                 "schema_name": "public",
                 "args": "",

--- a/datus/api/models/config_models.py
+++ b/datus/api/models/config_models.py
@@ -25,6 +25,10 @@ class ErrorCode(str, Enum):
     SQL_READ_ONLY = "SQL_READ_ONLY"
     TOOL_EXECUTION_ERROR = "TOOL_EXECUTION_ERROR"
     DATABASE_CONNECTION_ERROR = "DATABASE_CONNECTION_ERROR"
+    # A datasource's shared connector was busy for longer than the caller was
+    # allowed to wait. Distinct from SQL_EXECUTION_ERROR: the statement was
+    # never sent, so retrying is safe even for a write.
+    DATASOURCE_BUSY = "DATASOURCE_BUSY"
     CONTEXT_COMMAND_ERROR = "CONTEXT_COMMAND_ERROR"
     CHAT_COMMAND_ERROR = "CHAT_COMMAND_ERROR"
     INTERNAL_COMMAND_ERROR = "INTERNAL_COMMAND_ERROR"

--- a/datus/api/models/config_models.py
+++ b/datus/api/models/config_models.py
@@ -64,6 +64,27 @@ class DatasourceConfig(BaseModel):
     catalog: Optional[str] = Field(None, description="Database catalog (for databases that support catalogs)")
 
 
+class DatasourceSummary(BaseModel):
+    """One configured datasource, with nothing a caller does not need to name it.
+
+    Deliberately NOT ``DatasourceConfig``: that carries the decrypted password,
+    the credential-bearing ``uri`` and the Snowflake key passphrase. Listing the
+    datasources is something every client that renders a catalog does, on every
+    project entry — so it must not be a path that hands out credentials.
+    """
+
+    name: str = Field(..., description="Datasource (namespace) name")
+    type: str = Field(..., description="Datasource type (postgresql, starrocks, ...)")
+    is_current: bool = Field(False, description="Whether this is the project's current datasource")
+
+
+class DatasourceListData(BaseModel):
+    """Data for the datasource roster."""
+
+    datasources: list[DatasourceSummary] = Field(..., description="Configured datasources")
+    current_datasource: str = Field("", description="The project's current datasource")
+
+
 class StorageConfig(BaseModel):
     """Storage configuration for RAG."""
 

--- a/datus/api/models/database_models.py
+++ b/datus/api/models/database_models.py
@@ -10,6 +10,10 @@ class DatabaseInfo(BaseModel):
     """Information about a database connection."""
 
     name: str = Field(..., description="Database name")
+    # Which configured datasource this database came from. A project can bind
+    # several, and a client rendering them in one tree cannot address a table
+    # without knowing which connection profile to reach it through.
+    datasource: str = Field("", description="Name of the datasource (connection profile) serving this database")
     uri: str = Field(..., description="Database connection URI")
     type: str = Field(..., description="Database type (sqlite, duckdb, postgresql, etc.)")
     current: bool = Field(..., description="Whether this is the current database")
@@ -27,7 +31,9 @@ class DatabaseInfo(BaseModel):
 class ListDatabasesInput(BaseModel):
     """Input model for listing databases."""
 
-    datasource_id: str = Field("", description="The id of datasource to list databases from")
+    datasource_id: str = Field(
+        "", description="Name of the datasource to list databases from; empty means the current one"
+    )
     catalog_name: Optional[str] = Field(None, description="Catalog name")
     database_name: str = Field("", description="Database name")
     schema_name: str = Field("", description="Schema name")
@@ -40,6 +46,7 @@ class ListDatabasesData(BaseModel):
     databases: List[DatabaseInfo] = Field(..., description="List of databases")
     total_count: int = Field(..., description="Total number of databases")
     current_database: Optional[str] = Field(None, description="Current database name")
+    current_datasource: Optional[str] = Field(None, description="Datasource these databases were listed from")
 
 
 class DatabasesData(BaseModel):

--- a/datus/api/models/kb_models.py
+++ b/datus/api/models/kb_models.py
@@ -57,6 +57,14 @@ class BootstrapKbInput(BaseModel):
             "Expected values follow `datus-agent bootstrap-kb`: `table`, `view`, `mv`, or `full`."
         ),
     )
+    datasource: Optional[str] = Field(
+        default=None,
+        description=(
+            "Which configured datasource to index. Null means the project's current one. "
+            "Each datasource has its own metadata and its own KB rows, so a project bound to "
+            "several needs one bootstrap per datasource."
+        ),
+    )
     catalog: str = Field(
         default="",
         description=(

--- a/datus/api/models/table_models.py
+++ b/datus/api/models/table_models.py
@@ -57,6 +57,11 @@ class GetTablesColumnsInput(BaseModel):
         ...,
         description="Full table names, e.g. ['db.schema.orders', 'db.schema.users']",
     )
+    # One batch resolves against one datasource: the dotted names carry no
+    # datasource level, so a mixed batch would be unresolvable.
+    datasource: Optional[str] = Field(
+        None, description="Datasource to resolve these tables against; null means the current one"
+    )
 
 
 class TableColumnBrief(BaseModel):

--- a/datus/api/routes/config_routes.py
+++ b/datus/api/routes/config_routes.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from datus.api import deps
 from datus.api.deps import AppContextDep, ServiceDep
 from datus.api.models.base_models import Result
+from datus.api.models.config_models import DatasourceListData, DatasourceSummary
 from datus.configuration.agent_config import _SAFE_NAME_RE, DbConfig, load_model_config
 from datus.configuration.agent_config_loader import configuration_manager
 from datus.models.base import LLMBaseModel
@@ -144,6 +145,43 @@ async def get_agent_config_endpoint(
             "datasources": flat_datasources,
             "home": config.home,
         },
+    )
+
+
+@router.get(
+    "/config/datasources",
+    response_model=Result[DatasourceListData],
+    summary="List Datasources",
+    description="Names and types of the project's configured datasources. Carries no credentials.",
+)
+async def list_datasources_endpoint(
+    svc: ServiceDep,
+) -> Result[DatasourceListData]:
+    """The datasource roster, for clients that need to name them.
+
+    Separate from ``/config/agent`` on purpose. That endpoint returns the raw
+    ``DbConfig`` of every datasource — decrypted password, credential-bearing
+    ``uri``, Snowflake key passphrase — plus the models block with its API keys.
+    Anything a catalog UI does on project entry has to be reachable without
+    that, or every member who opens a project is handed the warehouse
+    credentials.
+    """
+    config = svc.agent_config
+    current = config.current_datasource or ""
+
+    summaries = [
+        DatasourceSummary(
+            name=name,
+            type=(db_config.type.value if hasattr(db_config.type, "value") else str(db_config.type)),
+            is_current=(name == current),
+        )
+        for name, db_config in config.datasource_configs.items()
+        if db_config is not None
+    ]
+
+    return Result(
+        success=True,
+        data=DatasourceListData(datasources=summaries, current_datasource=current),
     )
 
 

--- a/datus/api/routes/table_routes.py
+++ b/datus/api/routes/table_routes.py
@@ -3,6 +3,7 @@ API routes for Table and SemanticModel endpoints.
 """
 
 import asyncio
+from typing import Optional
 
 from fastapi import APIRouter, Query
 
@@ -22,6 +23,9 @@ from datus.api.models.table_models import (
 
 router = APIRouter(prefix="/api/v1", tags=["table"])
 
+# Pre-configured parameter to avoid definition-time evaluation in defaults.
+DATASOURCE_QUERY = Query("", description="Datasource to resolve the table against; empty means the current one")
+
 
 # ========== Table Endpoints ==========
 
@@ -38,9 +42,12 @@ async def get_table_detail(
         ...,
         description="Full table name e.g. 'production_db.public.frpm' or 'db.schema.table'",
     ),
+    datasource: Optional[str] = DATASOURCE_QUERY,
 ) -> Result[GetTableDetailData]:
     """Get table detail."""
-    return await asyncio.to_thread(svc.datasource.get_table_schema, table)
+    # Normalized here so an omitted query param and an explicit empty one both
+    # mean "the current datasource" to the service.
+    return await asyncio.to_thread(svc.datasource.get_table_schema, table, datasource or None)
 
 
 @router.post(
@@ -55,7 +62,7 @@ async def get_tables_columns(
     svc: ServiceDep,
 ) -> Result[GetTablesColumnsData]:
     """Batch table columns."""
-    return await asyncio.to_thread(svc.datasource.get_tables_columns, request.tables)
+    return await asyncio.to_thread(svc.datasource.get_tables_columns, request.tables, request.datasource)
 
 
 # ========== SemanticModel Endpoints ==========

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -912,9 +912,26 @@ class AgentService:
         }
         # Bind the subagent to the active datasource (mirrors the wizard so
         # ``SubAgentConfig.is_in_datasource`` can gate task delegation at runtime).
-        # ``request.datasource_id`` wins when set; otherwise fall back to the
-        # AgentConfig's current datasource.
-        datasource = request.datasource_id or getattr(agent_config, "current_datasource", "") or ""
+        # ``request.datasource_id`` wins when set, then ``datasource_name``;
+        # otherwise fall back to the AgentConfig's current datasource.
+        #
+        # The two are the same thing here: a datasource is addressed by its
+        # namespace key in a standalone agent, and the SaaS-side ids the name
+        # form exists for do not reach this service. Honouring it matters
+        # anyway — silently ignoring a field the request set would bind the
+        # agent to a different warehouse than the caller asked for.
+        datasource = (
+            request.datasource_id
+            or (getattr(request, "datasource_name", None) or "")
+            or getattr(agent_config, "current_datasource", "")
+            or ""
+        )
+        if datasource and datasource not in getattr(agent_config, "datasource_configs", {}):
+            return Result(
+                success=False,
+                errorCode="INVALID_DATASOURCE",
+                errorMessage=f"Unknown datasource '{datasource}'",
+            )
         subject_buckets = (
             _classify_subject_paths(
                 agent_config,
@@ -1091,7 +1108,13 @@ class AgentService:
         # API ``description`` lands on the runtime-visible ``agent_description``
         # key; drop any legacy flat ``description`` left over from older edits
         # so the read path doesn't see two competing values.
-        update_data = request.model_dump(exclude={"id", "name", "prompt_template", "channels"}, exclude_none=True)
+        # ``datasource_name`` is not a persisted field — it selects the binding
+        # resolved below. Left in, ``agent.update(update_data)`` would write it
+        # as a bogus top-level key on the sub-agent's yaml.
+        update_data = request.model_dump(
+            exclude={"id", "name", "prompt_template", "channels", "datasource_name"},
+            exclude_none=True,
+        )
         if "description" in update_data:
             update_data["agent_description"] = update_data.pop("description")
             agent.pop("description", None)
@@ -1137,7 +1160,15 @@ class AgentService:
             # fall back to "no datasource → all metrics" and silently
             # mis-bucket subjects against a binding that's about to be
             # re-persisted by ``_build_scoped_context``.
-            datasource = getattr(agent_config, "current_datasource", "") or base_ctx.get("datasource") or ""
+            # A request that names a datasource re-points the binding; that has
+            # to win over the config's current one, or an edit would silently
+            # rebind the agent back to the active datasource.
+            datasource = (
+                (getattr(request, "datasource_name", None) or "")
+                or getattr(agent_config, "current_datasource", "")
+                or base_ctx.get("datasource")
+                or ""
+            )
             subject_buckets = None
             if subjects_input is not None:
                 subject_buckets = _classify_subject_paths(

--- a/datus/api/services/agent_service.py
+++ b/datus/api/services/agent_service.py
@@ -1110,7 +1110,11 @@ class AgentService:
         # so the read path doesn't see two competing values.
         # ``datasource_name`` is not a persisted field — it selects the binding
         # resolved below. Left in, ``agent.update(update_data)`` would write it
-        # as a bogus top-level key on the sub-agent's yaml.
+        # as a bogus top-level key on the sub-agent's yaml. Captured first
+        # because excluding it also hides it from ``scope_touched``: an edit
+        # carrying only this field would then fall through to the no-op return
+        # and report success without moving the binding.
+        datasource_name_input = request.datasource_name
         update_data = request.model_dump(
             exclude={"id", "name", "prompt_template", "channels", "datasource_name"},
             exclude_none=True,
@@ -1137,7 +1141,12 @@ class AgentService:
         # edits are dropped so the read path can't see two competing copies.
         catalogs_input = update_data.pop("catalogs", None)
         subjects_input = update_data.pop("subjects", None)
-        scope_touched = catalogs_input is not None or subjects_input is not None or "scoped_context" in update_data
+        scope_touched = (
+            datasource_name_input is not None
+            or catalogs_input is not None
+            or subjects_input is not None
+            or "scoped_context" in update_data
+        )
         # Tracks deletions applied directly to ``agent`` (the live yaml dict)
         # rather than through ``update_data``. ``agent.update(update_data)``
         # below can't represent a key removal, so we have to bypass the
@@ -1160,15 +1169,28 @@ class AgentService:
             # fall back to "no datasource → all metrics" and silently
             # mis-bucket subjects against a binding that's about to be
             # re-persisted by ``_build_scoped_context``.
-            # A request that names a datasource re-points the binding; that has
-            # to win over the config's current one, or an edit would silently
-            # rebind the agent back to the active datasource.
+            # Request first, then the agent's own saved binding, then the
+            # active datasource. The saved one has to outrank the active one:
+            # ``EditAgentInput`` says an omitted ``datasource_name`` leaves the
+            # binding untouched, so an agent bound to B must not be silently
+            # rebound to A just because someone edited its catalogs while A was
+            # current.
             datasource = (
-                (getattr(request, "datasource_name", None) or "")
-                or getattr(agent_config, "current_datasource", "")
+                (datasource_name_input or "")
                 or base_ctx.get("datasource")
+                or getattr(agent_config, "current_datasource", "")
                 or ""
             )
+
+            # Only the explicit input is validated. A saved binding whose
+            # datasource has since left the config is historical data and falls
+            # through to the active one; a name the caller just typed should not.
+            if datasource_name_input and datasource_name_input not in getattr(agent_config, "datasource_configs", {}):
+                return Result(
+                    success=False,
+                    errorCode="INVALID_DATASOURCE",
+                    errorMessage=f"Unknown datasource '{datasource_name_input}'",
+                )
             subject_buckets = None
             if subjects_input is not None:
                 subject_buckets = _classify_subject_paths(

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -97,6 +97,15 @@ class CLIService:
         # use. The IDE console addresses one by name per request, and opening
         # every bound warehouse at startup would cost seconds per project.
         self._datasource_connectors: Dict[str, Any] = {}
+        # One lock per datasource, held across ``switch_context`` + execute.
+        #
+        # A connector is shared by every request on its datasource and carries
+        # mutable catalog/database context, while ``_execute_sql_sync`` runs in
+        # worker threads — so two interleaved requests could each execute under
+        # the other's database. Serializing per datasource is the same trade
+        # ``DatasourceService._schema_lock`` already makes for the same reason:
+        # a queued query beats a query answered from the wrong database.
+        self._connector_locks: Dict[str, threading.Lock] = {}
         self._db_tool_cache: Optional[func_tool_mod.DBFuncTool] = None
         # `_execute_sql_sync` runs under `asyncio.to_thread`, so two clicks on
         # Run can reach the lazy build below at the same time and each pay for
@@ -165,6 +174,20 @@ class CLIService:
             cached = connector
             self._datasource_connectors[key] = cached
         return key, cached
+
+    def _connector_lock(self, datasource: str) -> threading.Lock:
+        """The lock guarding one datasource's shared connector.
+
+        Tolerates an instance built without ``__init__`` (which the policy tests
+        do), and needs no lock of its own: ``dict.setdefault`` resolves the
+        create-vs-reuse race itself, so two threads asking at once still get the
+        same lock.
+        """
+        locks = getattr(self, "_connector_locks", None)
+        if locks is None:
+            locks = {}
+            self._connector_locks = locks
+        return locks.setdefault(datasource, threading.Lock())
 
     def _cleanup_sql_task(self, task_id: str) -> None:
         """Remove a completed SQL task from the tracking dict."""
@@ -254,6 +277,37 @@ class CLIService:
                         errorMessage=(f"This deployment is read-only (agent.sql_read_only). {reason}"),
                     )
 
+            # Held from the context switch through the execute below: the
+            # connector is shared across requests on this datasource and its
+            # catalog/database context is mutable, so releasing in between lets
+            # another request run under this one's database (or this one under
+            # theirs). Acquired after the read-only refusal above so a rejected
+            # request never queues behind a running query.
+            execution_lock = self._connector_lock(datasource)
+            execution_lock.acquire()
+            try:
+                return self._execute_resolved_sql(request, task_id, policy_context, datasource, connector)
+            finally:
+                execution_lock.release()
+
+        except Exception as e:
+            logger.error(f"Failed to execute SQL: {e}")
+            return Result(
+                success=False,
+                errorCode=ErrorCode.SQL_EXECUTION_ERROR,
+                errorMessage=str(e),
+            )
+
+    def _execute_resolved_sql(
+        self,
+        request: ExecuteSQLInput,
+        task_id: str,
+        policy_context: Optional[Dict[str, Any]],
+        datasource: str,
+        connector: Any,
+    ) -> Result[ExecuteSQLData]:
+        """Run one statement on an already-resolved connector, under its lock."""
+        try:
             # Switch to the requested database/catalog context before executing.
             if request.database_name:
                 catalog = getattr(connector, "catalog_name", "") or ""

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -32,6 +32,7 @@ from datus.schemas.action_history import (
     ActionStatus,
 )
 from datus.tools.db_tools.db_manager import DBManager
+from datus.utils.config_utils import coerce_positive_seconds
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import (
     SQLType,
@@ -49,6 +50,12 @@ logger = get_logger(__name__)
 #: anything the parser could not place must fall to the enforced path, where it
 #: is refused — the alternative is that a syntax the dialect accepts but sqlglot
 #: does not becomes an unfiltered read.
+# How long a statement waits for its datasource's connector before being refused.
+# Long enough to ride out a normal interactive query, short enough that a queue
+# cannot pin to_thread workers indefinitely. Override via
+# ``api.sql_queue_budget_seconds``.
+_DEFAULT_SQL_QUEUE_BUDGET_SECONDS = 30.0
+
 _WRITE_SQL_TYPES = frozenset(
     {
         SQLType.INSERT,
@@ -283,8 +290,34 @@ class CLIService:
             # another request run under this one's database (or this one under
             # theirs). Acquired after the read-only refusal above so a rejected
             # request never queues behind a running query.
+            #
+            # Bounded, because waiting here is not free: this runs on an
+            # ``asyncio.to_thread`` worker, and the default executor has only
+            # ``min(32, cpu + 4)`` of them. A few slow queries queued on one
+            # datasource could otherwise starve every other to_thread caller in
+            # the process — table detail, catalog listing, the agent's own tool
+            # calls. Timing out also bounds how long a cancelled request keeps a
+            # worker: ``stop_execute_sql`` cancels the asyncio task, which cannot
+            # interrupt a thread parked in ``acquire()``.
+            api_config = getattr(self.agent_config, "api_config", {}) or {}
+            wait_budget = coerce_positive_seconds(
+                api_config.get("sql_queue_budget_seconds"), _DEFAULT_SQL_QUEUE_BUDGET_SECONDS
+            )
             execution_lock = self._connector_lock(datasource)
-            execution_lock.acquire()
+            if not execution_lock.acquire(timeout=wait_budget):
+                logger.warning(
+                    "POST /sql/execute gave up waiting for the datasource connector",
+                    datasource=datasource,
+                    waited_seconds=wait_budget,
+                )
+                return Result(
+                    success=False,
+                    errorCode=ErrorCode.DATASOURCE_BUSY,
+                    errorMessage=(
+                        f"Datasource '{datasource}' is busy with another statement "
+                        f"(waited {wait_budget:g}s). Nothing was executed — try again."
+                    ),
+                )
             try:
                 return self._execute_resolved_sql(request, task_id, policy_context, datasource, connector)
             finally:

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -125,6 +125,12 @@ class CLIService:
 
         # Track running SQL execution tasks: {task_id: asyncio.Task}
         self._sql_tasks: Dict[str, asyncio.Task] = {}
+        # A thread-safe stop signal per task, because cancelling the asyncio task
+        # cannot reach the worker thread it dispatched: a worker parked in
+        # ``execution_lock.acquire()`` keeps waiting, then acquires and runs. For
+        # a write that means the statement lands *after* stop_execute_sql told
+        # the caller it stopped.
+        self._sql_cancels: Dict[str, threading.Event] = {}
         self._sql_tasks_lock = threading.Lock()
 
     def _initialize_connection(self):
@@ -214,15 +220,17 @@ class CLIService:
         return locks.setdefault(datasource, threading.Lock())
 
     def _cleanup_sql_task(self, task_id: str) -> None:
-        """Remove a completed SQL task from the tracking dict."""
+        """Remove a completed SQL task from the tracking dicts."""
         with self._sql_tasks_lock:
             self._sql_tasks.pop(task_id, None)
+            self._sql_cancels.pop(task_id, None)
 
     def _execute_sql_sync(
         self,
         request: ExecuteSQLInput,
         task_id: str,
         policy_context: Optional[Dict[str, Any]] = None,
+        cancelled: Optional[threading.Event] = None,
     ) -> Result[ExecuteSQLData]:
         """Synchronous SQL execution logic (runs in a thread)."""
         try:
@@ -336,6 +344,17 @@ class CLIService:
                     ),
                 )
             try:
+                # The one point a queued statement can still be stopped. The
+                # await in `execute_sql` is already gone by now — cancelling it
+                # never reached this thread — so without this check a write the
+                # caller was told had stopped would execute here.
+                if cancelled is not None and cancelled.is_set():
+                    logger.info("SQL execution cancelled while queued for the datasource connector", task_id=task_id)
+                    return Result(
+                        success=False,
+                        errorCode=ErrorCode.SQL_EXECUTION_ERROR,
+                        errorMessage="SQL execution was cancelled",
+                    )
                 return self._execute_resolved_sql(request, task_id, policy_context, datasource, connector)
             finally:
                 execution_lock.release()
@@ -566,10 +585,11 @@ class CLIService:
         via ``stop_execute_sql()``. Otherwise a server-generated UUID is used.
         """
         task_id = request.execute_task_id or str(uuid.uuid4())
+        cancelled = threading.Event()
 
         async def _run() -> Result[ExecuteSQLData]:
             try:
-                return await asyncio.to_thread(self._execute_sql_sync, request, task_id, policy_context)
+                return await asyncio.to_thread(self._execute_sql_sync, request, task_id, policy_context, cancelled)
             except asyncio.CancelledError:
                 logger.info(f"SQL execution task cancelled: {task_id}")
                 return Result(
@@ -589,6 +609,7 @@ class CLIService:
                 )
             task = asyncio.create_task(_run())
             self._sql_tasks[task_id] = task
+            self._sql_cancels[task_id] = cancelled
 
         return await task
 
@@ -603,6 +624,7 @@ class CLIService:
         """
         with self._sql_tasks_lock:
             task = self._sql_tasks.get(task_id)
+            cancelled = self._sql_cancels.get(task_id)
 
         if not task:
             return Result(
@@ -621,6 +643,10 @@ class CLIService:
                 data=StopExecuteSQLData(execute_task_id=task_id, stopped=False),
             )
 
+        # Raised before cancelling: the worker checks it once it owns the lock,
+        # which is the only place a queued statement can still be stopped.
+        if cancelled is not None:
+            cancelled.set()
         task.cancel()
         logger.info(f"Cancellation requested for SQL execution task: {task_id}")
         return Result(

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -93,6 +93,10 @@ class CLIService:
 
         # Initialize database connection
         self.current_db_connector = None
+        # Connectors for the project's other bound datasources, opened on first
+        # use. The IDE console addresses one by name per request, and opening
+        # every bound warehouse at startup would cost seconds per project.
+        self._datasource_connectors: Dict[str, Any] = {}
         self._db_tool_cache: Optional[func_tool_mod.DBFuncTool] = None
         # `_execute_sql_sync` runs under `asyncio.to_thread`, so two clicks on
         # Run can reach the lazy build below at the same time and each pay for
@@ -123,6 +127,33 @@ class CLIService:
             except Exception as e:
                 logger.warning(f"Failed to initialize database connection: {e}")
 
+    def _execution_target(self, datasource: Optional[str] = None) -> tuple[str, Any]:
+        """``(datasource, connector)`` this statement should run against.
+
+        Defaults to the project's current datasource. An unknown name is an
+        error rather than a fall-through: silently running the statement on a
+        different warehouse than the editor's tab is showing is how a query
+        returns plausible rows from the wrong place.
+        """
+        key = (datasource or "").strip() or (self.current_datasource or "")
+        if not key:
+            raise ValueError("No database connection available")
+
+        if key == self.current_datasource:
+            if not self.current_db_connector:
+                raise ValueError("No database connection available")
+            return key, self.current_db_connector
+
+        configs = getattr(self.agent_config, "datasource_configs", {}) or {}
+        if key not in configs:
+            raise ValueError(f"Unknown datasource '{key}'")
+
+        cached = self._datasource_connectors.get(key)
+        if cached is None:
+            _db_name, cached = self.db_manager.first_conn_with_name(key)
+            self._datasource_connectors[key] = cached
+        return key, cached
+
     def _cleanup_sql_task(self, task_id: str) -> None:
         """Remove a completed SQL task from the tracking dict."""
         with self._sql_tasks_lock:
@@ -136,11 +167,13 @@ class CLIService:
     ) -> Result[ExecuteSQLData]:
         """Synchronous SQL execution logic (runs in a thread)."""
         try:
-            if not self.current_db_connector:
+            try:
+                datasource, connector = self._execution_target(request.datasource)
+            except ValueError as e:
                 return Result(
                     success=False,
                     errorCode=ErrorCode.DATABASE_CONNECTION_ERROR,
-                    errorMessage="No database connection available",
+                    errorMessage=str(e),
                 )
 
             # Deployment-wide read-only posture. This route reaches the connector
@@ -172,7 +205,7 @@ class CLIService:
                     validate_read_only_sql,
                 )
 
-                dialect = getattr(self.current_db_connector, "dialect", "") or ""
+                dialect = getattr(connector, "dialect", "") or ""
                 violation, sql_type = validate_read_only_sql(request.sql_query, dialect)
                 if violation:
                     # The helper returns a code, not prose, so each entry point
@@ -211,8 +244,8 @@ class CLIService:
 
             # Switch to the requested database/catalog context before executing.
             if request.database_name:
-                catalog = getattr(self.current_db_connector, "catalog_name", "") or ""
-                self.current_db_connector.switch_context(
+                catalog = getattr(connector, "catalog_name", "") or ""
+                connector.switch_context(
                     catalog_name=catalog,
                     database_name=request.database_name,
                 )
@@ -250,7 +283,7 @@ class CLIService:
             # rejected there, which is the same answer it gave before any of
             # this existed.
             start_time = time.time()
-            sql_type = parse_sql_type(request.sql_query, self.current_db_connector.dialect)
+            sql_type = parse_sql_type(request.sql_query, connector.dialect)
             is_write = sql_type in _WRITE_SQL_TYPES and is_single_statement(request.sql_query)
 
             if is_write and policy_context:
@@ -259,7 +292,7 @@ class CLIService:
                 # policy covers. The plugin cannot help — it hooks reads only —
                 # so on a project that has policies at all, a write that embeds
                 # a query is refused here.
-                reads = write_statement_reads_data(request.sql_query, self.current_db_connector.dialect)
+                reads = write_statement_reads_data(request.sql_query, connector.dialect)
                 if reads:
                     message = (
                         "This project has row-level policies, so a write statement that "
@@ -283,15 +316,15 @@ class CLIService:
                     )
 
             if is_write:
-                result = self.current_db_connector.execute(
+                result = connector.execute(
                     input_params={"sql_query": request.sql_query},
                     result_format=request.result_format,
                 )
             else:
                 result = self._db_tool().execute_read_enforced(
                     request.sql_query,
-                    self.current_db_connector,
-                    datasource=self.current_datasource or "",
+                    connector,
+                    datasource=datasource,
                     result_format=request.result_format,
                     policy_context=policy_context,
                 )

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -150,7 +150,19 @@ class CLIService:
 
         cached = self._datasource_connectors.get(key)
         if cached is None:
-            _db_name, cached = self.db_manager.first_conn_with_name(key)
+            try:
+                # Declared in the config but unreachable raises DatusException,
+                # not ValueError — without this the caller's `except ValueError`
+                # misses it and the failure loses its DATABASE_CONNECTION_ERROR
+                # code to the generic handler.
+                _db_name, connector = self.db_manager.first_conn_with_name(key)
+            except Exception as e:  # noqa: BLE001 — normalized for the caller
+                raise ValueError(f"Datasource '{key}' has no usable connection: {e}") from e
+            if connector is None:
+                raise ValueError(f"Datasource '{key}' has no usable connection")
+            # Only cached once known good. Caching a None turned the next
+            # request's `connector.dialect` into an AttributeError.
+            cached = connector
             self._datasource_connectors[key] = cached
         return key, cached
 

--- a/datus/api/services/cli_service.py
+++ b/datus/api/services/cli_service.py
@@ -33,6 +33,8 @@ from datus.schemas.action_history import (
 )
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.config_utils import coerce_positive_seconds
+from datus.utils.exceptions import DatusException
+from datus.utils.exceptions import ErrorCode as DbErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import (
     SQLType,
@@ -50,10 +52,10 @@ logger = get_logger(__name__)
 #: anything the parser could not place must fall to the enforced path, where it
 #: is refused — the alternative is that a syntax the dialect accepts but sqlglot
 #: does not becomes an unfiltered read.
-# How long a statement waits for its datasource's connector before being refused.
-# Long enough to ride out a normal interactive query, short enough that a queue
-# cannot pin to_thread workers indefinitely. Override via
-# ``api.sql_queue_budget_seconds``.
+# Fallback for ``agent.api.sql_queue_budget_seconds`` (see conf/agent.yml.example),
+# used when a deployment's yaml predates the setting. Long enough to ride out a
+# normal interactive query, short enough that a queue cannot pin to_thread
+# workers indefinitely.
 _DEFAULT_SQL_QUEUE_BUDGET_SECONDS = 30.0
 
 _WRITE_SQL_TYPES = frozenset(
@@ -153,29 +155,44 @@ class CLIService:
         """
         key = (datasource or "").strip() or (self.current_datasource or "")
         if not key:
-            raise ValueError("No database connection available")
+            raise DatusException(
+                DbErrorCode.DB_CONNECTION_FAILED,
+                message_args={"error_message": "No database connection available"},
+            )
 
         if key == self.current_datasource:
             if not self.current_db_connector:
-                raise ValueError("No database connection available")
+                raise DatusException(
+                    DbErrorCode.DB_CONNECTION_FAILED,
+                    message_args={"error_message": "No database connection available"},
+                )
             return key, self.current_db_connector
 
         configs = getattr(self.agent_config, "datasource_configs", {}) or {}
         if key not in configs:
-            raise ValueError(f"Unknown datasource '{key}'")
+            raise DatusException(
+                DbErrorCode.COMMON_UNSUPPORTED, message_args={"field_name": "datasource", "your_value": key}
+            )
 
         cached = self._datasource_connectors.get(key)
         if cached is None:
+            # Whatever the db manager raises for a declared-but-unreachable
+            # datasource reaches the caller as the structured database error, so
+            # one exception type maps to one error response.
             try:
-                # Declared in the config but unreachable raises DatusException,
-                # not ValueError — without this the caller's `except ValueError`
-                # misses it and the failure loses its DATABASE_CONNECTION_ERROR
-                # code to the generic handler.
                 _db_name, connector = self.db_manager.first_conn_with_name(key)
+            except DatusException:
+                raise
             except Exception as e:  # noqa: BLE001 — normalized for the caller
-                raise ValueError(f"Datasource '{key}' has no usable connection: {e}") from e
+                raise DatusException(
+                    DbErrorCode.DB_CONNECTION_FAILED,
+                    message_args={"error_message": f"datasource '{key}' is unreachable: {e}"},
+                ) from e
             if connector is None:
-                raise ValueError(f"Datasource '{key}' has no usable connection")
+                raise DatusException(
+                    DbErrorCode.DB_CONNECTION_FAILED,
+                    message_args={"error_message": f"datasource '{key}' has no usable connection"},
+                )
             # Only cached once known good. Caching a None turned the next
             # request's `connector.dialect` into an AttributeError.
             cached = connector
@@ -211,7 +228,7 @@ class CLIService:
         try:
             try:
                 datasource, connector = self._execution_target(request.datasource)
-            except ValueError as e:
+            except DatusException as e:
                 return Result(
                     success=False,
                     errorCode=ErrorCode.DATABASE_CONNECTION_ERROR,

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -94,12 +94,19 @@ class DatasourceService:
         # The lock serializes the not-thread-safe connector across concurrent
         # asyncio.to_thread detail/batch requests.
         self._columns_cache: dict[str, list[ColumnInfo]] = {}
-        self._schema_lock = threading.Lock()
-        # Only one prefetch batch resolves uncached tables at a time. Several in
-        # parallel cannot go any faster — they serialize on _schema_lock anyway —
-        # they just each pin a to_thread worker while queuing, which is what
-        # starves interactive metadata reads.
-        self._prefetch_gate = threading.BoundedSemaphore(1)
+        # One lock and one prefetch gate per datasource, not one of each overall.
+        # Each datasource has its own connector, and the column cache is keyed by
+        # datasource — so a global lock would serialize metadata reads between
+        # unrelated warehouses. That is expensive here in particular: a single
+        # `list_tables` runs for seconds, so expanding two datasources' trees at
+        # once would queue for no reason.
+        self._schema_locks: dict[str, threading.Lock] = {}
+        # Only one prefetch batch per datasource resolves uncached tables at a
+        # time. Several in parallel on the same datasource cannot go any faster —
+        # they serialize on that datasource's schema lock anyway — they just each
+        # pin a to_thread worker while queuing, which is what starves interactive
+        # metadata reads.
+        self._prefetch_gates: dict[str, threading.BoundedSemaphore] = {}
         self._initialize_connection()
 
     def _active_semantic_adapter(self) -> str:
@@ -171,6 +178,26 @@ class DatasourceService:
     def resolve_datasource(self, datasource: Optional[str] = None) -> str:
         """Normalize a requested datasource name, falling back to the current one."""
         return (datasource or "").strip() or (self.current_datasource or "")
+
+    def _schema_lock_for(self, datasource: str) -> threading.Lock:
+        """The lock guarding one datasource's connector and cache entries.
+
+        No lock of its own: ``dict.setdefault`` resolves the create-vs-reuse race
+        itself, so two threads asking at once still get the same lock.
+        """
+        locks = getattr(self, "_schema_locks", None)
+        if locks is None:
+            locks = {}
+            self._schema_locks = locks
+        return locks.setdefault(datasource, threading.Lock())
+
+    def _prefetch_gate_for(self, datasource: str) -> threading.BoundedSemaphore:
+        """The gate bounding concurrent prefetch batches on one datasource."""
+        gates = getattr(self, "_prefetch_gates", None)
+        if gates is None:
+            gates = {}
+            self._prefetch_gates = gates
+        return gates.setdefault(datasource, threading.BoundedSemaphore(1))
 
     def _connector_for(self, datasource: Optional[str] = None) -> tuple[BaseSqlConnector, str]:
         """``(connector, database_name)`` for one of the project's datasources.
@@ -578,7 +605,8 @@ class DatasourceService:
             try:
                 identity = self._resolve_table_identity(full_path, connector, default_database)
                 table_name = identity[3]
-                cache_key = self._cache_key(self.resolve_datasource(datasource), identity)
+                datasource_key = self.resolve_datasource(datasource)
+                cache_key = self._cache_key(datasource_key, identity)
 
                 def _detail(cols: list[ColumnInfo]) -> Result[GetTableDetailData]:
                     return Result(
@@ -590,10 +618,12 @@ class DatasourceService:
                 if cached is not None:
                     return _detail(cached)
 
-                # Serialize the not-thread-safe connector; re-check the cache
-                # inside the lock (double-checked) so each table is fetched once
-                # even under concurrent detail/batch requests.
-                with self._schema_lock:
+                # Serialize this datasource's not-thread-safe connector; re-check
+                # the cache inside the lock (double-checked) so each table is
+                # fetched once even under concurrent detail/batch requests.
+                # Per datasource, so a slow warehouse does not hold up metadata
+                # reads on an unrelated one.
+                with self._schema_lock_for(datasource_key):
                     cached = self._columns_cache.get(cache_key)
                     if cached is not None:
                         return _detail(cached)
@@ -701,7 +731,8 @@ class DatasourceService:
         if not pending:
             return Result(success=True, data=GetTablesColumnsData(tables=results))
 
-        if not self._prefetch_gate.acquire(blocking=False):
+        prefetch_gate = self._prefetch_gate_for(self.resolve_datasource(datasource))
+        if not prefetch_gate.acquire(blocking=False):
             logger.info(
                 "Prefetch already in flight; serving %d cached of %d tables and omitting %d",
                 len(results),
@@ -729,7 +760,7 @@ class DatasourceService:
                 if detail.success and detail.data is not None:
                     results.append(TableColumns(table=full_path, columns=_brief_columns(detail.data.table.columns)))
         finally:
-            self._prefetch_gate.release()
+            prefetch_gate.release()
 
         return Result(success=True, data=GetTablesColumnsData(tables=results))
 

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -81,8 +81,16 @@ class DatasourceService:
 
         self.current_db_connector = None
         self.current_db_name = None
-        # In-memory column cache keyed by resolved table identity, so repeated
-        # table/detail + autocomplete prefetch requests don't re-hit the source.
+        # Connectors for the project's non-current datasources, resolved on
+        # demand. A project can bind several, and the catalog tree, table detail
+        # and SQL execution all address one by name — but only the current one is
+        # worth opening up front, since a warehouse listing costs seconds.
+        self._datasource_connectors: dict[str, tuple[BaseSqlConnector, str]] = {}
+        # In-memory column cache keyed by datasource + resolved table identity,
+        # so repeated table/detail + autocomplete prefetch requests don't re-hit
+        # the source. The datasource has to be part of the key: two bound
+        # warehouses routinely hold a same-named table, and without it the second
+        # one would serve the first one's columns.
         # The lock serializes the not-thread-safe connector across concurrent
         # asyncio.to_thread detail/batch requests.
         self._columns_cache: dict[str, list[ColumnInfo]] = {}
@@ -159,6 +167,44 @@ class DatasourceService:
                 logger.warning(f"Failed to initialize database connection: {e}")
                 self.current_db_connector = None
                 self.current_db_name = None
+
+    def resolve_datasource(self, datasource: Optional[str] = None) -> str:
+        """Normalize a requested datasource name, falling back to the current one."""
+        return (datasource or "").strip() or (self.current_datasource or "")
+
+    def _connector_for(self, datasource: Optional[str] = None) -> tuple[BaseSqlConnector, str]:
+        """``(connector, database_name)`` for one of the project's datasources.
+
+        The current datasource keeps using the connection opened at startup;
+        anything else is opened on first use and remembered, because DBManager
+        resolves a fresh wrapper per call and the column cache keys off the
+        datasource name rather than the object.
+
+        Raises ValueError for a name the config does not declare — callers turn
+        that into an error response rather than silently answering from the
+        wrong warehouse, which is what falling back to the current one would do.
+        """
+        key = self.resolve_datasource(datasource)
+        if not key:
+            raise ValueError("No datasource configured")
+
+        if key == self.current_datasource:
+            if self.current_db_connector is None:
+                raise ValueError(f"Datasource {key!r} has no usable connection")
+            return self.current_db_connector, self.current_db_name or ""
+
+        configs = getattr(self.agent_config, "datasource_configs", {}) or {}
+        if key not in configs:
+            raise ValueError(f"Unknown datasource {key!r}")
+
+        cached = self._datasource_connectors.get(key)
+        if cached is not None:
+            return cached
+
+        db_name, connector = self.db_manager.first_conn_with_name(key)
+        entry = (connector, connector.database_name or db_name or "")
+        self._datasource_connectors[key] = entry
+        return entry
 
     def _get_connection_info(
         self,
@@ -407,24 +453,42 @@ class DatasourceService:
                 )
 
             # Get connections from the specified datasource
-            datasource = request.datasource_id or self.current_datasource
+            datasource = self.resolve_datasource(request.datasource_id)
+            configs = getattr(self.agent_config, "datasource_configs", {}) or {}
+            # Refuse an unknown name instead of quietly listing the current
+            # datasource under it: a client rendering several datasources side by
+            # side would file the answer under the wrong tree node.
+            if datasource and datasource not in configs:
+                return Result(
+                    success=False,
+                    errorCode=ErrorCode.INVALID_PARAMETERS,
+                    errorMessage=f"Unknown datasource '{datasource}'",
+                )
+
             connections = self.db_manager.get_connections(datasource)
 
             databases = []
             # Handle both single connector and dictionary of connectors
             if isinstance(connections, dict):
-                for _ds_id, connector in connections.items():
-                    db_info = self._get_connection_info(connector, _ds_id, request)
+                for _db_name, connector in connections.items():
+                    db_info = self._get_connection_info(connector, _db_name, request)
                     databases.extend(db_info)
             else:
                 # Single connector case
                 db_info = self._get_connection_info(connections, datasource, request)
                 databases.extend(db_info)
 
+            # Stamped here rather than at each of the six DatabaseInfo call
+            # sites: every row in this response came from the one datasource
+            # resolved above.
+            for info in databases:
+                info.datasource = datasource
+
             data = ListDatabasesData(
                 databases=databases,
                 total_count=len(databases),
                 current_database=self.current_db_name,
+                current_datasource=datasource,
             )
 
             return Result(success=True, data=data)
@@ -437,50 +501,70 @@ class DatasourceService:
                 errorMessage=str(e),
             )
 
-    def _resolve_table_identity(self, full_path: str) -> tuple[str, str, str, str]:
+    def _resolve_table_identity(
+        self,
+        full_path: str,
+        connector: BaseSqlConnector,
+        default_database: str,
+    ) -> tuple[str, str, str, str]:
         """Resolve a dotted reference to (catalog, database, schema, table).
 
         Connector defaults fill in whatever the caller left out. For StarRocks
-        that is catalog.database.table, with no schema level.
+        that is catalog.database.table, with no schema level. The connector is
+        passed in rather than read off ``self`` because the reference may address
+        a datasource other than the current one — and the defaults that complete
+        a partial name differ per connection profile.
         """
-        name_parts = parse_table_name_parts(full_path, self.current_db_connector.get_type())
-        catalog_name = name_parts["catalog_name"] or getattr(self.current_db_connector, "catalog_name", "")
-        database_name = (
-            name_parts["database_name"] or self.current_db_name or getattr(self.current_db_connector, "database", "")
-        )
-        schema_name = name_parts["schema_name"] or getattr(self.current_db_connector, "schema_name", "")
+        name_parts = parse_table_name_parts(full_path, connector.get_type())
+        catalog_name = name_parts["catalog_name"] or getattr(connector, "catalog_name", "")
+        database_name = name_parts["database_name"] or default_database or getattr(connector, "database", "")
+        schema_name = name_parts["schema_name"] or getattr(connector, "schema_name", "")
         return catalog_name, database_name, schema_name, name_parts["table_name"]
 
-    def _cached_columns(self, full_path: str) -> Optional[list[ColumnInfo]]:
+    def _cache_key(self, datasource: str, identity: tuple[str, str, str, str]) -> str:
+        """Column-cache key. The datasource leads: two bound warehouses commonly
+        hold a same-named table, and a shared key would serve one's columns for
+        the other."""
+        catalog_name, database_name, schema_name, table_name = identity
+        return f"{datasource}\t{catalog_name}.{database_name}.{schema_name}.{table_name}"
+
+    def _cached_columns(self, full_path: str, datasource: Optional[str] = None) -> Optional[list[ColumnInfo]]:
         """Columns already in the cache for this reference, without touching the source."""
         try:
-            catalog_name, database_name, schema_name, table_name = self._resolve_table_identity(full_path)
+            connector, default_database = self._connector_for(datasource)
+            identity = self._resolve_table_identity(full_path, connector, default_database)
         except Exception:
-            # Unparseable name — let the per-table path report it.
+            # Unparseable name or unresolvable datasource — let the per-table
+            # path report it.
             return None
-        return self._columns_cache.get(f"{catalog_name}.{database_name}.{schema_name}.{table_name}")
+        return self._columns_cache.get(self._cache_key(self.resolve_datasource(datasource), identity))
 
-    def get_table_schema(self, full_path: str) -> Result[GetTableDetailData]:
+    def get_table_schema(self, full_path: str, datasource: Optional[str] = None) -> Result[GetTableDetailData]:
         """
         Get table schema details.
 
         Args:
             full_path: table name, [catalog.][database.][schema.]table
+            datasource: which configured datasource to resolve it against;
+                defaults to the current one
 
         Returns:
             GetTableSchemaResult with table schema
         """
         try:
-            if not self.current_db_connector:
+            try:
+                connector, default_database = self._connector_for(datasource)
+            except ValueError as e:
                 return Result(
                     success=False,
                     errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,
-                    errorMessage="No database connection",
+                    errorMessage=str(e),
                 )
 
             try:
-                catalog_name, database_name, schema_name, table_name = self._resolve_table_identity(full_path)
-                cache_key = f"{catalog_name}.{database_name}.{schema_name}.{table_name}"
+                identity = self._resolve_table_identity(full_path, connector, default_database)
+                table_name = identity[3]
+                cache_key = self._cache_key(self.resolve_datasource(datasource), identity)
 
                 def _detail(cols: list[ColumnInfo]) -> Result[GetTableDetailData]:
                     return Result(
@@ -500,10 +584,10 @@ class DatasourceService:
                     if cached is not None:
                         return _detail(cached)
 
-                    schema_info = self.current_db_connector.get_schema(
-                        catalog_name=catalog_name,
-                        database_name=database_name,
-                        schema_name=schema_name,
+                    schema_info = connector.get_schema(
+                        catalog_name=identity[0],
+                        database_name=identity[1],
+                        schema_name=identity[2],
                         table_name=table_name,
                     )
                     if not schema_info:
@@ -558,7 +642,7 @@ class DatasourceService:
                 errorMessage=str(e),
             )
 
-    def get_tables_columns(self, tables: list[str]) -> Result[GetTablesColumnsData]:
+    def get_tables_columns(self, tables: list[str], datasource: Optional[str] = None) -> Result[GetTablesColumnsData]:
         """Batch-fetch columns for multiple tables (autocomplete prefetch).
 
         Reuses get_table_schema (and its column cache) per table. Tables that
@@ -592,7 +676,7 @@ class DatasourceService:
         results: list[TableColumns] = []
         pending: list[str] = []
         for full_path in tables:
-            cached = self._cached_columns(full_path)
+            cached = self._cached_columns(full_path, datasource)
             if cached is None:
                 pending.append(full_path)
             else:
@@ -627,7 +711,7 @@ class DatasourceService:
                     )
                     break
 
-                detail = self.get_table_schema(full_path)
+                detail = self.get_table_schema(full_path, datasource)
                 if detail.success and detail.data is not None:
                     results.append(TableColumns(table=full_path, columns=_brief_columns(detail.data.table.columns)))
         finally:

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -41,6 +41,8 @@ from datus.storage.semantic_model.artifact_file import (
 from datus.tools.db_tools.capabilities import supports_namespace
 from datus.tools.db_tools.db_manager import DBManager
 from datus.utils.config_utils import coerce_positive_int, coerce_positive_seconds
+from datus.utils.exceptions import DatusException
+from datus.utils.exceptions import ErrorCode as DbErrorCode
 from datus.utils.loggings import get_logger
 from datus.utils.sql_utils import parse_table_name_parts
 from datus.utils.text_utils import redact_uri
@@ -213,35 +215,48 @@ class DatasourceService:
         """
         key = self.resolve_datasource(datasource)
         if not key:
-            raise ValueError("No datasource configured")
+            raise DatusException(
+                DbErrorCode.DB_CONNECTION_FAILED, message_args={"error_message": "no datasource configured"}
+            )
 
         if key == self.current_datasource:
             if self.current_db_connector is None:
-                raise ValueError(f"Datasource {key!r} has no usable connection")
+                raise DatusException(
+                    DbErrorCode.DB_CONNECTION_FAILED,
+                    message_args={"error_message": f"datasource {key!r} has no usable connection"},
+                )
             return self.current_db_connector, self.current_db_name or ""
 
         configs = getattr(self.agent_config, "datasource_configs", {}) or {}
         if key not in configs:
-            raise ValueError(f"Unknown datasource {key!r}")
+            raise DatusException(
+                DbErrorCode.COMMON_UNSUPPORTED, message_args={"field_name": "datasource", "your_value": key}
+            )
 
         cached = self._datasource_connectors.get(key)
         if cached is not None:
             return cached
 
+        # Anything the db manager raises for a declared-but-unreachable
+        # datasource is re-raised as the database-connection code, so the caller
+        # maps one exception type to one error response instead of guessing.
         try:
-            # Declared but unreachable raises DatusException, not ValueError, so
-            # normalize it — every caller of this method reports ValueError as a
-            # clean error response.
             db_name, connector = self.db_manager.first_conn_with_name(key)
-        except ValueError:
+        except DatusException:
             raise
         except Exception as e:  # noqa: BLE001 — normalized for the callers
-            raise ValueError(f"Datasource {key!r} has no usable connection: {e}") from e
+            raise DatusException(
+                DbErrorCode.DB_CONNECTION_FAILED,
+                message_args={"error_message": f"datasource {key!r} is unreachable: {e}"},
+            ) from e
 
         # Symmetric with the current-datasource branch above, which rejects a
         # missing connector rather than handing one back.
         if connector is None:
-            raise ValueError(f"Datasource {key!r} has no usable connection")
+            raise DatusException(
+                DbErrorCode.DB_CONNECTION_FAILED,
+                message_args={"error_message": f"datasource {key!r} has no usable connection"},
+            )
 
         entry = (connector, connector.database_name or db_name or "")
         self._datasource_connectors[key] = entry
@@ -595,7 +610,7 @@ class DatasourceService:
         try:
             try:
                 connector, default_database = self._connector_for(datasource)
-            except ValueError as e:
+            except DatusException as e:
                 return Result(
                     success=False,
                     errorCode=ErrorCode.PROVIDER_CONFIG_ERROR,

--- a/datus/api/services/database_service.py
+++ b/datus/api/services/database_service.py
@@ -201,7 +201,21 @@ class DatasourceService:
         if cached is not None:
             return cached
 
-        db_name, connector = self.db_manager.first_conn_with_name(key)
+        try:
+            # Declared but unreachable raises DatusException, not ValueError, so
+            # normalize it — every caller of this method reports ValueError as a
+            # clean error response.
+            db_name, connector = self.db_manager.first_conn_with_name(key)
+        except ValueError:
+            raise
+        except Exception as e:  # noqa: BLE001 — normalized for the callers
+            raise ValueError(f"Datasource {key!r} has no usable connection: {e}") from e
+
+        # Symmetric with the current-datasource branch above, which rejects a
+        # missing connector rather than handing one back.
+        if connector is None:
+            raise ValueError(f"Datasource {key!r} has no usable connection")
+
         entry = (connector, connector.database_name or db_name or "")
         self._datasource_connectors[key] = entry
         return entry

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -96,6 +96,24 @@ class KbService:
             )
             return
 
+        # Resolved here, before the first component runs, for two reasons: the
+        # datasource setter raises for a name the project has not bound, and by
+        # the time a component is running the SSE headers are out — an exception
+        # from inside this generator breaks the stream instead of reaching the
+        # client as an error it can read. Computed once and reused; cloning the
+        # config per component was pure waste.
+        try:
+            config = self._config_for(request)
+        except Exception as e:  # noqa: BLE001 — surfaced to the client below
+            yield self._make_event(
+                stream_id,
+                "all",
+                BatchStage.TASK_FAILED,
+                error=str(e),
+                payload={"components": summary},
+            )
+            return
+
         for comp_name, aliases, authoring_scope in self._component_execution_specs(request):
             if cancel_event.is_set():
                 yield self._make_event(
@@ -109,7 +127,7 @@ class KbService:
             # Stream BatchEvents from the queue in real-time while the thread runs.
             trace_component = comp_name.value if hasattr(comp_name, "value") else str(comp_name)
             trace_ctx = build_bootstrap_trace_context(
-                datasource=self._config_for(request).current_datasource,
+                datasource=config.current_datasource,
                 components=[trace_component],
                 strategy=request.strategy,
                 stream_id=stream_id,
@@ -130,6 +148,7 @@ class KbService:
                         loop,
                         cancel_event,
                         project_root,
+                        config=config,
                         authoring_scope=authoring_scope,
                     )
 
@@ -236,9 +255,12 @@ class KbService:
         cancel_event: asyncio.Event,
         project_root: str,
         *,
+        config: Optional[AgentConfig] = None,
         authoring_scope: Optional[str] = None,
     ) -> dict:
-        config = self._config_for(request)
+        # Resolved once by the caller, which is also where a bad datasource is
+        # turned into a readable failure event rather than a broken SSE stream.
+        config = config if config is not None else self._config_for(request)
         strategy = request.strategy
         pool_size = 1
         dir_path = config.rag_storage_path()

--- a/datus/api/services/kb_service.py
+++ b/datus/api/services/kb_service.py
@@ -1,6 +1,7 @@
 """Service for knowledge base bootstrap with SSE streaming."""
 
 import asyncio
+import copy
 import types
 from pathlib import Path
 from typing import AsyncGenerator, Optional
@@ -42,6 +43,26 @@ class KbService:
 
     def __init__(self, agent_config: AgentConfig):
         self.agent_config = agent_config
+
+    def _config_for(self, request: BootstrapKbInput) -> AgentConfig:
+        """The config this bootstrap runs under.
+
+        A project bound to several datasources has separate metadata and
+        separate KB rows per datasource (the stores scope rows by
+        ``current_datasource``), so indexing one must not be able to write
+        another's. Returns a copy with the datasource switched rather than
+        mutating the shared config, which is cached per project and read
+        concurrently by every other request.
+        """
+        requested = (getattr(request, "datasource", None) or "").strip()
+        if not requested or requested == self.agent_config.current_datasource:
+            return self.agent_config
+
+        clone = copy.copy(self.agent_config)
+        # Raises for a datasource the project has not bound — better than
+        # silently indexing the current one under the requested name.
+        clone.current_datasource = requested
+        return clone
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -88,7 +109,7 @@ class KbService:
             # Stream BatchEvents from the queue in real-time while the thread runs.
             trace_component = comp_name.value if hasattr(comp_name, "value") else str(comp_name)
             trace_ctx = build_bootstrap_trace_context(
-                datasource=self.agent_config.current_datasource,
+                datasource=self._config_for(request).current_datasource,
                 components=[trace_component],
                 strategy=request.strategy,
                 stream_id=stream_id,
@@ -217,7 +238,7 @@ class KbService:
         *,
         authoring_scope: Optional[str] = None,
     ) -> dict:
-        config = self.agent_config
+        config = self._config_for(request)
         strategy = request.strategy
         pool_size = 1
         dir_path = config.rag_storage_path()

--- a/tests/unit_tests/api/routes/test_config_routes.py
+++ b/tests/unit_tests/api/routes/test_config_routes.py
@@ -15,6 +15,7 @@ from datus.api.routes.config_routes import (
     UpdateDatasourcesRequest,
     UpdateModelsRequest,
     get_agent_config_endpoint,
+    list_datasources_endpoint,
     probe_datasource_connectivity_endpoint,
     probe_model_connectivity_endpoint,
     update_datasources_endpoint,
@@ -31,6 +32,77 @@ def _mock_svc(datasources, *, target="deepseek", current_datasource="starrocks",
     svc.agent_config.datasource_configs = datasources
     svc.agent_config.home = home
     return svc
+
+
+@pytest.mark.asyncio
+async def test_list_datasources_returns_names_types_and_current():
+    svc = _mock_svc(
+        datasources={
+            "starrocks": SimpleNamespace(type="starrocks"),
+            "lake": SimpleNamespace(type="duckdb"),
+        },
+    )
+
+    result = await list_datasources_endpoint(svc)
+
+    assert result.success is True
+    assert result.data.current_datasource == "starrocks"
+    assert [(d.name, d.type, d.is_current) for d in result.data.datasources] == [
+        ("starrocks", "starrocks", True),
+        ("lake", "duckdb", False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_datasources_carries_no_credentials():
+    """The reason this endpoint exists instead of reusing /config/agent.
+
+    A catalog UI lists the datasources on every project entry, for every member.
+    /config/agent answers that with each datasource's decrypted password and
+    credential-bearing uri; nothing here may carry them.
+    """
+    svc = _mock_svc(
+        datasources={
+            "starrocks": SimpleNamespace(
+                type="starrocks",
+                host="h1",
+                password="s3cret",
+                uri="starrocks://user:s3cret@h1:9030/db",
+                private_key_file_pwd="pk-pass",
+            )
+        },
+    )
+
+    result = await list_datasources_endpoint(svc)
+
+    serialized = result.data.model_dump_json()
+    for secret in ("s3cret", "pk-pass", "user:s3cret"):
+        assert secret not in serialized
+    assert set(result.data.datasources[0].model_dump()) == {"name", "type", "is_current"}
+
+
+@pytest.mark.asyncio
+async def test_list_datasources_unwraps_an_enum_type():
+    """`DbConfig.type` is an enum at runtime; the wire form must be its value."""
+    svc = _mock_svc(datasources={"lake": SimpleNamespace(type=SimpleNamespace(value="duckdb"))})
+
+    result = await list_datasources_endpoint(svc)
+
+    assert result.data.datasources[0].type == "duckdb"
+
+
+@pytest.mark.asyncio
+async def test_list_datasources_skips_none_entries_and_survives_no_current():
+    svc = _mock_svc(
+        datasources={"lake": SimpleNamespace(type="duckdb"), "broken": None},
+        current_datasource="",
+    )
+
+    result = await list_datasources_endpoint(svc)
+
+    assert [d.name for d in result.data.datasources] == ["lake"]
+    assert result.data.current_datasource == ""
+    assert result.data.datasources[0].is_current is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/api/routes/test_table_routes.py
+++ b/tests/unit_tests/api/routes/test_table_routes.py
@@ -24,10 +24,19 @@ class TestGetTableDetail:
         svc = MagicMock()
         svc.datasource.get_table_schema.return_value = Result(success=True)
 
-        result = await get_table_detail(svc, table="db.public.orders")
+        result = await get_table_detail(svc, table="db.public.orders", datasource="")
 
         assert result.success is True
-        svc.datasource.get_table_schema.assert_called_once_with("db.public.orders")
+        svc.datasource.get_table_schema.assert_called_once_with("db.public.orders", None)
+
+    @pytest.mark.asyncio
+    async def test_passes_the_requested_datasource_through(self):
+        svc = MagicMock()
+        svc.datasource.get_table_schema.return_value = Result(success=True)
+
+        await get_table_detail(svc, table="db.public.orders", datasource="lake")
+
+        svc.datasource.get_table_schema.assert_called_once_with("db.public.orders", "lake")
 
 
 class TestGetTablesColumns:
@@ -49,4 +58,16 @@ class TestGetTablesColumns:
 
         assert result.success is True
         assert [t.table for t in result.data.tables] == ["db.public.orders"]
-        svc.datasource.get_tables_columns.assert_called_once_with(["db.public.orders", "db.public.users"])
+        svc.datasource.get_tables_columns.assert_called_once_with(["db.public.orders", "db.public.users"], None)
+
+    @pytest.mark.asyncio
+    async def test_passes_the_batch_datasource_through(self):
+        svc = MagicMock()
+        svc.datasource.get_tables_columns.return_value = Result(
+            success=True, data=GetTablesColumnsData(tables=[])
+        )
+
+        request = GetTablesColumnsInput(tables=["db.public.orders"], datasource="lake")
+        await get_tables_columns(request, svc)
+
+        svc.datasource.get_tables_columns.assert_called_once_with(["db.public.orders"], "lake")

--- a/tests/unit_tests/api/routes/test_table_routes.py
+++ b/tests/unit_tests/api/routes/test_table_routes.py
@@ -63,9 +63,7 @@ class TestGetTablesColumns:
     @pytest.mark.asyncio
     async def test_passes_the_batch_datasource_through(self):
         svc = MagicMock()
-        svc.datasource.get_tables_columns.return_value = Result(
-            success=True, data=GetTablesColumnsData(tables=[])
-        )
+        svc.datasource.get_tables_columns.return_value = Result(success=True, data=GetTablesColumnsData(tables=[]))
 
         request = GetTablesColumnsInput(tables=["db.public.orders"], datasource="lake")
         await get_tables_columns(request, svc)

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -878,6 +878,52 @@ class TestCreateAgent:
         assert result.success is True
         assert result.data["name"] == "test_new_agent"
 
+    async def test_create_agent_binds_the_named_datasource(self, real_agent_config, agent_yml_with_singleton):
+        """`datasource_name` must reach `scoped_context.datasource`.
+
+        Ignoring it bound the agent to the active datasource instead of the one
+        the caller asked for — the same name the caller scoped its `catalogs`
+        against, so the scope would be matched on the wrong warehouse.
+        """
+        from datus.api.models.agent_models import CreateAgentInput
+
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
+
+        svc = AgentService()
+        result = await svc.create_agent(
+            CreateAgentInput(
+                name="agent_on_second",
+                type="gen_sql",
+                tools=["db_tools"],
+                datasource_name="second",
+            ),
+            real_agent_config,
+        )
+
+        assert result.success is True
+        agent = real_agent_config.agentic_nodes["agent_on_second"]
+        assert agent["scoped_context"]["datasource"] == "second"
+
+    async def test_create_agent_rejects_an_unbound_datasource(self, real_agent_config, agent_yml_with_singleton):
+        """Better than silently binding to the current one."""
+        from datus.api.models.agent_models import CreateAgentInput
+
+        svc = AgentService()
+        result = await svc.create_agent(
+            CreateAgentInput(
+                name="agent_nowhere",
+                type="gen_sql",
+                tools=["db_tools"],
+                datasource_name="not_bound",
+            ),
+            real_agent_config,
+        )
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_DATASOURCE"
+        assert "not_bound" in result.errorMessage
+
     async def test_create_agent_duplicate_name_fails(self, real_agent_config, agent_yml_with_singleton):
         """create_agent rejects duplicate agent name."""
         from datus.api.models.agent_models import CreateAgentInput

--- a/tests/unit_tests/api/services/test_agent_service.py
+++ b/tests/unit_tests/api/services/test_agent_service.py
@@ -904,6 +904,9 @@ class TestCreateAgent:
         assert result.success is True
         agent = real_agent_config.agentic_nodes["agent_on_second"]
         assert agent["scoped_context"]["datasource"] == "second"
+        # `datasource_name` selects the binding; it is not itself a stored field.
+        # A regression could bind correctly and still write it to the entry.
+        assert "datasource_name" not in agent
 
     async def test_create_agent_rejects_an_unbound_datasource(self, real_agent_config, agent_yml_with_singleton):
         """Better than silently binding to the current one."""
@@ -1204,6 +1207,88 @@ class TestEditAgent:
             assert "cross_path_agent" not in (home_data.get("agent", {}).get("agentic_nodes") or {})
         finally:
             agent_config_loader.CONFIGURATION_MANAGER = None
+
+    async def test_edit_agent_rebinds_on_datasource_name_alone(self, real_agent_config, agent_yml_with_singleton):
+        """An edit carrying only ``datasource_name`` must move the binding.
+
+        The field is excluded from ``model_dump`` (it is not a persisted
+        column), which also hid it from the "did anything change" check — so
+        this edit reached the no-op return and reported success while leaving the
+        agent bound where it was.
+        """
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput, EditAgentInput
+
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
+
+        svc = AgentService()
+        await svc.create_agent(CreateAgentInput(name="rebind_me", type="gen_sql"), real_agent_config)
+
+        result = await svc.edit_agent(
+            EditAgentInput(id="rebind_me", name="rebind_me", datasource_name="second"),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            entry = yaml.safe_load(f)["agent"]["agentic_nodes"]["rebind_me"]
+        assert entry["scoped_context"]["datasource"] == "second"
+        # And it is still not a column.
+        assert "datasource_name" not in entry
+
+    async def test_edit_agent_keeps_the_saved_binding_when_unnamed(self, real_agent_config, agent_yml_with_singleton):
+        """Editing catalogs must not silently rebind to the active datasource.
+
+        ``EditAgentInput`` says an omitted ``datasource_name`` leaves the binding
+        untouched. Resolving the active datasource ahead of the saved one meant an
+        agent bound to B was rebound to A by any scope edit made while A was
+        current.
+        """
+        import yaml
+
+        from datus.api.models.agent_models import CreateAgentInput, EditAgentInput
+
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
+
+        svc = AgentService()
+        await svc.create_agent(
+            CreateAgentInput(name="stay_on_second", type="gen_sql", datasource_name="second"),
+            real_agent_config,
+        )
+
+        # Only catalogs change; the active datasource is still `current`.
+        result = await svc.edit_agent(
+            EditAgentInput(id="stay_on_second", name="stay_on_second", catalogs=["main.*"]),
+            real_agent_config,
+        )
+        assert result.success is True
+
+        with open(agent_yml_with_singleton) as f:
+            entry = yaml.safe_load(f)["agent"]["agentic_nodes"]["stay_on_second"]
+        assert entry["scoped_context"]["datasource"] == "second"
+
+    async def test_edit_agent_rejects_an_unbound_datasource_name(self, real_agent_config, agent_yml_with_singleton):
+        """An explicitly named datasource the config does not declare is refused.
+
+        Otherwise the edit stores an undeclared datasource and returns success,
+        leaving an agent whose scope can never match.
+        """
+        from datus.api.models.agent_models import CreateAgentInput, EditAgentInput
+
+        svc = AgentService()
+        await svc.create_agent(CreateAgentInput(name="reject_edit", type="gen_sql"), real_agent_config)
+
+        result = await svc.edit_agent(
+            EditAgentInput(id="reject_edit", name="reject_edit", datasource_name="not_bound"),
+            real_agent_config,
+        )
+
+        assert result.success is False
+        assert result.errorCode == "INVALID_DATASOURCE"
+        assert "not_bound" in result.errorMessage
 
     async def test_edit_agent_persists_description_as_agent_description(
         self, real_agent_config, agent_yml_with_singleton

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -182,6 +182,54 @@ class TestCLIServiceExecuteSQL:
         assert datasource == real_agent_config.current_datasource
         assert connector is cli_svc.current_db_connector
 
+    def test_execution_target_reports_an_unreachable_datasource_as_valueerror(self, cli_svc, real_agent_config):
+        """A declared-but-unreachable datasource must not escape as DatusException.
+
+        `_execute_sql_sync` only catches ValueError; anything else loses its
+        DATABASE_CONNECTION_ERROR code to the generic handler.
+        """
+        from unittest.mock import patch
+
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        # `datasource_configs` is a property that copies, so registration has to
+        # go through `services.datasources`.
+        cli_svc.agent_config.services.datasources["broken"] = cli_svc.agent_config.services.datasources[
+            real_agent_config.current_datasource
+        ]
+        with patch.object(
+            cli_svc.db_manager,
+            "first_conn_with_name",
+            side_effect=DatusException(ErrorCode.COMMON_UNSUPPORTED, message_args={}),
+        ):
+            with pytest.raises(ValueError, match="no usable connection"):
+                cli_svc._execution_target("broken")
+
+        # And nothing unusable was remembered for the next request.
+        assert "broken" not in cli_svc._datasource_connectors
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_on_an_unreachable_datasource_keeps_its_error_code(self, cli_svc, real_agent_config):
+        from unittest.mock import patch
+
+        from datus.api.models.config_models import ErrorCode as ApiErrorCode
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        # `datasource_configs` is a property that copies, so registration has to
+        # go through `services.datasources`.
+        cli_svc.agent_config.services.datasources["broken"] = cli_svc.agent_config.services.datasources[
+            real_agent_config.current_datasource
+        ]
+        with patch.object(
+            cli_svc.db_manager,
+            "first_conn_with_name",
+            side_effect=DatusException(ErrorCode.COMMON_UNSUPPORTED, message_args={}),
+        ):
+            result = await cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT 1", datasource="broken"))
+
+        assert result.success is False
+        assert result.errorCode == ApiErrorCode.DATABASE_CONNECTION_ERROR
+
 
 class TestCLIServiceStopExecuteSQL:
     """Tests for stop_execute_sql."""

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -1,7 +1,9 @@
 """Tests for datus.api.services.cli_service — CLI command operations."""
 
 import asyncio
+import time
 import uuid
+from unittest.mock import patch
 
 import pytest
 
@@ -229,6 +231,69 @@ class TestCLIServiceExecuteSQL:
 
         assert result.success is False
         assert result.errorCode == ApiErrorCode.DATABASE_CONNECTION_ERROR
+
+
+class TestCLIServiceConnectorSerialization:
+    """The shared connector's mutable database context must not leak between
+    concurrent requests."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_on_one_datasource_do_not_interleave(self, cli_svc):
+        """Two requests that each switch database must not overlap.
+
+        The connector is shared per datasource and `switch_context` mutates it,
+        so an interleave would run one request's SQL against the other's
+        database — a wrong answer with no error.
+        """
+        import threading
+
+        overlapping = []
+        active = {"n": 0}
+        guard = threading.Lock()
+        real = cli_svc._execute_resolved_sql
+
+        def tracked(*args, **kwargs):
+            with guard:
+                active["n"] += 1
+                overlapping.append(active["n"])
+            try:
+                time.sleep(0.05)
+                return real(*args, **kwargs)
+            finally:
+                with guard:
+                    active["n"] -= 1
+
+        with patch.object(cli_svc, "_execute_resolved_sql", side_effect=tracked):
+            await asyncio.gather(
+                cli_svc.execute_sql(
+                    ExecuteSQLInput(
+                        sql_query="SELECT COUNT(*) FROM schools",
+                        database_name="california_schools",
+                        execute_task_id="a",
+                    )
+                ),
+                cli_svc.execute_sql(
+                    ExecuteSQLInput(
+                        sql_query="SELECT COUNT(*) FROM schools",
+                        database_name="california_schools",
+                        execute_task_id="b",
+                    )
+                ),
+            )
+
+        assert max(overlapping) == 1, f"requests overlapped: {overlapping}"
+
+    def test_lock_is_per_datasource(self, cli_svc, real_agent_config):
+        """Different datasources must not block each other."""
+        cli_svc.agent_config.services.datasources["other"] = cli_svc.agent_config.services.datasources[
+            real_agent_config.current_datasource
+        ]
+
+        first = cli_svc._connector_lock(real_agent_config.current_datasource)
+        second = cli_svc._connector_lock("other")
+
+        assert first is not second
+        assert first is cli_svc._connector_lock(real_agent_config.current_datasource)
 
 
 class TestCLIServiceStopExecuteSQL:

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -271,6 +271,20 @@ class TestCLIServiceConnectorSerialization:
         # And released once the statement is done, so the next request can run.
         assert cli_svc._connector_lock(ds).locked() is False
 
+    def test_execution_target_rejects_when_no_datasource_is_configured(self, cli_svc):
+        cli_svc.current_datasource = None
+
+        with pytest.raises(ValueError, match="No database connection available"):
+            cli_svc._execution_target(None)
+
+    def test_execution_target_rejects_a_current_datasource_with_no_connection(self, cli_svc):
+        """Symmetric with the non-current branch, which also refuses rather than
+        handing back a connector the caller would dereference."""
+        cli_svc.current_db_connector = None
+
+        with pytest.raises(ValueError, match="No database connection available"):
+            cli_svc._execution_target(None)
+
     def test_execution_target_opens_and_remembers_another_datasource(self, cli_svc, real_agent_config):
         current = real_agent_config.current_datasource
         cli_svc.agent_config.services.datasources["second"] = cli_svc.agent_config.services.datasources[current]

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -11,6 +11,7 @@ from datus.api.models.config_models import ErrorCode as ApiErrorCode
 from datus.api.services.chat_service import ChatService
 from datus.api.services.chat_task_manager import ChatTaskManager
 from datus.api.services.cli_service import CLIService
+from datus.utils.exceptions import DatusException
 
 
 @pytest.fixture
@@ -184,12 +185,10 @@ class TestCLIServiceExecuteSQL:
         assert datasource == real_agent_config.current_datasource
         assert connector is cli_svc.current_db_connector
 
-    def test_execution_target_reports_an_unreachable_datasource_as_valueerror(self, cli_svc, real_agent_config):
-        """A declared-but-unreachable datasource must not escape as DatusException.
-
-        `_execute_sql_sync` only catches ValueError; anything else loses its
-        DATABASE_CONNECTION_ERROR code to the generic handler.
-        """
+    def test_execution_target_reraises_a_structured_failure_as_is(self, cli_svc, real_agent_config):
+        """A DatusException from the db manager is already the type the boundary
+        maps, so it passes through rather than being re-wrapped and losing its
+        original code."""
         from unittest.mock import patch
 
         from datus.utils.exceptions import DatusException, ErrorCode
@@ -204,9 +203,10 @@ class TestCLIServiceExecuteSQL:
             "first_conn_with_name",
             side_effect=DatusException(ErrorCode.COMMON_UNSUPPORTED, message_args={}),
         ):
-            with pytest.raises(ValueError, match="no usable connection"):
+            with pytest.raises(DatusException) as raised:
                 cli_svc._execution_target("broken")
 
+        assert raised.value.code is ErrorCode.COMMON_UNSUPPORTED
         # And nothing unusable was remembered for the next request.
         assert "broken" not in cli_svc._datasource_connectors
 
@@ -274,7 +274,7 @@ class TestCLIServiceConnectorSerialization:
     def test_execution_target_rejects_when_no_datasource_is_configured(self, cli_svc):
         cli_svc.current_datasource = None
 
-        with pytest.raises(ValueError, match="No database connection available"):
+        with pytest.raises(DatusException, match="No database connection available"):
             cli_svc._execution_target(None)
 
     def test_execution_target_rejects_a_current_datasource_with_no_connection(self, cli_svc):
@@ -282,7 +282,7 @@ class TestCLIServiceConnectorSerialization:
         handing back a connector the caller would dereference."""
         cli_svc.current_db_connector = None
 
-        with pytest.raises(ValueError, match="No database connection available"):
+        with pytest.raises(DatusException, match="No database connection available"):
             cli_svc._execution_target(None)
 
     def test_execution_target_opens_and_remembers_another_datasource(self, cli_svc, real_agent_config):
@@ -296,6 +296,19 @@ class TestCLIServiceConnectorSerialization:
 
         assert opened.call_count == 1
 
+    def test_execution_target_wraps_an_unstructured_failure(self, cli_svc, real_agent_config):
+        """A plain exception from the db manager still reaches the caller as the
+        structured database error, so the boundary maps one type — and the
+        original message survives inside it."""
+        current = real_agent_config.current_datasource
+        cli_svc.agent_config.services.datasources["second"] = cli_svc.agent_config.services.datasources[current]
+
+        with patch.object(cli_svc.db_manager, "first_conn_with_name", side_effect=ValueError("bad uri")):
+            with pytest.raises(DatusException, match="bad uri"):
+                cli_svc._execution_target("second")
+
+        assert "second" not in cli_svc._datasource_connectors
+
     def test_execution_target_rejects_a_null_connector(self, cli_svc, real_agent_config):
         """Caching a None turned the next request's `connector.dialect` into an
         AttributeError instead of a reported connection failure."""
@@ -303,7 +316,7 @@ class TestCLIServiceConnectorSerialization:
         cli_svc.agent_config.services.datasources["empty"] = cli_svc.agent_config.services.datasources[current]
 
         with patch.object(cli_svc.db_manager, "first_conn_with_name", return_value=("db", None)):
-            with pytest.raises(ValueError, match="no usable connection"):
+            with pytest.raises(DatusException, match="no usable connection"):
                 cli_svc._execution_target("empty")
 
         assert "empty" not in cli_svc._datasource_connectors
@@ -322,14 +335,16 @@ class TestCLIServiceConnectorSerialization:
         held = cli_svc._connector_lock(real_agent_config.current_datasource)
         held.acquire()
         try:
-            result = await cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT 1"))
+            with patch.object(cli_svc, "_execute_resolved_sql") as ran:
+                result = await cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT 1"))
         finally:
             held.release()
 
         assert result.success is False
         assert result.errorCode == ApiErrorCode.DATASOURCE_BUSY
-        # The statement was never sent, so saying so matters: a refused write is
-        # safe to retry.
+        # The property the contract rests on, not just the message: a refused
+        # write is only safe to retry because nothing ran.
+        ran.assert_not_called()
         assert "Nothing was executed" in result.errorMessage
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -155,6 +155,33 @@ class TestCLIServiceExecuteSQL:
         assert result.success is True
         assert result.data.sql_query == "SELECT COUNT(*) FROM schools"
 
+    @pytest.mark.asyncio
+    async def test_execute_sql_with_the_current_datasource_named_explicitly(self, cli_svc, real_agent_config):
+        """Naming the current datasource is the same as omitting it."""
+        request = ExecuteSQLInput(
+            sql_query="SELECT COUNT(*) FROM schools",
+            datasource=real_agent_config.current_datasource,
+        )
+        result = await cli_svc.execute_sql(request)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_rejects_an_unknown_datasource(self, cli_svc):
+        """A datasource the project has not bound is refused.
+
+        Running it on the project's default instead would answer the editor tab
+        with plausible rows from the wrong warehouse.
+        """
+        request = ExecuteSQLInput(sql_query="SELECT 1", datasource="not_bound")
+        result = await cli_svc.execute_sql(request)
+        assert result.success is False
+        assert "not_bound" in result.errorMessage
+
+    def test_execution_target_defaults_to_current(self, cli_svc, real_agent_config):
+        datasource, connector = cli_svc._execution_target(None)
+        assert datasource == real_agent_config.current_datasource
+        assert connector is cli_svc.current_db_connector
+
 
 class TestCLIServiceStopExecuteSQL:
     """Tests for stop_execute_sql."""

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -1,7 +1,6 @@
 """Tests for datus.api.services.cli_service — CLI command operations."""
 
 import asyncio
-import time
 import uuid
 from unittest.mock import patch
 
@@ -238,50 +237,38 @@ class TestCLIServiceConnectorSerialization:
     concurrent requests."""
 
     @pytest.mark.asyncio
-    async def test_concurrent_requests_on_one_datasource_do_not_interleave(self, cli_svc):
-        """Two requests that each switch database must not overlap.
+    async def test_the_connector_lock_is_held_while_the_statement_runs(self, cli_svc, real_agent_config):
+        """The datasource's lock must be held across switch_context + execute.
 
-        The connector is shared per datasource and `switch_context` mutates it,
-        so an interleave would run one request's SQL against the other's
-        database — a wrong answer with no error.
+        The connector is shared per datasource and `switch_context` mutates its
+        database, so a request that ran without the lock held could execute
+        under another request's database — a wrong answer with no error.
+
+        Asserted by observing the lock from inside the guarded section rather
+        than by racing two requests: a timing-based overlap test is
+        non-deterministic in exactly the direction that makes it useless (it
+        passes when the machine is slow enough).
         """
-        import threading
-
-        overlapping = []
-        active = {"n": 0}
-        guard = threading.Lock()
+        ds = real_agent_config.current_datasource
+        observed = []
         real = cli_svc._execute_resolved_sql
 
         def tracked(*args, **kwargs):
-            with guard:
-                active["n"] += 1
-                overlapping.append(active["n"])
-            try:
-                time.sleep(0.05)
-                return real(*args, **kwargs)
-            finally:
-                with guard:
-                    active["n"] -= 1
+            observed.append(cli_svc._connector_lock(ds).locked())
+            return real(*args, **kwargs)
 
         with patch.object(cli_svc, "_execute_resolved_sql", side_effect=tracked):
-            await asyncio.gather(
-                cli_svc.execute_sql(
-                    ExecuteSQLInput(
-                        sql_query="SELECT COUNT(*) FROM schools",
-                        database_name="california_schools",
-                        execute_task_id="a",
-                    )
-                ),
-                cli_svc.execute_sql(
-                    ExecuteSQLInput(
-                        sql_query="SELECT COUNT(*) FROM schools",
-                        database_name="california_schools",
-                        execute_task_id="b",
-                    )
-                ),
+            result = await cli_svc.execute_sql(
+                ExecuteSQLInput(
+                    sql_query="SELECT COUNT(*) FROM schools",
+                    database_name="california_schools",
+                )
             )
 
-        assert max(overlapping) == 1, f"requests overlapped: {overlapping}"
+        assert result.success is True
+        assert observed == [True]
+        # And released once the statement is done, so the next request can run.
+        assert cli_svc._connector_lock(ds).locked() is False
 
     def test_lock_is_per_datasource(self, cli_svc, real_agent_config):
         """Different datasources must not block each other."""

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -270,6 +270,29 @@ class TestCLIServiceConnectorSerialization:
         # And released once the statement is done, so the next request can run.
         assert cli_svc._connector_lock(ds).locked() is False
 
+    def test_execution_target_opens_and_remembers_another_datasource(self, cli_svc, real_agent_config):
+        current = real_agent_config.current_datasource
+        cli_svc.agent_config.services.datasources["second"] = cli_svc.agent_config.services.datasources[current]
+        connector = object()
+
+        with patch.object(cli_svc.db_manager, "first_conn_with_name", return_value=("db", connector)) as opened:
+            assert cli_svc._execution_target("second") == ("second", connector)
+            assert cli_svc._execution_target("second") == ("second", connector)
+
+        assert opened.call_count == 1
+
+    def test_execution_target_rejects_a_null_connector(self, cli_svc, real_agent_config):
+        """Caching a None turned the next request's `connector.dialect` into an
+        AttributeError instead of a reported connection failure."""
+        current = real_agent_config.current_datasource
+        cli_svc.agent_config.services.datasources["empty"] = cli_svc.agent_config.services.datasources[current]
+
+        with patch.object(cli_svc.db_manager, "first_conn_with_name", return_value=("db", None)):
+            with pytest.raises(ValueError, match="no usable connection"):
+                cli_svc._execution_target("empty")
+
+        assert "empty" not in cli_svc._datasource_connectors
+
     def test_lock_is_per_datasource(self, cli_svc, real_agent_config):
         """Different datasources must not block each other."""
         cli_svc.agent_config.services.datasources["other"] = cli_svc.agent_config.services.datasources[

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -1,6 +1,7 @@
 """Tests for datus.api.services.cli_service — CLI command operations."""
 
 import asyncio
+import contextlib
 import uuid
 from unittest.mock import patch
 
@@ -354,6 +355,38 @@ class TestCLIServiceConnectorSerialization:
         result = await cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT COUNT(*) FROM schools"))
 
         assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_a_statement_cancelled_while_queued_never_executes(self, cli_svc, real_agent_config):
+        """stop_execute_sql must actually stop a queued statement.
+
+        Cancelling the asyncio task cannot interrupt the worker thread it
+        dispatched: a worker parked in `execution_lock.acquire()` keeps waiting,
+        then acquires and runs. For a write that means the statement landing
+        *after* the caller was told it stopped.
+        """
+        cli_svc.agent_config.api_config = {"sql_queue_budget_seconds": 5}
+        held = cli_svc._connector_lock(real_agent_config.current_datasource)
+        held.acquire()
+
+        with patch.object(cli_svc, "_execute_resolved_sql") as ran:
+            task = asyncio.create_task(
+                cli_svc.execute_sql(ExecuteSQLInput(sql_query="DELETE FROM schools", execute_task_id="queued-1"))
+            )
+            # Let the worker reach the lock and park there.
+            while "queued-1" not in cli_svc._sql_tasks:
+                await asyncio.sleep(0)
+            await asyncio.sleep(0.05)
+
+            stop = await cli_svc.stop_execute_sql("queued-1")
+            assert stop.success is True
+
+            held.release()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        # The point of the fix: told it stopped, so it must not have run.
+        ran.assert_not_called()
 
     def test_lock_is_per_datasource(self, cli_svc, real_agent_config):
         """Different datasources must not block each other."""

--- a/tests/unit_tests/api/services/test_cli_service.py
+++ b/tests/unit_tests/api/services/test_cli_service.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from datus.api.models.cli_models import ExecuteContextInput, ExecuteSQLInput
+from datus.api.models.config_models import ErrorCode as ApiErrorCode
 from datus.api.services.chat_service import ChatService
 from datus.api.services.chat_task_manager import ChatTaskManager
 from datus.api.services.cli_service import CLIService
@@ -292,6 +293,38 @@ class TestCLIServiceConnectorSerialization:
                 cli_svc._execution_target("empty")
 
         assert "empty" not in cli_svc._datasource_connectors
+
+    @pytest.mark.asyncio
+    async def test_a_busy_datasource_is_refused_rather_than_queued_forever(self, cli_svc, real_agent_config):
+        """Waiting for the connector is bounded.
+
+        This runs on an asyncio.to_thread worker and the default executor has
+        only min(32, cpu + 4); an unbounded queue on one datasource could starve
+        every other to_thread caller in the process. It also bounds a cancelled
+        request, since cancelling the asyncio task cannot interrupt a thread
+        parked in acquire().
+        """
+        cli_svc.agent_config.api_config = {"sql_queue_budget_seconds": 0.05}
+        held = cli_svc._connector_lock(real_agent_config.current_datasource)
+        held.acquire()
+        try:
+            result = await cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT 1"))
+        finally:
+            held.release()
+
+        assert result.success is False
+        assert result.errorCode == ApiErrorCode.DATASOURCE_BUSY
+        # The statement was never sent, so saying so matters: a refused write is
+        # safe to retry.
+        assert "Nothing was executed" in result.errorMessage
+
+    @pytest.mark.asyncio
+    async def test_a_free_datasource_is_not_delayed_by_the_budget(self, cli_svc):
+        cli_svc.agent_config.api_config = {"sql_queue_budget_seconds": 0.05}
+
+        result = await cli_svc.execute_sql(ExecuteSQLInput(sql_query="SELECT COUNT(*) FROM schools"))
+
+        assert result.success is True
 
     def test_lock_is_per_datasource(self, cli_svc, real_agent_config):
         """Different datasources must not block each other."""

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -1240,6 +1240,22 @@ class TestGetTablesColumnsBounds:
         assert first is svc._schema_lock_for(current)
         assert first is not svc._schema_lock_for("second")
 
+    def test_locks_tolerate_an_instance_built_without_init(self):
+        """The contract the lazy init exists for.
+
+        Parts of this suite build the service via ``__new__`` to skip its heavy
+        constructor, and cli_service was broken exactly this way once — the
+        accessors have to stand up a dict on first use rather than assume one.
+        """
+        svc = DatasourceService.__new__(DatasourceService)
+
+        lock = svc._schema_lock_for("prod")
+        gate = svc._prefetch_gate_for("prod")
+
+        assert lock is svc._schema_lock_for("prod")
+        assert gate is svc._prefetch_gate_for("prod")
+        assert lock is not svc._schema_lock_for("lake")
+
     def test_the_gate_is_released_for_the_next_batch(self, real_agent_config):
         svc = DatasourceService(agent_config=real_agent_config)
 

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -665,7 +665,10 @@ class TestPerDatasourceResolution:
         svc._datasource_connectors["other"] = (svc.current_db_connector, "california_schools")
         assert svc._connector_for("other")[0] is svc.current_db_connector
         assert svc._cached_columns("frpm", "other") is None
-        assert svc._cached_columns("frpm", current) is not None
+        # The current datasource still hits, with the columns it actually cached.
+        assert [c.name for c in svc._cached_columns("frpm", current) or []] == [
+            c.name for c in detail.data.table.columns
+        ]
 
 
 class _FakeServerConnector:

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -658,8 +658,12 @@ class TestPerDatasourceResolution:
         assert keys and all(k.startswith(f"{current}\t") for k in keys)
 
         # A second datasource asking for the same table name must miss.
+        # `datasource_configs` is a property that copies, so the registration has
+        # to go through `services.datasources` — otherwise `_connector_for`
+        # rejects "other" as unknown and this would pass for the wrong reason.
+        svc.agent_config.services.datasources["other"] = svc.agent_config.services.datasources[current]
         svc._datasource_connectors["other"] = (svc.current_db_connector, "california_schools")
-        svc.agent_config.datasource_configs["other"] = svc.agent_config.datasource_configs[current]
+        assert svc._connector_for("other")[0] is svc.current_db_connector
         assert svc._cached_columns("frpm", "other") is None
         assert svc._cached_columns("frpm", current) is not None
 

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -600,6 +600,69 @@ class TestListDatabases:
         result = svc.list_databases(request)
         assert result.data.current_database == "california_schools"
 
+    def test_list_databases_stamps_the_datasource(self, real_agent_config):
+        """Every row names the datasource it came from.
+
+        A client rendering several bound datasources in one tree cannot file the
+        rows without it — and cannot address a table afterwards.
+        """
+        svc = DatasourceService(agent_config=real_agent_config)
+        result = svc.list_databases(ListDatabasesInput())
+        assert result.data.current_datasource == real_agent_config.current_datasource
+        assert {db.datasource for db in result.data.databases} == {real_agent_config.current_datasource}
+
+    def test_list_databases_rejects_an_unknown_datasource(self, real_agent_config):
+        """An undeclared name is an error, not a silent fall-back.
+
+        Falling back to the current datasource would file another warehouse's
+        databases under the requested one in the caller's tree.
+        """
+        svc = DatasourceService(agent_config=real_agent_config)
+        result = svc.list_databases(ListDatabasesInput(datasource_id="not_bound"))
+        assert result.success is False
+        assert "not_bound" in result.errorMessage
+
+
+class TestPerDatasourceResolution:
+    """Table metadata addressed at a datasource other than the current one."""
+
+    def test_connector_for_defaults_to_current(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        connector, database = svc._connector_for()
+        assert connector is svc.current_db_connector
+        assert database == svc.current_db_name
+
+    def test_connector_for_rejects_unknown_datasource(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        with pytest.raises(ValueError, match="Unknown datasource"):
+            svc._connector_for("not_bound")
+
+    def test_table_detail_reports_an_unknown_datasource(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        result = svc.get_table_schema("frpm", datasource="not_bound")
+        assert result.success is False
+        assert "not_bound" in result.errorMessage
+
+    def test_column_cache_is_keyed_by_datasource(self, real_agent_config):
+        """Two bound warehouses commonly hold a same-named table.
+
+        Without the datasource in the key, the second one would be served the
+        first one's columns from cache — wrong answers, no error anywhere.
+        """
+        svc = DatasourceService(agent_config=real_agent_config)
+        detail = svc.get_table_schema("frpm")
+        assert detail.success is True
+
+        current = real_agent_config.current_datasource
+        keys = list(svc._columns_cache)
+        assert keys and all(k.startswith(f"{current}\t") for k in keys)
+
+        # A second datasource asking for the same table name must miss.
+        svc._datasource_connectors["other"] = (svc.current_db_connector, "california_schools")
+        svc.agent_config.datasource_configs["other"] = svc.agent_config.datasource_configs[current]
+        assert svc._cached_columns("frpm", "other") is None
+        assert svc._cached_columns("frpm", current) is not None
+
 
 class _FakeServerConnector:
     """No-schema (server-style) connector that distinguishes its configured

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -637,6 +637,83 @@ class TestPerDatasourceResolution:
         with pytest.raises(ValueError, match="Unknown datasource"):
             svc._connector_for("not_bound")
 
+    def test_connector_for_normalizes_an_unreachable_datasource(self, real_agent_config):
+        """Declared but unreachable raises DatusException from the db manager.
+
+        Every caller here turns ValueError into a clean error Result, so leaving
+        DatusException to escape loses that — and catching DatusException in the
+        callers would swallow unrelated ones from deeper in the stack.
+        """
+        from datus.utils.exceptions import DatusException, ErrorCode
+
+        svc = DatasourceService(agent_config=real_agent_config)
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["broken"] = real_agent_config.services.datasources[current]
+
+        with patch.object(
+            svc.db_manager,
+            "first_conn_with_name",
+            side_effect=DatusException(ErrorCode.COMMON_UNSUPPORTED, message_args={}),
+        ):
+            with pytest.raises(ValueError, match="no usable connection"):
+                svc._connector_for("broken")
+
+        # Nothing unusable was remembered for the next request.
+        assert "broken" not in svc._datasource_connectors
+
+    def test_connector_for_rejects_a_null_connector(self, real_agent_config):
+        """Symmetric with the current-datasource branch, which already does."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["empty"] = real_agent_config.services.datasources[current]
+
+        with patch.object(svc.db_manager, "first_conn_with_name", return_value=("db", None)):
+            with pytest.raises(ValueError, match="no usable connection"):
+                svc._connector_for("empty")
+
+        assert "empty" not in svc._datasource_connectors
+
+    def test_connector_for_opens_and_remembers_another_datasource(self, real_agent_config):
+        """The happy path for a non-current datasource: opened on first use, then
+        reused — DBManager hands back a fresh wrapper per call, and the column
+        cache keys off the name rather than the object."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
+        connector = MagicMock(database_name="")
+
+        with patch.object(svc.db_manager, "first_conn_with_name", return_value=("second_db", connector)) as opened:
+            first = svc._connector_for("second")
+            again = svc._connector_for("second")
+
+        assert first == (connector, "second_db")
+        assert again is first
+        assert opened.call_count == 1
+
+    def test_connector_for_rejects_a_current_datasource_with_no_connection(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.current_db_connector = None
+
+        with pytest.raises(ValueError, match="no usable connection"):
+            svc._connector_for(real_agent_config.current_datasource)
+
+    def test_connector_for_passes_a_valueerror_through_unwrapped(self, real_agent_config):
+        """Already the right type — re-wrapping would bury the original message."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
+
+        with patch.object(svc.db_manager, "first_conn_with_name", side_effect=ValueError("bad uri")):
+            with pytest.raises(ValueError, match="^bad uri$"):
+                svc._connector_for("second")
+
+    def test_connector_for_rejects_when_nothing_is_configured(self, real_agent_config):
+        svc = DatasourceService(agent_config=real_agent_config)
+        svc.current_datasource = ""
+
+        with pytest.raises(ValueError, match="No datasource configured"):
+            svc._connector_for(None)
+
     def test_table_detail_reports_an_unknown_datasource(self, real_agent_config):
         svc = DatasourceService(agent_config=real_agent_config)
         result = svc.get_table_schema("frpm", datasource="not_bound")

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -1184,11 +1184,11 @@ class TestGetTablesColumnsBounds:
         spy = MagicMock(wraps=svc.current_db_connector.get_schema)
         svc.current_db_connector.get_schema = spy
 
-        svc._prefetch_gate.acquire()
+        svc._prefetch_gate_for(real_agent_config.current_datasource).acquire()
         try:
             result = svc.get_tables_columns(["schools"])
         finally:
-            svc._prefetch_gate.release()
+            svc._prefetch_gate_for(real_agent_config.current_datasource).release()
 
         assert result.success is True
         assert result.data.tables == []
@@ -1199,15 +1199,46 @@ class TestGetTablesColumnsBounds:
         svc = DatasourceService(agent_config=real_agent_config)
         svc.get_tables_columns(["schools"])
 
-        svc._prefetch_gate.acquire()
+        svc._prefetch_gate_for(real_agent_config.current_datasource).acquire()
         try:
             result = svc.get_tables_columns(["schools", "frpm"])
         finally:
-            svc._prefetch_gate.release()
+            svc._prefetch_gate_for(real_agent_config.current_datasource).release()
 
         # schools is cached; frpm would need the source, so it is omitted.
         assert [t.table for t in result.data.tables] == ["schools"]
         assert result.data.tables[0].columns
+
+    def test_a_busy_datasource_does_not_gate_another(self, real_agent_config):
+        """The gate is per datasource, not per service.
+
+        Each datasource has its own connector and its own cache entries, so a
+        prefetch running against one must not withhold another's — on this code
+        path a single `list_tables` runs for seconds, and one global gate made
+        expanding two datasources' trees queue for no reason.
+        """
+        svc = DatasourceService(agent_config=real_agent_config)
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
+
+        held = svc._prefetch_gate_for(current)
+        held.acquire()
+        try:
+            other = svc._prefetch_gate_for("second")
+            assert other is not held
+            assert other.acquire(blocking=False) is True
+            other.release()
+        finally:
+            held.release()
+
+    def test_schema_locks_are_per_datasource(self, real_agent_config):
+        """Same reasoning for the connector lock the batch serializes on."""
+        svc = DatasourceService(agent_config=real_agent_config)
+        current = real_agent_config.current_datasource
+
+        first = svc._schema_lock_for(current)
+        assert first is svc._schema_lock_for(current)
+        assert first is not svc._schema_lock_for("second")
 
     def test_the_gate_is_released_for_the_next_batch(self, real_agent_config):
         svc = DatasourceService(agent_config=real_agent_config)

--- a/tests/unit_tests/api/services/test_database_service.py
+++ b/tests/unit_tests/api/services/test_database_service.py
@@ -633,8 +633,10 @@ class TestPerDatasourceResolution:
         assert database == svc.current_db_name
 
     def test_connector_for_rejects_unknown_datasource(self, real_agent_config):
+        from datus.utils.exceptions import DatusException
+
         svc = DatasourceService(agent_config=real_agent_config)
-        with pytest.raises(ValueError, match="Unknown datasource"):
+        with pytest.raises(DatusException, match="datasource"):
             svc._connector_for("not_bound")
 
     def test_connector_for_normalizes_an_unreachable_datasource(self, real_agent_config):
@@ -655,7 +657,8 @@ class TestPerDatasourceResolution:
             "first_conn_with_name",
             side_effect=DatusException(ErrorCode.COMMON_UNSUPPORTED, message_args={}),
         ):
-            with pytest.raises(ValueError, match="no usable connection"):
+            # Re-raised as-is: it is already the structured type the boundary maps.
+            with pytest.raises(DatusException):
                 svc._connector_for("broken")
 
         # Nothing unusable was remembered for the next request.
@@ -667,8 +670,10 @@ class TestPerDatasourceResolution:
         current = real_agent_config.current_datasource
         real_agent_config.services.datasources["empty"] = real_agent_config.services.datasources[current]
 
+        from datus.utils.exceptions import DatusException
+
         with patch.object(svc.db_manager, "first_conn_with_name", return_value=("db", None)):
-            with pytest.raises(ValueError, match="no usable connection"):
+            with pytest.raises(DatusException, match="no usable connection"):
                 svc._connector_for("empty")
 
         assert "empty" not in svc._datasource_connectors
@@ -691,27 +696,35 @@ class TestPerDatasourceResolution:
         assert opened.call_count == 1
 
     def test_connector_for_rejects_a_current_datasource_with_no_connection(self, real_agent_config):
+        from datus.utils.exceptions import DatusException
+
         svc = DatasourceService(agent_config=real_agent_config)
         svc.current_db_connector = None
 
-        with pytest.raises(ValueError, match="no usable connection"):
+        with pytest.raises(DatusException, match="no usable connection"):
             svc._connector_for(real_agent_config.current_datasource)
 
-    def test_connector_for_passes_a_valueerror_through_unwrapped(self, real_agent_config):
-        """Already the right type — re-wrapping would bury the original message."""
+    def test_connector_for_wraps_an_unstructured_failure(self, real_agent_config):
+        """A plain exception from the db manager still reaches the caller as the
+        structured database error, so the boundary maps one type, and the
+        original message survives inside it."""
+        from datus.utils.exceptions import DatusException
+
         svc = DatasourceService(agent_config=real_agent_config)
         current = real_agent_config.current_datasource
         real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
 
         with patch.object(svc.db_manager, "first_conn_with_name", side_effect=ValueError("bad uri")):
-            with pytest.raises(ValueError, match="^bad uri$"):
+            with pytest.raises(DatusException, match="bad uri"):
                 svc._connector_for("second")
 
     def test_connector_for_rejects_when_nothing_is_configured(self, real_agent_config):
         svc = DatasourceService(agent_config=real_agent_config)
         svc.current_datasource = ""
 
-        with pytest.raises(ValueError, match="No datasource configured"):
+        from datus.utils.exceptions import DatusException
+
+        with pytest.raises(DatusException, match="no datasource configured"):
             svc._connector_for(None)
 
     def test_table_detail_reports_an_unknown_datasource(self, real_agent_config):

--- a/tests/unit_tests/api/services/test_kb_service.py
+++ b/tests/unit_tests/api/services/test_kb_service.py
@@ -418,7 +418,11 @@ class TestKbServiceBootstrapStream:
             config=None,
             authoring_scope=None,
         ):
-            calls.append((component, authoring_scope))
+            # Record the forwarded config, not just the component: a double
+            # that drops it would pass even if bootstrap_stream stopped
+            # forwarding the pre-resolved one, which is the datasource-isolation
+            # contract.
+            calls.append((component, authoring_scope, getattr(config, "current_datasource", None)))
             return {"status": "success", "message": "done", "details": {}}
 
         with patch.object(svc, "_run_component", side_effect=fake_run_component):
@@ -432,7 +436,7 @@ class TestKbServiceBootstrapStream:
                 )
             ]
 
-        assert calls == [("semantic_model", "full")]
+        assert calls == [("semantic_model", "full", real_agent_config.current_datasource)]
         summary = events[-1].payload["components"]
         assert set(summary) == {"semantic_model", "metrics"}
         assert summary["metrics"]["details"]["shared_execution"] == "semantic_model"
@@ -800,6 +804,7 @@ async def test_kb_bootstrap_acceptance_orchestrates_components_in_order(real_age
         request, component, queue, loop, cancel_event, project_root, *, config=None, authoring_scope=None
     ):
         assert authoring_scope is None
+        assert config is not None and config.current_datasource == real_agent_config.current_datasource
         calls.append((component, request.subject_tree, project_root))
         return {
             "status": "success",

--- a/tests/unit_tests/api/services/test_kb_service.py
+++ b/tests/unit_tests/api/services/test_kb_service.py
@@ -368,6 +368,7 @@ class TestKbServiceBootstrapStream:
             cancel_event,
             project_root,
             *,
+            config=None,
             authoring_scope=None,
         ):
             calls.append((component, authoring_scope))
@@ -748,7 +749,9 @@ async def test_kb_bootstrap_acceptance_orchestrates_components_in_order(real_age
     )
     calls = []
 
-    def fake_run_component(request, component, queue, loop, cancel_event, project_root, *, authoring_scope=None):
+    def fake_run_component(
+        request, component, queue, loop, cancel_event, project_root, *, config=None, authoring_scope=None
+    ):
         assert authoring_scope is None
         calls.append((component, request.subject_tree, project_root))
         return {

--- a/tests/unit_tests/api/services/test_kb_service.py
+++ b/tests/unit_tests/api/services/test_kb_service.py
@@ -298,6 +298,53 @@ class TestKbServiceBatchEventToSse:
 class TestKbServiceBootstrapStream:
     """Tests for bootstrap_stream — the main async generator."""
 
+    async def test_an_unbound_datasource_becomes_a_readable_failure_event(self, real_agent_config):
+        """Not a broken stream.
+
+        The datasource setter raises for a name the project has not bound. Left
+        to happen inside the component loop, the exception escapes the async
+        generator after the SSE headers are already out, so the client sees the
+        stream die rather than a failure it can display.
+        """
+        import asyncio
+
+        svc = KbService(agent_config=real_agent_config)
+        request = BootstrapKbInput(components=["metadata"], strategy="check", datasource="not_bound")
+
+        events = []
+        async for event in svc.bootstrap_stream(request, "s", asyncio.Event(), str(real_agent_config.home)):
+            events.append(event)
+
+        assert len(events) == 1
+        assert events[0].component == "all"
+        assert events[0].stage == BatchStage.TASK_FAILED
+        assert "not_bound" in (events[0].error or "")
+
+    async def test_the_current_datasource_is_not_cloned(self, real_agent_config):
+        """Naming the current datasource (or none) reuses the shared config."""
+        svc = KbService(agent_config=real_agent_config)
+
+        assert svc._config_for(BootstrapKbInput(components=["metadata"])) is real_agent_config
+        assert (
+            svc._config_for(BootstrapKbInput(components=["metadata"], datasource=real_agent_config.current_datasource))
+            is real_agent_config
+        )
+
+    async def test_another_datasource_gets_its_own_config(self, real_agent_config):
+        """A clone, not a mutation: the shared config is read concurrently by
+        every other request, and the KB stores scope their rows by
+        `current_datasource` — so indexing one datasource must not be able to
+        write another's."""
+        svc = KbService(agent_config=real_agent_config)
+        current = real_agent_config.current_datasource
+        real_agent_config.services.datasources["second"] = real_agent_config.services.datasources[current]
+
+        clone = svc._config_for(BootstrapKbInput(components=["metadata"], datasource="second"))
+
+        assert clone is not real_agent_config
+        assert clone.current_datasource == "second"
+        assert real_agent_config.current_datasource == current
+
     async def test_bootstrap_stream_metadata_check(self, real_agent_config):
         """bootstrap_stream with metadata check strategy yields events and completes."""
         import asyncio


### PR DESCRIPTION
## Why

A project can be bound to several datasources — `AgentConfig.services.datasources` has always been a dict, and SaaS already registers a second entry (`local_files`) unconditionally. But every metadata and execution endpoint resolved against `current_datasource` only, so a client could neither list a second datasource's catalog nor run a statement against it.

This is the agent half of multi-datasource projects. Datus-backend and Datus-saas changes follow separately; both are additive, so nothing here changes behaviour for a single-datasource project.

## What

**Datasource identity in responses**
- `DatabaseInfo.datasource` and `ListDatabasesData.current_datasource`. A client rendering several datasources in one tree cannot file a row — or address a table afterwards — without knowing which connection served it.
- `catalog/list` now **refuses an undeclared datasource** instead of falling back to the current one. The fallback would file another warehouse's databases under the requested name in the caller's tree.

**Datasource as a request parameter**
- `ExecuteSQLInput.datasource`, `GET /table/detail?datasource=`, `GetTablesColumnsInput.datasource`, `BootstrapKbInput.datasource`.
- A dotted table name carries no datasource segment, so it has to travel beside the name — otherwise the statement silently runs on the project's default warehouse. Naming a datasource the project has not bound is an error, not a fall-through: quietly answering from the wrong warehouse is the failure mode worth preventing.

**Caches keyed by datasource**
- `DatasourceService._columns_cache` and the CLI connector map. Two bound warehouses routinely hold a same-named table, and a name-only key served the first one's columns for the second — wrong answers with nothing reporting an error.

**Binding a sub-agent by name**
- `datasource_name` on `CreateAgentInput` / `EditAgentInput`. A client that picked the datasource out of a catalog tree only knows the namespace name; the ids live on the SaaS side. Resolution happens in Datus-backend against that project's own bindings.

## Notes

- Non-current datasources open their connection on first use. Opening every bound warehouse up front costs seconds per project for connections most requests never touch.
- KB bootstrap runs against a `copy.copy` of the config with the datasource switched. The shared config is cached per project and read concurrently, and the KB stores scope their rows by `current_datasource` — so indexing one datasource must not be able to write another's.

## Tests

9 new cases covering the datasource stamp, the unknown-datasource refusal, per-datasource connector resolution and the column-cache keying. `tests/unit_tests/api` is at its pre-existing baseline (10 failures in `test_explorer_service.py` present on `main` before this branch).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Select a configured datasource when creating or editing agents.
  * Run SQL commands against a chosen datasource, defaulting to the current one.
  * Browse databases, tables, and columns across configured datasources.
  * View which datasource serves each database and table listing.
  * Build knowledge bases from a selected datasource with isolated metadata.
* **Bug Fixes**
  * Improved validation and clearer errors for unavailable or unbound datasources.
  * Preserved existing agent datasource bindings when no replacement is specified.
* **Tests**
  * Added coverage for datasource selection, validation, routing, and isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select configured datasources when creating or editing agents.
  * Run SQL and browse database metadata across datasources.
  * Build knowledge bases from a selected datasource.
  * View datasource names, types, and current selection without credentials.
* **Bug Fixes**
  * Improved validation and error handling for unavailable or busy datasources.
  * Preserved existing agent bindings when no replacement is specified.
  * Isolated concurrent operations between datasources.
* **Tests**
  * Added coverage for datasource selection, routing, validation, concurrency, and isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->