### PR TITLE
[Doc] Redraw the architecture around role-based entry points and retire MetricFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@
 
 Datus handles SQL authoring and validation, semantic model and metric construction, and the generation of pipelines, reports, and dashboards. Every run and every correction settles into context, which steadily raises the accuracy of its output. The whole stack stays open and flexible: databases, BI, schedulers, LLMs, and your team's own tools all connect through standard interfaces.
 
-![How Datus works](docs/assets/how_it_works.svg)
+## Architecture
+
+![Datus Architecture](docs/assets/datus_architecture.svg)
+
+The diagram reads top to bottom: who uses Datus, what the agent is made of, and what it connects to.
+
+- **Three entry points, by role**: data engineers work in [Datus-CLI](https://docs.datus.ai/latest/cli/introduction/) to explore data and build assets; analysts ask through [Datus-Chat](https://docs.datus.ai/latest/web_chatbot/introduction/) on the web, in Slack/Feishu, or in VS Code, and their feedback flows back into the agent; other agents and applications consume [Datus-API](https://docs.datus.ai/latest/API/introduction/) over REST and MCP.
+- **The agent core**: [subagents](https://docs.datus.ai/latest/subagent/introduction/) package curated context, tools, and rules for one business domain, [skills](https://docs.datus.ai/latest/skills/introduction/) add packaged tools, and [plugins](https://docs.datus.ai/latest/plugin/introduction/) connect third-party and in-house tools. Underneath sits the [context engine](https://docs.datus.ai/latest/knowledge_base/introduction/): metadata, metrics, reference SQL, knowledge, and local files, retrieved through business-domain trees plus vector search, with [storage](https://docs.datus.ai/latest/configuration/storage/) on embedded LanceDB and SQLite and PostgreSQL for teams that share context.
+- **Connected systems**: LLM providers, data warehouses, the [Dosi](https://dosi.datus.ai/) semantic layer, job schedulers, BI tools, and MCP servers and clients, all reached through adapters.
 
 ## Features
 
@@ -81,17 +89,6 @@ The examples below use a datasource named `demo`; create one first with `/dataso
 | [**VS Code**](https://docs.datus.ai/latest/vscode_extension/introduction/) (Datus Studio) | connects to `datus --web` | Catalog explorer, chat panel, SQL results & AI charts in the IDE |
 
 > **Tip:** Print mode streams JSON to stdout for scripting and CI: `datus -p "your question" --datasource demo`.
-
-## Architecture
-
-![Datus Architecture](docs/assets/datus_architecture.svg)
-
-The architecture has four layers, matching the diagram above:
-
-- **Delivery**: six entry points (CLI, web chatbot, REST API, MCP, IM gateway, and VS Code) that share one agent backend.
-- **Intelligence**: the chat agent plans and reasons, subagents handle specialized tasks, skills and plugins add tools, and governance applies here. Interactive requests run in agentic mode, where the agent plans its own steps; benchmark and batch runs use [workflow mode](https://docs.datus.ai/latest/workflow/introduction/), which executes a predefined plan of nodes.
-- **Semantic layer and context**: the asset layer the agent builds. One half is semantic models and metrics, executed by Dosi or MetricFlow; the other half is [context](https://docs.datus.ai/latest/knowledge_base/introduction/): schema metadata, reference SQL, knowledge, and memory. Retrieval combines business-domain trees with vector search, and [storage](https://docs.datus.ai/latest/configuration/storage/) defaults to embedded LanceDB and SQLite, with PostgreSQL as the option for teams that share context.
-- **Data and tool plane**: the databases, BI platforms, schedulers, and LLM providers reached through adapters.
 
 ## Development
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -27,7 +27,15 @@
 
 Datus 可以完成 SQL 编写与验证、语义模型与指标构建，以及数据管道、报告和看板的生成；每一次执行与修正都会沉淀为上下文，持续提升后续输出的准确性。整个体系在生态上保持开放与灵活：数据库、BI、调度、LLM 乃至团队自己的工具，都能以标准方式接入。
 
-![Datus 工作方式](docs/assets/how_it_works.svg)
+## 架构
+
+![Datus 架构](docs/assets/datus_architecture.svg)
+
+整体架构自上而下分三段：谁在用、Agent 由什么组成、连接哪些系统，与上图对应：
+
+- **按角色划分的三个入口**：数据工程师在 [Datus-CLI](https://docs.datus.ai/zh/latest/cli/introduction/) 里探索数据、构建资产；分析师通过 [Datus-Chat](https://docs.datus.ai/zh/latest/web_chatbot/introduction/)(Web、Slack/飞书、VS Code)提问，使用中的反馈会回流进 Agent；其他 Agent 和应用经 [Datus-API](https://docs.datus.ai/zh/latest/API/introduction/)(REST、MCP)消费。
+- **Agent 核心**：[Subagent](https://docs.datus.ai/zh/latest/subagent/introduction/) 为单个业务域打包配好的上下文、工具和规则，[Skill](https://docs.datus.ai/zh/latest/skills/introduction/) 提供打包的扩展工具，[Plugin](https://docs.datus.ai/zh/latest/plugin/introduction/) 接入第三方和公司内部工具；底座是[上下文引擎](https://docs.datus.ai/zh/latest/knowledge_base/introduction/)：元数据、指标、参考 SQL、知识与本地文件，检索用业务域树加向量召回，[存储](https://docs.datus.ai/zh/latest/configuration/storage/)默认内嵌 LanceDB 和 SQLite，团队共享上下文时可换 PostgreSQL。
+- **连接的系统**：LLM、数据仓库、[Dosi](https://dosi.datus.ai/) 语义层、作业调度、BI 工具与 MCP 服务端/客户端，均经适配器接入。
 
 ## 核心能力
 
@@ -81,17 +89,6 @@ curl -fsSL https://raw.githubusercontent.com/datus-ai/datus-agent/main/install.s
 | [**VS Code**](https://docs.datus.ai/zh/latest/vscode_extension/introduction/)(Datus Studio) | 连接 `datus --web` | IDE 内的目录浏览器、聊天面板、SQL 结果与 AI 图表 |
 
 > **提示：** Print 模式向 stdout 流式输出 JSON，适合脚本与 CI：`datus -p "你的问题" --datasource demo`。
-
-## 架构
-
-![Datus 架构](docs/assets/datus_architecture.svg)
-
-整体架构自上而下分四层，与上图对应：
-
-- **交付层**：CLI、Web 聊天、REST API、MCP、IM 网关和 VS Code 六个入口，共享同一个 Agent 后端。
-- **智能层**：Chat Agent 负责规划和推理，subagent 处理专项任务，Skill 与 Plugin 提供扩展工具，治理机制也作用在这一层。交互请求走 Agentic 模式，步骤由 Agent 自行规划；benchmark 和批量任务走 [Workflow 模式](https://docs.datus.ai/zh/latest/workflow/introduction/)，按预定义的节点计划执行。
-- **语义层与上下文**：Agent 构建的资产层。一半是语义模型与指标，由 Dosi 或 MetricFlow 执行；另一半是[上下文](https://docs.datus.ai/zh/latest/knowledge_base/introduction/)，包括 schema 元数据、参考 SQL、知识与记忆。检索用业务域树加向量召回；[存储](https://docs.datus.ai/zh/latest/configuration/storage/)默认是内嵌的 LanceDB 和 SQLite，团队需要共享上下文时可换成 PostgreSQL。
-- **数据与工具层**：经适配器连接的数据库、BI 平台、调度系统与 LLM 提供商。
 
 ## 开发
 

--- a/docs/assets/datus_architecture.svg
+++ b/docs/assets/datus_architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" role="img" aria-label="Datus architecture: delivery surfaces on top, the agent intelligence layer in the middle, standing on the semantic layer and context it builds, executing against databases, BI, schedulers, and LLM providers; feedback flows back into the semantic layer.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 640" role="img" aria-label="Datus architecture: three role-based entry points on top (Datus-CLI for data engineers, Datus-Chat for analysts, Datus-API for other agents), the agent core with subagents, skills, and the context engine in the middle, and connected systems at the bottom: LLMs, data warehouses, the Dosi semantic layer, job schedulers, BI tools, and MCPs.">
   <style>
     text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
     .band { fill: #f6f8fa; stroke: #d0d7de; }
@@ -41,111 +41,76 @@
     </marker>
   </defs>
 
-  <!-- ===== Delivery layer ===== -->
-  <rect x="60" y="20" width="880" height="100" rx="10" class="band"/>
-  <text x="76" y="44" class="label">DELIVERY · HOW TEAMS REACH THE AGENT</text>
-  <g>
-    <rect x="76" y="58" width="132" height="44" rx="8" class="chip"/>
-    <text x="142" y="84" text-anchor="middle" class="title">CLI</text>
-    <rect x="218" y="58" width="132" height="44" rx="8" class="chip"/>
-    <text x="284" y="78" text-anchor="middle" class="title">Web Chatbot</text>
-    <text x="284" y="94" text-anchor="middle" class="sub">:8501</text>
-    <rect x="360" y="58" width="132" height="44" rx="8" class="chip"/>
-    <text x="426" y="78" text-anchor="middle" class="title">REST API</text>
-    <text x="426" y="94" text-anchor="middle" class="sub">:8000</text>
-    <rect x="502" y="58" width="132" height="44" rx="8" class="chip"/>
-    <text x="568" y="84" text-anchor="middle" class="title">MCP</text>
-    <rect x="644" y="58" width="132" height="44" rx="8" class="chip"/>
-    <text x="710" y="78" text-anchor="middle" class="title">IM Gateway</text>
-    <text x="710" y="94" text-anchor="middle" class="sub">Slack · Feishu</text>
-    <rect x="786" y="58" width="132" height="44" rx="8" class="chip"/>
-    <text x="852" y="78" text-anchor="middle" class="title">VS Code</text>
-    <text x="852" y="94" text-anchor="middle" class="sub">Datus Studio</text>
-  </g>
+  <!-- entry points by role -->
+  <text x="190" y="52" text-anchor="middle" class="label">FOR DATA ENGINEERS</text>
+  <text x="500" y="52" text-anchor="middle" class="label">FOR DATA ANALYSTS</text>
+  <text x="810" y="52" text-anchor="middle" class="label">FOR OTHER AGENTS</text>
 
-  <!-- Delivery <-> Intelligence -->
-  <line x1="430" y1="120" x2="430" y2="158" class="flow" marker-end="url(#ah)"/>
-  <text x="420" y="144" text-anchor="end" class="flowlabel">questions · tasks</text>
-  <line x1="570" y1="158" x2="570" y2="120" class="flow" marker-end="url(#ah)"/>
-  <text x="580" y="144" class="flowlabel">validated SQL · artifacts</text>
+  <rect x="70" y="68" width="240" height="76" rx="10" class="chip"/>
+  <text x="190" y="100" text-anchor="middle" class="title">Datus-CLI</text>
+  <text x="190" y="122" text-anchor="middle" class="sub">interactive REPL &#183; build &amp; explore</text>
 
-  <!-- ===== Intelligence layer ===== -->
-  <rect x="60" y="160" width="880" height="130" rx="10" class="band"/>
-  <text x="76" y="184" class="label">INTELLIGENCE · HOW THE AGENT THINKS</text>
-  <g>
-    <rect x="76" y="198" width="206" height="76" rx="8" class="chip"/>
-    <text x="179" y="228" text-anchor="middle" class="title">Chat Agent + Planner</text>
-    <text x="179" y="246" text-anchor="middle" class="sub">plan mode · reasoning</text>
-    <rect x="290" y="198" width="206" height="76" rx="8" class="chip"/>
-    <text x="393" y="228" text-anchor="middle" class="title">Subagents</text>
-    <text x="393" y="246" text-anchor="middle" class="sub">semantic modeling · gen_sql</text>
-    <text x="393" y="260" text-anchor="middle" class="sub">ask_metrics · jobs · reports · …</text>
-    <rect x="504" y="198" width="206" height="76" rx="8" class="chip"/>
-    <text x="607" y="228" text-anchor="middle" class="title">Skills &amp; Plugins</text>
-    <text x="607" y="246" text-anchor="middle" class="sub">packaged tools · marketplace</text>
-    <rect x="718" y="198" width="200" height="76" rx="8" class="chip"/>
-    <text x="818" y="228" text-anchor="middle" class="title">Governance</text>
-    <text x="818" y="246" text-anchor="middle" class="sub">permissions · sandbox · AI review</text>
-    <text x="818" y="260" text-anchor="middle" class="sub">SQL policy · tracing</text>
-  </g>
+  <rect x="380" y="68" width="240" height="76" rx="10" class="chip"/>
+  <text x="500" y="100" text-anchor="middle" class="title">Datus-Chat</text>
+  <text x="500" y="122" text-anchor="middle" class="sub">web &#183; Slack / Feishu &#183; VS Code</text>
 
-  <!-- Intelligence <-> Semantic layer -->
-  <line x1="430" y1="328" x2="430" y2="290" class="flow-accent" marker-end="url(#ah-accent)"/>
-  <text x="420" y="314" text-anchor="end" class="flowlabel-accent">grounded semantics · context</text>
-  <line x1="570" y1="290" x2="570" y2="328" class="flow-accent" marker-end="url(#ah-accent)"/>
-  <text x="580" y="314" class="flowlabel-accent">write back learnings</text>
+  <rect x="690" y="68" width="240" height="76" rx="10" class="chip"/>
+  <text x="810" y="100" text-anchor="middle" class="title">Datus-API</text>
+  <text x="810" y="122" text-anchor="middle" class="sub">REST &#183; MCP server</text>
 
-  <!-- ===== Semantic layer & context ===== -->
-  <rect x="60" y="330" width="880" height="200" rx="10" class="band-accent"/>
-  <text x="76" y="354" class="label-accent">SEMANTIC LAYER &amp; CONTEXT · WHAT THE AGENT BUILDS AND STANDS ON</text>
-  <g>
-    <rect x="76" y="368" width="420" height="56" rx="8" class="chip-accent"/>
-    <text x="286" y="390" text-anchor="middle" class="title">Semantic Models &amp; Metrics</text>
-    <text x="286" y="408" text-anchor="middle" class="sub">OSI YAML · datasets · verified keys &amp; joins</text>
-    <rect x="504" y="368" width="414" height="56" rx="8" class="chip-accent"/>
-    <text x="711" y="390" text-anchor="middle" class="title">Execution Backends</text>
-    <text x="711" y="408" text-anchor="middle" class="sub">Dosi (OSI-native Rust) · MetricFlow</text>
-  </g>
-  <g>
-    <rect x="76" y="436" width="206" height="56" rx="8" class="chip-accent"/>
-    <text x="179" y="458" text-anchor="middle" class="title">Schema Metadata</text>
-    <text x="179" y="476" text-anchor="middle" class="sub">tables · lineage</text>
-    <rect x="290" y="436" width="206" height="56" rx="8" class="chip-accent"/>
-    <text x="393" y="458" text-anchor="middle" class="title">Reference SQL</text>
-    <text x="393" y="476" text-anchor="middle" class="sub">examples · Jinja2 templates</text>
-    <rect x="504" y="436" width="206" height="56" rx="8" class="chip-accent"/>
-    <text x="607" y="458" text-anchor="middle" class="title">Knowledge &amp; Memory</text>
-    <text x="607" y="476" text-anchor="middle" class="sub">AGENTS.md · MEMORY.md</text>
-    <rect x="718" y="436" width="200" height="56" rx="8" class="chip-accent"/>
-    <text x="818" y="458" text-anchor="middle" class="title">Platform Docs</text>
-    <text x="818" y="476" text-anchor="middle" class="sub">repos · sites · files</text>
-  </g>
-  <text x="500" y="514" text-anchor="middle" class="sub">business-domain tree + vector retrieval · embedded LanceDB &amp; SQLite, swappable to PostgreSQL</text>
+  <line x1="312" y1="106" x2="376" y2="106" class="flow" marker-end="url(#ah)"/>
+  <line x1="622" y1="106" x2="686" y2="106" class="flow" marker-end="url(#ah)"/>
 
-  <!-- Execution path: Intelligence -> tool plane (routed on the left) -->
-  <path d="M 60 240 L 34 240 L 34 602 L 58 602" class="flow" marker-end="url(#ah)"/>
-  <text x="44" y="548" text-anchor="start" class="flowlabel">runs SQL · jobs · dashboards</text>
+  <!-- flows between entries and the core -->
+  <line x1="190" y1="150" x2="190" y2="204" class="flow" marker-start="url(#ah)" marker-end="url(#ah)"/>
+  <line x1="500" y1="150" x2="500" y2="204" class="flow-accent" marker-end="url(#ah-accent)"/>
+  <text x="512" y="182" class="flowlabel-accent">feedback</text>
+  <line x1="810" y1="204" x2="810" y2="150" class="flow" marker-end="url(#ah)"/>
 
-  <!-- Feedback loop: Delivery -> Semantic layer (routed on the right) -->
-  <path d="M 940 84 L 966 84 L 966 430 L 948 430" class="flow-accent" marker-end="url(#ah-accent)"/>
-  <text x="962" y="140" text-anchor="end" class="flowlabel-accent">feedback ·</text>
-  <text x="962" y="154" text-anchor="end" class="flowlabel-accent">success stories</text>
+  <!-- the agent core -->
+  <rect x="70" y="210" width="860" height="230" rx="12" class="band"/>
+  <text x="94" y="240" class="label-accent">DATUS AGENT</text>
 
-  <!-- ===== Data & tool plane ===== -->
-  <rect x="60" y="570" width="880" height="100" rx="10" class="band"/>
-  <text x="76" y="594" class="label">DATA &amp; TOOL PLANE · WHAT THE AGENT CONNECTS TO</text>
-  <g>
-    <rect x="76" y="608" width="206" height="44" rx="8" class="chip"/>
-    <text x="179" y="628" text-anchor="middle" class="title">Databases</text>
-    <text x="179" y="644" text-anchor="middle" class="sub">15 engines via adapters</text>
-    <rect x="290" y="608" width="206" height="44" rx="8" class="chip"/>
-    <text x="393" y="628" text-anchor="middle" class="title">BI Platforms</text>
-    <text x="393" y="644" text-anchor="middle" class="sub">Superset · Grafana</text>
-    <rect x="504" y="608" width="206" height="44" rx="8" class="chip"/>
-    <text x="607" y="628" text-anchor="middle" class="title">Schedulers</text>
-    <text x="607" y="644" text-anchor="middle" class="sub">Airflow</text>
-    <rect x="718" y="608" width="200" height="44" rx="8" class="chip"/>
-    <text x="818" y="628" text-anchor="middle" class="title">LLM Providers</text>
-    <text x="818" y="644" text-anchor="middle" class="sub">10+ · per-node assignment</text>
-  </g>
+  <rect x="150" y="258" width="220" height="74" rx="10" class="chip"/>
+  <text x="260" y="288" text-anchor="middle" class="title">Subagent</text>
+  <text x="260" y="310" text-anchor="middle" class="sub">curated context &#183; tools &#183; rules</text>
+
+  <rect x="390" y="258" width="220" height="74" rx="10" class="chip"/>
+  <text x="500" y="288" text-anchor="middle" class="title">Skill</text>
+  <text x="500" y="310" text-anchor="middle" class="sub">packaged tools &#183; marketplace</text>
+
+  <rect x="630" y="258" width="220" height="74" rx="10" class="chip"/>
+  <text x="740" y="288" text-anchor="middle" class="title">Plugin</text>
+  <text x="740" y="310" text-anchor="middle" class="sub">third-party &amp; in-house tools</text>
+
+  <rect x="150" y="350" width="700" height="70" rx="10" class="chip-accent"/>
+  <text x="500" y="378" text-anchor="middle" class="title">Context engine</text>
+  <text x="500" y="400" text-anchor="middle" class="sub">metadata &#183; metrics &#183; reference SQL &#183; knowledge &#183; local files</text>
+
+  <!-- connected systems -->
+  <text x="70" y="490" class="label">CONNECTED SYSTEMS &#183; VIA ADAPTERS</text>
+
+  <rect x="70" y="506" width="130" height="72" rx="10" class="chip"/>
+  <text x="135" y="536" text-anchor="middle" class="title">LLMs</text>
+  <text x="135" y="556" text-anchor="middle" class="sub">10+ providers</text>
+
+  <rect x="216" y="506" width="130" height="72" rx="10" class="chip"/>
+  <text x="281" y="536" text-anchor="middle" class="title">Warehouses</text>
+  <text x="281" y="556" text-anchor="middle" class="sub">15 databases</text>
+
+  <rect x="362" y="506" width="130" height="72" rx="10" class="chip-accent"/>
+  <text x="427" y="536" text-anchor="middle" class="title">Semantic layer</text>
+  <text x="427" y="556" text-anchor="middle" class="sub">Dosi engine</text>
+
+  <rect x="508" y="506" width="130" height="72" rx="10" class="chip"/>
+  <text x="573" y="536" text-anchor="middle" class="title">Job scheduler</text>
+  <text x="573" y="556" text-anchor="middle" class="sub">Airflow</text>
+
+  <rect x="654" y="506" width="130" height="72" rx="10" class="chip"/>
+  <text x="719" y="536" text-anchor="middle" class="title">BI tools</text>
+  <text x="719" y="556" text-anchor="middle" class="sub">Superset &#183; Grafana</text>
+
+  <rect x="800" y="506" width="130" height="72" rx="10" class="chip"/>
+  <text x="865" y="536" text-anchor="middle" class="title">MCPs</text>
+  <text x="865" y="556" text-anchor="middle" class="sub">server &amp; client</text>
 </svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,24 +4,15 @@
 
 Datus handles SQL authoring and validation, semantic model and metric construction, and the generation of pipelines, reports, and dashboards. Every run and every correction settles into context, which steadily raises the accuracy of its output. The whole stack stays open and flexible: databases, BI, schedulers, LLMs, and your team's own tools all connect through standard interfaces.
 
-## How Datus works
+## Architecture
 
-The quality of an agent's answers is set by the quality of the context it receives. Datus therefore concentrates on accumulating and reusing context; the diagram shows the full loop:
+![Datus Architecture](assets/datus_architecture.svg)
 
-![How Datus works](assets/how_it_works.svg)
+The diagram reads top to bottom: who uses Datus, what the agent is made of, and what it connects to.
 
-The diagram reads in two halves. The front half is the data engineer's work: exploring data, building context, and modeling semantics; its output is reusable assets. The back half is how the organization consumes those assets: subagents turn them into a service anyone can question.
-
-The handoff is not one-way either: every correction an analyst makes flows back, and the assets thicken with use.
-
-1. **Explore**: no groundwork required. Chat with your database in the [CLI](cli/chat_command.md), referencing tables with `@table` and files with `@file`, and get familiar with the data as you go.
-2. **Build context**: [`/init`](skills/init.md) scans the current project, and `/bootstrap` and [`/build-kb`](skills/build_kb.md) collect the knowledge scattered across schemas, SQL history, and documents into the [knowledge base](knowledge_base/introduction.md); this is the raw material for all the accuracy that follows.
-3. **Model semantics**: the [semantic modeling subagent](subagent/semantic_modeling.md) mines datasets, semantic models, and metrics from your schema and SQL history, validates them, and registers them in the semantic layer; business definitions gain a single, executable form.
-4. **Create subagents**: with `/agent`, package the curated context, tools, and rules into a [subagent for one business domain](subagent/customized_subagent.md); from this step on, the assets become a service others can use directly.
-5. **Deliver**: analysts ask where they already work, whether that is the browser, Slack/Feishu, or the IDE (see [interfaces](#interfaces)); [AskMetrics](subagent/ask_metrics.md) answers from metric definitions, and [reports and dashboards](subagent/gen_visual_report.md) are generated right in the conversation.
-6. **Measure**: [benchmark](benchmark/benchmark_manual.md) SQL accuracy on BIRD, Spider 2.0-Snow, or [your own datasets](configuration/benchmark.md), turning what context adds into a quantified number.
-
-Corrections, feedback, and success stories from stage 5 flow back into the context of stage 2. The assets grow more complete with use, rather than starting to age the day they are built.
+- **Three entry points, by role**: data engineers work in [Datus-CLI](cli/introduction.md) to explore data and build assets; analysts ask through [Datus-Chat](web_chatbot/introduction.md) on the web, in Slack/Feishu, or in VS Code, and their feedback flows back into the agent; other agents and applications consume [Datus-API](API/introduction.md) over REST and MCP.
+- **The agent core**: [subagents](subagent/introduction.md) package curated context, tools, and rules for one business domain, [skills](skills/introduction.md) add packaged tools, and [plugins](plugin/introduction.md) connect third-party and in-house tools. Underneath sits the [context engine](knowledge_base/introduction.md): metadata, metrics, reference SQL, knowledge, and local files, retrieved through business-domain trees plus vector search, with [storage](configuration/storage.md) on embedded LanceDB and SQLite and PostgreSQL for teams that share context.
+- **Connected systems**: LLM providers, data warehouses, the [Dosi](https://dosi.datus.ai/) semantic layer, job schedulers, BI tools, and MCP servers and clients, all reached through adapters.
 
 ## Features
 
@@ -64,16 +55,24 @@ Curate context, tools, and rules for one business domain and package them as a [
 
 ![Open ecosystem: install a plugin, connect the stack you already run](assets/ecosystem_plugins.svg)
 
-## Architecture
+## How Datus works
 
-![Datus Architecture](assets/datus_architecture.svg)
+The quality of an agent's answers is set by the quality of the context it receives. Datus therefore concentrates on accumulating and reusing context; the diagram shows the full loop:
 
-The architecture has four layers, matching the diagram above:
+![How Datus works](assets/how_it_works.svg)
 
-- **Delivery**: six entry points (CLI, web chatbot, REST API, MCP, IM gateway, and VS Code) that share one agent backend.
-- **Intelligence**: the chat agent plans and reasons, subagents handle specialized tasks, skills and plugins add tools, and governance applies here. Interactive requests run in agentic mode, where the agent plans its own steps; benchmark and batch runs use [workflow mode](workflow/introduction.md), which executes a predefined plan of nodes.
-- **Semantic layer and context**: the asset layer the agent builds. One half is semantic models and metrics, executed by Dosi or MetricFlow; the other half is [context](knowledge_base/introduction.md): schema metadata, reference SQL, knowledge, and memory. Retrieval combines business-domain trees with vector search, and [storage](configuration/storage.md) defaults to embedded LanceDB and SQLite, with PostgreSQL as the option for teams that share context.
-- **Data and tool plane**: the databases, BI platforms, schedulers, and LLM providers reached through adapters.
+The diagram reads in two halves. The front half is the data engineer's work: exploring data, building context, and modeling semantics; its output is reusable assets. The back half is how the organization consumes those assets: subagents turn them into a service anyone can question.
+
+The handoff is not one-way either: every correction an analyst makes flows back, and the assets thicken with use.
+
+1. **Explore**: no groundwork required. Chat with your database in the [CLI](cli/chat_command.md), referencing tables with `@table` and files with `@file`, and get familiar with the data as you go.
+2. **Build context**: [`/init`](skills/init.md) scans the current project, and `/bootstrap` and [`/build-kb`](skills/build_kb.md) collect the knowledge scattered across schemas, SQL history, and documents into the [knowledge base](knowledge_base/introduction.md); this is the raw material for all the accuracy that follows.
+3. **Model semantics**: the [semantic modeling subagent](subagent/semantic_modeling.md) mines datasets, semantic models, and metrics from your schema and SQL history, validates them, and registers them in the semantic layer; business definitions gain a single, executable form.
+4. **Create subagents**: with `/agent`, package the curated context, tools, and rules into a [subagent for one business domain](subagent/customized_subagent.md); from this step on, the assets become a service others can use directly.
+5. **Deliver**: analysts ask where they already work, whether that is the browser, Slack/Feishu, or the IDE (see [interfaces](#interfaces)); [AskMetrics](subagent/ask_metrics.md) answers from metric definitions, and [reports and dashboards](subagent/gen_visual_report.md) are generated right in the conversation.
+6. **Measure**: [benchmark](benchmark/benchmark_manual.md) SQL accuracy on BIRD, Spider 2.0-Snow, or [your own datasets](configuration/benchmark.md), turning what context adds into a quantified number.
+
+Corrections, feedback, and success stories from stage 5 flow back into the context of stage 2. The assets grow more complete with use, rather than starting to age the day they are built.
 
 ## Getting started
 
@@ -123,7 +122,7 @@ All six entry points share one agent backend and one body of context: assets bui
 
     ---
 
-    How semantic models and metrics are generated, stored, and executed by Dosi or MetricFlow.
+    How semantic models and metrics are generated, stored, and executed by the Dosi engine.
 
     [:octicons-arrow-right-24: Semantic adapters](adapters/semantic_adapters.md)
 

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -4,24 +4,15 @@
 
 Datus 可以完成 SQL 编写与验证、语义模型与指标构建，以及数据管道、报告和看板的生成；每一次执行与修正都会沉淀为上下文，持续提升后续输出的准确性。整个体系在生态上保持开放与灵活：数据库、BI、调度、LLM 乃至团队自己的工具，都能以标准方式接入。
 
-## 工作方式
+## 架构
 
-Agent 回答的质量，取决于它拿到的上下文质量。Datus 因此把重点放在上下文的沉淀与复用上，下图是完整的循环：
+![Datus 架构](assets/datus_architecture.svg)
 
-![Datus 工作方式](assets/how_it_works.svg)
+整体架构自上而下分三段：谁在用、Agent 由什么组成、连接哪些系统，与上图对应：
 
-图分前后两半。前半段是数据工程师的工作：探索数据、构建上下文、完成语义建模，产出可复用的资产；后半段是组织对资产的消费：subagent 把它们变成任何人都能提问的服务。
-
-两半之间也不是单向交付：分析师的每次修正都会回流，资产随使用不断变厚。
-
-1. **探索**：不需要任何前置建设，在 [CLI](cli/chat_command.zh.md) 里直接与数据库对话，用 `@table` 引用表、`@file` 引用文件，边问边熟悉数据。
-2. **构建上下文**：[`/init`](skills/init.zh.md) 扫描当前项目，`/bootstrap` 和 [`/build-kb`](skills/build_kb.zh.md) 把散落在 schema、历史 SQL 和文档里的知识收进[知识库](knowledge_base/introduction.zh.md)；这是后面一切准确性的原料。
-3. **语义建模**：语义建模 subagent 从 schema 和历史 SQL 中挖掘数据集、[语义模型](knowledge_base/semantic_model.zh.md)与[指标](knowledge_base/metrics.zh.md)，校验后注册进语义层；业务口径从此有了唯一的、可执行的定义。
-4. **创建 Subagent**：用 `/agent` 把配好的上下文、工具和规则打包成[面向单个业务域的 subagent](subagent/customized_subagent.zh.md)；资产从这一步开始变成别人可以直接使用的服务。
-5. **交付**：分析师在自己习惯的地方提问，浏览器、Slack/飞书或 IDE 都可以(见[接入方式](#interfaces))；[AskMetrics](subagent/ask_metrics.zh.md) 依据指标定义回答，[报告和看板](subagent/gen_visual_report.zh.md)在对话里直接生成。
-6. **度量**：用 [benchmark](benchmark/benchmark_manual.zh.md) 在 BIRD、Spider 2.0-Snow 或[自定义数据集](configuration/benchmark.zh.md)上度量 SQL 准确率，把上下文带来的提升变成可量化的数字。
-
-第 5 步产生的修正、反馈和成功案例会回流进第 2 步的上下文。资产在使用中越来越完整，而不是建成之日就开始过时。
+- **按角色划分的三个入口**：数据工程师在 [Datus-CLI](cli/introduction.zh.md) 里探索数据、构建资产；分析师通过 [Datus-Chat](web_chatbot/introduction.zh.md)(Web、Slack/飞书、VS Code)提问，使用中的反馈会回流进 Agent；其他 Agent 和应用经 [Datus-API](API/introduction.zh.md)(REST、MCP)消费。
+- **Agent 核心**：[Subagent](subagent/introduction.zh.md) 为单个业务域打包配好的上下文、工具和规则，[Skill](skills/introduction.zh.md) 提供打包的扩展工具，[Plugin](plugin/introduction.zh.md) 接入第三方和公司内部工具；底座是[上下文引擎](knowledge_base/introduction.zh.md)：元数据、指标、参考 SQL、知识与本地文件，检索用业务域树加向量召回，[存储](configuration/storage.zh.md)默认内嵌 LanceDB 和 SQLite，团队共享上下文时可换 PostgreSQL。
+- **连接的系统**：LLM、数据仓库、[Dosi](https://dosi.datus.ai/) 语义层、作业调度、BI 工具与 MCP 服务端/客户端，均经适配器接入。
 
 ## 核心能力
 
@@ -64,16 +55,24 @@ Agent 读取数据库 schema 和历史 SQL，自动生成 [OSI](https://dosi.dat
 
 ![开放生态：安装 plugin，接入现有技术栈](assets/ecosystem_plugins.svg)
 
-## 架构
+## 工作方式
 
-![Datus 架构](assets/datus_architecture.svg)
+Agent 回答的质量，取决于它拿到的上下文质量。Datus 因此把重点放在上下文的沉淀与复用上，下图是完整的循环：
 
-整体架构自上而下分四层，与上图对应：
+![Datus 工作方式](assets/how_it_works.svg)
 
-- **交付层**：CLI、Web 聊天、REST API、MCP、IM 网关和 VS Code 六个入口，共享同一个 Agent 后端。
-- **智能层**：Chat Agent 负责规划和推理，subagent 处理专项任务，Skill 与 Plugin 提供扩展工具，治理机制也作用在这一层。交互请求走 Agentic 模式，步骤由 Agent 自行规划；benchmark 和批量任务走 [Workflow 模式](workflow/introduction.zh.md)，按预定义的节点计划执行。
-- **语义层与上下文**：Agent 构建的资产层。一半是语义模型与指标，由 Dosi 或 MetricFlow 执行；另一半是[上下文](knowledge_base/introduction.zh.md)，包括 schema 元数据、参考 SQL、知识与记忆。检索用业务域树加向量召回；[存储](configuration/storage.zh.md)默认是内嵌的 LanceDB 和 SQLite，团队需要共享上下文时可换成 PostgreSQL。
-- **数据与工具层**：经适配器连接的数据库、BI 平台、调度系统与 LLM 提供商。
+图分前后两半。前半段是数据工程师的工作：探索数据、构建上下文、完成语义建模，产出可复用的资产；后半段是组织对资产的消费：subagent 把它们变成任何人都能提问的服务。
+
+两半之间也不是单向交付：分析师的每次修正都会回流，资产随使用不断变厚。
+
+1. **探索**：不需要任何前置建设，在 [CLI](cli/chat_command.zh.md) 里直接与数据库对话，用 `@table` 引用表、`@file` 引用文件，边问边熟悉数据。
+2. **构建上下文**：[`/init`](skills/init.zh.md) 扫描当前项目，`/bootstrap` 和 [`/build-kb`](skills/build_kb.zh.md) 把散落在 schema、历史 SQL 和文档里的知识收进[知识库](knowledge_base/introduction.zh.md)；这是后面一切准确性的原料。
+3. **语义建模**：语义建模 subagent 从 schema 和历史 SQL 中挖掘数据集、[语义模型](knowledge_base/semantic_model.zh.md)与[指标](knowledge_base/metrics.zh.md)，校验后注册进语义层；业务口径从此有了唯一的、可执行的定义。
+4. **创建 Subagent**：用 `/agent` 把配好的上下文、工具和规则打包成[面向单个业务域的 subagent](subagent/customized_subagent.zh.md)；资产从这一步开始变成别人可以直接使用的服务。
+5. **交付**：分析师在自己习惯的地方提问，浏览器、Slack/飞书或 IDE 都可以(见[接入方式](#interfaces))；[AskMetrics](subagent/ask_metrics.zh.md) 依据指标定义回答，[报告和看板](subagent/gen_visual_report.zh.md)在对话里直接生成。
+6. **度量**：用 [benchmark](benchmark/benchmark_manual.zh.md) 在 BIRD、Spider 2.0-Snow 或[自定义数据集](configuration/benchmark.zh.md)上度量 SQL 准确率，把上下文带来的提升变成可量化的数字。
+
+第 5 步产生的修正、反馈和成功案例会回流进第 2 步的上下文。资产在使用中越来越完整，而不是建成之日就开始过时。
 
 ## 快速开始
 
@@ -123,7 +122,7 @@ curl -fsSL https://raw.githubusercontent.com/datus-ai/datus-agent/main/install.s
 
     ---
 
-    语义模型与指标如何生成、存储，并由 Dosi 或 MetricFlow 执行。
+    语义模型与指标如何生成、存储，并由 Dosi 引擎执行。
 
     [:octicons-arrow-right-24: 语义适配器](adapters/semantic_adapters.zh.md)
 


### PR DESCRIPTION
## Why

The architecture diagram still showed the old four-band layering, and both the README and the docs homepage described the semantic layer as "executed by Dosi or MetricFlow". With #1334 defaulting semantic modeling to Dosi, MetricFlow is no longer part of the story, and the team's new architecture sketch organizes the system by who uses it rather than by internal layers.

## Solution

- **Redraw `docs/assets/datus_architecture.svg`** following the role-led sketch: three entry points on top (Datus-CLI for data engineers, Datus-Chat for analysts with a feedback arrow flowing back into the agent, Datus-API for other agents over REST and MCP); the agent core in the middle holding Subagent, Skill, Plugin, and the context engine (metadata, metrics, reference SQL, knowledge, local files); connected systems at the bottom, with the Dosi semantic layer sitting alongside warehouses, job schedulers, BI tools, and MCPs. Light and dark themes both supported, as before.
- **Rewrite the architecture walkthrough** in the README and the docs homepage (both locales) to match the three-part diagram.
- **Make the architecture the first visual**: in the README it moves directly after the introduction and the how-it-works strip is removed (it had no accompanying walkthrough there, and the new diagram's feedback arrow carries the loop); on the docs homepage the architecture section swaps ahead of the loop walkthrough, which keeps the strip together with its six-step reading.
- **Retire MetricFlow** from the README and the homepage: every "Dosi or MetricFlow" becomes Dosi only, in the walkthroughs and the semantic-layer navigation card.

## Test Cases

Documentation-only change; no integration or nightly tests apply. Verified locally with `mkdocs build --strict` for both `DOCS_LOCALE=en` and `DOCS_LOCALE=zh` (zero warnings), a link-target existence check for every internal link and image reference, and light plus dark renders of the new diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
