### PR TITLE
[BugFix] Honour agentic_nodes[<name>].tools on chat nodes

### DIFF
--- a/datus/agent/node/base_artifact_ask_agentic_node.py
+++ b/datus/agent/node/base_artifact_ask_agentic_node.py
@@ -253,6 +253,12 @@ class BaseArtifactAskAgenticNode(ChatAgenticNode):
 
     # ── Tool whitelist enforcement (honor SubAgent.tools) ───────────────
 
+    #: The base class also reads ``tools``, but this node must not let it: the
+    #: whitelist below runs *after* the base builds every tool instance and
+    #: needs them all to exist (see the docstring). Two mechanisms narrowing on
+    #: the same field would leave `filesystem_func_tool` and friends None.
+    HONOURS_CONFIGURED_TOOLS: ClassVar[bool] = False
+
     def setup_tools(self) -> None:
         """Restrict the LLM-facing tool surface to the configured ``tools``.
 

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -367,25 +367,40 @@ class ChatAgenticNode(AgenticNode):
         super()._ensure_web_tools_in_tools()
 
     def _rebuild_tools(self):
-        """Rebuild the tools list with current tool instances including skills."""
+        """Rebuild the tools list with current tool instances including skills.
+
+        Every configurable family is re-checked against ``tools`` here, not just
+        tested for "did setup_tools leave an instance behind". Relying on the
+        attribute being None makes the exclusion depend on nothing else ever
+        populating it — an assumption that has already failed twice in this
+        class, once because the base re-creates the memory tool when it finds
+        None, and once because platform docs were mounted after the rebuild that
+        was supposed to own them. Asking the config makes the exclusion a
+        property of the node instead of an accident of ordering.
+        """
+        selected = self._selected_tool_families()
+
+        def enabled(family: str) -> bool:
+            return self._family_enabled(selected, family)
+
         self.tools = []
-        if self.db_func_tool:
+        if self.db_func_tool and enabled("db_tools"):
             self.tools.extend(self.db_func_tool.available_tools())
-        if self.context_search_tools:
+        if self.context_search_tools and enabled("context_search_tools"):
             self.tools.extend(self.context_search_tools.available_tools())
-        if self.reference_template_tools:
+        if self.reference_template_tools and enabled("reference_template_tools"):
             self.tools.extend(self.reference_template_tools.available_tools())
-        if self.date_parsing_tools:
+        if self.date_parsing_tools and enabled("date_parsing_tools"):
             self.tools.extend(self.date_parsing_tools.available_tools())
-        if self.filesystem_func_tool:
+        if self.filesystem_func_tool and enabled("filesystem_tools"):
             self.tools.extend(self.filesystem_func_tool.available_tools())
-        if self.memory_func_tool:
+        if self.memory_func_tool and enabled("memory_tools"):
             self.tools.extend(self.memory_func_tool.available_tools())
-        if self.bash_tool:
+        if self.bash_tool and enabled("bash_tools"):
             self.tools.extend(self.bash_tool.available_tools())
-        if self.skill_func_tool:
+        if self.skill_func_tool and enabled("skills"):
             self.tools.extend(self.skill_func_tool.available_tools())
-        if self.sub_agent_task_tool:
+        if self.sub_agent_task_tool and enabled("sub_agent_tools"):
             self.tools.extend(self.sub_agent_task_tool.available_tools())
         if self.ask_user_tool:
             self.tools.extend(self.ask_user_tool.available_tools())
@@ -401,7 +416,7 @@ class ChatAgenticNode(AgenticNode):
         # silently dropped platform docs from the LLM's surface mid-session.
         # Gated like the rest: a node that excluded the family must not get it
         # back on the next rebuild.
-        if self._platform_doc_tool and self._family_enabled(self._selected_tool_families(), "platform_doc_tools"):
+        if self._platform_doc_tool and enabled("platform_doc_tools"):
             self.tools.extend(self._platform_doc_tool.available_tools())
         # Plan-mode tools (confirm_plan + todo_*) for main agents; no-op for sub-agents.
         self._register_plan_mode_tools()

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -10,7 +10,7 @@ chat interactions with markdown output, database/filesystem tool support,
 skills, and permissions. This node is fully independent from GenSQLAgenticNode.
 """
 
-from typing import Dict, Literal, Optional
+from typing import ClassVar, Dict, Literal, Optional
 
 from datus.agent.node.agentic_node import AgenticNode
 from datus.agent.node.gen_sql_agentic_node import prepare_template_context
@@ -127,36 +127,108 @@ class ChatAgenticNode(AgenticNode):
 
     # ── Tool Setup ──────────────────────────────────────────────────────
 
+    #: Whether ``agentic_nodes[<name>].tools`` narrows what this node builds.
+    #:
+    #: True for a plain chat node. The ask_* subclasses set it False: they run
+    #: their own whitelist over ``self.tools`` *after* this base setup, and that
+    #: design depends on every tool instance existing — the artifact-anchored
+    #: filesystem instance in particular is infrastructure they use whether or
+    #: not ``filesystem_tools`` is exposed to the LLM. Gating construction here
+    #: would leave those attributes None and break the subclass, so the two
+    #: mechanisms must not both act on the same field.
+    HONOURS_CONFIGURED_TOOLS: ClassVar[bool] = True
+
+    def _selected_tool_families(self) -> Optional[set]:
+        """Tool families this node may mount, or ``None`` for "all of them".
+
+        ``None`` is the default and means today's behaviour verbatim: a chat
+        node with no ``tools`` key mounts every family, and the overwhelming
+        majority of chat nodes have no such key. Narrowing that default would be
+        a silent capability regression, so absence must never be read as "none".
+
+        A configured value is a comma-separated list of the same family patterns
+        the other agentic nodes accept (``db_tools``, ``db_tools.*``, and
+        ``db_tools.execute_sql``-style entries all select the ``db_tools``
+        family). Family granularity is what this node acts on; a per-tool suffix
+        still enables its family rather than being dropped on the floor, since
+        dropping it would quietly remove a tool the operator asked for.
+        """
+        if not self.HONOURS_CONFIGURED_TOOLS:
+            return None
+        raw = self.node_config.get("tools") if self.node_config else None
+        if not raw:
+            return None
+        families = set()
+        for pattern in str(raw).split(","):
+            pattern = pattern.strip()
+            if not pattern:
+                continue
+            families.add(pattern.split(".", 1)[0])
+        return families or None
+
+    @staticmethod
+    def _family_enabled(selected: Optional[set], family: str) -> bool:
+        return selected is None or family in selected
+
     def setup_tools(self):
-        """Initialize all tools, binding the DB tool to the active database (if any)."""
+        """Initialize tools, binding the DB tool to the active database (if any).
+
+        Honours ``agentic_nodes[<name>].tools`` the way the five other agentic
+        node classes do. Chat was the one class that ignored it, which mattered
+        beyond tidiness: a host publishing a chat sub-agent strips write-capable
+        tools from that list, and here the strip had no effect — the model was
+        still shown tools it would then be denied at the permission layer.
+        Nothing became writable (the permission profile and the database grants
+        both still refused), but a layer of defence was missing and the denials
+        surfaced as confusing mid-conversation errors.
+        """
+        selected = self._selected_tool_families()
         node_name = self.get_node_name()
-        self.db_func_tool = DBFuncTool(
-            agent_config=self.agent_config,
-            sub_agent_name=node_name,
-            default_database=getattr(self, "active_database", "") or None,
-            read_only=self._db_read_only,
-            # Same anchor the filesystem tools use, so a path the model got back
-            # from glob resolves identically inside load_file_as_table.
-            filesystem_root=self._resolve_workspace_root(),
-        )
-        self._setup_context_search_tools()
-        self._setup_reference_template_tools()
-        self._setup_date_parsing_tools()
-        self._setup_filesystem_tools()
-        self._setup_memory_tools()
-        # self.bash_tool was created in AgenticNode.__init__; just surface its
-        # tool in this node's eager tools list (rebuild_tools also re-appends).
-        if self.bash_tool:
-            self.tools.extend(self.bash_tool.available_tools())
-        self._setup_skill_tools()
-        self._setup_sub_agent_task_tool()
+        if self._family_enabled(selected, "db_tools"):
+            self.db_func_tool = DBFuncTool(
+                agent_config=self.agent_config,
+                sub_agent_name=node_name,
+                default_database=getattr(self, "active_database", "") or None,
+                read_only=self._db_read_only,
+                # Same anchor the filesystem tools use, so a path the model got back
+                # from glob resolves identically inside load_file_as_table.
+                filesystem_root=self._resolve_workspace_root(),
+            )
+        if self._family_enabled(selected, "context_search_tools"):
+            self._setup_context_search_tools()
+        if self._family_enabled(selected, "reference_template_tools"):
+            self._setup_reference_template_tools()
+        if self._family_enabled(selected, "date_parsing_tools"):
+            self._setup_date_parsing_tools()
+        if self._family_enabled(selected, "filesystem_tools"):
+            self._setup_filesystem_tools()
+        if self._family_enabled(selected, "memory_tools"):
+            self._setup_memory_tools()
+        # self.bash_tool was created in AgenticNode.__init__, so leaving it in
+        # place is what mounts it — dropping the reference is the only way to
+        # exclude it, and _rebuild_tools re-adds it from the attribute on every
+        # rebuild otherwise.
+        if self._family_enabled(selected, "bash_tools"):
+            if self.bash_tool:
+                self.tools.extend(self.bash_tool.available_tools())
+        else:
+            self.bash_tool = None
+        if self._family_enabled(selected, "skills"):
+            self._setup_skill_tools()
+        if self._family_enabled(selected, "sub_agent_tools"):
+            self._setup_sub_agent_task_tool()
         # Setup ask_user tool for clarification questions (interactive mode only)
+        #
+        # From here down is deliberately ungated: asking the user a question and
+        # reporting a result to an orchestrator are how the node converses and
+        # terminates, not data access an operator would want to scope away.
         if self.execution_mode == "interactive":
             self._setup_ask_user_tool()
         # No-op unless the request declared an orchestrator origin.
         self._setup_task_result_tool()
         self._rebuild_tools()
-        self._setup_platform_doc_tools()
+        if self._family_enabled(selected, "platform_doc_tools"):
+            self._setup_platform_doc_tools()
 
         # Populate the shared tool_registry eagerly so consumers that inspect
         # categories before the first LLM turn (tests, ``apply_proxy_tools``'

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -395,6 +395,14 @@ class ChatAgenticNode(AgenticNode):
         # dispatcher's only structured way to learn how the run ended.
         if getattr(self, "task_result_tool", None):
             self.tools.extend(self.task_result_tool.available_tools())
+        # Rebuilt here rather than only in setup_tools, where it is mounted
+        # *after* the initial rebuild and so was never re-added by a later one.
+        # `_update_database_connection` rebuilds on a task-database switch, which
+        # silently dropped platform docs from the LLM's surface mid-session.
+        # Gated like the rest: a node that excluded the family must not get it
+        # back on the next rebuild.
+        if self._platform_doc_tool and self._family_enabled(self._selected_tool_families(), "platform_doc_tools"):
+            self.tools.extend(self._platform_doc_tool.available_tools())
         # Plan-mode tools (confirm_plan + todo_*) for main agents; no-op for sub-agents.
         self._register_plan_mode_tools()
         # The rebuilt list holds fresh, unwrapped FunctionTool instances —

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -326,6 +326,46 @@ class ChatAgenticNode(AgenticNode):
         except Exception as e:
             logger.error(f"Failed to setup skill tools: {e}")
 
+    # ── Lazy re-injection gates ────────────────────────────────────────
+    #
+    # `AgenticNode._ensure_lazy_tools_mounted` re-adds bash, skills, memory and
+    # web on every prompt build and on a snapshot-cache hit — AFTER setup_tools
+    # already decided what this node may have. Without these gates the exclusion
+    # holds only until the first prompt is built, and memory is the worst case:
+    # the base *re-creates* the instance when it finds None, so clearing it in
+    # setup_tools is not enough on its own. The ask_* subclass hit the same
+    # bypass and gates it the same way.
+
+    def _ensure_bash_tool_in_tools(self) -> None:
+        if not self._family_enabled(self._selected_tool_families(), "bash_tools"):
+            return
+        super()._ensure_bash_tool_in_tools()
+
+    def _ensure_skill_tools_in_tools(self) -> None:
+        if not self._family_enabled(self._selected_tool_families(), "skills"):
+            return
+        super()._ensure_skill_tools_in_tools()
+
+    def _ensure_memory_tool_in_tools(self) -> None:
+        if not self._family_enabled(self._selected_tool_families(), "memory_tools"):
+            return
+        super()._ensure_memory_tool_in_tools()
+
+    def _ensure_web_tools_in_tools(self) -> None:
+        selected = self._selected_tool_families()
+        if not self._family_enabled(selected, "web_tool"):
+            # Scrub rather than just skip: the base resolves provider-native
+            # builtins too, and a stale local web tool left in the list would
+            # still be offered to the model.
+            from datus.tools.func_tool.web_tool import WebTool
+
+            web_names = set(WebTool.all_tools_name())
+            self.tools = [t for t in (self.tools or []) if getattr(t, "name", None) not in web_names]
+            self._builtin_web_tools = {"web_search": False, "web_fetch": False}
+            self._web_tool = None
+            return
+        super()._ensure_web_tools_in_tools()
+
     def _rebuild_tools(self):
         """Rebuild the tools list with current tool instances including skills."""
         self.tools = []

--- a/datus/agent/node/chat_agentic_node.py
+++ b/datus/agent/node/chat_agentic_node.py
@@ -226,9 +226,13 @@ class ChatAgenticNode(AgenticNode):
             self._setup_ask_user_tool()
         # No-op unless the request declared an orchestrator origin.
         self._setup_task_result_tool()
-        self._rebuild_tools()
+        # Before the rebuild, not after: the rebuild now mounts this group from
+        # the attribute, so building it afterwards appended a second copy of
+        # every name on the second `setup_tools()` — which the CLI does after a
+        # datasource change. Building first lets the rebuild own the mounting.
         if self._family_enabled(selected, "platform_doc_tools"):
             self._setup_platform_doc_tools()
+        self._rebuild_tools()
 
         # Populate the shared tool_registry eagerly so consumers that inspect
         # categories before the first LLM turn (tests, ``apply_proxy_tools``'

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -2190,3 +2190,56 @@ class TestChatAgenticNodeHonoursConfiguredTools:
         names = {tool.name for tool in node.tools}
         assert "add_memory" in names
         assert "bash" not in names
+
+    @staticmethod
+    def _stub_platform_doc(node, name="search_document"):
+        """Give the node a platform-doc tool with a real, named tool in it.
+
+        The genuine `PlatformDocSearchTool` builds fine in tests but exposes
+        nothing — there is no indexed docstore for the fixture project — so
+        asserting against its (empty) tool names passes whether or not the
+        rebuild re-adds it. Stub it so the assertion has something to be wrong
+        about.
+        """
+        stub = MagicMock()
+        tool = MagicMock()
+        tool.name = name
+        stub.available_tools.return_value = [tool]
+        node._platform_doc_tool = stub
+        return name
+
+    def test_platform_doc_tools_survive_a_rebuild(self, real_agent_config, mock_llm_create):
+        """`_setup_platform_doc_tools` mounts *after* the initial
+        `_rebuild_tools`, and the rebuild never re-added it — so a task-database
+        switch, which rebuilds, silently dropped platform docs from the LLM's
+        surface mid-session.
+        """
+        node = self._node(real_agent_config)
+        name = self._stub_platform_doc(node)
+
+        node._rebuild_tools()
+
+        assert name in {tool.name for tool in node.tools}
+
+    def test_the_rebuild_does_not_duplicate_platform_doc_tools(self, real_agent_config, mock_llm_create):
+        """Setup mounts it once after the first rebuild; later rebuilds mount it
+        from the attribute. Neither path may double-count."""
+        node = self._node(real_agent_config)
+        name = self._stub_platform_doc(node)
+
+        node._rebuild_tools()
+        node._rebuild_tools()
+
+        assert [tool.name for tool in node.tools].count(name) == 1
+
+    def test_an_excluded_platform_doc_family_stays_out_across_a_rebuild(self, real_agent_config, mock_llm_create):
+        """The re-add is gated like everything else — otherwise the rebuild
+        would hand the family back to a node that excluded it."""
+        node = self._node(real_agent_config, tools="db_tools.*")
+        assert node._platform_doc_tool is None
+        # Even if something later populated the attribute, the gate holds.
+        name = self._stub_platform_doc(node)
+
+        node._rebuild_tools()
+
+        assert name not in {tool.name for tool in node.tools}

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -2178,7 +2178,11 @@ class TestChatAgenticNodeHonoursConfiguredTools:
         node._ensure_lazy_tools_mounted()
 
         names = {tool.name for tool in node.tools}
-        for expected in ("add_memory", "bash", "load_skill"):
+        # `web_fetch` included deliberately: web is gated here too, so a
+        # regression that stops mounting it for an unconfigured node would
+        # otherwise pass — the exclusion test only proves configured nodes do
+        # not receive it.
+        for expected in ("add_memory", "bash", "load_skill", "web_fetch"):
             assert expected in names
 
     def test_a_selected_family_survives_the_lazy_mount(self, real_agent_config, mock_llm_create):
@@ -2191,22 +2195,37 @@ class TestChatAgenticNodeHonoursConfiguredTools:
         assert "add_memory" in names
         assert "bash" not in names
 
-    @staticmethod
-    def _stub_platform_doc(node, name="search_document"):
-        """Give the node a platform-doc tool with a real, named tool in it.
+    #: The genuine `PlatformDocSearchTool` builds fine in tests but exposes
+    #: nothing — there is no indexed docstore for the fixture project — so
+    #: assertions about its tool names pass whether or not the code under test
+    #: mounts it. These tests patch the constructor so the group has a name to
+    #: be wrong about, which is also what a deployment with indexed docs looks
+    #: like.
+    _DOC_TOOL_NAME = "search_document"
 
-        The genuine `PlatformDocSearchTool` builds fine in tests but exposes
-        nothing — there is no indexed docstore for the fixture project — so
-        asserting against its (empty) tool names passes whether or not the
-        rebuild re-adds it. Stub it so the assertion has something to be wrong
-        about.
-        """
+    @classmethod
+    def _doc_tool_stub(cls, *_args, **_kwargs):
         stub = MagicMock()
         tool = MagicMock()
-        tool.name = name
+        tool.name = cls._DOC_TOOL_NAME
         stub.available_tools.return_value = [tool]
-        node._platform_doc_tool = stub
-        return name
+        return stub
+
+    @classmethod
+    def _patch_platform_doc(cls):
+        """Patch the constructor, so a node built inside this context has a
+        platform-doc group with a real name — what a deployment with indexed
+        docs looks like."""
+        return patch(
+            "datus.agent.node.chat_agentic_node.PlatformDocSearchTool",
+            side_effect=cls._doc_tool_stub,
+        )
+
+    @classmethod
+    def _stub_platform_doc(cls, node):
+        """Attach a non-empty platform-doc group to an already-built node."""
+        node._platform_doc_tool = cls._doc_tool_stub()
+        return cls._DOC_TOOL_NAME
 
     def test_platform_doc_tools_survive_a_rebuild(self, real_agent_config, mock_llm_create):
         """`_setup_platform_doc_tools` mounts *after* the initial
@@ -2276,3 +2295,20 @@ class TestChatAgenticNodeHonoursConfiguredTools:
         node._rebuild_tools()
 
         assert tool_name not in {t.name for t in node.tools}
+
+    def test_a_second_setup_tools_does_not_duplicate_platform_doc_tools(self, real_agent_config, mock_llm_create):
+        """The CLI calls `setup_tools()` again after a datasource change.
+
+        Once the rebuild started mounting this group from the attribute,
+        building it *after* the rebuild appended a second copy of every name on
+        that second call. The fixture's real doc tool exposes nothing, so the
+        duplication is invisible without patching the constructor — the same
+        emptiness that made an earlier version of these tests vacuous.
+        """
+        with self._patch_platform_doc():
+            node = self._node(real_agent_config)
+            assert [t.name for t in node.tools].count(self._DOC_TOOL_NAME) == 1
+
+            node.setup_tools()
+
+            assert [t.name for t in node.tools].count(self._DOC_TOOL_NAME) == 1

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -2243,3 +2243,36 @@ class TestChatAgenticNodeHonoursConfiguredTools:
         node._rebuild_tools()
 
         assert name not in {tool.name for tool in node.tools}
+
+    @pytest.mark.parametrize(
+        ("attribute", "family", "tool_name"),
+        [
+            ("skill_func_tool", "skills", "load_skill"),
+            ("memory_func_tool", "memory_tools", "add_memory"),
+            ("filesystem_func_tool", "filesystem_tools", "read_file"),
+            ("bash_tool", "bash_tools", "bash"),
+        ],
+    )
+    def test_a_populated_instance_cannot_reinstate_an_excluded_family(
+        self, real_agent_config, mock_llm_create, attribute, family, tool_name
+    ):
+        """`_rebuild_tools` asks the config, not just whether the attribute is set.
+
+        Testing "did setup_tools leave it None" would make the exclusion depend
+        on nothing else ever populating the attribute — an assumption that has
+        already failed twice here: the base re-creates the memory tool when it
+        finds None, and platform docs were mounted after the rebuild meant to
+        own them. This pins the stronger property: whatever populates the
+        instance, an excluded family stays out.
+        """
+        node = self._node(real_agent_config, tools="db_tools.*")
+
+        stub = MagicMock()
+        tool = MagicMock()
+        tool.name = tool_name
+        stub.available_tools.return_value = [tool]
+        setattr(node, attribute, stub)
+
+        node._rebuild_tools()
+
+        assert tool_name not in {t.name for t in node.tools}

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -1984,3 +1984,169 @@ class TestChatAgenticNodeNoSchedulerTools:
         assert tool_names.isdisjoint(scheduler_tool_names), (
             f"Chat node still has scheduler tools: {tool_names & scheduler_tool_names}"
         )
+
+
+# ===========================================================================
+# agentic_nodes[<name>].tools
+# ===========================================================================
+
+
+class TestChatAgenticNodeHonoursConfiguredTools:
+    """`ChatAgenticNode` was the one agentic node class that ignored `tools`.
+
+    The five others (gen_sql, gen_report, ask_metrics, and the two artifact
+    bases) read `node_config.get("tools")` and build only what it names. Chat
+    mounted every family unconditionally, so a host that publishes a chat
+    sub-agent and strips write-capable tools from that list got no effect from
+    the strip: the model was still shown tools the permission layer would then
+    deny.
+    """
+
+    @staticmethod
+    def _node(real_agent_config, tools=None):
+        """Build a chat node with `tools` set to *tools*, or removed entirely.
+
+        The shared fixture's `chat` entry declares a narrow `tools` list, so a
+        test for the no-key default has to delete the key rather than just leave
+        the argument out.
+        """
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        chat_entry = dict((real_agent_config.agentic_nodes or {}).get("chat") or {})
+        if tools is None:
+            chat_entry.pop("tools", None)
+        else:
+            chat_entry["tools"] = tools
+        real_agent_config.agentic_nodes = {
+            **(real_agent_config.agentic_nodes or {}),
+            "chat": chat_entry,
+        }
+        return ChatAgenticNode(
+            node_id="test_tools",
+            description="Test configured tools",
+            node_type=NodeType.TYPE_CHAT,
+            agent_config=real_agent_config,
+        )
+
+    @staticmethod
+    def _families(node):
+        """The tool families actually mounted, by instance attribute."""
+        return {
+            "db_tools": node.db_func_tool is not None,
+            "context_search_tools": node.context_search_tools is not None,
+            "reference_template_tools": node.reference_template_tools is not None,
+            "date_parsing_tools": node.date_parsing_tools is not None,
+            "filesystem_tools": node.filesystem_func_tool is not None,
+            "memory_tools": node.memory_func_tool is not None,
+            "bash_tools": node.bash_tool is not None,
+        }
+
+    def test_no_tools_key_mounts_everything(self, real_agent_config, mock_llm_create):
+        """The default must not change. Chat nodes without a `tools` key are the
+        overwhelming majority, so narrowing this would be a silent capability
+        regression rather than a policy change anyone asked for."""
+        node = self._node(real_agent_config)
+
+        families = self._families(node)
+        assert families["db_tools"] is True
+        assert families["filesystem_tools"] is True
+        assert families["bash_tools"] is True
+
+    def test_an_empty_tools_value_is_treated_as_absent(self, real_agent_config, mock_llm_create):
+        """`tools: ""` is a missing value, not a request for no tools — reading
+        it as "none" would strip a node its operator never meant to strip."""
+        node = self._node(real_agent_config, tools="")
+
+        assert self._families(node) == self._families(self._node(real_agent_config))
+
+    def test_a_narrow_list_excludes_the_other_families(self, real_agent_config, mock_llm_create):
+        """The acceptance case: a db-only chat node must not carry filesystem or
+        bash tools."""
+        node = self._node(real_agent_config, tools="db_tools.*")
+
+        families = self._families(node)
+        assert families["db_tools"] is True
+        assert families["filesystem_tools"] is False
+        assert families["bash_tools"] is False
+        assert families["context_search_tools"] is False
+
+    def test_excluded_families_stay_out_of_available_tools(self, real_agent_config, mock_llm_create):
+        """Instance attributes are the mechanism; the tool list the LLM sees is
+        the thing that actually matters."""
+        node = self._node(real_agent_config, tools="db_tools.*")
+
+        names = {tool.name for tool in node.tools}
+        assert names, "a db-only node should still expose the db tools"
+        for excluded in ("read_file", "write_file", "glob", "bash"):
+            assert excluded not in names
+
+    def test_bash_is_dropped_even_though_init_built_it(self, real_agent_config, mock_llm_create):
+        """`bash_tool` is created in `AgenticNode.__init__`, not in
+        `setup_tools`, and `_rebuild_tools` re-adds it from the attribute on
+        every rebuild. Clearing the attribute is the only thing that keeps it
+        out — leaving it set would let a later rebuild resurrect it."""
+        node = self._node(real_agent_config, tools="db_tools.*")
+
+        assert node.bash_tool is None
+
+        node._rebuild_tools()
+
+        assert all(tool.name != "bash" for tool in node.tools)
+
+    def test_several_families_can_be_selected(self, real_agent_config, mock_llm_create):
+        node = self._node(real_agent_config, tools="db_tools.*, filesystem_tools.*")
+
+        families = self._families(node)
+        assert families["db_tools"] is True
+        assert families["filesystem_tools"] is True
+        assert families["bash_tools"] is False
+
+    def test_a_per_tool_pattern_still_enables_its_family(self, real_agent_config, mock_llm_create):
+        """Other node classes accept `context_search_tools.list_subject_tree`.
+        This node acts at family granularity, so the suffix selects the family
+        rather than being dropped — dropping it would silently remove a tool the
+        operator explicitly asked for."""
+        node = self._node(real_agent_config, tools="db_tools.execute_sql")
+
+        families = self._families(node)
+        assert families["db_tools"] is True
+        assert families["filesystem_tools"] is False
+
+    def test_an_unknown_family_selects_nothing_rather_than_everything(self, real_agent_config, mock_llm_create):
+        """Fail closed. A typo that fell back to "all tools" would hand a
+        published sub-agent the full surface its author meant to narrow."""
+        node = self._node(real_agent_config, tools="no_such_tools.*")
+
+        families = self._families(node)
+        assert families["db_tools"] is False
+        assert families["filesystem_tools"] is False
+        assert families["bash_tools"] is False
+
+    def test_the_ask_subclasses_opt_out(self):
+        """`BaseArtifactAskAgenticNode` inherits this setup but runs its own
+        whitelist over `self.tools` *after* it, and that design needs every tool
+        instance to exist — the artifact-anchored filesystem instance is
+        infrastructure it uses whether or not `filesystem_tools` is exposed.
+
+        Letting both mechanisms narrow on the same field left those attributes
+        None and broke the subclass, which is why the opt-out is explicit rather
+        than implied by overriding `setup_tools`.
+        """
+        from datus.agent.node.base_artifact_ask_agentic_node import BaseArtifactAskAgenticNode
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        assert ChatAgenticNode.HONOURS_CONFIGURED_TOOLS is True
+        assert BaseArtifactAskAgenticNode.HONOURS_CONFIGURED_TOOLS is False
+
+    def test_opting_out_ignores_a_configured_list(self, real_agent_config, mock_llm_create):
+        """The flag, not the class name, is what disables the narrowing."""
+        from datus.agent.node.chat_agentic_node import ChatAgenticNode
+
+        node = self._node(real_agent_config, tools="db_tools.*")
+        assert node.filesystem_func_tool is None
+
+        with patch.object(ChatAgenticNode, "HONOURS_CONFIGURED_TOOLS", False):
+            unrestricted = self._node(real_agent_config, tools="db_tools.*")
+
+        # The list is ignored entirely, not partly: same surface as no key at all.
+        assert self._families(unrestricted) == self._families(self._node(real_agent_config))

--- a/tests/unit_tests/agent/node/test_chat_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_chat_agentic_node.py
@@ -2150,3 +2150,43 @@ class TestChatAgenticNodeHonoursConfiguredTools:
 
         # The list is ignored entirely, not partly: same surface as no key at all.
         assert self._families(unrestricted) == self._families(self._node(real_agent_config))
+
+    def test_exclusions_survive_the_lazy_prompt_build_mount(self, real_agent_config, mock_llm_create):
+        """`AgenticNode._ensure_lazy_tools_mounted` re-adds bash, skills, memory
+        and web on every prompt build and on a snapshot-cache hit — after
+        `setup_tools` already decided what this node may have.
+
+        Without gating those too, the exclusion holds only until the first
+        prompt is built. Memory is the worst case: the base *re-creates* the
+        instance when it finds None, so clearing it in `setup_tools` does not
+        survive on its own.
+        """
+        node = self._node(real_agent_config, tools="db_tools.*")
+
+        node._ensure_lazy_tools_mounted()
+
+        names = {tool.name for tool in node.tools}
+        for resurrected in ("add_memory", "edit_memory", "web_fetch", "bash", "load_skill"):
+            assert resurrected not in names
+
+    def test_the_default_still_gets_the_lazy_tools(self, real_agent_config, mock_llm_create):
+        """The gates must not cost an ungated node its lazily mounted tools —
+        they are how a normal chat node gets bash, skills, memory and web at
+        all."""
+        node = self._node(real_agent_config)
+
+        node._ensure_lazy_tools_mounted()
+
+        names = {tool.name for tool in node.tools}
+        for expected in ("add_memory", "bash", "load_skill"):
+            assert expected in names
+
+    def test_a_selected_family_survives_the_lazy_mount(self, real_agent_config, mock_llm_create):
+        """Gating is per family, not a blanket "narrowed nodes get nothing lazy"."""
+        node = self._node(real_agent_config, tools="db_tools.*, memory_tools.*")
+
+        node._ensure_lazy_tools_mounted()
+
+        names = {tool.name for tool in node.tools}
+        assert "add_memory" in names
+        assert "bash" not in names

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -269,7 +269,13 @@ def _create_real_agent_config(
             },
             "chat": {
                 "system_prompt": "chat",
-                "tools": "db_tools.*,context_search_tools.*",
+                # No `tools`: a chat node is full-featured by default, which is
+                # what the tests below assert. The key used to sit here carrying
+                # "db_tools.*,context_search_tools.*", but ChatAgenticNode
+                # ignored it entirely, so it described a narrowing that never
+                # happened. Now that the node honours the field, leaving the
+                # dead value in place would silently strip filesystem, bash,
+                # skills and date parsing from every chat node in the suite.
                 "max_turns": 5,
             },
             "gen_sql": {


### PR DESCRIPTION
## Why

Five agentic node classes read `node_config.get("tools")` and build only the families it names — `gen_sql`, `gen_report`, `ask_metrics`, and the two artifact bases. `ChatAgenticNode` was the sixth, and read it nowhere:

```console
$ grep -c 'node_config.get("tools")' datus/agent/node/chat_agentic_node.py
0
```

`setup_tools()` mounted db, context search, reference template, date parsing, filesystem, memory, bash, skills and sub-agent task unconditionally, then `_rebuild_tools()` assembled `self.tools` from those instances — never consulting `node_config`.

This matters past tidiness. A host publishing a chat sub-agent strips write-capable tools from that list, and the strip had **no effect** here, so the model was shown tools the permission layer would then refuse.

**Severity: not writable.** The permission profile still defaults to DENY and the database grants are still read-only, so writes were still blocked. What was missing is a layer of defence, and the observable symptom is an LLM seeing and calling tools it then gets denied — permission refusals surfacing mid-conversation. `chat` is also the most natural type for a published question-answering agent, so it was the worst class to be missing it.

## Solution

`setup_tools()` now gates each family on the configured list. Absent or empty `tools` keeps today's full surface — that default is the whole risk here, since chat nodes without the key are the common case and reading absence as "nothing" would be a silent capability regression.

Gating each family in place, rather than branching into a separate "narrow" path, keeps the call order single-sourced so the default cannot drift away from what it is today.

Three things the field's history and this class's shape made necessary:

**The shared test fixture carried a dead `tools` value.** Its `chat` entry declared `tools: "db_tools.*,context_search_tools.*"` — written while the field was ignored, describing a narrowing that never happened. Honouring it would have stripped filesystem, bash, skills and date parsing from every chat node in the suite. Removed as the dead config it was, after which six existing tests that assert a chat node has those tools pass **untouched**. Real deployments carrying such a key are in the same position — see Compatibility below.

**`BaseArtifactAskAgenticNode` extends this class** and runs its own whitelist over `self.tools` *after* the base setup. Its docstring is explicit that this depends on every tool instance existing — it calls the artifact-anchored filesystem instance infrastructure it uses whether or not `filesystem_tools` is exposed to the LLM. Two mechanisms narrowing the same field left those attributes `None` and broke it. The opt-out is therefore an explicit `HONOURS_CONFIGURED_TOOLS` ClassVar rather than something implied by overriding `setup_tools`, so the interaction is visible at both ends.

**Bash needs its reference cleared, not its construction skipped.** `AgenticNode.__init__` builds it, and `_rebuild_tools` re-adds it from the attribute on every rebuild, so leaving the reference set would let a later rebuild (task-database switch, skill reload) resurrect a tool the operator excluded.

**The exclusion has to cover the lazy path too.** `AgenticNode._ensure_lazy_tools_mounted` re-adds bash, skills, memory and web on every prompt build and on a snapshot-cache hit — *after* `setup_tools` has decided what the node may have. Gating only `setup_tools` made the exclusion hold until the first prompt was built and then quietly stop holding:

```
tools: "db_tools.*"
  after setup_tools : execute_sql, list_tables, describe_table, ...
  after lazy mount  : ... + add_memory, edit_memory, web_fetch
```

bash and skills survive because the base guards those on the instance being set. Memory does not — the base *re-creates* it when it finds None, so clearing the attribute achieves nothing there. Web was never built in `setup_tools` at all. All four injectors are now gated the same way `BaseArtifactAskAgenticNode` already gates three of them; its docstrings describe this exact bypass. Web is scrubbed rather than skipped, since the base also resolves provider-native builtins.

A per-tool pattern like `db_tools.execute_sql` selects its family rather than being dropped — dropping it would silently remove a tool the operator explicitly asked for. An unrecognised family selects nothing rather than falling back to everything, so a typo cannot hand a published sub-agent the full surface its author meant to narrow.

## Test Cases

`tests/unit_tests/agent/node/test_chat_agentic_node.py::TestChatAgenticNodeHonoursConfiguredTools`, covering the TODO's acceptance criteria plus the two interactions above:

- **The default is unchanged** — a node with no `tools` key mounts every family, and `tools: ""` is treated as absent rather than as "none". Both compare the whole family map against a no-key node, so a partial regression fails too.
- **A narrow list excludes the rest** — `tools: "db_tools.*"` yields no filesystem, bash or context search, and none of `read_file` / `write_file` / `glob` / `bash` appear in the tool list the LLM sees.
- **Bash stays out across a rebuild** — asserts the attribute is cleared and that `_rebuild_tools()` does not resurrect it.
- **Multiple families**, a **per-tool pattern** enabling its family, and an **unknown family** selecting nothing.
- **The ask_* opt-out** — both that the flag differs between the classes and that patching it back on restores the full surface, so the flag rather than the class name is what disables the narrowing.
- **The exclusion survives `_ensure_lazy_tools_mounted()`** — the case the first round of tests missed by asserting straight after construction, which is the one moment the bypass is invisible. Also that an ungated node still *receives* its lazy tools, and that a selectively gated one keeps the families it did ask for.

The six pre-existing `TestChatAgenticNodeToolSetup` / `TestChatAgenticNodeSystemPrompt` tests are unmodified; removing the fixture's dead `tools` key was what kept them green, which is itself the evidence that the default is preserved.

No integration or nightly tests: this is node-construction wiring, fully reachable from the unit tier.

**Pre-existing failures, unrelated to this PR:** 16 tests fail on `main` itself (10 in `test_explorer_service.py::TestExplorerServiceOSIAuthoring`, 5 in `test_semantic_modeling_agentic_node.py`, 1 in `test_data_file_loader.py`). Verified by stashing this branch and re-running them at `upstream/main`, where they fail identically. Full suite on this branch: 18270 passed, same 16 failed.

## Compatibility

A chat node that **does** declare `tools` will narrow after this change. Those values were written while the field was ignored, so they were never exercised and may never have been curated — the repo's own test fixture is an example. Worth a release note: operators with a `tools` key on a chat node should confirm it lists everything that node actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Chat configurations can now select specific tool families instead of enabling all tools by default.
  * Supports combining multiple tool families and individual tool patterns.
  * Unknown tool selections fail safely without enabling unintended tools.
  * Bash and documentation tools are included only when configured.

* **Bug Fixes**
  * Prevented unselected tools from reappearing during tool initialization or updates.
  * Preserved existing behavior when no tool configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat configurations can select specific tool families or individual tools.
  * Multiple tool families can be combined in one configuration.
  * Bash and documentation tools are included only when selected.
  * Default chat configurations continue to provide the full available tool set.

* **Bug Fixes**
  * Prevented unselected memory, web, Bash, and skill tools from reappearing during prompt construction or tool updates.
  * Unknown tool selections now fail safely without enabling unintended tools.
  * Prevented duplicate documentation tools after repeated setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->