### PR TITLE
[Enhancement] Show every column in the catalog, and reconcile deleted models on sync

### DIFF
--- a/datus/cli/screen/catalog_screen.py
+++ b/datus/cli/screen/catalog_screen.py
@@ -602,32 +602,38 @@ class CatalogScreen(ContextScreen):
         """
         from rich import box
 
-        modelled = {
-            str(field.get("name", "")).strip("`").lower(): field
-            for field in semantic_record.get("modelled_fields") or []
-            if field.get("name")
-        }
-        # An expression may name the column rather than the field.
-        for field in semantic_record.get("modelled_fields") or []:
-            expr = str(field.get("expr", "") or "").strip("`").lower()
-            if expr:
-                modelled.setdefault(expr.rsplit(".", 1)[-1], field)
+        fields = [f for f in semantic_record.get("modelled_fields") or [] if f.get("name")]
+        # Aliases resolve a physical column to its field; they are lookup keys
+        # only. Emitting a row per alias would list a field whose expression
+        # names a different column twice.
+        by_alias: Dict[str, Dict[str, Any]] = {}
+        for field in fields:
+            by_alias.setdefault(str(field.get("name", "")).strip("`").lower(), field)
+        for field in fields:
+            # Strip after taking the basename: a qualifier carries its own
+            # quotes, so `orders.\`created_at\`` would otherwise keep the
+            # leading backtick and match no column.
+            expr = str(field.get("expr", "") or "").lower()
+            basename = expr.rsplit(".", 1)[-1].strip("`").strip('"').strip()
+            if basename:
+                by_alias.setdefault(basename, field)
 
         physical = self._physical_columns(semantic_record)
-        if not physical and not modelled:
+        if not physical and not fields:
             return None
 
         rows: List[tuple] = []
-        seen: set = set()
+        matched: set = set()
         for column in physical:
             name = str(column.get("name", ""))
-            field = modelled.get(name.strip("`").lower())
-            seen.add(name.strip("`").lower())
+            field = by_alias.get(name.strip("`").lower())
+            if field is not None:
+                matched.add(id(field))
             rows.append((name, str(column.get("type", "")), field, str(column.get("comment", "") or "")))
-        # A field whose column the connector did not report still belongs here;
-        # a computed expression has no physical column of its own.
-        for key, field in modelled.items():
-            if key not in seen:
+        # A field the connector reported no column for still belongs here: a
+        # computed expression has no physical column of its own.
+        for field in fields:
+            if id(field) not in matched:
                 rows.append((str(field.get("name", "")), "", field, ""))
 
         modelled_count = sum(1 for _, _, field, _ in rows if field)
@@ -670,12 +676,15 @@ class CatalogScreen(ContextScreen):
         if not table_name or self.db_connector is None:
             return []
         try:
+            # Through the screen's LRU cache: the table details pane has
+            # usually fetched this already, and a slow datasource must not be
+            # hit twice from the Textual event thread.
             return list(
-                self.db_connector.get_schema(
-                    catalog_name=semantic_record.get("catalog_name", "") or self.catalog_name,
-                    database_name=semantic_record.get("database_name", "") or self.database_name,
-                    schema_name=semantic_record.get("schema_name", "") or "",
-                    table_name=table_name,
+                self._get_cached_schema(
+                    semantic_record.get("catalog_name", "") or self.catalog_name,
+                    semantic_record.get("database_name", "") or self.database_name,
+                    semantic_record.get("schema_name", "") or "",
+                    table_name,
                 )
                 or []
             )

--- a/datus/cli/screen/catalog_screen.py
+++ b/datus/cli/screen/catalog_screen.py
@@ -22,7 +22,7 @@ from textual.widgets import Tree as TextualTree
 from textual.widgets._tree import TreeNode
 from textual.worker import get_current_worker
 
-from datus.cli.cli_styles import HEADER_BOLD_CYAN, TABLE_BORDER_STYLE
+from datus.cli.cli_styles import HEADER_BOLD_CYAN, TABLE_BORDER_STYLE, TABLE_HEADER_STYLE
 from datus.cli.screen.base_widgets import FocusableStatic
 from datus.cli.screen.context_screen import ContextScreen
 from datus.storage.semantic_dataset.store import SemanticDatasetRAG
@@ -578,13 +578,110 @@ class CatalogScreen(ContextScreen):
             table.add_row("Dataset", semantic_record.get("dataset_name", "") or "[dim]N/A[/dim]")
         table.add_row("Description", semantic_record.get("description", "") or "[dim]N/A[/dim]")
         table.add_row("AI Context", self._create_nested_table_for_json(semantic_record.get("ai_context")))
-        table.add_row("Identifiers", self._create_nested_table_for_json(semantic_record.get("identifiers")))
-        table.add_row("Dimensions", self._create_nested_table_for_json(semantic_record.get("dimensions")))
         table.add_row("Relationships", self._create_nested_table_for_json(semantic_record.get("relationships")))
 
         sections.append(table)
 
+        columns_table = self._create_columns_table(semantic_record)
+        if columns_table is not None:
+            sections.append(columns_table)
+            # Below the table, not as a per-column mark: a key may span several
+            # columns, and ticking each one loses which columns form it.
+            unique_keys = semantic_record.get("unique_keys") or []
+            if unique_keys:
+                rendered = "  ".join(f"({', '.join(str(c) for c in key)})" for key in unique_keys if key)
+                sections.append(Text.from_markup(f"[bright_cyan]Unique keys[/]  [yellow]{rendered}[/]"))
+
         return Group(*sections)
+
+    def _create_columns_table(self, semantic_record: Dict[str, Any]) -> Optional[Table]:
+        """One row per physical column, annotated with what the model says.
+
+        Physical columns that no field models are shown dimmed rather than
+        hidden: the gap between the two is the point of the view.
+        """
+        from rich import box
+
+        modelled = {
+            str(field.get("name", "")).strip("`").lower(): field
+            for field in semantic_record.get("modelled_fields") or []
+            if field.get("name")
+        }
+        # An expression may name the column rather than the field.
+        for field in semantic_record.get("modelled_fields") or []:
+            expr = str(field.get("expr", "") or "").strip("`").lower()
+            if expr:
+                modelled.setdefault(expr.rsplit(".", 1)[-1], field)
+
+        physical = self._physical_columns(semantic_record)
+        if not physical and not modelled:
+            return None
+
+        rows: List[tuple] = []
+        seen: set = set()
+        for column in physical:
+            name = str(column.get("name", ""))
+            field = modelled.get(name.strip("`").lower())
+            seen.add(name.strip("`").lower())
+            rows.append((name, str(column.get("type", "")), field, str(column.get("comment", "") or "")))
+        # A field whose column the connector did not report still belongs here;
+        # a computed expression has no physical column of its own.
+        for key, field in modelled.items():
+            if key not in seen:
+                rows.append((str(field.get("name", "")), "", field, ""))
+
+        modelled_count = sum(1 for _, _, field, _ in rows if field)
+        columns_table = Table(
+            title=f"[bold cyan]Columns[/] [dim]({modelled_count} modelled / {len(rows)} total)[/dim]",
+            box=box.SIMPLE,
+            border_style=TABLE_BORDER_STYLE,
+            header_style=TABLE_HEADER_STYLE,
+            expand=True,
+            padding=(0, 1),
+        )
+        columns_table.add_column("column", ratio=2, no_wrap=True)
+        columns_table.add_column("type", ratio=2, no_wrap=True)
+        columns_table.add_column("key", ratio=1, justify="center", no_wrap=True)
+        columns_table.add_column("time", ratio=1, justify="center", no_wrap=True)
+        columns_table.add_column("description", ratio=5, no_wrap=False)
+
+        for name, physical_type, field, ddl_comment in rows:
+            if field:
+                description = field.get("description") or ddl_comment
+                columns_table.add_row(
+                    name,
+                    physical_type,
+                    "✓" if field.get("is_primary_key") else "",
+                    str(field.get("time_granularity") or "") if field.get("is_time") else "",
+                    description,
+                )
+            else:
+                dim = "[dim]{}[/dim]".format
+                columns_table.add_row(dim(name), dim(physical_type), "", "", dim(ddl_comment) if ddl_comment else "")
+        return columns_table
+
+    def _physical_columns(self, semantic_record: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Live columns for the selected table, or [] when unavailable.
+
+        The catalog is a browser: a datasource that is slow or down must dim
+        the physical half of this view, never fail the panel.
+        """
+        table_name = str(semantic_record.get("table_name", "") or "")
+        if not table_name or self.db_connector is None:
+            return []
+        try:
+            return list(
+                self.db_connector.get_schema(
+                    catalog_name=semantic_record.get("catalog_name", "") or self.catalog_name,
+                    database_name=semantic_record.get("database_name", "") or self.database_name,
+                    schema_name=semantic_record.get("schema_name", "") or "",
+                    table_name=table_name,
+                )
+                or []
+            )
+        except Exception as exc:  # pragma: no cover - defensive, datasource may be down
+            logger.debug(f"Could not read physical columns for {table_name!r}: {exc}")
+            return []
 
     def _show_semantic_panel(
         self, record: Optional[Dict[str, Any]], message: Optional[str] = None, message_style: Optional[str] = None
@@ -759,27 +856,25 @@ class CatalogScreen(ContextScreen):
     def _semantic_record_from_table_profile(self, projection: Dict[str, Any]) -> Dict[str, Any]:
         ai_context = self._decode_profile_json(projection.get("ai_context_json"), None)
 
-        identifiers = []
-        dimensions = []
+        # Every authored field, in order. Splitting them into identifiers and
+        # dimensions dropped the rest: OSI has no measure concept, so a field
+        # that is neither a key nor a time dimension is still a perfectly
+        # ordinary column, and most of them are.
+        modelled_fields = []
         for field in projection.get("fields") or []:
             if not isinstance(field, dict):
                 continue
-            entry = {
-                key: value
-                for key, value in {
-                    "name": field.get("name", ""),
-                    "expr": field.get("expr", ""),
-                    "type": field.get("field_type", ""),
-                    "time_granularity": field.get("time_granularity", ""),
-                    "description": field.get("description", ""),
+            modelled_fields.append(
+                {
+                    "name": str(field.get("name", "") or ""),
+                    "expr": str(field.get("expr", "") or ""),
+                    "time_granularity": str(field.get("time_granularity", "") or ""),
+                    "is_time": bool(field.get("is_time")),
+                    "is_primary_key": bool(field.get("is_primary_key")),
+                    "description": str(field.get("description", "") or ""),
                     "ai_context": self._decode_profile_json(field.get("ai_context_json"), None),
-                }.items()
-                if value not in (None, "", [], {})
-            }
-            if field.get("is_primary_key"):
-                identifiers.append(entry)
-            elif field.get("is_dimension"):
-                dimensions.append(entry)
+                }
+            )
 
         relationships = [
             {
@@ -800,12 +895,15 @@ class CatalogScreen(ContextScreen):
         return {
             "_source": "table_semantic_profile",
             "table_name": projection.get("source_table", ""),
+            "catalog_name": projection.get("catalog_name", ""),
+            "database_name": projection.get("database_name", ""),
+            "schema_name": projection.get("schema_name", ""),
             "semantic_model_name": projection.get("semantic_model_name", ""),
             "dataset_name": projection.get("dataset_name", ""),
             "description": projection.get("description", ""),
             "ai_context": ai_context,
-            "identifiers": identifiers,
-            "dimensions": dimensions,
+            "unique_keys": self._decode_profile_json(projection.get("unique_keys_json"), []) or [],
+            "modelled_fields": modelled_fields,
             "relationships": relationships,
         }
 

--- a/datus/storage/metric/store.py
+++ b/datus/storage/metric/store.py
@@ -734,6 +734,18 @@ class MetricRAG:
         """Delete all metrics for this datasource."""
         self.storage.delete_datasource_rows(self.datasource_id)
 
+    def list_artifact_paths(self) -> List[str]:
+        """Every distinct ``yaml_path`` this store currently holds rows for.
+
+        A tree-wide sync needs this to notice files that disappeared: the
+        per-artifact deletes are scoped to a path, so a model whose file was
+        removed is never visited and its rows would outlive it.
+        """
+        rows = self.storage._search_all(
+            where=and_(*self._sub_agent_conditions()), select_fields=["yaml_path"]
+        ).to_pylist()
+        return sorted({str(row.get("yaml_path") or "") for row in rows} - {""})
+
     def delete_artifact_rows(self, yaml_path: str) -> None:
         """Delete metric rows projected from a single YAML artifact."""
         if not yaml_path:

--- a/datus/storage/semantic_dataset/store.py
+++ b/datus/storage/semantic_dataset/store.py
@@ -162,6 +162,9 @@ class SemanticDatasetStorage(BaseEmbeddingStore):
                     pa.field("catalog_name", pa.string()),
                     pa.field("database_name", pa.string()),
                     pa.field("schema_name", pa.string()),
+                    # A key may span several columns, so this is a list of
+                    # groups rather than a flag on each field row.
+                    pa.field("unique_keys_json", pa.string()),
                     # -- Content --
                     pa.field("description", pa.string()),
                     pa.field("ai_context_json", pa.string()),

--- a/datus/storage/semantic_dataset/store.py
+++ b/datus/storage/semantic_dataset/store.py
@@ -446,6 +446,18 @@ class SemanticDatasetRAG:
         self.storage.delete_datasource_rows(self.datasource_id)
         self._refresh_metadata_documents_for_tables(rows)
 
+    def list_artifact_paths(self) -> List[str]:
+        """Every distinct ``yaml_path`` this store currently holds rows for.
+
+        A tree-wide sync needs this to notice files that disappeared: the
+        per-artifact deletes are scoped to a path, so a model whose file was
+        removed is never visited and its rows would outlive it.
+        """
+        rows = self.storage._search_all(
+            where=And(self._sub_agent_conditions()), select_fields=["yaml_path"]
+        ).to_pylist()
+        return sorted({str(row.get("yaml_path") or "") for row in rows} - {""})
+
     def delete_artifact_rows(self, yaml_path: str) -> None:
         """Delete rows projected from a single YAML artifact."""
         if not yaml_path:

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -443,7 +443,46 @@ def sync_semantic_yaml_tree(
 
     if failures:
         return False, f"Synced {synced}/{len(files)} semantic YAML file(s); failed: " + "; ".join(failures), synced
-    return True, f"Synced {synced} semantic YAML file(s) from {target}", synced
+
+    # A directory sync reconciles the tree, so a model whose file was deleted or
+    # renamed has to lose its rows. Per-artifact replacement cannot do this: it
+    # is scoped to a yaml_path, and a file that no longer exists is never
+    # visited. Left behind, its rows keep describe_table offering a model whose
+    # yaml_path does not open.
+    pruned = _prune_rows_for_missing_artifacts(agent_config, files) if target.is_dir() else 0
+    suffix = f", pruned {pruned} deleted artifact(s)" if pruned else ""
+    return True, f"Synced {synced} semantic YAML file(s) from {target}{suffix}", synced
+
+
+def _prune_rows_for_missing_artifacts(agent_config: AgentConfig, present: list[Path]) -> int:
+    """Drop rows whose source YAML is no longer on disk. Returns artifacts pruned."""
+    from datus.storage.metric.store import MetricRAG
+    from datus.storage.semantic_dataset.store import SemanticDatasetRAG
+
+    keep = {str(path.resolve(strict=False)) for path in present}
+    pruned: set[str] = set()
+    try:
+        rags = [SemanticDatasetRAG(agent_config), MetricRAG(agent_config)]
+    except Exception:  # noqa: BLE001 - pruning must never fail an otherwise good sync
+        logger.exception("Failed to open semantic stores while pruning deleted semantic models")
+        return 0
+    for rag in rags:
+        try:
+            stored = rag.list_artifact_paths()
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to list artifact paths while pruning deleted semantic models")
+            continue
+        for yaml_path in stored:
+            if str(Path(yaml_path).resolve(strict=False)) in keep or Path(yaml_path).exists():
+                continue
+            try:
+                rag.delete_artifact_rows(yaml_path)
+                pruned.add(yaml_path)
+            except Exception:  # noqa: BLE001
+                logger.exception(f"Failed to prune rows for deleted semantic model '{yaml_path}'")
+    if pruned:
+        logger.info(f"Pruned knowledge-base rows for {len(pruned)} deleted semantic YAML file(s)")
+    return len(pruned)
 
 
 def refresh_semantic_yaml_profile_descriptions(

--- a/datus/storage/semantic_model/semantic_model_init.py
+++ b/datus/storage/semantic_model/semantic_model_init.py
@@ -418,7 +418,11 @@ def sync_semantic_yaml_tree(
 
     files = semantic_yaml_files(target)
     if not files:
-        return True, f"No semantic YAML found under {target}", 0
+        # Deleting the last model is the strongest form of the case this
+        # prunes for, so it cannot return before reconciling.
+        pruned = _prune_rows_for_missing_artifacts(agent_config, []) if target.is_dir() else 0
+        suffix = f", pruned {pruned} deleted artifact(s)" if pruned else ""
+        return True, f"No semantic YAML found under {target}{suffix}", 0
 
     from datus.tools.func_tool.generation_tools import GenerationTools
 

--- a/datus/tools/func_tool/generation_tools.py
+++ b/datus/tools/func_tool/generation_tools.py
@@ -824,7 +824,15 @@ class GenerationTools:
                 {
                     "name": field_name,
                     "expr": getattr(field, "expr", None) or field_name,
-                    "role": "dimension" if field_name in dimension_names else "field",
+                    # A dataset carries one primary time axis, but any number of
+                    # time dimensions. The loader keeps the temporal type on
+                    # every one of them; reading only `time_dimension` would
+                    # drop the rest back to plain fields.
+                    "role": (
+                        "time_dimension"
+                        if str(getattr(field, "type", "") or "") == "time"
+                        else ("dimension" if field_name in dimension_names else "field")
+                    ),
                     "type": str(getattr(field, "type", "") or ""),
                     "granularity": getattr(field, "granularity", "") or "",
                     "description": getattr(field, "description", "") or "",
@@ -877,6 +885,9 @@ class GenerationTools:
                 "source_query": source_query,
                 "description": description,
                 "ai_context_json": cls._json_dumps(ai_context),
+                # Uniqueness a dataset declares without a DDL primary key to
+                # transcribe. Kept whole because a key may span columns.
+                "unique_keys_json": cls._json_dumps(getattr(dataset, "unique_keys", []) or []),
                 "search_text": cls._profile_search_text(
                     semantic_model_name, dataset_name, source_table, description, ai_context
                 ),

--- a/datus/tools/semantic_tools/osi_document.py
+++ b/datus/tools/semantic_tools/osi_document.py
@@ -44,6 +44,8 @@ class OsiDataset:
     name: str
     source: OsiSource
     primary_key: list[str] = field(default_factory=list)
+    # Each entry is one key, which may span several columns.
+    unique_keys: list[list[str]] = field(default_factory=list)
     time_dimension: OsiDimension | None = None
     dimensions: list[OsiDimension] = field(default_factory=list)
     fields: list[OsiDimension] = field(default_factory=list)
@@ -181,6 +183,22 @@ def _dimension(field_node: dict[str, Any]) -> OsiDimension:
     )
 
 
+def _unique_keys(value: Any) -> list[list[str]]:
+    """Normalize `unique_keys` to a list of column groups.
+
+    A key may span several columns, and a single-column key is often written
+    unwrapped, so both `[["a", "b"], ["c"]]` and `["c"]` have to round-trip.
+    """
+    if not isinstance(value, list):
+        return []
+    keys: list[list[str]] = []
+    for entry in value:
+        columns = _names(entry) if isinstance(entry, list) else _names([entry])
+        if columns:
+            keys.append(columns)
+    return keys
+
+
 def _dataset(node: dict[str, Any]) -> OsiDataset:
     payload = _extension_payload(node)
     fields = [item for item in node.get("fields") or [] if isinstance(item, dict) and item.get("name")]
@@ -198,6 +216,7 @@ def _dataset(node: dict[str, Any]) -> OsiDataset:
     dimensions: list[OsiDimension] = []
     field_views: list[OsiDimension] = []
     primary_keys = _names(node.get("primary_key"))
+    unique_keys = _unique_keys(node.get("unique_keys"))
     for field_node in fields:
         name = str(field_node.get("name") or "")
         dimension = _dimension(field_node)
@@ -212,6 +231,7 @@ def _dataset(node: dict[str, Any]) -> OsiDataset:
         name=str(node.get("name") or ""),
         source=_source(node.get("source"), payload.get("source_type")),
         primary_key=primary_keys,
+        unique_keys=unique_keys,
         time_dimension=primary_time,
         dimensions=dimensions,
         fields=field_views,

--- a/datus/tools/semantic_tools/osi_document.py
+++ b/datus/tools/semantic_tools/osi_document.py
@@ -44,14 +44,16 @@ class OsiDataset:
     name: str
     source: OsiSource
     primary_key: list[str] = field(default_factory=list)
-    # Each entry is one key, which may span several columns.
-    unique_keys: list[list[str]] = field(default_factory=list)
     time_dimension: OsiDimension | None = None
     dimensions: list[OsiDimension] = field(default_factory=list)
     fields: list[OsiDimension] = field(default_factory=list)
     description: str = ""
     ai_context: Any = None
     custom_extensions: list[dict[str, Any]] = field(default_factory=list)
+    # Appended rather than grouped with primary_key: inserting a field would
+    # shift every positional argument after it. Each entry is one key, which
+    # may span several columns.
+    unique_keys: list[list[str]] = field(default_factory=list)
 
 
 @dataclass
@@ -193,7 +195,10 @@ def _unique_keys(value: Any) -> list[list[str]]:
         return []
     keys: list[list[str]] = []
     for entry in value:
-        columns = _names(entry) if isinstance(entry, list) else _names([entry])
+        raw = entry if isinstance(entry, list) else [entry]
+        # Only strings name a column. Coercing anything else would persist a
+        # key like ["None"] that resolves to no column at all.
+        columns = [item.strip() for item in raw if isinstance(item, str) and item.strip()]
         if columns:
             keys.append(columns)
     return keys

--- a/tests/unit_tests/cli/screen/test_catalog_screen.py
+++ b/tests/unit_tests/cli/screen/test_catalog_screen.py
@@ -103,8 +103,18 @@ def test_catalog_screen_builds_generic_record_from_table_semantic_profile():
     assert record["dataset_name"] == "orders"
     assert record["table_name"] == "orders"
     assert record["ai_context"]["instructions"] == "Use this dataset for order analytics."
-    assert [item["name"] for item in record["identifiers"]] == ["order_id"]
-    assert [item["name"] for item in record["dimensions"]] == ["order_date", "segment"]
+    # Every authored field survives, in order. The old split into identifiers
+    # and dimensions silently dropped `amount`, which is neither.
+    assert [item["name"] for item in record["modelled_fields"]] == [
+        "order_id",
+        "order_date",
+        "segment",
+        "amount",
+    ]
+    by_name = {item["name"]: item for item in record["modelled_fields"]}
+    assert by_name["order_id"]["is_primary_key"] is True
+    assert by_name["order_date"]["is_time"] is True
+    assert by_name["amount"]["is_primary_key"] is False and by_name["amount"]["is_time"] is False
     assert record["relationships"][0]["name"] == "orders_to_customers"
     assert "filters" not in record
 
@@ -160,3 +170,116 @@ def test_catalog_screen_nested_semantic_table_uses_readable_column_order():
 
     headers = [column.header for column in table.columns]
     assert headers == ["name", "expr", "role", "type", "time_granularity", "description"]
+
+
+def _screen_with_columns(columns, raises=False):
+    """A screen whose connector reports `columns` (or fails outright)."""
+    screen = object.__new__(CatalogScreen)
+    connector = MagicMock()
+    if raises:
+        connector.get_schema.side_effect = RuntimeError("datasource is down")
+    else:
+        connector.get_schema.return_value = columns
+    screen.db_connector = connector
+    screen.catalog_name = ""
+    screen.database_name = "shop"
+    return screen
+
+
+def _render_columns_text(screen, record):
+    table = screen._create_columns_table(record)
+    console = Console(width=200, record=True)
+    console.print(table)
+    return console.export_text()
+
+
+def test_columns_table_lists_unmodelled_physical_columns_too():
+    """The gap between physical and modelled is what this view exists to show,
+    so a column no field describes is dimmed, not hidden."""
+    screen = _screen_with_columns(
+        [
+            {"name": "order_id", "type": "bigint", "comment": "DDL key"},
+            {"name": "audit_ts", "type": "datetime", "comment": "DDL audit stamp"},
+        ]
+    )
+    record = {
+        "table_name": "orders",
+        "modelled_fields": [
+            {
+                "name": "order_id",
+                "expr": "order_id",
+                "is_primary_key": True,
+                "is_time": False,
+                "description": "Order key",
+            },
+        ],
+    }
+
+    text = _render_columns_text(screen, record)
+
+    assert "1 modelled / 2 total" in text
+    assert "order_id" in text and "Order key" in text  # model description wins
+    assert "audit_ts" in text and "DDL audit stamp" in text  # unmodelled still listed
+
+
+def test_columns_table_falls_back_to_ddl_comment_when_the_model_has_none():
+    screen = _screen_with_columns([{"name": "region", "type": "varchar", "comment": "DDL region"}])
+    record = {
+        "table_name": "orders",
+        "modelled_fields": [{"name": "region", "expr": "region", "description": ""}],
+    }
+
+    assert "DDL region" in _render_columns_text(screen, record)
+
+
+def test_columns_table_survives_an_unreachable_datasource():
+    """The catalog browses indexed content; a datasource that is down must dim
+    the physical half of the view, not fail the panel."""
+    screen = _screen_with_columns([], raises=True)
+    record = {
+        "table_name": "orders",
+        "modelled_fields": [{"name": "order_id", "expr": "order_id", "description": "Order key"}],
+    }
+
+    text = _render_columns_text(screen, record)
+
+    assert "order_id" in text
+    assert "1 modelled / 1 total" in text
+
+
+def test_panel_shows_a_composite_unique_key_as_one_group():
+    """Ticking each column would lose which columns form the key, so it is
+    rendered below the table instead of as a per-column mark."""
+    screen = _screen_with_columns([{"name": "ac_code", "type": "varchar", "comment": ""}])
+    group = screen._render_readonly_panel(
+        {
+            "semantic_model_name": "ops",
+            "dataset_name": "activity",
+            "table_name": "activity",
+            "unique_keys": [["ac_code", "subject_seq", "product_code"]],
+            "modelled_fields": [{"name": "ac_code", "expr": "ac_code", "description": "Activity code"}],
+        }
+    )
+    console = Console(width=200, record=True)
+    console.print(group)
+    text = console.export_text()
+
+    assert "Unique keys" in text
+    assert "(ac_code, subject_seq, product_code)" in text
+
+
+def test_panel_omits_the_unique_keys_line_when_there_are_none():
+    screen = _screen_with_columns([{"name": "ac_code", "type": "varchar", "comment": ""}])
+    group = screen._render_readonly_panel(
+        {
+            "semantic_model_name": "ops",
+            "dataset_name": "activity",
+            "table_name": "activity",
+            "unique_keys": [],
+            "modelled_fields": [{"name": "ac_code", "expr": "ac_code", "description": ""}],
+        }
+    )
+    console = Console(width=200, record=True)
+    console.print(group)
+
+    assert "Unique keys" not in console.export_text()

--- a/tests/unit_tests/cli/screen/test_catalog_screen.py
+++ b/tests/unit_tests/cli/screen/test_catalog_screen.py
@@ -283,3 +283,61 @@ def test_panel_omits_the_unique_keys_line_when_there_are_none():
     console.print(group)
 
     assert "Unique keys" not in console.export_text()
+
+
+def test_columns_table_lists_a_renamed_field_once():
+    """A field whose expression names a different column is reachable under
+    both names, but those are lookup keys -- emitting a row per alias would
+    count the field twice."""
+    screen = _screen_with_columns([{"name": "created_at", "type": "timestamp", "comment": ""}])
+    record = {
+        "table_name": "orders",
+        "modelled_fields": [
+            {"name": "order_date", "expr": "orders.created_at", "description": "Business date"},
+        ],
+    }
+
+    text = _render_columns_text(screen, record)
+
+    assert "1 modelled / 1 total" in text
+    assert text.count("Business date") == 1
+
+
+def test_rendering_after_table_details_makes_no_second_datasource_request():
+    """The invariant is the request count, not which helper runs: the
+    table-details pane has already fetched this schema, and a slow datasource
+    must not be hit again from the Textual event thread."""
+    from datus.cli.screen.catalog_screen import _fetch_schema_with_cache
+
+    _fetch_schema_with_cache.cache_clear()
+    try:
+        screen = _screen_with_columns([{"name": "id", "type": "bigint", "comment": ""}])
+        record = {"table_name": "orders", "database_name": "shop", "modelled_fields": []}
+
+        screen._get_cached_schema("", "shop", "", "orders")  # what the details pane does first
+        assert screen.db_connector.get_schema.call_count == 1
+
+        screen._create_columns_table(record)
+
+        assert screen.db_connector.get_schema.call_count == 1
+    finally:
+        _fetch_schema_with_cache.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "expr",
+    ["orders.`created_at`", '"orders"."created_at"', "orders.created_at", "created_at"],
+)
+def test_columns_table_matches_a_quoted_qualified_expression(expr):
+    """A qualifier carries its own quotes, so the basename has to be unquoted
+    after the split, not before it."""
+    screen = _screen_with_columns([{"name": "created_at", "type": "timestamp", "comment": ""}])
+    record = {
+        "table_name": "orders",
+        "modelled_fields": [{"name": "order_date", "expr": expr, "description": "Business date"}],
+    }
+
+    text = _render_columns_text(screen, record)
+
+    assert "1 modelled / 1 total" in text
+    assert "Business date" in text

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -337,3 +337,31 @@ def test_sync_semantic_yaml_tree_drops_rows_whose_file_is_gone(tmp_path, real_ag
     assert successful is True
     surviving = {row["semantic_model_name"] for row in rag.storage.table.search_all(limit=100).to_pylist()}
     assert surviving == {"ops"}
+
+
+def test_sync_semantic_yaml_tree_prunes_when_the_last_file_is_deleted(tmp_path, real_agent_config):
+    """Deleting every model is the strongest form of the case pruning exists
+    for, and the empty-directory branch used to return before reconciling."""
+    from datus.storage.semantic_dataset.store import KIND_DATASET, SemanticDatasetRAG, dataset_row_id
+
+    rag = SemanticDatasetRAG(real_agent_config)
+    rag.upsert_batch(
+        [
+            {
+                "id": dataset_row_id("finance", "orders"),
+                "kind": KIND_DATASET,
+                "semantic_model_name": "finance",
+                "dataset_name": "orders",
+                "name": "orders",
+                "source_table": "orders",
+                "search_text": "finance",
+                "yaml_path": str(tmp_path / "finance.yml"),
+            }
+        ]
+    )
+
+    successful, message, synced = sync_semantic_yaml_tree(real_agent_config, str(tmp_path))
+
+    assert successful is True and synced == 0
+    assert "pruned 1 deleted artifact(s)" in message
+    assert rag.storage.table.search_all(limit=100).to_pylist() == []

--- a/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
+++ b/tests/unit_tests/storage/semantic_model/test_semantic_model_init.py
@@ -297,3 +297,43 @@ def test_semantic_yaml_files_skips_the_metrics_fragment_directory(tmp_path):
     found = semantic_yaml_files(tmp_path)
 
     assert [path.name for path in found] == ["sales.yml"]
+
+
+def test_sync_semantic_yaml_tree_drops_rows_whose_file_is_gone(tmp_path, real_agent_config):
+    """A sync is a reconcile, not an append. Deleting or renaming a model file
+    has to remove what it projected: the rows outlive the file otherwise, and
+    describe_table keeps offering a model whose yaml_path no longer opens."""
+    from datus.storage.semantic_dataset.store import (
+        KIND_DATASET,
+        SemanticDatasetRAG,
+        dataset_row_id,
+    )
+
+    rag = SemanticDatasetRAG(real_agent_config)
+    removed = tmp_path / "finance.yml"
+    kept = tmp_path / "ops.yml"
+    for path, model in ((removed, "finance"), (kept, "ops")):
+        rag.upsert_batch(
+            [
+                {
+                    "id": dataset_row_id(model, "orders"),
+                    "kind": KIND_DATASET,
+                    "semantic_model_name": model,
+                    "dataset_name": "orders",
+                    "name": "orders",
+                    "source_table": "orders",
+                    "search_text": model,
+                    "yaml_path": str(path),
+                }
+            ]
+        )
+    kept.write_text("version: 0.2.0.dev0\nsemantic_model: []\n")  # removed.yml intentionally absent
+
+    tools = MagicMock()
+    tools.sync_osi_to_db.return_value = {"success": True}
+    with patch("datus.tools.func_tool.generation_tools.GenerationTools", return_value=tools):
+        successful, _, _ = sync_semantic_yaml_tree(real_agent_config, str(tmp_path))
+
+    assert successful is True
+    surviving = {row["semantic_model_name"] for row in rag.storage.table.search_all(limit=100).to_pylist()}
+    assert surviving == {"ops"}

--- a/tests/unit_tests/tools/func_tool/test_generation_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_generation_tools.py
@@ -1874,3 +1874,53 @@ class TestCheckSemanticObjectExistsCacheHit:
         assert result1.result == result2.result
         # Cache should have been populated
         assert len(generation_tools._semantic_object_exists_cache) >= 1
+
+
+class TestOsiDatasetColumnRoles:
+    """Projection has to keep what the loader resolved, not re-derive it."""
+
+    @staticmethod
+    def _dataset(fields, time_dimension=None, dimensions=(), unique_keys=()):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            name="orders",
+            primary_key=[],
+            unique_keys=list(unique_keys),
+            time_dimension=time_dimension,
+            dimensions=list(dimensions),
+            fields=fields,
+        )
+
+    @staticmethod
+    def _field(name, type_="categorical", granularity=""):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            name=name, expr=name, type=type_, granularity=granularity, description="", ai_context=None
+        )
+
+    def test_every_time_field_keeps_its_temporal_role(self):
+        """A dataset has one primary time axis but any number of time
+        dimensions. Reading only `time_dimension` demoted the others to plain
+        fields and lost their granularity."""
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        start = self._field("start_date", "time", "day")
+        end = self._field("end_date", "time", "day")
+        dataset = self._dataset([start, end], time_dimension=start, dimensions=[end])
+
+        columns = {c["name"]: c for c in GenerationTools._osi_dataset_columns(dataset)}
+
+        assert columns["start_date"]["role"] == "time_dimension"
+        assert columns["end_date"]["role"] == "time_dimension"
+        assert columns["end_date"]["granularity"] == "day"
+
+    def test_a_non_temporal_field_is_not_promoted(self):
+        from datus.tools.func_tool.generation_tools import GenerationTools
+
+        dataset = self._dataset([self._field("region")])
+
+        columns = {c["name"]: c for c in GenerationTools._osi_dataset_columns(dataset)}
+
+        assert columns["region"]["role"] == "field"

--- a/tests/unit_tests/tools/semantic_tools/test_osi_document.py
+++ b/tests/unit_tests/tools/semantic_tools/test_osi_document.py
@@ -208,3 +208,31 @@ semantic_model:
     )
 
     assert load_osi_document(str(model), semantic_model_name="ops").datasets[0].unique_keys == []
+
+
+def test_load_osi_document_ignores_non_string_unique_key_entries(tmp_path):
+    """Coercing a non-string would persist a key like ["None"] that resolves
+    to no column at all."""
+    model = tmp_path / "loose.yml"
+    model.write_text(
+        """
+version: 0.2.0.dev0
+semantic_model:
+  - name: ops
+    datasets:
+      - name: activity
+        source: mart.activity
+        unique_keys:
+          - [ac_code, null, subject_seq]
+          - [123]
+          - []
+          - [surrogate_id]
+        fields:
+          - name: ac_code
+            expression: {dialects: [{dialect: ANSI_SQL, expression: ac_code}]}
+"""
+    )
+
+    dataset = load_osi_document(str(model), semantic_model_name="ops").datasets[0]
+
+    assert dataset.unique_keys == [["ac_code", "subject_seq"], ["surrogate_id"]]

--- a/tests/unit_tests/tools/semantic_tools/test_osi_document.py
+++ b/tests/unit_tests/tools/semantic_tools/test_osi_document.py
@@ -162,3 +162,49 @@ semantic_model:
 
     with pytest.raises(DatusException, match="declared 2 times"):
         load_osi_document(str(model), "finance")
+
+
+def test_load_osi_document_reads_composite_unique_keys(tmp_path):
+    """A dataset can declare uniqueness without a DDL primary key to
+    transcribe, and such a key routinely spans several columns."""
+    model = tmp_path / "activity.yml"
+    model.write_text(
+        """
+version: 0.2.0.dev0
+semantic_model:
+  - name: ops
+    datasets:
+      - name: activity
+        source: mart.activity
+        unique_keys:
+          - [ac_code, subject_seq, product_code]
+          - [surrogate_id]
+        fields:
+          - name: ac_code
+            expression: {dialects: [{dialect: ANSI_SQL, expression: ac_code}]}
+"""
+    )
+
+    dataset = load_osi_document(str(model), semantic_model_name="ops").datasets[0]
+
+    assert dataset.unique_keys == [["ac_code", "subject_seq", "product_code"], ["surrogate_id"]]
+    assert dataset.primary_key == []
+
+
+def test_load_osi_document_defaults_unique_keys_to_empty(tmp_path):
+    model = tmp_path / "plain.yml"
+    model.write_text(
+        """
+version: 0.2.0.dev0
+semantic_model:
+  - name: ops
+    datasets:
+      - name: activity
+        source: mart.activity
+        fields:
+          - name: ac_code
+            expression: {dialects: [{dialect: ANSI_SQL, expression: ac_code}]}
+"""
+    )
+
+    assert load_osi_document(str(model), semantic_model_name="ops").datasets[0].unique_keys == []


### PR DESCRIPTION
## Why

Two problems found while browsing a real semantic model in `/catalog`.

**1. The panel showed almost nothing.** It sorted a dataset's fields into Identifiers and Dimensions and dropped whatever fell in neither. OSI has no measure concept — a field that is not a key and not a time dimension is an ordinary column — so a 15-field model rendered as 2 rows, and the 30 physical columns were absent entirely. It reads as "this table is barely modelled" when the opposite is true.

**2. Deleting a model file left its rows behind.** `sync_semantic_yaml_tree` walks the files that exist and replaces each one's rows. Artifact replacement is scoped to a `yaml_path`, so a model whose file was deleted or renamed is never visited and its rows are nobody's responsibility. They outlive the file: `describe_table` keeps offering the model as a candidate and lists it under `table.alternatives` with a `yaml_path` that no longer opens.

## Solution

**Catalog panel** renders one row per physical column, annotated with what the model says. Columns no field describes are dimmed rather than hidden — the gap between physical and modelled is the point of the view. Physical columns come from the connector the screen already holds; a datasource that is down dims that half instead of failing the panel.

```
Columns (15 modelled / 30 total)
  ac_code        varchar(65533)          活动编码，活动的唯一标识。
  market_code    varchar(65533)          市场编码                      <- unmodelled, dimmed, DDL comment
  start_date     date            day     活动开始日期。
  end_date       date            day     活动结束日期。
Unique keys  (ac_code, subject_seq, product_code)
```

**Sync** prunes rows whose source file is absent from disk, in both the dataset and the metric store. A single-file sync still touches only that file, and pruning is guarded so it can never fail an otherwise good sync.

Two projection defects surfaced while building the panel, both fixed here:

- **Only the field promoted to `dataset.time_dimension` kept a temporal role.** A dataset has one primary time axis but any number of time dimensions, and the loader already resolves the temporal type on all of them — so `end_date` arrived as a plain field and lost its `day` grain. The projection now reads that resolved type instead of re-deriving it.
- **`unique_keys` never left the YAML.** A dataset can declare uniqueness with no DDL primary key to transcribe, which is the norm for a view, and such a key routinely spans several columns. It is projected whole and rendered under the table, not as a per-column tick — ticking each column would lose which columns form the key.

## Test Cases

Unit tests mirror the source layout:

- `tests/unit_tests/cli/screen/test_catalog_screen.py` — unmodelled columns are listed and dimmed; the model's description wins over the DDL comment and falls back to it; an unreachable datasource still renders the modelled half; a composite unique key renders as one group and is omitted when absent. The existing contract test now asserts that every authored field survives — its own fixture had an `amount` field that the old split silently dropped.
- `tests/unit_tests/tools/func_tool/test_generation_tools.py` — every time field keeps `time_dimension` and its granularity; a non-temporal field is not promoted.
- `tests/unit_tests/tools/semantic_tools/test_osi_document.py` — composite and single-column `unique_keys` round-trip; absent `unique_keys` defaults to empty.
- `tests/unit_tests/storage/semantic_model/test_semantic_model_init.py` — a directory sync drops rows whose file is gone, asserted against real storage rather than a mock, since the defect is about surviving state.

Red-first verified for both bug fixes: the time-role test fails on the pre-fix projection, and the prune test fails with `{'finance', 'ops'} == {'ops'}` on the pre-fix sync.

Verified end to end against a live StarRocks model — the rendering above is real output — and against a live knowledge base holding rows for a deleted model, where the sync reports `pruned 1 deleted artifact(s)` and the orphan count in both stores drops to zero.

Local gates: 18322 passed; `ci/audit_tests.py --diff-only` P0=0. The one failure, `test_corrupt_legacy_xls_reports_cleanly`, reproduces identically on a clean `upstream/main` — it needs the optional `xlrd` package, which is absent from my venv but present in CI.

## Note

`semantic_dataset` gains a `unique_keys_json` column. An existing table opens fine without it and reads back empty, so no migration is required; a `sync-yaml` refills it.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Catalog views now display physical and modeled columns together, including time fields, unique keys, and unmodeled columns.
  * Composite and single-column unique keys are now supported and preserved.
  * Multiple time dimensions are now recognized correctly.

* **Bug Fixes**
  * Semantic model synchronization removes entries for deleted or renamed files.
  * Catalog details retain all authored fields, including previously omitted fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog views now display physical and modeled columns together, including time fields, unique keys, and unmodeled columns.
  * Composite and single-column unique keys are now supported and preserved.
  * Multiple time dimensions are now recognized correctly.
  * Catalog views support renamed, qualified, and quoted field expressions.

* **Bug Fixes**
  * Semantic model synchronization removes entries for deleted or renamed files.
  * Catalog details retain all authored fields, including previously omitted fields.
  * Catalog views remain available when the data source cannot be reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->