### PR TITLE
[BugFix] give a read refusal its own error code, and let it speak plainly

### DIFF
--- a/datus/api/services/dashboard_service.py
+++ b/datus/api/services/dashboard_service.py
@@ -44,6 +44,7 @@ from datus.schemas.gen_visual_dashboard_models import (
 from datus.schemas.gen_visual_report_models import QueryColumnMeta
 from datus.tools.func_tool.dashboard_artifact_tools import render_dashboard_template
 from datus.tools.func_tool.report_artifact_tools import _normalize_value
+from datus.utils.exceptions import ErrorCode
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
@@ -530,10 +531,18 @@ class DashboardService:
             )
 
         if not getattr(exec_result, "success", False):
+            error_text = getattr(exec_result, "error", None) or "unknown error"
+            # A policy refusal is not a failed query: the caller may not see
+            # these rows, which is a different thing to say and a different
+            # thing for a viewer to render. Passed through unwrapped — it is
+            # already a sentence addressed to whoever is reading it, and
+            # "query failed:" in front of it helps nobody.
+            if getattr(exec_result, "error_code", None) == ErrorCode.POLICY_DENIED.code:
+                return Result(success=False, errorCode="POLICY_DENIED", errorMessage=error_text)
             return Result(
                 success=False,
                 errorCode="QUERY_EXECUTION_FAILED",
-                errorMessage=f"query failed: {getattr(exec_result, 'error', 'unknown error')}",
+                errorMessage=f"query failed: {error_text}",
             )
 
         rows_raw = getattr(exec_result, "sql_return", None) or []

--- a/datus/schemas/node_models.py
+++ b/datus/schemas/node_models.py
@@ -436,6 +436,14 @@ class ExecuteSQLResult(BaseResult):
 
     sql_query: Optional[str] = Field("", description="The SQL query to execute")
     row_count: Optional[int] = Field(None, description="The number of rows returned")
+    error_code: Optional[str] = Field(
+        None,
+        description=(
+            "ErrorCode of a failure the caller may want to branch on — currently only a policy "
+            "refusal, which an API surface renders differently from a broken query. Absent on "
+            "engine errors, whose text is the whole story."
+        ),
+    )
     sql_return: Any = Field(  # TODO: change to Union[str, ArrowTable, List[Reuslt]]
         default=None, description="The result of SQL execution (string or Arrow data)"
     )

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -2142,7 +2142,7 @@ class DBFuncTool:
             )
             if not decision.allowed:
                 raise DatusException(
-                    ErrorCode.TOOL_INVALID_INPUT,
+                    ErrorCode.POLICY_DENIED,
                     message=decision.reason or "Policy denied the query",
                 )
             enforced_sql = decision.sql if decision.sql is not None else sql
@@ -2153,7 +2153,12 @@ class DBFuncTool:
                     datasource=effective_datasource,
                 )
         except DatusException as exc:
-            return ExecuteSQLResult(success=False, error=str(exc), sql_query=sql)
+            return ExecuteSQLResult(
+                success=False,
+                error=self._policy_error_text(exc),
+                error_code=exc.code.code,
+                sql_query=sql,
+            )
         if enforced_sql != sql:
             # A policy rewrite (e.g. an injected LIMIT) must still be a single
             # read-only statement — re-validate so it can't smuggle in DML/DDL.
@@ -2173,7 +2178,7 @@ class DBFuncTool:
             )
             if not result_decision.allowed:
                 raise DatusException(
-                    ErrorCode.TOOL_INVALID_INPUT,
+                    ErrorCode.POLICY_DENIED,
                     message=result_decision.reason or "Policy denied the query result",
                 )
             result.sql_return = result_decision.result
@@ -2185,7 +2190,24 @@ class DBFuncTool:
                 )
             return result
         except DatusException as exc:
-            return ExecuteSQLResult(success=False, error=str(exc), sql_query=enforced_sql)
+            return ExecuteSQLResult(
+                success=False,
+                error=self._policy_error_text(exc),
+                error_code=exc.code.code,
+                sql_query=enforced_sql,
+            )
+
+    @staticmethod
+    def _policy_error_text(exc: DatusException) -> str:
+        """What to put in ``error`` for a failure that reached the caller.
+
+        A policy refusal is already a sentence written for whoever is reading
+        it — SaaS composes it from the attribute they are missing — so it goes
+        out without the ``error_code=`` prefix that would otherwise be the
+        first thing they see. Everything else keeps the prefixed form the logs
+        and the existing callers expect.
+        """
+        return exc.detail if exc.code is ErrorCode.POLICY_DENIED else str(exc)
 
     def guard_estimated_rows(
         self,

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -120,6 +120,12 @@ class ErrorCode(Enum):
 
     # Plugin store errors
     PLUGIN_STORE_ERROR = ("400030", "Plugin store error: {error_message}")
+
+    # Read refused by a policy plugin, as opposed to a malformed request.
+    # Distinct from TOOL_INVALID_INPUT so a caller can tell "you may not see
+    # this" from "your query is wrong" — the two want different UI, and only
+    # one of them is worth a retry button.
+    POLICY_DENIED = ("400040", "Policy denied the read: {error_message}")
     PACKAGE_BUILD_ERROR = ("400031", "Package build error: {error_message}")
 
     # Storage errors - Vector Database Operations
@@ -205,6 +211,11 @@ class DatusException(Exception):
     def __init__(self, code: ErrorCode, message=None, message_args=None, *args):
         self.code = code
         self.message_args = message_args or {}
+        #: The message on its own. ``message`` prefixes it with the code, which
+        #: is right for a log and wrong for anything a person reads — a policy
+        #: refusal already explains itself and does not need "error_code=" in
+        #: front of it.
+        self.detail = self.build_detail(message, message_args)
         self.message = self.build_msg(message, message_args)
         super().__init__(self.message, *args)
 
@@ -227,6 +238,10 @@ class DatusException(Exception):
         return names
 
     def build_msg(self, message: Optional[str] = None, message_args: Optional[Dict[str, Any]] = None) -> str:
+        return f"error_code={self.code.code}, error_message={self.build_detail(message, message_args)}"
+
+    def build_detail(self, message: Optional[str] = None, message_args: Optional[Dict[str, Any]] = None) -> str:
+        """The message without the ``error_code=`` prefix."""
         if message:
             final_message = message
         elif message_args:
@@ -248,7 +263,7 @@ class DatusException(Exception):
                     final_message = formatted
         else:
             final_message = self.code.desc
-        return f"error_code={self.code.code}, error_message={final_message}"
+        return final_message
 
 
 def setup_exception_handler(console_logger=None, prefix_wrap_func=None):

--- a/tests/unit_tests/api/services/test_dashboard_service.py
+++ b/tests/unit_tests/api/services/test_dashboard_service.py
@@ -32,6 +32,7 @@ from datus.api.services.dashboard_service import (
     _validate_params,
 )
 from datus.schemas.gen_visual_dashboard_models import TemplateParamDecl
+from datus.utils.exceptions import ErrorCode
 
 _SAMPLE_SQL_J2 = "SELECT * FROM sales WHERE region = :region;\n"
 _SAMPLE_META = {
@@ -668,6 +669,38 @@ async def test_run_query_connector_returns_unsuccessful_envelope(tmp_path: Path,
     assert result.success is False
     assert result.errorCode == "QUERY_EXECUTION_FAILED"
     assert "syntax error" in (result.errorMessage or "")
+
+
+@pytest.mark.asyncio
+async def test_run_query_reports_a_policy_refusal_as_its_own_code(tmp_path: Path, monkeypatch):
+    """A refusal is not a failed query, and the viewer renders it differently.
+
+    Folded into QUERY_EXECUTION_FAILED it arrived as
+    ``query failed: error_code=400002, error_message=<the only useful part>``,
+    which a dashboard then repeated once per panel under a retry button that
+    could not help.
+    """
+    _write_dashboard(tmp_path)
+
+    class _Denied:
+        success = False
+        error = "you have no value for store_id, which this project's row policies filter by."
+        error_code = ErrorCode.POLICY_DENIED.code
+
+    _patch_failing_executor(monkeypatch, exec_result=_Denied())
+
+    result = await DashboardService(agent_config=MagicMock()).run_query(
+        project_files_root=tmp_path,
+        dashboard_slug="demo",
+        query_slug="by_region",
+        params={"region": "APAC"},
+    )
+
+    assert result.success is False
+    assert result.errorCode == "POLICY_DENIED"
+    # Verbatim: no "query failed:" in front of a sentence already written for
+    # whoever is reading it.
+    assert result.errorMessage == _Denied.error
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/tools/test_policy_runtime.py
+++ b/tests/unit_tests/tools/test_policy_runtime.py
@@ -6,7 +6,7 @@ import pytest
 
 from datus.tools.func_tool.database import DBFuncTool
 from datus.tools.policy_runtime import PolicyRuntime
-from datus.utils.exceptions import DatusException
+from datus.utils.exceptions import DatusException, ErrorCode
 
 
 class FakeRuntime:
@@ -181,6 +181,50 @@ def test_db_policy_denial_does_not_execute(monkeypatch):
     result = make_db_tool(db, config()).execute_read_enforced("SELECT * FROM orders", db)
     assert not result.success
     assert "access denied" in result.error
+    db.execute_query.assert_not_called()
+
+
+def test_db_policy_denial_is_coded_and_unprefixed(monkeypatch):
+    """A refusal has to be distinguishable from a broken query.
+
+    Both used to arrive as ``TOOL_INVALID_INPUT`` inside a string, so the only
+    way to tell "you may not see this" from "your SQL is wrong" was to match
+    the sentence — and an API surface has to tell them apart to know whether a
+    retry button means anything.
+    """
+    fake = FakeRuntime(allowed=False, reason="you have no value for store_id")
+    monkeypatch.setattr(
+        "datus.tools.policy_runtime.collect_plugin_policy_runtime_factories",
+        lambda active: {"sql-policy": lambda profile: fake},
+    )
+    db = connector()
+    result = make_db_tool(db, config()).execute_read_enforced("SELECT * FROM orders", db)
+
+    assert result.error_code == ErrorCode.POLICY_DENIED.code
+    # Reaches the reader as written, without the wire prefix in front of it.
+    assert result.error == "you have no value for store_id"
+
+
+def test_db_result_policy_denial_is_coded_too(monkeypatch):
+    fake = FakeRuntime(result_allowed=False, reason="you may not see these rows")
+    monkeypatch.setattr(
+        "datus.tools.policy_runtime.collect_plugin_policy_runtime_factories",
+        lambda active: {"sql-policy": lambda profile: fake},
+    )
+    db = connector()
+    result = make_db_tool(db, config()).execute_read_enforced("SELECT * FROM orders", db)
+
+    assert result.error_code == ErrorCode.POLICY_DENIED.code
+    assert result.error == "you may not see these rows"
+
+
+def test_db_non_policy_failure_keeps_the_prefixed_form(monkeypatch):
+    """Only a refusal is unwrapped — everything else keeps what the logs expect."""
+    db = connector()
+    result = make_db_tool(db, config()).execute_read_enforced("SELECT 1; DROP TABLE t", db)
+
+    assert result.success is False
+    assert result.error_code is None
     db.execute_query.assert_not_called()
 
 


### PR DESCRIPTION
## 问题

行级策略的拒绝和一条写错的 SQL，从 `execute_read_enforced` 出来时是同一个 `TOOL_INVALID_INPUT`，而且都只是一个字符串。调用方要区分两者只能去匹配句子，于是每个 API 面都把「你无权看这些行」当成「查询失败」处理。

Dashboard 查看器上的效果是每个 panel 显示一遍这个：

```
Query 'kpi_summary' failed: code = QUERY_EXECUTION_FAILED, query failed:
error_code=400002, error_message=Policy context denies all data reads:
you have no value for jeffshop_store_id, which this project's row policies
filter by. Ask a workspace admin to set it on your account.
```

三个 panel 三遍，八个 panel 八遍，每遍都配一个帮不上忙的「重试」按钮——缺属性是账号的持久状态，不是抖动。而这段里真正写给读者的只有末尾那半句，SaaS 当初正是为了让人能行动才那样写的，现在被三层包装埋住：

| 层 | 加了什么 |
|---|---|
| SaaS `_DENIAL_MESSAGES` | 可执行的那句话 |
| `policy_runtime._explain` | `Policy context denies all data reads: ` |
| `DatusException.build_msg` | `error_code=400002, error_message=` |
| `dashboard_service` | `query failed: ` |

## 改动

- **`ErrorCode.POLICY_DENIED`（400040）** —— `execute_read_enforced` 的两个拒绝点都改用它：读之前（`before_sql_read`）和拿到结果之后（`after_read_result`）
- **`ExecuteSQLResult.error_code`** —— 让错误码能跨过「异常 → 结果对象」这一跳。引擎错误上为空，那类错误的文本本身就是全部信息
- **`DatusException.detail`** —— 不带 `error_code=` 前缀的消息。`message` 和 `build_msg` 保持原样（日志和现有调用方都依赖那个形式），只有策略拒绝以不带前缀的形式传出去，因为它本就是一句写给读者的话
- **`DashboardService.run_query`** —— 遇到 `POLICY_DENIED` 原样返回那句话，不再折进 `QUERY_EXECUTION_FAILED`

## 为什么需要它

有了独立的码，客户端才能可靠地区分两者并分别渲染——而不是靠子串匹配。

Datus-saas#866 已经把常见情况挡在更前面：mint token 时就得知拒绝，于是那些查询根本不会发出。但**策略在 dashboard 打开之后才变更**的情况仍然会走到这里，查看器需要这个码才能认出它。

## 测试

`tests/unit_tests/api tests/unit_tests/tools` 共 5381 passed（另有 1 个 `test_metric_filesystem_tools.py` 的失败在本改动之前就存在，是本地 `datus_semantic_dosi` 版本问题，stash 掉改动后同样失败）。

新增 4 个：

- 读前拒绝带上 `POLICY_DENIED` 且消息无前缀
- 结果拒绝同样带码
- 非策略失败（多语句）仍保持原有的带前缀形式、`error_code` 为空
- `run_query` 对策略拒绝返回 `POLICY_DENIED` + 原句

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Policy-denied data reads are now clearly identified as policy refusals instead of generic query failures.
  - Preserves the original refusal reason without adding misleading prefixes.
  - Provides a consistent fallback message when query errors are missing or empty.
  - Non-policy query failures continue to be reported separately from policy denials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->