### PR TITLE
[Doc] Tell the Dosi authoring skill about the spec fields it never mentioned

### DIFF
--- a/datus/resources/skills/dosi-semantic-authoring/SKILL.md
+++ b/datus/resources/skills/dosi-semantic-authoring/SKILL.md
@@ -24,7 +24,9 @@ Author the active Dosi semantic model as strict OSI core YAML. Use this skill fo
 - Keep one `semantic_model` per file and stable `snake_case` names. Preserve unrelated content; an upsert replaces the complete same-named object.
 - Bind a dataset to a qualified physical table or a complete reusable SELECT. Declare every referenced physical column as a field with the active OSI dialect.
 - Mark time fields with `dimension: {is_time: true}`. Keep other fields available as dimensions.
-- Declare keys only from source metadata or verified data evidence.
+- For a dataset bound to a physical table, use `primary_key` to transcribe a source-declared physical primary key, and `unique_keys` to transcribe source-declared unique constraints and indexes. For a query-backed dataset, a source key holds only if the query preserves it: a one-to-many join repeats it, so validate against the result, not the base table. Declare a key the source does not declare only after full-table validation shows those columns are non-null and duplicate-free; a stated grain, a query pattern, or one partition is not evidence.
+- Give a field a `label` when its column name is not what a reader would call it.
+- Give a dataset `ai_context.instructions` when its grain or intended use does not follow from the description, and give a field `ai_context.synonyms` when users ask for it by a name the column does not carry. Leave both out otherwise: restating the description dilutes what a reader can act on.
 - Define model-level relationships with aligned `from_columns` and `to_columns`; bind the target columns to one complete verified key.
 
 ## Author DATUS extensions


### PR DESCRIPTION
## Why

The skill named only the fields it happened to describe, and generation followed it exactly:

| Field | Skill mentions it | Generated |
|---|---|---|
| `ai_context` on metrics | yes | 28/29 |
| `ai_context` on datasets | **no** | **0/5** |
| `ai_context` on fields | **no** | **0/37** |
| `label` | **no** | **0/37** |
| `primary_key` vs `unique_keys` | keys, but not which | picked by inference |

The spec was never the gap. It is injected whole — core plus DATUS extension, ~20k characters — and declares `ai_context` at all four levels. But a field being declared says it *exists*, not that it is *worth writing*. Only the skill gives that direction, and it was silent on these.

## Solution

Three additions to **Model reusable semantics**, each carrying the condition under which it applies:

- `primary_key` transcribes a key the source declares; `unique_keys` records a grain you verified that it does not — the usual case for a view.
- `label` when the column name is not what a reader would call it.
- Dataset `ai_context.instructions` when grain or intended use does not follow from the description; field `ai_context.synonyms` when users ask for it by a name the column does not carry. **Leave both out otherwise.**

That last clause matters as much as the instruction. The failure mode of "annotate everything" is an `ai_context` on every field restating its description, which buries the ones that carry meaning.

**`datatype` is deliberately absent.** The OSI schema defines it, but the Dosi engine rejects it — `unknown field 'datatype'` from a struct that denies unknown fields — so a model declaring it would fail to parse. Closing that gap belongs in the engine, not here.

## Test Cases

No unit tests added: this file is prose consumed by a model, and no assertion over its wording would show whether the wording works.

Verified by regenerating the baisheng model against a live StarRocks with the updated skill, same seed context as the baseline:

```
dataset ai_context     0/5  -> 4/5
field   ai_context    0/37  -> 11/48
field   label         0/37  -> 48/48
dataset unique_keys    5/5  -> 5/5   (unchanged, no regression)
```

Field-level `ai_context` staying selective is the point. It went to `ac_code` (`synonyms: [活动ID, 活动编号]`) and `request_name` (`创建人`), and stayed off `subject_name` and `product_name`, whose names already say what they are. The dataset annotation captured a grain trap the description could not: 行粒度为活动×机制×产品组合，活动数量类查询需按 ac_code 去重.

The result parses under the native engine: 28 metrics, 5 datasets, 48 dimensions.

Existing suites: 694 passed across skill and authoring tests.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for distinguishing declared primary keys from author-verified unique keys.
  * Added recommendations for providing field labels, dataset instructions, and field synonyms when names or data grain are unclear.
  * Clarified when these additional semantic annotations should be omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for distinguishing declared primary keys from author-verified unique keys.
  * Added recommendations for providing field labels, dataset instructions, and field synonyms when names or data grain are unclear.
  * Clarified when these additional semantic annotations should be omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->