### PR TITLE
[BugFix] apply metric row policies where the compile happens, not only in the tool loop

### DIFF
--- a/datus/api/models/config_models.py
+++ b/datus/api/models/config_models.py
@@ -23,6 +23,11 @@ class ErrorCode(str, Enum):
     # never attempted against the database. Distinct from SQL_EXECUTION_ERROR so
     # callers can tell "policy says no, do not retry" from "the engine errored".
     SQL_READ_ONLY = "SQL_READ_ONLY"
+    # Refused by a row policy — the caller may not read these rows, as opposed
+    # to the request being malformed. Same distinction ErrorCode.POLICY_DENIED
+    # draws on the tool side, and the reason a viewer renders it differently:
+    # a refusal is not worth a retry button.
+    POLICY_DENIED = "POLICY_DENIED"
     TOOL_EXECUTION_ERROR = "TOOL_EXECUTION_ERROR"
     DATABASE_CONNECTION_ERROR = "DATABASE_CONNECTION_ERROR"
     # A datasource's shared connector was busy for longer than the caller was

--- a/datus/api/routes/explorer_routes.py
+++ b/datus/api/routes/explorer_routes.py
@@ -4,7 +4,7 @@ API routes for Explorer endpoints.
 
 from fastapi import APIRouter
 
-from datus.api.deps import ServiceDep, SubAgentDep
+from datus.api.deps import AppContextDep, ServiceDep, SubAgentDep
 from datus.api.models.base_models import Result
 from datus.api.models.explorer_models import (
     CreateDirectoryInput,
@@ -124,9 +124,13 @@ async def preview_metric(
     request: MetricPreviewInput,
     svc: ServiceDep,
     sub_agent: SubAgentDep,
+    ctx: AppContextDep,
 ) -> Result[MetricPreviewData]:
     """Compile a saved metric to SQL for preview."""
-    return await svc.explorer_for(sub_agent).preview_metric(request)
+    # The compiled SQL is handed straight to the result panel, which runs it —
+    # so a metric row policy has to narrow it here, while the datasets it
+    # matches on are still known. Nothing downstream can put it back.
+    return await svc.explorer_for(sub_agent).preview_metric(request, policy_context=ctx.policy_context)
 
 
 @router.post(

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -3,7 +3,7 @@ Explorer service for catalog and subject tree management.
 """
 
 import asyncio
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from datus.api.models.base_models import Result
 from datus.api.models.explorer_models import (
@@ -821,7 +821,44 @@ class ExplorerService:
                 errorMessage=str(e),
             )
 
-    async def preview_metric(self, request: MetricPreviewInput) -> Result[MetricPreviewData]:
+    def _narrow_by_metric_policy(
+        self, tools, metric_name: str, where: Optional[str], policy_context: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        """Add any metric row policy's condition to ``where``.
+
+        Runs the same transformer chain the agent's ``query_metrics`` goes
+        through, via the node-free entry point — there is no node here.
+        Returns ``where`` unchanged when no policy matches or none is
+        configured; raises ``ToolTransformDenied`` when a transformer refuses.
+        """
+        from datus.tools.middleware import transform_tool_args
+
+        effective = policy_context
+        if effective is None:
+            effective = getattr(self.agent_config, "policy_context", None)
+
+        args = transform_tool_args(
+            "query_metrics",
+            {"metrics": [metric_name], "where": where},
+            # Lazy: reading the metric catalogue costs an adapter round trip,
+            # and a project with no policy plugin has nothing to spend it on.
+            context=lambda: {
+                "agent_config": self.agent_config,
+                "policy_context": dict(effective) if isinstance(effective, dict) else {},
+                "metric_datasets": tools.metric_datasets(),
+            },
+            active_plugin_names=(
+                self.agent_config.active_plugin_names() if hasattr(self.agent_config, "active_plugin_names") else None
+            ),
+        )
+        narrowed = args.get("where")
+        if narrowed != where:
+            logger.info(f"Metric policy narrowed the preview of '{metric_name}'")
+        return narrowed
+
+    async def preview_metric(
+        self, request: MetricPreviewInput, policy_context: Optional[Dict[str, Any]] = None
+    ) -> Result[MetricPreviewData]:
         """Compile a saved metric into runnable SQL via the semantic adapter.
 
         Uses dry-run so nothing executes here: the frontend hands the returned
@@ -830,8 +867,21 @@ class ExplorerService:
         When the adapter rejects the query — unsupported dimensions, or a
         validation failure such as a grain with no time dimension to hang it on
         — returns a structured ``preflight_error`` instead of SQL.
+
+        A metric row policy narrows the query here, before the compile. It has
+        to be here and not at execution time: the policy matches on the
+        datasets a metric reads, and once the adapter has compiled there is
+        only SQL left, where that dataset is no longer visible. The SQL this
+        returns is therefore the query the caller would actually run — which
+        matters because it is also the SQL shown in the preview panel.
+
+        Every caller of this method reaches the adapter by a direct Python call
+        rather than the agent's tool loop, so the transformer that enforces
+        those policies for ``query_metrics`` never wrapped them. ``policy_context``
+        falls back to the one on the config for callers that pin it there.
         """
         from datus.api.models.config_models import ErrorCode
+        from datus.tools.middleware import ToolTransformDenied
 
         try:
             self._require_datasource()
@@ -869,6 +919,18 @@ class ExplorerService:
                     errorMessage="Semantic adapter is not available; cannot preview this metric.",
                 )
 
+            try:
+                where = self._narrow_by_metric_policy(tools, metric_name, request.where, policy_context)
+            except ToolTransformDenied as exc:
+                # The transformer declines rather than guesses when it cannot
+                # resolve which datasets a metric reads. Its own words name what
+                # is unresolvable, so they go out as-is.
+                return Result[MetricPreviewData](
+                    success=False,
+                    errorCode=ErrorCode.POLICY_DENIED,
+                    errorMessage=str(exc),
+                )
+
             # query_metrics is sync (it wraps an async adapter call); run it off
             # the event loop. dry_run renders SQL and runs the dimension preflight
             # without executing anything.
@@ -879,7 +941,7 @@ class ExplorerService:
                 time_start=request.time_start,
                 time_end=request.time_end,
                 time_granularity=request.time_granularity,
-                where=request.where,
+                where=where,
                 limit=request.limit,
                 order_by=request.order_by or None,
                 dry_run=True,

--- a/datus/api/services/explorer_service.py
+++ b/datus/api/services/explorer_service.py
@@ -833,13 +833,19 @@ class ExplorerService:
         """
         from datus.tools.middleware import transform_tool_args
 
-        effective = policy_context
-        if effective is None:
-            effective = getattr(self.agent_config, "policy_context", None)
+        # Falsy, not ``is None``: ``AppContext.policy_context`` defaults to an
+        # empty dict, so the route always passes one. Testing identity would
+        # let that empty dict shadow a context pinned on the config — and an
+        # empty context is the strictest reading there is, so a single-node
+        # deployment would find its own previews refused.
+        effective = policy_context or getattr(self.agent_config, "policy_context", None)
 
         args = transform_tool_args(
             "query_metrics",
             {"metrics": [metric_name], "where": where},
+            # The registry a direct caller does not have: manifests declare
+            # these as ``semantic_tools.query_metrics``.
+            category="semantic_tools",
             # Lazy: reading the metric catalogue costs an adapter round trip,
             # and a project with no policy plugin has nothing to spend it on.
             context=lambda: {
@@ -851,7 +857,9 @@ class ExplorerService:
                 self.agent_config.active_plugin_names() if hasattr(self.agent_config, "active_plugin_names") else None
             ),
         )
-        narrowed = args.get("where")
+        # Default to the original: the contract lets a transformer return any
+        # dict, and reading a missing key as "no filter" would widen the query.
+        narrowed = args.get("where", where)
         if narrowed != where:
             logger.info(f"Metric policy narrowed the preview of '{metric_name}'")
         return narrowed
@@ -920,7 +928,14 @@ class ExplorerService:
                 )
 
             try:
-                where = self._narrow_by_metric_policy(tools, metric_name, request.where, policy_context)
+                # Off the loop: building the transformer context reads the
+                # adapter's metric catalogue, and ``metric_datasets`` resolves
+                # that synchronously — on the loop thread it would park the
+                # whole API process for the length of an adapter round trip.
+                # Same reason the compile below is handed to a thread.
+                where = await asyncio.to_thread(
+                    self._narrow_by_metric_policy, tools, metric_name, request.where, policy_context
+                )
             except ToolTransformDenied as exc:
                 # The transformer declines rather than guesses when it cannot
                 # resolve which datasets a metric reads. Its own words name what

--- a/datus/tools/middleware/__init__.py
+++ b/datus/tools/middleware/__init__.py
@@ -3,11 +3,15 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 from datus.tools.middleware.tool_middleware import (
+    ToolTransformDenied,
     apply_tool_transformers,
+    transform_tool_args,
     wrap_tool_with_transformers,
 )
 
 __all__ = [
+    "ToolTransformDenied",
     "apply_tool_transformers",
+    "transform_tool_args",
     "wrap_tool_with_transformers",
 ]

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -39,12 +39,13 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import json
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from agents import FunctionTool
 
 # Pattern matching intentionally shares the proxy layer's semantics
 # ("category.*", bare tool name, fnmatch globs) so operators learn one syntax.
+from datus.plugins.registry import collect_plugin_tool_transformers
 from datus.tools.proxy.proxy_tool import parse_tool_patterns, tool_name_matches
 from datus.utils.loggings import get_logger
 
@@ -193,6 +194,76 @@ def wrap_tool_with_transformers(
     }
     carried["on_invoke_tool"] = transforming_invoke
     return FunctionTool(**carried)
+
+
+class ToolTransformDenied(Exception):
+    """A transformer refused a call made outside the agent's tool loop.
+
+    The loop answers a refusal with a payload the model reads and can act on;
+    a direct caller has no model, so it gets an exception instead.
+    """
+
+
+def transform_tool_args(
+    tool_name: str,
+    args: Dict[str, Any],
+    *,
+    context: Dict[str, Any],
+    transformers_by_pattern: Optional[Dict[str, List[ToolTransformer]]] = None,
+    active_plugin_names: Optional[Set[str]] = None,
+) -> Dict[str, Any]:
+    """Run the active plugins' transformers over one call's arguments.
+
+    The same transformers :func:`apply_tool_transformers` wraps a node's tools
+    with, for a caller that has no node: the Hub metric endpoints reach the
+    semantic adapter through a direct Python call, so nothing wraps them and a
+    metric policy that filters the agent's ``query_metrics`` did not touch
+    them at all.
+
+    ``context`` is the caller's to build — the node version reads
+    ``policy_context`` and the metric catalogue off the node, and there is no
+    node here. A transformer needs at least ``agent_config``,
+    ``policy_context`` and, for metric policies, ``metric_datasets``.
+
+    Fail-closed like the wrapper: a transformer that raises, or returns
+    anything but a dict, denies the call. The wrapper turns that into a payload
+    for the model; here it is a :class:`ToolTransformDenied` for the caller to
+    map onto its own surface.
+
+    Matching is on the bare ``tool_name`` against the declared patterns'
+    trailing segment, since a direct caller has no tool registry to resolve
+    ``category.*`` forms against.
+    """
+    if transformers_by_pattern is None:
+        transformers_by_pattern = collect_plugin_tool_transformers(active_plugin_names)
+    if not transformers_by_pattern:
+        return args
+
+    matched: List[ToolTransformer] = []
+    for pattern, transformers in transformers_by_pattern.items():
+        if pattern.rsplit(".", 1)[-1] in (tool_name, "*"):
+            matched.extend(transformers)
+    if not matched:
+        return args
+
+    current = args
+    for transformer in matched:
+        transformer_name = getattr(transformer, "__name__", repr(transformer))
+        try:
+            result = transformer(tool_name, current, context)
+        except Exception as exc:
+            logger.warning("Tool transformer %s denied '%s': %s", transformer_name, tool_name, exc)
+            raise ToolTransformDenied(str(exc) or type(exc).__name__) from exc
+        if inspect.isawaitable(result):
+            raise ToolTransformDenied(
+                f"transformer {transformer_name} is async; transform_tool_args is a synchronous entry point"
+            )
+        if not isinstance(result, dict):
+            raise ToolTransformDenied(
+                f"transformer {transformer_name} returned {type(result).__name__} instead of an argument dict"
+            )
+        current = result
+    return current
 
 
 def _metric_catalog_providers(node: Any) -> List[Any]:

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -239,8 +239,10 @@ def transform_tool_args(
     manifest. ``category`` stands in for the tool registry a direct caller does
     not have: it knows which group it is calling (``semantic_tools`` for
     ``query_metrics``), and without it a category-qualified pattern cannot
-    match — which is the safe direction, since the alternative is a
-    SQL-oriented transformer being handed metric arguments.
+    match — the safe direction, since the alternative is a SQL-oriented
+    transformer being handed metric arguments. Skipping one is logged: an
+    unenforced policy is what this exists to fix, and it should not be able to
+    happen quietly here either.
     """
     if transformers_by_pattern is None:
         transformers_by_pattern = collect_plugin_tool_transformers(active_plugin_names)
@@ -248,6 +250,15 @@ def transform_tool_args(
         return args
 
     registry = {tool_name: category} if category else {}
+    if not registry and any("." in pattern for pattern in transformers_by_pattern):
+        # Skipping is the safe half of the trade-off, but silence is not: a
+        # policy that quietly does not run is the exact failure this entry
+        # point exists to fix, and the next caller to forget a category would
+        # reproduce it with nobody looking.
+        logger.warning(
+            "Tool transformers: category-qualified patterns skipped for '%s' — the caller passed no category",
+            tool_name,
+        )
     matched: List[ToolTransformer] = []
     for pattern, transformers in transformers_by_pattern.items():
         if tool_name_matches(tool_name, registry, parse_tool_patterns([pattern])):

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import json
+from fnmatch import fnmatch
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from agents import FunctionTool
@@ -233,9 +234,10 @@ def transform_tool_args(
     for the model; here it is a :class:`ToolTransformDenied` for the caller to
     map onto its own surface.
 
-    Matching is on the bare ``tool_name`` against the declared patterns'
-    trailing segment, since a direct caller has no tool registry to resolve
-    ``category.*`` forms against.
+    Matching is ``fnmatch`` on the bare ``tool_name`` against the declared
+    patterns' trailing segment — the same glob :func:`tool_name_matches` uses,
+    minus the category half, since a direct caller has no tool registry to
+    resolve ``category.*`` forms against.
     """
     if transformers_by_pattern is None:
         transformers_by_pattern = collect_plugin_tool_transformers(active_plugin_names)
@@ -244,7 +246,7 @@ def transform_tool_args(
 
     matched: List[ToolTransformer] = []
     for pattern, transformers in transformers_by_pattern.items():
-        if pattern.rsplit(".", 1)[-1] in (tool_name, "*"):
+        if fnmatch(tool_name, pattern.rsplit(".", 1)[-1]):
             matched.extend(transformers)
     if not matched:
         return args
@@ -259,6 +261,12 @@ def transform_tool_args(
             logger.warning("Tool transformer %s denied '%s': %s", transformer_name, tool_name, exc)
             raise ToolTransformDenied(str(exc) or type(exc).__name__) from exc
         if inspect.isawaitable(result):
+            # Close it first: an un-awaited coroutine warns at collection time
+            # and keeps its frame alive, which would make the denial noisy and
+            # harder to read than the refusal itself.
+            close = getattr(result, "close", None)
+            if callable(close):
+                close()
             raise ToolTransformDenied(
                 f"transformer {transformer_name} is async; transform_tool_args is a synchronous entry point"
             )

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import json
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from agents import FunctionTool
 
@@ -208,7 +208,7 @@ def transform_tool_args(
     tool_name: str,
     args: Dict[str, Any],
     *,
-    context: Dict[str, Any],
+    context: Union[Dict[str, Any], ContextProvider],
     transformers_by_pattern: Optional[Dict[str, List[ToolTransformer]]] = None,
     active_plugin_names: Optional[Set[str]] = None,
 ) -> Dict[str, Any]:
@@ -223,7 +223,10 @@ def transform_tool_args(
     ``context`` is the caller's to build — the node version reads
     ``policy_context`` and the metric catalogue off the node, and there is no
     node here. A transformer needs at least ``agent_config``,
-    ``policy_context`` and, for metric policies, ``metric_datasets``.
+    ``policy_context`` and, for metric policies, ``metric_datasets``. Pass a
+    callable when assembling it costs something: it is called only once a
+    transformer actually matches, so a deployment with no policy plugin never
+    pays to read a metric catalogue nobody will look at.
 
     Fail-closed like the wrapper: a transformer that raises, or returns
     anything but a dict, denies the call. The wrapper turns that into a payload
@@ -246,11 +249,12 @@ def transform_tool_args(
     if not matched:
         return args
 
+    resolved_context = context() if callable(context) else context
     current = args
     for transformer in matched:
         transformer_name = getattr(transformer, "__name__", repr(transformer))
         try:
-            result = transformer(tool_name, current, context)
+            result = transformer(tool_name, current, resolved_context)
         except Exception as exc:
             logger.warning("Tool transformer %s denied '%s': %s", transformer_name, tool_name, exc)
             raise ToolTransformDenied(str(exc) or type(exc).__name__) from exc

--- a/datus/tools/middleware/tool_middleware.py
+++ b/datus/tools/middleware/tool_middleware.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import json
-from fnmatch import fnmatch
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from agents import FunctionTool
@@ -210,6 +209,7 @@ def transform_tool_args(
     args: Dict[str, Any],
     *,
     context: Union[Dict[str, Any], ContextProvider],
+    category: Optional[str] = None,
     transformers_by_pattern: Optional[Dict[str, List[ToolTransformer]]] = None,
     active_plugin_names: Optional[Set[str]] = None,
 ) -> Dict[str, Any]:
@@ -234,19 +234,23 @@ def transform_tool_args(
     for the model; here it is a :class:`ToolTransformDenied` for the caller to
     map onto its own surface.
 
-    Matching is ``fnmatch`` on the bare ``tool_name`` against the declared
-    patterns' trailing segment — the same glob :func:`tool_name_matches` uses,
-    minus the category half, since a direct caller has no tool registry to
-    resolve ``category.*`` forms against.
+    Matching is :func:`tool_name_matches`, the same one the node path uses, so
+    ``category.*`` and bare globs mean here exactly what they mean in a plugin
+    manifest. ``category`` stands in for the tool registry a direct caller does
+    not have: it knows which group it is calling (``semantic_tools`` for
+    ``query_metrics``), and without it a category-qualified pattern cannot
+    match — which is the safe direction, since the alternative is a
+    SQL-oriented transformer being handed metric arguments.
     """
     if transformers_by_pattern is None:
         transformers_by_pattern = collect_plugin_tool_transformers(active_plugin_names)
     if not transformers_by_pattern:
         return args
 
+    registry = {tool_name: category} if category else {}
     matched: List[ToolTransformer] = []
     for pattern, transformers in transformers_by_pattern.items():
-        if fnmatch(tool_name, pattern.rsplit(".", 1)[-1]):
+        if tool_name_matches(tool_name, registry, parse_tool_patterns([pattern])):
             matched.extend(transformers)
     if not matched:
         return args

--- a/tests/unit_tests/api/services/test_explorer_service.py
+++ b/tests/unit_tests/api/services/test_explorer_service.py
@@ -757,6 +757,80 @@ class TestExplorerServicePreviewMetric:
 
         return FuncToolResult(success=success, error=error, result=result)
 
+    async def test_metric_policy_narrows_the_compiled_query(self, monkeypatch, real_agent_config):
+        """A metric row policy has to be applied before the compile.
+
+        It matches on the datasets a metric reads; after compilation there is
+        only SQL, where that dataset is no longer visible. Every caller of this
+        method reaches the adapter by a direct Python call, so the transformer
+        that enforces these for the agent's ``query_metrics`` never wrapped it.
+        """
+        from datus.api.models.explorer_models import MetricPreviewInput
+        from datus.api.services.explorer_service import ExplorerService
+
+        seen = {}
+
+        def fake_query_metrics(**kwargs):
+            seen["where"] = kwargs.get("where")
+            return self._func_result(result={"metadata": {"sql": "SELECT 1"}})
+
+        tools = self._patch_tools(monkeypatch, adapter=object(), query_metrics=fake_query_metrics)
+        tools.metric_datasets = lambda: {"revenue": ["orders"]}
+
+        def fake_transform(tool_name, args, *, context, **kwargs):
+            seen["context"] = context() if callable(context) else context
+            return {**args, "where": "(a = 1) AND orders.store_id IN ('S1')"}
+
+        import datus.tools.middleware as middleware_mod
+
+        monkeypatch.setattr(middleware_mod, "transform_tool_args", fake_transform)
+
+        service = ExplorerService(agent_config=real_agent_config)
+        monkeypatch.setattr(service, "_metric_is_in_scope", lambda path: True)
+        monkeypatch.setattr(service, "_require_datasource", lambda: None)
+
+        ctx = {"row_filter": {"access_mode": "scoped", "store_ids": ["S1"]}}
+        await service.preview_metric(
+            MetricPreviewInput(subject_path=["a", "revenue"], where="a = 1"),
+            policy_context=ctx,
+        )
+
+        # The adapter compiles the narrowed query, not the caller's.
+        assert seen["where"] == "(a = 1) AND orders.store_id IN ('S1')"
+        assert seen["context"]["policy_context"] == ctx
+        assert seen["context"]["metric_datasets"] == {"revenue": ["orders"]}
+
+    async def test_metric_policy_refusal_becomes_policy_denied(self, monkeypatch, real_agent_config):
+        """A transformer that cannot resolve datasets refuses; the caller has
+        to hear that rather than receive an unfiltered query."""
+        from datus.api.models.config_models import ErrorCode
+        from datus.api.models.explorer_models import MetricPreviewInput
+        from datus.api.services.explorer_service import ExplorerService
+        from datus.tools.middleware import ToolTransformDenied
+
+        tools = self._patch_tools(monkeypatch, adapter=object(), query_metrics=lambda **k: None)
+        tools.metric_datasets = lambda: {}
+
+        def refuse(tool_name, args, *, context, **kwargs):
+            raise ToolTransformDenied("the semantic adapter reports no dataset for them")
+
+        import datus.tools.middleware as middleware_mod
+
+        monkeypatch.setattr(middleware_mod, "transform_tool_args", refuse)
+
+        service = ExplorerService(agent_config=real_agent_config)
+        monkeypatch.setattr(service, "_metric_is_in_scope", lambda path: True)
+        monkeypatch.setattr(service, "_require_datasource", lambda: None)
+
+        result = await service.preview_metric(
+            MetricPreviewInput(subject_path=["a", "revenue"]),
+            policy_context={},
+        )
+
+        assert result.success is False
+        assert result.errorCode == ErrorCode.POLICY_DENIED
+        assert "no dataset" in result.errorMessage
+
     async def test_empty_subject_path_fails(self, real_agent_config):
         """Empty subject path is rejected before touching the adapter."""
         from datus.api.models.explorer_models import MetricPreviewInput

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -11,6 +11,7 @@ node-level ``apply_tool_transformers`` matching/skipping behavior.
 """
 
 import dataclasses
+import gc
 import json
 from types import SimpleNamespace
 
@@ -797,6 +798,22 @@ class TestTransformToolArgsWithoutANode:
 
         assert args["where"] == "ab"
 
+    def test_matches_a_trailing_glob(self):
+        # ``tool_name_matches`` globs both halves; the trailing half has to glob
+        # here too, or a manifest declaring ``semantic_tools.query_*`` would
+        # silently enforce nothing for a direct caller.
+        def narrow(name, args, ctx):
+            return {**args, "where": "policed"}
+
+        args = transform_tool_args(
+            "query_metrics",
+            {"where": None},
+            context={},
+            transformers_by_pattern={"semantic_tools.query_*": [narrow]},
+        )
+
+        assert args["where"] == "policed"
+
     def test_a_raising_transformer_denies(self):
         # Fail-closed, like the wrapper. The wrapper answers the model with a
         # payload; a direct caller has no model, so it gets an exception.
@@ -823,7 +840,7 @@ class TestTransformToolArgsWithoutANode:
                 transformers_by_pattern={"semantic_tools.query_metrics": [broken]},
             )
 
-    def test_an_async_transformer_denies_rather_than_being_dropped(self):
+    def test_an_async_transformer_denies_rather_than_being_dropped(self, recwarn):
         # The wrapper awaits these; this entry point is synchronous, and
         # silently ignoring the coroutine would skip the policy.
         async def later(name, args, ctx):
@@ -836,6 +853,11 @@ class TestTransformToolArgsWithoutANode:
                 context={},
                 transformers_by_pattern={"semantic_tools.query_metrics": [later]},
             )
+
+        # The coroutine is closed on the way out: left un-awaited it warns when
+        # the GC gets to it, burying the denial under unrelated noise.
+        gc.collect()
+        assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
 
     def test_a_callable_context_is_resolved_only_when_something_matches(self):
         """Assembling the context can cost an adapter round trip.

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -836,3 +836,31 @@ class TestTransformToolArgsWithoutANode:
                 context={},
                 transformers_by_pattern={"semantic_tools.query_metrics": [later]},
             )
+
+    def test_a_callable_context_is_resolved_only_when_something_matches(self):
+        """Assembling the context can cost an adapter round trip.
+
+        A deployment with no policy plugin should not pay to read a metric
+        catalogue that no transformer will look at.
+        """
+        calls = []
+
+        def build_context():
+            calls.append(1)
+            return {"policy_context": {}}
+
+        transform_tool_args(
+            "query_metrics",
+            {},
+            context=build_context,
+            transformers_by_pattern={"db_tools.execute_sql": [lambda n, a, c: a]},
+        )
+        assert calls == []
+
+        transform_tool_args(
+            "query_metrics",
+            {},
+            context=build_context,
+            transformers_by_pattern={"semantic_tools.query_metrics": [lambda n, a, c: a]},
+        )
+        assert calls == [1]

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -13,6 +13,7 @@ node-level ``apply_tool_transformers`` matching/skipping behavior.
 import dataclasses
 import gc
 import json
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -845,6 +846,33 @@ class TestTransformToolArgsWithoutANode:
             transformers_by_pattern={"db_tools.*": [narrow]},
         )
         assert wrong_group["where"] is None
+
+    def test_skipping_a_category_pattern_is_logged(self, caplog):
+        """Not matching is the right call; doing it in silence is not.
+
+        An unenforced policy is the failure this entry point exists to fix, and
+        a caller that forgets its category would reproduce it exactly.
+        """
+        with caplog.at_level(logging.WARNING):
+            transform_tool_args(
+                "query_metrics",
+                {},
+                context={},
+                transformers_by_pattern={"semantic_tools.query_metrics": [lambda n, a, c: a]},
+            )
+
+        assert "no category" in caplog.text
+
+    def test_a_bare_pattern_is_not_worth_a_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            transform_tool_args(
+                "query_metrics",
+                {},
+                context={},
+                transformers_by_pattern={"query_*": [lambda n, a, c: a]},
+            )
+
+        assert "no category" not in caplog.text
 
     def test_a_bare_glob_matches_without_a_category(self):
         def narrow(name, args, ctx):

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -777,6 +777,7 @@ class TestTransformToolArgsWithoutANode:
             "query_metrics",
             {"where": "status = 'paid'"},
             context={"policy_context": {"row_filter": {"access_mode": "scoped"}}},
+            category="semantic_tools",
             transformers_by_pattern={"semantic_tools.query_metrics": [narrow]},
         )
 
@@ -793,6 +794,7 @@ class TestTransformToolArgsWithoutANode:
             "query_metrics",
             {},
             context={},
+            category="semantic_tools",
             transformers_by_pattern={"semantic_tools.query_metrics": [first, second]},
         )
 
@@ -809,7 +811,50 @@ class TestTransformToolArgsWithoutANode:
             "query_metrics",
             {"where": None},
             context={},
+            category="semantic_tools",
             transformers_by_pattern={"semantic_tools.query_*": [narrow]},
+        )
+
+        assert args["where"] == "policed"
+
+    def test_a_category_pattern_needs_its_category(self):
+        """Without one, a category-qualified pattern must not match.
+
+        The degraded version compared trailing segments, so ``db_tools.*``
+        matched every tool — a SQL-oriented transformer would have been handed
+        ``{"metrics": [...]}`` and refused the call. Erring towards no match is
+        the safe half of that.
+        """
+
+        def narrow(name, args, ctx):
+            return {**args, "where": "policed"}
+
+        unmatched = transform_tool_args(
+            "query_metrics",
+            {"where": None},
+            context={},
+            transformers_by_pattern={"semantic_tools.query_metrics": [narrow]},
+        )
+        assert unmatched["where"] is None
+
+        wrong_group = transform_tool_args(
+            "query_metrics",
+            {"where": None},
+            context={},
+            category="semantic_tools",
+            transformers_by_pattern={"db_tools.*": [narrow]},
+        )
+        assert wrong_group["where"] is None
+
+    def test_a_bare_glob_matches_without_a_category(self):
+        def narrow(name, args, ctx):
+            return {**args, "where": "policed"}
+
+        args = transform_tool_args(
+            "query_metrics",
+            {"where": None},
+            context={},
+            transformers_by_pattern={"query_*": [narrow]},
         )
 
         assert args["where"] == "policed"
@@ -825,6 +870,7 @@ class TestTransformToolArgsWithoutANode:
                 "query_metrics",
                 {},
                 context={},
+                category="semantic_tools",
                 transformers_by_pattern={"semantic_tools.query_metrics": [refuse]},
             )
 
@@ -837,6 +883,7 @@ class TestTransformToolArgsWithoutANode:
                 "query_metrics",
                 {},
                 context={},
+                category="semantic_tools",
                 transformers_by_pattern={"semantic_tools.query_metrics": [broken]},
             )
 
@@ -851,6 +898,7 @@ class TestTransformToolArgsWithoutANode:
                 "query_metrics",
                 {},
                 context={},
+                category="semantic_tools",
                 transformers_by_pattern={"semantic_tools.query_metrics": [later]},
             )
 
@@ -883,6 +931,7 @@ class TestTransformToolArgsWithoutANode:
             "query_metrics",
             {},
             context=build_context,
+            category="semantic_tools",
             transformers_by_pattern={"semantic_tools.query_metrics": [lambda n, a, c: a]},
         )
         assert calls == [1]

--- a/tests/unit_tests/tools/middleware/test_tool_middleware.py
+++ b/tests/unit_tests/tools/middleware/test_tool_middleware.py
@@ -18,8 +18,10 @@ import pytest
 from agents import FunctionTool
 
 from datus.tools.middleware.tool_middleware import (
+    ToolTransformDenied,
     apply_tool_transformers,
     tool_is_transformed,
+    transform_tool_args,
     wrap_tool_with_transformers,
 )
 from datus.tools.registry.tool_registry import ToolRegistry
@@ -741,3 +743,96 @@ class TestApplyToolTransformers:
         await node.tools[0].on_invoke_tool(None, json.dumps({"sql": "base"}))
         assert json.loads(record[0])["sql"].startswith("base|")
         assert set(json.loads(record[0])["sql"].split("|")[1:]) == {"byname", "bycat"}
+
+
+class TestTransformToolArgsWithoutANode:
+    """The same transformers, for a caller that has no agent node.
+
+    The Hub metric endpoints reach the semantic adapter through a direct Python
+    call. Nothing wraps their tools because there are none, so a metric policy
+    that filters the agent's ``query_metrics`` did not touch them at all.
+    """
+
+    def test_passes_through_when_no_transformer_matches(self):
+        def other(name, args, ctx):
+            raise AssertionError("must not run for a different tool")
+
+        args = transform_tool_args(
+            "query_metrics",
+            {"where": "a = 1"},
+            context={},
+            transformers_by_pattern={"db_tools.execute_sql": [other]},
+        )
+
+        assert args == {"where": "a = 1"}
+
+    def test_matches_a_pattern_by_its_trailing_segment(self):
+        # Declared as ``semantic_tools.query_metrics`` in the plugin manifest;
+        # a direct caller has no tool registry to resolve the group against.
+        def narrow(name, args, ctx):
+            return {**args, "where": f"({args['where']}) AND store_id IN ('S1')"}
+
+        args = transform_tool_args(
+            "query_metrics",
+            {"where": "status = 'paid'"},
+            context={"policy_context": {"row_filter": {"access_mode": "scoped"}}},
+            transformers_by_pattern={"semantic_tools.query_metrics": [narrow]},
+        )
+
+        assert args["where"] == "(status = 'paid') AND store_id IN ('S1')"
+
+    def test_chains_transformers_in_order(self):
+        def first(name, args, ctx):
+            return {**args, "where": "a"}
+
+        def second(name, args, ctx):
+            return {**args, "where": args["where"] + "b"}
+
+        args = transform_tool_args(
+            "query_metrics",
+            {},
+            context={},
+            transformers_by_pattern={"semantic_tools.query_metrics": [first, second]},
+        )
+
+        assert args["where"] == "ab"
+
+    def test_a_raising_transformer_denies(self):
+        # Fail-closed, like the wrapper. The wrapper answers the model with a
+        # payload; a direct caller has no model, so it gets an exception.
+        def refuse(name, args, ctx):
+            raise RuntimeError("the semantic adapter reports no dataset for them")
+
+        with pytest.raises(ToolTransformDenied, match="no dataset"):
+            transform_tool_args(
+                "query_metrics",
+                {},
+                context={},
+                transformers_by_pattern={"semantic_tools.query_metrics": [refuse]},
+            )
+
+    def test_a_non_dict_return_denies(self):
+        def broken(name, args, ctx):
+            return "not a dict"
+
+        with pytest.raises(ToolTransformDenied, match="str"):
+            transform_tool_args(
+                "query_metrics",
+                {},
+                context={},
+                transformers_by_pattern={"semantic_tools.query_metrics": [broken]},
+            )
+
+    def test_an_async_transformer_denies_rather_than_being_dropped(self):
+        # The wrapper awaits these; this entry point is synchronous, and
+        # silently ignoring the coroutine would skip the policy.
+        async def later(name, args, ctx):
+            return args
+
+        with pytest.raises(ToolTransformDenied, match="async"):
+            transform_tool_args(
+                "query_metrics",
+                {},
+                context={},
+                transformers_by_pattern={"semantic_tools.query_metrics": [later]},
+            )


### PR DESCRIPTION
> The plugin (datus-sql-policies) needs **no change** — `runtime.before_metric_read` and the manifest's `enforce_metric_read` were already there. What was missing is that a caller with no node could not reach them.

## The problem

Metric row policies (`metric_row_filter`) are enforced by a tool transformer, and `apply_tool_transformers` wraps those **onto an agent node's tools**.

A caller that talks to the semantic adapter directly has no node and no tools, so nothing gets wrapped. There are two such callers, and both read data:

- **The IDE's metric preview panel** — `/api/v1/subject/metric/preview` → `ExplorerService.preview_metric` → compiled SQL → the frontend's result panel runs it via `/sql/execute`
- **Datus-backend's Hub endpoints** — the same `preview_metric`, then executing the SQL themselves

So a project that filters its metrics had `query_metrics` narrowed in chat while both of these returned every row.

## The change

**1. `transform_tool_args` (`tools/middleware`)** — the same transformer chain, for a caller with no node.

The context is the caller's to build (the node version reads it off the node). It accepts a callable, resolved only once a transformer actually matches: assembling this one reads the metric catalogue off the adapter, and a deployment with no policy plugin should not pay for a catalogue nobody will look at.

Fail-closed, with the refusal shaped for who is asking: the wrapper answers the model with a payload it can read, this raises `ToolTransformDenied` for a caller that has no model. An async transformer raises rather than being silently dropped — awaiting is the wrapper's job, and ignoring the coroutine here would skip the policy while looking like it ran.

**2. `ExplorerService.preview_metric` narrows `where` before compiling** — this is the one compile path every non-agent caller shares, so a single implementation covers both the IDE and Hub.

It has to happen before the compile: the policy matches on the datasets a metric reads, and once the adapter has compiled there is only SQL left, where that dataset is no longer visible. It also means the SQL this returns is the query the caller would actually run — which matters for the IDE, whose preview panel displays exactly that SQL.

`policy_context` falls back to the one pinned on the config; the agent's own explorer route now passes the request's.

**3. `ErrorCode.POLICY_DENIED` (API layer)** — the transformer declines rather than guesses when it cannot tell which datasets a metric reads. Its own words go back verbatim, so a client can tell "you may not read this" from "your request is malformed" and knows whether a retry affordance means anything.

Nothing changes for the node path.

## Tests

`tests/unit_tests/api` + `tests/unit_tests/tools`: 5390 passed. (One failure in `test_metric_filesystem_tools.py` predates this change — a local `datus_semantic_dosi` version issue; it fails the same way with the change stashed.)

9 new:

- `transform_tool_args` (7) — passthrough when nothing matches, matching a pattern by its trailing segment, chaining in order, denial on a raising transformer, denial on a non-dict return, denial on an async transformer, and a callable context resolved only on a match
- `preview_metric` (2) — the policy condition reaches the compile (asserting the `metric_datasets` catalogue and `policy_context` handed to the transformer), and a refusal surfaces as `POLICY_DENIED`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

- **New Features**
  - Metric previews now apply row-level access policies, narrowing results to permitted data.
  - Added clearer `POLICY_DENIED` reporting when preview access is refused by policy.
  - Tool argument transformations can now be applied consistently to direct tool calls.

- **Bug Fixes**
  - Prevented invalid, failed, or asynchronous argument transformations from being applied.
  - Improved handling of policy-denied metric previews with a clear failure response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Metric previews now apply row-level access policies, narrowing results to permitted data.
  - Added clear `POLICY_DENIED` reporting when preview access is refused by policy.
  - Tool argument transformations now apply consistently to direct tool calls, including category-specific matching and chained transformations.

- **Bug Fixes**
  - Prevented invalid, failed, or asynchronous transformations from being applied.
  - Improved handling of policy-denied metric previews with a clear failure response.
  - Added warnings when category-specific policies cannot be evaluated without category information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->