### PR TITLE
[BugFix] Resolve a tables scope against the column each store binds its table to

### DIFF
--- a/datus/storage/rag_scope.py
+++ b/datus/storage/rag_scope.py
@@ -31,8 +31,13 @@ def _build_sub_agent_filter(
     sub_agent_name: Optional[str],
     storage: "BaseEmbeddingStore",
     check_scope_attr: str,
+    table_column: str = "table_name",
 ) -> Optional[Node]:
-    """Build scope filter from sub-agent's scoped context."""
+    """Build scope filter from sub-agent's scoped context.
+
+    ``table_column`` names the column holding the physical table name in the
+    target store, and only applies to the ``tables`` scope.
+    """
     if not sub_agent_name:
         return None
 
@@ -50,7 +55,7 @@ def _build_sub_agent_filter(
 
     if check_scope_attr == "tables":
         dialect = getattr(agent_config, "db_type", "")
-        return ScopedFilterBuilder.build_table_filter(scope_value, dialect)
+        return ScopedFilterBuilder.build_table_filter(scope_value, dialect, table_column)
     elif check_scope_attr in ("metrics", "sqls"):
         subject_tree = getattr(storage, "subject_tree", None)
         if subject_tree is None:

--- a/datus/storage/scoped_filter.py
+++ b/datus/storage/scoped_filter.py
@@ -26,12 +26,15 @@ class ScopedFilterBuilder:
     """Build LanceDB WHERE filters from ScopedContext attributes."""
 
     @staticmethod
-    def build_table_filter(tables_str: str, dialect: str = "") -> Optional[Node]:
-        """Build a filter for metadata/semantic_model stores from table identifiers.
+    def build_table_filter(tables_str: str, dialect: str = "", table_column: str = "table_name") -> Optional[Node]:
+        """Build a filter for table-scoped stores from table identifiers.
 
         Args:
             tables_str: Comma/newline-separated table identifiers (e.g. "public.users, orders")
             dialect: Database dialect (e.g. DBType.SQLITE) for field-order resolution
+            table_column: Column holding the physical table name in the target
+                store. Every store that carries table coordinates names the
+                namespace columns the same way, so only the leaf differs.
 
         Returns:
             Combined OR condition, or None if no valid tokens
@@ -42,7 +45,7 @@ class ScopedFilterBuilder:
 
         conditions: List[Node] = []
         for token in tokens:
-            cond = _table_condition_for_token(token, dialect)
+            cond = _table_condition_for_token(token, dialect, table_column)
             if cond is not None:
                 conditions.append(cond)
 
@@ -149,7 +152,7 @@ def _value_condition(field: str, value: str) -> Node:
     return eq(field, value)
 
 
-def _table_condition_for_token(token: str, dialect: str = "") -> Optional[Node]:
+def _table_condition_for_token(token: str, dialect: str = "", table_column: str = "table_name") -> Optional[Node]:
     """Parse a single table identifier token into a LanceDB condition.
 
     Uses right-aligned field mapping based on the dialect's supported fields.
@@ -162,7 +165,7 @@ def _table_condition_for_token(token: str, dialect: str = "") -> Optional[Node]:
     for field, value in parsed.items():
         if not value:
             continue
-        conditions.append(_value_condition(field, value))
+        conditions.append(_value_condition(table_column if field == "table_name" else field, value))
 
     if not conditions:
         return None

--- a/datus/storage/semantic_dataset/store.py
+++ b/datus/storage/semantic_dataset/store.py
@@ -231,7 +231,12 @@ class SemanticDatasetRAG:
             project=agent_config.project_name,
             datasource_id=self.datasource_id,
         )
-        self._sub_agent_filter = _build_sub_agent_filter(agent_config, sub_agent_name, self.storage, "tables")
+        # This projection binds its physical table through ``source_table``, so
+        # a tables scope has to be resolved against that column: an empty one
+        # means query-backed, which no table scope should ever match.
+        self._sub_agent_filter = _build_sub_agent_filter(
+            agent_config, sub_agent_name, self.storage, "tables", table_column="source_table"
+        )
 
     def _sub_agent_conditions(self) -> list:
         conditions = [datasource_condition(self.datasource_id)]
@@ -437,7 +442,13 @@ class SemanticDatasetRAG:
     def get_size(self) -> int:
         try:
             return self.storage._count_rows(where=And([eq("kind", KIND_DATASET), *self._sub_agent_conditions()]))
-        except Exception:
+        except Exception as exc:
+            # Callers read 0 as "nothing projected", so a failed count has to
+            # say so somewhere: a scope filter naming a column this table does
+            # not have is indistinguishable from an empty projection otherwise.
+            logger.warning(
+                "Failed to size the semantic dataset projection for datasource '%s': %s", self.datasource_id, exc
+            )
             return 0
 
     # ------------------------------------------------------------------

--- a/tests/unit_tests/storage/document/test_store.py
+++ b/tests/unit_tests/storage/document/test_store.py
@@ -438,15 +438,19 @@ class TestDocumentStoreCreateIndices:
         assert len(results) == 2
 
     def test_create_indices_calls_vector_index(self, doc_store):
-        """create_indices must delegate to the backend's create_vector_index."""
+        """create_indices must delegate to the backend's create_vector_index.
+
+        Every backend builds its vector index at runtime, so the delegation is
+        unconditional -- gating it on the table's class name is what left
+        pgvector deployments running without an index at all.
+        """
         doc_store.store_chunks(_make_chunks(3))
         with patch.object(doc_store.table, "create_vector_index", wraps=doc_store.table.create_vector_index) as mock_vi:
             doc_store.create_indices()
-            expected_call_count = int(type(doc_store.table).__name__.startswith("Lance"))
-            assert mock_vi.call_count == expected_call_count
-            assert [args[0] for args, _ in mock_vi.call_args_list] == ["vector"] * expected_call_count
-            assert [kwargs["metric"] for _, kwargs in mock_vi.call_args_list] == ["cosine"] * expected_call_count
-            assert [kwargs["replace"] for _, kwargs in mock_vi.call_args_list] == [True] * expected_call_count
+            assert mock_vi.call_count == 1
+            assert [args[0] for args, _ in mock_vi.call_args_list] == ["vector"]
+            assert [kwargs["metric"] for _, kwargs in mock_vi.call_args_list] == ["cosine"]
+            assert [kwargs["replace"] for _, kwargs in mock_vi.call_args_list] == [True]
 
     def test_create_indices_calls_fts_index(self, doc_store):
         """create_indices must delegate to the backend's create_fts_index."""

--- a/tests/unit_tests/storage/semantic_dataset/test_store.py
+++ b/tests/unit_tests/storage/semantic_dataset/test_store.py
@@ -1,6 +1,8 @@
+import logging
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pyarrow as pa
 import pytest
 
 from datus.storage.semantic_dataset.store import (
@@ -367,3 +369,102 @@ def test_resolve_object_kinds_rejects_metrics():
     """An empty result would read as "no such metric" instead of "wrong tool"."""
     with pytest.raises(MetricKindNotHere, match="search_metrics"):
         resolve_object_kinds(["metric"])
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent table scope, against real storage
+# ---------------------------------------------------------------------------
+
+
+def _dataset_row(source_table: str, *, database_name: str = "") -> dict:
+    """A minimal ``kind=dataset`` row bound to one physical table."""
+    return {
+        "id": f"dataset:sales:{source_table}",
+        "kind": "dataset",
+        "semantic_model_name": "sales",
+        "dataset_name": source_table,
+        "name": source_table,
+        "source_table": source_table,
+        "source_query": "",
+        "catalog_name": "",
+        "database_name": database_name,
+        "schema_name": "",
+        "description": f"{source_table} dataset",
+        "ai_context_json": "",
+        "search_text": f"{source_table} dataset",
+        "expr": "",
+        "field_type": "",
+        "is_dimension": False,
+        "is_time": False,
+        "is_primary_key": False,
+        "time_granularity": "",
+        "from_dataset": "",
+        "to_dataset": "",
+        "from_columns_json": "",
+        "to_columns_json": "",
+        "rel_type": "",
+        "join_type": "",
+        "yaml_path": "",
+        "updated_at": pa.scalar(0, type=pa.timestamp("ms")),
+    }
+
+
+class TestSubAgentTableScope:
+    """A sub-agent scoped to tables must still see the datasets bound to them.
+
+    These run against real storage on purpose: the scope filter names a column,
+    and a filter naming a column the table does not have is exactly the failure
+    a mocked ``_sub_agent_conditions`` cannot reproduce.
+    """
+
+    @staticmethod
+    def _scoped_rag(real_agent_config, tables: str):
+        real_agent_config.agentic_nodes["scoped_reader"] = {"scoped_context": {"tables": tables}}
+        return SemanticDatasetRAG(real_agent_config, sub_agent_name="scoped_reader")
+
+    def test_scoped_sub_agent_counts_datasets_of_its_tables(self, real_agent_config):
+        SemanticDatasetRAG(real_agent_config).upsert_batch([_dataset_row("orders")])
+
+        assert self._scoped_rag(real_agent_config, "orders").get_size() == 1
+
+    def test_scoped_sub_agent_reads_datasets_of_its_tables(self, real_agent_config):
+        SemanticDatasetRAG(real_agent_config).upsert_batch([_dataset_row("orders")])
+
+        rows = self._scoped_rag(real_agent_config, "orders").list_datasets(table_name="orders")
+
+        assert [row["source_table"] for row in rows] == ["orders"]
+
+    def test_scoped_sub_agent_resolves_a_qualified_token(self, real_agent_config):
+        """The namespace parts of a scope token keep their own column names --
+        only the table leaf lives under a different one here.
+
+        The qualifier is a database because the fixture's datasource is SQLite,
+        whose identifier parser fills ``database_name`` for a two-part name.
+        """
+        SemanticDatasetRAG(real_agent_config).upsert_batch([_dataset_row("orders", database_name="shop")])
+
+        assert self._scoped_rag(real_agent_config, "shop.orders").get_size() == 1
+
+    def test_scoped_sub_agent_excludes_datasets_outside_its_tables(self, real_agent_config):
+        rag = SemanticDatasetRAG(real_agent_config)
+        rag.upsert_batch([_dataset_row("orders"), _dataset_row("customers")])
+
+        assert self._scoped_rag(real_agent_config, "orders").get_size() == 1
+
+
+def test_get_size_reports_a_failed_count_instead_of_swallowing_it(caplog):
+    """0 means "nothing projected" to every caller, so a failed count that
+    returns 0 silently is indistinguishable from an empty projection -- which
+    is how a filter naming a missing column stayed invisible."""
+    rag = SemanticDatasetRAG.__new__(SemanticDatasetRAG)
+    rag.storage = Mock()
+    rag.datasource_id = "ds_main"
+    rag._sub_agent_conditions = lambda: []
+    rag.storage._count_rows.side_effect = RuntimeError("Schema error: No field named table_name")
+
+    with caplog.at_level(logging.WARNING):
+        size = rag.get_size()
+
+    assert size == 0
+    assert "ds_main" in caplog.text
+    assert "No field named table_name" in caplog.text

--- a/tests/unit_tests/storage/test_rag_scope.py
+++ b/tests/unit_tests/storage/test_rag_scope.py
@@ -66,6 +66,16 @@ class TestBuildSubAgentFilter:
         clause = build_where(result)
         assert "users" in clause
 
+    def test_table_scope_honours_the_stores_table_column(self):
+        """Stores do not agree on the column holding the physical table name."""
+        config = _mock_agent_config(
+            sub_agent_configs={"team_a": {"scoped_context": {"tables": "public.users"}}},
+        )
+        result = _build_sub_agent_filter(config, "team_a", _mock_storage(), "tables", table_column="source_table")
+        clause = build_where(result)
+        assert "source_table = 'users'" in clause
+        assert "table_name" not in clause
+
     def test_subject_scope_without_tree_raises(self):
         """Subject-based scope without subject_tree on storage -> raises DatusException."""
         import pytest

--- a/tests/unit_tests/storage/test_scoped_filter.py
+++ b/tests/unit_tests/storage/test_scoped_filter.py
@@ -239,6 +239,26 @@ class TestBuildTableFilter:
         assert "schema_name = 'public'" in clause
         assert "table_name = 'users'" in clause
 
+    def test_table_column_renames_only_the_table_leaf(self):
+        """A store that binds its table under another column gets that column.
+
+        The namespace parts are named the same everywhere, so only the leaf may
+        move -- renaming them too would filter on columns that do not exist.
+        """
+        node = ScopedFilterBuilder.build_table_filter("public.users", "postgresql", table_column="source_table")
+        clause = build_where(node)
+        assert "source_table = 'users'" in clause
+        assert "schema_name = 'public'" in clause
+        assert "table_name" not in clause
+
+    def test_table_column_applies_to_every_token(self):
+        """Each OR branch has to carry the override, not just the first."""
+        node = ScopedFilterBuilder.build_table_filter("users, orders", table_column="source_table")
+        clause = build_where(node)
+        assert "source_table = 'users'" in clause
+        assert "source_table = 'orders'" in clause
+        assert "table_name" not in clause
+
 
 # ---------------------------------------------------------------------------
 # TestBuildSubjectFilter


### PR DESCRIPTION
## Why

Two nightly failures, both regressions from #1327.

**1. A tables-scoped sub-agent reads nothing from the dataset projection.**

`semantic_dataset` binds its physical table through `source_table`, but
`ScopedFilterBuilder.build_table_filter` hardcodes `table_name` — the column the
retired `semantic_model` table used. Every read a scoped sub-agent makes against
that store therefore filters on a column that does not exist, and the backend
answers with an error rather than rows:

```
lance error: Invalid user input: Schema error: No field named table_name.
Did you mean 'dataset_name'?
```

`get_size` swallowed that error and returned 0, and every caller reads 0 as
"nothing projected" — so a schema mismatch was indistinguishable from an empty
knowledge base. That is why this reached nightly instead of CI, and why it
surfaced as `Bootstrap data missing: semantic_model have 0 total rows across
sub-agents` in `test_bi_dashboard`, with nothing pointing at the real cause. The
same run logged `semantic_modeling bootstrap completed: semantic_objects=1`, so
the write side was fine throughout.

This is not test-only: any sub-agent with a `scoped_context.tables` gets an
empty semantic extension in `describe_table` and `search_semantic_objects`. BI
dashboard sub-agents always have one (`_build_scoped_context`).

**2. `test_create_indices_calls_vector_index[postgresql+postgresql]` fails.**

It derived its expected call count from `type(table).__name__.startswith("Lance")`,
which stopped matching when #1327 removed the class-name gate on index creation.
PR CI only runs the `sqlite+lance` parameter, so only nightly saw it.

## Solution

`build_table_filter` takes the column holding the physical table name. Only the
table leaf moves: `catalog_name`, `database_name` and `schema_name` are named
identically in every store that carries table coordinates, so renaming those
too would filter on columns that do not exist. The two other tables-scoped
stores — `schema_metadata` and `kb_retrieval` — keep the default and are
untouched.

`get_size` still returns 0 on failure. `ContextSearchTools` decides tool
availability from it during construction, so raising would take out the whole
tool set for what is an observability fix; it logs a warning first instead, so
the next mismatch says so rather than reading as an empty projection.

For (2), the expectation becomes unconditional: every backend builds its vector
index at runtime, which is exactly what #1327 fixed.

**Known gap, deliberately not addressed here.** Relationship rows carry no
`source_table` and no namespace coordinates, so a tables-scoped sub-agent still
cannot see them — the join graph stays invisible to scoped sub-agents. Since
`get_size` counts dataset rows only, the nightly assertion goes green without
that being fixed. Papering over it here would hide it further; it needs its own
decision about whether relationships should be exempt from table scoping.

## Test Cases

Unit only — the failing paths are storage-level and both nightly suites that
caught them are expensive end-to-end runs.

Added, all failing on the pre-fix code (verified by stashing the three source
files and re-running; the four store tests fail with the `No field named
table_name` error above, the rest with the missing keyword argument):

- `storage/semantic_dataset/test_store.py::TestSubAgentTableScope` — four tests
  against **real storage**, parameterized over `sqlite+lance` and
  `postgresql+postgresql`: a scoped sub-agent counts and reads the datasets of
  its tables, resolves a qualified token, and excludes tables outside its scope.
  The pre-existing tests in this file all mock storage and short-circuit
  `_sub_agent_conditions`, so they structurally cannot catch a filter naming a
  missing column — which is why this bug shipped.
- `storage/semantic_dataset/test_store.py::test_get_size_reports_a_failed_count_instead_of_swallowing_it`
  — pins that a failed count leaves a trace instead of reading as an empty
  projection.
- `storage/test_scoped_filter.py` — the override renames only the table leaf,
  and applies to every OR branch rather than just the first.
- `storage/test_rag_scope.py` — the column is passed through to the builder.

Modified: `storage/document/test_store.py::test_create_indices_calls_vector_index`.

Verified: `ci/run-pr-tests.py upstream/main` → 2191 passed, 0 failed, diff
coverage 100%. `ci/audit_tests.py --diff-only upstream/main` → P0=0, P1=0.
`tests/unit_tests/storage/` full run → 1932 passed.

**Not verified locally:** whether nightly's `test_bi_dashboard` actually goes
green. `get_size` matches namespace coordinates by equality and has none of the
compatibility fallback `list_datasets` grew in #1327, while BI scope tokens are
fully qualified by `qualify_table_names`. Both sides fall back to
`current_db_config`, but they layer different overrides on top
(`cli_context` vs `runtime_db_context`, plus a qualified dataset source). If the
BI suite still reports 0 rows *without* a schema error in the log, that is the
remaining mismatch and needs a separate fix. Worth a manual nightly dispatch
before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table-scoped filtering for datasets backed by query sources.
  * Prevented query-backed datasets from matching unrelated table scopes.
  * Ensured vector indexes are created consistently across supported storage backends.
  * Improved error logging when dataset size calculations fail.
* **Enhancements**
  * Added support for configuring the column used for physical table names, including qualified and multi-table filters.
* **Tests**
  * Added coverage for table scoping, filter behavior, index creation, and size calculation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->