### PR TITLE
[Doc] Rewrite semantic model and metrics guides

### DIFF
--- a/docs/knowledge_base/metrics.md
+++ b/docs/knowledge_base/metrics.md
@@ -1,159 +1,194 @@
-# Business Metrics Intelligence
+# Metrics
 
-Starting from **version 0.2.4**, the Metrics component focuses on creating standardized, queryable business metrics as an independent semantic query layer. Metrics can be executed directly through MetricFlow, rather than serving solely as references for LLM SQL generation.
+A metric is a reusable, executable business calculation such as revenue, active customers, or failed-bank assets. It gives a calculation one stable name and definition so users can ask business questions without rewriting its aggregation logic.
 
-## Core Value
+Metrics are part of a [semantic model](semantic_model.md). Their definitions live in the model's OSI YAML; Datus projects them into a separate Knowledge Base store for discovery, and the active semantic adapter compiles and executes metric queries. Dosi is the built-in default adapter.
 
-Solves common enterprise challenges:
+## What a metric defines
 
-- **Duplicate SQL queries**: Query metrics directly instead of rewriting similar SQL
-- **Inconsistent definitions**: Standardize metric definitions across teams through executable specifications
-- **Manual classification**: Organize metrics with hierarchical subject tree taxonomy
-- **Ad-hoc SQL complexity**: Use semantic queries (`query_metrics`) instead of generating SQL for common metrics
+A metric normally includes:
 
-## How It Works
+- a datasource-wide unique `name`;
+- a business `description` and `ai_context.instructions`;
+- an aggregate, ratio, or arithmetic `expression`;
+- the dataset and business time it uses;
+- a three-level `subject_path` for discovery;
+- optional display metadata such as `unit` and `format`;
+- optional reusable window behavior, such as rolling, cumulative, or period comparison.
 
-Metrics are business-level calculations built on top of semantic models. Starting from version 0.2.4, they operate independently:
+The dataset, fields, and relationships required by a metric are defined in the same semantic-model file. This keeps the calculation and the model needed to execute it in one authoritative artifact.
 
-- **Metrics** (this document): Standardized KPIs queryable via MetricFlow
-- **Semantic Models** (see [semantic_model.md](semantic_model.md)): Schema extensions for ad-hoc SQL generation
+## Definition, discovery, and execution
 
-Both can be generated from historical SQLs, but metrics focus on reusable business logic while semantic models focus on schema understanding.
+Metric data has three distinct roles:
 
-## Querying Metrics
+1. **OSI YAML is the definition.** It is the source of truth for expressions, time behavior, descriptions, and extensions.
+2. **The `metrics` Knowledge Base store is the discovery projection.** It indexes the metric name, description, subject path, model, dimensions, source YAML, and other retrieval metadata for the active datasource.
+3. **The semantic adapter executes queries.** `query_metrics` sends metric names, dimensions, time bounds, filters, and ordering to the active adapter, which compiles and runs the query.
 
-Once metrics are defined, query them directly using MetricFlow tools:
+Moving a metric to another `subject_path` changes its classification, not its identity. Metric names must therefore remain unique within one datasource.
+
+## Quick start with natural language
+
+The recommended user flow is to ask a business question. The main agent recognizes metric questions and automatically delegates them to `ask_metrics`:
+
+```bash
+datus --datasource duckdb_demo
+```
+
+```text
+Show the annual trend in the number of failed banks and their total assets.
+```
+
+The user does not need to know the metric names. AskMetrics uses the subject tree and metric descriptions to infer that this question needs `bank_failure_count` and `failed_assets_million`, discovers the available time dimension, and queries them by year.
+
+This flow assumes the metrics already exist on the active datasource. If no existing metric can answer the question, AskMetrics reports that limitation instead of switching to an unrelated raw-SQL answer. See [AskMetrics](../subagent/ask_metrics.md) for routing, configuration, and output behavior.
+
+## Current metric YAML
+
+The following definitions are from the `bank_failures.yml` file generated against Datus's sample DuckDB database. They use the dataset and fields shown in [Semantic Models](semantic_model.md):
+
+```yaml
+metrics:
+  - name: bank_failure_count
+    expression:
+      dialects:
+        - dialect: DUCKDB
+          expression: COUNT(*)
+    description: Number of failed banks, measured as bank failure event rows.
+    ai_context:
+      instructions: Use date as business time; group by state or a time grain when requested.
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"v":"1.4","dataset":"bank_failures","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","count"],"unit":"banks"}'
+
+  - name: failed_assets_million
+    expression:
+      dialects:
+        - dialect: DUCKDB
+          expression: SUM(bank_failures.assets_million)
+    description: Total assets of failed banks, in millions of US dollars.
+    ai_context:
+      instructions: Use date as business time and sum assets at failure.
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"v":"1.4","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","assets"],"unit":"USD million"}'
+```
+
+Metric expressions use the same `expression.dialects[]` structure as field expressions. Qualify fields with their dataset name, as in `SUM(bank_failures.assets_million)`. An aggregate such as `COUNT(*)` cannot reveal its dataset from a qualified field, so its DATUS extension supplies `dataset` explicitly.
+
+Do not place `dataset`, `time_dimension`, `subject_path`, `unit`, or window settings at the metric's top level. They are Datus behavior and belong in the metric's DATUS `custom_extensions` entry.
+
+## Metric extensions
+
+The DATUS extension is an OSI `custom_extensions` entry whose `data` value is a JSON string:
+
+```yaml
+custom_extensions:
+  - vendor_name: DATUS
+    data: '{"v":"1.4","time_dimension":"orders.order_date","subject_path":["sales","revenue","total"],"unit":"USD"}'
+```
+
+Common keys are:
+
+| Key | Purpose |
+| --- | --- |
+| `dataset` | Anchors an expression when its dataset cannot be inferred, for example `COUNT(*)`. |
+| `time_dimension` | Selects the metric's business time field. Qualify it when names may collide. |
+| `subject_path` | Places the metric in a three-level discovery hierarchy. |
+| `unit`, `format` | Describe how results should be labeled or displayed. |
+| `fill_nulls_with` | Defines explicit null-filling behavior. |
+| `window` | Defines a reusable rolling, cumulative, comparison, ranking, or value window. |
+
+`semantic_modeling` writes the extension version required by the installed engine. Preserve generated version values and keep only one DATUS entry on each object.
+
+## Querying metrics
+
+AskMetrics is the normal user-facing query path. For integrations or advanced agent workflows, the underlying tools separate discovery from execution:
 
 ```python
-# In agent conversation or workflow
-# Search for relevant metrics
-search_metrics(query_text="daily active users")
+# Discover candidate definitions from the Knowledge Base.
+search_metrics(
+    query_text="annual failed-bank count and assets",
+    top_n=5,
+)
 
-# Execute metric query
+# Discover queryable dimensions and the metric's primary time axis.
+get_dimensions(metric_name="bank_failure_count")
+
+# Execute both metrics by year.
 query_metrics(
-    metrics=["daily_active_users"],
-    group_by=["platform", "country"],
-    start_time="2024-01-01",
-    end_time="2024-01-31"
+    metrics=["bank_failure_count", "failed_assets_million"],
+    dimensions=["metric_time"],
+    time_granularity="year",
+    order_by=["metric_time__year"],
 )
 ```
 
-**Metrics-First Strategy**: When user queries involve KPIs (e.g., "show me DAU by platform"), the agent will:
-1. Search for matching metrics using `search_metrics`
-2. Execute via `query_metrics` if found (preferred)
-3. Fall back to ad-hoc SQL generation only if no metric exists
+`query_metrics` accepts these current parameters:
 
-This ensures consistent metric definitions across the organization.
+| Parameter | Meaning |
+| --- | --- |
+| `metrics` | One or more exact metric names. |
+| `dimensions` | Dimensions returned by `get_dimensions`; with Dosi, `metric_time` selects the primary time axis. |
+| `path` | Optional subject-tree path used to disambiguate a metric. |
+| `time_start`, `time_end` | Optional half-open time range: start is inclusive and end is exclusive. ISO dates and relative values such as `-7d` or `now` are supported by the adapter. |
+| `time_granularity` | `day`, `week`, `month`, `quarter`, or `year`. |
+| `where` | Optional filter expression without the `WHERE` keyword. |
+| `order_by` | Result columns to sort; prefix a name with `-` for descending order. |
+| `limit` | Maximum rows, used only when the user asks for Top N, a preview, or another explicit row limit. |
+| `dry_run` | Compile and validate the query plan without returning live metric values. |
 
-## Usage
+For example, to include all of January 2024, use `time_start="2024-01-01"` and `time_end="2024-02-01"`.
 
-With `--success_story`, this compatibility component runs the full Dosi-only `semantic_modeling` workflow, including any datasets and relationships required by the generated metrics. Existing YAML import remains a non-LLM compatibility operation.
+## Creating and updating metrics
 
-### Basic Command
+Use `semantic_modeling` for normal authoring. It can create required datasets and fields, add or update metrics in the same YAML, validate the complete model, dry-run representative queries when requested, and synchronize both Knowledge Base projections.
+
+```text
+Add a monthly revenue growth metric to the sales model, use order_date as business time, validate it, and dry-run a yearly query.
+```
+
+For batch authoring from a CSV containing `question` and `sql`, use the unified semantic-modeling component:
 
 ```bash
-# From CSV (historical SQLs)
 datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components metrics \
-    --success_story path/to/success_story.csv
-
-# From YAML (semantic models)
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components metrics \
-    --semantic_yaml path/to/semantic_model.yaml
+  --datasource <your_datasource> \
+  --components semantic_modeling \
+  --success_story path/to/success_story.csv \
+  --kb_update_strategy incremental \
+  --metrics-batch-size 5
 ```
 
-### Key Parameters
+`--metrics-batch-size` controls how many history rows are processed in one authoring batch. `--subject_tree` may provide allowed comma-separated categories; when omitted, authoring reuses existing categories or creates suitable ones.
 
-| Parameter | Required | Description | Example |
-|-----------|----------|-------------|---------|
-| `--datasource` | ✅ | Database datasource | `sales_db` |
-| `--components` | ✅ | Components to initialize | `metrics` |
-| `--success_story` | ⚠️ | CSV file with historical SQLs and questions (required if no `--semantic_yaml`) | `success_story.csv` |
-| `--semantic_yaml` | ⚠️ | Semantic model YAML file (required if no `--success_story`) | `semantic_model.yaml` |
-| `--kb_update_strategy` | ❌ | Update strategy | `overwrite`/`incremental` |
-| `--subject_tree` | ❌ | Predefined categories (comma-separated) | `Sales/Reporting/Daily,Finance/Revenue/Monthly` |
-| `--pool_size` | ❌ | Concurrent thread count | `4` |
+The default `check` strategy does not author metrics. It only reports the current semantic-dataset and metric projection counts, so use `incremental` or `overwrite` when generation is intended.
 
-Combining `metrics` with `semantic_model` or `semantic_modeling` executes one full `semantic_modeling` run. Existing MetricFlow and OSI projects remain query-only for generated changes.
+## Synchronizing the Knowledge Base
 
-### Subject Tree Categorization
-
-Organizes metrics using hierarchical taxonomy: `domain/layer1/layer2` (e.g., `Sales/Reporting/Daily`)
-
-**Two modes:**
-
-- **Predefined**: Use `--subject_tree` to enforce specific categories
-- **Learning**: Omit `--subject_tree` to reuse existing categories or create new ones
+A successful `semantic_modeling` run synchronizes its target file automatically. If YAML was edited manually, reconcile all semantic-object and metric projections with:
 
 ```bash
-# Predefined mode example
---subject_tree "Sales/Reporting/Daily,Finance/Revenue/Monthly"
-
-# Learning mode: omit --subject_tree parameter
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_model \
+  --kb_update_strategy sync-yaml
 ```
 
-**Generated Tag Format (legacy MetricFlow files):**
+`sync-yaml` reads every model under the active datasource by default, replaces each artifact's projected rows, removes metrics no longer declared in that artifact, and prunes rows for deleted files during a directory-wide sync. It does not call an LLM or query the warehouse.
 
-Existing MetricFlow metric files store the subject_tree classification in `locked_metadata.tags` with the format `"subject_tree: {domain}/{layer1}/{layer2}"`. This shape is shown for reference only — such files remain queryable but can no longer be generated or imported:
+To check the number of indexed metrics without changing them:
 
-```yaml
-# Legacy MetricFlow shape — query-only, not importable
-metric:
-  name: daily_revenue
-  type: simple
-  type_params:
-    measure: revenue
-  locked_metadata:
-    tags:
-      - "Finance"
-      - "subject_tree: Sales/Reporting/Daily"
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metrics \
+  --kb_update_strategy check
 ```
 
-**Important for YAML Import:**
+## Related guides
 
-`--semantic_yaml` accepts Dosi/OSI semantic YAML only, and only in Dosi projects. MetricFlow YAML (`data_source:` / `metric:` documents) is rejected with an explicit error; migrate the project to Dosi and re-author the model with `semantic_modeling`.
-
-## Data Source Formats
-
-### CSV Format
-
-```csv
-question,sql
-How many customers have been added per day?,"SELECT ds AS date, SUM(1) AS new_customers FROM customers GROUP BY ds ORDER BY ds;"
-What is the total transaction amount?,SELECT SUM(transaction_amount_usd) as total_amount FROM transactions;
-```
-
-### YAML Format (Metrics Import)
-
-Metric import reads the `metrics` collection of a Dosi/OSI semantic-model document — the same file the datasets live in:
-
-```yaml
-semantic_model:
-  - name: transactions
-    datasets:
-      - name: transactions
-        source: analytics.transactions
-    metrics:
-      - name: total_revenue
-        description: "Total revenue from all transactions"
-        expression: SUM(transactions.amount)
-        dataset: transactions
-```
-
-Standalone MetricFlow `metric:` documents are legacy and no longer importable. See [semantic_model.md](semantic_model.md) for how to define semantic models.
-
-## Summary
-
-The Metrics component establishes a **semantic query layer** that transforms historical SQLs into standardized, executable metric definitions. Unlike traditional semantic layers that only serve as LLM references, Datus metrics can be directly queried through MetricFlow, eliminating the need for ad-hoc SQL generation for common KPIs.
-
-Key differentiators:
-
-- **Executable Metrics**: Query via `query_metrics` instead of generating SQL
-- **Metrics-First Strategy**: Agent prioritizes metric queries over ad-hoc SQL
-- **Embedded Definitions, Independent Execution**: Metric definitions live in the semantic model's `metrics` collection; querying them via `query_metrics` is a separate execution path that needs no ad-hoc SQL
-- **Hierarchical Organization**: Subject tree taxonomy for discoverability
-
-This approach ensures consistent metric definitions across teams while reducing query complexity and improving performance.
+- [AskMetrics](../subagent/ask_metrics.md): natural-language metric questions and capability boundaries
+- [Semantic Modeling](../subagent/semantic_modeling.md): end-to-end authoring and complete generated YAML
+- [Semantic Models](semantic_model.md): datasets, fields, relationships, and Knowledge Base projection
+- [Semantic layer configuration](../configuration/semantic_layer.md): semantic adapter configuration

--- a/docs/knowledge_base/metrics.md
+++ b/docs/knowledge_base/metrics.md
@@ -46,33 +46,33 @@ This flow assumes the metrics already exist on the active datasource. If no exis
 
 ## Current metric YAML
 
-The following definitions are from the `bank_failures.yml` file generated against Datus's sample DuckDB database. They use the dataset and fields shown in [Semantic Models](semantic_model.md):
+The following excerpt is the `semantic_model[0].metrics` section from the `bank_failures.yml` file generated against Datus's sample DuckDB database. It uses the dataset and fields shown in [Semantic Models](semantic_model.md). The leading indentation is intentional: this block belongs inside a semantic model and is not a standalone YAML document.
 
 ```yaml
-metrics:
-  - name: bank_failure_count
-    expression:
-      dialects:
-        - dialect: DUCKDB
-          expression: COUNT(*)
-    description: Number of failed banks, measured as bank failure event rows.
-    ai_context:
-      instructions: Use date as business time; group by state or a time grain when requested.
-    custom_extensions:
-      - vendor_name: DATUS
-        data: '{"v":"1.4","dataset":"bank_failures","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","count"],"unit":"banks"}'
+    metrics:
+      - name: bank_failure_count
+        expression:
+          dialects:
+            - dialect: DUCKDB
+              expression: COUNT(*)
+        description: Number of failed banks, measured as bank failure event rows.
+        ai_context:
+          instructions: Use date as business time; group by state or a time grain when requested.
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"v":"1.4","dataset":"bank_failures","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","count"],"unit":"banks"}'
 
-  - name: failed_assets_million
-    expression:
-      dialects:
-        - dialect: DUCKDB
-          expression: SUM(bank_failures.assets_million)
-    description: Total assets of failed banks, in millions of US dollars.
-    ai_context:
-      instructions: Use date as business time and sum assets at failure.
-    custom_extensions:
-      - vendor_name: DATUS
-        data: '{"v":"1.4","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","assets"],"unit":"USD million"}'
+      - name: failed_assets_million
+        expression:
+          dialects:
+            - dialect: DUCKDB
+              expression: SUM(bank_failures.assets_million)
+        description: Total assets of failed banks, in millions of US dollars.
+        ai_context:
+          instructions: Use date as business time and sum assets at failure.
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"v":"1.4","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","assets"],"unit":"USD million"}'
 ```
 
 Metric expressions use the same `expression.dialects[]` structure as field expressions. Qualify fields with their dataset name, as in `SUM(bank_failures.assets_million)`. An aggregate such as `COUNT(*)` cannot reveal its dataset from a qualified field, so its DATUS extension supplies `dataset` explicitly.

--- a/docs/knowledge_base/metrics.zh.md
+++ b/docs/knowledge_base/metrics.zh.md
@@ -1,157 +1,194 @@
-# 业务指标智能化
+# 指标
 
-从 **0.2.4 版本**开始，指标组件专注于创建标准化、可查询的业务指标，作为独立的语义查询层。指标可通过 MetricFlow 直接执行查询，而不仅仅作为 LLM 生成 SQL 的参考。
+指标是可复用、可执行的业务计算，例如收入、活跃客户数或倒闭银行资产。它为一套计算逻辑提供稳定的名称和定义，让用户无需反复编写聚合 SQL 就能提出业务问题。
 
-## 核心价值
+指标属于[语义模型](semantic_model.md)。定义保存在模型的 OSI YAML 中；Datus 将其投影到独立的 Knowledge Base store 供检索，再由当前 semantic adapter 编译并执行指标查询。Dosi 是内置的默认 adapter。
 
-解决常见的企业挑战：
+## 指标定义什么
 
-- **重复的 SQL 查询**：直接查询指标，而非重写相似的 SQL
-- **不一致的定义**：通过可执行的规范跨团队标准化指标定义
-- **手动分类**：使用层级主题树分类体系组织指标
-- **临时 SQL 复杂性**：对常见指标使用语义查询（`query_metrics`）而非生成 SQL
+一个指标通常包含：
 
-## 工作原理
+- datasource 内唯一的 `name`；
+- 业务 `description` 和 `ai_context.instructions`；
+- 聚合、比率或算术 `expression`；
+- 所属 dataset 与业务时间；
+- 用于检索的三级 `subject_path`；
+- `unit`、`format` 等可选展示信息；
+- 滚动、累计或同期比较等可选的可复用 window 行为。
 
-指标是构建在语义模型之上的业务级计算。从 0.2.4 版本开始，它们独立运行：
+指标所需的 dataset、field 和 relationship 都定义在同一份语义模型文件中。因此，计算逻辑和执行它所需的模型只有一个权威 artifact。
 
-- **指标**（本文档）：通过 MetricFlow 查询的标准化 KPI
-- **语义模型**（参见 [semantic_model.zh.md](semantic_model.zh.md)）：用于临时 SQL 生成的 schema 扩展
+## 定义、检索与执行
 
-两者都可以从历史 SQLs 生成，但指标专注于可复用的业务逻辑，而语义模型专注于 schema 理解。
+指标数据有三个不同角色：
+
+1. **OSI YAML 是定义。** 表达式、时间行为、描述和 extension 都以它为准。
+2. **`metrics` Knowledge Base store 是检索投影。** 它按当前 datasource 索引指标名、描述、subject path、所属模型、可用维度、源 YAML 等检索信息。
+3. **Semantic adapter 负责执行。** `query_metrics` 把指标名、维度、时间范围、过滤和排序交给当前 adapter，由 adapter 编译并运行查询。
+
+把指标移动到其他 `subject_path` 只会改变分类，不会改变指标身份。因此，同一个 datasource 中的指标名必须保持唯一。
+
+## 使用自然语言快速查询
+
+推荐的用户流程是直接提业务问题。主 agent 会识别指标问题，并自动派发给 `ask_metrics`：
+
+```bash
+datus --datasource duckdb_demo
+```
+
+```text
+看看倒闭银行数量和倒闭资产总额按年份的变化趋势。
+```
+
+用户不需要知道指标名。AskMetrics 会根据主题树和指标描述推断该问题需要 `bank_failure_count` 与 `failed_assets_million`，发现可用时间维度，再按年查询。
+
+该流程要求当前 datasource 已经存在可执行指标。如果没有现有指标能回答问题，AskMetrics 会直接说明限制，不会切换成无关的原始 SQL 回答。路由方式、配置和输出行为见 [AskMetrics](../subagent/ask_metrics.md)。
+
+## 当前指标 YAML
+
+下面的定义来自 Datus 示例 DuckDB 数据库上真实生成的 `bank_failures.yml`，使用了[语义模型](semantic_model.md)页面中的 dataset 和 field：
+
+```yaml
+metrics:
+  - name: bank_failure_count
+    expression:
+      dialects:
+        - dialect: DUCKDB
+          expression: COUNT(*)
+    description: 倒闭银行数量，即银行倒闭事件的记录数。
+    ai_context:
+      instructions: 按 date 作为业务时间，统计倒闭事件条数；可按 state 或时间粒度分组。
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"v":"1.4","dataset":"bank_failures","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","count"],"unit":"banks"}'
+
+  - name: failed_assets_million
+    expression:
+      dialects:
+        - dialect: DUCKDB
+          expression: SUM(bank_failures.assets_million)
+    description: 倒闭银行资产总额（单位：百万美元）。
+    ai_context:
+      instructions: 按 date 作为业务时间，对倒闭时资产求和；单位是百万美元。
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"v":"1.4","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","assets"],"unit":"USD million"}'
+```
+
+Metric expression 与 field expression 一样使用 `expression.dialects[]`。字段应带 dataset 限定，例如 `SUM(bank_failures.assets_million)`。`COUNT(*)` 这类聚合无法根据限定字段判断所属 dataset，因此在 DATUS extension 中显式提供 `dataset`。
+
+不要把 `dataset`、`time_dimension`、`subject_path`、`unit` 或 window 设置写在 metric 顶层。这些属于 Datus 行为，应放入 metric 的 DATUS `custom_extensions` entry。
+
+## Metric extension
+
+DATUS extension 是一个 OSI `custom_extensions` entry，其中 `data` 的值是 JSON 字符串：
+
+```yaml
+custom_extensions:
+  - vendor_name: DATUS
+    data: '{"v":"1.4","time_dimension":"orders.order_date","subject_path":["sales","revenue","total"],"unit":"USD"}'
+```
+
+常用 key 包括：
+
+| Key | 作用 |
+| --- | --- |
+| `dataset` | 当表达式本身无法确定 dataset 时指定归属，例如 `COUNT(*)`。 |
+| `time_dimension` | 选择指标的业务时间字段；字段名可能冲突时应带 dataset 限定。 |
+| `subject_path` | 把指标放入三级检索分类。 |
+| `unit`、`format` | 描述结果的单位和展示格式。 |
+| `fill_nulls_with` | 定义明确的空值填充行为。 |
+| `window` | 定义可复用的滚动、累计、同期比较、排名或取值窗口。 |
+
+`semantic_modeling` 会写入已安装 engine 所需的 extension 版本。应保留生成的版本值，并保证每个对象最多只有一个 DATUS entry。
 
 ## 查询指标
 
-定义指标后，可使用 MetricFlow 工具直接查询：
+AskMetrics 是面向用户的常规查询入口。集成或高级 agent 工作流可以使用底层工具，将检索与执行分开：
 
 ```python
-# 在 agent 对话或工作流中
-# 搜索相关指标
-search_metrics(query_text="daily active users")
+# 从 Knowledge Base 中发现候选定义。
+search_metrics(
+    query_text="按年统计倒闭银行数量和资产",
+    top_n=5,
+)
 
-# 执行指标查询
+# 获取可查询维度和指标的主要时间轴。
+get_dimensions(metric_name="bank_failure_count")
+
+# 按年执行两个指标。
 query_metrics(
-    metrics=["daily_active_users"],
-    group_by=["platform", "country"],
-    start_time="2024-01-01",
-    end_time="2024-01-31"
+    metrics=["bank_failure_count", "failed_assets_million"],
+    dimensions=["metric_time"],
+    time_granularity="year",
+    order_by=["metric_time__year"],
 )
 ```
 
-**指标优先策略**：当用户查询涉及 KPI（例如 "按平台展示 DAU"）时，agent 将：
-1. 使用 `search_metrics` 搜索匹配的指标
-2. 如果找到，通过 `query_metrics` 执行（首选）
-3. 仅当不存在指标时才回退到临时 SQL 生成
+`query_metrics` 当前支持以下参数：
 
-这确保了组织内指标定义的一致性。
+| 参数 | 含义 |
+| --- | --- |
+| `metrics` | 一个或多个准确的指标名。 |
+| `dimensions` | `get_dimensions` 返回的维度；在 Dosi 中，`metric_time` 表示指标的主要时间轴。 |
+| `path` | 可选 subject-tree 路径，用于消除指标歧义。 |
+| `time_start`、`time_end` | 可选的左闭右开时间范围：start 包含，end 不包含。Adapter 支持 ISO 日期以及 `-7d`、`now` 等相对值。 |
+| `time_granularity` | `day`、`week`、`month`、`quarter` 或 `year`。 |
+| `where` | 可选过滤表达式，不包含 `WHERE` 关键字。 |
+| `order_by` | 排序所用的结果列；名称前加 `-` 表示降序。 |
+| `limit` | 最大行数；只在用户明确要求 Top N、预览或其他行数限制时使用。 |
+| `dry_run` | 编译并校验查询计划，不返回实时指标值。 |
 
-## 使用方法
+例如，要包含 2024 年 1 月的全部数据，应使用 `time_start="2024-01-01"` 和 `time_end="2024-02-01"`。
 
-使用 `--success_story` 时，该兼容组件会运行完整的 Dosi-only `semantic_modeling` 工作流，包括生成指标所需的 datasets 与 relationships。YAML 导入是非 LLM 的兼容操作，仅支持 Dosi 项目中的 Dosi/OSI YAML；MetricFlow YAML 会被拒绝。
+## 创建和更新指标
 
-### 基本命令
+日常创作使用 `semantic_modeling`。它可以在同一份 YAML 中补充所需 dataset 和 field、创建或更新 metric、校验完整模型、按需 dry-run 代表性查询，并同步两个 Knowledge Base 投影。
+
+```text
+在 sales 模型中增加月度收入增长指标，使用 order_date 作为业务时间，校验定义并 dry-run 一次按年查询。
+```
+
+如果要从包含 `question` 和 `sql` 的 CSV 批量创作，使用统一的 semantic-modeling component：
 
 ```bash
-# 从 CSV（历史 SQLs）
 datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components metrics \
-    --success_story path/to/success_story.csv
-
-# 从 YAML（语义模型）
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components metrics \
-    --semantic_yaml path/to/semantic_model.yaml
+  --datasource <your_datasource> \
+  --components semantic_modeling \
+  --success_story path/to/success_story.csv \
+  --kb_update_strategy incremental \
+  --metrics-batch-size 5
 ```
 
-### 关键参数
+`--metrics-batch-size` 控制每个创作批次处理的历史记录数。`--subject_tree` 可以传入逗号分隔的允许分类；不传时，创作流程会复用已有分类或创建合适的分类。
 
-| 参数 | 必需 | 描述 | 示例 |
-|-----------|----------|-------------|------------|
-| `--datasource` | ✅ | 数据库数据源 | `sales_db` |
-| `--components` | ✅ | 要初始化的组件 | `metrics` |
-| `--success_story` | ⚠️ | 包含历史 SQLs 和问题的 CSV 文件（如果没有 `--semantic_yaml` 则必需） | `success_story.csv` |
-| `--semantic_yaml` | ⚠️ | 语义模型 YAML 文件（如果没有 `--success_story` 则必需） | `semantic_model.yaml` |
-| `--kb_update_strategy` | ❌ | 更新策略 | `overwrite`/`incremental` |
-| `--subject_tree` | ❌ | 预定义分类（逗号分隔） | `Sales/Reporting/Daily,Finance/Revenue/Monthly` |
-| `--pool_size` | ❌ | 并发线程数 | `4` |
+默认的 `check` 策略不会创作指标，只报告当前 semantic-dataset 与 metric 投影数量。需要生成时应明确使用 `incremental` 或 `overwrite`。
 
-### 主题树分类
+## 同步 Knowledge Base
 
-使用层级分类法组织指标：`domain/layer1/layer2`（例如 `Sales/Reporting/Daily`）
-
-**两种模式：**
-
-- **预定义**：使用 `--subject_tree` 强制指定特定分类
-- **学习**：省略 `--subject_tree` 以复用现有分类或创建新分类
+`semantic_modeling` 成功完成后会自动同步目标文件。如果手工编辑了 YAML，可以用下面的命令协调全部 semantic-object 与 metric 投影：
 
 ```bash
-# 预定义模式示例
---subject_tree "Sales/Reporting/Daily,Finance/Revenue/Monthly"
-
-# 学习模式：省略 --subject_tree 参数
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_model \
+  --kb_update_strategy sync-yaml
 ```
 
-**生成的标签格式（旧版 MetricFlow 文件）：**
+`sync-yaml` 默认读取当前 datasource 下的全部模型，替换各 artifact 的投影行，删除该 artifact 中已不再声明的指标，并在同步整个目录时清理已删除文件留下的行；不会调用 LLM，也不会查询数仓。
 
-存量 MetricFlow 指标文件的主题树分类存储在 `locked_metadata.tags` 中，格式为 `"subject_tree: {domain}/{layer1}/{layer2}"`。以下形态仅作参考——这类文件仍可查询，但不再支持生成或导入：
+如果只想查看已索引指标数量，不做任何修改：
 
-```yaml
-# 旧版 MetricFlow 形态——仅可查询，不可导入
-metric:
-  name: daily_revenue
-  type: simple
-  type_params:
-    measure: revenue
-  locked_metadata:
-    tags:
-      - "Finance"
-      - "subject_tree: Sales/Reporting/Daily"
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components metrics \
+  --kb_update_strategy check
 ```
 
-**YAML 导入注意事项：**
+## 相关文档
 
-`--semantic_yaml` 仅接受 Dosi/OSI 语义 YAML，且仅在 Dosi 项目中可用。MetricFlow YAML（`data_source:` / `metric:` 文档）会被明确拒绝；请先把项目迁移到 Dosi，再用 `semantic_modeling` 重新生成模型。
-
-## 数据源格式
-
-### CSV 格式
-
-```csv
-question,sql
-How many customers have been added per day?,"SELECT ds AS date, SUM(1) AS new_customers FROM customers GROUP BY ds ORDER BY ds;"
-What is the total transaction amount?,SELECT SUM(transaction_amount_usd) as total_amount FROM transactions;
-```
-
-### YAML 格式（指标导入）
-
-指标导入读取的是 Dosi/OSI 语义模型文档中的 `metrics` 集合——与 datasets 在同一个文件里：
-
-```yaml
-semantic_model:
-  - name: transactions
-    datasets:
-      - name: transactions
-        source: analytics.transactions
-    metrics:
-      - name: total_revenue
-        description: "Total revenue from all transactions"
-        expression: SUM(transactions.amount)
-        dataset: transactions
-```
-
-独立的 MetricFlow `metric:` 文档属于旧格式，已不支持导入。参见 [semantic_model.zh.md](semantic_model.zh.md) 了解如何定义语义模型。
-
-## 总结
-
-指标组件建立了一个**语义查询层**，将历史 SQLs 转换为标准化、可执行的指标定义。与传统的仅作为 LLM 参考的语义层不同，Datus 指标可通过 MetricFlow 直接查询，无需为常见 KPI 生成临时 SQL。
-
-主要特点：
-
-- **可执行指标**：通过 `query_metrics` 查询而非生成 SQL
-- **指标优先策略**：Agent 优先使用指标查询而非临时 SQL
-- **定义内嵌、执行独立**：指标定义存放在语义模型的 `metrics` 集合中；通过 `query_metrics` 查询是独立的执行路径，无需临时生成 SQL
-- **层级组织**：主题树分类法提高可发现性
-
-这种方法确保了团队之间指标定义的一致性，同时降低了查询复杂性并提高了性能。
+- [AskMetrics](../subagent/ask_metrics.md)：自然语言指标问答和能力边界
+- [语义建模](../subagent/semantic_modeling.md)：完整创作流程与真实生成 YAML
+- [语义模型](semantic_model.md)：dataset、field、relationship 与 Knowledge Base 投影
+- [语义层配置](../configuration/semantic_layer.md)：semantic adapter 配置

--- a/docs/knowledge_base/metrics.zh.md
+++ b/docs/knowledge_base/metrics.zh.md
@@ -46,33 +46,33 @@ datus --datasource duckdb_demo
 
 ## 当前指标 YAML
 
-下面的定义来自 Datus 示例 DuckDB 数据库上真实生成的 `bank_failures.yml`，使用了[语义模型](semantic_model.md)页面中的 dataset 和 field：
+下面是 Datus 示例 DuckDB 数据库上真实生成的 `bank_failures.yml` 中 `semantic_model[0].metrics` 的片段，使用了[语义模型](semantic_model.md)页面中的 dataset 和 field。代码块保留了它在完整文件中的缩进；它属于 semantic model 内部，不是一份独立的 YAML 文档。
 
 ```yaml
-metrics:
-  - name: bank_failure_count
-    expression:
-      dialects:
-        - dialect: DUCKDB
-          expression: COUNT(*)
-    description: 倒闭银行数量，即银行倒闭事件的记录数。
-    ai_context:
-      instructions: 按 date 作为业务时间，统计倒闭事件条数；可按 state 或时间粒度分组。
-    custom_extensions:
-      - vendor_name: DATUS
-        data: '{"v":"1.4","dataset":"bank_failures","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","count"],"unit":"banks"}'
+    metrics:
+      - name: bank_failure_count
+        expression:
+          dialects:
+            - dialect: DUCKDB
+              expression: COUNT(*)
+        description: 倒闭银行数量，即银行倒闭事件的记录数。
+        ai_context:
+          instructions: 按 date 作为业务时间，统计倒闭事件条数；可按 state 或时间粒度分组。
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"v":"1.4","dataset":"bank_failures","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","count"],"unit":"banks"}'
 
-  - name: failed_assets_million
-    expression:
-      dialects:
-        - dialect: DUCKDB
-          expression: SUM(bank_failures.assets_million)
-    description: 倒闭银行资产总额（单位：百万美元）。
-    ai_context:
-      instructions: 按 date 作为业务时间，对倒闭时资产求和；单位是百万美元。
-    custom_extensions:
-      - vendor_name: DATUS
-        data: '{"v":"1.4","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","assets"],"unit":"USD million"}'
+      - name: failed_assets_million
+        expression:
+          dialects:
+            - dialect: DUCKDB
+              expression: SUM(bank_failures.assets_million)
+        description: 倒闭银行资产总额（单位：百万美元）。
+        ai_context:
+          instructions: 按 date 作为业务时间，对倒闭时资产求和；单位是百万美元。
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"v":"1.4","time_dimension":"bank_failures.date","subject_path":["banking","bank_failures","assets"],"unit":"USD million"}'
 ```
 
 Metric expression 与 field expression 一样使用 `expression.dialects[]`。字段应带 dataset 限定，例如 `SUM(bank_failures.assets_million)`。`COUNT(*)` 这类聚合无法根据限定字段判断所属 dataset，因此在 DATUS extension 中显式提供 `dataset`。

--- a/docs/knowledge_base/semantic_model.md
+++ b/docs/knowledge_base/semantic_model.md
@@ -1,214 +1,219 @@
-# Semantic Model
+# Semantic Models
 
-Starting from **version 0.2.4**, semantic models serve as **schema extensions** that enrich database tables with semantic information. They define table structures (columns, dimensions, measures, entities) to help the agent better understand data for ad-hoc query generation.
+A semantic model turns physical database structures into reusable business concepts. It tells Datus which tables or queries represent a business dataset, what its fields mean, which time field should drive analysis, and how datasets may be joined. Metrics are defined in the same model and are covered separately in [Metrics](metrics.md).
 
-## Core Value
+Datus authors semantic models as strict OSI YAML through Dosi. The YAML file is the source of truth; the Knowledge Base contains a searchable projection of that file for agents and product interfaces.
 
-Enhances database schema understanding for better SQL generation:
-- **Rich column descriptions**: Augment DDL comments with usage patterns and filter examples
-- **Dimension & measure classification**: Explicitly mark columns as dimensions (for grouping) or measures (for aggregation)
-- **Entity relationships**: Define foreign key relationships between tables for accurate joins
-- **Query pattern insights**: Capture how columns are typically filtered (LIKE, IN, FIND_IN_SET, etc.) from historical queries
+## What a semantic model contains
 
-## How It Works
+| Object | Purpose |
+| --- | --- |
+| **Semantic model** | Groups related datasets, relationships, and metrics into one business domain. |
+| **Dataset** | Maps a business entity or event set to a physical table or a reusable SQL query. |
+| **Field** | Gives a source column or expression a stable name and business description. A field may also be a time dimension. |
+| **Relationship** | Defines an allowed equality join between two datasets. |
+| **Metric** | Defines a reusable business calculation. Metrics live in the same YAML but use a separate Knowledge Base projection and query workflow. |
 
-Semantic models define the foundational schema layer. Starting from version 0.2.4, they operate independently:
+For example, a banking model can map `main.bank_failures` to a `bank_failures` dataset, describe its bank, state, failure date, and asset fields, and define metrics that count failed banks or sum their assets.
 
-- **Semantic Models** (this document): Schema extensions with dimensions, measures, and entity relationships
-  - Storage: `semantic_dataset` table in the knowledge base
-  - Purpose: Help agent understand table structures for ad-hoc SQL generation
+## Source file and Knowledge Base projection
 
-- **Metrics** (see [metrics.md](metrics.md)): Business calculations built on semantic models
-  - Storage: `metrics` table in LanceDB
-  - Purpose: Standardized KPIs queryable via MetricFlow
-
-Semantic models provide the building blocks (dimensions, measures) that metrics reference.
-
-## Storage Structure
-
-One row per authored object. A dataset row is identified by
-`(semantic_model, dataset)`; a field row adds its own name, and a
-relationship row is identified by `(semantic_model, relationship)`:
-
-```python
-# Row kinds:
-- "dataset": one authored dataset, bound to a physical table or a reusable query
-- "field": one field of a dataset
-- "relationship": one relationship of the semantic model
-
-# Flags on a field row:
-- is_dimension: usable for grouping/filtering
-- is_time: the dataset's time dimension
-- is_primary_key: part of the dataset's key
-```
-
-A physical table may be modelled by more than one dataset, in different semantic
-models. A query-backed dataset carries no `source_table`, so it is never mistaken
-for a real table that happens to share its name.
-
-## Usage
-
-With `--success_story`, this compatibility component runs the Dosi-only `semantic_modeling` workflow in datasets-only scope. It never creates, updates, or deletes metrics. Existing YAML import and profile refresh remain non-LLM compatibility operations for Dosi/OSI YAML in Dosi projects; MetricFlow YAML is rejected.
-
-### Basic Command
-
-```bash
-# From CSV (historical SQLs)
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --success_story path/to/success_story.csv
-
-# From YAML (existing semantic model files)
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --semantic_yaml path/to/semantic_model.yaml
-
-# Re-project authored YAML into the knowledge base (no LLM call)
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --kb_update_strategy sync-yaml
-
-# Refresh observed profile descriptions in an existing YAML
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --kb_update_strategy refresh-profile \
-    --semantic_yaml path/to/semantic_model.yaml \
-    --success_story path/to/success_story.csv
-```
-
-### Key Parameters
-
-| Parameter | Required | Description | Example |
-|-----------|----------|-------------|---------|
-| `--datasource` | ✅ | Database datasource | `sales_db` |
-| `--components` | ✅ | Components to initialize | `semantic_model` |
-| `--success_story` | ⚠️ | CSV file with historical SQLs. Required for generation from SQL history and for `refresh-profile`. | `success_story.csv` |
-| `--semantic_yaml` | ⚠️ | Semantic model YAML file. Required for YAML import and for `refresh-profile`. | `semantic_model.yaml` |
-| `--kb_update_strategy` | ❌ | Update strategy. Defaults to `check`; `refresh-profile` and `sync-yaml` are semantic-model only. | `check`/`overwrite`/`incremental`/`refresh-profile`/`sync-yaml` |
-
-When `semantic_model` is combined with `metrics` or `semantic_modeling`, bootstrap executes one full `semantic_modeling` run rather than separate legacy generators.
-
-`sync-yaml` re-projects authored semantic YAML into the knowledge base. The YAML files under
-`subject/semantic_models/<datasource>/` are the source of truth, and this replays them into storage one file at a
-time — no LLM call, no warehouse access, and safe to repeat. Pass `--semantic_yaml` to sync a single file or
-subdirectory; omit it to sync everything for the active datasource. Use it after editing YAML by hand, or to
-rebuild the projection after an upgrade changes the storage layout.
-
-`refresh-profile` updates an existing Dosi/OSI semantic YAML in place (MetricFlow YAML is rejected). It re-runs bounded, read-only data
-profiling guided by the historical SQLs in `--success_story`, replaces the generated `Observed profile:` suffixes in
-table and column descriptions, and syncs the updated YAML back to the semantic model vector store. It does not run full
-LLM semantic-model generation and does not truncate the semantic model store.
-
-## Data Source Formats
-
-### CSV Format
-
-```csv
-question,sql
-How many orders per customer?,SELECT customer_id, COUNT(*) as order_count FROM orders GROUP BY customer_id;
-What is the average order amount?,SELECT AVG(amount) FROM orders WHERE status = 'completed';
-```
-
-The agent analyzes these SQLs to:
-
-- Extract table structures
-- Identify dimensions (GROUP BY columns) and measures (aggregated columns)
-- Discover column usage patterns (WHERE clause filters)
-- Infer entity relationships (JOIN patterns)
-
-### YAML Format
-
-YAML import accepts Dosi/OSI documents only. The legacy MetricFlow format below is shown for reference and is no longer importable:
-
-```yaml
-data_source:
-  name: orders
-  description: "Order transactions table"
-
-  identifiers:
-    - name: order
-      type: PRIMARY
-      expr: id
-      description: "Unique order identifier"
-
-    - name: customer
-      type: FOREIGN
-      expr: customer_id
-      description: "References customers table"
-
-  dimensions:
-    - name: status
-      type: CATEGORICAL
-      expr: status
-      description: "Order status. Use IN for filtering. Common values: 'pending', 'completed', 'cancelled'"
-
-    - name: created_at
-      type: TIME
-      expr: created_at
-      description: "Order creation timestamp"
-
-  measures:
-    - name: amount
-      agg: sum
-      expr: amount
-      description: "Order amount in USD"
-
-    - name: order_count
-      agg: count
-      expr: id
-      description: "Count of orders"
-```
-
-## How Semantic Models Enhance SQL Generation
-
-When generating SQL, the agent uses semantic models to:
-
-1. **Schema Linking**: Find relevant tables and columns using vector search on descriptions
-2. **Proper JOIN Construction**: Use entity relationships to generate correct JOIN conditions
-3. **Smart Filtering**: Apply usage patterns (e.g., use `FIND_IN_SET()` for comma-separated tag columns)
-4. **Accurate Aggregation**: Select appropriate measures for aggregation functions
-
-Example query flow:
+Authored files are stored by datasource:
 
 ```text
-User: "Show me total revenue by customer status"
-
-Agent process:
-1. Search semantic objects: "revenue", "customer", "status"
-2. Find: orders.amount (measure, agg=sum), customers.status (dimension)
-3. Use entity relationship: orders.customer_id → customers.id
-4. Generate SQL:
-   SELECT c.status, SUM(o.amount) as revenue
-   FROM orders o
-   JOIN customers c ON o.customer_id = c.id
-   GROUP BY c.status
+subject/semantic_models/<datasource>/<semantic_model>.yml
 ```
 
-## Integration with Context Search
+Each file contains one semantic model. A successful `semantic_modeling` run validates the complete file, writes it, and synchronizes its contents to the Knowledge Base.
 
-Semantic models are searchable via `/subject` context command:
+The `semantic_dataset` projection stores one row for each authored dataset, field, or relationship:
+
+- A dataset is identified by `(semantic_model, dataset)` and carries its physical source or reusable query.
+- A field adds its dataset and field name, expression, time/key flags, and description.
+- A relationship is identified by `(semantic_model, relationship)` and records both endpoints and their paired columns.
+- A query-backed dataset has a `source_query` but no `source_table`, so it cannot be confused with a physical table of the same name.
+
+Metrics are not stored in `semantic_dataset`; they are projected into the `metrics` Knowledge Base store. Both projections retain the source YAML path and are scoped to the active datasource.
+
+## Quick start
+
+Start Datus with the datasource you want to model, then describe the desired business concepts in natural language. The main agent automatically delegates authoring requests to `semantic_modeling`:
 
 ```bash
-# In CLI chat mode
-/subject <domain>/<layer1>/<layer2>
-
-# Search for semantic objects
-search_semantic_objects(query_text="customer revenue", kinds=["dataset", "field"])
+datus --datasource duckdb_demo
 ```
 
-## Summary
+```text
+Model bank_failures. Add the bank, state, failure date, and asset fields, use the failure date as the primary time dimension, and define metrics for the number of failed banks and their total assets. Validate the model and run representative metric queries.
+```
 
-Semantic models extend database schemas with rich semantic information, enabling more accurate ad-hoc SQL generation. Starting from version 0.2.4, they operate independently from metrics:
+The generated file is:
 
-Key characteristics:
+```text
+subject/semantic_models/duckdb_demo/bank_failures.yml
+```
 
-- **Schema extensions**: Augment physical schemas with business semantics
-- **Field-level storage**: Store tables, columns, entities separately for flexible search
-- **Usage pattern enrichment**: Capture real-world query patterns from historical SQLs
-- **Independent from metrics**: Focus on schema understanding, not metric calculations
+The DuckDB datasource used in this example is configured in the [Semantic Modeling guide](../subagent/semantic_modeling.md). That guide also covers supported databases, datasource setup, and interactive agent selection.
 
-This separation ensures semantic models remain focused on their core purpose: helping the agent understand your data structure for generating correct, efficient SQL queries.
+## Current YAML structure
+
+The following dataset is from the model generated against Datus's `duckdb-demo.duckdb` sample database. It shows the current OSI structure used by Dosi:
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: bank_failures
+    datasets:
+      - name: bank_failures
+        source: main.bank_failures
+        description: Bank failure event fact table; each row records one failed bank.
+        ai_context: Use this dataset to analyze bank failures by date and state.
+        fields:
+          - name: bank
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: Bank
+            description: Name of the failed bank
+          - name: state
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: State
+            description: US state code for the failed bank
+          - name: date
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: Date
+            dimension:
+              is_time: true
+            description: Bank failure date
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"v":"1.4","time_granularity":"day"}'
+          - name: assets_million
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: '"Assets ($mil.)"'
+            label: Assets ($mil.)
+            description: Assets at failure, in millions of US dollars
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"v":"1.4","time_dimension":"date"}'
+    relationships: []
+    metrics: []
+```
+
+Important rules:
+
+- The root keys are `version` and `semantic_model`; `semantic_model` is a list.
+- A physical dataset uses a qualified table name in `source`. A reusable query may be used only when the query result itself is a stable business dataset.
+- Expressions use `expression.dialects[]`. Use the dialect selected for the active datasource, such as `DUCKDB`, `POSTGRESQL`, `SNOWFLAKE`, or `STARROCKS`.
+- `primary_key` and `unique_keys` describe verified keys. Datus does not infer a key from a column name or a single query.
+- A time field uses `dimension.is_time: true`; its stored grain is carried by the DATUS `time_granularity` extension.
+- Relationships belong to the semantic model, not to an individual dataset. Their `from_columns` and `to_columns` lists are positionally paired, and the target columns must be a complete verified key.
+- Metric definitions belong under the same semantic model's `metrics` list. See [Metrics](metrics.md) for their current shape.
+
+## Relationships
+
+A relationship declares the join path Dosi may use when a query combines fields from different datasets:
+
+```yaml
+relationships:
+  - name: order_customer
+    from: orders
+    to: customers
+    from_columns: [customer_id]
+    to_columns: [customer_id]
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"v":"1.4","join_type":"left"}'
+```
+
+`from` is normally the many side and `to` the one side. For a composite key, list all components in the same order on both sides.
+
+## DATUS extensions
+
+`custom_extensions` is the OSI mechanism for Datus-specific behavior. A DATUS entry keeps the document valid OSI while adding execution or display hints used by Dosi.
+
+```yaml
+custom_extensions:
+  - vendor_name: DATUS
+    data: '{"v":"1.4","time_dimension":"date"}'
+```
+
+The `data` value is a JSON string, not a nested YAML object. `semantic_modeling` writes the extension version expected by the installed engine, so generated version values should be preserved.
+
+Common semantic-model extensions are:
+
+| Object | Keys | Purpose |
+| --- | --- | --- |
+| Dataset | `time_dimension`, `source_type` | Select the primary business time or mark a query-backed source. |
+| Time field | `time_granularity` | Record the source grain: day, week, month, quarter, or year. |
+| Relationship | `join_type` | Select `left` or `inner` join behavior. |
+
+Metric-specific extensions are described in [Metrics](metrics.md).
+
+## Creating and updating models
+
+For normal interactive work, ask Datus to create or update the model in natural language. `semantic_modeling` inspects the live schema, edits one target file, validates it, and synchronizes both semantic objects and metrics after a successful run.
+
+For batch authoring from question/SQL history, provide a CSV with `question` and `sql` columns:
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_modeling \
+  --success_story path/to/success_story.csv \
+  --kb_update_strategy incremental \
+  --metrics-batch-size 5
+```
+
+Use `--components semantic_model` instead when the batch should author datasets and relationships only. `overwrite` and `incremental` both reconcile each selected semantic YAML artifact; neither should be mistaken for a read-only check. The default `check` strategy only reports the current projection counts.
+
+## Synchronizing existing YAML
+
+If YAML files were edited outside `semantic_modeling`, rebuild their Knowledge Base projections with:
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_model \
+  --kb_update_strategy sync-yaml
+```
+
+This reads all semantic YAML files for the active datasource, validates their shape, and reconciles both the `semantic_dataset` and `metrics` projections. It does not call an LLM or query the warehouse. Pass `--semantic_yaml path/to/model.yml` only when you intentionally want to synchronize one file or directory.
+
+To refresh profile-derived descriptions in one existing model, use `refresh-profile` with that YAML and the historical SQL CSV. This performs bounded read-only profiling, updates the YAML descriptions, and synchronizes the result:
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_model \
+  --kb_update_strategy refresh-profile \
+  --semantic_yaml path/to/model.yml \
+  --success_story path/to/success_story.csv
+```
+
+## Retrieval and use
+
+Agents search semantic objects with:
+
+```python
+search_semantic_objects(
+    query_text="bank failure date and state",
+    kinds=["dataset", "field", "relationship"],
+    top_n=5,
+)
+```
+
+This search does not return metrics; use `search_metrics` for those. Physical-table inspection can also merge the matching dataset projection into table metadata, while the Catalog semantic-model view is read-only. Edit the YAML through `semantic_modeling`, then let synchronization refresh every consumer.
+
+## Related guides
+
+- [Semantic Modeling](../subagent/semantic_modeling.md): end-to-end authoring, configuration, supported databases, and complete generated YAML
+- [Metrics](metrics.md): metric definitions, Knowledge Base projection, and query parameters
+- [AskMetrics](../subagent/ask_metrics.md): natural-language metric questions
+- [Semantic layer configuration](../configuration/semantic_layer.md): semantic adapter configuration

--- a/docs/knowledge_base/semantic_model.zh.md
+++ b/docs/knowledge_base/semantic_model.zh.md
@@ -1,209 +1,219 @@
 # 语义模型
 
-从 **0.2.4 版本**开始，语义模型作为**模式扩展（schema extensions）**，为数据库表提供语义信息的增强。它们定义表结构（列、维度、度量、实体）以帮助 agent 更好地理解数据，从而生成临时查询。
+语义模型把数据库的物理结构整理成可复用的业务概念。它告诉 Datus：哪些表或查询代表一个业务 dataset、字段的业务含义是什么、分析应该使用哪个时间字段，以及不同 dataset 可以如何关联。指标也定义在同一个模型中，详见[指标](metrics.md)。
 
-## 核心价值
+Datus 通过 Dosi 编写严格的 OSI YAML。YAML 文件是唯一事实来源；Knowledge Base 保存的是由 YAML 派生的可搜索投影，供 agent 和产品界面使用。
 
-增强数据库 schema 理解以改进 SQL 生成：
+## 语义模型包含什么
 
-- **丰富的列描述**：使用模式和过滤示例增强 DDL 注释
-- **维度和度量分类**：明确标记列为维度（用于分组）或度量（用于聚合）
-- **实体关系**：定义表之间的外键关系以准确生成 JOIN
-- **查询模式洞察**：从历史查询中捕获列的典型过滤方式（LIKE、IN、FIND_IN_SET 等）
+| 对象 | 作用 |
+| --- | --- |
+| **Semantic model** | 把相关的 dataset、relationship 和 metric 组织为一个业务域。 |
+| **Dataset** | 将业务实体或事件集合映射到物理表或可复用 SQL 查询。 |
+| **Field** | 为源列或表达式提供稳定名称和业务描述，也可以标记时间维度。 |
+| **Relationship** | 定义两个 dataset 之间允许使用的等值关联。 |
+| **Metric** | 定义可复用的业务计算。Metric 与 dataset 位于同一份 YAML，但使用独立的 Knowledge Base 投影和查询流程。 |
 
-## 工作原理
+例如，银行业务模型可以把 `main.bank_failures` 映射为 `bank_failures` dataset，描述银行、州、倒闭日期和资产字段，再定义倒闭银行数量与倒闭资产总额等指标。
 
-语义模型定义基础 schema 层。从 0.2.4 版本开始，它们独立运行：
+## 源文件与 Knowledge Base 投影
 
-- **语义模型**（本文档）：包含维度、度量和实体关系的 schema 扩展
-  - 存储：知识库中的 `semantic_dataset` 表
-  - 目的：帮助 agent 理解表结构以生成临时 SQL
-
-- **指标**（参见 [metrics.zh.md](metrics.zh.md)）：构建在语义模型之上的业务计算
-  - 存储：LanceDB 中的 `metrics` 表
-  - 目的：通过 MetricFlow 查询的标准化 KPI
-
-语义模型提供指标引用的构建块（维度、度量）。
-
-## 存储结构
-
-每个编写对象一行。dataset 行由 `(semantic_model, dataset)` 标识；
-field 行在此之上再加自身名称；relationship 行由
-`(semantic_model, relationship)` 标识：
-
-```python
-# 行的 kind:
-- "dataset": 一个授权的 dataset，绑定到物理表或可复用查询
-- "field": dataset 的一个字段
-- "relationship": semantic model 的一条关系
-
-# field 行上的标记:
-- is_dimension: 可用于分组/过滤
-- is_time: dataset 的时间维度
-- is_primary_key: 属于 dataset 的主键
-```
-
-一张物理表可以被多个 dataset 建模（分属不同的 semantic model）。query-backed 的 dataset
-不带 `source_table`，因此不会被误当成同名的真实表。
-
-## 使用方法
-
-使用 `--success_story` 时，该兼容组件会运行 Dosi-only 的 `semantic_modeling` 工作流（datasets-only 范围），不会创建、更新或删除指标。YAML 导入与 profile 刷新是非 LLM 的兼容操作，仅支持 Dosi 项目中的 Dosi/OSI YAML；MetricFlow YAML 会被拒绝。
-
-### 基本命令
-
-```bash
-# 从 CSV（历史 SQLs）
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --success_story path/to/success_story.csv
-
-# 从 YAML（现有语义模型文件）
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --semantic_yaml path/to/semantic_model.yaml
-
-# 将已授权的 YAML 重新投影进知识库（不调用 LLM）
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --kb_update_strategy sync-yaml
-
-# 刷新已有 YAML 中的观测 profile 描述
-datus-agent bootstrap-kb \
-    --datasource <your_datasource> \
-    --components semantic_model \
-    --kb_update_strategy refresh-profile \
-    --semantic_yaml path/to/semantic_model.yaml \
-    --success_story path/to/success_story.csv
-```
-
-### 关键参数
-
-| 参数 | 必需 | 描述 | 示例 |
-|-----------|----------|-------------|---------|
-| `--datasource` | ✅ | 数据库数据源 | `sales_db` |
-| `--components` | ✅ | 要初始化的组件 | `semantic_model` |
-| `--success_story` | ⚠️ | 包含历史 SQLs 的 CSV 文件。从 SQL 历史生成和 `refresh-profile` 都需要。 | `success_story.csv` |
-| `--semantic_yaml` | ⚠️ | 语义模型 YAML 文件。从 YAML 导入和 `refresh-profile` 都需要。 | `semantic_model.yaml` |
-| `--kb_update_strategy` | ❌ | 更新策略。默认是 `check`；`refresh-profile` 与 `sync-yaml` 仅支持 `semantic_model` 组件。 | `check`/`overwrite`/`incremental`/`refresh-profile`/`sync-yaml` |
-
-`sync-yaml` 把已授权的语义 YAML 重新投影进知识库。`subject/semantic_models/<datasource>/` 下的 YAML 是唯一真相源，
-该策略逐个文件将其重放进存储——不调用 LLM、不访问数仓，可安全重复执行。传 `--semantic_yaml` 可只同步单个文件或
-子目录；不传则同步当前 datasource 的全部文件。手工改完 YAML 后，或升级导致存储结构变化需要重建投影时使用。
-
-`refresh-profile` 会原地更新已有 Dosi/OSI 语义模型 YAML（MetricFlow YAML 会被拒绝）。它会根据 `--success_story` 中的历史 SQL
-重新做有界、只读的数据 profile，替换表和字段 description 中生成的 `Observed profile:` 片段，并把更新后的 YAML
-同步回语义模型向量库。它不会重新运行完整 LLM 语义模型生成，也不会清空 semantic model store。
-
-## 数据源格式
-
-### CSV 格式
-
-```csv
-question,sql
-How many orders per customer?,SELECT customer_id, COUNT(*) as order_count FROM orders GROUP BY customer_id;
-What is the average order amount?,SELECT AVG(amount) FROM orders WHERE status = 'completed';
-```
-
-Agent 分析这些 SQL 以：
-
-- 提取表结构
-- 识别维度（GROUP BY 列）和度量（聚合列）
-- 发现列使用模式（WHERE 子句过滤器）
-- 推断实体关系（JOIN 模式）
-
-### YAML 格式
-
-YAML 导入仅接受 Dosi/OSI 文档。下面的旧版 MetricFlow 格式仅作参考，已不再支持导入：
-
-```yaml
-data_source:
-  name: orders
-  description: "订单交易表"
-
-  identifiers:
-    - name: order
-      type: PRIMARY
-      expr: id
-      description: "唯一订单标识符"
-
-    - name: customer
-      type: FOREIGN
-      expr: customer_id
-      description: "引用 customers 表"
-
-  dimensions:
-    - name: status
-      type: CATEGORICAL
-      expr: status
-      description: "订单状态。使用 IN 进行过滤。常见值：'pending', 'completed', 'cancelled'"
-
-    - name: created_at
-      type: TIME
-      expr: created_at
-      description: "订单创建时间戳"
-
-  measures:
-    - name: amount
-      agg: sum
-      expr: amount
-      description: "订单金额（美元）"
-
-    - name: order_count
-      agg: count
-      expr: id
-      description: "订单数量"
-```
-
-## 语义模型如何增强 SQL 生成
-
-生成 SQL 时，agent 使用语义模型来：
-
-1. **Schema Linking**：使用描述的向量搜索找到相关表和列
-2. **正确的 JOIN 构造**：使用实体关系生成正确的 JOIN 条件
-3. **智能过滤**：应用使用模式（例如，对逗号分隔的标签列使用 `FIND_IN_SET()`）
-4. **准确的聚合**：为聚合函数选择适当的度量
-
-查询流程示例：
+模型文件按 datasource 存放：
 
 ```text
-用户："按客户状态显示总收入"
-
-Agent 处理流程：
-1. 搜索语义对象："revenue", "customer", "status"
-2. 找到：orders.amount (measure, agg=sum), customers.status (dimension)
-3. 使用实体关系：orders.customer_id → customers.id
-4. 生成 SQL:
-   SELECT c.status, SUM(o.amount) as revenue
-   FROM orders o
-   JOIN customers c ON o.customer_id = c.id
-   GROUP BY c.status
+subject/semantic_models/<datasource>/<semantic_model>.yml
 ```
 
-## 与上下文搜索集成
+每个文件只包含一个 semantic model。`semantic_modeling` 成功完成后，会校验完整文件、写入磁盘，并把内容同步到 Knowledge Base。
 
-语义模型可通过 `/subject` 上下文命令搜索：
+`semantic_dataset` 投影为每个 dataset、field 和 relationship 各保存一行：
+
+- Dataset 由 `(semantic_model, dataset)` 标识，记录物理来源或可复用查询。
+- Field 在此基础上增加 dataset 和 field 名、表达式、时间/键标记及描述。
+- Relationship 由 `(semantic_model, relationship)` 标识，记录两端 dataset 与按位置配对的列。
+- Query-backed dataset 只有 `source_query`，没有 `source_table`，因此不会与同名物理表混淆。
+
+Metric 不保存在 `semantic_dataset` 中，而是投影到 `metrics` Knowledge Base store。两个投影都会保留源 YAML 路径，并按当前 datasource 隔离。
+
+## 快速上手
+
+用需要建模的 datasource 启动 Datus，然后直接用自然语言描述业务概念。主 agent 会自动把创作请求派发给 `semantic_modeling`：
 
 ```bash
-# 在 CLI 聊天模式中
-/subject <domain>/<layer1>/<layer2>
-
-# 搜索语义对象
-search_semantic_objects(query_text="customer revenue", kinds=["dataset", "field"])
+datus --datasource duckdb_demo
 ```
 
-## 总结
+```text
+为 bank_failures 建模。添加银行、州、倒闭日期和资产字段，将倒闭日期设为主要时间维度，并定义倒闭银行数量和倒闭资产总额两个指标。校验模型并实际查询代表性的指标。
+```
 
-语义模型通过丰富的语义信息扩展数据库 schema，实现更准确的临时 SQL 生成。从 0.2.4 版本开始，它们独立于指标运行：
+生成的文件位于：
 
-主要特点：
+```text
+subject/semantic_models/duckdb_demo/bank_failures.yml
+```
 
-- **Schema 扩展**：用业务语义增强物理 schema
-- **字段级存储**：单独存储表、列、实体以实现灵活搜索
-- **使用模式增强**：从历史 SQLs 捕获实际查询模式
-- **独立于指标**：专注于 schema 理解，而非指标计算
+这个示例所用的 DuckDB datasource 配置见[语义建模指南](../subagent/semantic_modeling.md)。该指南还介绍了支持的数据库、datasource 准备和交互式 agent 选择方式。
 
-这种分离确保语义模型专注于其核心目的：帮助 agent 理解数据结构，以生成正确、高效的 SQL 查询。
+## 当前 YAML 结构
+
+下面的 dataset 来自 Datus `duckdb-demo.duckdb` 示例数据库上的真实生成结果，展示了 Dosi 当前使用的 OSI 结构：
+
+```yaml
+version: 0.2.0.dev0
+semantic_model:
+  - name: bank_failures
+    datasets:
+      - name: bank_failures
+        source: main.bank_failures
+        description: 银行倒闭事件事实表，每一行记录一家倒闭银行。
+        ai_context: 用于按日期和州分析银行倒闭事件。
+        fields:
+          - name: bank
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: Bank
+            description: 倒闭银行名称
+          - name: state
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: State
+            description: 银行所在州（美国州代码）
+          - name: date
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: Date
+            dimension:
+              is_time: true
+            description: 银行倒闭日期
+            custom_extensions:
+              - vendor_name: DATUS
+                data: '{"v":"1.4","time_granularity":"day"}'
+          - name: assets_million
+            expression:
+              dialects:
+                - dialect: DUCKDB
+                  expression: '"Assets ($mil.)"'
+            label: Assets ($mil.)
+            description: 倒闭时资产总额（百万美元）
+        custom_extensions:
+          - vendor_name: DATUS
+            data: '{"v":"1.4","time_dimension":"date"}'
+    relationships: []
+    metrics: []
+```
+
+需要遵守以下规则：
+
+- 根节点只有 `version` 和 `semantic_model`；`semantic_model` 是列表。
+- 物理 dataset 的 `source` 使用带限定的表名。只有查询结果本身是稳定业务 dataset 时，才使用可复用查询作为 source。
+- 表达式使用 `expression.dialects[]`，dialect 应与当前 datasource 匹配，例如 `DUCKDB`、`POSTGRESQL`、`SNOWFLAKE` 或 `STARROCKS`。
+- `primary_key` 和 `unique_keys` 只记录经过确认的键；Datus 不会根据列名或单条查询臆测主键。
+- 时间 field 使用 `dimension.is_time: true`，源数据粒度由 DATUS `time_granularity` extension 表达。
+- Relationship 属于 semantic model，而不是某个 dataset。`from_columns` 与 `to_columns` 按位置配对，目标列必须是完整且经过确认的键。
+- Metric 定义放在同一 semantic model 的 `metrics` 列表中，当前结构见[指标](metrics.md)。
+
+## Relationship
+
+Relationship 声明 Dosi 在跨 dataset 查询时可以使用的关联路径：
+
+```yaml
+relationships:
+  - name: order_customer
+    from: orders
+    to: customers
+    from_columns: [customer_id]
+    to_columns: [customer_id]
+    custom_extensions:
+      - vendor_name: DATUS
+        data: '{"v":"1.4","join_type":"left"}'
+```
+
+`from` 通常是多的一侧，`to` 是一的一侧。使用复合键时，两侧需要按相同顺序列出全部组成列。
+
+## DATUS extension
+
+`custom_extensions` 是 OSI 为厂商行为预留的扩展机制。DATUS entry 在保持文档符合 OSI 的同时，增加 Dosi 使用的执行或展示提示。
+
+```yaml
+custom_extensions:
+  - vendor_name: DATUS
+    data: '{"v":"1.4","time_dimension":"date"}'
+```
+
+`data` 是 JSON 字符串，不是嵌套 YAML 对象。`semantic_modeling` 会写入已安装 engine 所需的 extension 版本，因此应保留生成的版本值。
+
+常见的语义模型 extension 包括：
+
+| 对象 | Key | 作用 |
+| --- | --- | --- |
+| Dataset | `time_dimension`、`source_type` | 选择主要业务时间，或标记 query-backed source。 |
+| 时间 field | `time_granularity` | 记录源数据粒度：day、week、month、quarter 或 year。 |
+| Relationship | `join_type` | 选择 `left` 或 `inner` 关联。 |
+
+Metric 专用 extension 见[指标](metrics.md)。
+
+## 创建和更新模型
+
+日常交互中，直接用自然语言让 Datus 创建或更新模型即可。`semantic_modeling` 会检查真实 schema、编辑一个目标文件、完成校验，并在成功后同步 semantic object 和 metric。
+
+如果要从“问题 + SQL”历史批量创作，准备包含 `question` 和 `sql` 列的 CSV：
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_modeling \
+  --success_story path/to/success_story.csv \
+  --kb_update_strategy incremental \
+  --metrics-batch-size 5
+```
+
+如果批处理只需要 dataset 和 relationship，不生成 metric，可把 component 改为 `semantic_model`。`overwrite` 与 `incremental` 都会协调所选语义 YAML artifact；它们都不是只读检查。默认的 `check` 只报告当前投影数量。
+
+## 同步已有 YAML
+
+如果 YAML 不是通过 `semantic_modeling` 修改的，可用下面的命令重建 Knowledge Base 投影：
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_model \
+  --kb_update_strategy sync-yaml
+```
+
+该命令读取当前 datasource 下的全部语义 YAML，检查其结构，并协调 `semantic_dataset` 与 `metrics` 两个投影；不会调用 LLM，也不会查询数仓。只有明确想同步某个文件或目录时，才传 `--semantic_yaml path/to/model.yml`。
+
+如果要刷新某个已有模型中由 profile 生成的描述，可同时提供该 YAML 和历史 SQL CSV。`refresh-profile` 会执行有界的只读 profile、更新 YAML 描述并同步结果：
+
+```bash
+datus-agent bootstrap-kb \
+  --datasource <your_datasource> \
+  --components semantic_model \
+  --kb_update_strategy refresh-profile \
+  --semantic_yaml path/to/model.yml \
+  --success_story path/to/success_story.csv
+```
+
+## 检索和使用
+
+Agent 通过下面的工具搜索语义对象：
+
+```python
+search_semantic_objects(
+    query_text="银行倒闭日期和州",
+    kinds=["dataset", "field", "relationship"],
+    top_n=5,
+)
+```
+
+该搜索不返回 metric；指标应使用 `search_metrics`。查看物理表时，Datus 也可以把匹配的 dataset 投影合并到表元数据中；Catalog 中的语义模型视图是只读的。需要修改时应更新 YAML 或使用 `semantic_modeling`，再通过同步刷新所有使用方。
+
+## 相关文档
+
+- [语义建模](../subagent/semantic_modeling.md)：完整创作流程、配置、支持的数据库和真实生成 YAML
+- [指标](metrics.md)：指标定义、Knowledge Base 投影和查询参数
+- [AskMetrics](../subagent/ask_metrics.md)：自然语言指标问答
+- [语义层配置](../configuration/semantic_layer.md)：semantic adapter 配置


### PR DESCRIPTION
## Summary

- rewrite the semantic model knowledge-base guides around the current OSI YAML and derived `semantic_dataset` projection
- rewrite the metrics guides around Dosi execution, the `metrics` projection, AskMetrics, and the current `query_metrics` API
- replace legacy examples and parameters with the real DuckDB `bank_failures` output and current bootstrap/sync workflows
- keep the English and Chinese pages aligned

## Validation

- `DOCS_LOCALE=en mkdocs build --strict`
- `DOCS_LOCALE=zh mkdocs build --strict`
- validated the documented semantic model and combined metric examples with `dosi_engine.validate`
- served and smoke-tested both rendered local routes

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Documentation**
  * Replaced legacy Metrics and semantic model guides with current Dosi/OSI YAML workflows.
  * Added guidance for Knowledge Base discovery, semantic adapter execution, relationships, datasets, fields, and metrics.
  * Documented AskMetrics natural-language queries and retrieval APIs.
  * Added authoring, batch generation, synchronization, profile refresh, and DATUS extension workflows.
  * Updated English and Chinese examples to reflect current banking and DuckDB scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced legacy Metrics and semantic model guides with current Dosi/OSI YAML workflows.
  * Added guidance for Knowledge Base discovery, semantic adapter execution, relationships, datasets, fields, and metrics.
  * Documented AskMetrics natural-language queries and retrieval APIs.
  * Added authoring, batch generation, synchronization, profile refresh, and DATUS extension workflows.
  * Updated English and Chinese examples to reflect current banking and DuckDB scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->