### PR TITLE
[BugFix] Read before writing when opening the subject tree

### DIFF
--- a/datus/storage/subject_tree/store.py
+++ b/datus/storage/subject_tree/store.py
@@ -148,7 +148,20 @@ class SubjectTreeStore:
         logger.info("SubjectTreeStore initialized")
 
     def _migrate_null_parents(self):
-        """Migrate existing NULL parent_id values to ROOT_PARENT_ID (-1)."""
+        """Migrate existing NULL parent_id values to ROOT_PARENT_ID (-1).
+
+        Reads before writing. This runs on *every* construction, so an unconditional
+        UPDATE puts a write on the path of consumers that only ever read — a role
+        holding just SELECT cannot construct the store at all, and everyone else pays
+        for a statement that almost always matches nothing.
+        """
+        legacy_rows = self._table.query(
+            SubjectNodeRecord,
+            where=[("parent_id", WhereOp.IS_NULL, None)],
+            columns=["node_id"],
+        )
+        if not legacy_rows:
+            return
         self._table.update(
             {"parent_id": ROOT_PARENT_ID},
             where=[("parent_id", WhereOp.IS_NULL, None)],

--- a/tests/unit_tests/storage/test_subject_tree_store.py
+++ b/tests/unit_tests/storage/test_subject_tree_store.py
@@ -4,8 +4,9 @@ from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+from datus_storage_base.rdb.base import WhereOp
 
-from datus.storage.subject_tree.store import SubjectTreeStore
+from datus.storage.subject_tree.store import ROOT_PARENT_ID, SubjectNodeRecord, SubjectTreeStore
 
 
 class TestSubjectTreeStore:
@@ -882,3 +883,35 @@ class TestSubjectTreeDatasourceFields:
 
 
 # Datasource isolation is row-level in the shared project tree.
+
+
+# ========== Construction Write Tests ==========
+
+
+class TestSubjectTreeConstructionWrites:
+    """Constructing the store must not write unless there is something to migrate.
+
+    ``__init__`` runs the legacy NULL-parent migration on every construction. Issuing
+    that UPDATE unconditionally puts a write on the read path, which locks out
+    consumers that hold only SELECT on the knowledge base.
+    """
+
+    def test_construction_does_not_write_when_nothing_to_migrate(self, storage_test_project):
+        seed = SubjectTreeStore(project=storage_test_project)
+        seed.create_node(None, "Finance")
+        table_cls = type(seed._table)
+
+        with patch.object(table_cls, "update", autospec=True) as update_spy:
+            SubjectTreeStore(project=storage_test_project)
+
+        update_spy.assert_not_called()
+
+    def test_construction_still_migrates_legacy_null_parents(self, storage_test_project):
+        seed = SubjectTreeStore(project=storage_test_project)
+        node_id = seed.create_node(None, "Finance")["node_id"]
+        seed._table.update({"parent_id": None}, where=[("node_id", WhereOp.EQ, node_id)])
+
+        SubjectTreeStore(project=storage_test_project)
+
+        migrated = seed._table.query(SubjectNodeRecord, where=[("node_id", WhereOp.EQ, node_id)])
+        assert [row.parent_id for row in migrated] == [ROOT_PARENT_ID]


### PR DESCRIPTION
## Why

Constructing any subject-aware KB store issues an unconditional write from `SubjectTreeStore.__init__`:

```python
def _migrate_null_parents(self):
    self._table.update({"parent_id": ROOT_PARENT_ID}, where=[("parent_id", WhereOp.IS_NULL, None)])
```

It runs on **every** construction, without looking at whether the table was just created or whether a single NULL is left to migrate.

For a consumer that holds only `SELECT` on the knowledge base — a published, read-only deployment — that write is fatal: the store cannot be constructed at all, which takes down the whole KB read surface behind it (`context_search_tools.*`, anything that builds `SemanticTools`, the `/subject/*` endpoints). The rows are readable; the door to them is not.

For everyone else it is a pointless `UPDATE` on every startup, matching nothing.

This is one half of the fix. The other half is the no-op DDL `ensure_table` emits before this line ever runs — [Datus-ai/datus-storage-adapters#13](https://github.com/Datus-ai/datus-storage-adapters/pull/13). Neither alone unblocks a read-only consumer: with only that one, construction gets past `ensure_table` and then dies here.

## Solution

Read before writing. Query for a legacy NULL `parent_id`; return when there is none. The `UPDATE` is unchanged when rows genuinely need migrating, so the legacy data path is untouched.

The other two `ensure_table` callers — `FeedbackStore` and `TaskStore` — were checked and write nothing on construction, so this is the only site of its kind on the agent side.

## Test Cases

`TestSubjectTreeConstructionWrites` in `tests/unit_tests/storage/test_subject_tree_store.py`:

- **construction issues no `update` when there is nothing to migrate** — spies on the concrete `RdbTable.update` and asserts it is never called. Fails on the pre-fix code, verified with `git stash push -- datus/storage/subject_tree/store.py`.
- **construction still migrates a legacy NULL parent** — forces a row's `parent_id` to NULL, constructs a fresh store, asserts the row comes back as `ROOT_PARENT_ID`. Passes before *and* after, so the fix cannot degrade into "never migrate".

Diff coverage 100%; `ci/audit_tests.py --diff-only upstream/main` reports P0=0.

## Follow-up

`pyproject.toml` floors `datus-storage-postgresql` at `>=0.1.5`. Once the adapter fix is published as 0.1.7, that floor should be raised — otherwise a deployment can install 0.1.6 and hit the DDL half of the bug again. Left out of this PR so it does not break resolution before the release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
