### PR TITLE
[Doc] Add Flink, K8s, and EKS plugin guides

### DIFF
--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -924,6 +924,9 @@ flow_groups:
           - docs/plugin/airflow.md
           - docs/plugin/mwaa.md
           - docs/plugin/s3.md
+          - docs/plugin/eks.md
+          - docs/plugin/k8s.md
+          - docs/plugin/flink.md
         entrypoints:
           - "CLI: datus <plugin> subcommand dispatch"
           - Plugin profile resolution and project pins

--- a/docs/plugin/eks.md
+++ b/docs/plugin/eks.md
@@ -1,0 +1,160 @@
+# EKS Plugin
+
+The EKS plugin (`datus-eks-plugin`) lets you ask the Datus agent in natural
+language to inspect the Amazon Elastic Kubernetes Service control plane and
+provide short-lived Kubernetes authentication to the [K8s plugin](k8s.md). It
+uses the AWS SDK directly, requires no kubeconfig maintenance, and does not
+expose short-lived bearer tokens to the model.
+
+All EKS operational capabilities in the first version are read-only. The agent
+can inspect clusters, node groups, add-ons, access entries, Fargate profiles,
+updates, and upgrade insights, but it cannot create, change, or delete those
+AWS resources.
+
+## Installation and Activation
+
+```bash
+datus plugin install datus-eks-plugin
+```
+
+Also install the K8s plugin when the project needs namespace workload
+operations:
+
+```bash
+datus plugin install datus-k8s-plugin
+```
+
+Enable the required plugins for the current project after installation. See
+[Plugins](introduction.md) for other installation sources and project
+activation.
+
+## Skills
+
+| Skill | Purpose |
+|---|---|
+| `eks` | Inspect EKS clusters, compute, access configuration, updates, and the current AWS identity |
+| `eks-setup` | Create an EKS environment and verify it safely |
+
+### eks
+
+The core skill takes the fixed cluster name, region, and AWS authentication
+from the environment configuration. The agent confirms the caller identity and
+target cluster first, then reads node groups, add-ons, access entries, Fargate
+profiles, updates, or upgrade insights as needed. It prefers a compact summary
+and presents a redacted AWS response only when complete fields are needed.
+
+### eks-setup
+
+The setup skill asks for an environment name, EKS cluster name, region, and
+authentication source. It supports the standard AWS credential chain, a named
+profile in `~/.aws/config`, temporary keys referenced through environment
+variables, and AssumeRole. The agent stores `${ENV_VAR}` references only and
+never writes literal credentials or an ExternalId.
+
+## Configuring an EKS Environment
+
+Prefer the standard AWS chain or AssumeRole:
+
+```text
+Configure analytics-prod for the analytics-prod-eks cluster in us-east-1,
+using the engineering AWS profile and the datus-eks-operator role.
+```
+
+The agent restates the non-secret fields before saving them. If an ExternalId
+variable name, source profile, region, or other required detail is missing, it
+asks before writing configuration. Verification reports:
+
+- the current AWS account, principal ARN, and post-AssumeRole identity;
+- target EKS cluster name, region, status, and Kubernetes version;
+- whether the endpoint and CA are available to the K8s provider; and
+- whether a failure comes from credentials, IAM, region, cluster name, or
+  connectivity.
+
+Use temporary-key environment variables only when the standard chain or
+AssumeRole is unavailable:
+
+```text
+Use the existing AWS temporary-credential environment variables for
+analytics-temp.
+```
+
+## Inspecting an EKS Environment
+
+| Your request | Agent behavior |
+|---|---|
+| "Is analytics-prod healthy?" | Confirm caller identity and read cluster status, Kubernetes version, endpoint, and a network summary |
+| "Which node groups does this cluster have?" | List node groups, then show capacity, instance types, version, and health issues for the selected one |
+| "Are the critical add-ons healthy?" | Summarize add-on versions and states and surface degraded or failed details |
+| "Can this IAM role enter the cluster?" | Inspect the matching access entry and access policies without trying to create or change them |
+| "What could block the next upgrade?" | Inspect upgrade insights and recent updates and group open work by status and category |
+| "Does this cluster use Fargate?" | List Fargate profiles and summarize selectors, subnets, and state |
+
+For an overview, the agent does not dump complete AWS responses. Ask
+explicitly when complete fields are necessary:
+
+```text
+Show me the access configuration and networking for analytics-prod.
+```
+
+When an access entry, add-on, or upgrade remediation is missing, the agent
+reports the object, state, and administrator action rather than creating or
+updating the AWS resource.
+
+## Using EKS as a K8s Provider
+
+Ask the agent to configure the cloud and namespace environments together:
+
+```text
+Make analytics-prod K8s use the matching EKS environment, with analytics as
+the default namespace and analytics-staging also allowed.
+```
+
+The agent reads the EKS endpoint and CA internally and obtains a short-lived
+credential for each Kubernetes connection. Matching EKS and K8s environment
+names link automatically; when names differ, state the provider environment in
+your request.
+
+An EKS access entry only places an AWS identity in the Kubernetes
+authentication path. Kubernetes RBAC still determines whether it may read
+Pods, deploy a `FlinkDeployment`, or access a namespace. The agent reports IAM,
+access-entry, and RBAC results separately instead of treating one successful
+layer as complete authorization.
+
+## Working with Flink Deployment
+
+Before the [Flink plugin](flink.md) deploys a job, ask the agent to use the EKS
+plugin for control-plane checks and the K8s plugin for namespace and Operator
+resources:
+
+```text
+Can analytics-prod deploy orders-enrichment in flink-jobs? Check without
+changing anything.
+```
+
+The EKS plugin does not manage ECR login, repositories, or images, and does not
+install the Flink Operator, CRDs, webhook, or cluster-level RBAC. When one of
+those prerequisites is missing, the agent reports the appropriate
+administrator action.
+
+## Permissions and Security Boundaries
+
+- Every public EKS operation is read-only and does not create, update, or
+  delete AWS resources.
+- Credentials and ExternalId values are stored only as environment-variable
+  references.
+- Short-lived Kubernetes tokens are used internally by the K8s provider and
+  are not persisted or exposed to the model.
+- The agent does not mutate kubeconfig or manage ECR images.
+- AWS IAM, EKS access entries, and Kubernetes RBAC are three independent
+  authorization layers.
+- The EKS plugin owns control-plane inspection and authentication; the K8s
+  plugin owns namespace workload operations.
+- An administrator installs the Flink Operator, CRDs, webhook, and
+  cluster-level RBAC.
+
+## Related Docs
+
+- [K8s plugin](k8s.md) — operate namespace resources through the EKS provider
+- [Flink plugin](flink.md) — deploy Flink jobs to EKS through the Operator
+- [Plugins](introduction.md) — install sources, environment configuration, activation, and permissions
+- [Skills](../skills/introduction.md) — how skills are discovered and loaded

--- a/docs/plugin/eks.zh.md
+++ b/docs/plugin/eks.zh.md
@@ -1,0 +1,134 @@
+# EKS 插件
+
+EKS 插件（`datus-eks-plugin`）让你通过自然语言要求 Datus agent 查看 Amazon Elastic
+Kubernetes Service 控制面，并为 [K8s 插件](k8s.zh.md)提供短期 Kubernetes 认证。
+它直接使用 AWS SDK，不需要你生成或维护 kubeconfig，也不会把短期 bearer token
+展示给模型。
+
+首个版本的 EKS 运维能力全部是只读的：Agent 可以查看集群、node group、add-on、
+access entry、Fargate profile、更新和升级 insight，但不能创建、修改或删除这些
+AWS 资源。
+
+## 安装和启用
+
+```bash
+datus plugin install datus-eks-plugin
+```
+
+如果还需要操作集群内的 namespace 工作负载，同时安装 K8s plugin：
+
+```bash
+datus plugin install datus-k8s-plugin
+```
+
+安装完成后，在当前项目启用所需插件。其他安装来源和项目启用方式见
+[插件](introduction.zh.md)。
+
+## Skills
+
+| Skill | 作用 |
+|---|---|
+| `eks` | 查看 EKS 集群、计算资源、访问配置、更新和当前 AWS 身份 |
+| `eks-setup` | 创建 EKS 环境并安全验证连接 |
+
+### eks
+
+核心 skill 从环境配置取得固定的 cluster name、region 和 AWS 认证。Agent 会先确认
+当前 caller identity 与目标集群，再按问题读取 node group、add-on、access entry、
+Fargate profile、update 或 upgrade insight。它会优先给出紧凑摘要，需要完整字段时
+再展示脱敏后的 AWS 响应。
+
+### eks-setup
+
+设置 skill 会询问环境名、EKS cluster name、region 和认证来源。支持标准 AWS
+credential chain、`~/.aws/config` 中的命名 profile、环境变量引用的临时密钥，以及
+AssumeRole。Agent 只保存 `${ENV_VAR}` 引用，不会写入明文 credential 或 ExternalId。
+
+## 配置 EKS 环境
+
+推荐使用标准 AWS 链或 AssumeRole：
+
+```text
+帮我配置 analytics-prod EKS：集群是 analytics-prod-eks（us-east-1），使用
+engineering AWS profile 和 datus-eks-operator role。
+```
+
+Agent 会先复述将要保存的非敏感字段。缺少 ExternalId 环境变量名、源 profile 或
+region 等必要信息时，它会在写配置前询问。验证结果会明确显示：
+
+- 当前 AWS account、principal ARN 和 AssumeRole 后的身份；
+- 目标 EKS cluster name、region、状态和 Kubernetes 版本；
+- endpoint 与 CA 是否可供 K8s provider 使用；
+- 调用失败时，是凭据、IAM、region、cluster name 还是网络问题。
+
+仅在标准链或 AssumeRole 无法使用时，才提供临时密钥的环境变量名：
+
+```text
+给 analytics-temp 使用现有的 AWS 临时凭据环境变量。
+```
+
+## 查看 EKS 环境
+
+| 你的请求 | Agent 的行为 |
+|---|---|
+| “analytics-prod 是否健康？” | 确认 caller identity，读取集群状态、Kubernetes 版本、endpoint 和网络摘要 |
+| “这个集群有哪些 node group？” | 列出 node group；指定一个后再展示容量、实例类型、版本和健康问题 |
+| “关键 add-on 是否正常？” | 汇总 add-on 版本与状态，并指出降级或失败信息 |
+| “这个 IAM role 能进入集群吗？” | 查看匹配的 access entry 及其访问策略，不尝试创建或修改 |
+| “升级前有什么风险？” | 查看 upgrade insight 和近期 update，按状态与类别归纳待处理项 |
+| “是否使用了 Fargate？” | 列出 Fargate profile 及 selector、subnet 和状态摘要 |
+
+当你只要求概览时，Agent 不会倾倒完整 AWS 响应；需要某个资源的全部字段时，可以
+明确提出：
+
+```text
+帮我看下 analytics-prod 的访问配置和网络。
+```
+
+发现缺少 access entry、add-on 或升级修复时，Agent 会报告对象、状态和管理员需要
+采取的动作，不会直接创建或更新 AWS 资源。
+
+## 作为 K8s provider
+
+让 Agent 同时配置云端与 namespace 环境：
+
+```text
+让 analytics-prod K8s 使用同名 EKS，默认访问 analytics，也允许
+analytics-staging。
+```
+
+Agent 会在内部读取 EKS endpoint 和 CA，并为每次 Kubernetes 连接获取短期凭据。
+EKS 与 K8s 环境同名时自动关联；名称不同时，你可以在请求中明确 provider 环境名。
+
+EKS access entry 只决定 AWS identity 能否进入 Kubernetes 认证链。是否能读取 Pod、
+部署 `FlinkDeployment` 或访问某个 namespace，仍由 Kubernetes RBAC 决定。Agent 会
+分别报告 IAM、access entry 和 RBAC 三层结果，避免把其中一层成功误判为完整授权。
+
+## 与 Flink 部署配合
+
+[Flink 插件](flink.zh.md)部署作业前，可以让 Agent 用 EKS plugin 确认控制面，再由
+K8s plugin 检查 namespace 与 Operator 资源：
+
+```text
+帮我确认 analytics-prod 能不能在 flink-jobs 部署 orders-enrichment，先别改资源。
+```
+
+EKS plugin 不负责 ECR 登录、仓库或镜像，也不安装 Flink Operator、CRD、webhook
+和集群级 RBAC。这些前提缺失时，Agent 会把问题交给相应管理员处理。
+
+## 权限与安全边界
+
+- 所有公开 EKS 运维操作都是只读的，不创建、修改或删除 AWS 资源；
+- credential 和 ExternalId 只保存环境变量引用；
+- 短期 Kubernetes token 仅供 K8s provider 内部使用，不写入项目或模型输出；
+- Agent 不修改 kubeconfig，也不管理 ECR 镜像；
+- AWS IAM、EKS access entry 与 Kubernetes RBAC 是三层独立授权；
+- EKS plugin 管控制面查询和认证，namespace 工作负载由 K8s plugin 管理；
+- Flink Operator、CRD、webhook 和集群级 RBAC 由管理员安装。
+
+## 相关文档
+
+- [K8s 插件](k8s.zh.md) —— 使用 EKS provider 操作 namespace 资源
+- [Flink 插件](flink.zh.md) —— 在 EKS 上通过 Operator 部署 Flink 作业
+- [插件](introduction.zh.md) —— 安装来源、环境配置、项目启用与权限
+- [Skills](../skills/introduction.zh.md) —— skills 的发现和加载方式

--- a/docs/plugin/flink.md
+++ b/docs/plugin/flink.md
@@ -1,0 +1,210 @@
+# Flink Plugin
+
+The Flink plugin (`datus-flink-plugin`) lets the Datus agent validate Apache
+Flink jobs locally, package SQL applications, and deploy and operate jobs
+through the Apache Flink Kubernetes Operator. It is a skill-only plugin: you
+describe the outcome, the agent loads the relevant skill, and every Kubernetes
+resource operation is delegated to the [K8s plugin](k8s.md). On Amazon EKS,
+the [EKS plugin](eks.md) supplies cluster discovery and short-lived
+authentication.
+
+This page focuses on deploying a Flink job to an EKS cluster where the Flink
+Kubernetes Operator is already installed. Installing the Operator, CRDs,
+webhook, and cluster-level RBAC remains a Kubernetes administrator task and is
+not performed by these plugins.
+
+## Installation and Activation
+
+Install the three plugins in dependency order:
+
+```bash
+datus plugin install datus-eks-plugin
+datus plugin install datus-k8s-plugin
+datus plugin install datus-flink-plugin
+```
+
+Enable them for the current project after installation. See
+[Plugins](introduction.md) for other installation sources and project
+activation.
+
+## Skills
+
+| Skill | Purpose |
+|---|---|
+| `flink-local-dev` | Validate Flink SQL in a local MiniCluster without writing to production sinks |
+| `flink-sql` | Select and verify the version-compatible SQL entry point for Application Mode |
+| `flink-k8s-operator` | Build, deploy, upgrade, and diagnose Operator-managed Flink jobs |
+
+### flink-local-dev
+
+When you ask for local validation, the agent leaves production SQL unchanged
+and uses a separate local overlay. Sources are restricted to development
+systems and every sink is replaced with `print`, `blackhole`, or a local
+filesystem table. It refuses to run when local execution is not pinned, a
+production sink remains unshadowed, or Git could track local credentials.
+
+```text
+Validate orders/job.sql locally without writing to production.
+```
+
+### flink-sql
+
+After validation, ask the agent to settle the production SQL entry point.
+Flink 1.x normally needs a version-matched runner JAR; Flink 2.x can use the
+`SqlDriver` on the system classpath. The agent verifies SQL, connectors, and
+filesystem dependencies and hands the resulting image and job fields to
+`flink-k8s-operator` without inventing a JAR merely to fill a field.
+
+```text
+Prepare this SQL as a production job for Flink 1.20.
+```
+
+### flink-k8s-operator
+
+This skill supports Application Clusters, Session Clusters,
+`FlinkSessionJob`, and `FlinkStateSnapshot`. You provide the job and target
+environment; the agent handles the build, deployment preflight, custom-resource
+proposal, deployment, observation, and safe suspend, resume, upgrade, and
+deletion workflows.
+
+## Deploying a Flink Job on EKS
+
+### 1. Check infrastructure prerequisites
+
+Start with a read-only request:
+
+```text
+Can flink-prod deploy a Flink job in flink-jobs? Check without changing anything.
+```
+
+The agent verifies:
+
+- that the EKS cluster is healthy and the effective AWS identity points to the
+  expected account and cluster;
+- that the target namespace is inside the K8s profile's allowlist;
+- that the cluster serves the required `FlinkDeployment` API, plus
+  `FlinkSessionJob` for Session mode and `FlinkStateSnapshot` for snapshots;
+- that the Kubernetes identity used by Datus may read and create the target
+  custom resources;
+- that the Flink job service account can manage the Pods, Services, and
+  ConfigMaps needed for TaskManagers and read their Deployment owner
+  references;
+- that IRSA is configured when the job needs AWS services such as S3; and
+- that EKS worker nodes can reach the job image registry.
+
+If the Operator, a CRD, webhook, access entry, or cluster RBAC is missing, the
+agent reports the evidence and administrator action instead of bypassing the
+boundary or installing it itself.
+
+### 2. Configure the EKS and K8s environment
+
+If no profile exists, provide the cluster and namespace in natural language:
+
+```text
+Configure flink-prod for the analytics-prod EKS cluster in us-east-1, using
+the datus-flink-operator role and the flink-jobs namespace.
+```
+
+The agent runs `eks-setup` and `k8s-setup`, creating linked profiles with the
+same name. It shows a non-secret configuration summary and verifies the target
+without exposing a short-lived Kubernetes token or writing literal secrets.
+When required information is missing, it asks before writing configuration.
+
+### 3. Validate and publish the job image
+
+SQL jobs pass through `flink-local-dev` and `flink-sql`. JVM and PyFlink
+projects use their existing test and build workflows. Give the agent the target
+version and registry and require an immutable image identity:
+
+```text
+Build a Flink 1.20 production image for orders-enrichment and publish it to our
+existing ECR repository. Ask before pushing.
+```
+
+The EKS plugin does not log in to ECR, create repositories, or push images.
+The agent may use only a registry and authentication that are already
+available, and it asks before making the external push.
+
+### 4. Propose the deployment
+
+Ask for a plan before any cluster write:
+
+```text
+Plan the orders-enrichment deployment on flink-prod. Show me the proposal
+without deploying it.
+```
+
+The agent writes the proposal under `deploy/flink/<name>/` and makes these
+decisions visible:
+
+- the Flink API version actually served by the cluster;
+- image, Flink version, entry class or script, and arguments;
+- Application or Session mode, parallelism, and compute resources;
+- namespace, service account, and checkpoint/savepoint storage;
+- `stateless`, `savepoint`, or `last-state` upgrade policy; and
+- referenced Secrets, IRSA, and image-pull configuration, without literal
+  credentials.
+
+Use `stateless` for a first deployment. Move to `savepoint` or `last-state`
+only after the job is stable and durable checkpoints and HA prerequisites have
+been verified.
+
+### 5. Validate and confirm deployment
+
+```text
+Validate the proposal first, then ask me whether to deploy it.
+```
+
+The agent asks the K8s plugin for a Server-Side Apply dry-run. Passing it proves
+only that the API schema and current identity accept the request; it does not
+prove the Flink job has started. The agent submits the resource only after you
+confirm.
+
+### 6. Observe the result
+
+```text
+After deployment, watch it until it is healthy and tell me if it fails.
+```
+
+The agent uses bounded status reads rather than waiting indefinitely. It
+distinguishes among:
+
+- the custom resource existing;
+- the JobManager being ready;
+- the Flink job actually reaching `RUNNING`, or `FINISHED` for a bounded batch
+  job; and
+- `status.error`, Pod state, or warning events reporting a failure.
+
+The resource existing or the JobManager reporting `READY` is not sufficient
+to declare success.
+
+### 7. Diagnose a failure
+
+```text
+orders-enrichment did not start. Find out why without changing anything.
+```
+
+The agent reads the smallest necessary status fields and, when relevant,
+inspects init-container or previous-instance logs. Fixes belong in the image,
+manifest, Secret, or infrastructure configuration rather than as temporary
+changes to a running Pod.
+
+## Lifecycle Management
+
+| Your request | Agent behavior |
+|---|---|
+| "Suspend orders-enrichment but preserve recoverable state." | Verify upgrade mode and state storage, show the proposed change, then suspend after confirmation |
+| "Restore the job from its latest state." | Validate checkpoint/savepoint path, authorization, and version compatibility before restoring |
+| "Upgrade the job to the new image." | Update the version-controlled manifest, preserve the confirmed upgrade policy, and show the diff |
+| "Create a snapshot for the running job." | Create a uniquely named `FlinkStateSnapshot`, observe it to completion, and report its durable path |
+| "Delete this stateful job." | Ask whether a final savepoint is required and delete Session Jobs before their Session Cluster |
+
+Every step that changes a registry, project file, or cluster state presents its
+target and impact and asks for confirmation first.
+
+## Related Docs
+
+- [K8s plugin](k8s.md) — namespace resource operations, status, logs, and permissions
+- [EKS plugin](eks.md) — EKS discovery and short-lived Kubernetes authentication
+- [Plugins](introduction.md) — install sources, profiles, activation, and permissions
+- [Skills](../skills/introduction.md) — how skills are discovered and loaded

--- a/docs/plugin/flink.zh.md
+++ b/docs/plugin/flink.zh.md
@@ -1,0 +1,182 @@
+# Flink 插件
+
+Flink 插件（`datus-flink-plugin`）让 Datus agent 帮你完成 Apache Flink 作业的本地
+验证、SQL 打包，以及基于 Apache Flink Kubernetes Operator 的部署和运维。它是一个
+skill-only 插件：你只需要描述目标，Agent 会调用相应 skill，并把所有 Kubernetes
+资源操作交给 [K8s 插件](k8s.zh.md)；目标是 Amazon EKS 时，再由
+[EKS 插件](eks.zh.md)提供集群发现和短期认证。
+
+本文重点介绍在已经安装 Flink Kubernetes Operator 的 EKS 集群上部署 Flink 作业。
+Operator、CRD、webhook 和集群级 RBAC 的安装属于 Kubernetes 管理员职责，不由这些
+插件执行。
+
+## 安装和启用
+
+按依赖顺序安装三个插件：
+
+```bash
+datus plugin install datus-eks-plugin
+datus plugin install datus-k8s-plugin
+datus plugin install datus-flink-plugin
+```
+
+安装完成后，在当前项目启用这些插件。其他安装来源和项目启用方式见
+[插件](introduction.zh.md)。
+
+## Skills
+
+| Skill | 作用 |
+|---|---|
+| `flink-local-dev` | 在本机 MiniCluster 中验证 Flink SQL，不写生产 sink |
+| `flink-sql` | 为 Application Mode 选择并验证与 Flink 版本匹配的 SQL 入口 |
+| `flink-k8s-operator` | 构建、部署、升级和排查 Operator 管理的 Flink 作业 |
+
+### flink-local-dev
+
+当你要求在本地验证 Flink SQL 时，Agent 会保持生产 SQL 不变，通过单独的本地
+overlay 把 source 限制在开发环境，并把每个 sink 替换为 `print`、`blackhole` 或
+本地文件表。缺少本地执行约束、存在未替换的生产 sink，或本地凭据可能被 Git 跟踪
+时，它会拒绝运行并说明原因。
+
+```text
+帮我在本地验证 orders/job.sql，别写入生产环境。
+```
+
+### flink-sql
+
+验证通过后，让 Agent 为生产环境确定 SQL 入口。Flink 1.x 通常需要版本匹配的
+runner JAR；Flink 2.x 可以使用系统 classpath 中的 `SqlDriver`。Agent 会检查 SQL、
+connector 和 filesystem 依赖，并把确定的镜像及作业字段交给
+`flink-k8s-operator`，不会为了填充字段而虚构 JAR。
+
+```text
+把这个 SQL 准备成 Flink 1.20 的生产作业。
+```
+
+### flink-k8s-operator
+
+这个 skill 支持 Application Cluster、Session Cluster、`FlinkSessionJob` 和
+`FlinkStateSnapshot`。你提供业务作业和目标环境，Agent 负责构建、发布前检查、
+自定义资源方案、部署、状态观察，以及安全的暂停、恢复、升级和删除流程。
+
+## 在 EKS 上部署 Flink 作业
+
+### 1. 检查基础设施前提
+
+先让 Agent 做只读检查：
+
+```text
+帮我看看 flink-prod 能不能在 flink-jobs 部署 Flink 作业，先别做修改。
+```
+
+Agent 会确认：
+
+- EKS 集群是否健康，当前 AWS 身份是否指向预期账号和集群；
+- 目标 namespace 是否在 K8s profile 的允许范围内；
+- 集群是否提供所需版本的 `FlinkDeployment`，Session 模式是否提供
+  `FlinkSessionJob`，快照流程是否提供 `FlinkStateSnapshot`；
+- Datus 使用的 Kubernetes 身份能否读取和创建目标自定义资源；
+- Flink 作业 service account 是否拥有管理 TaskManager 所需的 Pod、Service、
+  ConfigMap 权限，以及读取 Deployment owner reference 的权限；
+- 作业需要访问 S3 等 AWS 服务时，service account 是否已配置 IRSA；
+- 作业镜像 registry 是否能从 EKS 工作节点访问。
+
+如果缺少 Operator、CRD、webhook、access entry 或集群级 RBAC，Agent 会列出证据和
+管理员需要完成的事项，不会尝试绕过边界或自行安装。
+
+### 2. 配置 EKS 与 K8s 环境
+
+如果 profile 尚不存在，用自然语言给出集群和 namespace 信息：
+
+```text
+帮我配置 flink-prod：EKS 集群是 analytics-prod（us-east-1），使用
+datus-flink-operator role，namespace 是 flink-jobs。
+```
+
+Agent 会分别运行 `eks-setup` 和 `k8s-setup`，建立同名且自动关联的 profile。它会
+展示非敏感配置摘要，并验证目标，但不会输出短期 Kubernetes token 或把明文密钥
+写入配置。缺少必须信息时，Agent 会在写入前询问你。
+
+### 3. 验证并发布作业镜像
+
+SQL 作业先经过 `flink-local-dev` 和 `flink-sql`；JVM 或 PyFlink 项目则使用项目已有
+的测试与构建方式。告诉 Agent 目标版本和 registry，同时要求不可变镜像标识：
+
+```text
+为 orders-enrichment 构建 Flink 1.20 生产镜像并发布到现有 ECR，推送前问我。
+```
+
+EKS plugin 不负责 ECR 登录、仓库创建或镜像推送。Agent 只能使用已经准备好的
+registry 与认证，并且在推送这个外部变更前请求确认。
+
+### 4. 生成部署方案
+
+让 Agent 先规划，不要直接写入集群：
+
+```text
+帮我规划 orders-enrichment 在 flink-prod 的部署，先给我方案，不要发布。
+```
+
+Agent 会把方案写到项目的 `deploy/flink/<name>/` 下，并明确展示：
+
+- 集群实际提供的 Flink API version；
+- 镜像、Flink version、入口类或脚本与参数；
+- Application 或 Session 模式、并行度和计算资源；
+- namespace、service account、checkpoint/savepoint 存储；
+- `stateless`、`savepoint` 或 `last-state` 升级策略；
+- 引用的 Secret、IRSA 和 image pull 配置，不包含任何明文凭据。
+
+首次部署默认使用 `stateless`。只有作业已进入稳定状态、持久 checkpoint 与 HA 前提
+已验证后，才适合改为 `savepoint` 或 `last-state`。
+
+### 5. 校验并确认部署
+
+```text
+先验证这个部署方案，没问题再问我要不要发布。
+```
+
+Agent 会通过 K8s plugin 做 Server-Side Apply dry-run。校验成功只说明资源格式和当前
+身份可接受该请求，不代表 Flink 作业已经启动。你确认后，Agent 才会正式提交资源。
+
+### 6. 观察运行结果
+
+```text
+发布后帮我等到它正常运行，失败就告诉我原因。
+```
+
+Agent 使用有界的状态读取，不会无限等待。它会区分：
+
+- 自定义资源已创建；
+- JobManager 已就绪；
+- Flink job 真正达到 `RUNNING`，或有界批作业达到 `FINISHED`；
+- `status.error`、Pod 状态和 warning event 是否显示失败。
+
+不能只因为资源存在或 JobManager 为 `READY` 就宣告成功。
+
+### 7. 诊断失败
+
+```text
+orders-enrichment 没跑起来，帮我查下原因，先不要改东西。
+```
+
+Agent 会优先读取最小必要状态字段，并在需要时查看 init container 或上一实例日志。
+修复应进入镜像、manifest、Secret 或基础设施配置，而不是临时修改运行中的 Pod。
+
+## 生命周期管理
+
+| 你的请求 | Agent 的行为 |
+|---|---|
+| “暂停 orders-enrichment，但保留可恢复状态” | 核对升级模式和状态存储，展示 patch，确认后暂停 |
+| “从上次状态恢复作业” | 验证 checkpoint/savepoint 路径、权限和版本兼容性后再恢复 |
+| “把镜像升级到新版本” | 修改受版本控制的 manifest，保留已确认的升级策略并展示差异 |
+| “为当前作业创建快照” | 创建唯一的 `FlinkStateSnapshot`，等待完成并报告持久化路径 |
+| “删除这个有状态作业” | 先询问是否需要最终 savepoint；Session Job 先于 Session Cluster 删除 |
+
+所有会改变镜像仓库、项目文件或集群状态的步骤都会先展示目标和影响，并请求确认。
+
+## 相关文档
+
+- [K8s 插件](k8s.zh.md) —— namespace 资源操作、状态、日志与权限
+- [EKS 插件](eks.zh.md) —— EKS 集群发现和短期 Kubernetes 认证
+- [插件](introduction.zh.md) —— 安装来源、profile、项目启用与权限
+- [Skills](../skills/introduction.zh.md) —— skills 的发现和加载方式

--- a/docs/plugin/k8s.md
+++ b/docs/plugin/k8s.md
@@ -1,0 +1,179 @@
+# K8s Plugin
+
+The K8s plugin (`datus-k8s-plugin`) lets you ask the Datus agent in natural
+language to inspect and operate namespace-scoped Kubernetes data workloads.
+The agent can discover resources, read status and logs, analyze events, check
+authorization, and apply or change manifests after confirmation. This includes
+Pods, Deployments, Jobs, and custom resources such as `FlinkDeployment`.
+
+The plugin deliberately has no cluster-administrator capability. It cannot
+query every namespace or operate cluster-scoped resources, and every request
+is constrained by the selected environment's namespace allowlist. On Amazon
+EKS it obtains cluster information and short-lived authentication from the
+[EKS plugin](eks.md).
+
+## Installation and Activation
+
+```bash
+datus plugin install datus-k8s-plugin
+```
+
+Also install the EKS plugin when connecting to EKS:
+
+```bash
+datus plugin install datus-eks-plugin
+```
+
+Enable the required plugins for the current project after installation. See
+[Plugins](introduction.md) for other installation sources and project
+activation.
+
+## Skills
+
+| Skill | Purpose |
+|---|---|
+| `k8s` | Inspect, diagnose, and change namespace-scoped Kubernetes workloads |
+| `k8s-setup` | Create a managed-cloud or kubeconfig-backed K8s environment |
+
+### k8s
+
+The core skill confirms the environment and namespace first, then chooses the
+smallest necessary resource status, events, logs, metrics, or authorization
+checks. For asynchronous resources it sets a maximum duration and check count,
+inspecting the target state and errors together instead of waiting blindly
+after a concrete failure has appeared.
+
+### k8s-setup
+
+The setup skill asks for a managed-Kubernetes provider or kubeconfig, a default
+namespace, and the allowed namespaces. Cloud identity and short-lived
+authentication stay in the provider plugin and are not copied into the K8s
+environment configuration.
+
+## Connecting to Amazon EKS
+
+Tell the agent the cluster, authentication method, and namespace:
+
+```text
+Configure analytics-prod for the analytics-prod-eks cluster in us-east-1, using
+analytics as the default namespace.
+```
+
+The agent uses `eks-setup` for the cloud environment and `k8s-setup` for the
+same-named K8s environment, linking them automatically. It verifies:
+
+- the effective AWS caller identity and target EKS cluster;
+- that the Kubernetes server matches the selected environment;
+- that the default namespace exists and is inside the allowlist; and
+- that the current Kubernetes identity has the requested namespace access.
+
+The short-lived bearer token is not exposed to the model or persisted to the
+project. Permission to inspect EKS does not automatically grant Kubernetes
+access; configure the EKS access entry and namespace RBAC separately.
+
+When the EKS and K8s environments need different names, state the relationship
+explicitly:
+
+```text
+Make flink-prod use analytics-prod EKS and allow only flink-jobs.
+```
+
+## Connecting through kubeconfig
+
+For an existing kubeconfig, give the agent its path and context:
+
+```text
+Use the staging context in ./conf/kubeconfig.yaml and allow only
+analytics-staging.
+```
+
+The agent resolves relative paths from the current project and rejects a path
+that escapes through `..` or a symlink. If you omit the context, kubeconfig's
+current context is used, but the agent presents the effective cluster identity
+before its first operation.
+
+## Inspecting and Diagnosing Workloads
+
+| Your request | Agent behavior |
+|---|---|
+| "Which Pods in analytics-prod are unhealthy?" | Summarize readiness, restarts, and actual waiting reasons, then inspect related warning events |
+| "Why does pipeline-api keep restarting?" | Confirm Pod and container state, then read the previous instance and any relevant init-container logs |
+| "What is the current state of the orders FlinkDeployment?" | Read job state, status.error, and JobManager/TaskManager state separately rather than trusting one field |
+| "Which Pod uses the most memory?" | Read namespace Pod metrics, sort by memory, and explain when metrics are unavailable |
+| "May the current identity create Jobs?" | Check authorization in the target namespace without probing through a failing write |
+
+Resource summaries distinguish `Running` from actually Ready and expose
+waiting reasons such as `Init:CrashLoopBackOff` and `ImagePullBackOff`. The
+agent prefers the individual status field that answers the question and reads
+the complete object only when it needs the full spec or conditions.
+
+## Observing Asynchronous Resources
+
+Include the success condition and observation limit in your request:
+
+```text
+Watch daily-etl in analytics-staging and tell me when it finishes or fails.
+```
+
+For Kubernetes Deployments, StatefulSets, and DaemonSets, the agent can follow
+their rollout. For custom resources such as Flink, it performs bounded reads of
+the resource's own status and error fields. A created resource, a Running Pod,
+or a ready controller does not necessarily mean the business workload
+succeeded.
+
+## Applying and Changing Resources
+
+Describe the outcome and ask the agent to present a proposal first:
+
+```text
+Check deploy/pipeline.yaml, then ask me whether to deploy it to analytics-prod.
+```
+
+```text
+Scale pipeline-api in analytics to four replicas.
+```
+
+```text
+Delete the daily-backfill Job from analytics.
+```
+
+The agent uses Server-Side Apply for local YAML or JSON manifests. Creating,
+applying, deleting, patching, scaling, labeling, annotating, restarting, or
+entering a container for a diagnostic probe requires confirmation. A
+server-side dry-run persists nothing, but the agent still identifies the exact
+environment and namespace being validated.
+
+## Permissions and Safety Boundaries
+
+- Resource discovery, status, details, logs, events, metrics, and authorization
+  checks are read-only.
+- An environment can reach only its allowed namespaces; the default namespace
+  is the only allowed one when no wider allowlist is configured.
+- Cross-namespace-all queries, cluster-scoped resources, kubeconfig mutation,
+  and identity impersonation are blocked.
+- Interactive shells, attach, file copy, port forwarding, and proxying are
+  unsupported.
+- An in-container diagnostic is one non-interactive command and requires
+  confirmation every time.
+- The agent never patches files or configuration inside a running container;
+  durable fixes belong in the image or manifest.
+
+## Orchestrating with the Flink Plugin
+
+The [Flink plugin](flink.md) `flink-k8s-operator` skill understands the job and
+generates resources such as `FlinkDeployment`. The K8s plugin performs
+discovery, validation, deployment, and diagnosis in the target EKS namespace.
+
+```text
+Deploy orders to analytics-prod and track the result.
+```
+
+The Operator, CRDs, webhook, and cluster-level RBAC are outside the K8s
+plugin's scope and must be installed by an administrator first.
+
+## Related Docs
+
+- [EKS plugin](eks.md) — EKS discovery and Kubernetes provider authentication
+- [Flink plugin](flink.md) — deploy and manage Flink jobs through the Operator
+- [Plugins](introduction.md) — install sources, environment configuration, activation, and permissions
+- [Skills](../skills/introduction.md) — how skills are discovered and loaded

--- a/docs/plugin/k8s.zh.md
+++ b/docs/plugin/k8s.zh.md
@@ -1,0 +1,158 @@
+# K8s 插件
+
+K8s 插件（`datus-k8s-plugin`）让你直接用自然语言要求 Datus agent 查看和操作
+namespace 范围内的 Kubernetes 数据工作负载。Agent 可以发现资源、读取状态与日志、
+分析事件、检查权限，以及在确认后应用或修改 manifest，包括 Pod、Deployment、Job
+和 `FlinkDeployment` 等自定义资源。
+
+插件刻意不提供集群管理员能力：不能跨所有 namespace 查询，也不能操作集群级资源；
+每次访问都受所选环境的 namespace allowlist 限制。连接 Amazon EKS 时，它从
+[EKS 插件](eks.zh.md)取得集群信息和短期认证。
+
+## 安装和启用
+
+```bash
+datus plugin install datus-k8s-plugin
+```
+
+连接 EKS 时还要安装 EKS plugin：
+
+```bash
+datus plugin install datus-eks-plugin
+```
+
+安装完成后，在当前项目启用所需插件。其他安装来源和项目启用方式见
+[插件](introduction.zh.md)。
+
+## Skills
+
+| Skill | 作用 |
+|---|---|
+| `k8s` | 查看、诊断和变更 namespace 内的 Kubernetes 工作负载 |
+| `k8s-setup` | 创建 managed-cloud 或 kubeconfig 类型的 K8s 环境 |
+
+### k8s
+
+核心 skill 会先确认环境和 namespace，再按问题选择最小必要的资源状态、事件、日志、
+指标或权限检查。对于异步资源，它会设置最长耗时和检查次数，每次同时检查目标状态与
+错误，不会在已经出现具体失败后继续盲目等待。
+
+### k8s-setup
+
+设置 skill 会询问 managed Kubernetes provider 或 kubeconfig、默认 namespace 和
+允许访问的 namespace。云端身份和短期认证保留在 provider plugin 中，不会复制到
+K8s 环境配置。
+
+## 连接 Amazon EKS
+
+告诉 Agent EKS 集群、认证方式和 namespace：
+
+```text
+帮我配置 analytics-prod，连接 us-east-1 的 analytics-prod-eks，默认使用 analytics
+namespace。
+```
+
+Agent 会先使用 `eks-setup` 配置云端环境，再用 `k8s-setup` 创建同名 K8s 环境，使
+两者自动关联。它会验证：
+
+- 当前 AWS caller identity 和目标 EKS 集群；
+- Kubernetes server 与所选环境是否一致；
+- 默认 namespace 是否存在且位于 allowlist；
+- 当前 Kubernetes 身份是否拥有请求的 namespace 权限。
+
+短期 bearer token 不会展示给模型或持久化到项目。AWS 身份能够查看 EKS 并不代表
+自动拥有 Kubernetes 权限；EKS access entry 与 namespace RBAC 必须分别配置。
+
+如果 EKS 与 K8s 环境需要使用不同名称，可以直接说明关联关系：
+
+```text
+让 flink-prod 使用 analytics-prod EKS，只访问 flink-jobs。
+```
+
+## 连接 kubeconfig 环境
+
+已有 kubeconfig 时，只把路径和 context 告诉 Agent：
+
+```text
+用 ./conf/kubeconfig.yaml 的 staging context 配一个环境，只访问
+analytics-staging。
+```
+
+Agent 会从当前项目解析相对路径，并拒绝通过 `..` 或 symlink 跳出项目。省略 context
+时会使用 kubeconfig 当前选择的 context，但 Agent 会在首次访问前把最终集群身份展示
+给你确认。
+
+## 查看和诊断工作负载
+
+| 你的请求 | Agent 的行为 |
+|---|---|
+| “analytics-prod 里哪些 Pod 不健康？” | 汇总 READY、重启次数和实际等待原因，再查看相关 warning event |
+| “为什么 pipeline-api 一直重启？” | 先确认 Pod 和容器状态，再读取上一实例及必要的 init container 日志 |
+| “orders 这个 FlinkDeployment 现在是什么状态？” | 分别读取 job state、status.error、JobManager/TaskManager 状态，避免只看单一字段 |
+| “哪个 Pod 的内存使用最高？” | 读取 namespace 内 Pod 指标并按内存排序，说明 metrics 不可用时的原因 |
+| “当前身份能否创建 Job？” | 对目标 namespace 做授权检查，不尝试通过失败的写操作试探权限 |
+
+资源表会区分 `Running` 与真正 Ready，也会显示 `Init:CrashLoopBackOff`、
+`ImagePullBackOff` 等等待原因。Agent 优先读取回答问题所需的单个状态字段；只有需要
+理解完整 spec 或 conditions 时才读取整个对象。
+
+## 观察异步资源
+
+请在请求中给出成功条件和最长观察时间：
+
+```text
+帮我看着 analytics-staging 的 daily-etl，跑完或失败时告诉我。
+```
+
+对于 Kubernetes Deployment、StatefulSet 和 DaemonSet，Agent 可以跟踪 rollout；
+对于 Flink 等自定义资源，它会有界地重复读取资源自身的状态与错误。资源已创建、Pod
+处于 Running 或 controller 已就绪，不一定等于业务工作负载成功。
+
+## 应用和变更资源
+
+从自然语言描述目标，要求 Agent 先展示 proposal：
+
+```text
+先检查 deploy/pipeline.yaml，没问题的话问我是否发布到 analytics-prod。
+```
+
+```text
+把 analytics 里的 pipeline-api 扩容到 4 个副本。
+```
+
+```text
+删除 analytics 里的 daily-backfill Job。
+```
+
+Agent 使用 Server-Side Apply 处理本地 YAML/JSON manifest。创建、应用、删除、patch、
+扩缩容、标签/注解、重启和进入容器检查都需要确认。服务端 dry-run 不持久化资源，但
+Agent 仍会清楚说明它正在验证哪个环境和 namespace。
+
+## 权限与安全边界
+
+- 资源发现、状态、详情、日志、事件、指标和授权检查属于只读操作；
+- 环境只能访问 allowlist 中的 namespace，未配置时默认为默认 namespace；
+- 禁止跨全部 namespace、集群级资源、kubeconfig 修改和身份模拟；
+- 不支持交互式 shell、attach、文件复制、port-forward 或 proxy；
+- 容器内检查只能是一次性、非交互命令，每次都需要确认；
+- Agent 不会在运行容器里临时修补文件或配置，持久修复必须进入镜像或 manifest。
+
+## 与 Flink 插件编排
+
+[Flink 插件](flink.zh.md)的 `flink-k8s-operator` skill 负责理解作业并生成
+`FlinkDeployment` 等资源，K8s plugin 负责在目标 EKS namespace 中执行发现、校验、
+部署和诊断。
+
+```text
+把 orders 发布到 analytics-prod，并帮我跟踪运行结果。
+```
+
+Operator、CRD、webhook 和集群级 RBAC 不属于 K8s plugin 的能力范围，必须由管理员
+预先安装。
+
+## 相关文档
+
+- [EKS 插件](eks.zh.md) —— EKS 集群发现和 Kubernetes provider 认证
+- [Flink 插件](flink.zh.md) —— 通过 Operator 部署和管理 Flink 作业
+- [插件](introduction.zh.md) —— 安装来源、环境配置、项目启用与权限
+- [Skills](../skills/introduction.zh.md) —— skills 的发现和加载方式

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,6 @@ nav:
       - Development: plugin/development.md
       - Plugin List:
         - Airflow: plugin/airflow.md
-        - MWAA: plugin/mwaa.md
         - S3: plugin/s3.md
         - EKS: plugin/eks.md
         - K8s: plugin/k8s.md
@@ -211,7 +210,6 @@ plugins:
             Plugin List: 插件列表
             Development: 开发指南
             Airflow: Airflow
-            MWAA: MWAA
             S3: S3
             EKS: EKS
             K8s: K8s

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,9 +46,13 @@ nav:
     - Plugin:
       - Introduction: plugin/introduction.md
       - Development: plugin/development.md
-      - Airflow: plugin/airflow.md
-      - MWAA: plugin/mwaa.md
-      - S3: plugin/s3.md
+      - Plugin List:
+        - Airflow: plugin/airflow.md
+        - MWAA: plugin/mwaa.md
+        - S3: plugin/s3.md
+        - EKS: plugin/eks.md
+        - K8s: plugin/k8s.md
+        - Flink: plugin/flink.md
     - Chatbot: web_chatbot/introduction.md
     - IM Gateway:
       - Introduction: gateway/introduction.md
@@ -204,10 +208,14 @@ plugins:
             Validation: 校验
             Auto Memory: 自动记忆
             Plugin: 插件
+            Plugin List: 插件列表
             Development: 开发指南
             Airflow: Airflow
             MWAA: MWAA
             S3: S3
+            EKS: EKS
+            K8s: K8s
+            Flink: Flink
             Develop: 开发
             Observability: 可观测性
             VSCode Extension: VSCode 插件


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

Datus now supports deploying Flink jobs through the Flink Kubernetes Operator, with Kubernetes access delegated to the K8s plugin and Amazon EKS discovery and authentication delegated to the EKS plugin. Users need one documentation path that explains this workflow and the boundaries between the three plugins.

## Solution

- Add English and Chinese user guides for the Flink, K8s, and EKS plugins.
- Document the EKS-to-K8s-to-Flink Operator workflow from a user perspective, using concise natural-language requests for agent interactions.
- Keep direct CLI usage limited to plugin installation and describe confirmation, namespace, credential, Operator, CRD, and RBAC boundaries.
- Group the concrete plugin guides under a dedicated Plugin List navigation submenu.

## Test Cases

- English MkDocs strict build passed.
- Chinese MkDocs strict build passed.
- PR coverage harness passed in an isolated clean worktree: 260 passed, 0 failed, diff coverage 100%.
- Diff-only test-quality audit passed with no test files to scan.
- Ruff format and lint gates passed.
- No integration or nightly tests were added because this PR changes documentation and navigation only.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive EKS, Kubernetes, and Flink plugin guides in English and Chinese.
  - Documented installation, authentication, skills, environment setup, workload inspection, deployments, troubleshooting, and lifecycle operations.
  - Clarified permissions, confirmation requirements, read-only boundaries, and safety limitations.
  - Added EKS, K8s, and Flink pages to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added English and Chinese guides for the EKS, Kubernetes, and Flink plugins.
  - Documented installation, authentication, skills, workload inspection, deployment workflows, lifecycle operations, and safety boundaries.
  - Clarified confirmation requirements, namespace scoping, read-only checks, credential handling, and Flink Kubernetes Operator integration.
  - Updated documentation navigation to remove the MWAA plugin entry and include the new plugin guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->