### PR TITLE
[BugFix] Fold identifiers the way SQLite resolves them

### DIFF
--- a/datus/storage/rdb/sqlite_backend.py
+++ b/datus/storage/rdb/sqlite_backend.py
@@ -35,6 +35,9 @@ _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 
 
+_ASCII_FOLD = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
+
+
 def _folded(name: str) -> str:
     """Fold an identifier the way SQLite resolves one.
 
@@ -42,10 +45,20 @@ def _folded(name: str) -> str:
     through ``PRAGMA table_info`` and ``sqlite_master.name`` — exactly as they were
     declared. Comparing a definition's spelling against the catalog's would call a
     column that is already there missing, and re-adding it fails outright with
-    "duplicate column name". ``lower()`` rather than ``casefold()`` because SQLite's
-    ``NOCASE`` folds A-Z only, and ``_IDENTIFIER_RE`` keeps identifiers to ASCII.
+    "duplicate column name".
+
+    A-Z only, because that is the whole of SQLite's ``NOCASE``. ``str.lower()`` folds
+    wider: it maps U+212A KELVIN SIGN to ASCII ``k`` (U+006B). A legacy column named
+    U+212A would therefore answer for a definition's ASCII ``K``, the ``ALTER TABLE``
+    would be skipped, and the required column would never exist — while SQLite, which
+    folds neither, keeps the two as separate columns. The two spell identically on
+    screen, so this is stated in codepoints rather than shown.
+
+    Catalog names arrive from the live database through ``PRAGMA table_info`` and
+    ``sqlite_master`` and never pass ``_IDENTIFIER_RE``, so they cannot be assumed
+    ASCII at all.
     """
-    return name.lower()
+    return name.translate(_ASCII_FOLD)
 
 
 def _safe_ident(name: str) -> str:

--- a/datus/storage/rdb/sqlite_backend.py
+++ b/datus/storage/rdb/sqlite_backend.py
@@ -35,6 +35,19 @@ _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 
 
+def _folded(name: str) -> str:
+    """Fold an identifier the way SQLite resolves one.
+
+    SQLite matches identifiers case-insensitively for ASCII but reports them back —
+    through ``PRAGMA table_info`` and ``sqlite_master.name`` — exactly as they were
+    declared. Comparing a definition's spelling against the catalog's would call a
+    column that is already there missing, and re-adding it fails outright with
+    "duplicate column name". ``lower()`` rather than ``casefold()`` because SQLite's
+    ``NOCASE`` folds A-Z only, and ``_IDENTIFIER_RE`` keeps identifiers to ASCII.
+    """
+    return name.lower()
+
+
 def _safe_ident(name: str) -> str:
     """Validate and quote a SQL identifier to prevent injection."""
     if not _IDENTIFIER_RE.fullmatch(name):
@@ -255,11 +268,11 @@ class SqliteRdbDatabase(RdbDatabase):
         """Add columns that exist in the definition but not in the live table."""
         safe_table = _safe_ident(table_def.table_name)
         cursor = conn.execute(f"PRAGMA table_info({safe_table})")
-        existing_cols = {row[1] for row in cursor.fetchall()}
+        existing_cols = {_folded(row[1]) for row in cursor.fetchall()}
         if not existing_cols:
             return  # table doesn't exist yet — CREATE TABLE will handle it
         for col in table_def.columns:
-            if col.name not in existing_cols:
+            if _folded(col.name) not in existing_cols:
                 col_ddl = _sqlite_col_ddl(col)
                 conn.execute(f"ALTER TABLE {safe_table} ADD COLUMN {col_ddl}")
                 logger.info(f"Migrated: ALTER TABLE {safe_table} ADD COLUMN {col_ddl}")
@@ -294,7 +307,7 @@ class SqliteRdbDatabase(RdbDatabase):
         # was first created. This is the only way to inspect inline constraints
         # because SQLite has no information_schema or constraint catalog.
         cursor = conn.execute(
-            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name = ? COLLATE NOCASE",
             (table_def.table_name,),
         )
         row = cursor.fetchone()
@@ -323,8 +336,12 @@ class SqliteRdbDatabase(RdbDatabase):
 
         # Only transfer columns that exist in both the old table and the new definition.
         # This safely handles columns that may have been added by _migrate_missing_columns.
-        new_col_names = {col.name for col in table_def.columns}
-        transfer_cols = ", ".join(c for c in existing_cols if c in new_col_names)
+        # Matched on the folded name, because a column the old table declared as "Name"
+        # is the definition's "name" — treating them as different silently drops the
+        # column, and its data, on the rebuild below. The old spelling is what gets
+        # emitted, which both tables resolve to.
+        new_col_names = {_folded(col.name) for col in table_def.columns}
+        transfer_cols = ", ".join(c for c in existing_cols if _folded(c) in new_col_names)
 
         # Build DDL for the temp table using the new definition (correct constraints).
         col_parts = [_sqlite_col_ddl(col) for col in table_def.columns] + list(table_def.constraints)

--- a/datus/storage/rdb/sqlite_backend.py
+++ b/datus/storage/rdb/sqlite_backend.py
@@ -38,7 +38,7 @@ _SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
 _ASCII_FOLD = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
 
 
-def _folded(name: str) -> str:
+def _nocase_folded(name: str) -> str:
     """Fold an identifier the way SQLite resolves one.
 
     SQLite matches identifiers case-insensitively for ASCII but reports them back —
@@ -59,6 +59,15 @@ def _folded(name: str) -> str:
     ASCII at all.
     """
     return name.translate(_ASCII_FOLD)
+
+
+def _live_column_names(conn, safe_table: str) -> List[str]:
+    """Column names as the live table declares them.
+
+    ``PRAGMA table_info`` reports the declared spelling, not a folded one — callers
+    that compare must fold (``_nocase_folded``), callers that emit SQL must not.
+    """
+    return [row[1] for row in conn.execute(f"PRAGMA table_info({safe_table})").fetchall()]
 
 
 def _safe_ident(name: str) -> str:
@@ -280,12 +289,11 @@ class SqliteRdbDatabase(RdbDatabase):
     def _migrate_missing_columns(conn, table_def: TableDefinition) -> None:
         """Add columns that exist in the definition but not in the live table."""
         safe_table = _safe_ident(table_def.table_name)
-        cursor = conn.execute(f"PRAGMA table_info({safe_table})")
-        existing_cols = {_folded(row[1]) for row in cursor.fetchall()}
+        existing_cols = {_nocase_folded(c) for c in _live_column_names(conn, safe_table)}
         if not existing_cols:
             return  # table doesn't exist yet — CREATE TABLE will handle it
         for col in table_def.columns:
-            if _folded(col.name) not in existing_cols:
+            if _nocase_folded(col.name) not in existing_cols:
                 col_ddl = _sqlite_col_ddl(col)
                 conn.execute(f"ALTER TABLE {safe_table} ADD COLUMN {col_ddl}")
                 logger.info(f"Migrated: ALTER TABLE {safe_table} ADD COLUMN {col_ddl}")
@@ -309,16 +317,17 @@ class SqliteRdbDatabase(RdbDatabase):
         # Validate the table name before embedding it in SQL — prevents injection.
         safe_table = _safe_ident(table_def.table_name)
 
-        # PRAGMA table_info returns one row per column; zero rows means the table
-        # doesn't exist yet, so CREATE TABLE (run after this) will handle it.
-        cursor = conn.execute(f"PRAGMA table_info({safe_table})")
-        existing_cols = [row[1] for row in cursor.fetchall()]
+        # Zero columns means the table doesn't exist yet, so CREATE TABLE (run after
+        # this) will handle it. Declared spellings, because they get emitted below.
+        existing_cols = _live_column_names(conn, safe_table)
         if not existing_cols:
             return  # table doesn't exist yet
 
         # Read the original CREATE TABLE statement SQLite stored when the table
         # was first created. This is the only way to inspect inline constraints
         # because SQLite has no information_schema or constraint catalog.
+        # COLLATE NOCASE is the SQL-side spelling of _nocase_folded; see its docstring
+        # for why the fold has to be the engine's and not Python's.
         cursor = conn.execute(
             "SELECT sql FROM sqlite_master WHERE type='table' AND name = ? COLLATE NOCASE",
             (table_def.table_name,),
@@ -327,11 +336,13 @@ class SqliteRdbDatabase(RdbDatabase):
         if not row or not row[0]:
             return
 
-        # Normalize constraint strings to uppercase with no whitespace so that
-        # formatting differences don't cause false mismatches, e.g.
-        # "UNIQUE( parent_id, name )" and "UNIQUE(parent_id,name)" are equal.
+        # Normalize constraint strings so formatting differences don't cause false
+        # mismatches, e.g. "UNIQUE( parent_id, name )" and "UNIQUE(parent_id,name)".
+        # Folded, not uppercased: str.upper() maps U+00DF to "SS", which would make
+        # UNIQUE(<U+00DF>) and UNIQUE(SS) compare equal when SQLite holds the two
+        # columns apart — and the rebuild would then be skipped as already done.
         def _norm(fragments):
-            return {re.sub(r"\s+", "", f.upper()) for f in fragments}
+            return {re.sub(r"\s+", "", _nocase_folded(f)) for f in fragments}
 
         # Extract UNIQUE constraints from the TableDefinition (what we want).
         desired = _norm(c for c in table_def.constraints if re.match(r"\s*UNIQUE", c, re.IGNORECASE))
@@ -353,8 +364,8 @@ class SqliteRdbDatabase(RdbDatabase):
         # is the definition's "name" — treating them as different silently drops the
         # column, and its data, on the rebuild below. The old spelling is what gets
         # emitted, which both tables resolve to.
-        new_col_names = {_folded(col.name) for col in table_def.columns}
-        transfer_cols = ", ".join(c for c in existing_cols if _folded(c) in new_col_names)
+        new_col_names = {_nocase_folded(col.name) for col in table_def.columns}
+        transfer_cols = ", ".join(c for c in existing_cols if _nocase_folded(c) in new_col_names)
 
         # Build DDL for the temp table using the new definition (correct constraints).
         col_parts = [_sqlite_col_ddl(col) for col in table_def.columns] + list(table_def.constraints)

--- a/tests/unit_tests/storage/rdb/test_sqlite_backend.py
+++ b/tests/unit_tests/storage/rdb/test_sqlite_backend.py
@@ -585,6 +585,34 @@ class TestIdentifierFolding:
         assert columns == ["Id", "Name", "Value"]
         assert rows == [("folded", "v1")]
 
+    def test_non_ascii_column_does_not_shadow_the_ascii_one(self, tmp_path):
+        """SQLite's NOCASE folds A-Z only, so U+212A KELVIN SIGN is not ASCII `K`.
+
+        `str.lower()` maps it onto `k`, which would make a legacy `\u212a` column
+        answer for the definition's `K` and leave the required column uncreated.
+        """
+        db_file = os.path.join(str(tmp_path), "kelvin.db")
+        self._raw_create(db_file, 'CREATE TABLE items (id INTEGER PRIMARY KEY, "\u212a" TEXT)')
+
+        db = SqliteRdbDatabase(db_file)
+        db.ensure_table(
+            TableDefinition(
+                table_name="items",
+                columns=[
+                    ColumnDef(name="id", col_type="INTEGER", primary_key=True, autoincrement=True),
+                    ColumnDef(name="K", col_type="TEXT"),
+                ],
+            )
+        )
+
+        conn = sqlite3.connect(db_file)
+        try:
+            columns = [row[1] for row in conn.execute("PRAGMA table_info(items)")]
+        finally:
+            conn.close()
+        # Both survive: SQLite treats them as different columns, and so must we.
+        assert columns == ["id", "\u212a", "K"]
+
     def test_constraint_rebuild_keeps_a_column_stored_under_another_case(self, tmp_path):
         """The rebuild copies only columns it recognises; a case mismatch would drop data."""
         db_file = os.path.join(str(tmp_path), "rebuild.db")

--- a/tests/unit_tests/storage/rdb/test_sqlite_backend.py
+++ b/tests/unit_tests/storage/rdb/test_sqlite_backend.py
@@ -5,6 +5,7 @@
 """Tests for SQLite RDB backend CRUD interface."""
 
 import os
+import sqlite3
 from dataclasses import dataclass
 
 import pytest
@@ -449,8 +450,6 @@ class TestMigrateConstraints:
     def test_noop_when_table_missing(self, tmp_path):
         """Skip rebuild when table does not exist yet."""
         db = self._make_db(tmp_path)
-        import sqlite3
-
         conn = sqlite3.connect(db.db_file)
         SqliteRdbDatabase._migrate_constraints(conn, self._new_def())
         conn.close()
@@ -536,3 +535,111 @@ class TestMigrateConstraints:
         new_table.insert(_NewNode(parent_id=1, name="dup", datasource_id="ds1"))
         with pytest.raises(UniqueViolationError):
             new_table.insert(_NewNode(parent_id=1, name="dup", datasource_id="ds1"))
+
+
+class TestIdentifierFolding:
+    """SQLite resolves ASCII identifiers case-insensitively but reports them as declared.
+
+    So a live table whose columns differ from the definition only by case is the *same*
+    table — comparing the catalog's spelling against the definition's makes the backend
+    think a column is missing, or that a column it is about to copy is not wanted.
+    """
+
+    @staticmethod
+    def _raw_create(db_file, create_statement, *inserts):
+        """Build the table outside the backend, so its declared case is ours to choose."""
+        conn = sqlite3.connect(db_file)
+        try:
+            conn.execute(create_statement)
+            for insert in inserts:
+                conn.execute(insert)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_column_differing_only_by_case_is_not_re_added(self, tmp_path):
+        """`ALTER TABLE ADD COLUMN name` on a table declaring `Name` is a duplicate."""
+        db_file = os.path.join(str(tmp_path), "case.db")
+        self._raw_create(db_file, "CREATE TABLE items (Id INTEGER PRIMARY KEY, Name TEXT, Value TEXT)")
+
+        db = SqliteRdbDatabase(db_file)
+        table = db.ensure_table(
+            TableDefinition(
+                table_name="items",
+                columns=[
+                    ColumnDef(name="id", col_type="INTEGER", primary_key=True, autoincrement=True),
+                    ColumnDef(name="name", col_type="TEXT"),
+                    ColumnDef(name="value", col_type="TEXT"),
+                ],
+            )
+        )
+        table.insert(_Item(name="folded", value="v1"))
+
+        conn = sqlite3.connect(db_file)
+        try:
+            columns = [row[1] for row in conn.execute("PRAGMA table_info(items)")]
+            rows = conn.execute("SELECT Name, Value FROM items").fetchall()
+        finally:
+            conn.close()
+        # No second `id`/`name`/`value` bolted on beside the declared ones.
+        assert columns == ["Id", "Name", "Value"]
+        assert rows == [("folded", "v1")]
+
+    def test_constraint_rebuild_keeps_a_column_stored_under_another_case(self, tmp_path):
+        """The rebuild copies only columns it recognises; a case mismatch would drop data."""
+        db_file = os.path.join(str(tmp_path), "rebuild.db")
+        self._raw_create(
+            db_file,
+            "CREATE TABLE items (Id INTEGER PRIMARY KEY, Name TEXT, Value TEXT, UNIQUE(Name))",
+            "INSERT INTO items (Name, Value) VALUES ('kept', 'payload')",
+        )
+
+        db = SqliteRdbDatabase(db_file)
+        table = db.ensure_table(
+            TableDefinition(
+                table_name="items",
+                columns=[
+                    ColumnDef(name="id", col_type="INTEGER", primary_key=True, autoincrement=True),
+                    ColumnDef(name="name", col_type="TEXT"),
+                    ColumnDef(name="value", col_type="TEXT"),
+                ],
+                constraints=["UNIQUE(name, value)"],
+            )
+        )
+
+        rows = table.query(_Item)
+        assert [(r.name, r.value) for r in rows] == [("kept", "payload")]
+
+    def test_constraint_migration_runs_for_a_table_named_in_another_case(self, tmp_path):
+        """`sqlite_master.name` stores the declared spelling; the lookup must fold."""
+        db_file = os.path.join(str(tmp_path), "master.db")
+        self._raw_create(
+            db_file,
+            "CREATE TABLE Items (id INTEGER PRIMARY KEY, name TEXT, value TEXT, UNIQUE(name))",
+            "INSERT INTO Items (name, value) VALUES ('kept', 'payload')",
+        )
+
+        db = SqliteRdbDatabase(db_file)
+        db.ensure_table(
+            TableDefinition(
+                table_name="items",
+                columns=[
+                    ColumnDef(name="id", col_type="INTEGER", primary_key=True, autoincrement=True),
+                    ColumnDef(name="name", col_type="TEXT"),
+                    ColumnDef(name="value", col_type="TEXT"),
+                ],
+                constraints=["UNIQUE(name, value)"],
+            )
+        )
+
+        conn = sqlite3.connect(db_file)
+        try:
+            stored = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name = 'items' COLLATE NOCASE"
+            ).fetchone()
+            payload = conn.execute("SELECT name, value FROM items").fetchall()
+        finally:
+            conn.close()
+        stored_ddl = stored[0].replace(" ", "") if stored else ""
+        assert "UNIQUE(name,value)" in stored_ddl
+        assert payload == [("kept", "payload")]

--- a/tests/unit_tests/storage/rdb/test_sqlite_backend.py
+++ b/tests/unit_tests/storage/rdb/test_sqlite_backend.py
@@ -638,6 +638,46 @@ class TestIdentifierFolding:
         rows = table.query(_Item)
         assert [(r.name, r.value) for r in rows] == [("kept", "payload")]
 
+    def test_constraint_comparison_does_not_fold_wider_than_sqlite(self, tmp_path):
+        """`str.upper()` maps U+00DF to "SS"; SQLite keeps those columns apart.
+
+        A stored `UNIQUE(<U+00DF>)` would then compare equal to a definition's
+        `UNIQUE(SS)`, and the rebuild would be skipped as though already done.
+        SQLite accepts both unquoted, so both reach `_norm` in the same shape.
+        """
+        db_file = os.path.join(str(tmp_path), "sharp_s.db")
+        self._raw_create(
+            db_file,
+            "CREATE TABLE items (id INTEGER PRIMARY KEY, \u00df TEXT, SS TEXT, UNIQUE(\u00df))",
+            "INSERT INTO items (\u00df, SS) VALUES ('old', 'kept')",
+        )
+
+        db = SqliteRdbDatabase(db_file)
+        db.ensure_table(
+            TableDefinition(
+                table_name="items",
+                columns=[
+                    ColumnDef(name="id", col_type="INTEGER", primary_key=True, autoincrement=True),
+                    ColumnDef(name="SS", col_type="TEXT"),
+                ],
+                constraints=["UNIQUE(SS)"],
+            )
+        )
+
+        conn = sqlite3.connect(db_file)
+        try:
+            stored = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name = 'items' COLLATE NOCASE"
+            ).fetchone()
+            payload = conn.execute("SELECT SS FROM items").fetchall()
+        finally:
+            conn.close()
+        stored_ddl = stored[0].replace(" ", "") if stored else ""
+        # The rebuild ran: the constraint the definition asked for is the one in place.
+        assert "UNIQUE(SS)" in stored_ddl
+        assert "UNIQUE(\u00df)" not in stored_ddl
+        assert payload == [("kept",)]
+
     def test_constraint_migration_runs_for_a_table_named_in_another_case(self, tmp_path):
         """`sqlite_master.name` stores the declared spelling; the lookup must fold."""
         db_file = os.path.join(str(tmp_path), "master.db")


### PR DESCRIPTION
## Why

SQLite matches identifiers case-insensitively **for A-Z only**, but reports them back exactly as they were declared — through `PRAGMA table_info` and `sqlite_master.name`. `SqliteRdbDatabase.ensure_table` decided identifier questions in Python instead, so a live table differing only in case broke it four ways:

| Site | What goes wrong |
|---|---|
| `_migrate_missing_columns` | sees `Name`, concludes `name` is missing → `ALTER TABLE ADD COLUMN name` fails outright with **`duplicate column name`**, and `ensure_table` raises |
| `_migrate_constraints` lookup | `sqlite_master WHERE name = ?` finds nothing for a table declared `Items` → the constraint rebuild is **silently skipped**, leaving a stale `UNIQUE` in place |
| `_migrate_constraints` `_norm` | normalized fragments with `str.upper()`, which folds wider than SQLite (`'ß'.upper() == 'SS'`) → a stored `UNIQUE(ß)` compares equal to a definition's `UNIQUE(SS)` and the rebuild is **skipped as already done**. SQLite accepts both unquoted and keeps the two columns apart |
| the rebuild's `transfer_cols` | keeps only columns whose spelling matches the definition → a `Name` column **and its data** do not survive the copy |

This is the SQLite half of the class surfaced by review on [Datus-ai/datus-storage-adapters#13](https://github.com/Datus-ai/datus-storage-adapters/pull/13), where the PostgreSQL probes compared Python strings against `pg_catalog` without the folding, truncation and schema resolution PostgreSQL applies. The engines differ in *which* rules they apply; the mistake is the same — deciding an identifier question in Python that only the engine can answer.

Reachable whenever a KB table was not created by this code path: a hand-run migration, a table restored from another tool, or a `TableDefinition` whose casing was changed.

## Solution

`_nocase_folded()` next to `_safe_ident()`, applied at the four comparison sites, plus `COLLATE NOCASE` on the `sqlite_master` lookup — the SQL-side spelling of the same rule.

The fold translates **A-Z only**, which is the whole of SQLite's `NOCASE`. Neither `str.lower()` nor `str.casefold()` will do: `lower()` maps U+212A KELVIN SIGN onto ASCII `k` (U+006B), so a legacy column named U+212A would answer for a definition's ASCII `K` and the required column would never be added — while SQLite, which folds neither, keeps the two as separate columns. Catalog names arrive from the live database and never pass `_IDENTIFIER_RE`, so they cannot be assumed ASCII at all.

The rebuild still emits the **old** spelling when copying columns, which both the old and new tables resolve to, so nothing has to be renamed mid-migration. `_live_column_names()` carries the PRAGMA preamble the two migrators share; they deliberately disagree on folding — one compares, one emits SQL — and that now lives in the helper's docstring rather than in the asymmetry.

## Test Cases

`TestIdentifierFolding` in `tests/unit_tests/storage/rdb/test_sqlite_backend.py` builds each table with raw SQL in the other case, then opens it through the backend:

- **a column differing only by case is not re-added** — asserts `PRAGMA table_info` still reports exactly `Id`/`Name`/`Value`, and the row inserted afterwards is readable
- **the constraint rebuild keeps a column stored under another case**, with its row intact
- **the constraint migration runs for a table named in another case** — asserts the stored `CREATE` ends up carrying the new `UNIQUE(name, value)` and the row survived
- **the constraint comparison does not fold wider than SQLite** — a stored `UNIQUE(ß)` must not satisfy a definition's `UNIQUE(SS)`

Those four are red against `upstream/main` — two with `duplicate column name: id`, two with the constraint left un-migrated.

A fifth, **`test_non_ascii_column_does_not_shadow_the_ascii_one`** (U+212A vs ASCII `K`), is **green against `upstream/main` and is not a red-first regression**. It guards the choice of an A-Z-only fold over `str.lower()`: it goes red only against a `str.lower()` implementation. Stated explicitly so the red-first claim above is not read as covering all five.

Each source hunk was also reverted individually; every one leaves at least one test red, so no part of the change is untested. The pre-existing `TestMigrateMissingColumns` cases (add a missing column, no-op when up to date, idempotent `ensure_table`) still pass, which is what pins that the folding did not weaken the normal path.

Diff coverage 100%; `ci/audit_tests.py --diff-only upstream/main` reports P0=0, P1=0.

## Known gap, not fixed here

`SqliteRdbDatabase._query` maps rows with `model(**dict(row))`, so a `SELECT *` against a table declaring `Name` still raises `TypeError` on a model whose field is `name`. That is the row-to-model layer rather than identifier probing, and closing it means choosing a mapping policy for arbitrary model types — left out rather than half-done.

Scope of that gap, stated precisely: the constraint rebuild recreates the table from the definition and so normalises the spelling, but **only when `table_def.constraints` is non-empty** — `_migrate_constraints` returns early otherwise. Every RDB store in this repo does declare constraints (`subject_tree`, `feedback`, `task`), so they all normalise. For a hypothetical constraint-free definition, row 1 of the table above trades `duplicate column name` for a later `TypeError` on typed reads rather than yielding a fully working store. `ensure_table` itself succeeds either way, which is what the first test asserts — it deliberately verifies through `PRAGMA`/raw SQL rather than `table.query`.

The same comparison shape also appears in `datus/cli/metadata_commands.py` (`tbl_name='{table_name}'` when listing indexes for a user's SQLite database) and `datus/models/session_manager.py::_table_exists`. The first is reachable but cosmetic — a CLI listing comes back empty — and the second is not, since every caller passes a literal name for tables that code creates itself. Both are outside the storage backend and left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite schema migrations to recognize table and column names regardless of letter casing.
  * Prevented duplicate columns from being created when names differ only by case.
  * Preserved existing data and column naming during constraint-related migrations.
  * Ensured non-ASCII identifiers remain distinct from ASCII identifiers during schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->