### PR TITLE
[BugFix] Say "query-only", not "Subagent not found", when semantic_modeling is gated

### DIFF
--- a/datus/api/routes/chat_routes.py
+++ b/datus/api/routes/chat_routes.py
@@ -74,12 +74,11 @@ _EXTRA_BUILTIN_SUBAGENTS = {"feedback"}
 
 
 def _is_valid_subagent_id(svc, subagent_id: str) -> bool:
-    """Return True if *subagent_id* resolves to a builtin or custom sub-agent."""
-    if subagent_id == "semantic_modeling":
-        from datus.agent.node.semantic_authoring import is_semantic_modeling_available
+    """Return True if *subagent_id* resolves to a builtin or custom sub-agent.
 
-        if not is_semantic_modeling_available(svc.agent_config):
-            return False
+    Existence only. Whether an existing agent may run on *this* project is a
+    separate question — see :func:`_query_only_semantic_detail`.
+    """
     if subagent_id in BUILTIN_SUBAGENTS or subagent_id in _EXTRA_BUILTIN_SUBAGENTS:
         return True
     agentic_nodes = getattr(svc.agent_config, "agentic_nodes", None) or {}
@@ -91,6 +90,24 @@ def _is_valid_subagent_id(svc, subagent_id: str) -> bool:
         if isinstance(entry, dict) and entry.get("id") == subagent_id:
             return True
     return False
+
+
+def _query_only_semantic_detail(svc, subagent_id: Optional[str]) -> Optional[str]:
+    """Return the query-only message when this project cannot author semantics.
+
+    Kept out of ``_is_valid_subagent_id`` on purpose: a Dosi-only gate deserves
+    a 400 naming the migration, not a 404 that reads as "no such agent".
+    """
+    if subagent_id != "semantic_modeling":
+        return None
+    from datus.agent.node.semantic_authoring import (
+        QUERY_ONLY_MIGRATION_MESSAGE,
+        is_semantic_modeling_available,
+    )
+
+    if is_semantic_modeling_available(svc.agent_config):
+        return None
+    return QUERY_ONLY_MIGRATION_MESSAGE
 
 
 def _policy_context_pre_check(svc: "DatusService", ctx: "AppContext") -> Optional[ChatPreCheckOutcome]:
@@ -138,6 +155,9 @@ async def stream_chat(
             status_code=400,
             detail=retired_semantic_agent_message(sub_agent_id, svc.agent_config),
         )
+    query_only_detail = _query_only_semantic_detail(svc, sub_agent_id)
+    if query_only_detail:
+        raise HTTPException(status_code=400, detail=query_only_detail)
     if sub_agent_id and not _is_valid_subagent_id(svc, sub_agent_id):
         raise HTTPException(
             status_code=404,

--- a/tests/unit_tests/api/routes/test_chat_routes.py
+++ b/tests/unit_tests/api/routes/test_chat_routes.py
@@ -168,9 +168,10 @@ class TestIsValidSubagentId:
         svc = _mock_svc_with_nodes()
         assert _is_valid_subagent_id(svc, "feedback") is True
 
-    def test_semantic_modeling_is_visible_only_for_dosi(self):
+    def test_semantic_modeling_exists_on_every_dialect(self):
+        """The Dosi-only gate lives in the 400 branch, not in this existence check."""
         svc = _mock_svc_with_nodes()
-        assert _is_valid_subagent_id(svc, "semantic_modeling") is False
+        assert _is_valid_subagent_id(svc, "semantic_modeling") is True
 
         svc.agent_config.resolve_semantic_adapter.return_value = "dosi"
         assert _is_valid_subagent_id(svc, "semantic_modeling") is True
@@ -243,6 +244,34 @@ class TestStreamChat404Gate:
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.detail == f"{retired_type} is retired. Use semantic_modeling instead."
+
+    @pytest.mark.asyncio
+    async def test_semantic_modeling_on_legacy_project_is_400_not_404(self):
+        """A query-only project must say so — the old 404 read as "agent missing"."""
+        svc = _mock_svc_with_nodes()
+        ctx = MagicMock()
+        request = StreamChatInput(message="/build-kb", subagent_id="semantic_modeling")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await stream_chat(request, svc, ctx, MagicMock())
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == (
+            "This project is query-only. To make changes, migrate it to Dosi first, then use semantic_modeling."
+        )
+
+    @pytest.mark.asyncio
+    async def test_semantic_modeling_on_dosi_project_streams(self):
+        svc = _mock_svc_with_nodes()
+        svc.agent_config.resolve_semantic_adapter.return_value = "dosi"
+        svc.chat.stream_chat = MagicMock(return_value=AsyncMock().__aiter__())
+        ctx = MagicMock(user_id="u1")
+        request = StreamChatInput(message="/build-kb", subagent_id="semantic_modeling")
+
+        response = await stream_chat(request, svc, ctx, MagicMock())
+
+        assert isinstance(response, StreamingResponse)
+        assert response.status_code == 200
 
     @pytest.mark.asyncio
     async def test_none_subagent_bypasses_gate(self):


### PR DESCRIPTION
## Problem

On a private deployment, `/build-kb` routed to `semantic_modeling` failed with:

```
404 {"detail":"Subagent 'semantic_modeling' not found"}
```

The agent is not missing. `stream_chat`'s existence check folded the Dosi-only
authoring gate into `_is_valid_subagent_id`:

```python
if subagent_id == "semantic_modeling":
    if not is_semantic_modeling_available(svc.agent_config):
        return False        # ← reported as "not found"
```

`is_semantic_modeling_available` is `resolve_semantic_adapter_type(...) == "dosi"`,
and the adapter comes from `agent.services.semantic_layer`, which the backend
seeds from the project's semantic dialect. Any project still on `osi` or
`metricflow` therefore got a 404 — indistinguishable from a broken deployment or
a bad `subagent_id`. Meanwhile the KB path (`kb_service`) already answers the
exact same gate with an actionable message, and the retired
`gen_semantic_model` / `gen_metrics` names already answer it with a 400.

## Change

Split existence from eligibility:

- `_is_valid_subagent_id` answers existence only (404 keeps its literal meaning).
- New `_query_only_semantic_detail` raises **400** with the shared
  `QUERY_ONLY_MIGRATION_MESSAGE`: *"This project is query-only. To make changes,
  migrate it to Dosi first, then use semantic_modeling."*

Ordering in `stream_chat` is retired → query-only → unknown-id, so a retired
name on a legacy project still gets its own message.

No behavior change for Dosi projects, and no change to which agents are listed.
Error semantics only — deliberately not touching the agent listing, since Dosi
is becoming the standard and the other dialects are being retired.

## Tests

`tests/unit_tests/api/routes/test_chat_routes.py`

- `test_semantic_modeling_exists_on_every_dialect` — the existence helper no
  longer carries the dialect gate.
- `test_semantic_modeling_on_legacy_project_is_400_not_404` — 400 + migration
  message.
- `test_semantic_modeling_on_dosi_project_streams` — Dosi still streams.

`tests/unit_tests/api` — 1424 passed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat routing for semantic modeling projects that are unavailable for authoring.
  - Added a clear migration-specific error response for query attempts requiring unavailable semantic authoring.
  - Existing project IDs are now handled correctly across supported project types and dialects.

- **Tests**
  - Expanded coverage for successful Dosi project streaming and legacy project migration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->