### PR TITLE
Stop save_query crashing the whole report when a parameter is omitted

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -188,6 +188,7 @@ def trans_to_function_tool(
     *,
     strict_mode: bool = True,
     excluded_params: Optional[Iterable[str]] = None,
+    required_params: Optional[Iterable[str]] = None,
 ) -> FunctionTool:
     """
     Transfer a bound method to a function tool.
@@ -202,6 +203,12 @@ def trans_to_function_tool(
             a declaration the tool itself validates.
         excluded_params: Optional parameter names to remove from the exposed JSON schema.
             Use this for dialect-specific parameters that the current tool instance does not support.
+        required_params: Optional parameter names to mark required in the exposed JSON
+            schema even though the Python signature gives them defaults. Use this for a
+            non-strict tool whose parameters carry defaults purely so an incomplete call
+            reaches the method's own validation (a structured, retryable error) instead
+            of dying on a raw ``TypeError`` — the schema keeps telling the model the
+            fields are required, and the defaults only make the failure recoverable.
     """
     tool_template = function_tool(bound_method, strict_mode=strict_mode)
     excluded_param_set = set(excluded_params or [])
@@ -213,6 +220,17 @@ def trans_to_function_tool(
             del corrected_schema["properties"][param_name]
         if param_name in corrected_schema.get("required", []):
             corrected_schema["required"].remove(param_name)
+
+    if required_params:
+        # The generator omits (or nulls) ``required`` when every parameter has a
+        # default, so rebuild the list rather than trusting the key's shape.
+        required = list(corrected_schema.get("required") or [])
+        for param_name in required_params:
+            if param_name not in corrected_schema.get("properties", {}):
+                raise ValueError(f"required_params names unknown parameter {param_name!r} for {tool_template.name}")
+            if param_name not in required:
+                required.append(param_name)
+        corrected_schema["required"] = required
 
     # The invoker MUST be an 'async' function.
     # We define a closure to correctly capture the 'bound_method' for each iteration.

--- a/datus/tools/func_tool/report_artifact_tools.py
+++ b/datus/tools/func_tool/report_artifact_tools.py
@@ -343,7 +343,15 @@ class ReportArtifactTools:
             # strict-mode JSON schema rejects ``additionalProperties: true``
             # which ``Dict[str, Any]`` emits. We validate the shape
             # ourselves via :func:`coerce_uses_arg` once the call lands.
-            trans_to_function_tool(self.save_query, strict_mode=False),
+            # ``required_params`` keeps the schema telling the model these four
+            # are mandatory: the Python defaults exist only so an incomplete
+            # call reaches save_query's own validation (a retryable error)
+            # instead of a raw TypeError that kills the whole report.
+            trans_to_function_tool(
+                self.save_query,
+                strict_mode=False,
+                required_params=("name", "sql", "goal", "hypothesis"),
+            ),
             trans_to_function_tool(self.validate_render),
         ]
 
@@ -564,10 +572,17 @@ class ReportArtifactTools:
 
     def save_query(
         self,
-        name: str,
-        sql: str,
-        goal: str,
-        hypothesis: str,
+        # These four carry defaults on purpose. save_query is the only report
+        # tool built with strict_mode=False, so the tool API does not enforce
+        # "required" — a model that omits one reaches Python and raises a raw
+        # TypeError, which aborts the whole report run with no artifact. With
+        # defaults the call lands in the validation below and returns a
+        # retryable error the agent can act on. ``required_params`` on the
+        # registration keeps the advertised schema saying these are mandatory.
+        name: str = "",
+        sql: str = "",
+        goal: str = "",
+        hypothesis: str = "",
         uses: Optional[Dict[str, Any]] = None,
         caveats: str = "",
         datasource: str = "",
@@ -640,7 +655,10 @@ class ReportArtifactTools:
         if not name or not QUERY_SLUG_RE.fullmatch(name):
             return FuncToolResult(
                 success=0,
-                error=f"name must match {QUERY_SLUG_RE.pattern}; got {name!r}",
+                error=(
+                    f"name must match {QUERY_SLUG_RE.pattern}; got {name!r}. "
+                    "Retry save_query with ALL of: name, sql, goal, hypothesis."
+                ),
             )
         if not sql or not sql.strip():
             return FuncToolResult(success=0, error="sql must not be empty")


### PR DESCRIPTION
## What breaks

`save_query` is the only report tool registered with `strict_mode=False` — its
`uses` argument needs a free-form object schema, which strict mode rejects.

A side effect of that: the tool API no longer enforces the tool's required
parameters. When the model omits one, the call reaches Python and raises a raw
`TypeError` before the method body runs. That propagates out of the tool layer
and aborts the whole `gen_visual_report` run — losing every query and artifact
already produced in it, not just the one call.

In a long-running deployment this was our single largest source of lost report
work: one omitted `name`, and a report that had already executed several queries
ends with no artifact.

### Reproduce

```python
tools = ReportArtifactTools(agent_config=cfg, db_func_tool=db)
sq = {t.name: t for t in tools.available_tools()}["save_query"]
# what the SDK does when the model omits "name":
await sq.on_invoke_tool(ctx, '{"sql": "SELECT 1", "goal": "g", "hypothesis": "h"}')
# TypeError: save_query() missing 1 required positional argument: 'name'
```

## Why the fix is two commits

The method **already** handles a missing `name` correctly, a few lines in:

```python
if not name or not QUERY_SLUG_RE.fullmatch(name):
    return FuncToolResult(success=0, error=...)
```

That returns a clean, retryable `FuncToolResult`. It was simply unreachable,
because Python raised first. Giving the four parameters defaults makes it
reachable — the agent gets an error it can act on instead of a dead run.

But defaults alone would quietly weaken the tool contract. `trans_to_function_tool`
derives the exposed JSON schema from the Python signature, so any parameter with
a default is advertised to the model as **optional**. The model would stop being
told these four are mandatory — inviting exactly the omissions the fix exists to
survive.

So the first commit adds `required_params` to `trans_to_function_tool`: names to
keep marked required in the exposed schema even though the signature gives them
defaults. The defaults then change only *how* an incomplete call fails, never
what the model is told.

The advertised schema is unchanged by this PR:

```
before:  required = ['name', 'sql', 'goal', 'hypothesis']
after:   required = ['name', 'sql', 'goal', 'hypothesis']
```

`required_params` is deliberately general rather than a special case — it suits
any non-strict tool that wants recoverable failure without weakening its schema.
Two details worth noting in review:

- it **rebuilds** the required list rather than mutating in place, because the
  schema generator omits (or nulls) the key when every parameter has a default;
- it **raises at registration** on an unknown parameter name, so a typo cannot
  silently advertise the wrong contract.

## Verification

- Omitting `name` returns a structured `FuncToolResult` instead of raising.
- Advertised schema identical to before the change (shown above).
- `ruff check` clean on both files.
- `tests/unit_tests/tools` and
  `tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py`: the
  **failure set is byte-identical** to clean `main` — 0 introduced, 0 fixed.
  (This environment has 21 pre-existing failures on `main` from optional
  dependencies, so I compared failure IDs between the two trees rather than
  counts.)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool schemas can now explicitly mark selected parameters as required, including parameters with default values.
  * Query-saving tools now clearly require the query name, SQL, goal, and hypothesis.

* **Bug Fixes**
  * Incomplete query submissions now return retryable validation errors instead of failing immediately.
  * Invalid query names provide clearer guidance to resubmit all required details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->