### PR TITLE
[BugFix] Coerce tool arguments the model sent as strings

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -50,7 +50,9 @@ def coerce_llm_arg(value: Any, annotation: Any) -> Any:
         origin = get_origin(annotation)
         args = get_args(annotation)
 
-    if origin in (list, List):
+    # ``list[str]`` reports origin ``list``; a bare ``list`` reports no origin
+    # at all, so the annotation itself has to be checked too.
+    if origin in (list, List) or annotation in (list, List):
         text = value.strip()
         if not text:
             return value

--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -67,7 +67,7 @@ def coerce_llm_arg(value: Any, annotation: Any) -> Any:
                 return value
         return parsed if isinstance(parsed, list) else value
 
-    if annotation is int and not isinstance(value, bool):
+    if annotation is int:
         try:
             return int(value.strip())
         except ValueError:

--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -6,7 +6,7 @@
 import asyncio
 import inspect
 import json
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union, get_args, get_origin
 
 import json_repair
 from agents import FunctionTool, function_tool
@@ -15,6 +15,60 @@ from pydantic import BaseModel, Field
 from datus.utils.loggings import get_logger
 
 logger = get_logger(__name__)
+
+
+def coerce_llm_arg(value: Any, annotation: Any) -> Any:
+    """Coerce an argument the model sent as a string into the declared type.
+
+    Some models serialize a nested list argument as a JSON *string*, so a
+    parameter declared ``List[str]`` arrives as ``'["a", "b"]'``, and an ``int``
+    arrives as ``"5"``. The JSON itself is well formed, so ``parse_tool_args``
+    has nothing to repair — the value simply has the wrong type, and the tool
+    then filters on a string, compares against a string, or indexes with one.
+
+    Failures from this are quiet: a filter that matches nothing returns an empty
+    result rather than an error, which reads to the caller as "there is no data"
+    instead of "the argument was the wrong type".
+
+    Only ``str`` values are touched, and only when the annotation asks for a list
+    or an int. Anything unparseable is returned unchanged so the tool's own
+    validation still sees what the model actually sent.
+    """
+    if not isinstance(value, str):
+        return value
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is Union:  # Optional[X] / X | None
+        inner = [a for a in args if a is not type(None)]
+        if len(inner) != 1:
+            return value
+        annotation = inner[0]
+        origin = get_origin(annotation)
+        args = get_args(annotation)
+
+    if origin in (list, List):
+        text = value.strip()
+        if not text:
+            return value
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            return value
+        if isinstance(parsed, str):  # double-encoded
+            try:
+                parsed = json.loads(parsed)
+            except (ValueError, TypeError):
+                return value
+        return parsed if isinstance(parsed, list) else value
+
+    if annotation is int and not isinstance(value, bool):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return value
+
+    return value
 
 
 def normalize_null(value):
@@ -256,6 +310,16 @@ def trans_to_function_tool(
                         f"{extra_params}, filtering them out"
                     )
                     args_dict = {k: v for k, v in args_dict.items() if k in valid_params}
+
+            # Coerce arguments the model stringified (a List[str] sent as
+            # '["a"]', an int sent as "5"). The JSON parsed fine, so nothing
+            # above had anything to repair — the value is simply the wrong type,
+            # and passing it through makes the tool filter on a string and
+            # return an empty result with no error.
+            for arg_name, arg_value in list(args_dict.items()):
+                param = sig.parameters.get(arg_name)
+                if param is not None and param.annotation is not inspect.Parameter.empty:
+                    args_dict[arg_name] = coerce_llm_arg(arg_value, param.annotation)
 
             # Reject missing required parameters symmetrically with the extra/
             # excluded-parameter handling above. Without this, an LLM tool call

--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -6,6 +6,7 @@
 import asyncio
 import inspect
 import json
+from types import UnionType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union, get_args, get_origin
 
 import json_repair
@@ -39,7 +40,9 @@ def coerce_llm_arg(value: Any, annotation: Any) -> Any:
 
     origin = get_origin(annotation)
     args = get_args(annotation)
-    if origin is Union:  # Optional[X] / X | None
+    # ``Optional[X]`` gives ``typing.Union``; the PEP 604 form ``X | None``
+    # gives ``types.UnionType``. Both mean the same thing here.
+    if origin is Union or origin is UnionType:
         inner = [a for a in args if a is not type(None)]
         if len(inner) != 1:
             return value

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -7,7 +7,7 @@ import asyncio
 import json
 import threading
 from types import SimpleNamespace
-from typing import Optional
+from typing import List, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -556,3 +556,59 @@ class TestFuncToolListResult:
         assert dumped["items"] == []
         assert dumped["total"] == 0
         assert dumped["has_more"] is False
+
+
+class TestStringifiedArgumentCoercion:
+    """Some models serialize a list argument as a JSON string, and an int as a
+    string. The JSON itself is well formed, so nothing upstream repairs it — the
+    value simply arrives with the wrong type."""
+
+    @staticmethod
+    def _probe():
+        seen = {}
+
+        class Tool:
+            def probe(
+                self,
+                query_text: str,
+                kinds: Optional[List[str]] = None,
+                top_n: int = 5,
+                label: str = "",
+                flag: bool = False,
+            ):
+                """Probe tool."""
+                seen.update(kinds=kinds, top_n=top_n, label=label, flag=flag)
+                return FuncToolResult(success=1, result="ok")
+
+        return trans_to_function_tool(Tool().probe), seen
+
+    def _call(self, **arguments):
+        tool, seen = self._probe()
+        arguments.setdefault("query_text", "q")
+        asyncio.run(tool.on_invoke_tool(None, json.dumps(arguments)))
+        return seen
+
+    def test_stringified_list_becomes_a_list(self):
+        assert self._call(kinds='["dataset"]')["kinds"] == ["dataset"]
+
+    def test_double_encoded_list_becomes_a_list(self):
+        assert self._call(kinds='"[\\"field\\"]"')["kinds"] == ["field"]
+
+    def test_stringified_int_becomes_an_int(self):
+        assert self._call(top_n="7")["top_n"] == 7
+
+    def test_a_real_list_is_untouched(self):
+        assert self._call(kinds=["dataset", "field"])["kinds"] == ["dataset", "field"]
+
+    def test_a_string_parameter_is_never_coerced(self):
+        """A str parameter whose value looks like a list must stay a string."""
+        assert self._call(label="[1, 2]")["label"] == "[1, 2]"
+
+    def test_unparseable_values_reach_the_tool_unchanged(self):
+        """The tool's own validation must still see what the model actually sent."""
+        seen = self._call(kinds="not json", top_n="many")
+        assert seen["kinds"] == "not json"
+        assert seen["top_n"] == "many"
+
+    def test_bool_is_not_treated_as_an_int(self):
+        assert self._call(flag=True)["flag"] is True

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -610,8 +610,25 @@ class TestStringifiedArgumentCoercion:
         assert seen["kinds"] == "not json"
         assert seen["top_n"] == "many"
 
-    def test_bool_is_not_treated_as_an_int(self):
-        assert self._call(flag=True)["flag"] is True
+    def test_non_string_values_are_passed_through_untouched(self):
+        """Coercion only ever inspects strings.
+
+        A bool handed to an int-annotated parameter is the case worth pinning:
+        ``int(True)`` would silently become ``1``, so the guard is that a
+        non-string is returned before any conversion is considered.
+        """
+        seen = {}
+
+        class Tool:
+            def probe(self, query_text: str, top_n: int = 5, kinds: Optional[List[str]] = None):
+                """Probe tool."""
+                seen.update(top_n=top_n, kinds=kinds)
+                return FuncToolResult(success=1, result="ok")
+
+        tool = trans_to_function_tool(Tool().probe)
+        asyncio.run(tool.on_invoke_tool(None, json.dumps({"query_text": "q", "top_n": True, "kinds": ["a"]})))
+        assert seen["top_n"] is True
+        assert seen["kinds"] == ["a"]
 
     def test_pep604_optional_int_is_coerced(self):
         """``int | None`` reports types.UnionType, not typing.Union."""
@@ -632,6 +649,20 @@ class TestStringifiedArgumentCoercion:
 
         class Tool:
             def probe(self, query_text: str, kinds: list[str] | None = None):
+                """Probe tool."""
+                seen["kinds"] = kinds
+                return FuncToolResult(success=1, result="ok")
+
+        tool = trans_to_function_tool(Tool().probe)
+        asyncio.run(tool.on_invoke_tool(None, json.dumps({"query_text": "q", "kinds": '["dataset"]'})))
+        assert seen["kinds"] == ["dataset"]
+
+    def test_bare_list_annotation_without_none_is_coerced(self):
+        """``list`` on its own reports no origin either."""
+        seen = {}
+
+        class Tool:
+            def probe(self, query_text: str, kinds: list = None):
                 """Probe tool."""
                 seen["kinds"] = kinds
                 return FuncToolResult(success=1, result="ok")

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -639,3 +639,17 @@ class TestStringifiedArgumentCoercion:
         tool = trans_to_function_tool(Tool().probe)
         asyncio.run(tool.on_invoke_tool(None, json.dumps({"query_text": "q", "kinds": '["dataset"]'})))
         assert seen["kinds"] == ["dataset"]
+
+    def test_bare_list_annotation_is_coerced(self):
+        """``list`` and ``list | None`` report no origin of their own."""
+        seen = {}
+
+        class Tool:
+            def probe(self, query_text: str, kinds: list | None = None):
+                """Probe tool."""
+                seen["kinds"] = kinds
+                return FuncToolResult(success=1, result="ok")
+
+        tool = trans_to_function_tool(Tool().probe)
+        asyncio.run(tool.on_invoke_tool(None, json.dumps({"query_text": "q", "kinds": '["dataset"]'})))
+        assert seen["kinds"] == ["dataset"]

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -612,3 +612,30 @@ class TestStringifiedArgumentCoercion:
 
     def test_bool_is_not_treated_as_an_int(self):
         assert self._call(flag=True)["flag"] is True
+
+    def test_pep604_optional_int_is_coerced(self):
+        """``int | None`` reports types.UnionType, not typing.Union."""
+        seen = {}
+
+        class Tool:
+            def probe(self, query_text: str, top_n: int | None = None):
+                """Probe tool."""
+                seen["top_n"] = top_n
+                return FuncToolResult(success=1, result="ok")
+
+        tool = trans_to_function_tool(Tool().probe)
+        asyncio.run(tool.on_invoke_tool(None, json.dumps({"query_text": "q", "top_n": "7"})))
+        assert seen["top_n"] == 7
+
+    def test_pep604_optional_list_is_coerced(self):
+        seen = {}
+
+        class Tool:
+            def probe(self, query_text: str, kinds: list[str] | None = None):
+                """Probe tool."""
+                seen["kinds"] = kinds
+                return FuncToolResult(success=1, result="ok")
+
+        tool = trans_to_function_tool(Tool().probe)
+        asyncio.run(tool.on_invoke_tool(None, json.dumps({"query_text": "q", "kinds": '["dataset"]'})))
+        assert seen["kinds"] == ["dataset"]


### PR DESCRIPTION
## What breaks

Some models serialize a nested list argument as a JSON **string**. A parameter
declared `List[str]` then arrives as `'["dataset"]'`, and an `int` arrives as
`"5"`.

The JSON itself is well formed, so `parse_tool_args` has nothing to repair — the
value simply has the wrong type, and it reaches the tool that way.

For `search_semantic_objects` the consequence is silent and total. The store is
already lenient about this parameter's type, but only for a *single* kind name:

```python
>>> from datus.storage.semantic_dataset.store import resolve_object_kinds
>>> resolve_object_kinds(["dataset"])      # a real list
ResolvedKinds(kinds=['dataset'], ...)      # ✅
>>> resolve_object_kinds("dataset")        # a bare string — handled on purpose
ResolvedKinds(kinds=['dataset'], ...)      # ✅
>>> resolve_object_kinds('["dataset"]')    # a stringified list
ResolvedKinds(kinds=['["dataset"]'], ...)  # ❌
```

That last one becomes `kind IN ('["dataset"]')` — valid SQL that matches zero
rows. The tool returns an empty list and no error, so the caller reads it as
"there is nothing in the catalogue" rather than "that argument had the wrong
type". We ran against a fully populated store where *every* semantic search
returned `[]` before tracing it to this.

## Why the fix is at the tool boundary

`resolve_object_kinds` would be the narrower place to patch, but this is not a
one-tool problem: **24 parameters across 11 func_tool modules** are declared
`Optional[List[str]]` — `context_search`, `semantic_tools`, `web_tool`,
`sub_agent_task_tool`, `generation_tools`, `attribution_utils`,
`reference_template_tools`, `task_result_tools`, and others. Any of them
receives the same shape from the same models.

So the coercion sits in `trans_to_function_tool`'s invoker, next to the existing
argument handling (`parse_tool_args`, the extra-parameter filter, the
missing-required check) — the layer that already exists to reconcile what a model
sent with what the method declares.

It runs *after* the extra-parameter filter and *before* the missing-required
check, so neither is affected.

## What it deliberately does not do

The coercion is narrow, because the failure mode of over-coercing is worse than
the bug:

- only `str` values are considered;
- only when the annotation asks for a list or an `int`;
- a `str` parameter whose value merely *looks* like a list is never touched;
- a `bool` is never read as an `int`;
- anything unparseable is passed through **unchanged**, so the tool's own
  validation still sees exactly what the model sent.

`Optional[X]` is unwrapped so `Optional[List[str]]` behaves like `List[str]`.

## Tests

Seven cases in `TestStringifiedArgumentCoercion`, driven through
`on_invoke_tool` — the real path a tool call takes, not the method directly:

| test | asserts |
|---|---|
| `test_stringified_list_becomes_a_list` | `'["dataset"]'` → `["dataset"]` |
| `test_double_encoded_list_becomes_a_list` | double-encoded strings resolve |
| `test_stringified_int_becomes_an_int` | `"7"` → `7` |
| `test_a_real_list_is_untouched` | correct input is not disturbed |
| `test_a_string_parameter_is_never_coerced` | a `str` holding `"[1, 2]"` stays a string |
| `test_unparseable_values_reach_the_tool_unchanged` | `"not json"` reaches the tool as-is |
| `test_bool_is_not_treated_as_an_int` | `True` stays `True` |

The first three fail with the change reverted and pass with it. The last four
pass either way by design — they exist to pin what the change must *not* do.

## Verification

- `tests/unit_tests/tools`: 3,972 passed, and the failure set is **identical** to
  clean `main` — 0 introduced, 0 fixed. (This environment has 2 pre-existing
  failures there from optional dependencies, so I compared failure IDs rather
  than counts.)
- `ruff check` clean.

## One thing I have not proven

The `kinds` case above is demonstrated end to end. For `top_n`, a string flows
into the store's `limit()`, and I have **not** shown a concrete failure there —
it may be coerced harmlessly downstream. It is handled here as the same class of
wrong-typing rather than because I can point at a broken query. Happy to drop the
int half if you would rather keep the change strictly to what is demonstrated.
)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool invocation by automatically interpreting stringified list and integer arguments according to their expected types.
  * Preserved valid existing values, booleans, strings, and unparseable inputs without unwanted changes.
  * Added support for optional argument types during validation and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool invocation by automatically interpreting stringified list and integer arguments according to their expected types.
  * Added support for optional and union-typed arguments, including generic and untyped lists.
  * Preserved valid existing values, booleans, strings, and unparseable inputs without unwanted changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->