### PR TITLE
[Enhancement] Pin datus-semantic-dosi to 0.1.7 and extend its platform markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,9 +215,9 @@ dev = [
 ]
 ci = [
     "datus-storage-postgresql>=0.1.5",
-    # dosi-engine publishes manylinux wheels only, so the marker keeps a macOS
-    # checkout resolvable; that platform builds the engine from source instead.
-    "datus-semantic-dosi>=0.1.6 ; platform_machine == 'x86_64' and sys_platform == 'linux'",
+    # dosi-engine ships wheels for manylinux (x86_64/aarch64) and, since
+    # 0.1.7, macOS arm64; the marker keeps other platforms resolvable.
+    "datus-semantic-dosi>=0.1.6 ; (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'darwin')",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,9 +215,10 @@ dev = [
 ]
 ci = [
     "datus-storage-postgresql>=0.1.5",
-    # dosi-engine ships wheels for manylinux (x86_64/aarch64) and, since
-    # 0.1.7, macOS arm64; the marker keeps other platforms resolvable.
-    "datus-semantic-dosi>=0.1.6 ; (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'darwin')",
+    # Pinned exactly: 0.1.7 is the first release that itself pins
+    # dosi-engine==0.1.7, whose wheels cover manylinux (x86_64/aarch64) and
+    # macOS arm64; the marker keeps other platforms resolvable.
+    "datus-semantic-dosi==0.1.7 ; (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'darwin')",
 ]
 
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ci = [
-    { name = "datus-semantic-dosi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')", specifier = ">=0.1.6" },
+    { name = "datus-semantic-dosi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')", specifier = "==0.1.7" },
     { name = "datus-storage-postgresql", specifier = ">=0.1.5" },
 ]
 dev = [
@@ -749,7 +749,7 @@ wheels = [
 
 [[package]]
 name = "datus-semantic-dosi"
-version = "0.1.6"
+version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datus-semantic-core" },
@@ -758,9 +758,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/60/ae3f1fd838fd84170e3991e0843a18cab7a33752846881f82bec2798abed/datus_semantic_dosi-0.1.6.tar.gz", hash = "sha256:5d35b14232dc5f3b20d8c5695925a684ec534ccb9801cd14e3e6345dd78b9d27", size = 50259, upload-time = "2026-08-24T13:29:42.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/d9/8e7257bd65391f0d2deb36860811c73f46bd331f2cf4dc61ff13c50b6c86/datus_semantic_dosi-0.1.7.tar.gz", hash = "sha256:6fdc54fd54dd6b8334205f1a46db9a7fd2f692223f178180e9f0f39cee062dd4", size = 50354, upload-time = "2026-08-26T12:28:17.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/14/e473cf29f39449449fc4ee272acc8a0aa1ccaa8aa5f09c97dc60ab84abc6/datus_semantic_dosi-0.1.6-py3-none-any.whl", hash = "sha256:d58387316d03e5c580ddab5b05e606cf8605eed267ffbc69cbce1809e18efce2", size = 40846, upload-time = "2026-08-24T13:29:42.073Z" },
+    { url = "https://files.pythonhosted.org/packages/30/cc/f8cd7b2c156b587e28421355ec97f4657fee49d8ee53cde42e99f70e7efd/datus_semantic_dosi-0.1.7-py3-none-any.whl", hash = "sha256:2f25b214a68f7aa05fe3edaab510ee9d9463b0fe6cc65813782f795b09eeac24", size = 40844, upload-time = "2026-08-26T12:28:16.54Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [package.dev-dependencies]
 ci = [
-    { name = "datus-semantic-dosi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "datus-semantic-dosi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "datus-storage-postgresql" },
 ]
 dev = [
@@ -669,7 +669,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ci = [
-    { name = "datus-semantic-dosi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=0.1.6" },
+    { name = "datus-semantic-dosi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')", specifier = ">=0.1.6" },
     { name = "datus-storage-postgresql", specifier = ">=0.1.5" },
 ]
 dev = [
@@ -857,10 +857,12 @@ wheels = [
 
 [[package]]
 name = "dosi-engine"
-version = "0.1.6"
+version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/67/0f801d7a0f4bfc7608e856d203444650e84edfbd9ec7e4ffc6505ccd30a6/dosi_engine-0.1.6-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a70baca8287bf97aa20d1c1e4a1af1bd9757de883be57dfd510539dd61a8f1d2", size = 34517496, upload-time = "2026-08-18T11:08:48.49Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fb/6c2cc7336eee5d88ecc0550df88b7975bb9197720d00986e0fbedeedbb1b/dosi_engine-0.1.7-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:1ec355eed88d650b75f9ae99bffd11e96b5797956ddad0a99fc47127645c5edc", size = 51970068, upload-time = "2026-08-24T13:19:15.657Z" },
+    { url = "https://files.pythonhosted.org/packages/57/44/bd34e0e3578a1ed149b437d68b35b37f774fca2901374d495a51c2eda2f0/dosi_engine-0.1.7-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2533082d2b8151685f773635e0bdb96f7476e0d0cb5d7b426986e2e0b43f1b8c", size = 42656411, upload-time = "2026-08-24T13:19:18.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/09/b6f64d5ed6a7e936157ef1672bb2dba9d7690a321b35a26311019d4434f4/dosi_engine-0.1.7-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:371a54bc629411917c8d94bbc803e1f5d4f166cf87b15abd35432c8ea56434d4", size = 44520976, upload-time = "2026-08-24T13:19:21.084Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`datus-semantic-dosi` in the `ci` dependency group was gated to linux x86_64 only, because dosi-engine used to publish manylinux wheels exclusively. On macOS dev machines `uv sync --group ci` therefore silently skipped the adapter, and every test importing `datus_semantic_dosi` (e.g. `tests/unit_tests/api/services/test_explorer_service.py::TestExplorerServiceOSIAuthoring`) failed with `ModuleNotFoundError` unless the package was installed by hand — 15 spurious failures in a local PR-harness run traced back to this.

The old `>=0.1.6` floor also left cross-platform installability up to the resolver: datus-semantic-dosi 0.1.6 constrains only `dosi-engine>=0.1.4`, so a correct wheel selection depended on this repo's lockfile explicitly holding dosi-engine at 0.1.7.

## Solution

- Extend the platform marker to linux aarch64 (dosi-engine ships manylinux aarch64 wheels since 0.1.6) and macOS arm64 (macosx_11_0_arm64 wheel since 0.1.7).
- Pin `datus-semantic-dosi==0.1.7` — the first release that itself pins `dosi-engine==0.1.7` — so every resolution path, locked or not, lands on an installable combination.
- `uv.lock` regenerated accordingly (datus-semantic-dosi 0.1.7, dosi-engine 0.1.7 incl. the macOS wheel).

CI behavior is unchanged: `run-ut-and-coverage.yml` reinstalls datus-semantic-dosi from the source checkout regardless of the lockfile, so this affects local/`uv sync` resolution only.

## Test Cases

No new tests — the change is dependency metadata only. Verified resolution with `uv lock` (minimal diff) and `uv sync --group ci --dry-run` on macOS arm64, which now selects datus-semantic-dosi 0.1.7 + dosi-engine 0.1.7 instead of skipping the package. The previously failing `TestExplorerServiceOSIAuthoring` suite passes on macOS once the group is synced (85 passed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [x] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI environment to use `datus-semantic-dosi` version 0.1.7.
  * Expanded CI compatibility to Linux x86_64, Linux aarch64, and macOS arm64.
  * Removed the macOS source-build requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->