### PR TITLE
[BugFix] Unblock REPL startup on missing DB adapters and stop mislabeling context failures

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -313,9 +313,9 @@ class AgenticNode(Node):
         self.degraded_capabilities[key] = message
 
     def _record_context_search_degraded(self, error: BaseException | str) -> str:
-        from datus.storage.embedding_diagnostics import format_context_degraded_warning
+        from datus.storage.embedding_diagnostics import format_context_unavailable
 
-        message = format_context_degraded_warning(error)
+        message = format_context_unavailable(error)
         self._record_degraded_capability("context_search_tools", message)
         return message
 

--- a/datus/api/services/tool_service.py
+++ b/datus/api/services/tool_service.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Optional
 from datus.api.models.base_models import Result
 from datus.api.models.config_models import ErrorCode
 from datus.configuration.agent_config import AgentConfig
-from datus.storage.embedding_diagnostics import format_context_degraded_warning
+from datus.storage.embedding_diagnostics import format_context_unavailable
 from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.context_search import ContextSearchTools
 from datus.utils.loggings import get_logger
@@ -42,7 +42,7 @@ class ToolService:
             self._context_search_tools = ContextSearchTools(agent_config, sub_agent_name=sub_agent_name)
         except Exception as exc:
             self._context_search_tools = None
-            self.context_warning = format_context_degraded_warning(exc)
+            self.context_warning = format_context_unavailable(exc)
             logger.warning("Context search tool registry disabled: %s", self.context_warning)
         self._registry: Dict[str, Callable[..., FuncToolResult]] = self._build_registry()
 

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -83,7 +83,7 @@ from datus.configuration.agent_config_loader import configuration_manager, load_
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
 from datus.storage.embedding_diagnostics import format_context_unavailable, is_datasource_scope_error
-from datus.tools.db_tools.db_manager import db_manager_instance
+from datus.tools.db_tools.db_manager import AdapterInstallStatus, db_manager_instance
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS, DBType, SQLType
 from datus.utils.exceptions import setup_exception_handler
 from datus.utils.loggings import get_logger
@@ -1379,17 +1379,20 @@ class DatusCLI:
         """Surface ``@``-completer preload failures with a cause-matched message.
 
         The three completers (table / metric / SQL) usually fail for the same
-        reason, so identical errors are collapsed before formatting. "No
-        datasource selected" is a normal state, not a failure: the banner
-        already shows it, so it gets a dim hint instead of a startup warning.
+        reason, so identical errors are collapsed first. Classification is
+        per-error, never on a joined blob — one completer's "no datasource
+        selected" must not relabel another completer's real failure. Scope
+        errors are a normal state (the banner already shows it) and only get
+        a dim hint; every other cause becomes a startup warning.
         """
         unique = list(dict.fromkeys(str(error) for error in errors if error))
         if not unique:
             return
-        if all(is_datasource_scope_error(error) for error in unique):
-            self.console.print("[dim]@ table/metric/SQL references will populate once a datasource is selected.[/]")
+        real_errors = [error for error in unique if not is_datasource_scope_error(error)]
+        if not real_errors:
+            print_info(self.console, "@ table/metric/SQL references will populate once a datasource is selected.")
             return
-        warning = format_context_unavailable("; ".join(unique))
+        warning = format_context_unavailable("; ".join(real_errors))
         self.startup_warnings.append(warning)
         logger.warning("REPL context autocomplete preload degraded: %s", warning)
         print_warning(self.console, warning)
@@ -2580,16 +2583,35 @@ class DatusCLI:
                 connector = self.db_manager.get_conn(current_datasource, self.cli_context.current_db_name)
                 return self.cli_context.current_db_name, connector
 
-        # Announce a pending adapter install before the blocking connection
+        # Announce the adapter-install situation before the blocking connection
         # attempt — otherwise the auto-install's pip download runs silently
-        # before the banner and the terminal just looks frozen.
+        # before the banner and the terminal just looks frozen. The wording
+        # follows the process-wide install state so a failed install is never
+        # re-announced as "installing".
         missing_connector = getattr(self.db_manager, "missing_connector_type", lambda _ds: None)(current_datasource)
+        install_status = None
         if missing_connector:
-            print_info(
-                self.console,
-                f"Installing database adapter datus-{missing_connector} for datasource "
-                f"'{current_datasource}' (first use; may take a minute)...",
-            )
+            install_status = self.db_manager.adapter_install_status(missing_connector)
+            if install_status is AdapterInstallStatus.NOT_ATTEMPTED:
+                print_info(
+                    self.console,
+                    f"Installing database adapter datus-{missing_connector} for datasource "
+                    f"'{current_datasource}' (first use; may take a minute)...",
+                )
+            elif install_status is AdapterInstallStatus.INSTALLING:
+                print_info(
+                    self.console,
+                    f"Database adapter datus-{missing_connector} is still installing from an earlier "
+                    "attempt; waiting for it to finish...",
+                )
+            else:
+                print_warning(
+                    self.console,
+                    f"Database adapter datus-{missing_connector} is unavailable — auto-install failed "
+                    f"earlier in this session. Install it manually: uv pip install datus-{missing_connector}",
+                )
+
+        install_may_be_running = missing_connector and install_status is not AdapterInstallStatus.FAILED
 
         try:
             try:
@@ -2597,11 +2619,18 @@ class DatusCLI:
                     _do_init_connection, timeout_seconds, f"connection init ({current_datasource})"
                 )
             except TimeoutError:
-                self.console.print(
-                    f"[red]Error:[/] Database connection timed out after {timeout_seconds} seconds. "
-                    f"Please check if the database server for datasource '{current_datasource}' is running "
-                    "and accessible."
-                )
+                if install_may_be_running:
+                    self.console.print(
+                        f"[red]Error:[/] Database connection timed out after {timeout_seconds} seconds while "
+                        f"the datus-{missing_connector} adapter install may still be running in the background. "
+                        "Reconnect with /database once it finishes."
+                    )
+                else:
+                    self.console.print(
+                        f"[red]Error:[/] Database connection timed out after {timeout_seconds} seconds. "
+                        f"Please check if the database server for datasource '{current_datasource}' is running "
+                        "and accessible."
+                    )
                 logger.error(f"Database connection timeout for datasource: {current_datasource}")
                 self.db_connector = None
                 return

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import queue
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
@@ -83,7 +82,7 @@ from datus.cli.tui.live_display_state import LiveDisplayState
 from datus.configuration.agent_config_loader import configuration_manager, load_agent_config
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
-from datus.storage.embedding_diagnostics import format_context_degraded_warning
+from datus.storage.embedding_diagnostics import format_context_unavailable, is_datasource_scope_error
 from datus.tools.db_tools.db_manager import db_manager_instance
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS, DBType, SQLType
 from datus.utils.exceptions import setup_exception_handler
@@ -102,6 +101,54 @@ DATUS_BANNER_TEXT = (
     "╚═════╝  ╚═╝  ╚═╝    ╚═╝     ╚═════╝  ╚══════╝"
 )
 _BANNER_MIN_WIDTH = 60
+
+
+def _call_with_timeout(fn, timeout_seconds: float, description: str):
+    """Run ``fn`` on a daemon thread; abandon it after ``timeout_seconds``.
+
+    ``ThreadPoolExecutor`` cannot express "stop waiting": its context-manager
+    exit calls ``shutdown(wait=True)``, which joins the worker even after
+    ``future.result(timeout=...)`` already raised — so a stuck connection
+    attempt blocks startup for as long as the worker runs. A daemon thread is
+    joined by neither the caller nor interpreter shutdown; on expiry the call
+    is abandoned and its eventual outcome only logged.
+
+    Raises :class:`TimeoutError` on expiry; re-raises ``fn``'s exception
+    otherwise.
+    """
+    result_q: queue.Queue = queue.Queue(maxsize=1)
+    state_lock = threading.Lock()
+    abandoned = False
+
+    def _worker():
+        try:
+            outcome = (True, fn())
+        except BaseException as exc:  # noqa: BLE001 - delivered to the caller below
+            outcome = (False, exc)
+        with state_lock:
+            if not abandoned:
+                result_q.put(outcome)
+                return
+        ok, value = outcome
+        if ok:
+            logger.info("%s finished after the CLI stopped waiting; result kept in the pool.", description)
+        else:
+            logger.debug("%s failed after the CLI stopped waiting: %s", description, value)
+
+    threading.Thread(target=_worker, name=f"datus-{description}", daemon=True).start()
+    try:
+        ok, value = result_q.get(timeout=timeout_seconds)
+    except queue.Empty:
+        with state_lock:
+            if result_q.empty():
+                abandoned = True
+        if abandoned:
+            raise TimeoutError(f"{description} timed out after {timeout_seconds} seconds") from None
+        # The worker delivered inside the race window between expiry and flagging.
+        ok, value = result_q.get_nowait()
+    if not ok:
+        raise value
+    return value
 
 
 class CommandType(Enum):
@@ -1324,16 +1371,28 @@ class DatusCLI:
                     )
                     if error
                 ]
-                if errors:
-                    warning = format_context_degraded_warning("; ".join(errors))
-                    self.startup_warnings.append(warning)
-                    logger.warning("REPL context autocomplete preload degraded: %s", warning)
-                    print_warning(self.console, warning)
+                self._report_context_preload_errors(errors)
             except Exception as exc:
-                warning = format_context_degraded_warning(exc)
-                self.startup_warnings.append(warning)
-                logger.warning("REPL context autocomplete preload failed: %s", warning)
-                print_warning(self.console, warning)
+                self._report_context_preload_errors([exc])
+
+    def _report_context_preload_errors(self, errors: List[Any]) -> None:
+        """Surface ``@``-completer preload failures with a cause-matched message.
+
+        The three completers (table / metric / SQL) usually fail for the same
+        reason, so identical errors are collapsed before formatting. "No
+        datasource selected" is a normal state, not a failure: the banner
+        already shows it, so it gets a dim hint instead of a startup warning.
+        """
+        unique = list(dict.fromkeys(str(error) for error in errors if error))
+        if not unique:
+            return
+        if all(is_datasource_scope_error(error) for error in unique):
+            self.console.print("[dim]@ table/metric/SQL references will populate once a datasource is selected.[/]")
+            return
+        warning = format_context_unavailable("; ".join(unique))
+        self.startup_warnings.append(warning)
+        logger.warning("REPL context autocomplete preload degraded: %s", warning)
+        print_warning(self.console, warning)
 
     def _warm_bang_node(self) -> None:
         """Eagerly build the default chat node during background init so ``!``
@@ -2521,21 +2580,31 @@ class DatusCLI:
                 connector = self.db_manager.get_conn(current_datasource, self.cli_context.current_db_name)
                 return self.cli_context.current_db_name, connector
 
+        # Announce a pending adapter install before the blocking connection
+        # attempt — otherwise the auto-install's pip download runs silently
+        # before the banner and the terminal just looks frozen.
+        missing_connector = getattr(self.db_manager, "missing_connector_type", lambda _ds: None)(current_datasource)
+        if missing_connector:
+            print_info(
+                self.console,
+                f"Installing database adapter datus-{missing_connector} for datasource "
+                f"'{current_datasource}' (first use; may take a minute)...",
+            )
+
         try:
-            # Use ThreadPoolExecutor with timeout for connection initialization
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(_do_init_connection)
-                try:
-                    db_name, self.db_connector = future.result(timeout=timeout_seconds)
-                except FuturesTimeoutError:
-                    self.console.print(
-                        f"[red]Error:[/] Database connection timed out after {timeout_seconds} seconds. "
-                        f"Please check if the database server for datasource '{current_datasource}' is running "
-                        "and accessible."
-                    )
-                    logger.error(f"Database connection timeout for datasource: {current_datasource}")
-                    self.db_connector = None
-                    return
+            try:
+                db_name, self.db_connector = _call_with_timeout(
+                    _do_init_connection, timeout_seconds, f"connection init ({current_datasource})"
+                )
+            except TimeoutError:
+                self.console.print(
+                    f"[red]Error:[/] Database connection timed out after {timeout_seconds} seconds. "
+                    f"Please check if the database server for datasource '{current_datasource}' is running "
+                    "and accessible."
+                )
+                logger.error(f"Database connection timeout for datasource: {current_datasource}")
+                self.db_connector = None
+                return
 
             if not self.db_connector:
                 self.console.print("[red]Error:[/] No database connection.")
@@ -2551,18 +2620,18 @@ class DatusCLI:
                 )
 
             # Test the connection with timeout
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(self.db_connector.test_connection)
-                try:
-                    connection_result = future.result(timeout=timeout_seconds)
-                    logger.debug(f"Connection test result: {connection_result}")
-                except FuturesTimeoutError:
-                    self.console.print(
-                        f"[red]Error:[/] Connection test timed out after {timeout_seconds} seconds. "
-                        f"The database server for datasource '{current_datasource}' may be unresponsive."
-                    )
-                    logger.error(f"Connection test timeout for datasource: {current_datasource}")
-                    self.db_connector = None
+            try:
+                connection_result = _call_with_timeout(
+                    self.db_connector.test_connection, timeout_seconds, f"connection test ({current_datasource})"
+                )
+                logger.debug(f"Connection test result: {connection_result}")
+            except TimeoutError:
+                self.console.print(
+                    f"[red]Error:[/] Connection test timed out after {timeout_seconds} seconds. "
+                    f"The database server for datasource '{current_datasource}' may be unresponsive."
+                )
+                logger.error(f"Connection test timeout for datasource: {current_datasource}")
+                self.db_connector = None
 
         except Exception as e:
             self.console.print(f"[red]Error:[/] Failed to connect to database: {str(e)}")

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -2608,7 +2608,8 @@ class DatusCLI:
                 print_warning(
                     self.console,
                     f"Database adapter datus-{missing_connector} is unavailable — auto-install failed "
-                    f"earlier in this session. Install it manually: pip install datus-{missing_connector}",
+                    f"earlier in this session. Install it manually: pip install datus-{missing_connector}, "
+                    "then reconnect with /database.",
                 )
             # REGISTERED: the connector became available between the probe and
             # this status read (e.g. the background sync finished the install);

--- a/datus/cli/repl.py
+++ b/datus/cli/repl.py
@@ -82,7 +82,7 @@ from datus.cli.tui.live_display_state import LiveDisplayState
 from datus.configuration.agent_config_loader import configuration_manager, load_agent_config
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager, ActionRole, ActionStatus
 from datus.schemas.node_models import SQLContext
-from datus.storage.embedding_diagnostics import format_context_unavailable, is_datasource_scope_error
+from datus.storage.embedding_diagnostics import format_context_unavailable_many, is_datasource_scope_error
 from datus.tools.db_tools.db_manager import AdapterInstallStatus, db_manager_instance
 from datus.utils.constants import HIDDEN_SYS_SUB_AGENTS, SYS_SUB_AGENTS, DBType, SQLType
 from datus.utils.exceptions import setup_exception_handler
@@ -1392,7 +1392,7 @@ class DatusCLI:
         if not real_errors:
             print_info(self.console, "@ table/metric/SQL references will populate once a datasource is selected.")
             return
-        warning = format_context_unavailable("; ".join(real_errors))
+        warning = format_context_unavailable_many(real_errors)
         self.startup_warnings.append(warning)
         logger.warning("REPL context autocomplete preload degraded: %s", warning)
         print_warning(self.console, warning)
@@ -2604,14 +2604,20 @@ class DatusCLI:
                     f"Database adapter datus-{missing_connector} is still installing from an earlier "
                     "attempt; waiting for it to finish...",
                 )
-            else:
+            elif install_status is AdapterInstallStatus.FAILED:
                 print_warning(
                     self.console,
                     f"Database adapter datus-{missing_connector} is unavailable — auto-install failed "
-                    f"earlier in this session. Install it manually: uv pip install datus-{missing_connector}",
+                    f"earlier in this session. Install it manually: pip install datus-{missing_connector}",
                 )
+            # REGISTERED: the connector became available between the probe and
+            # this status read (e.g. the background sync finished the install);
+            # nothing to announce.
 
-        install_may_be_running = missing_connector and install_status is not AdapterInstallStatus.FAILED
+        install_may_be_running = missing_connector and install_status in (
+            AdapterInstallStatus.NOT_ATTEMPTED,
+            AdapterInstallStatus.INSTALLING,
+        )
 
         try:
             try:
@@ -2620,23 +2626,25 @@ class DatusCLI:
                 )
             except TimeoutError:
                 if install_may_be_running:
-                    self.console.print(
-                        f"[red]Error:[/] Database connection timed out after {timeout_seconds} seconds while "
+                    print_error(
+                        self.console,
+                        f"Database connection timed out after {timeout_seconds} seconds while "
                         f"the datus-{missing_connector} adapter install may still be running in the background. "
-                        "Reconnect with /database once it finishes."
+                        "Reconnect with /database once it finishes.",
                     )
                 else:
-                    self.console.print(
-                        f"[red]Error:[/] Database connection timed out after {timeout_seconds} seconds. "
+                    print_error(
+                        self.console,
+                        f"Database connection timed out after {timeout_seconds} seconds. "
                         f"Please check if the database server for datasource '{current_datasource}' is running "
-                        "and accessible."
+                        "and accessible.",
                     )
                 logger.error(f"Database connection timeout for datasource: {current_datasource}")
                 self.db_connector = None
                 return
 
             if not self.db_connector:
-                self.console.print("[red]Error:[/] No database connection.")
+                print_error(self.console, "No database connection.")
                 return
 
             # Update context based on dialect
@@ -2655,15 +2663,16 @@ class DatusCLI:
                 )
                 logger.debug(f"Connection test result: {connection_result}")
             except TimeoutError:
-                self.console.print(
-                    f"[red]Error:[/] Connection test timed out after {timeout_seconds} seconds. "
-                    f"The database server for datasource '{current_datasource}' may be unresponsive."
+                print_error(
+                    self.console,
+                    f"Connection test timed out after {timeout_seconds} seconds. "
+                    f"The database server for datasource '{current_datasource}' may be unresponsive.",
                 )
                 logger.error(f"Connection test timeout for datasource: {current_datasource}")
                 self.db_connector = None
 
         except Exception as e:
-            self.console.print(f"[red]Error:[/] Failed to connect to database: {str(e)}")
+            print_error(self.console, f"Failed to connect to database: {str(e)}")
             logger.error(f"Database connection failed for datasource {current_datasource}: {e}")
             self.db_connector = None
 

--- a/datus/storage/embedding_diagnostics.py
+++ b/datus/storage/embedding_diagnostics.py
@@ -82,3 +82,34 @@ def is_embedding_unavailable_error(error: BaseException | str | None) -> bool:
             "embedding model is unavailable",
         )
     )
+
+
+DATASOURCE_SCOPE_MARKER = "datasource is required for datasource-scoped storage"
+
+
+def is_datasource_scope_error(error: BaseException | str | None) -> bool:
+    """Return True for the "no datasource selected" storage-scope failure."""
+    return bool(error) and DATASOURCE_SCOPE_MARKER in str(error)
+
+
+def format_context_unavailable(error: BaseException | str | None = None) -> str:
+    """Build a context-degradation message that matches the actual cause.
+
+    ``format_context_degraded_warning`` hardcodes the embedding-unavailable
+    text; routing every failure through it blames the embedding model (and
+    recommends Hugging Face mirrors) for unrelated causes such as a missing
+    datasource. Classify first, then format.
+    """
+    if is_embedding_unavailable_error(error):
+        return format_context_degraded_warning(error)
+    if is_datasource_scope_error(error):
+        return (
+            "Context search and @ references are inactive because no datasource is selected. "
+            "Database tools and normal chat remain available. "
+            "Select a datasource (/database in the CLI, or --datasource) to enable them."
+        )
+    details = str(error).strip() if error else ""
+    message = "Context search and @ references are disabled. Database tools and normal chat remain available."
+    if details:
+        message = f"{message} Details: {details}"
+    return message

--- a/datus/storage/embedding_diagnostics.py
+++ b/datus/storage/embedding_diagnostics.py
@@ -92,13 +92,24 @@ def is_datasource_scope_error(error: BaseException | str | None) -> bool:
     return bool(error) and DATASOURCE_SCOPE_MARKER in str(error)
 
 
+def _generic_unavailable_message(details: str = "") -> str:
+    """Neutral degradation message that attributes no specific cause."""
+    message = "Context search and @ references are disabled. Database tools and normal chat remain available."
+    if details:
+        message = f"{message} Details: {details}"
+    return message
+
+
 def format_context_unavailable(error: BaseException | str | None = None) -> str:
     """Build a context-degradation message that matches the actual cause.
 
     ``format_context_degraded_warning`` hardcodes the embedding-unavailable
     text; routing every failure through it blames the embedding model (and
     recommends Hugging Face mirrors) for unrelated causes such as a missing
-    datasource. Classify first, then format.
+    datasource. Classify first, then format. For a batch of errors use
+    :func:`format_context_unavailable_many` — a joined string passed here
+    would classify the whole batch by whichever member's marker matches
+    first.
     """
     if is_embedding_unavailable_error(error):
         return format_context_degraded_warning(error)
@@ -108,8 +119,23 @@ def format_context_unavailable(error: BaseException | str | None = None) -> str:
             "Database tools and normal chat remain available. "
             "Select a datasource (/database in the CLI, or --datasource) to enable them."
         )
-    details = str(error).strip() if error else ""
-    message = "Context search and @ references are disabled. Database tools and normal chat remain available."
-    if details:
-        message = f"{message} Details: {details}"
-    return message
+    return _generic_unavailable_message(str(error).strip() if error else "")
+
+
+def format_context_unavailable_many(errors: "list[BaseException | str]") -> str:
+    """Build one degradation message for a batch of errors, classified per-error.
+
+    A cause-specific headline (embedding remediation, datasource hint) is
+    used only when every error in the batch shares that cause; a mixed batch
+    gets the neutral headline with every cause preserved in the details, so
+    one member's marker never relabels the others' failures.
+    """
+    unique = list(dict.fromkeys(str(error).strip() for error in errors if error and str(error).strip()))
+    if not unique:
+        return _generic_unavailable_message()
+    if len(unique) == 1:
+        return format_context_unavailable(unique[0])
+    for classifier in (is_embedding_unavailable_error, is_datasource_scope_error):
+        if all(classifier(error) for error in unique):
+            return format_context_unavailable("; ".join(unique))
+    return _generic_unavailable_message("; ".join(unique))

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -70,7 +70,13 @@ def _auto_install_adapter(db_type: str) -> None:
     """
     with _adapter_install_lock:
         if db_type in _adapter_install_attempted:
-            logger.debug("Adapter '%s' auto-install already attempted; skipping", db_type)
+            # The memo only guards the expensive pip subprocess. Retry the
+            # cheap import + register so a manual ``pip install datus-<type>``
+            # after a failed auto-install takes effect without a restart.
+            if _try_register_adapter_module(db_type):
+                logger.info("Adapter '%s' registered after manual install", db_type)
+            else:
+                logger.debug("Adapter '%s' auto-install already attempted; skipping", db_type)
             return
         # Active before attempted: lock-free status readers must never see
         # "attempted but not active" for an install that is about to run —
@@ -83,8 +89,34 @@ def _auto_install_adapter(db_type: str) -> None:
             _adapter_install_active.discard(db_type)
 
 
-def _run_adapter_install(db_type: str) -> None:
+def _try_register_adapter_module(db_type: str) -> bool:
+    """Import and register an already-installed ``datus_<type>`` package.
+
+    Cheap (no subprocess): used after a fresh auto-install, and on every
+    retry after a failed one so a manual install becomes usable in the
+    running process.
+    """
     import importlib
+
+    try:
+        importlib.invalidate_caches()
+        module = importlib.import_module(f"datus_{db_type}")
+    except ImportError:
+        return False
+    except Exception as e:  # noqa: BLE001 - a broken adapter must not crash the caller
+        logger.warning("Adapter module datus_%s failed to load: %s", db_type, e)
+        return False
+    register = getattr(module, "register", None)
+    if callable(register):
+        try:
+            register()
+        except Exception as e:  # noqa: BLE001 - a broken adapter must not crash the caller
+            logger.warning("Adapter datus_%s register() failed: %s", db_type, e)
+            return False
+    return True
+
+
+def _run_adapter_install(db_type: str) -> None:
     import shutil
     import subprocess
     import sys
@@ -106,12 +138,10 @@ def _run_adapter_install(db_type: str) -> None:
             logger.warning("Auto-install of %s failed: %s", package, result.stderr.strip())
             return
 
-        importlib.invalidate_caches()
-        module_name = f"datus_{db_type}"
-        module = importlib.import_module(module_name)
-        if hasattr(module, "register"):
-            module.register()
-        logger.info("Auto-installed and loaded adapter: %s", db_type)
+        if _try_register_adapter_module(db_type):
+            logger.info("Auto-installed and loaded adapter: %s", db_type)
+        else:
+            logger.warning("Auto-install of %s succeeded but the adapter module did not load", package)
     except subprocess.TimeoutExpired:
         logger.warning("Auto-install of %s timed out", package)
     except Exception as e:

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -3,7 +3,8 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 import dataclasses
-from typing import Callable, Dict, Optional, Tuple, Union
+import threading
+from typing import Callable, Dict, Optional, Set, Tuple, Union
 
 from datus_db_core import BaseSqlConnector, ConnectionConfig, DatusDbException, connector_registry
 from sqlalchemy.engine.url import URL, make_url
@@ -18,8 +19,30 @@ from datus.utils.path_utils import get_files_from_glob_pattern
 logger = get_logger(__name__)
 
 
+# Single-flight guard for adapter auto-installs: concurrent callers (e.g. the
+# REPL connection init and the background schema sync) must not spawn duplicate
+# ``pip install`` processes racing on the same environment, and a failed install
+# must not be retried on every connection attempt within the process.
+_adapter_install_lock = threading.Lock()
+_adapter_install_attempted: Set[str] = set()
+
+
 def _auto_install_adapter(db_type: str) -> None:
-    """Attempt to pip-install the adapter package for *db_type* and register it."""
+    """Attempt to pip-install the adapter package for *db_type* and register it.
+
+    Serialized process-wide: the first caller runs the install while holding the
+    lock (so concurrent callers wait for its outcome instead of racing), and
+    each *db_type* is attempted at most once per process.
+    """
+    with _adapter_install_lock:
+        if db_type in _adapter_install_attempted:
+            logger.debug("Adapter '%s' auto-install already attempted; skipping", db_type)
+            return
+        _adapter_install_attempted.add(db_type)
+        _run_adapter_install(db_type)
+
+
+def _run_adapter_install(db_type: str) -> None:
     import importlib
     import shutil
     import subprocess
@@ -238,6 +261,22 @@ class DBManager:
         # file path, which ``cfg.database`` doesn't carry); fall back to the config-resolved
         # name. Both are real database names — never the datasource name.
         return (connector.database_name or resolved), connector
+
+    def missing_connector_type(self, datasource: str) -> Optional[str]:
+        """Return ``datasource``'s (normalized) db type when its connector is
+        not registered yet, else ``None``.
+
+        A metadata-only probe — never triggers the adapter auto-install — so
+        UI layers can announce a pending install before the blocking
+        connection attempt starts.
+        """
+        cfg = self._db_configs.get(datasource)
+        if cfg is None:
+            return None
+        db_type = _normalize_dialect_name(cfg.type)
+        if not db_type or connector_registry.is_registered(db_type):
+            return None
+        return db_type
 
     def get_db_uris(self, datasource: str) -> Dict[str, str]:
         cfg = self._db_configs.get(datasource)

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -4,7 +4,7 @@
 
 import dataclasses
 import threading
-from enum import Enum
+from enum import StrEnum
 from typing import Callable, Dict, Optional, Set, Tuple, Union
 
 from datus_db_core import BaseSqlConnector, ConnectionConfig, DatusDbException, connector_registry
@@ -35,14 +35,16 @@ _adapter_install_attempted: Set[str] = set()
 _adapter_install_active: Set[str] = set()
 
 
-class AdapterInstallStatus(str, Enum):
-    """Install state of a missing adapter, for UI layers to message accurately.
+class AdapterInstallStatus(StrEnum):
+    """Install state of an adapter's connector, for UI layers to message accurately.
 
-    Only meaningful while the connector is unregistered: a successful install
-    registers the connector, after which ``missing_connector_type`` reports no
-    gap and this status is moot.
+    Self-contained: consults the connector registry first, so a concurrently
+    completed install reports ``REGISTERED`` rather than leaking the
+    "attempted" memo as a false failure — callers need no particular read
+    ordering relative to ``missing_connector_type``.
     """
 
+    REGISTERED = "registered"  # connector available; any earlier attempt is moot
     NOT_ATTEMPTED = "not_attempted"  # next connection attempt will auto-install
     INSTALLING = "installing"  # an install subprocess is running right now
     FAILED = "failed"  # attempted this process and the connector is still missing
@@ -50,6 +52,8 @@ class AdapterInstallStatus(str, Enum):
 
 def adapter_install_status(db_type: str) -> AdapterInstallStatus:
     """Return the process-wide auto-install state for *db_type*."""
+    if connector_registry.is_registered(db_type):
+        return AdapterInstallStatus.REGISTERED
     if db_type in _adapter_install_active:
         return AdapterInstallStatus.INSTALLING
     if db_type in _adapter_install_attempted:
@@ -68,8 +72,11 @@ def _auto_install_adapter(db_type: str) -> None:
         if db_type in _adapter_install_attempted:
             logger.debug("Adapter '%s' auto-install already attempted; skipping", db_type)
             return
-        _adapter_install_attempted.add(db_type)
+        # Active before attempted: lock-free status readers must never see
+        # "attempted but not active" for an install that is about to run —
+        # that combination means FAILED.
         _adapter_install_active.add(db_type)
+        _adapter_install_attempted.add(db_type)
         try:
             _run_adapter_install(db_type)
         finally:

--- a/datus/tools/db_tools/db_manager.py
+++ b/datus/tools/db_tools/db_manager.py
@@ -4,6 +4,7 @@
 
 import dataclasses
 import threading
+from enum import Enum
 from typing import Callable, Dict, Optional, Set, Tuple, Union
 
 from datus_db_core import BaseSqlConnector, ConnectionConfig, DatusDbException, connector_registry
@@ -23,8 +24,37 @@ logger = get_logger(__name__)
 # REPL connection init and the background schema sync) must not spawn duplicate
 # ``pip install`` processes racing on the same environment, and a failed install
 # must not be retried on every connection attempt within the process.
+# Deliberately ONE process-wide lock rather than one per db_type: concurrent
+# pip/uv processes mutate the same environment, so installs of *different*
+# adapters must serialize too.
 _adapter_install_lock = threading.Lock()
 _adapter_install_attempted: Set[str] = set()
+# db_types whose install subprocess is currently running. Read without the
+# lock (the installer holds it for the whole install) — set membership is
+# GIL-atomic and UI staleness of one check is harmless.
+_adapter_install_active: Set[str] = set()
+
+
+class AdapterInstallStatus(str, Enum):
+    """Install state of a missing adapter, for UI layers to message accurately.
+
+    Only meaningful while the connector is unregistered: a successful install
+    registers the connector, after which ``missing_connector_type`` reports no
+    gap and this status is moot.
+    """
+
+    NOT_ATTEMPTED = "not_attempted"  # next connection attempt will auto-install
+    INSTALLING = "installing"  # an install subprocess is running right now
+    FAILED = "failed"  # attempted this process and the connector is still missing
+
+
+def adapter_install_status(db_type: str) -> AdapterInstallStatus:
+    """Return the process-wide auto-install state for *db_type*."""
+    if db_type in _adapter_install_active:
+        return AdapterInstallStatus.INSTALLING
+    if db_type in _adapter_install_attempted:
+        return AdapterInstallStatus.FAILED
+    return AdapterInstallStatus.NOT_ATTEMPTED
 
 
 def _auto_install_adapter(db_type: str) -> None:
@@ -39,7 +69,11 @@ def _auto_install_adapter(db_type: str) -> None:
             logger.debug("Adapter '%s' auto-install already attempted; skipping", db_type)
             return
         _adapter_install_attempted.add(db_type)
-        _run_adapter_install(db_type)
+        _adapter_install_active.add(db_type)
+        try:
+            _run_adapter_install(db_type)
+        finally:
+            _adapter_install_active.discard(db_type)
 
 
 def _run_adapter_install(db_type: str) -> None:
@@ -268,7 +302,9 @@ class DBManager:
 
         A metadata-only probe — never triggers the adapter auto-install — so
         UI layers can announce a pending install before the blocking
-        connection attempt starts.
+        connection attempt starts. Combine with :meth:`adapter_install_status`
+        to phrase the announcement accurately (about to install / installing /
+        already failed).
         """
         cfg = self._db_configs.get(datasource)
         if cfg is None:
@@ -277,6 +313,10 @@ class DBManager:
         if not db_type or connector_registry.is_registered(db_type):
             return None
         return db_type
+
+    def adapter_install_status(self, db_type: str) -> AdapterInstallStatus:
+        """Process-wide auto-install state for ``db_type``."""
+        return adapter_install_status(db_type)
 
     def get_db_uris(self, datasource: str) -> Dict[str, str]:
         cfg = self._db_configs.get(datasource)

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -306,6 +306,25 @@ class TestPreLoadStorage:
         assert "lance cache unavailable" in cli.startup_warnings[0]
         assert "no datasource is selected" not in cli.startup_warnings[0]
 
+    def test_pre_load_storage_mixed_real_causes_get_neutral_headline(self, cli):
+        cli.at_completer = SimpleNamespace(
+            reload_data=MagicMock(),
+            table_completer=SimpleNamespace(last_error="error_code=300019: embedding download failed"),
+            metric_completer=SimpleNamespace(last_error="lance table corrupted"),
+            sql_completer=SimpleNamespace(last_error=None),
+        )
+
+        cli._pre_load_storage()
+
+        # Property: an embedding failure in one completer must not relabel an
+        # unrelated failure in another — mixed batches keep a neutral headline
+        # with every cause in the details.
+        assert len(cli.startup_warnings) == 1
+        warning = cli.startup_warnings[0]
+        assert "Hugging Face" not in warning
+        assert "embedding download failed" in warning
+        assert "lance table corrupted" in warning
+
     def test_pre_load_storage_embedding_error_keeps_embedding_remediation(self, cli):
         cli.at_completer = SimpleNamespace(
             reload_data=MagicMock(),
@@ -1976,9 +1995,24 @@ class TestInitConnectionTimeout:
         output = _console_text(cli)
         # Property: once the process-wide memo says the install failed, the
         # REPL must not claim an install is happening — it must hand the user
-        # the manual command instead.
+        # the manual command, phrased the way every doc and hint in the
+        # project phrases it (plain pip; uv may be absent on this machine).
         assert "Installing" not in output
-        assert "uv pip install datus-oracle" in output
+        assert "Install it manually: pip install datus-oracle" in output
+
+    def test_registered_status_announces_nothing(self, cli):
+        # The connector became available between the missing-probe and the
+        # status read (concurrent install finished): no announcement at all.
+        from datus.tools.db_tools.db_manager import AdapterInstallStatus
+
+        self._wire(cli, missing="oracle", install_status=AdapterInstallStatus.REGISTERED)
+
+        cli._init_connection(timeout_seconds=5)
+
+        output = _console_text(cli)
+        assert "Installing" not in output
+        assert "unavailable" not in output
+        assert "still installing" not in output
 
     def test_in_progress_install_announced_as_waiting(self, cli):
         from datus.tools.db_tools.db_manager import AdapterInstallStatus

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -1964,7 +1964,10 @@ class TestInitConnectionTimeout:
         assert "unresponsive" in _console_text(cli)
 
     def test_missing_adapter_announced_before_connecting(self, cli):
+        seen_before_connect = []
+
         def _fail(ds):
+            seen_before_connect.append(_console_text(cli))
             raise RuntimeError("Connector 'oracle' not found")
 
         self._wire(cli, first_conn=_fail, missing="oracle")
@@ -1973,6 +1976,9 @@ class TestInitConnectionTimeout:
 
         output = _console_text(cli)
         assert "datus-oracle" in output
+        # Property: the install notice reaches the user before the blocking
+        # connection attempt starts, not after it fails.
+        assert "datus-oracle" in seen_before_connect[0]
         assert cli.db_connector is None
 
     def test_no_install_notice_when_connector_registered(self, cli):
@@ -1999,6 +2005,9 @@ class TestInitConnectionTimeout:
         # project phrases it (plain pip; uv may be absent on this machine).
         assert "Installing" not in output
         assert "Install it manually: pip install datus-oracle" in output
+        # The advice works in-session (the memo path retries import/register),
+        # so it must point at /database, not at a process restart.
+        assert "reconnect with /database" in output
 
     def test_registered_status_announces_nothing(self, cli):
         # The connector became available between the missing-probe and the

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -251,6 +251,55 @@ class TestPreLoadStorage:
         assert len(cli.startup_warnings) == 1
         assert "table cache unavailable" in cli.startup_warnings[0]
 
+    def test_pre_load_storage_no_datasource_is_hint_not_warning(self, cli):
+        # The exact error resolve_datasource_id raises when nothing is selected.
+        scope_error = (
+            "error_code=410007, error_message=Invalid storage argument: "
+            "datasource is required for datasource-scoped storage"
+        )
+        cli.at_completer = SimpleNamespace(
+            reload_data=MagicMock(),
+            table_completer=SimpleNamespace(last_error=scope_error),
+            metric_completer=SimpleNamespace(last_error=scope_error),
+            sql_completer=SimpleNamespace(last_error=scope_error),
+        )
+
+        cli._pre_load_storage()
+
+        # Property: "no datasource selected" is a normal state — it must not
+        # become a startup warning and must never blame the embedding model.
+        assert cli.startup_warnings == []
+        output = " ".join(cli.console.file.getvalue().split())
+        assert "datasource is selected" in output
+        assert "embedding" not in output.lower()
+
+    def test_pre_load_storage_dedupes_identical_completer_errors(self, cli):
+        cli.at_completer = SimpleNamespace(
+            reload_data=MagicMock(),
+            table_completer=SimpleNamespace(last_error="lance cache unavailable"),
+            metric_completer=SimpleNamespace(last_error="lance cache unavailable"),
+            sql_completer=SimpleNamespace(last_error="lance cache unavailable"),
+        )
+
+        cli._pre_load_storage()
+
+        assert len(cli.startup_warnings) == 1
+        assert cli.startup_warnings[0].count("lance cache unavailable") == 1
+
+    def test_pre_load_storage_embedding_error_keeps_embedding_remediation(self, cli):
+        cli.at_completer = SimpleNamespace(
+            reload_data=MagicMock(),
+            table_completer=SimpleNamespace(last_error="error_code=300019: embedding download failed"),
+            metric_completer=SimpleNamespace(last_error=None),
+            sql_completer=SimpleNamespace(last_error=None),
+        )
+
+        cli._pre_load_storage()
+
+        assert len(cli.startup_warnings) == 1
+        assert "embedding model is unavailable" in cli.startup_warnings[0]
+        assert "Hugging Face" in cli.startup_warnings[0]
+
     def test_background_init_keeps_agent_ready_after_preload_failure(self, cli):
         agent = object()
         cli.args = SimpleNamespace(debug=False)
@@ -1739,3 +1788,154 @@ class TestInterruptAgent:
         cli.tui_app.restore_input_after_dispatch.assert_not_called()
         cli.chat_commands.current_streaming_ctx.request_unanswered_rollback.assert_not_called()
         cli.chat_commands.current_streaming_ctx.request_interrupted_notice.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: _call_with_timeout
+# ---------------------------------------------------------------------------
+
+
+def _console_text(cli) -> str:
+    """Console output with wrapping-induced newlines collapsed."""
+    return " ".join(cli.console.file.getvalue().split())
+
+
+class TestCallWithTimeout:
+    def test_returns_result_within_timeout(self):
+        from datus.cli.repl import _call_with_timeout
+
+        assert _call_with_timeout(lambda: 42, 5, "quick call") == 42
+
+    def test_reraises_worker_exception(self):
+        from datus.cli.repl import _call_with_timeout
+
+        def _boom():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            _call_with_timeout(_boom, 5, "failing call")
+
+    def test_expiry_unblocks_caller_without_joining_worker(self):
+        import time as time_mod
+
+        from datus.cli.repl import _call_with_timeout
+
+        start = time_mod.monotonic()
+        with pytest.raises(TimeoutError):
+            _call_with_timeout(lambda: time_mod.sleep(2), 0.2, "stuck call")
+        # Property: expiry must unblock the caller promptly. Joining the
+        # worker (the ThreadPoolExecutor.__exit__ behavior this replaces)
+        # would hold the caller for the worker's full 2s runtime.
+        assert time_mod.monotonic() - start < 1.5
+
+    def test_abandoned_success_is_logged_not_raised(self):
+        import time as time_mod
+
+        from datus.cli.repl import _call_with_timeout
+
+        with patch("datus.cli.repl.logger") as mock_logger:
+            with pytest.raises(TimeoutError):
+                _call_with_timeout(lambda: time_mod.sleep(0.3) or "late", 0.05, "late call")
+            deadline = time_mod.monotonic() + 2
+            while not mock_logger.info.called and time_mod.monotonic() < deadline:
+                time_mod.sleep(0.05)
+        assert mock_logger.info.called
+        assert "late call" in mock_logger.info.call_args.args
+
+
+# ---------------------------------------------------------------------------
+# Tests: _init_connection timeout semantics and adapter-install notice
+# ---------------------------------------------------------------------------
+
+
+class TestInitConnectionTimeout:
+    def _wire(self, cli, *, connector=None, first_conn=None, missing=None):
+        from datus.utils.constants import DBType
+
+        if connector is None:
+            connector = SimpleNamespace(
+                dialect=DBType.SQLITE,
+                database_name="demo_db",
+                catalog_name=None,
+                test_connection=MagicMock(return_value=True),
+            )
+        cli.agent_config = SimpleNamespace(current_datasource="ds1")
+        cli.db_manager = SimpleNamespace(
+            first_conn_with_name=first_conn or (lambda ds: ("demo_db", connector)),
+            missing_connector_type=lambda ds: missing,
+        )
+        return connector
+
+    def test_no_datasource_clears_connector(self, cli):
+        cli.agent_config = SimpleNamespace(current_datasource="")
+
+        cli._init_connection()
+
+        assert cli.db_connector is None
+
+    def test_successful_connection_updates_context(self, cli):
+        connector = self._wire(cli)
+
+        cli._init_connection(timeout_seconds=5)
+
+        assert cli.db_connector is connector
+        assert cli.cli_context.current_db_name == "demo_db"
+        connector.test_connection.assert_called_once_with()
+
+    def test_timeout_unblocks_startup(self, cli):
+        import time as time_mod
+
+        def _stuck(ds):
+            time_mod.sleep(4)
+            return ("db", MagicMock())
+
+        self._wire(cli, first_conn=_stuck)
+
+        start = time_mod.monotonic()
+        cli._init_connection(timeout_seconds=0.5)
+        elapsed = time_mod.monotonic() - start
+
+        # Property: the timeout bounds how long startup blocks. Pre-fix the
+        # executor's __exit__ joined the stuck worker and held startup for
+        # the worker's full runtime despite the expired timeout.
+        assert elapsed < 3.0
+        assert cli.db_connector is None
+        assert "timed out" in _console_text(cli)
+
+    def test_connection_test_timeout_clears_connector(self, cli):
+        import time as time_mod
+
+        connector = SimpleNamespace(
+            dialect=None,
+            database_name="db",
+            catalog_name=None,
+            test_connection=lambda: time_mod.sleep(4) or True,
+        )
+        self._wire(cli, connector=connector)
+
+        start = time_mod.monotonic()
+        cli._init_connection(timeout_seconds=0.5)
+        elapsed = time_mod.monotonic() - start
+
+        assert elapsed < 3.0
+        assert cli.db_connector is None
+        assert "unresponsive" in _console_text(cli)
+
+    def test_missing_adapter_announced_before_connecting(self, cli):
+        def _fail(ds):
+            raise RuntimeError("Connector 'oracle' not found")
+
+        self._wire(cli, first_conn=_fail, missing="oracle")
+
+        cli._init_connection(timeout_seconds=5)
+
+        output = _console_text(cli)
+        assert "datus-oracle" in output
+        assert cli.db_connector is None
+
+    def test_no_install_notice_when_connector_registered(self, cli):
+        self._wire(cli, missing=None)
+
+        cli._init_connection(timeout_seconds=5)
+
+        assert "Installing" not in _console_text(cli)

--- a/tests/unit_tests/cli/test_repl.py
+++ b/tests/unit_tests/cli/test_repl.py
@@ -286,6 +286,26 @@ class TestPreLoadStorage:
         assert len(cli.startup_warnings) == 1
         assert cli.startup_warnings[0].count("lance cache unavailable") == 1
 
+    def test_pre_load_storage_mixed_causes_keep_real_error(self, cli):
+        scope_error = (
+            "error_code=410007, error_message=Invalid storage argument: "
+            "datasource is required for datasource-scoped storage"
+        )
+        cli.at_completer = SimpleNamespace(
+            reload_data=MagicMock(),
+            table_completer=SimpleNamespace(last_error=scope_error),
+            metric_completer=SimpleNamespace(last_error="lance cache unavailable"),
+            sql_completer=SimpleNamespace(last_error=None),
+        )
+
+        cli._pre_load_storage()
+
+        # Property: one completer's "no datasource selected" state must not
+        # relabel or swallow another completer's real failure.
+        assert len(cli.startup_warnings) == 1
+        assert "lance cache unavailable" in cli.startup_warnings[0]
+        assert "no datasource is selected" not in cli.startup_warnings[0]
+
     def test_pre_load_storage_embedding_error_keeps_embedding_remediation(self, cli):
         cli.at_completer = SimpleNamespace(
             reload_data=MagicMock(),
@@ -1849,7 +1869,8 @@ class TestCallWithTimeout:
 
 
 class TestInitConnectionTimeout:
-    def _wire(self, cli, *, connector=None, first_conn=None, missing=None):
+    def _wire(self, cli, *, connector=None, first_conn=None, missing=None, install_status=None):
+        from datus.tools.db_tools.db_manager import AdapterInstallStatus
         from datus.utils.constants import DBType
 
         if connector is None:
@@ -1859,10 +1880,12 @@ class TestInitConnectionTimeout:
                 catalog_name=None,
                 test_connection=MagicMock(return_value=True),
             )
+        status = install_status or AdapterInstallStatus.NOT_ATTEMPTED
         cli.agent_config = SimpleNamespace(current_datasource="ds1")
         cli.db_manager = SimpleNamespace(
             first_conn_with_name=first_conn or (lambda ds: ("demo_db", connector)),
             missing_connector_type=lambda ds: missing,
+            adapter_install_status=lambda db_type: status,
         )
         return connector
 
@@ -1939,3 +1962,61 @@ class TestInitConnectionTimeout:
         cli._init_connection(timeout_seconds=5)
 
         assert "Installing" not in _console_text(cli)
+
+    def test_failed_install_reports_manual_command_not_installing(self, cli):
+        from datus.tools.db_tools.db_manager import AdapterInstallStatus
+
+        def _fail(ds):
+            raise RuntimeError("Connector 'oracle' not found")
+
+        self._wire(cli, first_conn=_fail, missing="oracle", install_status=AdapterInstallStatus.FAILED)
+
+        cli._init_connection(timeout_seconds=5)
+
+        output = _console_text(cli)
+        # Property: once the process-wide memo says the install failed, the
+        # REPL must not claim an install is happening — it must hand the user
+        # the manual command instead.
+        assert "Installing" not in output
+        assert "uv pip install datus-oracle" in output
+
+    def test_in_progress_install_announced_as_waiting(self, cli):
+        from datus.tools.db_tools.db_manager import AdapterInstallStatus
+
+        self._wire(cli, missing="oracle", install_status=AdapterInstallStatus.INSTALLING)
+
+        cli._init_connection(timeout_seconds=5)
+
+        output = _console_text(cli)
+        assert "still installing" in output
+        assert "Installing database adapter" not in output
+
+    def test_timeout_during_install_blames_install_not_server(self, cli):
+        import time as time_mod
+
+        def _stuck(ds):
+            time_mod.sleep(4)
+            return ("db", MagicMock())
+
+        self._wire(cli, first_conn=_stuck, missing="oracle")
+
+        cli._init_connection(timeout_seconds=0.5)
+
+        output = _console_text(cli)
+        # Property: when an adapter install was just announced, the timeout
+        # must not be misdiagnosed as an unreachable database server.
+        assert "install may still be running" in output
+        assert "running and accessible" not in output
+
+    def test_timeout_without_install_keeps_server_message(self, cli):
+        import time as time_mod
+
+        def _stuck(ds):
+            time_mod.sleep(4)
+            return ("db", MagicMock())
+
+        self._wire(cli, first_conn=_stuck, missing=None)
+
+        cli._init_connection(timeout_seconds=0.5)
+
+        assert "running and accessible" in _console_text(cli)

--- a/tests/unit_tests/storage/test_embedding_diagnostics.py
+++ b/tests/unit_tests/storage/test_embedding_diagnostics.py
@@ -1,0 +1,61 @@
+"""Unit tests for embedding_diagnostics classification and formatting helpers."""
+
+from datus.storage.embedding_diagnostics import (
+    format_context_unavailable,
+    is_datasource_scope_error,
+)
+
+# The exact shape produced by datasource_scope.resolve_datasource_id when no
+# datasource is selected — the bug this guards against surfaced this string
+# wrapped in an "embedding model is unavailable" warning.
+DATASOURCE_SCOPE_ERROR = (
+    "error_code=410007, error_message=Invalid storage argument: datasource is required for datasource-scoped storage"
+)
+
+
+class TestIsDatasourceScopeError:
+    def test_matches_resolve_datasource_id_error(self):
+        assert is_datasource_scope_error(DATASOURCE_SCOPE_ERROR) is True
+
+    def test_matches_exception_instances(self):
+        assert is_datasource_scope_error(RuntimeError(DATASOURCE_SCOPE_ERROR)) is True
+
+    def test_rejects_none_and_empty(self):
+        assert is_datasource_scope_error(None) is False
+        assert is_datasource_scope_error("") is False
+
+    def test_rejects_other_storage_invalid_argument_errors(self):
+        # Same 410007 code, different cause — must not classify as "no datasource".
+        assert is_datasource_scope_error("error_code=410007: business id is required to build storage_key") is False
+
+    def test_rejects_embedding_errors(self):
+        assert is_datasource_scope_error("error_code=300019 embedding download failed") is False
+
+
+class TestFormatContextUnavailable:
+    def test_embedding_error_keeps_embedding_remediation(self):
+        message = format_context_unavailable("error_code=300019: embedding download failed")
+        assert "embedding model is unavailable" in message
+        assert "Hugging Face" in message
+
+    def test_datasource_error_never_blames_embeddings(self):
+        message = format_context_unavailable(DATASOURCE_SCOPE_ERROR)
+        assert "embedding" not in message.lower()
+        assert "Hugging Face" not in message
+        assert "no datasource is selected" in message
+
+    def test_generic_error_keeps_details_without_embedding_remediation(self):
+        message = format_context_unavailable("lance table corrupted")
+        assert "Context search and @ references are disabled" in message
+        assert "lance table corrupted" in message
+        assert "embedding" not in message.lower()
+        assert "Hugging Face" not in message
+
+    def test_exception_instances_accepted(self):
+        message = format_context_unavailable(RuntimeError(DATASOURCE_SCOPE_ERROR))
+        assert "no datasource is selected" in message
+
+    def test_none_yields_generic_message_without_details(self):
+        message = format_context_unavailable(None)
+        assert "Context search and @ references are disabled" in message
+        assert "Details:" not in message

--- a/tests/unit_tests/storage/test_embedding_diagnostics.py
+++ b/tests/unit_tests/storage/test_embedding_diagnostics.py
@@ -32,6 +32,49 @@ class TestIsDatasourceScopeError:
         assert is_datasource_scope_error("error_code=300019 embedding download failed") is False
 
 
+class TestFormatContextUnavailableMany:
+    EMBEDDING_ERROR = "error_code=300019: embedding download failed"
+    GENERIC_ERROR = "lance table corrupted"
+
+    def test_mixed_causes_get_neutral_headline_with_all_details(self):
+        from datus.storage.embedding_diagnostics import format_context_unavailable_many
+
+        message = format_context_unavailable_many([self.EMBEDDING_ERROR, self.GENERIC_ERROR])
+        # Property: one member's marker must not relabel the whole batch.
+        assert "embedding model is unavailable" not in message
+        assert "Hugging Face" not in message
+        assert self.EMBEDDING_ERROR in message
+        assert self.GENERIC_ERROR in message
+
+    def test_uniform_embedding_batch_keeps_embedding_remediation(self):
+        from datus.storage.embedding_diagnostics import format_context_unavailable_many
+
+        message = format_context_unavailable_many([self.EMBEDDING_ERROR, "error_code=300019: cache gone"])
+        assert "embedding model is unavailable" in message
+        assert "Hugging Face" in message
+
+    def test_uniform_scope_batch_keeps_datasource_hint(self):
+        from datus.storage.embedding_diagnostics import format_context_unavailable_many
+
+        message = format_context_unavailable_many([DATASOURCE_SCOPE_ERROR, f"prefix; {DATASOURCE_SCOPE_ERROR}"])
+        assert "no datasource is selected" in message
+
+    def test_single_error_matches_single_classifier(self):
+        from datus.storage.embedding_diagnostics import (
+            format_context_unavailable,
+            format_context_unavailable_many,
+        )
+
+        assert format_context_unavailable_many([self.GENERIC_ERROR]) == format_context_unavailable(self.GENERIC_ERROR)
+
+    def test_empty_batch_yields_generic_message(self):
+        from datus.storage.embedding_diagnostics import format_context_unavailable_many
+
+        message = format_context_unavailable_many([])
+        assert "Context search and @ references are disabled" in message
+        assert "Details:" not in message
+
+
 class TestFormatContextUnavailable:
     def test_embedding_error_keeps_embedding_remediation(self):
         message = format_context_unavailable("error_code=300019: embedding download failed")

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -668,11 +668,13 @@ class TestAutoInstallAdapterSingleFlight:
         from datus.tools.db_tools import db_manager as dm
 
         dm._adapter_install_attempted.clear()
+        dm._adapter_install_active.clear()
 
     def teardown_method(self):
         from datus.tools.db_tools import db_manager as dm
 
         dm._adapter_install_attempted.clear()
+        dm._adapter_install_active.clear()
 
     def test_concurrent_callers_spawn_one_install(self):
         import threading
@@ -681,27 +683,35 @@ class TestAutoInstallAdapterSingleFlight:
 
         entered = threading.Event()
         release = threading.Event()
+        errors = []
 
         def fake_run(*args, **kwargs):
             entered.set()
-            release.wait(timeout=5)
+            release.wait(timeout=1)
             return SimpleNamespace(returncode=1, stderr="simulated failure")
 
+        def _install():
+            try:
+                dm._auto_install_adapter("faketype")
+            except Exception as exc:  # noqa: BLE001 - surfaced via the errors list
+                errors.append(exc)
+
         with patch("subprocess.run", side_effect=fake_run) as mock_run:
-            first = threading.Thread(target=dm._auto_install_adapter, args=("faketype",))
+            first = threading.Thread(target=_install)
             first.start()
-            assert entered.wait(timeout=5)
-            second = threading.Thread(target=dm._auto_install_adapter, args=("faketype",))
+            assert entered.wait(timeout=1)
+            second = threading.Thread(target=_install)
             second.start()
             # Property: the second caller must wait on the first install, not
             # race a duplicate pip process against the same environment.
             second.join(timeout=0.3)
             assert second.is_alive()
             release.set()
-            first.join(timeout=5)
-            second.join(timeout=5)
-            assert not first.is_alive() and not second.is_alive()
+            first.join(timeout=2)
+            second.join(timeout=2)
+            assert not first.is_alive() and not second.is_alive(), "deadlock guard"
 
+        assert not errors
         assert mock_run.call_count == 1
 
     def test_failed_install_not_retried_within_process(self):
@@ -721,6 +731,86 @@ class TestAutoInstallAdapterSingleFlight:
             dm._auto_install_adapter("faketype_b")
 
         assert mock_run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# adapter_install_status
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterInstallStatus:
+    def setup_method(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        dm._adapter_install_attempted.clear()
+        dm._adapter_install_active.clear()
+
+    def teardown_method(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        dm._adapter_install_attempted.clear()
+        dm._adapter_install_active.clear()
+
+    def test_not_attempted_initially(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.NOT_ATTEMPTED
+
+    def test_failed_after_unsuccessful_install(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        with patch("subprocess.run", return_value=SimpleNamespace(returncode=1, stderr="no such package")):
+            dm._auto_install_adapter("faketype")
+
+        assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.FAILED
+
+    def test_installing_while_subprocess_runs_then_failed(self):
+        import threading
+
+        from datus.tools.db_tools import db_manager as dm
+
+        entered = threading.Event()
+        release = threading.Event()
+        errors = []
+
+        def fake_run(*args, **kwargs):
+            entered.set()
+            release.wait(timeout=1)
+            return SimpleNamespace(returncode=1, stderr="simulated failure")
+
+        def _install():
+            try:
+                dm._auto_install_adapter("faketype")
+            except Exception as exc:  # noqa: BLE001 - surfaced via the errors list
+                errors.append(exc)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            worker = threading.Thread(target=_install)
+            worker.start()
+            assert entered.wait(timeout=1)
+            assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.INSTALLING
+            release.set()
+            worker.join(timeout=2)
+            assert not worker.is_alive(), "deadlock guard"
+
+        assert not errors
+        assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.FAILED
+
+    def test_active_marker_cleared_when_install_raises(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        with patch("subprocess.run", side_effect=RuntimeError("boom")):
+            dm._auto_install_adapter("faketype")
+
+        # The finally block must clear the active marker so the state never
+        # sticks at INSTALLING after the subprocess is gone.
+        assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.FAILED
+
+    def test_dbmanager_method_delegates_to_process_state(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        mgr = DBManager({})
+        assert mgr.adapter_install_status("faketype") is dm.AdapterInstallStatus.NOT_ATTEMPTED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -687,7 +687,7 @@ class TestAutoInstallAdapterSingleFlight:
 
         def fake_run(*args, **kwargs):
             entered.set()
-            release.wait(timeout=1)
+            release.wait(timeout=3)
             return SimpleNamespace(returncode=1, stderr="simulated failure")
 
         def _install():
@@ -775,7 +775,7 @@ class TestAdapterInstallStatus:
 
         def fake_run(*args, **kwargs):
             entered.set()
-            release.wait(timeout=1)
+            release.wait(timeout=3)
             return SimpleNamespace(returncode=1, stderr="simulated failure")
 
         def _install():
@@ -811,6 +811,16 @@ class TestAdapterInstallStatus:
 
         mgr = DBManager({})
         assert mgr.adapter_install_status("faketype") is dm.AdapterInstallStatus.NOT_ATTEMPTED
+
+    def test_registered_wins_over_attempted_memo(self):
+        # Property: the status is self-contained — once the connector is
+        # registered (e.g. a concurrent caller's install just succeeded), the
+        # permanent "attempted" memo must not be read as a failure.
+        from datus.tools.db_tools import db_manager as dm
+
+        dm._adapter_install_attempted.add("faketype")
+        with patch("datus.tools.db_tools.db_manager.connector_registry.is_registered", return_value=True):
+            assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.REGISTERED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -656,3 +656,107 @@ class TestDbManagerInstanceCaching:
         a = db_manager_instance({"ds_a": _cfg(type="sqlite", database="db")})
         b = db_manager_instance({"ds_b": _cfg(type="sqlite", database="db")})
         assert a is not b
+
+
+# ---------------------------------------------------------------------------
+# _auto_install_adapter single-flight
+# ---------------------------------------------------------------------------
+
+
+class TestAutoInstallAdapterSingleFlight:
+    def setup_method(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        dm._adapter_install_attempted.clear()
+
+    def teardown_method(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        dm._adapter_install_attempted.clear()
+
+    def test_concurrent_callers_spawn_one_install(self):
+        import threading
+
+        from datus.tools.db_tools import db_manager as dm
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def fake_run(*args, **kwargs):
+            entered.set()
+            release.wait(timeout=5)
+            return SimpleNamespace(returncode=1, stderr="simulated failure")
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            first = threading.Thread(target=dm._auto_install_adapter, args=("faketype",))
+            first.start()
+            assert entered.wait(timeout=5)
+            second = threading.Thread(target=dm._auto_install_adapter, args=("faketype",))
+            second.start()
+            # Property: the second caller must wait on the first install, not
+            # race a duplicate pip process against the same environment.
+            second.join(timeout=0.3)
+            assert second.is_alive()
+            release.set()
+            first.join(timeout=5)
+            second.join(timeout=5)
+            assert not first.is_alive() and not second.is_alive()
+
+        assert mock_run.call_count == 1
+
+    def test_failed_install_not_retried_within_process(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        with patch("subprocess.run", return_value=SimpleNamespace(returncode=1, stderr="no such package")) as mock_run:
+            dm._auto_install_adapter("faketype")
+            dm._auto_install_adapter("faketype")
+
+        assert mock_run.call_count == 1
+
+    def test_distinct_types_install_independently(self):
+        from datus.tools.db_tools import db_manager as dm
+
+        with patch("subprocess.run", return_value=SimpleNamespace(returncode=1, stderr="no such package")) as mock_run:
+            dm._auto_install_adapter("faketype_a")
+            dm._auto_install_adapter("faketype_b")
+
+        assert mock_run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# DBManager.missing_connector_type
+# ---------------------------------------------------------------------------
+
+
+class TestMissingConnectorType:
+    def test_registered_type_returns_none(self):
+        mgr = DBManager({"ds": _cfg(type="sqlite", database="db")})
+        assert mgr.missing_connector_type("ds") is None
+
+    def test_unregistered_type_returned(self):
+        mgr = DBManager({"ds": _cfg(type="nonexistent_db_xyz")})
+        assert mgr.missing_connector_type("ds") == "nonexistent_db_xyz"
+
+    def test_unknown_datasource_returns_none(self):
+        mgr = DBManager({})
+        assert mgr.missing_connector_type("nope") is None
+
+    def test_empty_type_returns_none(self):
+        mgr = DBManager({"ds": _cfg(type=None)})
+        assert mgr.missing_connector_type("ds") is None
+
+    def test_alias_normalized_before_registry_lookup(self):
+        mgr = DBManager({"ds": _cfg(type="postgres")})
+        with patch(
+            "datus.tools.db_tools.db_manager.connector_registry.is_registered", return_value=False
+        ) as mock_registered:
+            assert mgr.missing_connector_type("ds") == "postgresql"
+        mock_registered.assert_called_once_with("postgresql")
+
+    def test_probe_never_triggers_auto_install(self):
+        # Contract: the probe is metadata-only. The REPL calls it before the
+        # banner; a pip install here would reintroduce the silent startup hang.
+        mgr = DBManager({"ds": _cfg(type="nonexistent_db_xyz")})
+        with patch("datus.tools.db_tools.db_manager._auto_install_adapter") as mock_install:
+            mgr.missing_connector_type("ds")
+        mock_install.assert_not_called()

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -723,6 +723,27 @@ class TestAutoInstallAdapterSingleFlight:
 
         assert mock_run.call_count == 1
 
+    def test_manual_install_takes_effect_without_new_subprocess(self):
+        # Property: the once-per-process memo guards only the pip subprocess.
+        # After a failed auto-install, a later attempt must still retry the
+        # cheap import + register so a manual `pip install datus-<type>` in
+        # the running session becomes usable — without spawning pip again.
+        from datus.tools.db_tools import db_manager as dm
+
+        with patch("subprocess.run", return_value=SimpleNamespace(returncode=1, stderr="no such package")) as mock_run:
+            dm._auto_install_adapter("faketype")
+        assert mock_run.call_count == 1
+
+        fake_module = SimpleNamespace(register=MagicMock())
+        with (
+            patch("subprocess.run") as mock_run_again,
+            patch("importlib.import_module", return_value=fake_module),
+        ):
+            dm._auto_install_adapter("faketype")
+
+        mock_run_again.assert_not_called()
+        fake_module.register.assert_called_once_with()
+
     def test_distinct_types_install_independently(self):
         from datus.tools.db_tools import db_manager as dm
 

--- a/tests/unit_tests/tools/db_tools/test_db_manager.py
+++ b/tests/unit_tests/tools/db_tools/test_db_manager.py
@@ -727,22 +727,33 @@ class TestAutoInstallAdapterSingleFlight:
         # Property: the once-per-process memo guards only the pip subprocess.
         # After a failed auto-install, a later attempt must still retry the
         # cheap import + register so a manual `pip install datus-<type>` in
-        # the running session becomes usable — without spawning pip again.
+        # the running session leaves the adapter genuinely usable — observable
+        # through the connector registry, which is what the REPL and
+        # _build_conn read — without spawning pip again.
+        from datus_db_core import connector_registry
+
         from datus.tools.db_tools import db_manager as dm
 
         with patch("subprocess.run", return_value=SimpleNamespace(returncode=1, stderr="no such package")) as mock_run:
             dm._auto_install_adapter("faketype")
         assert mock_run.call_count == 1
+        assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.FAILED
 
-        fake_module = SimpleNamespace(register=MagicMock())
-        with (
-            patch("subprocess.run") as mock_run_again,
-            patch("importlib.import_module", return_value=fake_module),
-        ):
-            dm._auto_install_adapter("faketype")
+        # The fake module registers a real (test-scoped) connector, like an
+        # actual datus_<type> package's register() would.
+        fake_module = SimpleNamespace(register=lambda: connector_registry.register("faketype", MagicMock))
+        try:
+            with (
+                patch("subprocess.run") as mock_run_again,
+                patch("importlib.import_module", return_value=fake_module),
+            ):
+                dm._auto_install_adapter("faketype")
 
-        mock_run_again.assert_not_called()
-        fake_module.register.assert_called_once_with()
+            mock_run_again.assert_not_called()
+            assert dm.adapter_install_status("faketype") is dm.AdapterInstallStatus.REGISTERED
+        finally:
+            for attr in ("_connectors", "_factories", "_metadata", "_capabilities"):
+                getattr(connector_registry, attr, {}).pop("faketype", None)
 
     def test_distinct_types_install_independently(self):
         from datus.tools.db_tools import db_manager as dm


### PR DESCRIPTION
## Why

Running bare `datus` with a default datasource whose DB adapter is not installed froze the terminal on a black screen for ~90 seconds (observed with an oracle datasource and no `datus-oracle`):

1. `_init_connection`'s 30s timeout was defeated. `future.result(timeout=...)` raised on time, but the `with ThreadPoolExecutor` exit calls `shutdown(wait=True)`, which joins the stuck worker anyway — startup stayed blocked for the worker's full runtime.
2. The worker was stuck inside a silent, blocking `pip install datus-oracle` (up to 120s) that the adapter auto-install runs before the banner is printed, with no UI feedback at all.
3. Two startup paths (REPL connection init and the background schema sync) raced duplicate `uv pip install` processes against the same environment.
4. Separately, every context-search preload failure was wrapped in a hardcoded "embedding model is unavailable … configure a Hugging Face proxy or mirror" warning, even when the real cause was simply "no datasource selected" (`error_code=410007`) — the same mislabeling later reproduced on SaaS with an unrelated storage error.

## Solution

Three commits, layered:

**Unblock startup (`1780dacf6`)**
- Replace both `ThreadPoolExecutor` blocks in `_init_connection` with `_call_with_timeout`: an abandonable daemon-thread helper. On expiry the caller returns immediately; the abandoned worker's connector (when it eventually succeeds) lands in the `DBManager` pool and is reused on the next reconnect.
- `DBManager.missing_connector_type()` — a metadata-only probe — lets the REPL announce a pending adapter install before the blocking attempt, so the wait is visible instead of a frozen screen.
- `_auto_install_adapter` is single-flight and once-per-process: concurrent callers wait on one install instead of racing duplicate pip processes; a failed install is not retried on every connection attempt. The lock is deliberately process-global (concurrent pip runs mutate one environment).
- `format_context_unavailable()` classifies before formatting: embedding failures keep the Hugging Face remediation, "no datasource selected" becomes a dim hint instead of a warning, anything else gets a neutral message with the real error attached. Applied at all three call sites (REPL preload, agentic node, API tool service).

**Make install-state a single source of truth (`dfeda240f`)**
- `AdapterInstallStatus` exposes the process-wide install state (`NOT_ATTEMPTED` / `INSTALLING` / `FAILED`), so the pre-connect notice, the timeout wording, and reconnect messaging all read one fact instead of guessing: a failed install is announced with a manual install command rather than a fake "Installing…", and a timeout during a pending install blames the install, not the database server.
- Completer preload errors are deduplicated and classified per-error: one completer's "no datasource selected" no longer relabels another completer's real failure.

**Second review pass (`a240be724`)**
- `adapter_install_status` consults the connector registry first and reports `REGISTERED`, making the status self-contained — a concurrently completed install can no longer be read as `FAILED` through the permanent "attempted" memo; the installer marks `active` before `attempted` so lock-free readers never observe a false failure window.
- `format_context_unavailable_many()` classifies batches per-error: a cause-specific headline applies only when every error shares that cause.
- Consistency: manual-install hint says `pip install datus-X` (matching every doc and hint in the repo; uv may be absent), `AdapterInstallStatus` is a `StrEnum` (PR #1001 convention), `_init_connection` errors route through `print_error`, concurrency-test guard timeouts widened against CI jitter.

## Test Cases

New/updated unit tests (mirrored paths): `tests/unit_tests/cli/test_repl.py` (timeout helper semantics; `_init_connection` wall-clock bound, status-aware messages for all four states, install-aware vs server-blaming timeout wording; preload classification incl. mixed-cause batches), `tests/unit_tests/tools/db_tools/test_db_manager.py` (single-flight concurrency with shared-errors/deadlock guards, install-status state machine incl. REGISTERED-wins-over-memo, metadata-only probe contract), and new `tests/unit_tests/storage/test_embedding_diagnostics.py` (classification matrix for single errors and batches).

**Red-first verified** (per commit, by stashing the implementation and rerunning): the timeout test fails on pre-fix code by blocking ~4s past its bound; the classification tests fail with the embedding-blame wording; the messaging tests fail with the wrong announcements; the status-API tests fail on the missing symbols. Details in each commit message.

Gates: `ci/run-pr-tests.py upstream/main` — 9258 passed / 0 failed, diff coverage 98%; `ci/audit_tests.py` P0=0; `tests/integration/cli/test_cli_commands.py` 6 passed. No integration tests added: the changed behavior (thread-timeout semantics, message wording, warning classification) is deterministic and fully exercised at unit level; `test_regression_web_e2e.py` is nightly-tier and unaffected in interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-search diagnostics by distinguishing unavailable embeddings, missing datasource selection, and other failures.
  * Prevented connection timeouts and failed operations from blocking CLI shutdown.
  * Reduced duplicate autocomplete warnings and clarified datasource-related hints.

* **Improvements**
  * Added clearer adapter installation status and connection messages.
  * Coordinated adapter installations to avoid duplicate attempts during concurrent operations.
  * Expanded automated coverage for diagnostics, timeouts, autocomplete, and adapter installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-search diagnostics for missing embeddings, datasource selection, and other failures.
  * Prevented connection timeouts and failed operations from blocking CLI shutdown.
  * Reduced duplicate autocomplete warnings and clarified datasource-related hints.

* **Improvements**
  * Added adapter installation statuses, clearer connection messages, and reconnect guidance after manual installation.
  * Coordinated concurrent adapter installations and enabled adapter recovery without restarting.
  * Expanded automated coverage for diagnostics, timeouts, autocomplete, and adapter installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->