### PR TITLE
[Feature] Emit native v1 benchmark trajectories

### DIFF
--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -36,6 +36,7 @@ from datus.storage.semantic_model.semantic_model_init import (
 from datus.storage.semantic_model.semantic_modeling_init import init_success_story_semantic_modeling
 from datus.tools.db_tools.db_manager import DBManager, db_manager_instance
 from datus.utils.benchmark_artifacts import allocate_benchmark_attempt, finalize_benchmark_attempt
+from datus.utils.benchmark_trajectory import write_benchmark_trajectory
 from datus.utils.benchmark_utils import load_benchmark_tasks
 from datus.utils.exceptions import DatusException, ErrorCode
 from datus.utils.json_utils import to_str
@@ -191,6 +192,19 @@ class Agent:
         runner = self.create_workflow_runner(check_db=check_db, run_id=run_id)
         return runner.run(sql_task=sql_task, check_storage=check_storage)
 
+    def _write_benchmark_trajectory(self, attempt, workflow, exception=None):
+        """Write the native v1 trajectory; return its path or None on failure."""
+        try:
+            return write_benchmark_trajectory(
+                attempt,
+                workflow=workflow,
+                agent_config=self.global_config,
+                exception=exception,
+            )
+        except Exception:
+            logger.exception("Failed to write benchmark trajectory for task %s", attempt.task_id)
+            return None
+
     def _run_benchmark_task(
         self,
         sql_task: SqlTask,
@@ -221,25 +235,29 @@ class Agent:
         try:
             result = runner.run(sql_task=benchmark_task, check_storage=check_storage)
         except Exception as exc:
+            trajectory_path = self._write_benchmark_trajectory(attempt, runner.workflow, exception=exc)
             try:
                 finalize_benchmark_attempt(
                     attempt,
                     task=benchmark_task,
                     workflow=runner.workflow,
-                    trajectory_path=runner.last_run_metadata.get("save_path"),
+                    trajectory_path=trajectory_path,
                     agent_config=self.global_config,
                     exception=exc,
+                    trajectory_profile="native_v1",
                 )
             except Exception:
                 logger.exception("Failed to finalize benchmark failure manifest for task %s", benchmark_task.id)
             raise
 
+        trajectory_path = self._write_benchmark_trajectory(attempt, runner.workflow)
         manifest_path = finalize_benchmark_attempt(
             attempt,
             task=benchmark_task,
             workflow=runner.workflow,
-            trajectory_path=runner.last_run_metadata.get("save_path"),
+            trajectory_path=trajectory_path,
             agent_config=self.global_config,
+            trajectory_profile="native_v1",
         )
         logger.info(
             "Benchmark task %s attempt %s manifest saved to %s",

--- a/datus/agent/agent.py
+++ b/datus/agent/agent.py
@@ -250,7 +250,32 @@ class Agent:
                 logger.exception("Failed to finalize benchmark failure manifest for task %s", benchmark_task.id)
             raise
 
-        trajectory_path = self._write_benchmark_trajectory(attempt, runner.workflow)
+        try:
+            trajectory_path = write_benchmark_trajectory(
+                attempt,
+                workflow=runner.workflow,
+                agent_config=self.global_config,
+            )
+        except Exception as exc:
+            # A completed native_v1 manifest must reference its trajectory, so a
+            # persistence failure fails the attempt instead of dropping the link.
+            try:
+                finalize_benchmark_attempt(
+                    attempt,
+                    task=benchmark_task,
+                    workflow=runner.workflow,
+                    trajectory_path=None,
+                    agent_config=self.global_config,
+                    exception=exc,
+                    trajectory_profile="native_v1",
+                )
+            except Exception:
+                logger.exception("Failed to finalize benchmark failure manifest for task %s", benchmark_task.id)
+            raise DatusException(
+                ErrorCode.COMMON_UNKNOWN,
+                message=f"benchmark trajectory persistence failed for task {benchmark_task.id}",
+            ) from exc
+
         manifest_path = finalize_benchmark_attempt(
             attempt,
             task=benchmark_task,

--- a/datus/agent/workflow_runner.py
+++ b/datus/agent/workflow_runner.py
@@ -134,12 +134,14 @@ class WorkflowRunner:
                 f"span_id={trace_reference.span_id} provider={trace_reference.provider}"
             )
 
-        save_path = f"{trajectory_dir}/{file_name}_{timestamp}.yaml"
         if artifact_profile == "benchmark_v1":
-            self.workflow.save(save_path, schema_version=1)
+            # The benchmark attempt finalizer writes the native v1 trajectory;
+            # skip the compatibility envelope to avoid a duplicated payload.
+            save_path = None
         else:
+            save_path = f"{trajectory_dir}/{file_name}_{timestamp}.yaml"
             self.workflow.save(save_path)
-        logger.info(f"Workflow saved to {save_path}")
+            logger.info(f"Workflow saved to {save_path}")
         final_result = self.workflow.get_final_result()
         logger.info(f"Workflow execution completed. Steps:{step_count}")
 

--- a/datus/utils/benchmark_artifacts.py
+++ b/datus/utils/benchmark_artifacts.py
@@ -432,6 +432,7 @@ def finalize_benchmark_attempt(
     trajectory_path: Optional[Path | str],
     agent_config: Any,
     exception: Optional[BaseException] = None,
+    trajectory_profile: str = "compatibility_v1",
 ) -> Path:
     """Write the authoritative manifest, then refresh legacy flat aliases."""
     completed_at = _utc_now()
@@ -476,7 +477,7 @@ def finalize_benchmark_attempt(
                 "path": _relative_posix(trajectory_file, attempt.trajectory_run_root),
                 "format": "yaml",
                 "schema_version": 1,
-                "contract_profile": "compatibility_v1",
+                "contract_profile": trajectory_profile,
                 "attempt_id": attempt.attempt_id,
             }
 

--- a/datus/utils/benchmark_trajectory.py
+++ b/datus/utils/benchmark_trajectory.py
@@ -1,0 +1,341 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Native v1 benchmark trajectory artifacts.
+
+Builds the consumer-contract trajectory envelope (``artifact_type: trajectory``,
+``schema_version: 1``) from an executed workflow: identity and lifecycle fields,
+aggregate model/usage, a deduplicated table-schema registry with per-node
+references, normalized per-node timing/actions/errors, and a trace reference.
+The contract lives in ``datus-benchmark`` (``contracts/v1/trajectory.schema.json``).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import yaml
+
+from datus.utils.benchmark_artifacts import (
+    BenchmarkAttempt,
+    _aggregate_usage,
+    _as_mapping,
+    _model_identity,
+    _node_sequence,
+    _node_usage,
+    _rfc3339,
+    _structured_error,
+    _utc_now,
+)
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+TRAJECTORY_ARTIFACT_TYPE = "trajectory"
+TRAJECTORY_SCHEMA_VERSION = 1
+
+# Node statuses the contract accepts; anything else has not durably executed.
+_CONTRACT_NODE_STATUSES = {"running", "completed", "failed"}
+
+
+def _epoch_rfc3339(value: Any) -> Optional[str]:
+    """Render an epoch-seconds timestamp as RFC 3339, or ``None`` when unset."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        return None
+    return _rfc3339(datetime.fromtimestamp(float(value), tz=timezone.utc))
+
+
+def _node_duration_seconds(node: Any) -> Optional[float]:
+    """Duration between a node's start/end epoch timestamps when both exist."""
+    start = getattr(node, "start_time", None)
+    end = getattr(node, "end_time", None)
+    if isinstance(start, (int, float)) and isinstance(end, (int, float)) and end >= start > 0:
+        return float(end) - float(start)
+    return None
+
+
+def _schema_key(identifier: str) -> str:
+    """Stable registry key for one table schema body."""
+    return f"table:{identifier}"
+
+
+def _iter_table_schemas(container: Any) -> list[Mapping[str, Any]]:
+    """Collect table-schema mappings from a node input/result-like object."""
+    data = _as_mapping(container)
+    entries = data.get("table_schemas")
+    if not isinstance(entries, list):
+        return []
+    collected = []
+    for entry in entries:
+        entry_data = _as_mapping(entry)
+        if entry_data.get("definition") and (entry_data.get("identifier") or entry_data.get("table_name")):
+            collected.append(entry_data)
+    return collected
+
+
+def _register_schema(registry: dict[str, dict[str, Any]], entry: Mapping[str, Any]) -> str:
+    """Store one schema body once and return its registry key."""
+    identifier = str(entry.get("identifier") or entry.get("table_name"))
+    key = _schema_key(identifier)
+    if key not in registry:
+        metadata = {
+            field: value
+            for field, value in entry.items()
+            if field not in {"identifier", "definition"} and isinstance(value, (str, int, float, bool))
+        }
+        registry[key] = {
+            "identifier": identifier,
+            "ddl": str(entry["definition"]),
+            "metadata": metadata,
+        }
+    return key
+
+
+def _action_content(entry: Mapping[str, Any]) -> Any:
+    """Extract the action payload the consumer reads from ``content`` directly.
+
+    Collapses the historical ``output.raw_output.result`` / ``output.result`` /
+    raw ``output`` probing into the single native shape.
+    """
+    content = entry.get("content")
+    if content is not None:
+        return content
+    output = entry.get("output")
+    output_data = _as_mapping(output)
+    if output_data:
+        raw_output = _as_mapping(output_data.get("raw_output"))
+        if "result" in raw_output:
+            return raw_output.get("result")
+        if "result" in output_data:
+            return output_data.get("result")
+        return dict(output_data)
+    return output
+
+
+def _normalize_action(entry: Any) -> Optional[dict[str, Any]]:
+    """Normalize one action-history entry into the native action shape."""
+    data = _as_mapping(entry)
+    if not data:
+        return None
+    action: dict[str, Any] = {
+        "role": str(data.get("role") or "workflow"),
+        "status": str(data.get("status") or "completed"),
+        "content": _action_content(data),
+    }
+    name = data.get("tool_name") or data.get("name") or data.get("action_type")
+    if name:
+        action["name"] = str(name)
+    error = data.get("error")
+    if error:
+        action["error"] = str(error)
+    usage = _as_mapping(data.get("output")).get("usage")
+    if isinstance(usage, Mapping) and usage:
+        action["usage"] = dict(usage)
+    return action
+
+
+def _node_error(node: Any) -> Optional[dict[str, Any]]:
+    """Structured error for a failed node, or ``None``."""
+    if str(getattr(node, "status", "")) != "failed":
+        return None
+    result_error = getattr(getattr(node, "result", None), "error", None)
+    node_type = str(getattr(node, "type", "") or "unknown")
+    return {
+        "type": "node_failure",
+        "message": str(result_error) or f"Benchmark node {getattr(node, 'id', node_type)} failed",
+        "code": None,
+        "retryable": None,
+        "details": {"node_type": node_type},
+    }
+
+
+def _build_node_payload(
+    node: Any,
+    schemas: dict[str, dict[str, Any]],
+    agent_config: Any,
+    fallback_started_at: str,
+) -> dict[str, Any]:
+    """Serialize one executed node without inlining schema bodies."""
+    result = getattr(node, "result", None)
+    schema_refs: list[str] = []
+    for container in (getattr(node, "input", None), result):
+        for entry in _iter_table_schemas(container):
+            key = _register_schema(schemas, entry)
+            if key not in schema_refs:
+                schema_refs.append(key)
+
+    actions = []
+    action_history = _as_mapping(result).get("action_history") or []
+    if isinstance(action_history, list):
+        for entry in action_history:
+            action = _normalize_action(entry)
+            if action is not None:
+                actions.append(action)
+
+    execution_stats = _as_mapping(result).get("execution_stats")
+
+    # Planner-completed nodes (e.g. the start node) never call Node.start(), so
+    # backfill their start from the end timestamp or the attempt creation time.
+    started_at = _epoch_rfc3339(getattr(node, "start_time", None))
+    completed_at = _epoch_rfc3339(getattr(node, "end_time", None))
+    if started_at is None:
+        started_at = completed_at or fallback_started_at
+
+    return {
+        "id": str(getattr(node, "id", "") or "unknown"),
+        "type": str(getattr(node, "type", "") or "unknown"),
+        "status": str(getattr(node, "status", "") or "completed"),
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "duration_seconds": _node_duration_seconds(node),
+        "model": _model_identity_for_node(node, agent_config),
+        "usage": _node_usage(node),
+        "schema_refs": schema_refs,
+        "actions": actions,
+        "execution_stats": dict(execution_stats) if isinstance(execution_stats, Mapping) else {},
+        "error": _node_error(node),
+        "metadata": {},
+    }
+
+
+def _model_identity_for_node(node: Any, agent_config: Any) -> Optional[dict[str, Any]]:
+    """Model identity for one node only; ``None`` when the node ran no model."""
+    node_model = getattr(node, "model", None)
+    if getattr(node_model, "model_config", None) is None:
+        return None
+    single_node_workflow = type("_W", (), {"nodes": {"n": node}, "node_order": ["n"]})()
+    return _model_identity(single_node_workflow, agent_config)
+
+
+def _trace_reference(workflow: Any) -> dict[str, Any]:
+    """Trace reference from workflow metadata; empty when tracing was off."""
+    metadata = _as_mapping(getattr(workflow, "metadata", None))
+    trace_id = metadata.get("trace_id")
+    if not trace_id:
+        return {}
+    trace: dict[str, Any] = {"trace_id": str(trace_id)}
+    for source_key, target_key in (
+        ("trace_span_id", "span_id"),
+        ("trace_run_id", "run_id"),
+        ("trace_provider", "provider"),
+    ):
+        value = metadata.get(source_key)
+        if value:
+            trace[target_key] = str(value)
+    return trace
+
+
+def build_trajectory_payload(
+    attempt: BenchmarkAttempt,
+    *,
+    workflow: Any,
+    agent_config: Any,
+    exception: Optional[BaseException] = None,
+) -> dict[str, Any]:
+    """Build the schema-valid native v1 trajectory payload for one attempt."""
+    completed_at = _utc_now()
+    duration_seconds = max(0.0, time.monotonic() - attempt.started_monotonic)
+
+    schemas: dict[str, dict[str, Any]] = {}
+    created_at_text = _rfc3339(attempt.created_at)
+    nodes = [
+        _build_node_payload(node, schemas, agent_config, created_at_text)
+        for node in _node_sequence(workflow)
+        if str(getattr(node, "status", "")) in _CONTRACT_NODE_STATUSES
+    ]
+    # Workflow-context schemas repeat node schemas; register them so the
+    # registry stays complete even when node payloads were trimmed upstream.
+    for entry in _iter_table_schemas(getattr(workflow, "context", None)):
+        _register_schema(schemas, entry)
+
+    completed = exception is None and str(getattr(workflow, "status", "")) == "completed"
+    error = None if completed else _structured_error(workflow, exception, outputs_exist=True)
+    failure_types = [str(error["type"])] if error else []
+
+    return {
+        "artifact_type": TRAJECTORY_ARTIFACT_TYPE,
+        "schema_version": TRAJECTORY_SCHEMA_VERSION,
+        "run_id": attempt.run_id,
+        "task_id": attempt.task_id,
+        "attempt_id": attempt.attempt_id,
+        "status": "completed" if completed else "failed",
+        "partial": False,
+        "created_at": created_at_text,
+        "completed_at": _rfc3339(completed_at),
+        "duration_seconds": duration_seconds,
+        "model": _model_identity(workflow, agent_config),
+        "usage": _aggregate_usage(workflow),
+        "failure_types": failure_types,
+        "error": error,
+        "schemas": schemas,
+        "nodes": nodes,
+        "trace": _trace_reference(workflow),
+        "execution_stats": {
+            "total_nodes": len(nodes),
+            "completed_nodes": sum(1 for node in nodes if node["status"] == "completed"),
+        },
+        "metadata": {"capture_level": "standard"},
+    }
+
+
+class _TrajectoryDumper(yaml.SafeDumper):
+    """SafeDumper that keeps long SQL/DDL readable via block scalars."""
+
+
+def _str_representer(dumper: yaml.SafeDumper, value: str) -> yaml.ScalarNode:
+    """Represent multi-line strings as block scalars per the contract."""
+    if "\n" in value:
+        # Block scalars cannot carry trailing spaces on lines; normalize them.
+        cleaned = "\n".join(line.rstrip() for line in value.splitlines())
+        return dumper.represent_scalar("tag:yaml.org,2002:str", cleaned, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value)
+
+
+_TrajectoryDumper.add_representer(str, _str_representer)
+
+
+def trajectory_file_path(attempt: BenchmarkAttempt) -> Path:
+    """Deterministic trajectory path for one attempt (no timestamp authority)."""
+    return attempt.trajectory_run_root / f"task_{attempt.task_id}.{attempt.attempt_id}.yaml"
+
+
+def write_benchmark_trajectory(
+    attempt: BenchmarkAttempt,
+    *,
+    workflow: Any,
+    agent_config: Any,
+    exception: Optional[BaseException] = None,
+) -> Path:
+    """Atomically write the native v1 trajectory YAML and return its path."""
+    payload = build_trajectory_payload(
+        attempt,
+        workflow=workflow,
+        agent_config=agent_config,
+        exception=exception,
+    )
+    path = trajectory_file_path(attempt)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            yaml.dump(
+                payload,
+                handle,
+                Dumper=_TrajectoryDumper,
+                default_flow_style=False,
+                sort_keys=False,
+                allow_unicode=True,
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    return path

--- a/datus/utils/benchmark_trajectory.py
+++ b/datus/utils/benchmark_trajectory.py
@@ -289,11 +289,14 @@ class _TrajectoryDumper(yaml.SafeDumper):
 
 
 def _str_representer(dumper: yaml.SafeDumper, value: str) -> yaml.ScalarNode:
-    """Represent multi-line strings as block scalars per the contract."""
+    """Represent multi-line strings as block scalars per the contract.
+
+    The content is passed through unchanged; when a line carries trailing
+    whitespace the emitter falls back to a quoted style rather than mutate
+    the canonical SQL/DDL text.
+    """
     if "\n" in value:
-        # Block scalars cannot carry trailing spaces on lines; normalize them.
-        cleaned = "\n".join(line.rstrip() for line in value.splitlines())
-        return dumper.represent_scalar("tag:yaml.org,2002:str", cleaned, style="|")
+        return dumper.represent_scalar("tag:yaml.org,2002:str", value, style="|")
     return dumper.represent_scalar("tag:yaml.org,2002:str", value)
 
 

--- a/tests/fixtures/benchmark_artifacts/v1/trajectory.schema.json
+++ b/tests/fixtures/benchmark_artifacts/v1/trajectory.schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://datus.ai/schemas/benchmark-artifacts/v1/trajectory.schema.json",
+  "title": "Datus benchmark trajectory v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifact_type",
+    "schema_version",
+    "run_id",
+    "task_id",
+    "attempt_id",
+    "status",
+    "partial",
+    "created_at",
+    "completed_at",
+    "duration_seconds",
+    "model",
+    "usage",
+    "failure_types",
+    "error",
+    "schemas",
+    "nodes",
+    "trace",
+    "execution_stats",
+    "metadata"
+  ],
+  "properties": {
+    "artifact_type": {"const": "trajectory"},
+    "schema_version": {"const": 1},
+    "run_id": {"type": "string", "minLength": 1},
+    "task_id": {"type": "string", "minLength": 1},
+    "attempt_id": {"type": "string", "minLength": 1},
+    "status": {
+      "enum": ["pending", "running", "completed", "failed", "interrupted", "task_timeout"]
+    },
+    "partial": {"type": "boolean"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "completed_at": {
+      "oneOf": [
+        {"type": "string", "format": "date-time"},
+        {"type": "null"}
+      ]
+    },
+    "duration_seconds": {
+      "oneOf": [
+        {"type": "number", "minimum": 0},
+        {"type": "null"}
+      ]
+    },
+    "model": {"$ref": "#/$defs/nullableModel"},
+    "usage": {"$ref": "#/$defs/tokenUsage"},
+    "failure_types": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true
+    },
+    "error": {"$ref": "#/$defs/nullableError"},
+    "schemas": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/schemaEntry"}
+    },
+    "nodes": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/node"}
+    },
+    "trace": {"type": "object", "additionalProperties": true},
+    "execution_stats": {"type": "object", "additionalProperties": true},
+    "metadata": {"type": "object", "additionalProperties": true}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"status": {"const": "completed"}}},
+      "then": {
+        "properties": {
+          "partial": {"const": false},
+          "completed_at": {"type": "string", "format": "date-time"},
+          "error": {"type": "null"}
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "nullableModel": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "properties": {
+            "provider": {"type": ["string", "null"]},
+            "name": {"type": "string", "minLength": 1},
+            "configuration": {"type": "object", "additionalProperties": true}
+          }
+        },
+        {"type": "null"}
+      ]
+    },
+    "tokenUsage": {
+      "type": "object",
+      "additionalProperties": {"type": "integer", "minimum": 0},
+      "properties": {
+        "input_tokens": {"type": "integer", "minimum": 0},
+        "output_tokens": {"type": "integer", "minimum": 0},
+        "cached_input_tokens": {"type": "integer", "minimum": 0},
+        "total_tokens": {"type": "integer", "minimum": 0}
+      }
+    },
+    "nullableError": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "message"],
+          "properties": {
+            "type": {"type": "string", "minLength": 1},
+            "message": {"type": "string", "minLength": 1},
+            "code": {"type": ["string", "null"]},
+            "retryable": {"type": ["boolean", "null"]},
+            "details": {"type": "object", "additionalProperties": true}
+          }
+        },
+        {"type": "null"}
+      ]
+    },
+    "schemaEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identifier", "ddl", "metadata"],
+      "properties": {
+        "identifier": {"type": "string", "minLength": 1},
+        "ddl": {"type": "string", "minLength": 1},
+        "metadata": {"type": "object", "additionalProperties": true}
+      }
+    },
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "status",
+        "started_at",
+        "completed_at",
+        "duration_seconds",
+        "model",
+        "usage",
+        "schema_refs",
+        "actions",
+        "execution_stats",
+        "error",
+        "metadata"
+      ],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "type": {"type": "string", "minLength": 1},
+        "status": {"enum": ["running", "completed", "failed"]},
+        "started_at": {"type": "string", "format": "date-time"},
+        "completed_at": {
+          "oneOf": [
+            {"type": "string", "format": "date-time"},
+            {"type": "null"}
+          ]
+        },
+        "duration_seconds": {
+          "oneOf": [
+            {"type": "number", "minimum": 0},
+            {"type": "null"}
+          ]
+        },
+        "model": {"$ref": "#/$defs/nullableModel"},
+        "usage": {"$ref": "#/$defs/tokenUsage"},
+        "schema_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "actions": {"type": "array", "items": {"type": "object"}},
+        "execution_stats": {"type": "object", "additionalProperties": true},
+        "error": {"$ref": "#/$defs/nullableError"},
+        "metadata": {"type": "object", "additionalProperties": true}
+      }
+    }
+  }
+}

--- a/tests/unit_tests/agent/test_workflow_runner.py
+++ b/tests/unit_tests/agent/test_workflow_runner.py
@@ -319,8 +319,8 @@ class TestFinalizeWorkflow:
         assert mock_wf.metadata.get("trace_run_id") == "run1"
         assert result["trace_reference"]["trace_id"] == "4bf92f3577b34da6a3ce929d0e0e4736"
 
-    def test_benchmark_workflow_uses_compatibility_v1_envelope(self, tmp_path: Path) -> None:
-        """Benchmark-profile runs save trajectories with a schema_version 1 envelope."""
+    def test_benchmark_workflow_defers_trajectory_to_attempt_finalizer(self, tmp_path: Path) -> None:
+        """Benchmark-profile runs skip the compatibility envelope; the finalizer owns the trajectory."""
         runner = _make_runner()
         runner.global_config.current_datasource = "default"
         runner.global_config.trajectory_run_dir.return_value = tmp_path
@@ -336,7 +336,8 @@ class TestFinalizeWorkflow:
         with patch("datus.agent.workflow_runner.get_trace_reference", return_value=None):
             result = runner._finalize_workflow(1)
 
-        mock_wf.save.assert_called_once_with(result["save_path"], schema_version=1)
+        mock_wf.save.assert_not_called()
+        assert result["save_path"] is None
         runner.global_config.trajectory_run_dir.assert_called_once_with("analytics", runner.run_id)
         runner.global_config.get_trajectory_run_dir.assert_not_called()
         assert runner.last_run_metadata == result

--- a/tests/unit_tests/utils/test_benchmark_artifacts.py
+++ b/tests/unit_tests/utils/test_benchmark_artifacts.py
@@ -515,6 +515,7 @@ def test_agent_wrapper_writes_manifest_when_runner_raises_before_output(tmp_path
         run=MagicMock(side_effect=RuntimeError("plan generation failed")),
     )
     agent = SimpleNamespace(global_config=config, create_workflow_runner=MagicMock(return_value=runner))
+    agent._write_benchmark_trajectory = Agent._write_benchmark_trajectory.__get__(agent)
 
     with pytest.raises(RuntimeError, match="plan generation failed"):
         Agent._run_benchmark_task(agent, _task(), run_id="run-1")
@@ -523,6 +524,8 @@ def test_agent_wrapper_writes_manifest_when_runner_raises_before_output(tmp_path
     _validator().validate(payload)
     assert payload["status"] == "failed"
     assert payload["error"]["type"] == "benchmark_execution"
-    assert payload["trajectory"] is None
+    # Even a crash before workflow init yields a native trajectory reference.
+    assert payload["trajectory"]["contract_profile"] == "native_v1"
+    assert (trajectory_root / payload["trajectory"]["path"]).is_file()
     config.save_run_dir.assert_called_once_with("analytics", "run-1")
     config.trajectory_run_dir.assert_called_once_with("analytics", "run-1")

--- a/tests/unit_tests/utils/test_benchmark_artifacts.py
+++ b/tests/unit_tests/utils/test_benchmark_artifacts.py
@@ -529,3 +529,33 @@ def test_agent_wrapper_writes_manifest_when_runner_raises_before_output(tmp_path
     assert (trajectory_root / payload["trajectory"]["path"]).is_file()
     config.save_run_dir.assert_called_once_with("analytics", "run-1")
     config.trajectory_run_dir.assert_called_once_with("analytics", "run-1")
+
+
+def test_trajectory_write_failure_fails_the_attempt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful run whose trajectory cannot persist finalizes as failed, not completed."""
+    save_root = tmp_path / "save" / "analytics" / "run-1"
+    trajectory_root = tmp_path / "trajectory" / "analytics" / "run-1"
+    config = MagicMock()
+    config.save_run_dir.return_value = save_root
+    config.trajectory_run_dir.return_value = trajectory_root
+    config.current_datasource = "analytics"
+    config.active_model.return_value = _model_config()
+    task = _task()
+    runner = SimpleNamespace(
+        workflow=_success_workflow(task),
+        last_run_metadata={},
+        run=MagicMock(return_value={"status": "success"}),
+    )
+    agent = SimpleNamespace(global_config=config, create_workflow_runner=MagicMock(return_value=runner))
+    monkeypatch.setattr(
+        "datus.agent.agent.write_benchmark_trajectory",
+        MagicMock(side_effect=OSError("disk full")),
+    )
+
+    with pytest.raises(DatusException, match="trajectory persistence failed"):
+        Agent._run_benchmark_task(agent, task, run_id="run-1")
+
+    payload = json.loads((save_root / "tasks" / "42" / "task-output.json").read_text(encoding="utf-8"))
+    _validator().validate(payload)
+    assert payload["status"] == "failed"
+    assert payload["trajectory"] is None

--- a/tests/unit_tests/utils/test_benchmark_trajectory.py
+++ b/tests/unit_tests/utils/test_benchmark_trajectory.py
@@ -1,0 +1,281 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+from datus.schemas.node_models import SqlTask
+from datus.utils.benchmark_artifacts import allocate_benchmark_attempt, finalize_benchmark_attempt
+from datus.utils.benchmark_trajectory import (
+    build_trajectory_payload,
+    trajectory_file_path,
+    write_benchmark_trajectory,
+)
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "benchmark_artifacts" / "v1" / "trajectory.schema.json"
+
+ORDERS_DDL = "CREATE TABLE analytics.orders (\n    order_id BIGINT,\n    amount DECIMAL(18, 2)\n)"
+
+
+def _validator() -> Draft202012Validator:
+    """Build a format-checking validator for the v1 trajectory schema."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def _model_config() -> SimpleNamespace:
+    """Model config stub carrying private fields that must never reach trajectories."""
+    return SimpleNamespace(
+        type="openai",
+        model="gpt-5.5",
+        api_key="must-not-leak",
+        base_url="https://private.invalid",
+        reasoning_effort=None,
+        temperature=None,
+        top_p=None,
+        enable_thinking=None,
+    )
+
+
+def _agent_config() -> MagicMock:
+    """Agent config mock exposing the active model."""
+    config = MagicMock()
+    config.active_model.return_value = _model_config()
+    return config
+
+
+def _table_schema() -> dict:
+    """One table schema entry as workflow nodes carry it today."""
+    return {
+        "identifier": "analytics.orders",
+        "table_name": "orders",
+        "database_name": "analytics",
+        "definition": ORDERS_DDL,
+        "table_type": "table",
+    }
+
+
+def _success_workflow() -> SimpleNamespace:
+    """Workflow stub: two nodes sharing one schema body, timed, with actions."""
+    now = time.time()
+    schema_node = SimpleNamespace(
+        id="schema_linking",
+        type="schema_linking",
+        status="completed",
+        start_time=now - 10.0,
+        end_time=now - 8.0,
+        input={"input_text": "List order amounts", "table_schemas": [_table_schema()]},
+        result=SimpleNamespace(
+            table_schemas=[_table_schema()],
+            action_history=[
+                {
+                    "role": "tool",
+                    "tool_name": "search_table",
+                    "status": "completed",
+                    "output": {"raw_output": {"result": [{"table_name": "analytics.orders"}]}},
+                }
+            ],
+            execution_stats={"tool_calls_count": 1},
+        ),
+        model=None,
+    )
+    gen_node = SimpleNamespace(
+        id="gen_sql",
+        type="gen_sql",
+        status="completed",
+        start_time=now - 8.0,
+        end_time=now - 1.0,
+        input={"table_schemas": [_table_schema()]},
+        result=SimpleNamespace(
+            action_history=[
+                {
+                    "role": "assistant",
+                    "action_type": "message",
+                    "status": "completed",
+                    "content": "Generated SQL",
+                    "output": {"usage": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120}},
+                }
+            ],
+            execution_stats={},
+        ),
+        model=SimpleNamespace(model_config=_model_config()),
+    )
+    pending_node = SimpleNamespace(
+        id="output",
+        type="output",
+        status="pending",
+        start_time=None,
+        end_time=None,
+        input={},
+        result=None,
+        model=None,
+    )
+    return SimpleNamespace(
+        task=SqlTask(id="42", task="List order amounts", artifact_profile="benchmark_v1"),
+        status="completed",
+        nodes={"schema_linking": schema_node, "gen_sql": gen_node, "output": pending_node},
+        node_order=["schema_linking", "gen_sql", "output"],
+        context=SimpleNamespace(table_schemas=[_table_schema()], sql_contexts=[]),
+        metadata={"trace_id": "trace-42", "trace_provider": "langfuse"},
+    )
+
+
+def _failed_workflow() -> SimpleNamespace:
+    """Workflow stub whose only node failed."""
+    now = time.time()
+    node = SimpleNamespace(
+        id="gen_sql",
+        type="gen_sql",
+        status="failed",
+        start_time=now - 5.0,
+        end_time=now - 1.0,
+        input={},
+        result=SimpleNamespace(error="No schema found", action_history=None, execution_stats=None),
+        model=SimpleNamespace(model_config=_model_config()),
+    )
+    return SimpleNamespace(
+        task=SqlTask(id="42", task="List order amounts", artifact_profile="benchmark_v1"),
+        status="running",
+        nodes={"gen_sql": node},
+        node_order=["gen_sql"],
+        context=SimpleNamespace(table_schemas=[], sql_contexts=[SimpleNamespace(sql_error=None, row_count=0)]),
+        metadata={},
+    )
+
+
+def _allocate(tmp_path: Path):
+    """Allocate an attempt under nested save/trajectory run roots."""
+    save_root = tmp_path / "save" / "analytics" / "run-1"
+    trajectory_root = tmp_path / "trajectory" / "analytics" / "run-1"
+    trajectory_root.mkdir(parents=True, exist_ok=True)
+    return allocate_benchmark_attempt(save_root, trajectory_root, run_id="run-1", task_id="42")
+
+
+def test_success_payload_validates_and_stores_each_schema_once(tmp_path: Path) -> None:
+    """A completed workflow yields a schema-valid payload with a deduplicated registry."""
+    attempt = _allocate(tmp_path)
+    payload = build_trajectory_payload(attempt, workflow=_success_workflow(), agent_config=_agent_config())
+
+    _validator().validate(payload)
+    assert payload["status"] == "completed"
+    assert payload["run_id"] == "run-1"
+    assert payload["attempt_id"] == "attempt-1"
+    assert payload["partial"] is False
+    assert payload["model"]["name"] == "gpt-5.5"
+    assert payload["usage"] == {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120}
+    assert payload["trace"] == {"trace_id": "trace-42", "provider": "langfuse"}
+
+    # The DDL body appears exactly once; nodes carry references only.
+    assert list(payload["schemas"]) == ["table:analytics.orders"]
+    assert payload["schemas"]["table:analytics.orders"]["ddl"] == ORDERS_DDL
+    assert json.dumps(payload["nodes"]).count("CREATE TABLE") == 0
+    assert [node["schema_refs"] for node in payload["nodes"]] == [
+        ["table:analytics.orders"],
+        ["table:analytics.orders"],
+    ]
+    assert "must-not-leak" not in json.dumps(payload)
+
+
+def test_nodes_have_normalized_timing_actions_and_stats(tmp_path: Path) -> None:
+    """Executed nodes expose RFC3339 timing and native-shape actions; pending nodes are excluded."""
+    attempt = _allocate(tmp_path)
+    payload = build_trajectory_payload(attempt, workflow=_success_workflow(), agent_config=_agent_config())
+
+    assert [node["id"] for node in payload["nodes"]] == ["schema_linking", "gen_sql"]
+    schema_node = payload["nodes"][0]
+    assert schema_node["started_at"].endswith("Z") and schema_node["completed_at"].endswith("Z")
+    assert schema_node["duration_seconds"] == pytest.approx(2.0)
+    # Tool result is lifted out of output.raw_output.result into content.
+    tool_action = schema_node["actions"][0]
+    assert tool_action["name"] == "search_table"
+    assert tool_action["content"] == [{"table_name": "analytics.orders"}]
+    assert schema_node["execution_stats"] == {"tool_calls_count": 1}
+    assert payload["execution_stats"] == {"total_nodes": 2, "completed_nodes": 2}
+
+
+def test_failure_payload_validates_with_error_and_failure_types(tmp_path: Path) -> None:
+    """A failed workflow yields a schema-valid payload with structured error data."""
+    attempt = _allocate(tmp_path)
+    payload = build_trajectory_payload(attempt, workflow=_failed_workflow(), agent_config=_agent_config())
+
+    _validator().validate(payload)
+    assert payload["status"] == "failed"
+    assert payload["failure_types"] == [payload["error"]["type"]]
+    assert payload["nodes"][0]["error"]["message"] == "No schema found"
+
+
+def test_exception_payload_validates_without_workflow(tmp_path: Path) -> None:
+    """A crash before workflow init still yields a schema-valid failed payload."""
+    attempt = _allocate(tmp_path)
+    payload = build_trajectory_payload(
+        attempt,
+        workflow=None,
+        agent_config=_agent_config(),
+        exception=RuntimeError("plan generation failed"),
+    )
+
+    _validator().validate(payload)
+    assert payload["status"] == "failed"
+    assert payload["error"]["message"] == "plan generation failed"
+    assert payload["nodes"] == []
+
+
+def test_written_yaml_uses_block_scalars_and_deterministic_path(tmp_path: Path) -> None:
+    """The YAML file keeps DDL readable and uses the attempt-based filename."""
+    attempt = _allocate(tmp_path)
+    path = write_benchmark_trajectory(attempt, workflow=_success_workflow(), agent_config=_agent_config())
+
+    assert path == trajectory_file_path(attempt)
+    assert path.name == "task_42.attempt-1.yaml"
+    text = path.read_text(encoding="utf-8")
+    assert "ddl: |" in text
+    assert "\\n" not in text.split("ddl: |")[1].split("metadata:")[0]
+    assert yaml.safe_load(text)["artifact_type"] == "trajectory"
+    assert not list(path.parent.glob(f".{path.name}.*.tmp"))
+
+
+def test_manifest_references_native_trajectory(tmp_path: Path) -> None:
+    """finalize_benchmark_attempt records a native_v1 trajectory reference."""
+    attempt = _allocate(tmp_path)
+    workflow = _success_workflow()
+    trajectory_path = write_benchmark_trajectory(attempt, workflow=workflow, agent_config=_agent_config())
+    (attempt.output_dir / "42.sql").write_text("SELECT 1", encoding="utf-8")
+    (attempt.output_dir / "42.csv").write_text("a\n1\n", encoding="utf-8")
+
+    # The success stub has no completed output node, so add one for finalize.
+    workflow.nodes["output"] = SimpleNamespace(
+        id="output",
+        type="output",
+        status="completed",
+        start_time=None,
+        end_time=None,
+        input={},
+        result=SimpleNamespace(success=True, action_history=None, execution_stats=None),
+        model=None,
+    )
+    manifest_path = finalize_benchmark_attempt(
+        attempt,
+        task=workflow.task,
+        workflow=workflow,
+        trajectory_path=trajectory_path,
+        agent_config=_agent_config(),
+        trajectory_profile="native_v1",
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["trajectory"] == {
+        "root": "trajectory",
+        "path": "task_42.attempt-1.yaml",
+        "format": "yaml",
+        "schema_version": 1,
+        "contract_profile": "native_v1",
+        "attempt_id": "attempt-1",
+    }

--- a/tests/unit_tests/utils/test_benchmark_trajectory.py
+++ b/tests/unit_tests/utils/test_benchmark_trajectory.py
@@ -279,3 +279,21 @@ def test_manifest_references_native_trajectory(tmp_path: Path) -> None:
         "contract_profile": "native_v1",
         "attempt_id": "attempt-1",
     }
+
+
+def test_yaml_round_trip_preserves_scalar_content_exactly(tmp_path: Path) -> None:
+    """Serialization must not mutate SQL/DDL text, including trailing whitespace."""
+    attempt = _allocate(tmp_path)
+    workflow = _success_workflow()
+    tricky_ddl = "CREATE TABLE t (\n    a INT,  \n    b TEXT\n)"
+    schema = _table_schema()
+    schema["definition"] = tricky_ddl
+    workflow.nodes["schema_linking"].input["table_schemas"] = [schema]
+    workflow.nodes["schema_linking"].result.table_schemas = [schema]
+    workflow.nodes["gen_sql"].input["table_schemas"] = [schema]
+    workflow.context.table_schemas = [schema]
+
+    path = write_benchmark_trajectory(attempt, workflow=workflow, agent_config=_agent_config())
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    assert payload["schemas"]["table:analytics.orders"]["ddl"] == tricky_ddl


### PR DESCRIPTION
## Why

Closes #1145's sibling #1146 (parent epic #1144). Agent-written trajectories had no schema version, timestamp-glob file authority, table schemas repeated ~3x per file, incomplete node timing, and node output shapes consumers had to probe (`output.raw_output.result` / `output.result` / raw `output`).

This implements the producer side of the trajectory v1 contract defined in Datus-ai/datus-benchmark#140 (`contracts/v1/trajectory.schema.json`). Consumer-side manifest-first resolution: Datus-ai/datus-benchmark#170.

## Solution

- New `datus/utils/benchmark_trajectory.py` builds the versioned envelope: `artifact_type`/`schema_version`, run/task/attempt identity, lifecycle status with RFC3339 timestamps and duration, aggregate model identity and token usage, structured errors and failure types, and the trace reference from workflow metadata.
- **Schema dedup**: each table schema body is stored once in a `schemas` registry keyed by `table:{identifier}`; nodes carry `schema_refs` only and never inline DDL.
- **Normalized nodes**: per-node timing (with backfill for planner-completed nodes that never call `Node.start()`), per-node model/usage, native-shape actions (tool results lifted into `content`), execution stats, structured errors. Pending nodes are excluded per the contract.
- **Readable and deterministic**: atomic YAML writes with block scalars for multi-line SQL/DDL at `task_{task_id}.{attempt_id}.yaml`; the task manifest references it with `contract_profile: native_v1`, replacing filename authority.
- The workflow runner no longer writes the redundant compatibility envelope for `benchmark_v1` runs; interactive flows are unchanged. Exceptions before or during the run still produce a trajectory from the in-memory workflow.

## Acceptance criteria mapping

- Success/failure/no-workflow trajectories validate against the vendored consumer schema (tests) ✔
- `schema_version`, run/task/attempt identity, lifecycle status ✔
- Normalized node timing and terminal status ✔
- One documented model/usage shape (shared with the #1149 manifest implementation) ✔
- Schema body serialized once with references ✔
- Authoritative attempt selected via the manifest (with datus-benchmark#170) ✔
- Block scalars for long SQL/DDL ✔
- Fixture/parser compatibility covered by consumer tests in datus-benchmark ✔
- Raw prompt/response capture stays opt-out (`capture_level: standard`); incremental persistence deferred to #1147 ✔

## Test Cases

- New `tests/unit_tests/utils/test_benchmark_trajectory.py` (6 tests): schema validation for success/failure/crash payloads, dedup registry, normalized timing/actions, block-scalar YAML, native manifest reference.
- Updated runner and artifacts tests for the deferred-trajectory behavior; affected suites: 3,674 passed.
- Real end-to-end run (bird task 0, deepseek-v4-flash): trajectory validates against `contracts/v1/trajectory.schema.json`; datus-benchmark evaluators recover full tool-call breakdown (list_tables/describe_table/execute_sql), 7 LLM turns, and 22,547 tokens through the manifest reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Added native v1 benchmark trajectory artifacts for successful and failed tasks.
  * Trajectories capture execution details, timing, errors, model usage, schemas, and trace data.
  * Benchmark manifests now include trajectory paths and profile metadata.

* **Bug Fixes**
  * Trajectory-write failures now finalize attempts as failed with a valid manifest and no trajectory path.
  * Benchmark workflows no longer create redundant compatibility artifacts.

* **Tests**
  * Added comprehensive validation for trajectory schemas, output consistency, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->