### PR TITLE
[BugFix] Reset the occupancy meter after a major compact

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1907,6 +1907,49 @@ class AgenticNode(Node):
             return None
         return path
 
+    def _reset_context_occupancy(self, summary_token: int) -> None:
+        """Point the occupancy meter at the post-compact history size.
+
+        ``_decide_compact_mode`` reads the ratio from
+        ``_history_token_ratio_sync``, which prefers the ``running_turn_usage``
+        snapshot. Compaction rewrites the history but leaves that snapshot at
+        its pre-compact value, so the next pre-turn check sees the same
+        near-limit figure and compacts again — every turn, until the session is
+        gutted.
+
+        The recap is the whole of the new history, so its token count is the new
+        occupancy. Underestimating is safe: the next LLM call refreshes the
+        snapshot with the true figure, and a genuine crossing still triggers.
+
+        Best-effort throughout — the compact has already succeeded by the time
+        this runs, so nothing here may turn it into a reported failure.
+        """
+        post_compact_tokens = int(summary_token or 0) or 1
+        try:
+            context_length = (
+                int(getattr(self, "context_length", 0) or 0)
+                or int(getattr(self, "_restored_context_length", 0) or 0)
+                or 0
+            )
+        except Exception:  # noqa: BLE001 - a model without a known window
+            context_length = 0
+
+        usage = getattr(self, "running_turn_usage", None)
+        if usage is not None:
+            try:
+                usage.session_total_tokens = post_compact_tokens
+                usage.input_tokens = post_compact_tokens
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Could not reset running_turn_usage after compact: %s", exc)
+
+        try:
+            if context_length:
+                self.persist_context_state(post_compact_tokens, context_length)
+            else:
+                self._restored_context_used = post_compact_tokens
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not persist post-compact context state: %s", exc)
+
     async def _major_compact(self, *, reason: str) -> Dict[str, Any]:
         """LLM-driven full-history compact pass.
 
@@ -1986,6 +2029,7 @@ class AgenticNode(Node):
         # a single assistant continuation message, so the next minor pass
         # starts scanning from the top of the rewritten session.
         self._compacted_until = 0
+        self._reset_context_occupancy(summary_token)
 
         logger.info(
             "Major compact complete: %d chars summary, %d output tokens, history=%s",

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -53,6 +53,17 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _coerce_token_count(value: Any) -> int:
+    """A provider-reported token count as a non-negative int, or 0.
+
+    Usage dicts come from the provider, so a count may be missing, a string, or
+    negative. Callers run on paths where raising is not acceptable."""
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
 def _estimate_tokens(text: str) -> int:
     """Rough token count for text, matching the fallback used elsewhere in the
     codebase (see ``compress_utils.count_tokens``): roughly 4 characters per
@@ -1932,13 +1943,12 @@ class AgenticNode(Node):
         Best-effort throughout — the compact has already succeeded by the time
         this runs, so nothing here may turn it into a reported failure.
         """
-        # ``summary_token`` is the recap's reported output tokens, which is 0 on
-        # any provider that does not report usage. A zero would fall through the
-        # ``tok > 0`` guard in ``_history_token_ratio_sync``, sending it back to
-        # the stale pre-compact fallback — the loop this exists to close. Fall
-        # back to a size estimate of the text actually persisted, so those
-        # providers get a real floor rather than a sentinel.
-        post_compact_tokens = int(summary_token or 0) or _estimate_tokens(continuation) or 1
+        # A zero — any provider that does not report usage — would fall through
+        # the ``tok > 0`` guard in ``_history_token_ratio_sync`` and send it back
+        # to the stale pre-compact fallback, which is the loop this exists to
+        # close. Measure the text actually persisted instead, so those providers
+        # get a real floor rather than a sentinel.
+        post_compact_tokens = _coerce_token_count(summary_token) or _estimate_tokens(continuation) or 1
         try:
             context_length = (
                 int(getattr(self, "context_length", 0) or 0)
@@ -2020,7 +2030,12 @@ class AgenticNode(Node):
             )
             summary = result.get("content", "") if isinstance(result, dict) else getattr(result, "content", "") or ""
             usage = result.get("usage", {}) if isinstance(result, dict) else {}
-            summary_token = usage.get("output_tokens", 0) if isinstance(usage, dict) else 0
+            # Straight from the provider, so it may be absent, non-numeric or
+            # negative. Normalize once here: everything downstream — the %d in
+            # the completion log, the occupancy reset, the returned dict —
+            # assumes an int, and all of it runs after the compact has already
+            # persisted, where raising would turn a good compact into a failure.
+            summary_token = _coerce_token_count(usage.get("output_tokens", 0) if isinstance(usage, dict) else 0)
         except Exception as exc:
             logger.error("Failed to generate major-compact summary: %s", exc)
             return {"mode": "major", "reason": reason, "success": False, "summary": "", "summary_token": 0}

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -53,6 +53,14 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _estimate_tokens(text: str) -> int:
+    """Rough token count for text, matching the fallback used elsewhere in the
+    codebase (see ``compress_utils.count_tokens``): roughly 4 characters per
+    token. Used where an exact count is unavailable and a floor is better than
+    zero."""
+    return len(text) // 4 if text else 0
+
+
 class AgenticNode(Node):
     """
     Base agentic node that provides session-based, streaming interactions
@@ -1907,7 +1915,7 @@ class AgenticNode(Node):
             return None
         return path
 
-    def _reset_context_occupancy(self, summary_token: int) -> None:
+    def _reset_context_occupancy(self, summary_token: int, continuation: str = "") -> None:
         """Point the occupancy meter at the post-compact history size.
 
         ``_decide_compact_mode`` reads the ratio from
@@ -1924,7 +1932,13 @@ class AgenticNode(Node):
         Best-effort throughout — the compact has already succeeded by the time
         this runs, so nothing here may turn it into a reported failure.
         """
-        post_compact_tokens = int(summary_token or 0) or 1
+        # ``summary_token`` is the recap's reported output tokens, which is 0 on
+        # any provider that does not report usage. A zero would fall through the
+        # ``tok > 0`` guard in ``_history_token_ratio_sync``, sending it back to
+        # the stale pre-compact fallback — the loop this exists to close. Fall
+        # back to a size estimate of the text actually persisted, so those
+        # providers get a real floor rather than a sentinel.
+        post_compact_tokens = int(summary_token or 0) or _estimate_tokens(continuation) or 1
         try:
             context_length = (
                 int(getattr(self, "context_length", 0) or 0)
@@ -1937,8 +1951,12 @@ class AgenticNode(Node):
         usage = getattr(self, "running_turn_usage", None)
         if usage is not None:
             try:
+                # Only ``session_total_tokens`` is touched. The ratio reads
+                # ``session_total_tokens or input_tokens``, so this is the field
+                # that matters — and ``input_tokens`` is the turn-cumulative
+                # counter reported verbatim in the API's end event, where a
+                # post-compact value would contradict the turn's own totals.
                 usage.session_total_tokens = post_compact_tokens
-                usage.input_tokens = post_compact_tokens
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Could not reset running_turn_usage after compact: %s", exc)
 
@@ -2036,7 +2054,7 @@ class AgenticNode(Node):
         # a single assistant continuation message, so the next minor pass
         # starts scanning from the top of the rewritten session.
         self._compacted_until = 0
-        self._reset_context_occupancy(summary_token)
+        self._reset_context_occupancy(summary_token, continuation)
 
         logger.info(
             "Major compact complete: %d chars summary, %d output tokens, history=%s",

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1942,13 +1942,20 @@ class AgenticNode(Node):
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Could not reset running_turn_usage after compact: %s", exc)
 
-        try:
-            if context_length:
+        # Set the in-memory mirrors FIRST. ``persist_context_state`` updates them
+        # only after a successful save, and it returns early when there is no
+        # resolvable state path — so relying on it would leave
+        # ``_restored_context_used`` at the pre-compact value. Once
+        # ``running_turn_usage`` is cleared at turn end,
+        # ``_history_token_ratio_sync`` falls back to exactly that value, and the
+        # re-compact loop this fix exists to close would reopen through it.
+        self._restored_context_used = post_compact_tokens
+        if context_length:
+            self._restored_context_length = context_length
+            try:
                 self.persist_context_state(post_compact_tokens, context_length)
-            else:
-                self._restored_context_used = post_compact_tokens
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("Could not persist post-compact context state: %s", exc)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Could not persist post-compact context state: %s", exc)
 
     async def _major_compact(self, *, reason: str) -> Dict[str, Any]:
         """LLM-driven full-history compact pass.

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -848,6 +848,60 @@ class TestManualCompact:
         assert node._history_token_ratio_sync() < 0.8
 
     @pytest.mark.asyncio
+    async def test_major_compact_measures_the_continuation_when_usage_is_zero(self):
+        """Providers that report no usage give `output_tokens: 0`. The occupancy
+        must then come from the continuation actually persisted, not a sentinel —
+        driven through `_major_compact` so the wiring is what is pinned."""
+        node = _make_node(context_length=100_000)
+        node.session_id = "compact_test"
+        mock_session = _make_async_session_mock()
+        node._session = mock_session
+        node._session_manager = MagicMock()
+        mock_model = MagicMock()
+        mock_model.context_length.return_value = 100_000
+        mock_model.generate_with_tools = AsyncMock(
+            return_value={"content": "recap " * 500, "usage": {"output_tokens": 0}}
+        )
+        node.model = mock_model
+        node.running_turn_usage = TokenUsage(session_total_tokens=95_000, input_tokens=95_000, context_length=100_000)
+
+        with patch.object(_ConcreteAgenticNode, "_dump_session_history_jsonl", new=AsyncMock(return_value=None)):
+            with patch.object(_ConcreteAgenticNode, "_get_archive", return_value=None):
+                with patch.object(_ConcreteAgenticNode, "_get_system_prompt", return_value="sys"):
+                    result = await node._major_compact(reason="hook_major")
+
+        assert result["success"] is True
+        # The occupancy tracks the text that was actually stored.
+        persisted = mock_session.add_items.await_args.args[0][0]["content"][0]["text"]
+        assert node.running_turn_usage.session_total_tokens == len(persisted) // 4
+        assert node._history_token_ratio_sync() < 0.8
+
+    @pytest.mark.asyncio
+    async def test_major_compact_survives_a_provider_reporting_junk_usage(self):
+        """`output_tokens` comes straight from the provider. It runs after the
+        compact has already persisted, so a bad value must not raise."""
+        node = _make_node(context_length=100_000)
+        node.session_id = "compact_test"
+        node._session = _make_async_session_mock()
+        node._session_manager = MagicMock()
+        mock_model = MagicMock()
+        mock_model.context_length.return_value = 100_000
+        mock_model.generate_with_tools = AsyncMock(
+            return_value={"content": "recap " * 500, "usage": {"output_tokens": "not a number"}}
+        )
+        node.model = mock_model
+        node.running_turn_usage = TokenUsage(session_total_tokens=95_000, input_tokens=95_000, context_length=100_000)
+
+        with patch.object(_ConcreteAgenticNode, "_dump_session_history_jsonl", new=AsyncMock(return_value=None)):
+            with patch.object(_ConcreteAgenticNode, "_get_archive", return_value=None):
+                with patch.object(_ConcreteAgenticNode, "_get_system_prompt", return_value="sys"):
+                    result = await node._major_compact(reason="hook_major")
+
+        assert result["success"] is True
+        assert node.running_turn_usage.session_total_tokens > 0
+        assert node._history_token_ratio_sync() < 0.8
+
+    @pytest.mark.asyncio
     async def test_major_compact_leaves_the_turn_cumulative_counter_alone(self):
         """``input_tokens`` is the turn-cumulative counter reported in the API's
         end event. Rewriting it to the recap size would contradict the turn's own

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -2185,3 +2185,23 @@ class TestPostCompactOccupancyReset:
         node.running_turn_usage = None
 
         node._reset_context_occupancy(1_200)  # must not raise
+
+    def test_the_ratio_is_safe_even_when_persistence_fails(self):
+        """`persist_context_state` swallows save failures and updates its mirrors
+        only on success. If the reset relied on it, the stale pre-compact value
+        would survive in `_restored_context_used` and re-trigger a compact as
+        soon as `running_turn_usage` is cleared at turn end."""
+        node = _make_simple_node(context_length=100_000)
+        node.running_turn_usage = SimpleNamespace(
+            session_total_tokens=95_000, input_tokens=95_000, context_length=100_000
+        )
+        node._restored_context_used = 95_000
+        node._restored_context_length = 100_000
+
+        with patch.object(AgenticNode, "persist_context_state", side_effect=OSError("disk full")):
+            node._reset_context_occupancy(1_200)
+
+        # Turn end clears the in-memory snapshot; the fallback must be current.
+        node.running_turn_usage = None
+        assert node._restored_context_used == 1_200
+        assert node._history_token_ratio_sync() < 0.8

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -2179,12 +2179,17 @@ class TestPostCompactOccupancyReset:
 
         assert node.running_turn_usage.session_total_tokens == 1
 
-    def test_a_missing_meter_is_not_an_error(self):
-        """The compact has already succeeded; nothing here may fail it."""
+    def test_the_restored_mirror_is_set_when_there_is_no_snapshot(self):
+        """A node with no in-memory snapshot still has to end up with a current
+        fallback, because that is what `_history_token_ratio_sync` reads next."""
         node = _make_simple_node(context_length=100_000)
         node.running_turn_usage = None
+        node._restored_context_used = 95_000
 
-        node._reset_context_occupancy(1_200)  # must not raise
+        node._reset_context_occupancy(1_200)
+
+        assert node._restored_context_used == 1_200
+        assert node._history_token_ratio_sync() < 0.8
 
     def test_the_ratio_is_safe_even_when_persistence_fails(self):
         """`persist_context_state` swallows save failures and updates its mirrors

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -817,6 +817,59 @@ class TestManualCompact:
         assert result["success"] is False
 
     @pytest.mark.asyncio
+    async def test_major_compact_drops_the_ratio_below_the_threshold(self):
+        """The regression this guards: a compact must leave the meter describing
+        the NEW history, or the next pre-turn check re-triggers on the stale
+        figure and compacts again every turn.
+
+        Driven through ``_major_compact`` rather than the helper, so removing the
+        call site fails this test.
+        """
+        node = _make_node(context_length=100_000)
+        node.session_id = "compact_test"
+        node._session = _make_async_session_mock()
+        node._session_manager = MagicMock()
+        mock_model = MagicMock()
+        mock_model.context_length.return_value = 100_000
+        mock_model.generate_with_tools = AsyncMock(return_value={"content": "recap", "usage": {"output_tokens": 100}})
+        node.model = mock_model
+        # The real producer's type, not a stand-in: if TokenUsage ever becomes
+        # frozen or validated, the production write degrades to a logged warning
+        # and this test is what notices.
+        node.running_turn_usage = TokenUsage(session_total_tokens=95_000, input_tokens=95_000, context_length=100_000)
+        assert node._history_token_ratio_sync() >= 0.8
+
+        with patch.object(_ConcreteAgenticNode, "_dump_session_history_jsonl", new=AsyncMock(return_value=None)):
+            with patch.object(_ConcreteAgenticNode, "_get_archive", return_value=None):
+                with patch.object(_ConcreteAgenticNode, "_get_system_prompt", return_value="sys"):
+                    result = await node._major_compact(reason="hook_major")
+
+        assert result["success"] is True
+        assert node._history_token_ratio_sync() < 0.8
+
+    @pytest.mark.asyncio
+    async def test_major_compact_leaves_the_turn_cumulative_counter_alone(self):
+        """``input_tokens`` is the turn-cumulative counter reported in the API's
+        end event. Rewriting it to the recap size would contradict the turn's own
+        output totals, and the ratio never reads it anyway."""
+        node = _make_node(context_length=100_000)
+        node.session_id = "compact_test"
+        node._session = _make_async_session_mock()
+        node._session_manager = MagicMock()
+        mock_model = MagicMock()
+        mock_model.context_length.return_value = 100_000
+        mock_model.generate_with_tools = AsyncMock(return_value={"content": "recap", "usage": {"output_tokens": 100}})
+        node.model = mock_model
+        node.running_turn_usage = TokenUsage(session_total_tokens=95_000, input_tokens=95_000, context_length=100_000)
+
+        with patch.object(_ConcreteAgenticNode, "_dump_session_history_jsonl", new=AsyncMock(return_value=None)):
+            with patch.object(_ConcreteAgenticNode, "_get_archive", return_value=None):
+                with patch.object(_ConcreteAgenticNode, "_get_system_prompt", return_value="sys"):
+                    await node._major_compact(reason="hook_major")
+
+        assert node.running_turn_usage.input_tokens == 95_000
+
+    @pytest.mark.asyncio
     async def test_major_compact_success_persists_continuation_message(self):
         node = _make_node()
         node.session_id = "compact_test"
@@ -2150,13 +2203,15 @@ class TestPostCompactOccupancyReset:
 
     def test_meter_is_reset_to_the_recap_size(self):
         node = _make_simple_node(context_length=100_000)
-        node.running_turn_usage = SimpleNamespace(session_total_tokens=95_000, input_tokens=95_000)
+        node.running_turn_usage = TokenUsage(session_total_tokens=95_000, input_tokens=95_000, context_length=100_000)
         node._restored_context_used = 95_000
 
         node._reset_context_occupancy(1_200)
 
         assert node.running_turn_usage.session_total_tokens == 1_200
-        assert node.running_turn_usage.input_tokens == 1_200
+        # input_tokens is the turn-cumulative counter, reported verbatim in the
+        # API's end event. The ratio never reads it here, so it stays truthful.
+        assert node.running_turn_usage.input_tokens == 95_000
 
     def test_the_ratio_drops_below_the_threshold_after_a_compact(self):
         """The property that matters: the next check must not re-trigger."""
@@ -2171,13 +2226,17 @@ class TestPostCompactOccupancyReset:
 
         assert node._history_token_ratio_sync() < 0.8  # no longer compacts
 
-    def test_a_zero_token_recap_still_clears_the_meter(self):
+    def test_a_provider_that_reports_no_usage_still_clears_the_meter(self):
+        """`summary_token` is 0 on any provider that does not report usage. A
+        zero would fall through the `tok > 0` guard in the ratio and send it back
+        to the stale fallback, so the recap text is measured instead."""
         node = _make_simple_node(context_length=100_000)
-        node.running_turn_usage = SimpleNamespace(session_total_tokens=95_000, input_tokens=95_000)
+        node.running_turn_usage = TokenUsage(session_total_tokens=95_000, input_tokens=95_000, context_length=100_000)
 
-        node._reset_context_occupancy(0)
+        node._reset_context_occupancy(0, continuation="a recap of the conversation " * 20)
 
-        assert node.running_turn_usage.session_total_tokens == 1
+        assert node._history_token_ratio_sync() < 0.8
+        assert node.running_turn_usage.session_total_tokens > 1
 
     def test_the_restored_mirror_is_set_when_there_is_no_snapshot(self):
         """A node with no in-memory snapshot still has to end up with a current

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -2138,3 +2138,50 @@ class TestEnsureToolTransformers:
         assert node.tools is captured
         assert captured[0] is not original_tool
         assert captured[0].name == "execute_sql"
+
+
+class TestPostCompactOccupancyReset:
+    """``_major_compact`` must leave the occupancy meter describing the NEW history.
+
+    ``_decide_compact_mode`` reads the ratio from ``running_turn_usage``. Left at
+    its pre-compact value, the next pre-turn check sees the same near-limit
+    figure and compacts again — on every turn.
+    """
+
+    def test_meter_is_reset_to_the_recap_size(self):
+        node = _make_simple_node(context_length=100_000)
+        node.running_turn_usage = SimpleNamespace(session_total_tokens=95_000, input_tokens=95_000)
+        node._restored_context_used = 95_000
+
+        node._reset_context_occupancy(1_200)
+
+        assert node.running_turn_usage.session_total_tokens == 1_200
+        assert node.running_turn_usage.input_tokens == 1_200
+
+    def test_the_ratio_drops_below_the_threshold_after_a_compact(self):
+        """The property that matters: the next check must not re-trigger."""
+        node = _make_simple_node(context_length=100_000)
+        node.running_turn_usage = SimpleNamespace(
+            session_total_tokens=95_000, input_tokens=95_000, context_length=100_000
+        )
+
+        assert node._history_token_ratio_sync() >= 0.8  # would compact
+
+        node._reset_context_occupancy(1_200)
+
+        assert node._history_token_ratio_sync() < 0.8  # no longer compacts
+
+    def test_a_zero_token_recap_still_clears_the_meter(self):
+        node = _make_simple_node(context_length=100_000)
+        node.running_turn_usage = SimpleNamespace(session_total_tokens=95_000, input_tokens=95_000)
+
+        node._reset_context_occupancy(0)
+
+        assert node.running_turn_usage.session_total_tokens == 1
+
+    def test_a_missing_meter_is_not_an_error(self):
+        """The compact has already succeeded; nothing here may fail it."""
+        node = _make_simple_node(context_length=100_000)
+        node.running_turn_usage = None
+
+        node._reset_context_occupancy(1_200)  # must not raise


### PR DESCRIPTION
## Why

`_decide_compact_mode` reads context usage from `_history_token_ratio_sync`, which
prefers the `running_turn_usage` snapshot. `_major_compact` rewrites the history into
a single recap but never touches that snapshot.

So the moment a compact finishes, the meter still reports the pre-compact figure. The
next pre-turn check reads the same near-limit ratio, decides "major" again, and
compacts again — one LLM summarization per turn for the rest of the session, each
discarding more history than the last. We watched a session compact six times in about
two minutes before it was gutted.

## Solution

Reset the meter to the size of the recap after a successful compact, since the recap is
now the whole of the history.

Key decisions:

- **In-memory mirrors are set before `persist_context_state`, not through it.** That
  method returns early when there is no resolvable state path and syncs its mirrors only
  on a successful save, so routing through it would leave `_restored_context_used` stale.
  That matters because at `pre_user_turn` the snapshot has already been dropped at turn
  end, making the restored value the one the ratio actually reads.
- **Only `session_total_tokens` is written.** The ratio reads
  `session_total_tokens or input_tokens`, so the former is the field that matters.
  `input_tokens` is the turn-cumulative counter reported verbatim in the API's end
  event, where a post-compact value would contradict the turn's own output totals.
- **The provider's token count is normalized where it enters.** It can be absent,
  non-numeric or negative, and everything downstream assumes an int — including the `%d`
  in the completion log, which raised `TypeError` on a string. All of it runs after the
  compact has persisted, where raising turns a good compact into a failure.
- **A zero count falls back to measuring the recap text**, reusing the
  4-chars-per-token estimate `compress_utils` already falls back to. Zero is what any
  provider that does not report usage returns, and it would fall through the `tok > 0`
  guard straight back to the stale value.

Tradeoff, deliberate: the recap's token count under-reports true occupancy, which also
includes the system prompt and tool schemas. The bar dips low and jumps on the next
call. Safe as designed — the next call refreshes the snapshot, and a genuine crossing
still fires.

## Test Cases

Nine cases in `tests/unit_tests/agent/node/test_agentic_node.py`. All fail on the
pre-fix code, verified by reverting the source with `git stash push -- <paths>`:

Driving `_major_compact`, so the wiring is what is pinned:
- `test_major_compact_drops_the_ratio_below_the_threshold` — deleting the
  `_reset_context_occupancy` call fails this with `assert 0.95 < 0.8`
- `test_major_compact_leaves_the_turn_cumulative_counter_alone`
- `test_major_compact_measures_the_continuation_when_usage_is_zero` — asserts the
  occupancy matches the continuation actually handed to `session.add_items`
- `test_major_compact_survives_a_provider_reporting_junk_usage`

On the helper:
- `test_meter_is_reset_to_the_recap_size`
- `test_the_ratio_drops_below_the_threshold_after_a_compact`
- `test_a_provider_that_reports_no_usage_still_clears_the_meter`
- `test_the_restored_mirror_is_set_when_there_is_no_snapshot`
- `test_the_ratio_is_safe_even_when_persistence_fails`

Tests use the real `TokenUsage`, so a future `frozen=True` or `validate_assignment=True`
surfaces here rather than degrading into a logged warning.