### PR TITLE
[BugFix] Do not run a major compact mid-turn

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1727,6 +1727,19 @@ class AgenticNode(Node):
         except Exception:
             ratio = 0.0
         if cfg.major.enabled and ratio >= cfg.major.token_threshold:
+            if mid_turn:
+                # A mid-turn major cannot help. The in-flight agents-SDK run
+                # holds the conversation in memory, so clearing the session
+                # shrinks nothing the model is being sent: occupancy does not
+                # drop, and the trigger fires again after the very next tool
+                # call. Only the compact at the START of the next turn, before
+                # the session is loaded into a run, changes what the model sees.
+                logger.info(
+                    "Mid-turn major compact suppressed (ratio=%.2f): the live run's context "
+                    "cannot shrink; compacting at next turn start instead.",
+                    ratio,
+                )
+                return "noop"
             return "major"
         if mid_turn:
             return "noop"

--- a/tests/unit_tests/agent/node/test_compact_helpers.py
+++ b/tests/unit_tests/agent/node/test_compact_helpers.py
@@ -145,12 +145,18 @@ class TestDecideCompactMode:
                 assert await node._decide_compact_mode() == "minor"
 
     @pytest.mark.asyncio
-    async def test_mid_turn_still_allows_major(self, tmp_path):
-        """major still fires mid-turn — its token-ratio gate genuinely changes
-        as the turn progresses."""
+    async def test_mid_turn_major_is_suppressed(self, tmp_path):
+        """A mid-turn major is a no-op however high the ratio climbs.
+
+        The ratio does change as a turn progresses, but a mid-turn major cannot
+        act on it: the in-flight run holds the conversation in memory, so
+        clearing the session shrinks nothing the model is being sent. The
+        trigger would simply fire again after the next tool call."""
         node = _build_node(tmp_path)
         with patch.object(_Node, "_history_token_ratio_sync", return_value=0.95):
-            assert await node._decide_compact_mode(mid_turn=True) == "major"
+            assert await node._decide_compact_mode(mid_turn=True) == "noop"
+            # ...and the same state still compacts at the start of a turn.
+            assert await node._decide_compact_mode() == "major"
 
 
 class TestUserTurnCountFromSession:


### PR DESCRIPTION
## What breaks

A major compact clears the session and writes a recap in its place. Mid-turn,
that achieves nothing.

The in-flight agents-SDK run holds the conversation **in memory** and keeps
sending it. Clearing the session shrinks nothing the model actually receives, so
the occupancy the trigger reads never drops — and the next tool call trips the
same threshold again.

The result is a summarization every few seconds for the remainder of the turn.
We measured roughly **one every 13 seconds** across a heavy turn: each an LLM
call, each changing nothing the model can see.

## The fix

Only the compact at the **start of the next turn** — before the session is
loaded into a run — changes what the model is sent. Mid-turn majors become a
no-op, and the work happens there instead.

Minor compaction is untouched: it was already decided only at turn start.

## The test change

`test_mid_turn_still_allows_major` pinned the old behaviour, so it is updated
rather than added to. Its previous rationale — *"major still fires mid-turn, its
token-ratio gate genuinely changes as the turn progresses"* — is true about the
ratio but not about the outcome: the gate moves, and acting on it still cannot
shrink anything.

The replacement pins both halves of the real contract:

```python
assert await node._decide_compact_mode(mid_turn=True) == "noop"
assert await node._decide_compact_mode() == "major"   # same state, turn start
```

## Verification

- `tests/unit_tests/agent/node`: failure set **identical** to clean `main` — 0
  introduced.
- `ruff check datus/` clean.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
