### PR TITLE
[BugFix] Keep a session's title across a major compact

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -1907,6 +1907,24 @@ class AgenticNode(Node):
             return None
         return path
 
+    def _preserve_session_title(self) -> None:
+        """Save the session's current title so a compact cannot erase it.
+
+        Best-effort: a lost title must never fail a compact, and
+        ``session_manager`` is a property that resolves a path manager, so it can
+        raise for a node with no project context.
+        """
+        if not self.session_id:
+            return
+        try:
+            manager = self.session_manager
+            info = manager.get_session_info(self.session_id) or {}
+            title = (info.get("first_user_message") or "").strip()
+            if title:
+                manager.save_title_sidecar(self.session_id, title)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not preserve the session title before compacting: %s", exc)
+
     async def _major_compact(self, *, reason: str) -> Dict[str, Any]:
         """LLM-driven full-history compact pass.
 
@@ -1935,6 +1953,10 @@ class AgenticNode(Node):
             return {"mode": "major", "reason": reason, "success": False, "summary": "", "summary_token": 0}
 
         logger.info("Starting major compact for session %s (reason=%s)", self.session_id, reason)
+        # Capture the chat's title BEFORE the history is cleared: the compact
+        # re-adds only an assistant recap, leaving no user rows for the sidebar's
+        # first-user-message scan to find.
+        self._preserve_session_title()
         history_jsonl_path = await self._dump_session_history_jsonl()
 
         sys_prompt = self._get_system_prompt()

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -412,6 +412,17 @@ class SessionManager:
             except OSError as exc:
                 logger.warning("Failed to remove session archive dir %s: %s", archive_root, exc)
 
+        # The title sidecar holds the deleted conversation's first user message,
+        # so it must not outlive it: leaving it behind keeps user text on disk
+        # after a delete, and would retitle a later session that reuses the id.
+        title_path = self.title_sidecar_path(session_id)
+        if os.path.isfile(title_path):
+            try:
+                os.remove(title_path)
+                logger.debug(f"Deleted session title sidecar: {title_path}")
+            except OSError as exc:
+                logger.warning("Failed to remove session title sidecar %s: %s", title_path, exc)
+
         # The frozen system prompt belongs to the deleted conversation.
         self.delete_system_prompt_snapshot(session_id)
 

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -27,6 +27,9 @@ from datus.utils.time_utils import to_utc_iso
 
 logger = get_logger(__name__)
 
+#: Cap on the preserved title. It is a sidebar label, not a document.
+MAX_TITLE_SIDECAR_CHARS = 500
+
 if TYPE_CHECKING:
     from datus.utils.path_manager import DatusPathManager
 
@@ -940,6 +943,15 @@ class SessionManager:
             if key in session_metadata and session_metadata[key]:
                 session_metadata[key] = to_utc_iso(session_metadata[key])
 
+        # A major compact clears the session and re-adds only an assistant
+        # recap, so the scan above finds no user rows and the title nulls — or,
+        # once the conversation continues, picks a mid-conversation message and
+        # silently retitles the chat. The sidecar written before the first
+        # compact holds the ORIGINAL first user message and wins.
+        preserved_title = self._read_title_sidecar(session_id)
+        if preserved_title:
+            session_metadata["first_user_message"] = preserved_title
+
         return {
             "exists": True,
             "session_id": session_id,
@@ -947,6 +959,36 @@ class SessionManager:
             **file_info,
             **session_metadata,
         }
+
+    def title_sidecar_path(self, session_id: str) -> str:
+        """Path of the ``<session_id>.title`` sidecar for this session."""
+        return os.path.join(self.session_dir, f"{session_id}.title")
+
+    def save_title_sidecar(self, session_id: str, title: str) -> None:
+        """Preserve a session's title before compaction clears its user rows.
+
+        Only ever called with a title that could still be read, so a later
+        compact — which sees no user rows — cannot overwrite a good title with
+        nothing.
+        """
+        if not session_id or not title or not title.strip():
+            return
+        try:
+            with open(self.title_sidecar_path(session_id), "w", encoding="utf-8") as handle:
+                handle.write(title.strip()[:MAX_TITLE_SIDECAR_CHARS])
+        except OSError as e:
+            logger.warning(f"Could not save title sidecar for {session_id}: {e}")
+
+    def _read_title_sidecar(self, session_id: str) -> Optional[str]:
+        """Read ``<session_id>.title``, written before a compact cleared history."""
+        try:
+            path = self.title_sidecar_path(session_id)
+            if os.path.isfile(path):
+                with open(path, encoding="utf-8") as handle:
+                    return handle.read().strip() or None
+        except OSError as e:
+            logger.debug(f"Could not read title sidecar for {session_id}: {e}")
+        return None
 
     def get_detailed_usage(self, session_id: str) -> Dict[str, Any]:
         """Query turn_usage table and return aggregated + per-turn token usage.

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -2461,3 +2461,53 @@ class TestSystemPromptSnapshot:
         sm_custom.save_system_prompt_snapshot("chat_session_tmp", "P", dict(self.META))
         leftovers = [f for f in os.listdir(sm_custom.session_dir) if f.endswith(".tmp")]
         assert leftovers == []
+
+
+class TestTitleSidecar:
+    """A major compact clears the session and re-adds only an assistant recap,
+    so the first-user-message scan has nothing left to find. The sidecar keeps
+    the sidebar label the operator recognises."""
+
+    def _seed(self, sm, session_id, messages):
+        sm.get_session(session_id)
+        db_path = os.path.join(sm.session_dir, f"{session_id}.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("INSERT OR IGNORE INTO agent_sessions (session_id) VALUES (?)", (session_id,))
+            conn.commit()
+        _insert_messages(sm.session_dir, session_id, messages)
+
+    def test_title_survives_a_history_that_lost_its_user_rows(self, sm):
+        """Post-compact shape: an assistant recap and no user rows at all."""
+        session_id = "compacted-session"
+        sm.save_title_sidecar(session_id, "How many buses ran today?")
+        self._seed(sm, session_id, [
+            {"role": "assistant", "content": "Recap of the conversation.", "created_at": "2025-01-01T01:00:00"},
+        ])
+
+        info = sm.get_session_info(session_id)
+        assert info["first_user_message"] == "How many buses ran today?"
+
+    def test_the_sidecar_wins_over_a_later_user_message(self, sm):
+        """Post-compact the earliest surviving user row is mid-conversation, so
+        the scan alone would silently retitle the chat."""
+        session_id = "retitled-session"
+        sm.save_title_sidecar(session_id, "How many buses ran today?")
+        self._seed(sm, session_id, [
+            {"role": "user", "content": "And by route?", "created_at": "2025-01-01T02:00:00"},
+        ])
+
+        assert sm.get_session_info(session_id)["first_user_message"] == "How many buses ran today?"
+
+    def test_no_sidecar_leaves_the_scan_untouched(self, sm):
+        session_id = "normal-session"
+        self._seed(sm, session_id, [
+            {"role": "user", "content": "What is SQL?", "created_at": "2025-01-01T00:00:00"},
+        ])
+        assert sm.get_session_info(session_id)["first_user_message"] == "What is SQL?"
+
+    def test_an_empty_title_is_never_written(self, sm):
+        """A later compact sees no user rows; it must not clobber a good title."""
+        session_id = "guard-session"
+        sm.save_title_sidecar(session_id, "How many buses ran today?")
+        sm.save_title_sidecar(session_id, "   ")
+        assert sm._read_title_sidecar(session_id) == "How many buses ran today?"

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -2480,9 +2480,13 @@ class TestTitleSidecar:
         """Post-compact shape: an assistant recap and no user rows at all."""
         session_id = "compacted-session"
         sm.save_title_sidecar(session_id, "How many buses ran today?")
-        self._seed(sm, session_id, [
-            {"role": "assistant", "content": "Recap of the conversation.", "created_at": "2025-01-01T01:00:00"},
-        ])
+        self._seed(
+            sm,
+            session_id,
+            [
+                {"role": "assistant", "content": "Recap of the conversation.", "created_at": "2025-01-01T01:00:00"},
+            ],
+        )
 
         info = sm.get_session_info(session_id)
         assert info["first_user_message"] == "How many buses ran today?"
@@ -2492,17 +2496,25 @@ class TestTitleSidecar:
         the scan alone would silently retitle the chat."""
         session_id = "retitled-session"
         sm.save_title_sidecar(session_id, "How many buses ran today?")
-        self._seed(sm, session_id, [
-            {"role": "user", "content": "And by route?", "created_at": "2025-01-01T02:00:00"},
-        ])
+        self._seed(
+            sm,
+            session_id,
+            [
+                {"role": "user", "content": "And by route?", "created_at": "2025-01-01T02:00:00"},
+            ],
+        )
 
         assert sm.get_session_info(session_id)["first_user_message"] == "How many buses ran today?"
 
     def test_no_sidecar_leaves_the_scan_untouched(self, sm):
         session_id = "normal-session"
-        self._seed(sm, session_id, [
-            {"role": "user", "content": "What is SQL?", "created_at": "2025-01-01T00:00:00"},
-        ])
+        self._seed(
+            sm,
+            session_id,
+            [
+                {"role": "user", "content": "What is SQL?", "created_at": "2025-01-01T00:00:00"},
+            ],
+        )
         assert sm.get_session_info(session_id)["first_user_message"] == "What is SQL?"
 
     def test_an_empty_title_is_never_written(self, sm):
@@ -2516,9 +2528,13 @@ class TestTitleSidecar:
         """The sidecar holds user text, so it must not outlive the session — and
         a later session reusing the id must not inherit the old title."""
         session_id = "deleted-session"
-        self._seed(sm, session_id, [
-            {"role": "user", "content": "How many buses ran today?", "created_at": "2025-01-01T00:00:00"},
-        ])
+        self._seed(
+            sm,
+            session_id,
+            [
+                {"role": "user", "content": "How many buses ran today?", "created_at": "2025-01-01T00:00:00"},
+            ],
+        )
         sm.save_title_sidecar(session_id, "How many buses ran today?")
         assert os.path.isfile(sm.title_sidecar_path(session_id))
 
@@ -2528,8 +2544,12 @@ class TestTitleSidecar:
 
     def test_deleting_a_session_without_a_sidecar_is_fine(self, sm):
         session_id = "no-sidecar-session"
-        self._seed(sm, session_id, [
-            {"role": "user", "content": "What is SQL?", "created_at": "2025-01-01T00:00:00"},
-        ])
+        self._seed(
+            sm,
+            session_id,
+            [
+                {"role": "user", "content": "What is SQL?", "created_at": "2025-01-01T00:00:00"},
+            ],
+        )
         sm.delete_session(session_id)  # must not raise
         assert not os.path.isfile(sm.title_sidecar_path(session_id))

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -2511,3 +2511,25 @@ class TestTitleSidecar:
         sm.save_title_sidecar(session_id, "How many buses ran today?")
         sm.save_title_sidecar(session_id, "   ")
         assert sm._read_title_sidecar(session_id) == "How many buses ran today?"
+
+    def test_deleting_a_session_removes_its_title_sidecar(self, sm):
+        """The sidecar holds user text, so it must not outlive the session — and
+        a later session reusing the id must not inherit the old title."""
+        session_id = "deleted-session"
+        self._seed(sm, session_id, [
+            {"role": "user", "content": "How many buses ran today?", "created_at": "2025-01-01T00:00:00"},
+        ])
+        sm.save_title_sidecar(session_id, "How many buses ran today?")
+        assert os.path.isfile(sm.title_sidecar_path(session_id))
+
+        sm.delete_session(session_id)
+
+        assert not os.path.isfile(sm.title_sidecar_path(session_id))
+
+    def test_deleting_a_session_without_a_sidecar_is_fine(self, sm):
+        session_id = "no-sidecar-session"
+        self._seed(sm, session_id, [
+            {"role": "user", "content": "What is SQL?", "created_at": "2025-01-01T00:00:00"},
+        ])
+        sm.delete_session(session_id)  # must not raise
+        assert not os.path.isfile(sm.title_sidecar_path(session_id))


### PR DESCRIPTION
## What breaks

The sidebar title comes from scanning a session for its first user message.

A major compact clears the session and re-adds **only an assistant recap**. No
user rows survive, so the scan finds nothing and the chat goes untitled — the
operator can no longer identify it in the session list.

Once the conversation continues, it gets worse rather than better: the earliest
surviving user row is now some mid-conversation message, so the chat silently
**retitles itself** to whatever was said after the compact.

## The fix

A `<session_id>.title` sidecar is written before the history is cleared, and
preferred on read. The title stays the original first message across any number
of compacts.

Two details that matter:

- **It is only ever written when a title can still be read.** A later compact
  sees no user rows, so without that guard it would overwrite a good title with
  nothing.
- **Saving is best-effort.** A lost title must never fail a compact, and the
  call site tolerates a node whose `session_manager` cannot be resolved.

## Tests

Four cases in `TestTitleSidecar`:

| test | asserts |
|---|---|
| `test_title_survives_a_history_that_lost_its_user_rows` | the post-compact shape — assistant recap, no user rows — still reports the original title |
| `test_the_sidecar_wins_over_a_later_user_message` | a mid-conversation user row does not retitle the chat |
| `test_no_sidecar_leaves_the_scan_untouched` | ordinary sessions are unaffected |
| `test_an_empty_title_is_never_written` | a blank save cannot clobber a good title |

Three of the four fail with the change reverted; the fourth is the
untouched-behaviour guard and passes either way by design.

## Verification

- `tests/unit_tests/agent/node` and `tests/unit_tests/models`: failure set
  **identical** to clean `main` — 0 introduced (790 pre-existing in this
  environment).
- `ruff check datus/` clean.
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved session titles when conversation history is compacted.
  - Kept sidebar titles stable even when earlier messages are removed or later messages might otherwise change the title.
  - Ignored blank replacement titles to prevent accidental loss of existing session names.

- **Tests**
  - Added coverage for title preservation across compaction and normal session histories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
