### PR TITLE
[Enhancement] Add P0 nightly release coverage gates

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -232,3 +232,5 @@ jobs:
     with:
       expected_version: ${{ needs.prepare-release.outputs.version }}
       ref: ${{ needs.prepare-release.outputs.branch }}
+    secrets:
+      RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -23,6 +23,10 @@ on:
         required: false
         default: ""
         type: string
+    secrets:
+      RELEASE_BOT_TOKEN:
+        description: "Read token for private repositories required by P0 Nightly."
+        required: true
   pull_request:
     branches:
       - "release/**"
@@ -41,6 +45,19 @@ env:
   RELEASE_CANDIDATE_DIST_ARTIFACT: datus-agent-release-candidate-dist-${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
+  p0-nightly-contracts:
+    name: P0 nightly contracts on release commit
+    # Never execute pull-request code on the long-lived Nightly runner. PRs
+    # still receive the GitHub-hosted package/docs smoke below; the protected
+    # release-branch push (or Prepare Release workflow_call) owns the P0 gate.
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: ./.github/workflows/run-nightly.yml
+    with:
+      datus_agent_ref: ${{ inputs.ref || github.ref }}
+      nightly_group_filter: '^P0 '
+    secrets:
+      RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+
   package-smoke:
     name: Package and docs smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -35,6 +35,9 @@ on:
         description: "Optional failure-notification webhook for direct reusable calls."
         required: false
 
+permissions:
+  contents: read
+
 concurrency:
   # Keep nightly runs serialized because the workflow intentionally uses the
   # stable datus-nightly-* compose project names below. Per-suite startup runs

--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -15,6 +15,25 @@ on:
         required: false
         default: ""
         type: string
+  workflow_call:
+    inputs:
+      datus_agent_ref:
+        description: "Datus-agent branch, tag, or SHA to test."
+        required: false
+        default: ""
+        type: string
+      nightly_group_filter:
+        description: "Optional regex for NIGHTLY_GROUP_FILTER."
+        required: false
+        default: ""
+        type: string
+    secrets:
+      RELEASE_BOT_TOKEN:
+        description: "Read token for private repositories required by Nightly."
+        required: true
+      FEISHU_NOTIFY_CI_URL:
+        description: "Optional failure-notification webhook for direct reusable calls."
+        required: false
 
 concurrency:
   # Keep nightly runs serialized because the workflow intentionally uses the
@@ -27,8 +46,8 @@ jobs:
   run-nightly:
     runs-on: self-hosted
     env:
-      DATUS_AGENT_REF: ${{ github.event.inputs.datus_agent_ref || github.ref_name }}
-      NIGHTLY_GROUP_FILTER: ${{ github.event.inputs.nightly_group_filter || '' }}
+      DATUS_AGENT_REF: ${{ inputs.datus_agent_ref || github.ref_name }}
+      NIGHTLY_GROUP_FILTER: ${{ inputs.nightly_group_filter || '' }}
       DATUS_TEST_RUN_ID: datus-agent-${{ github.run_id }}-${{ github.run_attempt }}
       # The job deliberately overlays packages from the adapter checkouts after
       # the locked project sync. Do not let later `uv run` commands restore the
@@ -86,6 +105,33 @@ jobs:
           ref: main
           path: external/datus-storage-adapters
           persist-credentials: false
+
+      - name: Checkout Datus-Plugins main
+        uses: actions/checkout@v4
+        with:
+          repository: Datus-ai/Datus-Plugins
+          ref: main
+          path: external/Datus-Plugins
+          persist-credentials: false
+
+      - name: Require private repository checkout token
+        shell: bash
+        env:
+          PRIVATE_REPO_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        run: |
+          if [[ -z "${PRIVATE_REPO_TOKEN}" ]]; then
+            echo "::error::RELEASE_BOT_TOKEN is required to checkout Datus-ai/datus-sql-policies"
+            exit 1
+          fi
+
+      - name: Checkout datus-sql-policies main
+        uses: actions/checkout@v4
+        with:
+          repository: Datus-ai/datus-sql-policies
+          ref: main
+          path: external/datus-sql-policies
+          persist-credentials: false
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       # Source checkouts of datus-gaussdb carry no vendored libpq (wheels get
       # it at release-build time); without it the gaussdb driver binds the

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -119,9 +119,15 @@ flow_groups:
           nightly:
             status: covered
             nodeids:
+              - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_installs_plugin_and_exports_verified_superset_queries
+              - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_real_llm_loads_skill_and_stops_at_manifest
               - tests/integration/agent/test_gen_dashboard_agentic.py
               - tests/integration/tools/test_bi_dashboard.py
               - tests/integration/tools/test_bi_grafana.py
+            notes: >
+              The P0 Superset path installs the managed plugin from source, verifies a real
+              dashboard SQL export manifest and checksums, and uses a real LLM to load the
+              dashboard-bootstrap skill and stop at its explicit confirmation boundary.
           weekly_benchmark:
             status: not_applicable
             notes: >
@@ -397,12 +403,14 @@ flow_groups:
               - tests/unit_tests/tools/test_policy_runtime.py
           nightly:
             status: covered
-            notes: >
-              Nightly API and adapter jobs exercise chat streaming and database reads; deterministic unit
-              tests cover policy-context parsing and the plugin runtime contract without requiring a live deployment.
             nodeids:
+              - tests/integration/plugins/test_sql_policy_plugin.py::test_managed_sql_policy_enforces_sql_semantic_and_api_reads
               - tests/integration/api/test_api_chat.py
               - tests/integration/adapters/test_starrocks.py
+            notes: >
+              The P0 managed-plugin test installs the real policy package and exercises fresh-process
+              CLI discovery, SQL row filtering, semantic argument rewriting, API context validation,
+              deny behavior, and user-permission precedence without an LLM.
           weekly_benchmark:
             status: covered
             notes: Baisheng weekly benchmark can run against StarRocks with request-scoped market filters.
@@ -536,7 +544,12 @@ flow_groups:
           nightly:
             status: covered
             nodeids:
+              - tests/integration/storage/test_postgresql_semantic_kb.py::test_postgresql_semantic_kb_reconcile_is_idempotent
               - tests/integration/agent/test_semantic_modeling_agentic.py
+            notes: >
+              The P0 PostgreSQL test configures both Agent RDB and vector storage to real
+              PostgreSQL/pgvector and verifies semantic projection, nullable booleans,
+              reconcile idempotency, vectors, subject tree rows, and RAG reads.
           weekly_benchmark:
             status: covered
             notes: Metadata is part of the Baisheng scenario context.
@@ -593,7 +606,13 @@ flow_groups:
             nodeids:
               - tests/unit_tests/configuration/test_agent_config.py::TestAgentConfigServiceSelectors::test_build_semantic_adapter_config_uses_runtime_database_when_datasource_omits_database
               - tests/unit_tests/tools/func_tool/test_semantic_tools.py::TestRuntimeDbContext::test_validate_semantic_initializes_adapter_with_runtime_database
-              - tests/integration/agent/test_semantic_modeling_agentic.py
+              - tests/integration/agent/test_semantic_modeling_agentic.py::test_dosi_authoring_validates_reconciles_and_queries_without_llm
+              - tests/integration/agent/test_semantic_modeling_agentic.py::test_semantic_modeling_authors_one_queryable_dosi_model_with_real_llm
+              - tests/integration/storage/test_postgresql_semantic_kb.py::test_postgresql_semantic_kb_reconcile_is_idempotent
+            notes: >
+              The P0 Dosi group owns a deterministic author-validate-reconcile-query test and one
+              real-LLM authoring smoke. PostgreSQL semantic projection is verified separately at
+              the Agent/storage seam.
           weekly_benchmark:
             status: covered
             notes: Baisheng weekly benchmark exercises retrieval-backed query generation.
@@ -952,14 +971,19 @@ flow_groups:
               - tests/unit_tests/cli/test_plugin_dispatch.py
               - tests/unit_tests/tools/middleware/test_tool_middleware.py
           nightly:
-            status: gap
+            status: covered
+            nodeids:
+              - tests/integration/plugins/test_sql_policy_plugin.py::test_managed_sql_policy_enforces_sql_semantic_and_api_reads
+              - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_installs_plugin_and_exports_verified_superset_queries
+              - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_real_llm_loads_skill_and_stops_at_manifest
             notes: >
-              No integration test installs a real plugin package end-to-end
-              (entry-point discovery through pip-installed distribution).
+              P0 installs two real source packages only into isolated managed plugin stores (with no
+              globally installed fallback), exercises fresh-process entry-point discovery and CLI
+              dispatch, verifies bundled skill delivery, user permission precedence, a tool transformer,
+              and real Superset API/export behavior.
           weekly_benchmark:
             status: not_applicable
-        gaps:
-          - https://github.com/Datus-ai/Datus-agent/issues/910
+        gaps: []
 
       - id: extension.auto_memory
         title: Auto memory

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -49,6 +49,8 @@ PACKAGE_NAMES = (
     "datus-semantic-metricflow",
     "datus-semantic-dosi",
     "datus-semantic-osi",
+    "datus-storage-base",
+    "datus-storage-postgresql",
 )
 
 
@@ -130,6 +132,7 @@ def env_value(name: str) -> str:
 def init_manifest(args: argparse.Namespace) -> None:
     repo_root = Path(args.repo_root).resolve()
     external_root = Path(args.external_repos_root).resolve()
+    tested_sha = git_output(repo_root, "rev-parse", "HEAD")
     manifest = {
         "schema_version": 1,
         "generated_at": utc_now(),
@@ -140,7 +143,11 @@ def init_manifest(args: argparse.Namespace) -> None:
             "run_number": env_value("GITHUB_RUN_NUMBER"),
             "run_attempt": env_value("GITHUB_RUN_ATTEMPT"),
             "ref": env_value("GITHUB_REF"),
-            "sha": env_value("GITHUB_SHA") or git_output(repo_root, "rev-parse", "HEAD"),
+            # ``GITHUB_SHA`` identifies the workflow trigger.  A manual run may
+            # check out a different ``datus_agent_ref``, so the release gate
+            # must key its evidence to the commit that was actually tested.
+            "sha": tested_sha,
+            "workflow_sha": env_value("GITHUB_SHA"),
             "event_name": env_value("GITHUB_EVENT_NAME"),
             "datus_agent_ref": env_value("DATUS_AGENT_REF"),
             "nightly_group_filter": env_value("NIGHTLY_GROUP_FILTER"),
@@ -167,6 +174,9 @@ def init_manifest(args: argparse.Namespace) -> None:
             repo_info(external_root / "datus-bi-adapters"),
             repo_info(external_root / "datus-scheduler-adapters"),
             repo_info(external_root / "datus-semantic-adapter"),
+            repo_info(external_root / "datus-storage-adapters"),
+            repo_info(external_root / "Datus-Plugins"),
+            repo_info(external_root / "datus-sql-policies"),
         ],
         "packages": [package_info(name) for name in PACKAGE_NAMES],
         "compose_projects": [],

--- a/ci/pytest_fail_on_skip_plugin.py
+++ b/ci/pytest_fail_on_skip_plugin.py
@@ -1,0 +1,27 @@
+"""Make an explicitly strict pytest suite fail when any test is skipped."""
+
+from __future__ import annotations
+
+from pytest import ExitCode
+
+
+def pytest_addoption(parser) -> None:
+    parser.addoption(
+        "--fail-on-skip",
+        action="store_true",
+        default=False,
+        help="Fail the pytest session when one or more selected tests are skipped.",
+    )
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    if not session.config.getoption("--fail-on-skip"):
+        return
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    skipped = reporter.stats.get("skipped", []) if reporter is not None else []
+    if not skipped:
+        return
+    if reporter is not None:
+        reporter.write_sep("=", f"FAIL-ON-SKIP: {len(skipped)} selected test(s) skipped")
+    if exitstatus == ExitCode.OK:
+        session.exitstatus = ExitCode.TESTS_FAILED

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -32,6 +32,7 @@ export DATUS_TEST_PROJECT_NAME
 NIGHTLY_REQUIRE_LANGFUSE_TRACING="${NIGHTLY_REQUIRE_LANGFUSE_TRACING:-0}"
 NIGHTLY_STARTED_AT="${NIGHTLY_STARTED_AT:-}"
 NIGHTLY_COMPOSE_PROJECT_PREFIX="${NIGHTLY_COMPOSE_PROJECT_PREFIX:-datus-nightly-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-}"
+UV_CACHE_DIR="${UV_CACHE_DIR:-$(uv cache dir)}"
 
 WORKSPACE_ROOT="${WORKSPACE_ROOT:-$(cd "${REPO_ROOT}/.." && pwd)}"
 EXTERNAL_REPOS_ROOT="${EXTERNAL_REPOS_ROOT:-${REPO_ROOT}/external}"
@@ -41,7 +42,7 @@ UNIT_TEST_HOME="${NIGHTLY_UNIT_TEST_HOME:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-
 UNIT_TEST_PROJECT_ROOT="${NIGHTLY_UNIT_TEST_PROJECT_ROOT:-${UNIT_TEST_HOME}/workspace}"
 NIGHTLY_PYTEST_BASETEMP="${NIGHTLY_PYTEST_BASETEMP:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/datus-agent-nightly-pytest-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}}"
 AGENT_TEST_CONFIG_BACKUP="${AGENT_TEST_CONFIG_BACKUP:-${TMPDIR:-/tmp}/datus-agent-nightly-config-${GITHUB_RUN_ID:-$$}.bak}"
-export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE PROVIDER_COVERAGE_MANIFEST_FILE NIGHTLY_TRACE_REFERENCES_FILE NIGHTLY_TRACE_SUMMARY_FILE NIGHTLY_PROCESS_DIAGNOSTICS_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP NIGHTLY_STARTED_AT
+export LOG_FILE NIGHTLY_MANIFEST_FILE NIGHTLY_FAILURE_CLASSIFICATION_FILE PROVIDER_COVERAGE_MANIFEST_FILE NIGHTLY_TRACE_REFERENCES_FILE NIGHTLY_TRACE_SUMMARY_FILE NIGHTLY_PROCESS_DIAGNOSTICS_FILE NIGHTLY_HOME NIGHTLY_PROJECT_ROOT UNIT_TEST_HOME NIGHTLY_PYTEST_BASETEMP NIGHTLY_STARTED_AT EXTERNAL_REPOS_ROOT UV_CACHE_DIR
 
 NIGHTLY_PYTEST_ROOTS=(tests/integration tests/regression)
 
@@ -96,7 +97,7 @@ COMPOSE_FILES=(
 )
 
 COMPOSE_GROUPS=(
-  "Superset Nightly Tests"
+  "P0 Dashboard Bootstrap Skill E2E"
   "Grafana Nightly Tests"
   "Airflow Nightly Tests"
   "PostgreSQL Adapter Tests"
@@ -112,6 +113,7 @@ COMPOSE_GROUPS=(
 )
 
 DOCKER_GROUPS=(
+  "P0 PostgreSQL Agent Storage Contracts"
   "PostgreSQL Storage Adapter Tests"
   "${COMPOSE_GROUPS[@]}"
 )
@@ -481,7 +483,7 @@ compose_project_slug() {
   local group_name="$1"
 
   case "$group_name" in
-    "Superset Nightly Tests") echo "superset" ;;
+    "P0 Dashboard Bootstrap Skill E2E") echo "superset" ;;
     "Grafana Nightly Tests") echo "grafana" ;;
     "Airflow Nightly Tests") echo "airflow" ;;
     "PostgreSQL Adapter Tests") echo "postgresql" ;;
@@ -538,7 +540,7 @@ cleanup_all_compose() {
   local project_name
   for group_name in "${COMPOSE_GROUPS[@]}"; do
     case "$group_name" in
-      "Superset Nightly Tests") compose_file="$SUPERSET_COMPOSE" ;;
+      "P0 Dashboard Bootstrap Skill E2E") compose_file="$SUPERSET_COMPOSE" ;;
       "Grafana Nightly Tests") compose_file="$GRAFANA_COMPOSE" ;;
       "Airflow Nightly Tests") compose_file="$AIRFLOW_COMPOSE" ;;
       "PostgreSQL Adapter Tests") compose_file="$POSTGRES_COMPOSE" ;;
@@ -678,10 +680,11 @@ prepare_nightly_langfuse_tracing() {
 nightly_trace_expected_for_group() {
   case "$1" in
     "Gen Agent Tests" | \
+      "P0 Dosi Semantic Modeling E2E" | \
       "Reference Template Nightly Tests" | \
       "Web UI Nightly Tests" | \
       "Product E2E Nightly Tests" | \
-      "Superset Nightly Tests" | \
+      "P0 Dashboard Bootstrap Skill E2E" | \
       "Grafana Nightly Tests" | \
       "Airflow Nightly Tests" | \
       "Provider Health Tests")
@@ -1148,7 +1151,7 @@ compose_host_port_specs() {
   local group_name="$1"
 
   case "$group_name" in
-    "Superset Nightly Tests")
+    "P0 Dashboard Bootstrap Skill E2E")
       printf 'Superset web:%s\nSuperset PostgreSQL:%s\n' "${SUPERSET_PORT:-18088}" "${SUPERSET_POSTGRES_PORT:-15433}"
       ;;
     "Grafana Nightly Tests")
@@ -1444,7 +1447,7 @@ wait_for_compose_client_readiness() {
   local airflow_base
 
   case "$group_name" in
-    "Superset Nightly Tests")
+    "P0 Dashboard Bootstrap Skill E2E")
       wait_for_http_readiness "Superset" "${SUPERSET_URL%/}/health" 300
       ;;
     "Grafana Nightly Tests")
@@ -1665,7 +1668,19 @@ ensure_nightly_kb_data
 
 run_logged "MCP Server Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/tools/test_mcp_server.py --tb=short --verbose --timeout=60 --timeout-method=thread
 
-run_logged "Gen Agent Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_semantic_modeling_agentic.py --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
+run_logged "Gen Agent Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_semantic_modeling_agentic.py \
+  --deselect tests/integration/agent/test_semantic_modeling_agentic.py::test_dosi_authoring_validates_reconciles_and_queries_without_llm \
+  --deselect tests/integration/agent/test_semantic_modeling_agentic.py::test_semantic_modeling_authors_one_queryable_dosi_model_with_real_llm \
+  --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
+
+run_logged "P0 PostgreSQL Agent Storage Contracts" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run python -m pytest tests/integration/storage/test_postgresql_semantic_kb.py -p ci.pytest_fail_on_skip_plugin --fail-on-skip --tb=short --verbose --timeout=300 --timeout-method=thread
+
+run_logged "P0 SQL Policy Plugin Contracts" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run python -m pytest tests/integration/plugins/test_sql_policy_plugin.py -p ci.pytest_fail_on_skip_plugin --fail-on-skip --tb=short --verbose --timeout=300 --timeout-method=thread
+
+run_logged "P0 Dosi Semantic Modeling E2E" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run python -m pytest \
+  tests/integration/agent/test_semantic_modeling_agentic.py::test_dosi_authoring_validates_reconciles_and_queries_without_llm \
+  tests/integration/agent/test_semantic_modeling_agentic.py::test_semantic_modeling_authors_one_queryable_dosi_model_with_real_llm \
+  -p ci.pytest_fail_on_skip_plugin --fail-on-skip --tb=short --verbose --timeout=600 --timeout-method=thread
 
 run_logged "Reference Template Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/tools/test_reference_template.py --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
 
@@ -1680,6 +1695,9 @@ NIGHTLY_DEDICATED_SUITE_DESELECTS=(
   --deselect tests/integration/agent/test_gen_dashboard_agentic.py
   --deselect tests/integration/agent/test_scheduler_agentic.py
   --deselect tests/integration/tools/test_bi_dashboard.py
+  --deselect tests/integration/plugins/test_dashboard_bootstrap_plugin.py
+  --deselect tests/integration/plugins/test_sql_policy_plugin.py
+  --deselect tests/integration/storage/test_postgresql_semantic_kb.py
   --deselect tests/integration/tools/test_bi_grafana.py
   --deselect tests/integration/tools/test_reference_template.py
   --deselect tests/integration/adapters/test_postgresql.py
@@ -1703,7 +1721,7 @@ run_logged "Main Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PR
 
 run_logged "Product E2E Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and product_e2e and not provider_health" "${NIGHTLY_PYTEST_ROOTS[@]}" "${NIGHTLY_DEDICATED_SUITE_DESELECTS[@]}" --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
 
-run_compose_suite "Superset Nightly Tests" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
+run_compose_suite "P0 Dashboard Bootstrap Skill E2E" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run python -m pytest -m nightly tests/integration/plugins/test_dashboard_bootstrap_plugin.py tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py -p ci.pytest_fail_on_skip_plugin --fail-on-skip --tb=short --verbose --timeout=600 --timeout-method=thread
 
 run_compose_suite "Grafana Nightly Tests" "$GRAFANA_COMPOSE" "postgres:300" "grafana:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/tools/test_bi_grafana.py --tb=short --verbose --timeout=300 --timeout-method=thread --reruns 1 --reruns-delay 5
 

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that nightly adapter packages came from the checked-out repositories."""
+"""Verify that nightly external packages came from the checked-out repositories."""
 
 from __future__ import annotations
 
@@ -246,7 +246,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--external-repos-root",
         type=Path,
         required=True,
-        help="Directory containing the checked-out adapter repositories.",
+        help="Directory containing the checked-out external repositories.",
     )
     return parser
 
@@ -262,7 +262,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"ERROR: {error}")
         return 1
 
-    print(f"Verified {len(EXPECTED_LOCAL_PACKAGES)} adapter packages from {args.external_repos_root.resolve()}")
+    print(f"Verified {len(EXPECTED_LOCAL_PACKAGES)} external packages from {args.external_repos_root.resolve()}")
     return 0
 
 

--- a/datus/cli/bootstrap_bi_commands.py
+++ b/datus/cli/bootstrap_bi_commands.py
@@ -52,7 +52,8 @@ _DASHBOARD_BOOTSTRAP_PROMPT = (
     'Call `load_skill(skill_name="dashboard-bootstrap")` first and execute its steps in order. '
     "Use the selected BI plugin for dashboard discovery and SQL export, and use the builtin "
     "agents named by the skill to build context. Do not use the legacy bootstrap picker, "
-    "legacy BI streams, or create dashboard-specific subagents."
+    "or legacy BI streams. Let the skill decide whether its optional final subagent step is "
+    "available."
     "{user_context}"
 )
 

--- a/datus/resources/skills/dashboard-bootstrap/SKILL.md
+++ b/datus/resources/skills/dashboard-bootstrap/SKILL.md
@@ -19,6 +19,7 @@ Bootstrap dashboard query context through an installed BI plugin. Keep BI access
 - Never assume one datasource for a BI profile or dashboard. Resolve and match source identity independently for every selected query.
 - Do not switch the shared datasource during the workflow. Run metric authoring only for query batches whose uniquely matched Datus datasource is already active.
 - Treat dashboard subagent creation as an optional final persistence step. It may reference only context identifiers confirmed by their owning builtin agents.
+- Before the Generation Manifest is confirmed, discovery is read-only. Never call an export command to inspect, probe, preview, or validate its contract, even when the plugin offers no dry-run mode. This prohibition applies to every shell/tool call whose parameters invoke the export subcommand, including help probes, discarded output, temporary output roots such as `/tmp`, and commands described as a test or `never-run` check.
 
 ## Step 0 — Resolve execution mode and routing
 
@@ -43,6 +44,8 @@ Bootstrap dashboard query context through an installed BI plugin. Keep BI access
 5. Put `--profile <name>` on every plugin call after selection. Never rely on a default that could change between calls.
 
 If no installed plugin satisfies the contract, stop and name the missing capabilities. Do not probe undocumented commands.
+
+Validate the export contract from the loaded plugin skill and read-only CLI help on parent commands. Do not invoke or request help from the export subcommand itself before confirmation; loading the plugin skill is sufficient command-contract evidence. The pre-confirmation manifest describes the expected export mode and selected candidates; it cannot contain exported file paths or checksums that do not exist yet.
 
 ## Step 2 — Select a dashboard
 
@@ -110,7 +113,7 @@ Before any plugin export or builtin generation task, print this manifest:
 | Ambiguities | unresolved business meaning or plugin limitations |
 | Subagents | planned main and attribution names, or `unavailable` when `create-subagent` is not discoverable |
 
-When `auto_run=false`, **STOP after the manifest and end the turn**. Do not call `ask_user` merely to confirm it, do not export files, and do not invoke generation tasks. Tell the user to confirm or correct the manifest in the next message.
+When `auto_run=false`, **STOP after the manifest and end the turn**. Do not call `ask_user` merely to confirm it, do not invoke the export subcommand for any reason (including help, contract validation, preview, probes, temporary output, or discarded output), and do not invoke generation tasks. Tell the user to confirm or correct the manifest in the next message.
 
 When `auto_run=true`, print the same manifest, state that confirmation was skipped by explicit instruction, and continue. This never bypasses system permission prompts.
 

--- a/tests/integration/agent/test_semantic_modeling_agentic.py
+++ b/tests/integration/agent/test_semantic_modeling_agentic.py
@@ -4,9 +4,25 @@
 
 """Integration coverage for the unified Dosi semantic-modeling node."""
 
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+
 import pytest
+from lancedb.embeddings import register
+from lancedb.embeddings.base import TextEmbeddingFunction
 
 from datus.agent.node.semantic_modeling_agentic_node import SemanticModelingAgenticNode
+from datus.configuration.agent_config import AgentConfig, NodeConfig
+from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
+from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, SourceQueryEvidence
+from datus.storage import embedding_models
+from datus.storage.embedding_models import EmbeddingModel
+from datus.storage.metric.store import MetricRAG
+from datus.storage.registry import clear_storage_registry, configure_storage_defaults
+from datus.storage.semantic_dataset.store import SemanticDatasetRAG
 from datus.utils.path_manager import DatusPathManager
 
 pytestmark = [pytest.mark.nightly, pytest.mark.product_e2e]
@@ -21,6 +37,187 @@ def _use_dosi(agent_config, project_root):
         project_root=str(project_root),
     )
     return agent_config
+
+
+@register("nightly_dosi_test")
+class _DeterministicEmbeddings(TextEmbeddingFunction):
+    def ndims(self) -> int:
+        return 4
+
+    def generate_embeddings(self, texts, *args, **kwargs):
+        del args, kwargs
+        vectors = []
+        for text in texts:
+            buckets = [0.0, 0.0, 0.0, 0.0]
+            for index, value in enumerate(str(text).encode("utf-8")):
+                buckets[index % 4] += float(value)
+            scale = sum(buckets) or 1.0
+            vectors.append([value / scale for value in buckets])
+        return vectors
+
+
+def _use_deterministic_embeddings(monkeypatch) -> None:
+    model = EmbeddingModel("nightly-dosi", 4, registry_name="nightly-dosi")
+    model._model = _DeterministicEmbeddings.create()
+    monkeypatch.setattr(
+        embedding_models,
+        "EMBEDDING_MODELS",
+        {
+            name: model
+            for name in (
+                "database",
+                "document",
+                "metric",
+                "reference_sql",
+                "semantic_model",
+                "subject",
+            )
+        },
+    )
+    configure_storage_defaults()
+    clear_storage_registry()
+
+
+def _deterministic_dosi_config(tmp_path, monkeypatch) -> AgentConfig:
+    _use_deterministic_embeddings(monkeypatch)
+    database = tmp_path / "orders.sqlite"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE orders (
+                order_id INTEGER PRIMARY KEY,
+                region TEXT NOT NULL,
+                amount REAL NOT NULL
+            );
+            INSERT INTO orders VALUES
+                (1, 'east', 100.0),
+                (2, 'west', 150.0),
+                (3, 'east', 200.0);
+            """
+        )
+
+    config = AgentConfig(
+        nodes={"semantic": NodeConfig(model="mock", input=None)},
+        home=str(tmp_path / "home"),
+        project_name="nightly_dosi",
+        project_root=str(tmp_path / "workspace"),
+        target="mock",
+        models={
+            "mock": {
+                "type": "openai",
+                "api_key": "unused",
+                "model": "unused",
+                "base_url": "http://127.0.0.1:1",
+            }
+        },
+        services={
+            "datasources": {
+                "orders": {
+                    "type": "sqlite",
+                    "uri": str(database),
+                    "default": True,
+                }
+            },
+            "semantic_layer": {"dosi": {"type": "dosi", "default": True}},
+        },
+    )
+    config.current_datasource = "orders"
+    return config
+
+
+def _orders_dataset() -> dict:
+    return {
+        "name": "orders",
+        "description": "Nightly Dosi orders",
+        "source": "main.orders",
+        "primary_key": ["order_id"],
+        "fields": [
+            {
+                "name": "order_id",
+                "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "order_id"}]},
+            },
+            {
+                "name": "region",
+                "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "region"}]},
+                "dimension": {},
+            },
+            {
+                "name": "amount",
+                "expression": {"dialects": [{"dialect": "ANSI_SQL", "expression": "amount"}]},
+            },
+        ],
+    }
+
+
+def _revenue_metric() -> dict:
+    return {
+        "name": "revenue",
+        "description": "Total order revenue",
+        "expression": {
+            "dialects": [{"dialect": "ANSI_SQL", "expression": "SUM(orders.amount)"}],
+        },
+        "custom_extensions": [
+            {
+                "vendor_name": "DATUS",
+                "data": json.dumps(
+                    {"v": "1.4", "dataset": "orders", "subject_path": ["sales", "orders"]},
+                    separators=(",", ":"),
+                ),
+            }
+        ],
+    }
+
+
+def test_dosi_authoring_validates_reconciles_and_queries_without_llm(tmp_path, monkeypatch):
+    """Cover the documented Dosi authoring contract through Agent-owned tools."""
+    config = _deterministic_dosi_config(tmp_path, monkeypatch)
+    node = SemanticModelingAgenticNode(agent_config=config, execution_mode="workflow")
+
+    inventory = node.list_existing_osi_semantic_models()
+    assert inventory.success == 1
+    planned = node.plan_osi_semantic_model_target(
+        semantic_model_name="orders_model",
+        business_domain="sales",
+        fact_tables=["main.orders"],
+    )
+    assert planned.success == 1
+    target = node.osi_target_state.selected_path
+    assert target
+
+    dataset_result = node.filesystem_func_tool.upsert_osi_datasets(target, json.dumps([_orders_dataset()]))
+    metric_result = node.filesystem_func_tool.upsert_osi_metrics(target, json.dumps([_revenue_metric()]))
+    assert dataset_result.success == 1, dataset_result.error
+    assert metric_result.success == 1, metric_result.error
+
+    public_path = node._finalize_selected_osi_artifact()
+    assert public_path == "subject/semantic_models/orders/orders_model.yml"
+    assert config.path_manager.project_root.joinpath(public_path).is_file()
+
+    catalog = node.semantic_tools.list_metrics(limit=20, offset=0)
+    assert catalog.success == 1, catalog.error
+    assert {item["name"] for item in catalog.result["items"]} == {"revenue"}
+
+    dry_run = node.semantic_tools.query_metrics(metrics=["revenue"], dry_run=True)
+    assert dry_run.success == 1, dry_run.error
+    assert "main.orders" in dry_run.result["metadata"]["sql"]
+
+    live = node.semantic_tools.query_metrics(metrics=["revenue"])
+    assert live.success == 1, live.error
+    cached = node.semantic_tools.get_cached_query_metrics_result(live.result["result_id"])
+    assert cached is not None
+    assert cached["columns"] == ["revenue"]
+    assert "450" in cached["csv"]
+
+    semantic_rag = SemanticDatasetRAG(config)
+    metric_rag = MetricRAG(config)
+    assert semantic_rag.get_size() == 1
+    assert {item["name"] for item in semantic_rag.list_fields("orders_model", "orders")} == {
+        "amount",
+        "order_id",
+        "region",
+    }
+    assert metric_rag.get_metrics_size() == 1
+    assert [item["name"] for item in metric_rag.search_all_metrics()] == ["revenue"]
 
 
 def test_semantic_modeling_scopes_share_one_real_project_workspace(nightly_agent_config, tmp_path):
@@ -48,3 +245,56 @@ def test_semantic_modeling_scopes_share_one_real_project_workspace(nightly_agent
     assert {"upsert_osi_datasets", "delete_osi_datasets", "upsert_osi_metrics", "delete_osi_metrics"} <= full_tools
     assert {"upsert_osi_datasets", "delete_osi_datasets"} <= datasets_tools
     assert {"upsert_osi_metrics", "delete_osi_metrics"}.isdisjoint(datasets_tools)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_semantic_modeling_authors_one_queryable_dosi_model_with_real_llm(
+    nightly_agent_config,
+    tmp_path,
+    monkeypatch,
+):
+    """Smoke the complete LLM authoring loop after the deterministic contract."""
+    assert os.environ.get("DEEPSEEK_API_KEY"), "P0 Dosi smoke requires DEEPSEEK_API_KEY"
+    _use_deterministic_embeddings(monkeypatch)
+    nightly_agent_config.home = str(tmp_path / "home")
+    config = _use_dosi(nightly_agent_config, tmp_path / "workspace")
+    config.semantic_layer_configs = {"dosi": {"type": "dosi", "default": True}}
+
+    node = SemanticModelingAgenticNode(agent_config=config, execution_mode="workflow")
+    node.input = SemanticNodeInput(
+        user_message=(
+            "Create one Dosi semantic model named nightly_school_counts for the main.schools table. "
+            "Include the reusable dataset fields needed for a metric named school_count that counts schools. "
+            "Validate it, reconcile it to the Knowledge Base, and return status generated."
+        ),
+        semantic_model_name="nightly_school_counts",
+        business_domain="schools",
+        fact_tables=["main.schools"],
+        max_turns=30,
+        source_queries=[
+            SourceQueryEvidence(
+                source_sql_name="school_count",
+                question="How many schools are there?",
+                sql="SELECT COUNT(*) AS school_count FROM schools",
+            )
+        ],
+    )
+
+    actions = [action async for action in node.execute_stream(ActionHistoryManager())]
+    successful_tools = {
+        action.action_type
+        for action in actions
+        if action.role == ActionRole.TOOL and action.status == ActionStatus.SUCCESS
+    }
+    assert {"upsert_osi_datasets", "upsert_osi_metrics"} <= successful_tools
+    assert actions[-1].status == ActionStatus.SUCCESS, actions[-1].output
+    assert actions[-1].output["success"] is True
+    assert actions[-1].output["status"] == "generated"
+    assert len(actions[-1].output["semantic_models"]) == 1
+
+    model_path = config.path_manager.project_root / actions[-1].output["semantic_models"][0]
+    assert model_path.is_file()
+    metric_catalog = node.semantic_tools.list_metrics(limit=50, offset=0)
+    assert metric_catalog.success == 1, metric_catalog.error
+    assert "school_count" in {item["name"] for item in metric_catalog.result["items"]}

--- a/tests/integration/agent/test_semantic_modeling_agentic.py
+++ b/tests/integration/agent/test_semantic_modeling_agentic.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 import os
 import sqlite3
@@ -21,7 +23,7 @@ from datus.schemas.semantic_agentic_node_models import SemanticNodeInput, Source
 from datus.storage import embedding_models
 from datus.storage.embedding_models import EmbeddingModel
 from datus.storage.metric.store import MetricRAG
-from datus.storage.registry import clear_storage_registry, configure_storage_defaults
+from datus.storage.registry import clear_storage_registry, configure_storage_defaults, get_storage_defaults
 from datus.storage.semantic_dataset.store import SemanticDatasetRAG
 from datus.utils.path_manager import DatusPathManager
 
@@ -76,6 +78,17 @@ def _use_deterministic_embeddings(monkeypatch) -> None:
     )
     configure_storage_defaults()
     clear_storage_registry()
+
+
+@pytest.fixture
+def restore_storage_defaults():
+    """Restore process-wide storage state after deterministic P0 tests."""
+    defaults = get_storage_defaults()
+    try:
+        yield
+    finally:
+        configure_storage_defaults(**defaults)
+        clear_storage_registry()
 
 
 def _deterministic_dosi_config(tmp_path, monkeypatch) -> AgentConfig:
@@ -168,7 +181,11 @@ def _revenue_metric() -> dict:
     }
 
 
-def test_dosi_authoring_validates_reconciles_and_queries_without_llm(tmp_path, monkeypatch):
+def test_dosi_authoring_validates_reconciles_and_queries_without_llm(
+    tmp_path,
+    monkeypatch,
+    restore_storage_defaults,
+):
     """Cover the documented Dosi authoring contract through Agent-owned tools."""
     config = _deterministic_dosi_config(tmp_path, monkeypatch)
     node = SemanticModelingAgenticNode(agent_config=config, execution_mode="workflow")
@@ -206,7 +223,9 @@ def test_dosi_authoring_validates_reconciles_and_queries_without_llm(tmp_path, m
     cached = node.semantic_tools.get_cached_query_metrics_result(live.result["result_id"])
     assert cached is not None
     assert cached["columns"] == ["revenue"]
-    assert "450" in cached["csv"]
+    rows = list(csv.DictReader(io.StringIO(cached["csv"])))
+    assert len(rows) == 1
+    assert float(rows[0]["revenue"]) == 450.0
 
     semantic_rag = SemanticDatasetRAG(config)
     metric_rag = MetricRAG(config)
@@ -253,6 +272,7 @@ async def test_semantic_modeling_authors_one_queryable_dosi_model_with_real_llm(
     nightly_agent_config,
     tmp_path,
     monkeypatch,
+    restore_storage_defaults,
 ):
     """Smoke the complete LLM authoring loop after the deterministic contract."""
     assert os.environ.get("DEEPSEEK_API_KEY"), "P0 Dosi smoke requires DEEPSEEK_API_KEY"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,9 +12,14 @@ that load from tests/conf/agent.yml — mirroring the real agent startup flow.
 import copy
 import os
 import shutil
+import subprocess
+import sys
 import time
 from argparse import Namespace
+from dataclasses import dataclass
+from importlib import metadata
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -31,6 +36,155 @@ SKILLS_DIR = TESTS_ROOT / "data" / "skills"
 # Real LLM integration test paths
 REAL_SKILLS_DIR = Path.home() / ".datus" / "skills"
 REAL_SQLITE_DB = Path.home() / ".datus" / "benchmark" / "california_schools" / "california_schools.sqlite"
+
+
+@dataclass(frozen=True)
+class RequiredPostgresqlStorage:
+    """Provisioned PostgreSQL RDB + pgvector test environments."""
+
+    rdb_config: Any
+    vector_config: Any
+
+
+@dataclass(frozen=True)
+class P0ExternalSources:
+    """Source checkouts required by the deterministic P0 integration suites."""
+
+    storage_adapters: Path
+    sql_policies: Path
+    datus_plugins: Path
+
+    @property
+    def superset_plugin(self) -> Path:
+        return self.datus_plugins / "datus-superset-plugin"
+
+
+@dataclass(frozen=True)
+class ManagedPluginRuntime:
+    """Isolated managed plugin store exercised through fresh CLI processes."""
+
+    home: Path
+    datus_executable: Path
+
+    def run(
+        self,
+        *args: str,
+        check: bool = True,
+        cwd: Path | None = None,
+        timeout: float | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        # Isolating HOME must not also discard uv's dependency/build cache;
+        # otherwise every managed source install re-downloads its wheelhouse.
+        env.setdefault("UV_CACHE_DIR", str(Path.home() / ".cache" / "uv"))
+        env["HOME"] = str(self.home)
+        return subprocess.run(
+            [str(self.datus_executable), *args],
+            check=check,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=cwd,
+            timeout=timeout,
+        )
+
+    def install(self, source: Path) -> subprocess.CompletedProcess[str]:
+        return self.run("plugin", "install", f"src:{source}")
+
+
+def _entry_points_for(group: str, name: str) -> list[Any]:
+    entry_points = metadata.entry_points()
+    if hasattr(entry_points, "select"):
+        return list(entry_points.select(group=group, name=name))
+    return [entry_point for entry_point in entry_points.get(group, []) if entry_point.name == name]
+
+
+def _required_test_environment(group: str, name: str):
+    matches = _entry_points_for(group, name)
+    if len(matches) != 1:
+        pytest.fail(
+            f"P0 requires exactly one {group}:{name} entry point, found {len(matches)}",
+            pytrace=False,
+        )
+    try:
+        return matches[0].load()()
+    except Exception as exc:  # noqa: BLE001 - fail with the external provider's concrete error.
+        pytest.fail(f"P0 could not load {group}:{name}: {exc}", pytrace=False)
+
+
+@pytest.fixture(scope="session")
+def required_postgresql_storage() -> RequiredPostgresqlStorage:
+    """Start real PostgreSQL and pgvector providers, failing instead of skipping."""
+    rdb_environment = _required_test_environment("datus.storage.rdb.testing", "postgresql")
+    vector_environment = _required_test_environment("datus.storage.vector.testing", "postgresql")
+    started = []
+    try:
+        for environment in (rdb_environment, vector_environment):
+            started.append(environment)
+            environment.setup()
+        rdb_config = rdb_environment.get_config()
+        vector_config = vector_environment.get_config()
+        if rdb_config.backend_type != "postgresql" or vector_config.backend_type != "postgresql":
+            pytest.fail(
+                "P0 PostgreSQL providers must both report backend_type=postgresql",
+                pytrace=False,
+            )
+        yield RequiredPostgresqlStorage(rdb_config=rdb_config, vector_config=vector_config)
+    except Exception as exc:
+        pytest.fail(f"P0 PostgreSQL/pgvector setup failed: {exc}", pytrace=False)
+    finally:
+        teardown_errors = []
+        for environment in reversed(started):
+            try:
+                environment.teardown()
+            except Exception as exc:  # noqa: BLE001 - report every provider cleanup error.
+                teardown_errors.append(str(exc))
+        if teardown_errors:
+            pytest.fail(f"P0 PostgreSQL/pgvector teardown failed: {'; '.join(teardown_errors)}", pytrace=False)
+
+
+def _resolve_external_root() -> Path:
+    configured = os.environ.get("EXTERNAL_REPOS_ROOT")
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    for candidate in repo_root.parents:
+        if (candidate / "datus-storage-adapters").is_dir() and (candidate / "Datus-Plugins").is_dir():
+            return candidate
+    pytest.fail("P0 external repository root was not found; set EXTERNAL_REPOS_ROOT", pytrace=False)
+
+
+@pytest.fixture(scope="session")
+def p0_external_sources() -> P0ExternalSources:
+    """Require the three P0 source checkouts used by Nightly."""
+    root = _resolve_external_root()
+    sources = P0ExternalSources(
+        storage_adapters=root / "datus-storage-adapters",
+        sql_policies=root / "datus-sql-policies",
+        datus_plugins=root / "Datus-Plugins",
+    )
+    required = {
+        "datus-storage-adapters": sources.storage_adapters,
+        "datus-sql-policies": sources.sql_policies,
+        "Datus-Plugins": sources.datus_plugins,
+        "datus-superset-plugin": sources.superset_plugin,
+    }
+    missing = [f"{name} ({path})" for name, path in required.items() if not path.is_dir()]
+    if missing:
+        pytest.fail(f"P0 external source checkout(s) missing: {', '.join(missing)}", pytrace=False)
+    return sources
+
+
+@pytest.fixture
+def managed_plugin_runtime(tmp_path) -> ManagedPluginRuntime:
+    """Return a clean managed store; every command runs in a new process."""
+    executable = Path(sys.executable).with_name("datus")
+    if not executable.is_file():
+        pytest.fail(f"Datus CLI executable not found beside test Python: {executable}", pytrace=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    return ManagedPluginRuntime(home=home, datus_executable=executable)
 
 
 # ── AgentConfig fixtures ──

--- a/tests/integration/plugins/test_dashboard_bootstrap_plugin.py
+++ b/tests/integration/plugins/test_dashboard_bootstrap_plugin.py
@@ -1,0 +1,280 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Dashboard Bootstrap and managed Superset plugin P0 integration."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from rich.console import Console
+
+from datus.cli.bootstrap_bi_picker import BootstrapBiPicker
+from datus.configuration.agent_config_loader import load_agent_config
+from tests.conftest import TEST_CONF_DIR
+from tests.integration.tools.test_bi_dashboard import _create_adapter, _ensure_seed_dashboard
+
+
+def _print_mode_tool_calls(stdout: str) -> list[dict]:
+    """Extract actual tool invocations from print-mode JSONL output."""
+    calls = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        calls.extend(
+            item["payload"]
+            for item in payload.get("content", [])
+            if item.get("type") == "call-tool" and isinstance(item.get("payload"), dict)
+        )
+    return calls
+
+
+def _plugin_agent_document(home: Path, workspace: Path, superset_url: str) -> dict:
+    return {
+        "agent": {
+            "home": str(home),
+            "project_name": "nightly_dashboard_bootstrap",
+            "project_root": str(workspace),
+            "target": "mock",
+            "models": {
+                "mock": {
+                    "type": "openai",
+                    "api_key": "unused",
+                    "model": "unused",
+                    "base_url": "http://127.0.0.1:1",
+                }
+            },
+            "nodes": {"chat": {"model": "mock"}},
+            "plugins": {
+                "superset": {
+                    "local": {
+                        "default": True,
+                        "api_base_url": superset_url,
+                        "auth_mode": "login",
+                        "username": "admin",
+                        "password": "admin",
+                        "provider": "db",
+                        "verify_ssl": True,
+                        "timeout": 30,
+                        "serving_datasource": "superset",
+                        "serving_database_name": "superset_examples",
+                    }
+                }
+            },
+        }
+    }
+
+
+def _llm_agent_document(home: Path, workspace: Path, superset_url: str) -> dict:
+    document = yaml.safe_load((TEST_CONF_DIR / "agent.yml").read_text(encoding="utf-8"))
+    agent = document["agent"]
+    agent["home"] = str(home)
+    agent["project_name"] = "nightly_dashboard_bootstrap_llm"
+    agent["project_root"] = str(workspace)
+    agent["plugins"] = _plugin_agent_document(home, workspace, superset_url)["agent"]["plugins"]
+    for datasource in agent["services"]["datasources"].values():
+        datasource.pop("default", None)
+    agent["services"]["datasources"]["superset"] = {
+        "type": "postgresql",
+        "host": os.environ.get("SUPERSET_POSTGRES_HOST", "127.0.0.1"),
+        "port": os.environ.get("SUPERSET_POSTGRES_PORT", "5433"),
+        "username": "superset",
+        "password": "superset",
+        "database": "superset_examples",
+        "schema": "public",
+        "default": True,
+    }
+    agent["services"]["bi_platforms"]["superset"]["api_base_url"] = superset_url
+    return document
+
+
+def _seed_dashboard(superset_url: str) -> tuple[int, str]:
+    config = load_agent_config(
+        config=str(TEST_CONF_DIR / "agent.yml"),
+        datasource="superset",
+        reload=True,
+        force=True,
+        yes=True,
+    )
+    config.dashboard_config["superset"].api_base_url = superset_url
+
+    database = config.services.datasources["superset"]
+    database.host = os.environ.get("SUPERSET_POSTGRES_HOST", database.host)
+    database.port = os.environ.get("SUPERSET_POSTGRES_PORT", "5433")
+    database.username = "superset"
+    database.password = "superset"
+    database.database = "superset_examples"
+    database.schema = "public"
+
+    item = {
+        "platform": "superset",
+        "api_base_url": superset_url,
+        "dashboard_url": f"{superset_url}/superset/dashboard/datus-nightly-placeholder/",
+        "dialect": "postgresql",
+        "seed_dashboard": True,
+    }
+    picker = BootstrapBiPicker(config, Console(log_path=False, force_terminal=False))
+    adapter = _create_adapter(picker, config, item)
+    try:
+        _ensure_seed_dashboard(adapter, item)
+        dashboard_id = int(adapter.parse_dashboard_id(item["dashboard_url"]))
+        dashboard = adapter.get_dashboard_info(dashboard_id)
+        assert dashboard is not None
+        return dashboard_id, dashboard.name
+    finally:
+        adapter.close()
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(300)
+def test_dashboard_bootstrap_installs_plugin_and_exports_verified_superset_queries(
+    p0_external_sources,
+    managed_plugin_runtime,
+    tmp_path,
+):
+    """Exercise source install, discovery, real Superset export, and manifest integrity."""
+    assert importlib.util.find_spec("datus_superset_plugin") is None, (
+        "P0 must not have a globally installed datus-superset-plugin fallback"
+    )
+    superset_url = os.environ.get("SUPERSET_URL", "http://127.0.0.1:8088").rstrip("/")
+    dashboard_id, dashboard_name = _seed_dashboard(superset_url)
+
+    installed = managed_plugin_runtime.install(p0_external_sources.superset_plugin)
+    assert "superset" in installed.stdout
+
+    datus_home = managed_plugin_runtime.home / ".datus"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    document = _plugin_agent_document(datus_home, workspace, superset_url)
+    config_file = datus_home / "conf" / "agent.yml"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+
+    listed_plugins = managed_plugin_runtime.run("plugin", "list")
+    assert "superset" in listed_plugins.stdout
+    info = managed_plugin_runtime.run("plugin", "info", "superset")
+    assert "entry:   datus_superset_plugin" in info.stdout
+    installed_export_skill = (
+        datus_home / "plugins" / "superset" / "datus_superset_plugin" / "skills" / "superset-query-export" / "SKILL.md"
+    )
+    assert installed_export_skill.is_file()
+    assert "context export-dashboard" in installed_export_skill.read_text(encoding="utf-8")
+
+    health = managed_plugin_runtime.run("superset", "--profile", "local", "status", "health", "-o", "json")
+    assert json.loads(health.stdout) == "OK"
+
+    dashboards = managed_plugin_runtime.run(
+        "superset",
+        "--profile",
+        "local",
+        "dashboards",
+        "list",
+        "--param",
+        f'q={{"filters":[{{"col":"id","opr":"eq","value":{dashboard_id}}}]}}',
+        "-o",
+        "json",
+    )
+    dashboard_rows = json.loads(dashboards.stdout)["result"]
+    assert [int(row["id"]) for row in dashboard_rows] == [dashboard_id]
+
+    exported = managed_plugin_runtime.run(
+        "superset",
+        "--profile",
+        "local",
+        "context",
+        "export-dashboard",
+        str(dashboard_id),
+        "--output-root",
+        "reference_sql",
+        "-o",
+        "json",
+        cwd=workspace,
+    )
+    export_result = json.loads(exported.stdout)
+    assert export_result["failed"] == 0
+    assert export_result["succeeded"] == 2
+
+    output_dir = Path(export_result["output_dir"])
+    manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    assert manifest["platform"] == "superset"
+    assert manifest["profile"] == "local"
+    assert int(manifest["dashboard"]["id"]) == dashboard_id
+    assert manifest["dashboard"]["title"] == dashboard_name
+    assert manifest["summary"] == {"total": 2, "succeeded": 2, "failed": 0}
+
+    for query in manifest["queries"]:
+        assert query["status"] == "ok"
+        assert query["asset_id"]
+        assert query["datasource"]
+        sql_file = output_dir / query["file"]
+        assert sql_file.is_file()
+        sql_text = sql_file.read_text(encoding="utf-8")
+        assert hashlib.sha256(sql_text.encode()).hexdigest() == query["sha256"]
+        assert "SELECT" in sql_text.upper()
+
+    source_text = "\n".join(path.read_text(encoding="utf-8") for path in (output_dir / "_source").glob("*.json"))
+    assert '"password"' not in source_text.lower()
+    assert '"access_token"' not in source_text.lower()
+
+
+@pytest.mark.nightly
+@pytest.mark.product_e2e
+@pytest.mark.timeout(300)
+def test_dashboard_bootstrap_real_llm_loads_skill_and_stops_at_manifest(
+    p0_external_sources,
+    managed_plugin_runtime,
+    tmp_path,
+):
+    """Keep one real-model smoke at the skill's explicit confirmation boundary."""
+    assert os.environ.get("DEEPSEEK_API_KEY"), "P0 Dashboard LLM smoke requires DEEPSEEK_API_KEY"
+    assert importlib.util.find_spec("datus_superset_plugin") is None, (
+        "P0 must not have a globally installed datus-superset-plugin fallback"
+    )
+    superset_url = os.environ.get("SUPERSET_URL", "http://127.0.0.1:8088").rstrip("/")
+    dashboard_id, dashboard_name = _seed_dashboard(superset_url)
+    managed_plugin_runtime.install(p0_external_sources.superset_plugin)
+
+    datus_home = managed_plugin_runtime.home / ".datus"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    document = _llm_agent_document(datus_home, workspace, superset_url)
+    config_file = datus_home / "conf" / "agent.yml"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+
+    prompt = (
+        "Bootstrap reference SQL and metrics from the installed Superset plugin, profile local, "
+        f"dashboard id {dashboard_id} ({dashboard_name}). Select every visible chart for both scopes. "
+        "Do not run automatically: follow dashboard-bootstrap and stop after emitting the Generation Manifest."
+    )
+    result = managed_plugin_runtime.run(
+        "--config",
+        str(config_file),
+        "--datasource",
+        "superset",
+        "--permission-mode",
+        "dangerous",
+        "--print",
+        prompt,
+        cwd=workspace,
+        timeout=300,
+    )
+    tool_calls = _print_mode_tool_calls(result.stdout)
+    assert any(
+        call.get("toolName") == "load_skill" and call.get("toolParams", {}).get("skill_name") == "dashboard-bootstrap"
+        for call in tool_calls
+    )
+    assert not any("export-dashboard" in json.dumps(call.get("toolParams", {})) for call in tool_calls)
+    assert "dashboard-bootstrap" in result.stdout
+    assert "Generation Manifest" in result.stdout
+    assert dashboard_name in result.stdout
+    assert not (workspace / "reference_sql").exists()
+    assert not list(workspace.rglob("manifest.json"))

--- a/tests/integration/plugins/test_sql_policy_plugin.py
+++ b/tests/integration/plugins/test_sql_policy_plugin.py
@@ -1,0 +1,235 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Deterministic Datus Agent + managed SQL policy plugin regression."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from starlette.requests import Request
+
+from datus.api.auth.header_context_provider import HeaderContextProvider
+from datus.api.routes.chat_routes import _policy_context_pre_check
+from datus.configuration.agent_config import AgentConfig, NodeConfig
+from datus.plugins.registry import invalidate_plugin_cache
+from datus.tools.db_tools.config import SQLiteConfig
+from datus.tools.db_tools.sqlite_connector import SQLiteConnector
+from datus.tools.func_tool.database import DBFuncTool
+from datus.tools.middleware.tool_middleware import transform_tool_args
+from datus.tools.permission.bash_rules import evaluate_bash_command
+from datus.tools.permission.permission_config import PermissionLevel
+
+
+def _policies() -> list[dict]:
+    return [
+        {
+            "name": "store_scope_sql",
+            "type": "row_filter",
+            "applies_to": {"datasources": ["warehouse"], "tables": ["orders"]},
+            "condition": {
+                "column": "store_id",
+                "operator": "in",
+                "value_from": "policy_context.row_filter.store_ids",
+            },
+        },
+        {
+            "name": "store_scope_metrics",
+            "type": "metric_row_filter",
+            "applies_to": {"datasets": ["orders"]},
+            "condition": {
+                "column": "orders.store_id",
+                "operator": "in",
+                "value_from": "policy_context.row_filter.store_ids",
+            },
+        },
+    ]
+
+
+def _agent_document(home, workspace, database) -> dict:
+    return {
+        "agent": {
+            "home": str(home),
+            "project_name": "nightly_sql_policy",
+            "project_root": str(workspace),
+            "target": "mock",
+            "models": {
+                "mock": {
+                    "type": "openai",
+                    "api_key": "unused",
+                    "model": "unused",
+                    "base_url": "http://127.0.0.1:1",
+                }
+            },
+            "nodes": {"chat": {"model": "mock"}},
+            "services": {
+                "datasources": {
+                    "warehouse": {
+                        "type": "sqlite",
+                        "uri": str(database),
+                        "default": True,
+                    }
+                }
+            },
+            "plugins": {
+                "sql-policy": {
+                    "default": {
+                        "default": True,
+                        "policies": _policies(),
+                    }
+                }
+            },
+            "permissions": {
+                "profile": "normal",
+                "bash_commands": {"deny": ["datus sql-policy status"]},
+            },
+        }
+    }
+
+
+def _agent_config(document: dict) -> AgentConfig:
+    raw = document["agent"]
+    nodes = {name: NodeConfig(input=None, **value) for name, value in raw["nodes"].items()}
+    config = AgentConfig(nodes=nodes, **{key: value for key, value in raw.items() if key != "nodes"})
+    config.current_datasource = "warehouse"
+    return config
+
+
+def _request(policy_context: dict) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/chat/stream",
+            "headers": [
+                (
+                    b"x-datus-policy-context",
+                    json.dumps(policy_context, separators=(",", ":")).encode(),
+                )
+            ],
+        }
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(300)
+@pytest.mark.asyncio
+async def test_managed_sql_policy_enforces_sql_semantic_and_api_reads(
+    p0_external_sources,
+    managed_plugin_runtime,
+    tmp_path,
+):
+    """Exercise the managed plugin and every Agent-side enforcement seam."""
+    assert importlib.util.find_spec("datus_sql_policies") is None, (
+        "P0 must not have a globally installed datus-sql-policies fallback"
+    )
+    installed = managed_plugin_runtime.install(p0_external_sources.sql_policies)
+    assert "sql-policy" in installed.stdout
+
+    database = tmp_path / "orders.sqlite"
+    connector = SQLiteConnector(SQLiteConfig(db_path=str(database)))
+    try:
+        assert connector.execute_query("CREATE TABLE orders (store_id TEXT NOT NULL, amount INTEGER NOT NULL)").success
+        assert connector.execute_query("INSERT INTO orders VALUES ('S001', 10), ('S002', 20)").success
+
+        datus_home = managed_plugin_runtime.home / ".datus"
+        document = _agent_document(datus_home, tmp_path / "workspace", database)
+        config_file = datus_home / "conf" / "agent.yml"
+        config_file.parent.mkdir(parents=True)
+        config_file.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+
+        listed = managed_plugin_runtime.run("plugin", "list")
+        assert "sql-policy" in listed.stdout
+        info = managed_plugin_runtime.run("plugin", "info", "sql-policy")
+        assert "entry:   datus_sql_policies" in info.stdout
+        status = managed_plugin_runtime.run("sql-policy", "status")
+        assert "2 policies configured" in status.stdout
+        assert "store_scope_sql" in status.stdout
+        checked = managed_plugin_runtime.run(
+            "sql-policy",
+            "check",
+            "--sql",
+            "SELECT store_id, amount FROM orders ORDER BY store_id",
+            "--datasource",
+            "warehouse",
+            "--dialect",
+            "sqlite",
+            "--policy-context",
+            json.dumps({"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}}),
+        )
+        assert "store_scope_sql" in checked.stdout
+        assert "S001" in checked.stdout
+
+        config = _agent_config(document)
+        invalidate_plugin_cache()
+        assert config.active_plugin_names() is None
+        plugin_spec = importlib.util.find_spec("datus_sql_policies")
+        assert plugin_spec is not None and plugin_spec.origin
+        managed_plugin_dir = datus_home / "plugins" / "sql-policy"
+        assert Path(plugin_spec.origin).resolve().is_relative_to(managed_plugin_dir.resolve())
+
+        scoped = {"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}}
+        config.policy_context = scoped
+        tool = DBFuncTool(connector, agent_config=config, default_datasource="warehouse")
+        sql_result = tool.execute_read_enforced(
+            "SELECT store_id, amount FROM orders ORDER BY store_id",
+            connector,
+            datasource="warehouse",
+        )
+        assert sql_result.success, sql_result.error
+        assert sql_result.sql_return == [{"store_id": "S001", "amount": 10}]
+
+        transformed = transform_tool_args(
+            "query_metrics",
+            {"metrics": ["order_revenue"], "where": "orders.amount > 0"},
+            category="semantic_tools",
+            active_plugin_names=config.active_plugin_names(),
+            context={
+                "agent_config": config,
+                "policy_context": scoped,
+                "metric_datasets": {"order_revenue": ["orders"]},
+            },
+        )
+        assert "orders.amount > 0" in transformed["where"]
+        assert "orders.store_id" in transformed["where"]
+        assert "S001" in transformed["where"]
+
+        provider = HeaderContextProvider()
+        scoped_context = await provider.authenticate(_request(scoped))
+        assert scoped_context.policy_context == scoped
+        assert _policy_context_pre_check(SimpleNamespace(agent_config=config), scoped_context) is None
+
+        denied = {"row_filter": {"access_mode": "denied"}}
+        denied_context = await provider.authenticate(_request(denied))
+        outcome = _policy_context_pre_check(SimpleNamespace(agent_config=config), denied_context)
+        assert outcome is not None
+        assert outcome.allow is False
+        assert outcome.error_type == "POLICY_CONTEXT_REJECTED"
+
+        config.policy_context = denied
+        denied_result = tool.execute_read_enforced(
+            "SELECT store_id, amount FROM orders",
+            connector,
+            datasource="warehouse",
+        )
+        assert not denied_result.success
+        assert "denies all data reads" in denied_result.error
+
+        plugin_decision = evaluate_bash_command(
+            "datus sql-policy status",
+            config.plugin_bash_rules["normal"],
+        )
+        assert plugin_decision.level == PermissionLevel.ALLOW
+
+        user_override_decision = evaluate_bash_command(
+            "datus sql-policy status",
+            config.permissions_config.bash_commands,
+        )
+        assert user_override_decision.level == PermissionLevel.DENY
+    finally:
+        connector.close()

--- a/tests/integration/storage/test_postgresql_semantic_kb.py
+++ b/tests/integration/storage/test_postgresql_semantic_kb.py
@@ -1,0 +1,235 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Deterministic Agent semantic projection + PostgreSQL storage regression."""
+
+from __future__ import annotations
+
+import textwrap
+import uuid
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+from psycopg import sql
+
+from datus.configuration.agent_config import AgentConfig, NodeConfig
+from datus.storage import embedding_models
+from datus.storage.embedding_models import EmbeddingModel
+from datus.storage.metric.store import MetricRAG
+from datus.storage.registry import clear_storage_registry, configure_storage_defaults
+from datus.storage.semantic_dataset.store import SemanticDatasetRAG
+from datus.tools.func_tool.generation_tools import GenerationTools
+
+
+class _DeterministicEmbeddings:
+    """Small stable embedding function: no model download and no LLM call."""
+
+    def ndims(self) -> int:
+        return 4
+
+    def generate_embeddings(self, texts, *args, **kwargs):
+        del args, kwargs
+        vectors = []
+        for text in texts:
+            encoded = str(text).encode("utf-8")
+            buckets = [0.0, 0.0, 0.0, 0.0]
+            for index, value in enumerate(encoded):
+                buckets[index % 4] += float(value)
+            scale = sum(buckets) or 1.0
+            vectors.append([value / scale for value in buckets])
+        return vectors
+
+
+def _embedding_model() -> EmbeddingModel:
+    model = EmbeddingModel("nightly-deterministic", 4, registry_name="nightly-deterministic")
+    model._model = _DeterministicEmbeddings()
+    return model
+
+
+def _osi_document(description: str, metric_description: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        version: "0.2.0.dev0"
+        semantic_model:
+          - name: nightly_orders
+            description: PostgreSQL reconcile regression model
+            datasets:
+              - name: orders
+                description: {description}
+                source: analytics.orders
+                primary_key: [order_id]
+                fields:
+                  - name: order_id
+                    expression:
+                      dialects:
+                        - dialect: ANSI_SQL
+                          expression: order_id
+                  - name: region
+                    expression:
+                      dialects:
+                        - dialect: ANSI_SQL
+                          expression: region
+                    dimension: {{}}
+                  - name: amount
+                    expression:
+                      dialects:
+                        - dialect: ANSI_SQL
+                          expression: amount
+            metrics:
+              - name: order_revenue
+                description: {metric_description}
+                expression:
+                  dialects:
+                    - dialect: ANSI_SQL
+                      expression: SUM(orders.amount)
+                custom_extensions:
+                  - vendor_name: DATUS
+                    data: '{{"v":"1.4","dataset":"orders","subject_path":["sales","orders"]}}'
+        """
+    )
+
+
+def _connect(params: dict):
+    return psycopg.connect(
+        host=params["host"],
+        port=params["port"],
+        user=params["user"],
+        password=params["password"],
+        dbname=params["dbname"],
+    )
+
+
+@pytest.fixture
+def postgresql_agent_config(required_postgresql_storage, tmp_path, monkeypatch) -> Iterator[AgentConfig]:
+    project_name = f"nightly_pg_{uuid.uuid4().hex[:10]}"
+    datasource = "warehouse"
+    deterministic_model = _embedding_model()
+    monkeypatch.setitem(embedding_models.EMBEDDING_MODELS, "semantic_model", deterministic_model)
+    monkeypatch.setitem(embedding_models.EMBEDDING_MODELS, "metric", deterministic_model)
+    configure_storage_defaults()
+    clear_storage_registry()
+
+    rdb_params = dict(required_postgresql_storage.rdb_config.params)
+    vector_params = dict(required_postgresql_storage.vector_config.params)
+    config = AgentConfig(
+        nodes={"test": NodeConfig(model="mock", input=None)},
+        home=str(tmp_path / "home"),
+        project_name=project_name,
+        project_root=str(tmp_path / "workspace"),
+        target="mock",
+        models={
+            "mock": {
+                "type": "openai",
+                "api_key": "unused",
+                "model": "unused",
+                "base_url": "http://127.0.0.1:1",
+            }
+        },
+        services={
+            "datasources": {
+                datasource: {
+                    "type": "postgresql",
+                    "host": "unused",
+                    "database": "analytics",
+                    "schema": "public",
+                    "default": True,
+                }
+            }
+        },
+        storage={
+            "rdb": {"type": "postgresql", **rdb_params},
+            "vector": {"type": "postgresql", **vector_params},
+        },
+    )
+    config.current_datasource = datasource
+
+    try:
+        yield config
+    finally:
+        clear_storage_registry()
+        # The testing providers own cleanup semantics.  Drop only this random
+        # project schema, never shared/public data.
+        with _connect(rdb_params) as connection:
+            connection.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(project_name)))
+            connection.commit()
+        with _connect(vector_params) as connection:
+            connection.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(project_name)))
+            connection.commit()
+
+
+@pytest.mark.nightly
+@pytest.mark.timeout(300)
+def test_postgresql_semantic_kb_reconcile_is_idempotent(postgresql_agent_config, tmp_path):
+    """Exercise insert, update, and no-op reconcile through the Agent seam."""
+    config = postgresql_agent_config
+    artifact = tmp_path / "nightly_orders.yml"
+    artifact.write_text(_osi_document("Initial orders dataset", "Initial revenue metric"), encoding="utf-8")
+    tools = GenerationTools(config, authoring_format="osi")
+
+    first = tools.sync_osi_to_db(str(artifact))
+    artifact.write_text(_osi_document("Reconciled orders dataset", "Reconciled revenue metric"), encoding="utf-8")
+    second = tools.sync_osi_to_db(str(artifact))
+    third = tools.sync_osi_to_db(str(artifact))
+
+    for result in (first, second, third):
+        assert result["success"] is True, result
+        assert result["semantic_dataset_rows"] == 4
+        assert result["metric_names"] == ["order_revenue"]
+
+    semantic_rag = SemanticDatasetRAG(config)
+    metric_rag = MetricRAG(config)
+    datasets = semantic_rag.list_datasets(table_name="orders")
+    metrics = metric_rag.search_all_metrics()
+    assert [row["name"] for row in datasets] == ["orders"]
+    assert datasets[0]["description"] == "Reconciled orders dataset"
+    assert [row["name"] for row in metrics] == ["order_revenue"]
+    assert metrics[0]["description"] == "Reconciled revenue metric"
+    assert semantic_rag.list_objects("reconciled orders", kinds=["dataset"])[0]["name"] == "orders"
+    assert metric_rag.search_metrics("order_revenue")[0]["name"] == "order_revenue"
+
+    project = config.project_name
+    datasource = config.current_datasource
+    rdb_params = dict(config._backend_config.rdb.params)
+    vector_params = dict(config._backend_config.vector.params)
+
+    with _connect(vector_params) as connection:
+        semantic_rows = connection.execute(
+            sql.SQL(
+                "SELECT id, kind, description, is_primary_key, is_time, is_dimension, "
+                "vector IS NOT NULL AS has_vector FROM {}.semantic_dataset ORDER BY id"
+            ).format(sql.Identifier(project))
+        ).fetchall()
+        metric_rows = connection.execute(
+            sql.SQL(
+                "SELECT id, name, description, subject_node_id, vector IS NOT NULL AS has_vector "
+                "FROM {}.metrics ORDER BY id"
+            ).format(sql.Identifier(project))
+        ).fetchall()
+
+    assert len(semantic_rows) == 4
+    assert len({row[0] for row in semantic_rows}) == 4
+    dataset_row = next(row for row in semantic_rows if row[1] == "dataset")
+    assert dataset_row[2:] == ("Reconciled orders dataset", None, None, None, True)
+    field_flags = {row[0].rsplit(".", 1)[-1]: row[3:6] for row in semantic_rows if row[1] == "field"}
+    assert field_flags == {
+        "amount": (False, False, False),
+        "order_id": (True, False, False),
+        "region": (False, False, True),
+    }
+    assert len(metric_rows) == 1
+    assert metric_rows[0][0:3] == ("metric:order_revenue", "order_revenue", "Reconciled revenue metric")
+    assert metric_rows[0][4] is True
+
+    with _connect(rdb_params) as connection:
+        subject_rows = connection.execute(
+            sql.SQL(
+                "SELECT node_id, parent_id, name FROM {}.subject_nodes WHERE datasource_id = %s ORDER BY node_id"
+            ).format(sql.Identifier(project)),
+            (datasource,),
+        ).fetchall()
+
+    assert [row[2] for row in subject_rows] == ["sales", "orders"]
+    assert subject_rows[0][1] == -1
+    assert subject_rows[1][1] == subject_rows[0][0]
+    assert metric_rows[0][3] == subject_rows[1][0]

--- a/tests/integration/storage/test_postgresql_semantic_kb.py
+++ b/tests/integration/storage/test_postgresql_semantic_kb.py
@@ -17,7 +17,7 @@ from datus.configuration.agent_config import AgentConfig, NodeConfig
 from datus.storage import embedding_models
 from datus.storage.embedding_models import EmbeddingModel
 from datus.storage.metric.store import MetricRAG
-from datus.storage.registry import clear_storage_registry, configure_storage_defaults
+from datus.storage.registry import clear_storage_registry, configure_storage_defaults, get_storage_defaults
 from datus.storage.semantic_dataset.store import SemanticDatasetRAG
 from datus.tools.func_tool.generation_tools import GenerationTools
 
@@ -105,6 +105,7 @@ def postgresql_agent_config(required_postgresql_storage, tmp_path, monkeypatch) 
     project_name = f"nightly_pg_{uuid.uuid4().hex[:10]}"
     datasource = "warehouse"
     deterministic_model = _embedding_model()
+    storage_defaults = get_storage_defaults()
     monkeypatch.setitem(embedding_models.EMBEDDING_MODELS, "semantic_model", deterministic_model)
     monkeypatch.setitem(embedding_models.EMBEDDING_MODELS, "metric", deterministic_model)
     configure_storage_defaults()
@@ -148,14 +149,18 @@ def postgresql_agent_config(required_postgresql_storage, tmp_path, monkeypatch) 
         yield config
     finally:
         clear_storage_registry()
-        # The testing providers own cleanup semantics.  Drop only this random
-        # project schema, never shared/public data.
-        with _connect(rdb_params) as connection:
-            connection.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(project_name)))
-            connection.commit()
-        with _connect(vector_params) as connection:
-            connection.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(project_name)))
-            connection.commit()
+        try:
+            # The testing providers own cleanup semantics.  Drop only this
+            # random project schema, never shared/public data.
+            with _connect(rdb_params) as connection:
+                connection.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(project_name)))
+                connection.commit()
+            with _connect(vector_params) as connection:
+                connection.execute(sql.SQL("DROP SCHEMA IF EXISTS {} CASCADE").format(sql.Identifier(project_name)))
+                connection.commit()
+        finally:
+            configure_storage_defaults(**storage_defaults)
+            clear_storage_registry()
 
 
 @pytest.mark.nightly

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-nightly.yml"
+RELEASE_CANDIDATE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-candidate.yml"
 NIGHTLY_SCRIPT = REPO_ROOT / "ci" / "run-nightly-tests.sh"
 
 
@@ -53,6 +54,38 @@ def test_nightly_installs_storage_packages_from_latest_checkout():
         assert package_path in workflow
 
 
+def test_nightly_installs_p0_plugins_only_through_managed_store():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    for repository, path in (
+        ("Datus-ai/Datus-Plugins", "external/Datus-Plugins"),
+        ("Datus-ai/datus-sql-policies", "external/datus-sql-policies"),
+    ):
+        assert f"repository: {repository}" in workflow
+        assert f"path: {path}" in workflow
+
+    private_checkout = workflow.split("- name: Checkout datus-sql-policies main", maxsplit=1)[1].split(
+        "- name:", maxsplit=1
+    )[0]
+    assert "token: ${{ secrets.RELEASE_BOT_TOKEN }}" in private_checkout
+    assert "github.token" not in private_checkout
+    assert "- name: Require private repository checkout token" in workflow
+
+    install_block = workflow.split("- name: Install dependencies", maxsplit=1)[1].split(
+        "- name: Ensure Docker runtime", maxsplit=1
+    )[0]
+    for package_name, package_path in (
+        ("datus-superset-plugin", "./external/Datus-Plugins/datus-superset-plugin"),
+        ("datus-sql-policies", "./external/datus-sql-policies"),
+    ):
+        assert f"--reinstall-package {package_name}" not in install_block
+        assert package_path not in install_block
+
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+    assert "export LOG_FILE" in script
+    assert "EXTERNAL_REPOS_ROOT" in next(line for line in script.splitlines() if line.startswith("export LOG_FILE"))
+
+
 def test_nightly_installs_new_database_adapters_from_latest_checkout():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
@@ -68,6 +101,43 @@ def test_nightly_runs_postgresql_storage_adapter_tests_from_checkout():
     assert 'run_logged "PostgreSQL Storage Adapter Tests"' in script
     assert 'uv run --no-sync pytest "$STORAGE_ADAPTERS_ROOT/datus-storage-postgresql/tests"' in script
     assert '"PostgreSQL Storage Adapter Tests"' in script.split("DOCKER_GROUPS=(", maxsplit=1)[1]
+
+
+def test_nightly_runs_p0_contracts_without_reruns_or_skips():
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+    logical_lines = script.replace("\\\n", " ").splitlines()
+
+    for group in (
+        "P0 PostgreSQL Agent Storage Contracts",
+        "P0 SQL Policy Plugin Contracts",
+        "P0 Dosi Semantic Modeling E2E",
+        "P0 Dashboard Bootstrap Skill E2E",
+    ):
+        command = next(line for line in logical_lines if line.startswith("run_") and f'"{group}"' in line)
+        assert "--fail-on-skip" in command
+        assert "--reruns" not in command
+        assert "uv run python -m pytest" in command
+
+    assert '"P0 PostgreSQL Agent Storage Contracts"' in script.split("DOCKER_GROUPS=(", maxsplit=1)[1]
+    assert '"P0 Dashboard Bootstrap Skill E2E"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
+
+
+def test_release_candidate_reuses_p0_nightly_on_the_release_ref():
+    nightly = WORKFLOW.read_text(encoding="utf-8")
+    release = RELEASE_CANDIDATE_WORKFLOW.read_text(encoding="utf-8")
+    prepare = (REPO_ROOT / ".github" / "workflows" / "prepare-release.yml").read_text(encoding="utf-8")
+
+    assert "workflow_call:" in nightly
+    assert "DATUS_AGENT_REF: ${{ inputs.datus_agent_ref || github.ref_name }}" in nightly
+    assert "NIGHTLY_GROUP_FILTER: ${{ inputs.nightly_group_filter || '' }}" in nightly
+    assert "uses: ./.github/workflows/run-nightly.yml" in release
+    assert "if: ${{ github.event_name != 'pull_request' }}" in release
+    assert "datus_agent_ref: ${{ inputs.ref || github.ref }}" in release
+    assert "nightly_group_filter: '^P0 '" in release
+    assert "secrets: inherit" not in release
+    assert "RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}" in release
+    assert "uses: ./.github/workflows/release-candidate.yml" in prepare
+    assert "RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}" in prepare
 
 
 def test_nightly_runs_doris_agent_contract_from_checkout():

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -128,6 +128,7 @@ def test_release_candidate_reuses_p0_nightly_on_the_release_ref():
     prepare = (REPO_ROOT / ".github" / "workflows" / "prepare-release.yml").read_text(encoding="utf-8")
 
     assert "workflow_call:" in nightly
+    assert "\npermissions:\n  contents: read\n" in nightly
     assert "DATUS_AGENT_REF: ${{ inputs.datus_agent_ref || github.ref_name }}" in nightly
     assert "NIGHTLY_GROUP_FILTER: ${{ inputs.nightly_group_filter || '' }}" in nightly
     assert "uses: ./.github/workflows/run-nightly.yml" in release

--- a/tests/unit_tests/ci/test_nightly_manifest.py
+++ b/tests/unit_tests/ci/test_nightly_manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[3] / "ci" / "nightly_manifest.py"
@@ -10,6 +11,52 @@ if MODULE_SPEC is None or MODULE_SPEC.loader is None:
     raise RuntimeError(f"Unable to load nightly_manifest module from {MODULE_PATH}")
 nightly_manifest = importlib.util.module_from_spec(MODULE_SPEC)
 MODULE_SPEC.loader.exec_module(nightly_manifest)
+
+
+def test_manifest_records_actual_checkout_and_all_p0_sources(tmp_path, monkeypatch):
+    repo_root = tmp_path / "Datus-agent"
+    external_root = tmp_path / "external"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo_root)], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.email", "nightly@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.name", "Nightly Test"], check=True)
+    (repo_root / "README.md").write_text("nightly\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo_root), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-qm", "fixture"], check=True)
+    tested_sha = subprocess.check_output(["git", "-C", str(repo_root), "rev-parse", "HEAD"], text=True).strip()
+    manifest_path = tmp_path / "nightly-manifest.json"
+    monkeypatch.setenv("GITHUB_SHA", "workflow-trigger-sha")
+
+    assert (
+        nightly_manifest.main(
+            [
+                "init",
+                "--output",
+                str(manifest_path),
+                "--repo-root",
+                str(repo_root),
+                "--external-repos-root",
+                str(external_root),
+            ]
+        )
+        == 0
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["run"]["sha"] == tested_sha
+    assert manifest["run"]["workflow_sha"] == "workflow-trigger-sha"
+    assert {repo["name"] for repo in manifest["repositories"]} >= {
+        "datus-storage-adapters",
+        "Datus-Plugins",
+        "datus-sql-policies",
+    }
+    assert {package["name"] for package in manifest["packages"]} >= {
+        "datus-storage-base",
+        "datus-storage-postgresql",
+    }
+    assert {package["name"] for package in manifest["packages"]}.isdisjoint(
+        {"datus-sql-policies", "datus-superset-plugin"}
+    )
 
 
 def test_parse_collection_output_extracts_nodeids_and_counts():

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -59,13 +59,20 @@ def test_nightly_pytest_commands_set_explicit_test_layer():
     pytest_commands = [
         command
         for command in _nightly_shell_commands()
-        if " uv run pytest " in command
+        if (" uv run pytest " in command or " uv run python -m pytest " in command)
         and any(wrapper in command for wrapper in ("run_logged", "run_compose_suite", "run_with_agent_home"))
     ]
 
-    assert len(pytest_commands) == 22
+    assert len(pytest_commands) == 25
     assert any("tests/integration/adapters/test_doris.py" in command for command in pytest_commands)
     assert any("tests/integration/adapters/test_gaussdb.py" in command for command in pytest_commands)
+    for group in (
+        "P0 PostgreSQL Agent Storage Contracts",
+        "P0 SQL Policy Plugin Contracts",
+        "P0 Dosi Semantic Modeling E2E",
+        "P0 Dashboard Bootstrap Skill E2E",
+    ):
+        assert any(group in command for command in pytest_commands)
     for command in pytest_commands:
         expected_layer = "unit" if "Full Unit Tests" in command else "nightly"
         assert f"env DATUS_TEST_LAYER={expected_layer}" in command

--- a/tests/unit_tests/ci/test_pytest_fail_on_skip_plugin.py
+++ b/tests/unit_tests/ci/test_pytest_fail_on_skip_plugin.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from pytest import ExitCode
+
+from ci.pytest_fail_on_skip_plugin import pytest_sessionfinish
+
+
+class _Reporter:
+    def __init__(self, skipped):
+        self.stats = {"skipped": skipped}
+        self.messages = []
+
+    def write_sep(self, separator, message):
+        self.messages.append((separator, message))
+
+
+def _session(*, enabled: bool, skipped: list) -> SimpleNamespace:
+    reporter = _Reporter(skipped)
+    pluginmanager = SimpleNamespace(get_plugin=lambda _name: reporter)
+    config = SimpleNamespace(
+        getoption=lambda _name: enabled,
+        pluginmanager=pluginmanager,
+    )
+    return SimpleNamespace(config=config, exitstatus=ExitCode.OK, reporter=reporter)
+
+
+def test_fail_on_skip_changes_successful_session_to_failure():
+    session = _session(enabled=True, skipped=[object()])
+
+    pytest_sessionfinish(session, ExitCode.OK)
+
+    assert session.exitstatus == ExitCode.TESTS_FAILED
+    assert session.reporter.messages == [("=", "FAIL-ON-SKIP: 1 selected test(s) skipped")]
+
+
+def test_fail_on_skip_is_opt_in():
+    session = _session(enabled=False, skipped=[object()])
+
+    pytest_sessionfinish(session, ExitCode.OK)
+
+    assert session.exitstatus == ExitCode.OK
+    assert session.reporter.messages == []

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -69,6 +69,11 @@ def test_expected_sources_include_storage_packages():
     )
 
 
+def test_managed_p0_plugins_are_not_required_as_global_packages():
+    assert "datus-sql-policies" not in verify_sources.EXPECTED_LOCAL_PACKAGES
+    assert "datus-superset-plugin" not in verify_sources.EXPECTED_LOCAL_PACKAGES
+
+
 def test_expected_sources_include_new_database_adapters():
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-doris"] == "datus-db-adapters/datus-doris"
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-hologres"] == "datus-db-adapters/datus-hologres"

--- a/tests/unit_tests/cli/test_bootstrap_bi_commands.py
+++ b/tests/unit_tests/cli/test_bootstrap_bi_commands.py
@@ -113,6 +113,8 @@ def test_cmd_delegates_to_dashboard_bootstrap_skill(agent_config, console) -> No
     message = cli.chat_commands.execute_chat_command.call_args.args[0]
     assert 'load_skill(skill_name="dashboard-bootstrap")' in message
     assert "legacy bootstrap picker" in message
+    assert "Let the skill decide" in message
+    assert "or create dashboard-specific subagents" not in message
 
 
 def test_cmd_forwards_user_context_and_plan_mode(agent_config, console) -> None:

--- a/tests/unit_tests/tools/skill_tools/test_dashboard_bootstrap_skill.py
+++ b/tests/unit_tests/tools/skill_tools/test_dashboard_bootstrap_skill.py
@@ -47,6 +47,10 @@ def test_dashboard_bootstrap_skill_has_ordered_selection_and_generation_gate():
     assert offsets == sorted(offsets)
     assert "STOP after the manifest and end the turn" in body
     assert "auto_run=true" in body
+    assert "Never call an export command to inspect, probe, preview, or validate its contract" in body
+    assert "temporary output roots such as `/tmp`" in body
+    assert "Do not invoke or request help from the export subcommand itself before confirmation" in body
+    assert "cannot contain exported file paths or checksums" in body
 
 
 def test_dashboard_bootstrap_skill_routes_to_builtin_owners():


### PR DESCRIPTION
## Summary

- gate prepared release candidates with the P0 Nightly contracts on the exact release ref while keeping pull-request code off the long-lived self-hosted runner
- pass only the named RELEASE_BOT_TOKEN secret required for the private SQL policy checkout; install SQL policy and Superset plugins only through isolated managed plugin stores
- add deterministic PostgreSQL semantic-KB reconcile, managed SQL policy, deterministic/LLM Dosi authoring, and real Superset dashboard bootstrap coverage
- make P0 skips blocking, record the actually tested checkout and external source provenance, and update the documented coverage map
- enforce the Dashboard Bootstrap confirmation boundary from structured tool-call output, including a regression for probe exports before confirmation

## User-visible behavior

Release preparation now waits for the P0 Nightly gate. Direct release-branch pull requests still receive the GitHub-hosted package/docs smoke, but do not execute untrusted PR code on the self-hosted Nightly runner.

Nightly validates the Agent/storage/plugin combinations that adapter-only suites could not cover, without a globally installed plugin fallback masking managed-install failures.

## Test Cases

- P0 PostgreSQL Agent Storage Contracts: 1 passed
- P0 SQL Policy Plugin Contracts: 1 passed
- P0 Dosi Semantic Modeling E2E: 2 passed
- P0 Dashboard Bootstrap Skill E2E: 7 passed against a real local Superset
- related unit suites: 48 passed
- Ruff check and format check
- strict coverage-map validation
- Actionlint workflow validation, excluding existing SC2086/SC2129 shellcheck notices
- bash syntax validation and git diff --check

## Local environment note

The first full runner attempt reached the Dashboard compose group after the PostgreSQL, SQL Policy, and Dosi groups passed, but the newly started Superset container hit an external psycopg2-binary download SSL/hash error. The complete seven-test Dashboard group was then validated against an already healthy real local Superset instance.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Added reusable nightly validation for priority contract suites during release-candidate checks.
  * Expanded coverage for dashboard bootstrapping, SQL policy enforcement, semantic modeling, and PostgreSQL storage.
  * Added support for tracking tested revisions and external validation sources in nightly reports.
* **Bug Fixes**
  * Improved dashboard bootstrap safeguards to prevent export operations before confirmation.
  * Nightly runs can now fail when selected tests are skipped, preventing incomplete validation from passing.
* **Tests**
  * Added comprehensive integration and regression coverage for the new validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable nightly validation for priority contract suites during release-candidate checks.
  * Expanded coverage for dashboard bootstrapping, SQL policy enforcement, semantic modeling, and PostgreSQL storage.
  * Nightly reports now track tested revisions, validation sources, and additional storage packages.
* **Bug Fixes**
  * Improved dashboard bootstrap safeguards to prevent export operations before confirmation.
  * Nightly runs now fail when selected tests are skipped.
* **Tests**
  * Added comprehensive integration and regression coverage for the new validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->