### PR TITLE
[Feature] Integrate the TiDB adapter (datus-tidb)

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -220,6 +220,7 @@ jobs:
             --reinstall-package datus-semantic-osi \
             --reinstall-package datus-snowflake \
             --reinstall-package datus-doris \
+            --reinstall-package datus-tidb \
             --reinstall-package datus-hologres \
             --reinstall-package datus-oracle \
             --reinstall-package datus-gaussdb \
@@ -240,6 +241,7 @@ jobs:
             ./external/datus-db-adapters/datus-clickhouse \
             ./external/datus-db-adapters/datus-starrocks \
             ./external/datus-db-adapters/datus-doris \
+            ./external/datus-db-adapters/datus-tidb \
             ./external/datus-db-adapters/datus-hologres \
             ./external/datus-db-adapters/datus-oracle \
             ./external/datus-db-adapters/datus-trino \
@@ -412,6 +414,7 @@ jobs:
           echo "ADAPTERS_CH=1" >> $GITHUB_ENV
           echo "ADAPTERS_SR=1" >> $GITHUB_ENV
           echo "ADAPTERS_DORIS=1" >> $GITHUB_ENV
+          echo "ADAPTERS_TIDB=1" >> $GITHUB_ENV
           echo "ADAPTERS_TRINO=1" >> $GITHUB_ENV
           echo "ADAPTERS_GP=1" >> $GITHUB_ENV
           echo "ADAPTERS_HIVE=1" >> $GITHUB_ENV
@@ -437,6 +440,8 @@ jobs:
           echo "STARROCKS_HTTP_HOST_PORT=28030" >> $GITHUB_ENV
           echo "DORIS_QUERY_HOST_PORT=29031" >> $GITHUB_ENV
           echo "DORIS_HTTP_HOST_PORT=28031" >> $GITHUB_ENV
+          echo "TIDB_HOST_PORT=24000" >> $GITHUB_ENV
+          echo "TIDB_STATUS_HOST_PORT=20080" >> $GITHUB_ENV
           echo "TRINO_HOST_PORT=28080" >> $GITHUB_ENV
           echo "GREENPLUM_HOST_PORT=15434" >> $GITHUB_ENV
           echo "HIVE_METASTORE_HOST_PORT=29083" >> $GITHUB_ENV

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -362,6 +362,7 @@ flow_groups:
               - tests/integration/adapters/test_clickhouse.py
               - tests/integration/adapters/test_starrocks.py
               - tests/integration/adapters/test_doris.py
+              - tests/integration/adapters/test_tidb.py
               - tests/integration/adapters/test_trino.py
               - tests/integration/adapters/test_greenplum.py
               - tests/integration/adapters/test_hive.py
@@ -457,6 +458,7 @@ flow_groups:
               - tests/integration/agent/test_scheduler_agentic.py
               - tests/integration/adapters/test_starrocks.py
               - tests/integration/adapters/test_doris.py
+              - tests/integration/adapters/test_tidb.py
           weekly_benchmark:
             status: covered
             notes: Weekly benchmark uses datus-agent with released/source adapter packages for the selected scenario.

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -40,6 +40,7 @@ PACKAGE_NAMES = (
     "datus-hive",
     "datus-spark",
     "datus-gaussdb",
+    "datus-tidb",
     "datus-bi-core",
     "datus-bi-superset",
     "datus-bi-grafana",

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -1724,6 +1724,7 @@ NIGHTLY_DEDICATED_SUITE_DESELECTS=(
   --deselect tests/integration/adapters/test_clickhouse.py
   --deselect tests/integration/adapters/test_starrocks.py
   --deselect tests/integration/adapters/test_doris.py
+  --deselect tests/integration/adapters/test_tidb.py
   --deselect tests/integration/adapters/test_trino.py
   --deselect tests/integration/adapters/test_greenplum.py
   --deselect tests/integration/adapters/test_hive.py

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -71,6 +71,7 @@ MYSQL_COMPOSE="${MYSQL_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-mysql/docker-compose.y
 CLICKHOUSE_COMPOSE="${CLICKHOUSE_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-clickhouse/docker-compose.yml}"
 STARROCKS_COMPOSE="${STARROCKS_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-starrocks/docker-compose.yml}"
 DORIS_COMPOSE="${DORIS_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-doris/docker-compose.yml}"
+TIDB_COMPOSE="${TIDB_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-tidb/docker-compose.yml}"
 TRINO_COMPOSE="${TRINO_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-trino/docker-compose.yml}"
 GREENPLUM_COMPOSE="${GREENPLUM_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-greenplum/docker-compose.yml}"
 HIVE_COMPOSE="${HIVE_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-hive/docker-compose.yml}"
@@ -105,6 +106,7 @@ COMPOSE_GROUPS=(
   "ClickHouse Adapter Tests"
   "StarRocks Adapter Tests"
   "Doris Adapter Tests"
+  "TiDB Adapter Tests"
   "Trino Adapter Tests"
   "Greenplum Adapter Tests"
   "Hive Adapter Tests"
@@ -491,6 +493,7 @@ compose_project_slug() {
     "ClickHouse Adapter Tests") echo "clickhouse" ;;
     "StarRocks Adapter Tests") echo "starrocks" ;;
     "Doris Adapter Tests") echo "doris" ;;
+    "TiDB Adapter Tests") echo "tidb" ;;
     "Trino Adapter Tests") echo "trino" ;;
     "Greenplum Adapter Tests") echo "greenplum" ;;
     "Hive Adapter Tests") echo "hive" ;;
@@ -548,6 +551,7 @@ cleanup_all_compose() {
       "ClickHouse Adapter Tests") compose_file="$CLICKHOUSE_COMPOSE" ;;
       "StarRocks Adapter Tests") compose_file="$STARROCKS_COMPOSE" ;;
       "Doris Adapter Tests") compose_file="$DORIS_COMPOSE" ;;
+      "TiDB Adapter Tests") compose_file="$TIDB_COMPOSE" ;;
       "Trino Adapter Tests") compose_file="$TRINO_COMPOSE" ;;
       "Greenplum Adapter Tests") compose_file="$GREENPLUM_COMPOSE" ;;
       "Hive Adapter Tests") compose_file="$HIVE_COMPOSE" ;;
@@ -916,6 +920,14 @@ if [ "${NIGHTLY_FORCE_ADAPTER_ENV:-1}" = "1" ]; then
   export DORIS_CATALOG=internal
   export DORIS_DATABASE=test
 
+  export TIDB_HOST_PORT="${TIDB_HOST_PORT:-24000}"
+  export TIDB_STATUS_HOST_PORT="${TIDB_STATUS_HOST_PORT:-20080}"
+  export TIDB_HOST=127.0.0.1
+  export TIDB_PORT="$TIDB_HOST_PORT"
+  export TIDB_USER=root
+  export TIDB_PASSWORD=
+  export TIDB_DATABASE=test
+
   export TRINO_HOST_PORT="${TRINO_HOST_PORT:-28080}"
   export TRINO_HOST=127.0.0.1
   export TRINO_PORT="$TRINO_HOST_PORT"
@@ -1174,6 +1186,9 @@ compose_host_port_specs() {
       ;;
     "Doris Adapter Tests")
       printf 'Doris query:%s\nDoris HTTP:%s\n' "${DORIS_QUERY_HOST_PORT:-29031}" "${DORIS_HTTP_HOST_PORT:-28031}"
+      ;;
+    "TiDB Adapter Tests")
+      printf 'TiDB query:%s\nTiDB status:%s\n' "${TIDB_HOST_PORT:-24000}" "${TIDB_STATUS_HOST_PORT:-20080}"
       ;;
     "Trino Adapter Tests")
       printf 'Trino HTTP:%s\n' "${TRINO_HOST_PORT:-28080}"
@@ -1442,6 +1457,22 @@ wait_for_doris_client_readiness() {
   return 0
 }
 
+wait_for_tidb_client_readiness() {
+  local timeout_seconds="${1:-300}"
+
+  # Waits for the SQL port *and* a registered TiFlash store: the columnar
+  # fixtures issue ALTER TABLE ... SET TIFLASH REPLICA, which TiDB rejects until
+  # TiFlash has reported itself to PD.
+  uv run --no-sync python "$DB_ADAPTERS_ROOT/datus-tidb/scripts/wait_for_tidb.py" \
+    --timeout "$timeout_seconds" 2>&1 | tee -a "$LOG_FILE"
+  local status=${PIPESTATUS[0]}
+  if [ "$status" -ne 0 ]; then
+    test_exit_code="$status"
+    return "$status"
+  fi
+  return 0
+}
+
 wait_for_compose_client_readiness() {
   local group_name="$1"
   local airflow_base
@@ -1472,6 +1503,9 @@ wait_for_compose_client_readiness() {
       ;;
     "Doris Adapter Tests")
       wait_for_doris_client_readiness "${DORIS_READY_TIMEOUT:-600}"
+      ;;
+    "TiDB Adapter Tests")
+      wait_for_tidb_client_readiness "${TIDB_READY_TIMEOUT:-300}"
       ;;
     "Trino Adapter Tests")
       wait_for_http_readiness "Trino" "http://${TRINO_HOST:-127.0.0.1}:${TRINO_PORT:-8080}/v1/info" 300
@@ -1634,6 +1668,7 @@ log "POSTGRESQL_HOST=${POSTGRESQL_HOST:-} POSTGRESQL_PORT=${POSTGRESQL_PORT:-} P
 log "MYSQL_HOST=${MYSQL_HOST:-} MYSQL_PORT=${MYSQL_PORT:-} MYSQL_HOST_PORT=${MYSQL_HOST_PORT:-}"
 log "CLICKHOUSE_HOST=${CLICKHOUSE_HOST:-} CLICKHOUSE_PORT=${CLICKHOUSE_PORT:-} CLICKHOUSE_HTTP_HOST_PORT=${CLICKHOUSE_HTTP_HOST_PORT:-} CLICKHOUSE_NATIVE_HOST_PORT=${CLICKHOUSE_NATIVE_HOST_PORT:-}"
 log "STARROCKS_HOST=${STARROCKS_HOST:-} STARROCKS_PORT=${STARROCKS_PORT:-} STARROCKS_QUERY_HOST_PORT=${STARROCKS_QUERY_HOST_PORT:-} STARROCKS_HTTP_HOST_PORT=${STARROCKS_HTTP_HOST_PORT:-}"
+log "TIDB_HOST=${TIDB_HOST:-} TIDB_PORT=${TIDB_PORT:-} TIDB_STATUS_HOST_PORT=${TIDB_STATUS_HOST_PORT:-}"
 log "DORIS_HOST=${DORIS_HOST:-} DORIS_PORT=${DORIS_PORT:-} DORIS_QUERY_HOST_PORT=${DORIS_QUERY_HOST_PORT:-} DORIS_HTTP_HOST_PORT=${DORIS_HTTP_HOST_PORT:-}"
 log "TRINO_HOST=${TRINO_HOST:-} TRINO_PORT=${TRINO_PORT:-}"
 log "GREENPLUM_HOST=${GREENPLUM_HOST:-} GREENPLUM_PORT=${GREENPLUM_PORT:-} GREENPLUM_HOST_PORT=${GREENPLUM_HOST_PORT:-}"
@@ -1733,6 +1768,7 @@ run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with
 run_compose_suite "ClickHouse Adapter Tests" "$CLICKHOUSE_COMPOSE" "clickhouse:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_clickhouse.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "StarRocks Adapter Tests" "$STARROCKS_COMPOSE" "starrocks:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_starrocks.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Doris Adapter Tests" "$DORIS_COMPOSE" "doris:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_doris.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_compose_suite "TiDB Adapter Tests" "$TIDB_COMPOSE" "pd0:120" "tikv0:120" "tidb0:120" "tiflash0:120" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_tidb.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_trino.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300 --timeout-method=thread

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -1457,22 +1457,6 @@ wait_for_doris_client_readiness() {
   return 0
 }
 
-wait_for_tidb_client_readiness() {
-  local timeout_seconds="${1:-300}"
-
-  # Waits for the SQL port *and* a registered TiFlash store: the columnar
-  # fixtures issue ALTER TABLE ... SET TIFLASH REPLICA, which TiDB rejects until
-  # TiFlash has reported itself to PD.
-  uv run --no-sync python "$DB_ADAPTERS_ROOT/datus-tidb/scripts/wait_for_tidb.py" \
-    --timeout "$timeout_seconds" 2>&1 | tee -a "$LOG_FILE"
-  local status=${PIPESTATUS[0]}
-  if [ "$status" -ne 0 ]; then
-    test_exit_code="$status"
-    return "$status"
-  fi
-  return 0
-}
-
 wait_for_compose_client_readiness() {
   local group_name="$1"
   local airflow_base
@@ -1505,7 +1489,7 @@ wait_for_compose_client_readiness() {
       wait_for_doris_client_readiness "${DORIS_READY_TIMEOUT:-600}"
       ;;
     "TiDB Adapter Tests")
-      wait_for_tidb_client_readiness "${TIDB_READY_TIMEOUT:-300}"
+      wait_for_http_readiness "TiDB" "http://${TIDB_HOST:-127.0.0.1}:${TIDB_STATUS_HOST_PORT:-20080}/status" 300
       ;;
     "Trino Adapter Tests")
       wait_for_http_readiness "Trino" "http://${TRINO_HOST:-127.0.0.1}:${TRINO_PORT:-8080}/v1/info" 300
@@ -1768,7 +1752,7 @@ run_compose_suite "MySQL Adapter Tests" "$MYSQL_COMPOSE" "mysql:300" -- run_with
 run_compose_suite "ClickHouse Adapter Tests" "$CLICKHOUSE_COMPOSE" "clickhouse:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_clickhouse.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "StarRocks Adapter Tests" "$STARROCKS_COMPOSE" "starrocks:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_starrocks.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Doris Adapter Tests" "$DORIS_COMPOSE" "doris:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_doris.py --tb=short --verbose --timeout=300 --timeout-method=thread
-run_compose_suite "TiDB Adapter Tests" "$TIDB_COMPOSE" "pd0:120" "tikv0:120" "tidb0:120" "tiflash0:120" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_tidb.py --tb=short --verbose --timeout=300 --timeout-method=thread
+run_compose_suite "TiDB Adapter Tests" "$TIDB_COMPOSE" "tidb:120" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_tidb.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Trino Adapter Tests" "$TRINO_COMPOSE" "trino:300" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_trino.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Greenplum Adapter Tests" "$GREENPLUM_COMPOSE" "greenplum:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_greenplum.py --tb=short --verbose --timeout=300 --timeout-method=thread
 run_compose_suite "Hive Adapter Tests" "$HIVE_COMPOSE" "hive-metastore:600" "hive-server:900" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/adapters/test_hive.py --tb=short --verbose --timeout=300 --timeout-method=thread

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -29,6 +29,7 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-hive": "datus-db-adapters/datus-hive",
     "datus-spark": "datus-db-adapters/datus-spark",
     "datus-gaussdb": "datus-db-adapters/datus-gaussdb",
+    "datus-tidb": "datus-db-adapters/datus-tidb",
     "datus-bi-core": "datus-bi-adapters/datus-bi-core",
     "datus-bi-superset": "datus-bi-adapters/datus-bi-superset",
     "datus-bi-grafana": "datus-bi-adapters/datus-bi-grafana",
@@ -77,6 +78,14 @@ DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
         db_type="gaussdb",
         parser_dialect="postgres",
         required_hooks=("get_identifier_parser", "get_sql_generation_notes"),
+    ),
+    # sqlglot has no TiDB dialect, so TiDB parses as MySQL. The db_type stays
+    # distinct because the semantic engine selects its native TiDB dialect by
+    # datasource type.
+    "datus_tidb": DatabaseAdapterContract(
+        db_type="tidb",
+        parser_dialect="mysql",
+        required_hooks=("get_sql_generation_notes",),
     ),
 }
 

--- a/datus/cli/datasource_app.py
+++ b/datus/cli/datasource_app.py
@@ -56,6 +56,7 @@ INSTALLABLE_TYPES = (
     "snowflake",
     "spark",
     "starrocks",
+    "tidb",
     "trino",
 )
 

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -2635,7 +2635,7 @@ class DBFuncTool:
 
     @staticmethod
     def _identifier_quote_char(dialect: str) -> str:
-        backtick_dialects = ("mysql", "starrocks", "doris", "hive", "spark", "bigquery", "clickhouse")
+        backtick_dialects = ("mysql", "tidb", "starrocks", "doris", "hive", "spark", "bigquery", "clickhouse")
         return "`" if dialect in backtick_dialects else '"'
 
     @classmethod

--- a/datus/tools/sql_guard.py
+++ b/datus/tools/sql_guard.py
@@ -45,6 +45,7 @@ to "allow".
 from __future__ import annotations
 
 import re
+from math import ceil
 from typing import Any, List, Optional
 
 # Ceiling on the optimizer's per-operator row estimate. See the module docstring
@@ -123,8 +124,10 @@ def _tidb_max_est_rows(explain_rows: List[Any]) -> Optional[int]:
         if raw is None:
             continue
         try:
-            value = int(float(raw))
-        except (TypeError, ValueError):
+            # Round up: truncating 50000000.99 would let a plan that exceeds the
+            # ceiling through. OverflowError covers an infinite estRows.
+            value = ceil(float(raw))
+        except (TypeError, ValueError, OverflowError):
             continue
         largest = value if largest is None else max(largest, value)
     return largest

--- a/datus/tools/sql_guard.py
+++ b/datus/tools/sql_guard.py
@@ -107,6 +107,29 @@ def _mysql_rows_product(explain_rows: List[Any]) -> Optional[int]:
     return product
 
 
+def _tidb_max_est_rows(explain_rows: List[Any]) -> Optional[int]:
+    """Take the largest ``estRows`` across a TiDB plan's operators.
+
+    TiDB's EXPLAIN emits one row per operator, each carrying its own ``estRows``
+    estimate as a float (``10000.00``). Max rather than the root's value, for
+    the same reason as PostgreSQL: a join blows up mid-plan while a GROUP BY or
+    LIMIT shrinks the root, and the join is where the memory goes.
+    """
+    largest: Optional[int] = None
+    for row in explain_rows:
+        if not isinstance(row, dict):
+            continue
+        raw = next((v for k, v in row.items() if isinstance(k, str) and k.lower() == "estrows"), None)
+        if raw is None:
+            continue
+        try:
+            value = int(float(raw))
+        except (TypeError, ValueError):
+            continue
+        largest = value if largest is None else max(largest, value)
+    return largest
+
+
 def estimate_rows_from_explain(dialect: str, explain_rows: List[Any]) -> Optional[int]:
     """Parse an EXPLAIN result set into a conservative row-count estimate.
 
@@ -115,6 +138,12 @@ def estimate_rows_from_explain(dialect: str, explain_rows: List[Any]) -> Optiona
     """
     if not explain_rows:
         return None
+    # TiDB is checked before normalization on purpose: its parser dialect is
+    # `mysql` (sqlglot has no TiDB dialect), but the two EXPLAIN shapes differ —
+    # TiDB has no `rows` column at all, it reports `estRows` per operator. Going
+    # through the MySQL branch would find nothing and silently disable the guard.
+    if (dialect or "").strip().lower() == "tidb":
+        return _tidb_max_est_rows(explain_rows)
     # Adapter names are not always sqlglot/engine-family names. Resolve the
     # adapter-provided parser dialect so PostgreSQL-compatible engines such as
     # Hologres retain the same pre-execution safety guard as PostgreSQL.

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -337,7 +337,7 @@ these.
 
 **TiFlash.** TiDB's columnar replica engine is per table: `ALTER TABLE t SET TIFLASH REPLICA 1` and the
 optimizer starts choosing between row store and columnar on its own — no query change needed.
-`TiDBConnector.get_tiflash_replicas()` reports which tables have a synced replica. Note that most window
+`information_schema.TIFLASH_REPLICA` reports which tables have a synced replica. Note that most window
 functions do not run in TiFlash MPP (only `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `LEAD`, `LAG`,
 `FIRST_VALUE` and `LAST_VALUE` push down); aggregate window functions fall back to single-node
 computation on the TiDB layer, correct but not parallel.

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -336,11 +336,11 @@ indexes are silently dropped. The adapter ships a SQL skill that keeps generated
 these.
 
 **TiFlash.** TiDB's columnar replica engine is per table: `ALTER TABLE t SET TIFLASH REPLICA 1` and the
-optimizer starts choosing between row store and columnar on its own — no query change needed.
-`information_schema.TIFLASH_REPLICA` reports which tables have a synced replica. Note that most window
-functions do not run in TiFlash MPP (only `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `LEAD`, `LAG`,
-`FIRST_VALUE` and `LAST_VALUE` push down); aggregate window functions fall back to single-node
-computation on the TiDB layer, correct but not parallel.
+optimizer starts choosing between row store and columnar on its own — no query change, and nothing to
+configure in Datus. `information_schema.TIFLASH_REPLICA` reports which tables have a synced replica.
+Aggregate window functions are the one thing that does not gain from a replica: they fall back to
+single-node computation on the TiDB layer, correct but not parallel, so prefer `GROUP BY` aggregation
+where a query can be written either way.
 
 TLS is not supported yet, so TiDB Cloud endpoints that require it are out of reach for now.
 

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -338,9 +338,11 @@ these.
 **TiFlash.** TiDB's columnar replica engine is per table: `ALTER TABLE t SET TIFLASH REPLICA 1` and the
 optimizer starts choosing between row store and columnar on its own — no query change, and nothing to
 configure in Datus. `information_schema.TIFLASH_REPLICA` reports which tables have a synced replica.
-Aggregate window functions are the one thing that does not gain from a replica: they fall back to
-single-node computation on the TiDB layer, correct but not parallel, so prefer `GROUP BY` aggregation
-where a query can be written either way.
+Aggregate window functions are the one thing that tends not to gain from a replica: on TiDB v8.5 they
+fall back to single-node computation on the TiDB layer — correct, but not parallel — so prefer
+`GROUP BY` aggregation where a query can be written either way. Push-down coverage varies by version
+and by the operators around the call, so confirm with `EXPLAIN` and look for `mpp[tiflash]` on the
+window operator before assuming either behaviour.
 
 The `datus-tidb` adapter does not support TLS configuration yet, so it cannot reach TiDB Cloud endpoints that require TLS. This is an adapter limitation, not a TiDB one.
 

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -27,6 +27,7 @@ This design keeps the core package lightweight while allowing you to add support
 | ClickHouse | datus-clickhouse | `pip install datus-clickhouse` | Ready |
 | Trino | datus-trino | `pip install datus-trino` | Ready |
 | Apache Doris | datus-doris | `pip install datus-doris` | Ready |
+| TiDB | datus-tidb | `pip install datus-tidb` | Ready |
 | Hologres | datus-hologres | `pip install datus-hologres` | Ready |
 | Oracle | datus-oracle | `pip install datus-oracle` | Ready |
 | GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | Ready (Linux and macOS) |
@@ -296,6 +297,52 @@ credentials the catalog type needs) and confirm it is listed by `SHOW CATALOGS`.
 Within a session, `SWITCH <catalog>` changes the catalog and `USE [<catalog>.]<database>` changes the
 database. Switching catalogs clears the current database, because a database of that name usually does
 not exist under the new catalog; issue a `USE` afterwards to select one.
+
+### TiDB
+
+```yaml
+tidb_data:
+  type: tidb
+  host: 127.0.0.1
+  port: 4000
+  username: root
+  password: your_password
+  database: your_database
+  charset: utf8mb4       # optional, default is utf8mb4
+  autocommit: true       # optional, default is true
+  timeout_seconds: 30    # optional, default is 30
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `host` | `127.0.0.1` | TiDB server host |
+| `port` | `4000` | TiDB's own default SQL port — not MySQL's 3306 |
+| `username` | required | TiDB user |
+| `password` | empty | TiDB password |
+| `database` | none | Database the connection starts in |
+| `charset` | `utf8mb4` | Connection character set |
+| `autocommit` | `true` | Autocommit mode |
+| `timeout_seconds` | `30` | Connection timeout |
+
+TiDB speaks the MySQL wire protocol and is addressed as `database.table`: like MySQL it has no schema
+level, so leave both `catalog` and `schema` unset. Set `port` explicitly — TiDB listens on 4000, and
+3306 on the same host is usually a different server entirely.
+
+Being MySQL-compatible does not make TiDB a MySQL superset. It has no `FULL OUTER JOIN`, `JSON_TABLE`,
+`LATERAL`, `CREATE TABLE ... AS SELECT`, `CORR`/`COVAR_*`, materialized views, or updatable views, and
+its default collation is the case-sensitive `utf8mb4_bin`. Two clauses are accepted and then ignored:
+`CHECK` constraints are not enforced unless `tidb_enable_check_constraint` is `ON`, and `FULLTEXT`
+indexes are silently dropped. The adapter ships a SQL skill that keeps generated SQL clear of all of
+these.
+
+**TiFlash.** TiDB's columnar replica engine is per table: `ALTER TABLE t SET TIFLASH REPLICA 1` and the
+optimizer starts choosing between row store and columnar on its own — no query change needed.
+`TiDBConnector.get_tiflash_replicas()` reports which tables have a synced replica. Note that most window
+functions do not run in TiFlash MPP (only `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `LEAD`, `LAG`,
+`FIRST_VALUE` and `LAST_VALUE` push down); aggregate window functions fall back to single-node
+computation on the TiDB layer, correct but not parallel.
+
+TLS is not supported yet, so TiDB Cloud endpoints that require it are out of reach for now.
 
 ### Hologres
 

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -342,7 +342,7 @@ Aggregate window functions are the one thing that does not gain from a replica: 
 single-node computation on the TiDB layer, correct but not parallel, so prefer `GROUP BY` aggregation
 where a query can be written either way.
 
-TLS is not supported yet, so TiDB Cloud endpoints that require it are out of reach for now.
+The `datus-tidb` adapter does not support TLS configuration yet, so it cannot reach TiDB Cloud endpoints that require TLS. This is an adapter limitation, not a TiDB one.
 
 ### Hologres
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -326,10 +326,9 @@ TiDB 使用 MySQL 通信协议，对象按 `database.table` 寻址：与 MySQL �
 强制执行，`FULLTEXT` 索引会被静默丢弃。适配器自带的 SQL skill 会让生成的 SQL 避开这些构造。
 
 **TiFlash。** TiDB 的列存副本引擎按表启用：执行 `ALTER TABLE t SET TIFLASH REPLICA 1` 后，优化器会自动
-在行存与列存之间选择，查询本身无需改动。查询 `information_schema.TIFLASH_REPLICA` 可以查看哪些表已有同步
-完成的副本。需要注意大部分窗口函数无法在 TiFlash MPP 中执行（只有 `ROW_NUMBER`、`RANK`、`DENSE_RANK`、
-`LEAD`、`LAG`、`FIRST_VALUE`、`LAST_VALUE` 会下推），聚合类窗口函数会回退到 TiDB 单节点计算，结果正确
-但失去并行。
+在行存与列存之间选择，查询本身无需改动，Datus 侧也无需任何配置。查询 `information_schema.TIFLASH_REPLICA`
+可以查看哪些表已有同步完成的副本。唯一无法从副本获益的是聚合类窗口函数——它们会回退到 TiDB 单节点计算，
+结果正确但失去并行，因此在两种写法都可行时应优先使用 `GROUP BY` 聚合。
 
 暂不支持 TLS，因此需要 TLS 的 TiDB Cloud 端点目前无法连接。
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -330,7 +330,7 @@ TiDB 使用 MySQL 通信协议，对象按 `database.table` 寻址：与 MySQL �
 可以查看哪些表已有同步完成的副本。唯一无法从副本获益的是聚合类窗口函数——它们会回退到 TiDB 单节点计算，
 结果正确但失去并行，因此在两种写法都可行时应优先使用 `GROUP BY` 聚合。
 
-暂不支持 TLS，因此需要 TLS 的 TiDB Cloud 端点目前无法连接。
+`datus-tidb` 适配器目前不支持 TLS 配置，因此无法连接需要 TLS 的 TiDB Cloud 端点。这是适配器的限制，不是 TiDB 本身的限制。
 
 ### Hologres
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -327,8 +327,9 @@ TiDB 使用 MySQL 通信协议，对象按 `database.table` 寻址：与 MySQL �
 
 **TiFlash。** TiDB 的列存副本引擎按表启用：执行 `ALTER TABLE t SET TIFLASH REPLICA 1` 后，优化器会自动
 在行存与列存之间选择，查询本身无需改动，Datus 侧也无需任何配置。查询 `information_schema.TIFLASH_REPLICA`
-可以查看哪些表已有同步完成的副本。唯一无法从副本获益的是聚合类窗口函数——它们会回退到 TiDB 单节点计算，
-结果正确但失去并行，因此在两种写法都可行时应优先使用 `GROUP BY` 聚合。
+可以查看哪些表已有同步完成的副本。通常无法从副本获益的是聚合类窗口函数——在 TiDB v8.5 上它们会回退到 TiDB 单节点计算，结果正确但失去
+并行，因此在两种写法都可行时应优先使用 `GROUP BY` 聚合。下推范围随版本和调用周围的算子而变，判断前
+请用 `EXPLAIN` 确认窗口算子是否标记为 `mpp[tiflash]`。
 
 `datus-tidb` 适配器目前不支持 TLS 配置，因此无法连接需要 TLS 的 TiDB Cloud 端点。这是适配器的限制，不是 TiDB 本身的限制。
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -27,6 +27,7 @@ Datus 使用模块化适配器架构，允许连接不同的数据库：
 | ClickHouse | datus-clickhouse | `pip install datus-clickhouse` | 可用 |
 | Trino | datus-trino | `pip install datus-trino` | 可用 |
 | Apache Doris | datus-doris | `pip install datus-doris` | 可用 |
+| TiDB | datus-tidb | `pip install datus-tidb` | 可用 |
 | Hologres | datus-hologres | `pip install datus-hologres` | 可用 |
 | Oracle | datus-oracle | `pip install datus-oracle` | 可用 |
 | GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | 可用（Linux 和 macOS） |
@@ -288,6 +289,49 @@ doris_hive:
 
 在会话内，`SWITCH <catalog>` 用于切换 catalog，`USE [<catalog>.]<database>` 用于切换数据库。切换 catalog
 会清空当前数据库上下文——同名数据库通常并不存在于新的 catalog 中，切换后需要再执行一次 `USE`。
+
+### TiDB
+
+```yaml
+tidb_data:
+  type: tidb
+  host: 127.0.0.1
+  port: 4000
+  username: root
+  password: your_password
+  database: your_database
+  charset: utf8mb4       # 可选，默认 utf8mb4
+  autocommit: true       # 可选，默认 true
+  timeout_seconds: 30    # 可选，默认 30
+```
+
+| 选项 | 默认值 | 说明 |
+|------|--------|------|
+| `host` | `127.0.0.1` | TiDB 服务器地址 |
+| `port` | `4000` | TiDB 自身的默认 SQL 端口，不是 MySQL 的 3306 |
+| `username` | 必填 | TiDB 用户名 |
+| `password` | 空 | TiDB 密码 |
+| `database` | 无 | 连接初始数据库 |
+| `charset` | `utf8mb4` | 连接字符集 |
+| `autocommit` | `true` | 自动提交模式 |
+| `timeout_seconds` | `30` | 连接超时 |
+
+TiDB 使用 MySQL 通信协议，对象按 `database.table` 寻址：与 MySQL 一样没有 schema 层级，`catalog` 和
+`schema` 都留空即可。请显式设置 `port`——TiDB 监听 4000，同一台机器上的 3306 通常是另一个完全不相干的
+服务。
+
+兼容 MySQL 不等于是 MySQL 的超集。TiDB 不支持 `FULL OUTER JOIN`、`JSON_TABLE`、`LATERAL`、
+`CREATE TABLE ... AS SELECT`、`CORR`/`COVAR_*`、物化视图和可更新视图，默认排序规则是区分大小写的
+`utf8mb4_bin`。另有两个子句会被接受但不生效：未开启 `tidb_enable_check_constraint` 时 `CHECK` 约束不
+强制执行，`FULLTEXT` 索引会被静默丢弃。适配器自带的 SQL skill 会让生成的 SQL 避开这些构造。
+
+**TiFlash。** TiDB 的列存副本引擎按表启用：执行 `ALTER TABLE t SET TIFLASH REPLICA 1` 后，优化器会自动
+在行存与列存之间选择，查询本身无需改动。`TiDBConnector.get_tiflash_replicas()` 可以查看哪些表已有同步
+完成的副本。需要注意大部分窗口函数无法在 TiFlash MPP 中执行（只有 `ROW_NUMBER`、`RANK`、`DENSE_RANK`、
+`LEAD`、`LAG`、`FIRST_VALUE`、`LAST_VALUE` 会下推），聚合类窗口函数会回退到 TiDB 单节点计算，结果正确
+但失去并行。
+
+暂不支持 TLS，因此需要 TLS 的 TiDB Cloud 端点目前无法连接。
 
 ### Hologres
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -326,7 +326,7 @@ TiDB 使用 MySQL 通信协议，对象按 `database.table` 寻址：与 MySQL �
 强制执行，`FULLTEXT` 索引会被静默丢弃。适配器自带的 SQL skill 会让生成的 SQL 避开这些构造。
 
 **TiFlash。** TiDB 的列存副本引擎按表启用：执行 `ALTER TABLE t SET TIFLASH REPLICA 1` 后，优化器会自动
-在行存与列存之间选择，查询本身无需改动。`TiDBConnector.get_tiflash_replicas()` 可以查看哪些表已有同步
+在行存与列存之间选择，查询本身无需改动。查询 `information_schema.TIFLASH_REPLICA` 可以查看哪些表已有同步
 完成的副本。需要注意大部分窗口函数无法在 TiFlash MPP 中执行（只有 `ROW_NUMBER`、`RANK`、`DENSE_RANK`、
 `LEAD`、`LAG`、`FIRST_VALUE`、`LAST_VALUE` 会下推），聚合类窗口函数会回退到 TiDB 单节点计算，结果正确
 但失去并行。

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -159,6 +159,18 @@ my_doris:
   catalog: internal             # Optional, default is internal
 ```
 
+### TiDB
+
+```yaml
+my_tidb:
+  type: tidb
+  host: ${TIDB_HOST}
+  port: 4000                    # TiDB's own default, not MySQL's 3306
+  username: ${TIDB_USER}
+  password: ${TIDB_PASSWORD}
+  database: ${TIDB_DATABASE}
+```
+
 ### Hologres
 
 ```yaml

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -164,6 +164,18 @@ my_doris:
   catalog: internal             # 可选，默认为 internal
 ```
 
+### TiDB
+
+```yaml
+my_tidb:
+  type: tidb
+  host: ${TIDB_HOST}
+  port: 4000                    # TiDB 自身默认端口，不是 MySQL 的 3306
+  username: ${TIDB_USER}
+  password: ${TIDB_PASSWORD}
+  database: ${TIDB_DATABASE}
+```
+
 ### Hologres
 
 ```yaml

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -76,7 +76,6 @@ Several adapters use default ports that are commonly occupied:
 - trino (8080) — conflicts with Airflow / many web dev servers
 - starrocks (9030) — conflicts with existing StarRocks instances
 - doris (9030) — conflicts with StarRocks and existing Doris instances
-- tidb (4000) — the compose file publishes 24000
 - hive / spark (10000) — both default to the HiveServer2/Spark Thrift port; run one suite at a time or remap one service
 
 For the Trino adapter, the compose file already supports a `TRINO_HOST_PORT`

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -76,7 +76,7 @@ Several adapters use default ports that are commonly occupied:
 - trino (8080) — conflicts with Airflow / many web dev servers
 - starrocks (9030) — conflicts with existing StarRocks instances
 - doris (9030) — conflicts with StarRocks and existing Doris instances
-- tidb (4000) — the compose file publishes 24000; `docker compose up -d --wait` is required so TiFlash finishes registering
+- tidb (4000) — the compose file publishes 24000
 - hive / spark (10000) — both default to the HiveServer2/Spark Thrift port; run one suite at a time or remap one service
 
 For the Trino adapter, the compose file already supports a `TRINO_HOST_PORT`

--- a/tests/integration/adapters/README.md
+++ b/tests/integration/adapters/README.md
@@ -62,6 +62,7 @@ docker compose down -v
 | clickhouse | `ADAPTERS_CH=1` | `CLICKHOUSE_HOST/PORT/USER/PASSWORD/DATABASE` | `localhost:8123 default_user/default_test/default_test` |
 | starrocks | `ADAPTERS_SR=1` | `STARROCKS_HOST/PORT/USER/PASSWORD/CATALOG/DATABASE` | `127.0.0.1:9030 root//default_catalog/test` |
 | doris | `ADAPTERS_DORIS=1` | `DORIS_HOST/PORT/USER/PASSWORD/CATALOG/DATABASE` | `127.0.0.1:9030 root//internal/test` |
+| tidb | `ADAPTERS_TIDB=1` | `TIDB_HOST/PORT/USER/PASSWORD/DATABASE` | `127.0.0.1:4000 root//test` |
 | trino | `ADAPTERS_TRINO=1` | `TRINO_HOST/PORT/USER` | `localhost:8080 trino` (uses built-in `tpch.tiny`, no seeding) |
 | greenplum | `ADAPTERS_GP=1` | `GREENPLUM_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA` | `localhost:15432 gpadmin/pivotal/postgres/public` |
 | gaussdb | `ADAPTERS_GAUSSDB=1` | `GAUSSDB_HOST/PORT/USER/PASSWORD/DATABASE/SCHEMA/DRIVER/SSLMODE/SSLROOTCERT` | `127.0.0.1:25434 datus/Datus@123/postgres/public`; `gaussdb` on Linux, `pg8000` on macOS |
@@ -75,6 +76,7 @@ Several adapters use default ports that are commonly occupied:
 - trino (8080) — conflicts with Airflow / many web dev servers
 - starrocks (9030) — conflicts with existing StarRocks instances
 - doris (9030) — conflicts with StarRocks and existing Doris instances
+- tidb (4000) — the compose file publishes 24000; `docker compose up -d --wait` is required so TiFlash finishes registering
 - hive / spark (10000) — both default to the HiveServer2/Spark Thrift port; run one suite at a time or remap one service
 
 For the Trino adapter, the compose file already supports a `TRINO_HOST_PORT`

--- a/tests/integration/adapters/test_tidb.py
+++ b/tests/integration/adapters/test_tidb.py
@@ -186,5 +186,5 @@ def test_transfer_quotes_identifiers_with_backticks(db_tool: DBFuncTool, seeded_
         {"sql_query": f"SELECT {quoted} FROM `{REGION_TABLE}` ORDER BY `r_regionkey` LIMIT 1"},
         result_format="list",
     )
-    assert result.success, f"backtick-quoted identifier rejected: {result.error}"
+    assert result.success == 1, f"backtick-quoted identifier rejected: {result.error}"
     assert result.sql_return[0]["r_name"] == "AFRICA"

--- a/tests/integration/adapters/test_tidb.py
+++ b/tests/integration/adapters/test_tidb.py
@@ -188,17 +188,3 @@ def test_transfer_quotes_identifiers_with_backticks(db_tool: DBFuncTool, seeded_
     )
     assert result.success, f"backtick-quoted identifier rejected: {result.error}"
     assert result.sql_return[0]["r_name"] == "AFRICA"
-
-
-def test_tiflash_replica_state_is_reportable(seeded_connector: TiDBConnector) -> None:
-    """The columnar replica inventory the SQL skill points the model at.
-
-    An empty list is a valid answer (no table has been granted a replica); the
-    contract is that the query works and returns the documented shape.
-    """
-    replicas = seeded_connector.get_tiflash_replicas()
-
-    assert isinstance(replicas, list)
-    for replica in replicas:
-        assert {"database_name", "table_name", "replica_count", "available", "progress"} <= set(replica)
-        assert isinstance(replica["available"], bool)

--- a/tests/integration/adapters/test_tidb.py
+++ b/tests/integration/adapters/test_tidb.py
@@ -3,7 +3,7 @@ Contract tests: TiDB adapter via DBFuncTool.
 
 Opt-in (all required):
   * install:    `uv pip install datus-tidb`
-  * start:      `cd datus-db-adapters/datus-tidb && docker compose up -d --wait`
+  * start:      `cd datus-db-adapters/datus-tidb && docker compose up -d`
   * env:         ADAPTERS_TIDB=1
 
 Env overrides (defaults match the adapter's docker-compose.yml):
@@ -93,8 +93,8 @@ def tidb_connector(tidb_config: TiDBConfig) -> Generator[TiDBConnector, None, No
     try:
         if not conn.test_connection():
             pytest.fail(
-                "TiDB cluster unreachable despite ADAPTERS_TIDB=1. "
-                "Did you run `docker compose up -d --wait` in datus-db-adapters/datus-tidb?"
+                "TiDB unreachable despite ADAPTERS_TIDB=1. "
+                "Did you run `docker compose up -d` in datus-db-adapters/datus-tidb?"
             )
         yield conn
     finally:

--- a/tests/integration/adapters/test_tidb.py
+++ b/tests/integration/adapters/test_tidb.py
@@ -1,0 +1,204 @@
+"""
+Contract tests: TiDB adapter via DBFuncTool.
+
+Opt-in (all required):
+  * install:    `uv pip install datus-tidb`
+  * start:      `cd datus-db-adapters/datus-tidb && docker compose up -d --wait`
+  * env:         ADAPTERS_TIDB=1
+
+Env overrides (defaults match the adapter's docker-compose.yml):
+  TIDB_HOST=127.0.0.1  TIDB_PORT=4000
+  TIDB_USER=root       TIDB_PASSWORD=
+  TIDB_DATABASE=test
+
+See `tests/integration/adapters/README.md`.
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+from tests.nightly_requirements import import_required, require_opt_in_env
+
+require_opt_in_env("ADAPTERS_TIDB", "tests/integration/adapters/README.md")
+
+datus_tidb = import_required(
+    "datus_tidb",
+    reason="datus-tidb not installed; run `uv pip install datus-tidb`",
+)
+
+TiDBConfig = datus_tidb.TiDBConfig
+TiDBConnector = datus_tidb.TiDBConnector
+
+from datus.tools.func_tool.database import DBFuncTool  # noqa: E402
+
+pytestmark = [pytest.mark.integration, pytest.mark.nightly]
+
+
+REGION_TABLE = "datus_adapter_region"
+NATION_TABLE = "datus_adapter_nation"
+
+REGION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{REGION_TABLE}` (
+    `r_regionkey` INT NOT NULL,
+    `r_name` VARCHAR(25) NOT NULL,
+    `r_comment` VARCHAR(152),
+    PRIMARY KEY (`r_regionkey`)
+)
+"""
+NATION_DDL = f"""
+CREATE TABLE IF NOT EXISTS `{NATION_TABLE}` (
+    `n_nationkey` INT NOT NULL,
+    `n_name` VARCHAR(25) NOT NULL,
+    `n_regionkey` INT NOT NULL,
+    `n_comment` VARCHAR(152),
+    PRIMARY KEY (`n_nationkey`)
+)
+"""
+REGION_ROWS = [
+    (0, "AFRICA", "lar deposits."),
+    (1, "AMERICA", "hs use ironic requests."),
+    (2, "ASIA", "ges. pinto beans."),
+]
+NATION_ROWS = [
+    (0, "ALGERIA", 0, "haggle."),
+    (1, "ARGENTINA", 1, "foxes promise."),
+    (2, "BRAZIL", 1, "of pending deposits."),
+]
+
+
+def _escape(v: object) -> str:
+    if v is None:
+        return "NULL"
+    if isinstance(v, str):
+        return "'" + v.replace("'", "''") + "'"
+    return str(v)
+
+
+@pytest.fixture(scope="module")
+def tidb_config() -> TiDBConfig:
+    return TiDBConfig(
+        host=os.getenv("TIDB_HOST", "127.0.0.1"),
+        port=int(os.getenv("TIDB_PORT", "4000")),
+        username=os.getenv("TIDB_USER", "root"),
+        password=os.getenv("TIDB_PASSWORD", ""),
+        database=os.getenv("TIDB_DATABASE", "test"),
+    )
+
+
+@pytest.fixture(scope="module")
+def tidb_connector(tidb_config: TiDBConfig) -> Generator[TiDBConnector, None, None]:
+    conn = TiDBConnector(tidb_config)
+    try:
+        if not conn.test_connection():
+            pytest.fail(
+                "TiDB cluster unreachable despite ADAPTERS_TIDB=1. "
+                "Did you run `docker compose up -d --wait` in datus-db-adapters/datus-tidb?"
+            )
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def seeded_connector(tidb_connector: TiDBConnector) -> Generator[TiDBConnector, None, None]:
+    def _exec(sql: str) -> None:
+        result = tidb_connector.execute({"sql_query": sql})
+        assert result.success == 1, f"seed SQL failed: {sql[:120]} -> {result.error}"
+
+    _exec(f"DROP TABLE IF EXISTS `{NATION_TABLE}`")
+    _exec(f"DROP TABLE IF EXISTS `{REGION_TABLE}`")
+    _exec(REGION_DDL)
+    _exec(NATION_DDL)
+    for row in REGION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{REGION_TABLE}` VALUES ({values})")
+    for row in NATION_ROWS:
+        values = ", ".join(_escape(v) for v in row)
+        _exec(f"INSERT INTO `{NATION_TABLE}` VALUES ({values})")
+
+    try:
+        yield tidb_connector
+    finally:
+        tidb_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{NATION_TABLE}`"})
+        tidb_connector.execute({"sql_query": f"DROP TABLE IF EXISTS `{REGION_TABLE}`"})
+
+
+@pytest.fixture(scope="module")
+def db_tool(seeded_connector: TiDBConnector) -> DBFuncTool:
+    return DBFuncTool(seeded_connector)
+
+
+def test_list_tables_returns_seeded_tables(db_tool: DBFuncTool) -> None:
+    result = db_tool.list_tables()
+    assert result.success == 1, f"list_tables failed: {result.error}"
+    names = {entry["qualified_name"].split(".")[-1] for entry in result.result}
+    assert REGION_TABLE in names, f"{REGION_TABLE} missing from {sorted(names)}"
+    assert NATION_TABLE in names, f"{NATION_TABLE} missing from {sorted(names)}"
+
+
+def test_list_tables_hides_tidb_system_databases(db_tool: DBFuncTool, seeded_connector: TiDBConnector) -> None:
+    """METRICS_SCHEMA is TiDB-only; the inherited MySQL filter does not know it."""
+    databases = {name.lower() for name in seeded_connector.get_databases()}
+
+    assert "metrics_schema" not in databases
+    assert databases.isdisjoint({"information_schema", "performance_schema", "mysql", "sys"})
+
+
+def test_describe_table_returns_expected_columns(db_tool: DBFuncTool) -> None:
+    result = db_tool.describe_table(REGION_TABLE)
+    assert result.success == 1, f"describe_table failed: {result.error}"
+    assert isinstance(result.result, dict), f"expected dict, got {type(result.result).__name__}"
+    columns = result.result.get("columns") or []
+    col_names = [c["name"] for c in columns]
+    assert col_names == ["r_regionkey", "r_name", "r_comment"], f"unexpected columns: {col_names}"
+
+
+def test_read_query_executes_select(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT COUNT(*) AS cnt FROM {REGION_TABLE}")
+    assert result.success == 1, f"read_query failed: {result.error}"
+    payload = result.result
+    assert isinstance(payload, dict), f"compressed payload must be dict, got {type(payload).__name__}"
+    assert payload.get("original_rows") == 1, f"expected 1 row, got {payload.get('original_rows')}"
+    assert "3" in (payload.get("compressed_data") or ""), f"count(*) should be 3; payload={payload}"
+
+
+def test_read_query_rejects_dml(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"INSERT INTO {REGION_TABLE} VALUES (99, 'X', '')")
+    assert result.success == 0, "INSERT via read_query should have been rejected"
+    assert "read-only" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_read_query_rejects_multi_statement(db_tool: DBFuncTool) -> None:
+    result = db_tool.read_query(f"SELECT 1; DELETE FROM {REGION_TABLE}")
+    assert result.success == 0, "multi-statement SQL should have been rejected"
+    assert "multi-statement" in (result.error or "").lower(), f"unexpected error: {result.error}"
+
+
+def test_transfer_quotes_identifiers_with_backticks(db_tool: DBFuncTool, seeded_connector: TiDBConnector) -> None:
+    """TiDB rejects double-quoted identifiers under its default sql_mode, so a
+    transfer target built with the wrong quote character fails outright."""
+    quoted = DBFuncTool._quote_column_identifier("r_name", seeded_connector.dialect)
+    assert quoted == "`r_name`", f"TiDB identifiers must use backticks, got {quoted}"
+
+    result = seeded_connector.execute(
+        {"sql_query": f"SELECT {quoted} FROM `{REGION_TABLE}` ORDER BY `r_regionkey` LIMIT 1"},
+        result_format="list",
+    )
+    assert result.success, f"backtick-quoted identifier rejected: {result.error}"
+    assert result.sql_return[0]["r_name"] == "AFRICA"
+
+
+def test_tiflash_replica_state_is_reportable(seeded_connector: TiDBConnector) -> None:
+    """The columnar replica inventory the SQL skill points the model at.
+
+    An empty list is a valid answer (no table has been granted a replica); the
+    contract is that the query works and returns the documented shape.
+    """
+    replicas = seeded_connector.get_tiflash_replicas()
+
+    assert isinstance(replicas, list)
+    for replica in replicas:
+        assert {"database_name", "table_name", "replica_count", "available", "progress"} <= set(replica)
+        assert isinstance(replica["available"], bool)

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -141,6 +142,20 @@ def test_release_candidate_reuses_p0_nightly_on_the_release_ref():
     assert "RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}" in prepare
 
 
+def test_every_adapter_suite_is_deselected_from_the_main_nightly_run():
+    """An adapter suite with its own compose lifecycle must be excluded from the
+    generic nightly command, or it runs a second time with no container up and
+    fails on connection rather than skipping."""
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+    deselect_block = script.split("NIGHTLY_DEDICATED_SUITE_DESELECTS=(", maxsplit=1)[1].split("\n)", maxsplit=1)[0]
+
+    pattern = r"tests/integration/adapters/test_\w+\.py"
+    deselected = set(re.findall(pattern, deselect_block))
+    referenced = set(re.findall(pattern, script))
+
+    assert referenced <= deselected, f"adapter suites missing a --deselect: {sorted(referenced - deselected)}"
+
+
 def test_nightly_runs_doris_agent_contract_from_checkout():
     workflow = WORKFLOW.read_text(encoding="utf-8")
     script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
@@ -168,9 +183,11 @@ def test_nightly_runs_tidb_agent_contract_from_checkout():
     assert 'TIDB_COMPOSE="${TIDB_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-tidb/docker-compose.yml}"' in script
     # One container: the adapter's compose runs TiDB's built-in unistore engine.
     assert 'run_compose_suite "TiDB Adapter Tests" "$TIDB_COMPOSE" "tidb:120" --' in script
-    # The status endpoint answers only once bootstrap finished, so it says more
-    # than a bare TCP probe on the SQL port.
-    assert 'wait_for_http_readiness "TiDB"' in script
+    # Assert the whole readiness call, not just the function name: a wrong port
+    # or path would still satisfy a fragment search.
+    assert (
+        'wait_for_http_readiness "TiDB" "http://${TIDB_HOST:-127.0.0.1}:${TIDB_STATUS_HOST_PORT:-20080}/status" 300'
+    ) in script
     assert "tests/integration/adapters/test_tidb.py" in script
     assert '"TiDB Adapter Tests"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
 

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -166,14 +166,11 @@ def test_nightly_runs_tidb_agent_contract_from_checkout():
     assert 'echo "ADAPTERS_TIDB=1" >> $GITHUB_ENV' in workflow
     assert 'echo "TIDB_HOST_PORT=24000" >> $GITHUB_ENV' in workflow
     assert 'TIDB_COMPOSE="${TIDB_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-tidb/docker-compose.yml}"' in script
-    # Four services: TiFlash needs the real storage stack behind it, so waiting
-    # on a single `tidb` service would start pytest before the columnar replica
-    # engine can accept SET TIFLASH REPLICA.
-    assert (
-        'run_compose_suite "TiDB Adapter Tests" "$TIDB_COMPOSE" "pd0:120" "tikv0:120" "tidb0:120" "tiflash0:120" --'
-    ) in script
-    assert 'uv run --no-sync python "$DB_ADAPTERS_ROOT/datus-tidb/scripts/wait_for_tidb.py"' in script
-    assert 'wait_for_tidb_client_readiness "${TIDB_READY_TIMEOUT:-300}"' in script
+    # One container: the adapter's compose runs TiDB's built-in unistore engine.
+    assert 'run_compose_suite "TiDB Adapter Tests" "$TIDB_COMPOSE" "tidb:120" --' in script
+    # The status endpoint answers only once bootstrap finished, so it says more
+    # than a bare TCP probe on the SQL port.
+    assert 'wait_for_http_readiness "TiDB"' in script
     assert "tests/integration/adapters/test_tidb.py" in script
     assert '"TiDB Adapter Tests"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
 

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -89,7 +89,7 @@ def test_nightly_installs_p0_plugins_only_through_managed_store():
 def test_nightly_installs_new_database_adapters_from_latest_checkout():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    for package_name in ("datus-doris", "datus-hologres", "datus-oracle", "datus-gaussdb"):
+    for package_name in ("datus-doris", "datus-hologres", "datus-oracle", "datus-gaussdb", "datus-tidb"):
         assert f"--reinstall-package {package_name}" in workflow
         assert f"./external/datus-db-adapters/{package_name}" in workflow
 
@@ -157,6 +157,25 @@ def test_nightly_runs_doris_agent_contract_from_checkout():
     assert 'wait_for_doris_client_readiness "${DORIS_READY_TIMEOUT:-600}"' in script
     assert 'wait_for_tcp_readiness "Doris"' not in script
     assert "tests/integration/adapters/test_doris.py" in script
+
+
+def test_nightly_runs_tidb_agent_contract_from_checkout():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'echo "ADAPTERS_TIDB=1" >> $GITHUB_ENV' in workflow
+    assert 'echo "TIDB_HOST_PORT=24000" >> $GITHUB_ENV' in workflow
+    assert 'TIDB_COMPOSE="${TIDB_COMPOSE:-${DB_ADAPTERS_ROOT}/datus-tidb/docker-compose.yml}"' in script
+    # Four services: TiFlash needs the real storage stack behind it, so waiting
+    # on a single `tidb` service would start pytest before the columnar replica
+    # engine can accept SET TIFLASH REPLICA.
+    assert (
+        'run_compose_suite "TiDB Adapter Tests" "$TIDB_COMPOSE" "pd0:120" "tikv0:120" "tidb0:120" "tiflash0:120" --'
+    ) in script
+    assert 'uv run --no-sync python "$DB_ADAPTERS_ROOT/datus-tidb/scripts/wait_for_tidb.py"' in script
+    assert 'wait_for_tidb_client_readiness "${TIDB_READY_TIMEOUT:-300}"' in script
+    assert "tests/integration/adapters/test_tidb.py" in script
+    assert '"TiDB Adapter Tests"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
 
 
 def test_nightly_runs_gaussdb_agent_contract_from_checkout():

--- a/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
+++ b/tests/unit_tests/ci/test_nightly_tracing_boundaries.py
@@ -63,9 +63,10 @@ def test_nightly_pytest_commands_set_explicit_test_layer():
         and any(wrapper in command for wrapper in ("run_logged", "run_compose_suite", "run_with_agent_home"))
     ]
 
-    assert len(pytest_commands) == 25
+    assert len(pytest_commands) == 26
     assert any("tests/integration/adapters/test_doris.py" in command for command in pytest_commands)
     assert any("tests/integration/adapters/test_gaussdb.py" in command for command in pytest_commands)
+    assert any("tests/integration/adapters/test_tidb.py" in command for command in pytest_commands)
     for group in (
         "P0 PostgreSQL Agent Storage Contracts",
         "P0 SQL Policy Plugin Contracts",

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -62,6 +62,12 @@ def test_verify_local_sources_accepts_every_expected_checkout(monkeypatch, tmp_p
     assert verify_sources.verify_local_sources(external_root) == []
 
 
+def test_expected_sources_include_the_tidb_checkout_path():
+    """`test_verify_local_sources_accepts_every_expected_checkout` builds its
+    fixtures from this same mapping, so a typo here would pass it unnoticed."""
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-tidb"] == "datus-db-adapters/datus-tidb"
+
+
 def test_expected_sources_include_storage_packages():
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-storage-base"] == ("datus-storage-adapters/datus-storage-base")
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-storage-postgresql"] == (

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -16,9 +16,9 @@ MODULE_SPEC.loader.exec_module(verify_sources)
 
 
 # Registration shape a healthy nightly checkout produces, per db_type.
-_PARSER_DIALECTS = {"hologres": "postgres", "gaussdb": "postgres", "oracle": "oracle"}
+_PARSER_DIALECTS = {"hologres": "postgres", "gaussdb": "postgres", "oracle": "oracle", "tidb": "mysql"}
 _IDENTIFIER_PARSER_ADAPTERS = {"hologres", "gaussdb"}
-_SQL_NOTES_ADAPTERS = {"hologres", "gaussdb", "oracle"}
+_SQL_NOTES_ADAPTERS = {"hologres", "gaussdb", "oracle", "tidb"}
 
 
 class _FakeDistribution:
@@ -105,6 +105,7 @@ def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
         "datus_hologres": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
+        "datus_tidb": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
@@ -125,6 +126,7 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
         "datus_hologres": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
+        "datus_tidb": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
@@ -165,6 +167,7 @@ def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, mi
         "datus_hologres": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
+        "datus_tidb": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
@@ -185,6 +188,7 @@ def test_verify_database_adapter_imports_requires_oracle_operations(monkeypatch)
         "datus_hologres": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
+        "datus_tidb": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 
@@ -207,6 +211,7 @@ def test_verify_database_adapter_imports_requires_complete_oracle_operations(mon
         "datus_hologres": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
+        "datus_tidb": SimpleNamespace(register=lambda: None),
     }
     monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
 

--- a/tests/unit_tests/cli/test_datasource_commands.py
+++ b/tests/unit_tests/cli/test_datasource_commands.py
@@ -443,7 +443,7 @@ class TestDatasourceAppViews:
             assert ("sqlite", "sqlite", True) in app._db_types
 
     def test_new_database_adapters_are_installable(self):
-        assert {"doris", "gaussdb", "hologres", "oracle"} <= set(INSTALLABLE_TYPES)
+        assert {"doris", "gaussdb", "hologres", "oracle", "tidb"} <= set(INSTALLABLE_TYPES)
 
     def test_enter_config_form(self):
         cli = _make_cli()

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -1441,6 +1441,11 @@ class TestTransferQueryResult:
         )
 
         assert DBFuncTool._identifier_quote_char("doris") == "`"
+        # TiDB is matched on the adapter's own dialect name, not the parser
+        # dialect: falling through to double quotes would emit transfer DDL and
+        # INSERTs that TiDB rejects under its default sql_mode.
+        assert DBFuncTool._identifier_quote_char("tidb") == "`"
+        assert DBFuncTool._quote_column_identifier("order", "tidb") == "`order`"
         assert DBFuncTool._infer_transfer_column_type(pd.Series([1.5]), "hologres") == "DOUBLE PRECISION"
 
     def test_transfer_replace_mode_success(self):

--- a/tests/unit_tests/tools/test_sql_guard.py
+++ b/tests/unit_tests/tools/test_sql_guard.py
@@ -80,11 +80,17 @@ class TestEstimateRowsFromExplain:
             lambda dialect: "mysql" if dialect == "tidb" else None,
             raising=False,
         )
+        # Smallest first: a first-match implementation would pass otherwise.
         rows = [
-            {"id": "HashJoin_12", "estRows": "9000000000.00", "task": "root"},
             {"id": "TableFullScan_9", "estRows": "100000.00", "task": "cop[tikv]"},
+            {"id": "HashJoin_12", "estRows": "9000000000.00", "task": "root"},
+            {"id": "Projection_3", "estRows": "500.00", "task": "root"},
         ]
         assert estimate_rows_from_explain("tidb", rows) == 9_000_000_000
+
+    def test_tidb_rounds_fractional_estimates_up(self):
+        """Truncating biases the guard towards allowing an oversize plan."""
+        assert estimate_rows_from_explain("tidb", [{"estRows": "50000000.99"}]) == 50_000_001
 
     def test_tidb_est_rows_key_is_case_insensitive(self):
         assert estimate_rows_from_explain("tidb", [{"ESTROWS": "1500.00"}]) == 1500

--- a/tests/unit_tests/tools/test_sql_guard.py
+++ b/tests/unit_tests/tools/test_sql_guard.py
@@ -70,6 +70,28 @@ class TestEstimateRowsFromExplain:
     def test_mysql_no_rows_column_returns_none(self):
         assert estimate_rows_from_explain("mysql", [{"id": 1, "table": "a"}]) is None
 
+    def test_tidb_takes_the_largest_est_rows(self, monkeypatch):
+        """TiDB's parser dialect is mysql, but its EXPLAIN has no `rows` column
+        at all — the estimate lives in a per-operator `estRows` float. Routing it
+        through the MySQL branch would find nothing and disable the guard."""
+        monkeypatch.setattr(
+            connector_registry,
+            "get_parser_dialect",
+            lambda dialect: "mysql" if dialect == "tidb" else None,
+            raising=False,
+        )
+        rows = [
+            {"id": "HashJoin_12", "estRows": "9000000000.00", "task": "root"},
+            {"id": "TableFullScan_9", "estRows": "100000.00", "task": "cop[tikv]"},
+        ]
+        assert estimate_rows_from_explain("tidb", rows) == 9_000_000_000
+
+    def test_tidb_est_rows_key_is_case_insensitive(self):
+        assert estimate_rows_from_explain("tidb", [{"ESTROWS": "1500.00"}]) == 1500
+
+    def test_tidb_without_est_rows_returns_none(self):
+        assert estimate_rows_from_explain("tidb", [{"id": "TableReader_5", "task": "root"}]) is None
+
     def test_unknown_dialect_returns_none(self):
         assert estimate_rows_from_explain("sqlite", [{"detail": "SCAN t"}]) is None
         assert estimate_rows_from_explain("snowflake", [{"plan": "cardinality: 5"}]) is None


### PR DESCRIPTION
## Why

`datus-tidb` (Datus-ai/datus-db-adapters#114) has no Agent-side integration: the type is not installable from `/datasource`, nightly does not exercise it, and the docs do not mention it.

Two existing code paths also mishandle the `tidb` dialect name outright:

- **Identifier quoting.** `DBFuncTool._identifier_quote_char` matches on the adapter's own dialect name, so `tidb` fell through to double quotes. TiDB's default `sql_mode` treats double quotes as a string delimiter, not an identifier one — transfer DDL and the INSERTs derived from it are rejected.
- **Oversize-result guard.** `sql_guard.estimate_rows_from_explain` resolved `tidb` → `mysql` through the parser dialect, then looked for a `rows` column. TiDB's EXPLAIN has no `rows` column at all; the estimate is a per-operator `estRows` float. The lookup found nothing, returned `None`, and the guard silently allowed every query.

## Solution

Both fixes are minimal and pinned by unit tests:

- `backtick_dialects` gains `tidb`.
- `estimate_rows_from_explain` checks TiDB **before** normalization — its parser dialect is legitimately `mysql` (sqlglot has no TiDB dialect), so the branch cannot key off the normalized name. It takes the max `estRows` across operators, matching the PostgreSQL branch's reasoning: a join blows up mid-plan while a `GROUP BY` shrinks the root.

Integration:

| Area | Change |
|---|---|
| CLI | `INSTALLABLE_TYPES` gains `tidb` |
| Nightly | TiDB adapter suite over a four-container compose (PD, TiKV, TiDB, TiFlash) |
| Contract | `parser_dialect="mysql"` with the `get_sql_generation_notes` hook |
| Docs | en + zh, in both `docs/adapters/` and `docs/configuration/` |

Nightly waits through the adapter's own `wait_for_tidb.py` rather than a TCP probe: TiFlash registers with PD a moment after the SQL port opens, and `ALTER TABLE ... SET TIFLASH REPLICA` is rejected until it does.

The docs spend space on limits because TiDB is MySQL-compatible without being a MySQL superset — no `FULL OUTER JOIN`, `JSON_TABLE`, `LATERAL`, `CREATE TABLE ... AS SELECT`, `CORR`/`COVAR_*`, materialized views or updatable views; a case-sensitive `utf8mb4_bin` default; and two clauses accepted then ignored (`CHECK` unless `tidb_enable_check_constraint` is on, `FULLTEXT` silently dropped). Port 4000 is called out too, since 3306 on the same host is usually a different server entirely.

## Test Cases

- **`tests/integration/adapters/test_tidb.py`** (new, 7 cases) — the DBFuncTool contract against a live four-container cluster: table listing, system-database filtering (`METRICS_SCHEMA` must not surface), `describe_table`, `read_query` including its DML and multi-statement rejections, and backtick identifier quoting end to end. Verified live, not just collected.
- **`tests/unit_tests/tools/test_sql_guard.py`** (+3) — TiDB takes the max `estRows`, the key is matched case-insensitively, and a plan without `estRows` returns `None`.
- **`tests/unit_tests/tools/func_tool/test_database.py`** (+2) — `tidb` resolves to backticks through both `_identifier_quote_char` and `_quote_column_identifier`.
- **`tests/unit_tests/ci/test_nightly_checkout_contract.py`** (+1) — pins the nightly suite: four-service wait, the `wait_for_tidb.py` readiness call, and the compose group registration.
- Existing guard tests updated for the new adapter: nightly pytest-command count, the adapter-source contract fixtures, and `INSTALLABLE_TYPES`.

`ci/audit_tests.py --diff-only upstream/main` reports P0=0, P1=0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TiDB as a supported and installable database type.
  * Added TiDB connection configuration and SQL compatibility guidance.
  * Added TiDB support for identifier quoting and query-plan row estimates.

* **Bug Fixes**
  * Improved SQL safety checks for TiDB execution plans.

* **Documentation**
  * Documented TiDB setup, connection options, compatibility, and limitations.

* **Tests**
  * Added integration and nightly coverage for TiDB connectivity, queries, schema inspection, and adapter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
