### PR TITLE
[BugFix] Isolate managed plugin nightly config

### DIFF
--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -1652,9 +1652,9 @@ validate_nightly_group_filter || exit 1
 validate_pytest_basetemp "$NIGHTLY_PYTEST_BASETEMP" || exit 1
 rm -rf "$NIGHTLY_PYTEST_BASETEMP"
 if [ -n "${PYTEST_ADDOPTS:-}" ]; then
-  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --basetemp=$NIGHTLY_PYTEST_BASETEMP -p ci.pytest_trace_reference_plugin"
+  export PYTEST_ADDOPTS="${PYTEST_ADDOPTS} --basetemp=$NIGHTLY_PYTEST_BASETEMP -p ci.pytest_trace_reference_plugin --no-showlocals"
 else
-  export PYTEST_ADDOPTS="--basetemp=$NIGHTLY_PYTEST_BASETEMP -p ci.pytest_trace_reference_plugin"
+  export PYTEST_ADDOPTS="--basetemp=$NIGHTLY_PYTEST_BASETEMP -p ci.pytest_trace_reference_plugin --no-showlocals"
 fi
 require_docker_runtime || exit "$test_exit_code"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -78,15 +78,39 @@ class ManagedPluginRuntime:
         # otherwise every managed source install re-downloads its wheelhouse.
         env.setdefault("UV_CACHE_DIR", str(Path.home() / ".cache" / "uv"))
         env["HOME"] = str(self.home)
-        return subprocess.run(
-            [str(self.datus_executable), *args],
-            check=check,
-            capture_output=True,
-            text=True,
-            env=env,
-            cwd=cwd,
-            timeout=timeout,
-        )
+        command = [str(self.datus_executable), *args]
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=cwd or self.home,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # pytest runs with --showlocals. Do not retain provider credentials
+            # in a traceback frame when a managed command times out.
+            env.clear()
+            raise subprocess.TimeoutExpired(
+                exc.cmd,
+                exc.timeout,
+                output=exc.output,
+                stderr=exc.stderr,
+            ) from None
+
+        if check and completed.returncode != 0:
+            # ``subprocess.run(check=True)`` retains the full environment in
+            # its failing frame, which --showlocals would publish to CI logs.
+            env.clear()
+            raise subprocess.CalledProcessError(
+                completed.returncode,
+                completed.args,
+                output=completed.stdout,
+                stderr=completed.stderr,
+            )
+        return completed
 
     def install(self, source: Path) -> subprocess.CompletedProcess[str]:
         return self.run("plugin", "install", f"src:{source}")

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -122,6 +122,14 @@ def test_nightly_runs_p0_contracts_without_reruns_or_skips():
     assert '"P0 Dashboard Bootstrap Skill E2E"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
 
 
+def test_nightly_tracebacks_do_not_publish_local_credentials():
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+
+    pytest_addopts = [line for line in script.splitlines() if 'export PYTEST_ADDOPTS="' in line]
+    assert len(pytest_addopts) == 2
+    assert all("--no-showlocals" in line for line in pytest_addopts)
+
+
 def test_release_candidate_reuses_p0_nightly_on_the_release_ref():
     nightly = WORKFLOW.read_text(encoding="utf-8")
     release = RELEASE_CANDIDATE_WORKFLOW.read_text(encoding="utf-8")

--- a/tests/unit_tests/plugins/test_managed_plugin_runtime.py
+++ b/tests/unit_tests/plugins/test_managed_plugin_runtime.py
@@ -1,0 +1,71 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+
+"""Regression tests for the isolated managed-plugin test runtime."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+import pytest
+
+from tests.integration.conftest import ManagedPluginRuntime
+
+
+def _runtime(tmp_path: Path) -> ManagedPluginRuntime:
+    home = tmp_path / "home"
+    home.mkdir()
+    return ManagedPluginRuntime(home=home, datus_executable=Path(sys.executable))
+
+
+def test_managed_plugin_runtime_defaults_to_isolated_home(tmp_path):
+    runtime = _runtime(tmp_path)
+
+    completed = runtime.run(
+        "-c",
+        "import json, os; from pathlib import Path; "
+        "print(json.dumps({'cwd': str(Path.cwd()), 'home': os.environ['HOME']}))",
+    )
+
+    assert json.loads(completed.stdout) == {
+        "cwd": str(runtime.home),
+        "home": str(runtime.home),
+    }
+
+
+def test_managed_plugin_runtime_clears_environment_before_raising(monkeypatch, tmp_path):
+    runtime = _runtime(tmp_path)
+    sentinel = "nightly-secret-must-not-appear-in-showlocals"
+    monkeypatch.setenv("DATUS_TEST_SENTINEL_SECRET", sentinel)
+
+    with pytest.raises(subprocess.CalledProcessError) as raised:
+        runtime.run("-c", "raise SystemExit(3)")
+
+    run_frame = next(
+        frame
+        for frame, _ in traceback.walk_tb(raised.value.__traceback__)
+        if frame.f_code.co_name == "run" and "env" in frame.f_locals
+    )
+    assert run_frame.f_locals["env"] == {}
+    assert sentinel not in str(raised.value)
+
+
+def test_managed_plugin_runtime_clears_environment_on_timeout(monkeypatch, tmp_path):
+    runtime = _runtime(tmp_path)
+    sentinel = "nightly-timeout-secret-must-not-appear-in-showlocals"
+    monkeypatch.setenv("DATUS_TEST_SENTINEL_SECRET", sentinel)
+
+    with pytest.raises(subprocess.TimeoutExpired) as raised:
+        runtime.run("-c", "import time; time.sleep(10)", timeout=0.01)
+
+    run_frame = next(
+        frame
+        for frame, _ in traceback.walk_tb(raised.value.__traceback__)
+        if frame.f_code.co_name == "run" and "env" in frame.f_locals
+    )
+    assert run_frame.f_locals["env"] == {}
+    assert sentinel not in str(raised.value)


### PR DESCRIPTION
## Summary
- run managed plugin commands from their isolated temporary home by default, so repository-level `conf/agent.yml` cannot shadow the fixture config
- sanitize managed subprocess failure and timeout tracebacks before they reach pytest local-variable rendering
- disable pytest local-variable rendering across Nightly to prevent credentials embedded in configuration objects from entering logs
- add regression coverage for working-directory isolation and traceback environment cleanup

## Root cause
Nightly copies the runner configuration to `./conf/agent.yml`. The config loader prefers that file over `~/.datus/conf/agent.yml`, while the managed plugin fixture changed only `HOME` and continued running commands from the repository root. SQL Policy therefore saw no configured policies, and Superset could not find its `local` profile.

Failed run: https://github.com/Datus-ai/Datus-agent/actions/runs/33073700141

## Validation
- SQL Policy P0 integration test passed with a conflicting repository-root `conf/agent.yml`
- deterministic Dashboard managed-plugin integration test passed with the same conflict against a real local Superset
- 15 related unit and Nightly contract tests passed
- `uv run ruff check` passed
- `uv run ruff format --check` passed
- `bash -n ci/run-nightly-tests.sh` passed
- `git diff --check` passed

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection of local credentials in nightly-test failure tracebacks.
  * Ensured managed plugin commands use isolated home and working-directory defaults.
  * Improved handling of command failures and timeouts while preventing sensitive environment data from being exposed.

* **Tests**
  * Added coverage verifying credential protection and isolated runtime behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->