### PR TITLE
[BugFix] Fix nightly failure completion and status detection

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -673,13 +673,29 @@ jobs:
               }
             };
 
-            const req = https.request(options, (res) => {
-              console.log('Feishu notification sent:', res.statusCode);
-            });
+            await new Promise((resolve) => {
+              const req = https.request(options, (res) => {
+                // Drain the response so the socket can close immediately instead
+                // of keeping the workflow alive until the server's keep-alive timeout.
+                res.resume();
+                res.on('end', () => {
+                  console.log('Feishu notification sent:', res.statusCode);
+                  resolve();
+                });
+                res.on('error', (error) => {
+                  console.error('Error reading Feishu response:', error);
+                  resolve();
+                });
+              });
 
-            req.on('error', (error) => {
-              console.error('Error sending to Feishu:', error);
-            });
+              req.setTimeout(10_000, () => {
+                req.destroy(new Error('Feishu notification timed out after 10 seconds'));
+              });
+              req.on('error', (error) => {
+                console.error('Error sending to Feishu:', error);
+                resolve();
+              });
 
-            req.write(data);
-            req.end();
+              req.write(data);
+              req.end();
+            });

--- a/build_scripts/build_test_data.sh
+++ b/build_scripts/build_test_data.sh
@@ -48,12 +48,17 @@ validate_test_home() {
 }
 
 # The CLI exits 0 even when bootstrap reports {'status': 'failed', ...}, so a
-# broken component would only surface later as an empty dataset. Scan the
-# captured output for a failed Final Result and stop at the first bad step.
+# broken component would only surface later as an empty dataset. Match only the
+# top-level Final Result; debug output can contain expected failed tool attempts
+# that are retried before the bootstrap succeeds.
+bootstrap_result_failed() {
+  grep -Fq "Final Result: {'status': 'failed'"
+}
+
 run_bootstrap_kb() {
   local output
   output="$(uv run datus-agent "$@" 2>&1 | tee /dev/stderr)"
-  if printf '%s' "$output" | grep -q "'status': 'failed'"; then
+  if bootstrap_result_failed <<< "$output"; then
     echo "bootstrap-kb reported a failed status: datus-agent $*" >&2
     exit 1
   fi

--- a/tests/unit_tests/build_scripts/test_build_test_data.py
+++ b/tests/unit_tests/build_scripts/test_build_test_data.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -7,3 +8,30 @@ def test_build_test_data_uses_official_agent_entrypoint():
     build_script = (_REPO_ROOT / "build_scripts" / "build_test_data.sh").read_text(encoding="utf-8")
 
     assert 'uv run datus-agent "$@"' in build_script
+
+
+def _bootstrap_result_failed(output: str) -> bool:
+    build_script = (_REPO_ROOT / "build_scripts" / "build_test_data.sh").read_text(encoding="utf-8")
+    start = build_script.index("bootstrap_result_failed() {")
+    end = build_script.index("\n}\n", start) + len("\n}\n")
+    function_source = build_script[start:end]
+    result = subprocess.run(
+        ["bash", "-c", f"{function_source}\nbootstrap_result_failed"],
+        check=False,
+        input=output,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def test_build_test_data_ignores_retried_nested_failure_when_final_result_succeeds():
+    output = """tool result: {'metadata': {'status': 'failed', 'error': 'expected dry-run retry'}}
+Final Result: {'status': 'success', 'message': 'semantic_modeling bootstrap completed'}"""
+
+    assert not _bootstrap_result_failed(output)
+
+
+def test_build_test_data_detects_failed_final_result():
+    output = "Final Result: {'status': 'failed', 'message': 'bootstrap failed'}"
+
+    assert _bootstrap_result_failed(output)

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -25,6 +25,16 @@ def test_nightly_preserves_checkout_packages_after_locked_sync():
     assert "uv run --no-sync playwright install --with-deps chromium" in workflow
 
 
+def test_nightly_feishu_notification_drains_response_and_has_timeout():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    notification = workflow.split("- name: Send Feishu notification", maxsplit=1)[1]
+
+    assert "await new Promise((resolve) =>" in notification
+    assert "res.resume();" in notification
+    assert "res.on('end'" in notification
+    assert "req.setTimeout(10_000" in notification
+
+
 def test_nightly_kb_cache_tracks_all_adapter_checkouts():
     workflow = WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- inspect only the top-level bootstrap Final Result when deciding whether test-data generation failed
- ignore expected nested tool failures that are retried before a successful semantic bootstrap
- drain the Feishu HTTP response so the notification step releases its socket immediately
- cap a stalled notification request at 10 seconds without masking the original nightly result
- add regression coverage for both failure-handling paths

## Root causes

Nightly run 33081816451 exposed two independent issues:

1. Build test data scanned all debug output for a failed status. A failed warehouse dry-run that was subsequently repaired appeared in nested tool metadata, while the final semantic_modeling result was successful, so the script reported a false failure.
2. Feishu returned HTTP 200 after about one second, but the response stream was never consumed. Node kept the socket open until the server keep-alive timeout, so the workflow appeared to run for another minute after the notification was delivered.

## Validation

- bash -n build_scripts/build_test_data.sh
- uv run pytest tests/unit_tests/build_scripts/test_build_test_data.py tests/unit_tests/ci/test_nightly_checkout_contract.py tests/unit_tests/ci/test_format_nightly_feishu_report.py -q
- uv run ruff check tests/unit_tests/build_scripts/test_build_test_data.py tests/unit_tests/ci/test_nightly_checkout_contract.py
- uv run ruff format --check tests/unit_tests/build_scripts/test_build_test_data.py tests/unit_tests/ci/test_nightly_checkout_contract.py
- workflow YAML parse
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly Feishu notifications now complete promptly and terminate cleanly, including request timeout handling.
  * Bootstrap test-data generation now distinguishes nested tool failures from an actual failed final result.

* **Tests**
  * Added coverage for notification response handling and timeout behavior.
  * Added tests verifying accurate detection of failed bootstrap results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->