### PR TITLE
[Enhancement] Expose MaxCompute adapter in Agent

### DIFF
--- a/.github/workflows/run-nightly.yml
+++ b/.github/workflows/run-nightly.yml
@@ -222,6 +222,7 @@ jobs:
             --reinstall-package datus-doris \
             --reinstall-package datus-tidb \
             --reinstall-package datus-hologres \
+            --reinstall-package datus-maxcompute \
             --reinstall-package datus-oracle \
             --reinstall-package datus-gaussdb \
             --reinstall-package datus-storage-base \
@@ -243,6 +244,7 @@ jobs:
             ./external/datus-db-adapters/datus-doris \
             ./external/datus-db-adapters/datus-tidb \
             ./external/datus-db-adapters/datus-hologres \
+            ./external/datus-db-adapters/datus-maxcompute \
             ./external/datus-db-adapters/datus-oracle \
             ./external/datus-db-adapters/datus-trino \
             ./external/datus-db-adapters/datus-greenplum \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The diagram reads top to bottom: who uses Datus, what the agent is made of, and 
 
 ### Openness and governance
 
-- **Open ecosystem**: adapters for [15 databases](https://docs.datus.ai/latest/adapters/db_adapters/), 10+ LLM providers, and an [MCP](https://docs.datus.ai/latest/integration/mcp/) server and client.
+- **Open ecosystem**: adapters for [17 databases](https://docs.datus.ai/latest/adapters/db_adapters/), 10+ LLM providers, and an [MCP](https://docs.datus.ai/latest/integration/mcp/) server and client.
 - **External integrations**: the [plugin](https://docs.datus.ai/latest/plugin/introduction/) framework connects third-party platforms and in-house tools to the agent; one `datus-plugin.yml` manifest declares CLI commands, skills, and prompt context, with per-project activation.
 - **[Skills](https://docs.datus.ai/latest/skills/introduction/)**: packaged tools following the agentskills.io convention, installable from a marketplace.
 - **Enterprise governance**: tiered permission profiles, statement-level [SQL authorization](https://docs.datus.ai/latest/configuration/sql_policy/) with AI pre-review, bash confined to an OS-level sandbox, and [traces](https://docs.datus.ai/latest/develop/observability/) exportable to any OTLP platform.

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,7 +54,7 @@ Datus 可以完成 SQL 编写与验证、语义模型与指标构建，以及数
 
 ### 开放与治理
 
-- **开放生态**：[15 种数据库适配器](https://docs.datus.ai/zh/latest/adapters/db_adapters/)、10+ LLM 提供商，以及 [MCP](https://docs.datus.ai/zh/latest/integration/mcp/) 服务端与客户端。
+- **开放生态**：[17 种数据库适配器](https://docs.datus.ai/zh/latest/adapters/db_adapters/)、10+ LLM 提供商，以及 [MCP](https://docs.datus.ai/zh/latest/integration/mcp/) 服务端与客户端。
 - **外部生态对接**：[Plugin](https://docs.datus.ai/zh/latest/plugin/introduction/) 框架把第三方平台和公司内部工具接入 Agent，一份 `datus-plugin.yml` 清单即可声明 CLI 命令、Skill 和 prompt 上下文，按项目启用。
 - **[Skill](https://docs.datus.ai/zh/latest/skills/introduction/)**：遵循 agentskills.io 约定的打包工具，支持从 marketplace 安装。
 - **企业级治理**：权限分级，SQL 按语句类型授权并由 AI 预审，bash 运行在 OS 级沙箱中，[trace](https://docs.datus.ai/zh/latest/develop/observability/) 可导出到任意 OTLP 平台。

--- a/ci/nightly_manifest.py
+++ b/ci/nightly_manifest.py
@@ -34,6 +34,7 @@ PACKAGE_NAMES = (
     "datus-starrocks",
     "datus-doris",
     "datus-hologres",
+    "datus-maxcompute",
     "datus-oracle",
     "datus-trino",
     "datus-greenplum",

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -23,6 +23,7 @@ EXPECTED_LOCAL_PACKAGES = {
     "datus-starrocks": "datus-db-adapters/datus-starrocks",
     "datus-doris": "datus-db-adapters/datus-doris",
     "datus-hologres": "datus-db-adapters/datus-hologres",
+    "datus-maxcompute": "datus-db-adapters/datus-maxcompute",
     "datus-oracle": "datus-db-adapters/datus-oracle",
     "datus-trino": "datus-db-adapters/datus-trino",
     "datus-greenplum": "datus-db-adapters/datus-greenplum",
@@ -60,6 +61,11 @@ DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
     "datus_hologres": DatabaseAdapterContract(
         db_type="hologres",
         parser_dialect="postgres",
+        required_hooks=("get_identifier_parser", "get_sql_generation_notes"),
+    ),
+    "datus_maxcompute": DatabaseAdapterContract(
+        db_type="maxcompute",
+        parser_dialect="hive",
         required_hooks=("get_identifier_parser", "get_sql_generation_notes"),
     ),
     "datus_oracle": DatabaseAdapterContract(

--- a/ci/verify_nightly_adapter_sources.py
+++ b/ci/verify_nightly_adapter_sources.py
@@ -95,6 +95,8 @@ DATABASE_ADAPTER_CONTRACTS: dict[str, DatabaseAdapterContract] = {
     ),
 }
 
+CALLABLE_DATABASE_HOOKS = frozenset({"get_identifier_parser"})
+
 
 def distribution_source_path(package_name: str) -> tuple[Path | None, str | None]:
     try:
@@ -198,6 +200,8 @@ def verify_database_adapter_imports() -> list[str]:
             hook = getter(db_type) if callable(getter) else None
             if not hook:
                 errors.append(f"{module_name} did not register {hook_name}")
+            elif hook_name in CALLABLE_DATABASE_HOOKS and not callable(hook):
+                errors.append(f"{module_name} registered non-callable {hook_name}")
             else:
                 registered_hooks[hook_name] = hook
 

--- a/datus/cli/datasource_app.py
+++ b/datus/cli/datasource_app.py
@@ -49,6 +49,7 @@ INSTALLABLE_TYPES = (
     "greenplum",
     "hive",
     "hologres",
+    "maxcompute",
     "mysql",
     "oracle",
     "postgresql",

--- a/docs/adapters/db_adapters.md
+++ b/docs/adapters/db_adapters.md
@@ -29,6 +29,7 @@ This design keeps the core package lightweight while allowing you to add support
 | Apache Doris | datus-doris | `pip install datus-doris` | Ready |
 | TiDB | datus-tidb | `pip install datus-tidb` | Ready |
 | Hologres | datus-hologres | `pip install datus-hologres` | Ready |
+| MaxCompute | datus-maxcompute | `pip install datus-maxcompute` | Ready |
 | Oracle | datus-oracle | `pip install datus-oracle` | Ready |
 | GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | Ready (Linux and macOS) |
 
@@ -75,6 +76,9 @@ pip install datus-doris
 
 # Hologres
 pip install datus-hologres
+
+# MaxCompute
+pip install datus-maxcompute
 
 # Oracle
 pip install datus-oracle
@@ -166,6 +170,30 @@ Snowflake supports password authentication and key-pair authentication. Configur
 `password` or `private_key_file` when `private_key` is absent. `private_key` takes precedence over
 `private_key_file` and `password`; set `private_key_file_pwd` only when the private key is encrypted. Snowflake uses
 `database` and `schema`; do not set `catalog` for Snowflake.
+
+### MaxCompute
+
+```yaml
+maxcompute_data:
+  type: maxcompute
+  database: ${MAXCOMPUTE_PROJECT}
+  endpoint: ${MAXCOMPUTE_ENDPOINT}
+  access_key_id: ${MAXCOMPUTE_ACCESS_KEY_ID}
+  access_key_secret: ${MAXCOMPUTE_ACCESS_KEY_SECRET}
+  # schema: default               # optional; schema-enabled projects only
+  namespace_mode: auto            # auto, two_level, or three_level
+  # quota_name: ${MAXCOMPUTE_QUOTA_NAME}
+  # tunnel_endpoint: ${MAXCOMPUTE_TUNNEL_ENDPOINT}
+  # timeout_seconds: 30
+  # query_timeout_seconds: 600
+```
+
+`database` is the MaxCompute project. Each datasource is bound to one project, has no catalog, and does not generate
+cross-project SQL. Leave `schema` unset for a two-level `project.table` project. Schema-enabled projects use
+`project.schema.table`; when `schema` is omitted, the adapter uses `default`. Keep `namespace_mode: auto` unless the
+configured identity cannot probe schema support. `endpoint` is the MaxCompute service endpoint; configure
+`tunnel_endpoint` separately only when Instance Tunnel uses a different endpoint. Advanced execution settings also
+include `timeout_seconds`, `query_timeout_seconds`, and `default_hints`.
 
 ### StarRocks
 

--- a/docs/adapters/db_adapters.zh.md
+++ b/docs/adapters/db_adapters.zh.md
@@ -29,6 +29,7 @@ Datus 使用模块化适配器架构，允许连接不同的数据库：
 | Apache Doris | datus-doris | `pip install datus-doris` | 可用 |
 | TiDB | datus-tidb | `pip install datus-tidb` | 可用 |
 | Hologres | datus-hologres | `pip install datus-hologres` | 可用 |
+| MaxCompute | datus-maxcompute | `pip install datus-maxcompute` | 可用 |
 | Oracle | datus-oracle | `pip install datus-oracle` | 可用 |
 | GaussDB / openGauss | datus-gaussdb | `pip install datus-gaussdb` | 可用（Linux 和 macOS） |
 
@@ -72,6 +73,9 @@ pip install datus-doris
 
 # Hologres
 pip install datus-hologres
+
+# MaxCompute
+pip install datus-maxcompute
 
 # Oracle
 pip install datus-oracle
@@ -160,6 +164,30 @@ warehouse:
 ```
 
 Snowflake 支持密码认证和 key-pair 认证。可以配置 `private_key`，或在没有 `private_key` 时配置 `password` 和 `private_key_file` 其中一个。`private_key` 会优先于 `private_key_file` 和 `password`；私钥加密时再配置 `private_key_file_pwd`。Snowflake 使用 `database` 和 `schema`，不要为 Snowflake 配置 `catalog`。
+
+### MaxCompute
+
+```yaml
+maxcompute_data:
+  type: maxcompute
+  database: ${MAXCOMPUTE_PROJECT}
+  endpoint: ${MAXCOMPUTE_ENDPOINT}
+  access_key_id: ${MAXCOMPUTE_ACCESS_KEY_ID}
+  access_key_secret: ${MAXCOMPUTE_ACCESS_KEY_SECRET}
+  # schema: default               # 可选；仅三层模型项目使用
+  namespace_mode: auto            # auto、two_level 或 three_level
+  # quota_name: ${MAXCOMPUTE_QUOTA_NAME}
+  # tunnel_endpoint: ${MAXCOMPUTE_TUNNEL_ENDPOINT}
+  # timeout_seconds: 30
+  # query_timeout_seconds: 600
+```
+
+`database` 对应 MaxCompute 项目。每个 datasource 只绑定一个项目，不使用 catalog，也不会生成跨项目 SQL。
+两层模型使用 `project.table`，此时不要配置 `schema`；开启 schema 的三层模型使用
+`project.schema.table`，未配置 `schema` 时默认为 `default`。通常保持 `namespace_mode: auto`，只有当前身份
+无法探测 schema 能力时才显式设置。`endpoint` 是 MaxCompute 服务 endpoint；仅当 Instance Tunnel 使用
+不同地址时再单独配置 `tunnel_endpoint`。其他高级执行配置包括 `timeout_seconds`、
+`query_timeout_seconds` 和 `default_hints`。
 
 ### StarRocks
 

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -98,6 +98,26 @@ when the private key is encrypted. The adapter uses Snowflake JWT authentication
 Snowflake uses a `database` + `schema` namespace. Leave `catalog` unset for Snowflake; catalog filters are for
 catalog-aware engines such as StarRocks.
 
+### MaxCompute
+
+```yaml
+my_maxcompute:
+  type: maxcompute
+  database: ${MAXCOMPUTE_PROJECT}
+  endpoint: ${MAXCOMPUTE_ENDPOINT}
+  access_key_id: ${MAXCOMPUTE_ACCESS_KEY_ID}
+  access_key_secret: ${MAXCOMPUTE_ACCESS_KEY_SECRET}
+  # schema: default               # Optional; schema-enabled projects only
+  namespace_mode: auto            # auto, two_level, or three_level
+  # quota_name: ${MAXCOMPUTE_QUOTA_NAME}
+  # tunnel_endpoint: ${MAXCOMPUTE_TUNNEL_ENDPOINT}
+  # query_timeout_seconds: 600
+```
+
+`database` names the MaxCompute project. Leave `schema` unset for two-level projects; schema-enabled projects default
+to the `default` schema. A datasource has no catalog and stays within its configured project. See
+[Database Adapters](../adapters/db_adapters.md#maxcompute) for namespace and endpoint details.
+
 ### StarRocks
 ```yaml
 my_starrocks:

--- a/docs/configuration/datasources.zh.md
+++ b/docs/configuration/datasources.zh.md
@@ -98,6 +98,26 @@ Snowflake 支持密码认证和 key-pair 认证。托管/SaaS 场景推荐把 PE
 Snowflake 使用 `database` + `schema` 命名空间。Snowflake 不要配置 `catalog`；`catalog` 过滤只适用于
 StarRocks 等支持 catalog 的引擎。
 
+### MaxCompute
+
+```yaml
+my_maxcompute:
+  type: maxcompute
+  database: ${MAXCOMPUTE_PROJECT}
+  endpoint: ${MAXCOMPUTE_ENDPOINT}
+  access_key_id: ${MAXCOMPUTE_ACCESS_KEY_ID}
+  access_key_secret: ${MAXCOMPUTE_ACCESS_KEY_SECRET}
+  # schema: default               # 可选；仅三层模型项目使用
+  namespace_mode: auto            # auto、two_level 或 three_level
+  # quota_name: ${MAXCOMPUTE_QUOTA_NAME}
+  # tunnel_endpoint: ${MAXCOMPUTE_TUNNEL_ENDPOINT}
+  # query_timeout_seconds: 600
+```
+
+`database` 对应 MaxCompute 项目。两层模型不要配置 `schema`；开启 schema 的项目未配置时默认使用
+`default`。datasource 不使用 catalog，且查询范围保持在配置的项目内。命名空间与 endpoint 说明见
+[数据库适配器](../adapters/db_adapters.zh.md#maxcompute)。
+
 ### StarRocks
 
 ```yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ Curate context, tools, and rules for one business domain and package them as a [
 ### Plugin ecosystem and governance
 
 - The [plugin](plugin/introduction.md) framework connects third-party platforms and in-house tools to the agent: one `datus-plugin.yml` manifest declares CLI commands, skills, and prompt context, activated per project.
-- Adapters cover [15 databases](adapters/db_adapters.md) and 10+ LLM providers, and Datus ships both an [MCP](integration/mcp.md) server and client; [skills](skills/introduction.md) follow the agentskills.io convention and install from a marketplace.
+- Adapters cover [17 databases](adapters/db_adapters.md) and 10+ LLM providers, and Datus ships both an [MCP](integration/mcp.md) server and client; [skills](skills/introduction.md) follow the agentskills.io convention and install from a marketplace.
 - Governance covers tiered permission profiles, statement-level [SQL authorization](configuration/sql_policy.md) with AI pre-review, bash confined to an OS-level sandbox, and [traces](develop/observability.md) exportable to any OTLP platform.
 
 ![Open ecosystem: install a plugin, connect the stack you already run](assets/ecosystem_plugins.svg)

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -50,7 +50,7 @@ Agent 读取数据库 schema 和历史 SQL，自动生成 [OSI](https://dosi.dat
 ### Plugin 生态与治理
 
 - [Plugin](plugin/introduction.zh.md) 框架把第三方平台和公司内部工具接入 Agent：一份 `datus-plugin.yml` 清单声明 CLI 命令、Skill 和 prompt 上下文，按项目启用。
-- 适配器覆盖 [15 种数据库](adapters/db_adapters.zh.md)和 10+ LLM 提供商，另有 [MCP](integration/mcp.zh.md) 服务端与客户端；[Skill](skills/introduction.zh.md) 遵循 agentskills.io 约定，支持从 marketplace 安装。
+- 适配器覆盖 [17 种数据库](adapters/db_adapters.zh.md)和 10+ LLM 提供商，另有 [MCP](integration/mcp.zh.md) 服务端与客户端；[Skill](skills/introduction.zh.md) 遵循 agentskills.io 约定，支持从 marketplace 安装。
 - 治理上，权限分级，SQL 按语句类型授权并由 AI 预审，bash 运行在 OS 级沙箱中，[trace](develop/observability.zh.md) 可导出到任意 OTLP 平台。
 
 ![开放生态：安装 plugin，接入现有技术栈](assets/ecosystem_plugins.svg)

--- a/tests/unit_tests/ci/test_nightly_manifest.py
+++ b/tests/unit_tests/ci/test_nightly_manifest.py
@@ -51,6 +51,7 @@ def test_manifest_records_actual_checkout_and_all_p0_sources(tmp_path, monkeypat
         "datus-sql-policies",
     }
     assert {package["name"] for package in manifest["packages"]} >= {
+        "datus-maxcompute",
         "datus-storage-base",
         "datus-storage-postgresql",
     }

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -57,6 +57,14 @@ class _FakeDialectOperations:
         return 0
 
 
+def _fake_identifier_parser(_identifier):
+    return {"catalog_name": "", "database_name": "", "schema_name": "", "table_name": "table"}
+
+
+def _identifier_parser_for(db_type):
+    return _fake_identifier_parser if db_type in _IDENTIFIER_PARSER_ADAPTERS else None
+
+
 def test_verify_local_sources_accepts_every_expected_checkout(monkeypatch, tmp_path):
     external_root = tmp_path / "external"
     distributions = {
@@ -120,7 +128,7 @@ def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
         get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
-        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_identifier_parser=_identifier_parser_for,
         get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
     )
@@ -142,7 +150,7 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
         get_parser_dialect=lambda db_type: None if db_type == "hologres" else _PARSER_DIALECTS.get(db_type),
-        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_identifier_parser=_identifier_parser_for,
         get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
     )
@@ -181,7 +189,7 @@ def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, mi
             None
             if db_type not in _IDENTIFIER_PARSER_ADAPTERS
             or (db_type == "hologres" and missing_hook == "get_identifier_parser")
-            else object()
+            else _fake_identifier_parser
         ),
         get_sql_generation_notes=lambda db_type: (
             None if db_type == "hologres" and missing_hook == "get_sql_generation_notes" else "notes"
@@ -202,11 +210,35 @@ def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, mi
     assert verify_sources.verify_database_adapter_imports() == [expected_error]
 
 
+def test_verify_database_adapter_imports_rejects_non_callable_maxcompute_identifier_parser(monkeypatch):
+    registry = SimpleNamespace(
+        get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
+        get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
+        get_identifier_parser=lambda db_type: object() if db_type == "maxcompute" else _identifier_parser_for(db_type),
+        get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
+        get_dialect_operations=lambda db_type: _FakeDialectOperations() if db_type == "oracle" else None,
+    )
+    modules = {
+        "datus_db_core": SimpleNamespace(connector_registry=registry),
+        "datus_doris": SimpleNamespace(register=lambda: None),
+        "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_maxcompute": SimpleNamespace(register=lambda: None),
+        "datus_gaussdb": SimpleNamespace(register=lambda: None),
+        "datus_oracle": SimpleNamespace(register=lambda: None),
+        "datus_tidb": SimpleNamespace(register=lambda: None),
+    }
+    monkeypatch.setattr(verify_sources.importlib, "import_module", modules.__getitem__)
+
+    assert verify_sources.verify_database_adapter_imports() == [
+        "datus_maxcompute registered non-callable get_identifier_parser"
+    ]
+
+
 def test_verify_database_adapter_imports_requires_oracle_operations(monkeypatch):
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
         get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
-        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_identifier_parser=_identifier_parser_for,
         get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda _db_type: None,
     )
@@ -230,7 +262,7 @@ def test_verify_database_adapter_imports_requires_complete_oracle_operations(mon
     registry = SimpleNamespace(
         get_metadata=lambda db_type: SimpleNamespace(db_type=db_type),
         get_parser_dialect=lambda db_type: _PARSER_DIALECTS.get(db_type),
-        get_identifier_parser=lambda db_type: object() if db_type in _IDENTIFIER_PARSER_ADAPTERS else None,
+        get_identifier_parser=_identifier_parser_for,
         get_sql_generation_notes=lambda db_type: "notes" if db_type in _SQL_NOTES_ADAPTERS else None,
         get_dialect_operations=lambda db_type: operations if db_type == "oracle" else None,
     )

--- a/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
+++ b/tests/unit_tests/ci/test_verify_nightly_adapter_sources.py
@@ -16,9 +16,15 @@ MODULE_SPEC.loader.exec_module(verify_sources)
 
 
 # Registration shape a healthy nightly checkout produces, per db_type.
-_PARSER_DIALECTS = {"hologres": "postgres", "gaussdb": "postgres", "oracle": "oracle", "tidb": "mysql"}
-_IDENTIFIER_PARSER_ADAPTERS = {"hologres", "gaussdb"}
-_SQL_NOTES_ADAPTERS = {"hologres", "gaussdb", "oracle", "tidb"}
+_PARSER_DIALECTS = {
+    "hologres": "postgres",
+    "gaussdb": "postgres",
+    "maxcompute": "hive",
+    "oracle": "oracle",
+    "tidb": "mysql",
+}
+_IDENTIFIER_PARSER_ADAPTERS = {"hologres", "gaussdb", "maxcompute"}
+_SQL_NOTES_ADAPTERS = {"hologres", "gaussdb", "maxcompute", "oracle", "tidb"}
 
 
 class _FakeDistribution:
@@ -68,6 +74,18 @@ def test_expected_sources_include_the_tidb_checkout_path():
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-tidb"] == "datus-db-adapters/datus-tidb"
 
 
+def test_expected_sources_include_the_maxcompute_checkout_path():
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-maxcompute"] == "datus-db-adapters/datus-maxcompute"
+
+
+def test_maxcompute_contract_requires_dialect_and_sql_guidance_hooks():
+    contract = verify_sources.DATABASE_ADAPTER_CONTRACTS["datus_maxcompute"]
+
+    assert contract.db_type == "maxcompute"
+    assert contract.parser_dialect == "hive"
+    assert contract.required_hooks == ("get_identifier_parser", "get_sql_generation_notes")
+
+
 def test_expected_sources_include_storage_packages():
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-storage-base"] == ("datus-storage-adapters/datus-storage-base")
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-storage-postgresql"] == (
@@ -83,6 +101,7 @@ def test_managed_p0_plugins_are_not_required_as_global_packages():
 def test_expected_sources_include_new_database_adapters():
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-doris"] == "datus-db-adapters/datus-doris"
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-hologres"] == "datus-db-adapters/datus-hologres"
+    assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-maxcompute"] == "datus-db-adapters/datus-maxcompute"
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-oracle"] == "datus-db-adapters/datus-oracle"
     assert verify_sources.EXPECTED_LOCAL_PACKAGES["datus-gaussdb"] == "datus-db-adapters/datus-gaussdb"
 
@@ -109,6 +128,7 @@ def test_verify_database_adapter_imports_accepts_registered_hooks(monkeypatch):
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_maxcompute": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
         "datus_tidb": SimpleNamespace(register=lambda: None),
@@ -130,6 +150,7 @@ def test_verify_database_adapter_imports_requires_hologres_parser_hook(monkeypat
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_maxcompute": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
         "datus_tidb": SimpleNamespace(register=lambda: None),
@@ -171,6 +192,7 @@ def test_verify_database_adapter_imports_requires_hologres_hooks(monkeypatch, mi
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_maxcompute": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
         "datus_tidb": SimpleNamespace(register=lambda: None),
@@ -192,6 +214,7 @@ def test_verify_database_adapter_imports_requires_oracle_operations(monkeypatch)
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_maxcompute": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
         "datus_tidb": SimpleNamespace(register=lambda: None),
@@ -215,6 +238,7 @@ def test_verify_database_adapter_imports_requires_complete_oracle_operations(mon
         "datus_db_core": SimpleNamespace(connector_registry=registry),
         "datus_doris": SimpleNamespace(register=lambda: None),
         "datus_hologres": SimpleNamespace(register=lambda: None),
+        "datus_maxcompute": SimpleNamespace(register=lambda: None),
         "datus_gaussdb": SimpleNamespace(register=lambda: None),
         "datus_oracle": SimpleNamespace(register=lambda: None),
         "datus_tidb": SimpleNamespace(register=lambda: None),

--- a/tests/unit_tests/cli/test_datasource_commands.py
+++ b/tests/unit_tests/cli/test_datasource_commands.py
@@ -441,9 +441,14 @@ class TestDatasourceAppViews:
             assert app._view == _View.TYPE_SELECT
             assert ("duckdb", "duckdb", True) in app._db_types
             assert ("sqlite", "sqlite", True) in app._db_types
+            assert (
+                "maxcompute",
+                "maxcompute (not installed — will install datus-maxcompute)",
+                False,
+            ) in app._db_types
 
     def test_new_database_adapters_are_installable(self):
-        assert {"doris", "gaussdb", "hologres", "oracle", "tidb"} <= set(INSTALLABLE_TYPES)
+        assert {"doris", "gaussdb", "hologres", "maxcompute", "oracle", "tidb"} <= set(INSTALLABLE_TYPES)
 
     def test_enter_config_form(self):
         cli = _make_cli()


### PR DESCRIPTION
## Summary

- expose `maxcompute` in the datasource picker so Agent can install `datus-maxcompute` on demand
- document MaxCompute installation, credentials, endpoints, and two-level versus three-level namespace configuration in English and Chinese
- install the adapter source in nightly bootstrap and verify its parser, identifier parser, and SQL guidance registration without requiring a live MaxCompute service
- include MaxCompute in the nightly package manifest and update the documented database count

This PR assumes `datus-maxcompute` is published. The adapter implementation and manually dispatched real-cloud coverage are tracked in Datus-ai/datus-db-adapters#115; Agent nightly remains credential-free for MaxCompute.

## Validation

- `uv run pytest tests/unit_tests/ci/test_verify_nightly_adapter_sources.py tests/unit_tests/ci/test_nightly_manifest.py tests/unit_tests/cli/test_datasource_commands.py -q` (72 passed)
- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `actionlint -shellcheck= .github/workflows/run-nightly.yml`
- `uv lock --check`
- `.venv/bin/python ci/audit_tests.py --paths ...` (0 issues)
- `.venv/bin/mkdocs build --strict`
- source-installed `datus-db-core` and `datus-maxcompute` from datus-db-adapters#115, then verified connector registration, SQL notes, `datus.skills` discovery, and `db-maxcompute-sql` loading

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Added support for Alibaba Cloud MaxCompute as a database adapter.
  * MaxCompute is now available as an installable datasource type.
  * Added configuration options for credentials, endpoints, namespaces, quotas, and timeouts.

* **Documentation**
  * Added English and Chinese setup guides for MaxCompute.
  * Updated ecosystem coverage from 15 to 17 supported databases.

* **Tests**
  * Added coverage for MaxCompute installation, configuration, and adapter verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Alibaba Cloud MaxCompute as a database adapter.
  * MaxCompute is now available as an installable datasource type.
  * Added configuration options for credentials, endpoints, namespaces, quotas, and timeouts.

* **Documentation**
  * Added English and Chinese setup guides for MaxCompute.
  * Updated ecosystem coverage from 15 to 17 supported databases.

* **Tests**
  * Added coverage for MaxCompute installation and adapter verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->