### PR TITLE
[BugFix] Normalize empty query metrics limit

### DIFF
--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -1033,12 +1033,15 @@ class SemanticTools:
                 ),
             )
 
-        # Sanitize time parameters: LLM may pass string "null"/"None" instead of omitting
+        # Sanitize optional parameters: LLMs may pass string null placeholders
+        # instead of omitting them. In particular, an empty-string limit must not
+        # reach adapters that convert a present limit with ``int(limit)``.
         path = _normalize_optional_path(path)
         time_start = normalize_null(time_start)
         time_end = normalize_null(time_end)
         time_granularity = normalize_null(time_granularity)
         where = normalize_null(where)
+        limit = normalize_null(limit)
         logger.info(
             f"query_metrics called: metrics={metrics}, dimensions={dimensions}, path={path}, "
             f"time=[{time_start},{time_end}], granularity={time_granularity}, where={where}, "

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -315,6 +315,17 @@ class TestQueryMetricsCompression:
             dry_run=False,
         )
 
+    @pytest.mark.parametrize("limit", ["", " ", "null", "None"])
+    def test_query_metrics_normalizes_null_limit(self, semantic_tools, mock_adapter, limit):
+        """LLM null placeholders must not reach adapters as a present limit."""
+        query_result = QueryResult(columns=["revenue"], data=[{"revenue": 10}], metadata={})
+
+        with patch("datus.tools.func_tool.semantic_tools._run_async", return_value=query_result):
+            result = semantic_tools.query_metrics(metrics=["revenue"], limit=limit)
+
+        assert result.success == 1
+        assert mock_adapter.query_metrics.call_args.kwargs["limit"] is None
+
     def test_query_metrics_runs_warehouse_dry_run_for_compiled_sql(self, semantic_tools, mock_adapter):
         query_result = QueryResult(
             columns=["sql"],


### PR DESCRIPTION
## Summary
- normalize null-like `query_metrics.limit` values before adapter dispatch
- prevent empty-string limits from reaching adapters that call `int(limit)`
- add regression coverage for empty, whitespace, `null`, and `None` placeholders

## User impact
`query_metrics` no longer fails with `invalid literal for int()` when a model serializes an omitted optional limit as an empty or null-like string.

## Validation
- `uv run pytest tests/unit_tests/tools/func_tool/test_semantic_tools.py -q` (127 passed)
- `uv run ruff check datus/tools/func_tool/semantic_tools.py tests/unit_tests/tools/func_tool/test_semantic_tools.py`
- `uv run ruff format --check datus/tools/func_tool/semantic_tools.py tests/unit_tests/tools/func_tool/test_semantic_tools.py`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric queries by safely handling empty or null-like limit values.
  * Prevented invalid placeholder values from being passed to metric adapters.
* **Tests**
  * Added coverage for blank, `"null"`, and `"None"` limit inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->