### PR TITLE
[Enhancement] Give "no model configured" its own error code

### DIFF
--- a/datus/configuration/agent_config.py
+++ b/datus/configuration/agent_config.py
@@ -2483,7 +2483,7 @@ class AgentConfig:
         if self.target and self.target in self.models:
             return self._apply_reasoning_override(self.models[self.target])
         raise DatusException(
-            code=ErrorCode.COMMON_FIELD_REQUIRED,
+            code=ErrorCode.MODEL_NOT_SELECTED,
             message=(
                 "No active LLM model configured. "
                 "Run the Datus CLI and use the /model command to set up a provider and model:\n"

--- a/datus/utils/exceptions.py
+++ b/datus/utils/exceptions.py
@@ -72,6 +72,13 @@ class ErrorCode(Enum):
         "300025",
         "Unknown custom model `{model_name}`. Available: {available_models}",
     )
+    # Distinct from MODEL_NOT_CONFIGURED: nothing is selected at all, rather
+    # than a selection naming a model that doesn't exist. A UI host branches on
+    # this to offer "add a model" instead of "pick another one".
+    MODEL_NOT_SELECTED = (
+        "300026",
+        "No active LLM model configured",
+    )
 
     # OAuth authentication errors
     OAUTH_NOT_AUTHENTICATED = ("300030", "Not authenticated. Please run OAuth login first.")

--- a/tests/unit_tests/configuration/test_agent_config.py
+++ b/tests/unit_tests/configuration/test_agent_config.py
@@ -2368,6 +2368,9 @@ class TestProviderConfigurationDispatch:
             cfg.active_model()
         assert "/model" in exc_info.value.message
         assert "datus init" not in exc_info.value.message
+        # A host UI branches on this code to offer "add a model", so it must
+        # stay distinct from the generic missing-field code.
+        assert exc_info.value.code is ErrorCode.MODEL_NOT_SELECTED
 
     # ── Setters ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

`AgentConfig.active_model()` raises when a project has neither a provider/model pair nor a legacy custom model. It used the generic `COMMON_FIELD_REQUIRED` (100003), so the only way for a caller to recognise "this project has no model at all" was to match the message text.

This adds `MODEL_NOT_SELECTED` (300026) and raises that instead.

It stays distinct from the existing `MODEL_NOT_CONFIGURED` (300025, "unknown custom model") on purpose: nothing-selected wants an "add a model" affordance, while a selection naming a model that does not exist wants "pick another one".

## Why

A SaaS user hitting this sees the raw message in the chat stream — "Run the Datus CLI and use the /model command" — which is not an action available in the web app. Datus-saas branches on this code to render an "Add LLM Connection" card instead, falling back to matching the message so it also works against agents predating this change.

## Test

`pytest tests/unit_tests/configuration/test_agent_config.py -k active_model` — the existing raise test now also asserts the code.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error reported when no active AI model is selected.
  * Applications can now distinguish between having no model selected and selecting an unavailable model, enabling more relevant guidance.

* **Tests**
  * Added coverage to verify the new error condition and code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->