### PR TITLE
[BugFix] End a visual-artifact consultative turn normally

### DIFF
--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -650,12 +650,19 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         return None
 
     def _binding_tool_action_types(self) -> set:
-        """Tool action types that bind an artifact for this run.
-
-        Used to tell a real "never bound" failure apart from an
-        informational prose answer (which makes no binding attempt).
-        """
+        """Tool action types that bind an artifact for this run."""
         return {f"start_new_{self.ARTIFACT_KIND}", f"bind_existing_{self.ARTIFACT_KIND}"}
+
+    def _build_attempt_action_types(self) -> set:
+        """Tool action types that prove the run actually started building.
+
+        Binding alone doesn't: the system prompt requires a bind on turn 1
+        even for meta-discussion, so a consultative turn ("is this chart
+        worth keeping?") binds, reads, and answers in prose. Only a write
+        into the artifact tree — or a validate attempt — means the model
+        was mid-build and owes a successful ``validate_render``.
+        """
+        return {"write_file", "edit_file", "delete_file", self.QUERY_SAVE_ACTION_TYPE, "validate_render"}
 
     def _missing_binding_error(self) -> str:
         kind = self.ARTIFACT_KIND
@@ -744,15 +751,15 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
         )
 
         if app_jsx_rel_path is None:
-            # No render produced. Separate a genuine "forgot to bind / render"
-            # failure from a legitimate informational turn: when the model
-            # never attempted to bind an artifact and answered the user in
-            # prose (e.g. "what changes did I make?"), that's a valid response
-            # — end normally instead of forcing the missing-binding error.
-            binding_attempted = any(a.action_type in self._binding_tool_action_types() for a in all_actions)
-            informational_answer = (
-                self._active_artifact_slug is None and not binding_attempted and bool(response_content.strip())
-            )
+            # No render produced. Separate a genuine "forgot to render" failure
+            # from a legitimate informational turn: a run that never wrote into
+            # the artifact tree and answered the user in prose ("what changes
+            # did I make?", "is this chart worth keeping?") is a valid response
+            # — end normally instead of forcing an artifact error. Binding is
+            # not the discriminator: Hard rule 1 of the system prompt makes the
+            # model bind before any answer, consultative turns included.
+            build_attempted = any(a.action_type in self._build_attempt_action_types() for a in all_actions)
+            informational_answer = not build_attempted and bool(response_content.strip())
             if informational_answer:
                 if hasattr(result, "success"):
                     result.success = True  # type: ignore[attr-defined]

--- a/datus/agent/node/base_visual_artifact_agentic_node.py
+++ b/datus/agent/node/base_visual_artifact_agentic_node.py
@@ -707,6 +707,10 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
     # ── Template hooks ─────────────────────────────────────────────────────
 
     async def _before_stream(self, ctx: "StreamRunContext") -> None:
+        # One manager can span several runs (the backend's mid-run-insert
+        # continuation loop reuses it), so record where this run starts:
+        # classification below must not see a previous pass's actions.
+        ctx.extras["artifact_run_action_start"] = ctx.action_history_manager.checkpoint()
         # Bind artifact tools for this run (regenerates artifact id every call).
         self._prepare_artifacts(ctx.user_input)
 
@@ -758,7 +762,8 @@ class BaseVisualArtifactAgenticNode(AgenticNode, Generic[InputT, ResultT]):
             # — end normally instead of forcing an artifact error. Binding is
             # not the discriminator: Hard rule 1 of the system prompt makes the
             # model bind before any answer, consultative turns included.
-            build_attempted = any(a.action_type in self._build_attempt_action_types() for a in all_actions)
+            run_start = int(ctx.extras.get("artifact_run_action_start") or 0)
+            build_attempted = any(a.action_type in self._build_attempt_action_types() for a in all_actions[run_start:])
             informational_answer = not build_attempted and bool(response_content.strip())
             if informational_answer:
                 if hasattr(result, "success"):

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -696,6 +696,19 @@ async def test_execute_stream_fails_when_validate_render_not_called(real_agent_c
                             }
                         ),
                     ),
+                    # The write is what makes this a half-finished build rather
+                    # than a consultative turn — without it the run is just prose.
+                    MockToolCall(
+                        name="write_file",
+                        arguments=json.dumps(
+                            {
+                                "path": "dashboards/incomplete/render/app.jsx",
+                                "content": (
+                                    "import React from 'react';\nexport default function App() { return null; }\n"
+                                ),
+                            }
+                        ),
+                    ),
                 ],
                 content="started but never validated",
             ),
@@ -715,6 +728,66 @@ async def test_execute_stream_fails_when_validate_render_not_called(real_agent_c
     # ``_active_dashboard_slug`` got captured even though validate_render didn't run.
     assert result["dashboard_slug"] == "incomplete"
     assert "validate_render" in (result.get("error") or "")
+
+
+@pytest.mark.asyncio
+async def test_execute_stream_bound_consultative_turn_ends_normally(real_agent_config, mock_llm_create):
+    """Binding + reading + a prose answer is a valid turn, not an incomplete artifact.
+
+    Hard rule 1 of the system prompt makes the model bind before answering
+    anything — meta-discussion included — so "is this chart worth keeping?"
+    binds, reads the render tree, and replies with options. Nothing was
+    written, so there is no render to validate and no error to surface.
+    """
+    project_root = Path(real_agent_config.project_root)
+    existing_slug = "consult_demo"
+    dash_dir = project_root / "dashboards" / existing_slug
+    (dash_dir / "render").mkdir(parents=True, exist_ok=True)
+    (dash_dir / "render" / "app.jsx").write_text(
+        "import React from 'react';\nexport default function App() { return null; }\n",
+        encoding="utf-8",
+    )
+    (dash_dir / "manifest.json").write_text(
+        f'{{"slug":"{existing_slug}","name":"consult demo","description":"Seeded for a read-only turn.",'
+        '"kind":"dashboard","created_at":"2026-05-14T00:00:00Z"}\n',
+        encoding="utf-8",
+    )
+
+    answer = "That chart tracks a step nobody owns. Three options: drop it, demote it to text, or refocus it."
+    mock_llm_create.reset(
+        responses=[
+            build_tool_then_response(
+                tool_calls=[
+                    MockToolCall(
+                        name="bind_existing_dashboard",
+                        arguments=json.dumps({"dashboard_slug": existing_slug}),
+                    ),
+                    MockToolCall(
+                        name="read_file",
+                        arguments=json.dumps({"path": f"dashboards/{existing_slug}/render/app.jsx"}),
+                    ),
+                ],
+                content=answer,
+            ),
+        ]
+    )
+
+    node = _make_node(real_agent_config)
+    node.input = GenVisualDashboardNodeInput(
+        user_message="this chart doesn't look useful — is it worth keeping?",
+        database="california_schools",
+    )
+    actions = []
+    async for action in node.execute_stream(ActionHistoryManager()):
+        actions.append(action)
+
+    final = actions[-1]
+    assert final.status == ActionStatus.SUCCESS
+    result = final.output
+    assert result["success"] is True
+    assert not result.get("error")
+    assert result["app_jsx_path"] is None
+    assert result["response"] == answer
 
 
 class TestFinalizeLanguageDirective:

--- a/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py
@@ -790,6 +790,73 @@ async def test_execute_stream_bound_consultative_turn_ends_normally(real_agent_c
     assert result["response"] == answer
 
 
+@pytest.mark.asyncio
+async def test_reused_action_manager_does_not_leak_a_prior_runs_write(real_agent_config, mock_llm_create):
+    """A run is classified on its own actions, not on what an earlier pass left behind.
+
+    The backend's mid-run-insert continuation loop calls ``execute_stream``
+    again with the manager the previous pass filled, so a ``write_file`` from
+    pass 1 must not make a pass-2 consultative turn look half-finished.
+    """
+    slug = "reused_mgr"
+    app_jsx = "import React from 'react';\nexport default function App() { return null; }\n"
+    mock_llm_create.reset(
+        responses=[
+            build_tool_then_response(
+                tool_calls=[
+                    MockToolCall(
+                        name="start_new_dashboard",
+                        arguments=json.dumps(
+                            {"slug": slug, "name": slug, "description": "Half-built — unit-test fixture."}
+                        ),
+                    ),
+                    MockToolCall(
+                        name="write_file",
+                        arguments=json.dumps({"path": f"dashboards/{slug}/render/app.jsx", "content": app_jsx}),
+                    ),
+                ],
+                content="wrote the render tree",
+            ),
+            build_tool_then_response(
+                tool_calls=[
+                    MockToolCall(
+                        name="bind_existing_dashboard",
+                        arguments=json.dumps({"dashboard_slug": slug}),
+                    ),
+                    MockToolCall(
+                        name="read_file",
+                        arguments=json.dumps({"path": f"dashboards/{slug}/render/app.jsx"}),
+                    ),
+                ],
+                content="Hold off — that chart tracks a step nobody owns. Drop it, or refocus it?",
+            ),
+        ]
+    )
+
+    node = _make_node(real_agent_config)
+    manager = ActionHistoryManager()
+
+    node.input = GenVisualDashboardNodeInput(user_message="build it", database="california_schools")
+    first = [action async for action in node.execute_stream(manager)]
+    # Pass 1 wrote render files and never validated — still a real failure.
+    assert first[-1].output["success"] is False
+    assert "validate_render" in (first[-1].output.get("error") or "")
+    assert (Path(real_agent_config.project_root) / "dashboards" / slug / "render" / "app.jsx").is_file()
+
+    node.input = GenVisualDashboardNodeInput(
+        user_message="actually hold on — is that chart worth keeping?",
+        database="california_schools",
+    )
+    second = [action async for action in node.execute_stream(manager)]
+
+    final = second[-1]
+    assert final.status == ActionStatus.SUCCESS
+    result = final.output
+    assert result["success"] is True
+    assert not result.get("error")
+    assert result["app_jsx_path"] is None
+
+
 class TestFinalizeLanguageDirective:
     """The finalize stage is an independent LLM call with no system prompt, so
     the node has to hand it the response-language directive explicitly —

--- a/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_gen_visual_report_agentic_node.py
@@ -536,7 +536,7 @@ async def test_execute_stream_informational_answer_ends_normally(real_agent_conf
 
 @pytest.mark.asyncio
 async def test_execute_stream_bound_but_no_validate_marks_failure(real_agent_config, mock_llm_create):
-    """LLM binds but never calls validate_render → distinct incomplete-artifact failure."""
+    """LLM writes render files but never calls validate_render → incomplete-artifact failure."""
     mock_llm_create.reset(
         responses=[
             build_tool_then_response(
@@ -551,8 +551,21 @@ async def test_execute_stream_bound_but_no_validate_marks_failure(real_agent_con
                             }
                         ),
                     ),
+                    # The write is what makes this a half-finished build rather
+                    # than a consultative turn — without it the run is just prose.
+                    MockToolCall(
+                        name="write_file",
+                        arguments=json.dumps(
+                            {
+                                "path": "reports/halfway/render/app.jsx",
+                                "content": (
+                                    "import React from 'react';\nexport default function App() { return null; }\n"
+                                ),
+                            }
+                        ),
+                    ),
                 ],
-                content="I bound a report but forgot to finalize.",
+                content="I wrote the render tree but forgot to finalize.",
             ),
         ]
     )
@@ -579,3 +592,52 @@ async def test_execute_stream_bound_but_no_validate_marks_failure(real_agent_con
     assert result["name"] == "halfway"
     assert result["description"] == "Bound but never validated — unit-test fixture."
     assert result["created_at"]  # ISO timestamp written by start_new_report
+
+
+@pytest.mark.asyncio
+async def test_execute_stream_bound_consultative_turn_ends_normally(real_agent_config, mock_llm_create):
+    """Binding + reading + a prose answer is a valid turn, not an incomplete artifact.
+
+    Hard rule 1 of the system prompt makes the model bind before answering
+    anything — meta-discussion included — so a "should I keep this section?"
+    question binds, reads the render tree, and replies with options. Nothing
+    was written, so there is no render to validate and no error to surface.
+    """
+    project_root = Path(real_agent_config.project_root)
+    existing_slug = "consult_demo"
+    _seed_render_on_disk(project_root, existing_slug)
+
+    answer = "That section restates the KPI strip. Three options: drop it, merge it, or make it a callout."
+    mock_llm_create.reset(
+        responses=[
+            build_tool_then_response(
+                tool_calls=[
+                    MockToolCall(
+                        name="bind_existing_report",
+                        arguments=json.dumps({"report_slug": existing_slug}),
+                    ),
+                    MockToolCall(
+                        name="read_file",
+                        arguments=json.dumps({"path": f"reports/{existing_slug}/render/app.jsx"}),
+                    ),
+                ],
+                content=answer,
+            ),
+        ]
+    )
+
+    node = _make_node(real_agent_config)
+    node.input = GenVisualReportNodeInput(user_message="is this section worth keeping?")
+
+    actions = []
+    async for action in node.execute_stream(ActionHistoryManager()):
+        actions.append(action)
+
+    final = actions[-1]
+    assert final.status == ActionStatus.SUCCESS
+    result = final.output
+    assert isinstance(result, dict)
+    assert result["success"] is True
+    assert not result.get("error")
+    assert result["app_jsx_path"] is None
+    assert result["response"] == answer


### PR DESCRIPTION
## Why

Private-deployment users hit this error banner repeatedly while working on dashboards with `gen_visual_dashboard`:

> validate_render never returned success — the dashboard artifact is incomplete. The LLM must write_file the render/*.jsx components and then call validate_render() to finalize.

Most of the time the turn was perfectly fine. Typical shape: the user points at a chart and asks whether it earns its place; the model binds the dashboard, reads the render tree, and answers with three options ("drop it / demote it to text / refocus it — which do you want?"). Nothing was built, so nothing needed validating — but the answer still came back with a red error under it.

The cause is in `_build_success_result`. When no `validate_render` returned an `app_jsx_path`, the run was excused only if it had **never bound** an artifact (#876). But Hard rule 1 of both system prompts requires a bind on turn 1, explicitly including meta-discussion:

> Your very first response MUST be one of these calls — no prose-only opening … Even meta-discussion, debugging hints, or quoted error logs count as dashboard requests

So the escape hatch could only ever fire for brand-new sessions with no artifact in play. Every consultative turn on an existing artifact — the exact interaction the prompt's "Style of communication" section encourages — was reported as a failed build, and the SSE converter's FAILED catch-all turned it into an error bubble.

## Solution

Key the check on whether the run actually **started building**, not on whether it bound:

```python
build_attempted = any(a.action_type in self._build_attempt_action_types() for a in all_actions)
informational_answer = not build_attempted and bool(response_content.strip())
```

`_build_attempt_action_types()` = `{write_file, edit_file, delete_file, <save_query|save_query_template>, validate_render}` — a write into the artifact tree, or a validate attempt, is what puts the run on the hook for a successful `validate_render`. Binding alone is a read gesture.

Behaviour after this change:

| run shape | before | after |
|---|---|---|
| bind → read → prose answer | ❌ incomplete-artifact error | ✅ ends normally |
| bind → write_file → stop | ❌ error | ❌ error (unchanged) |
| bind → write_file → validate_render fails → stop | ❌ error | ❌ error (unchanged) |
| no bind, prose answer | ✅ ends normally | ✅ ends normally |
| no bind, no answer | ❌ missing-binding error | ❌ missing-binding error |

Failed tool actions are scanned from `all_actions` (not the SUCCESS-only `tool_calls`), so a run whose `validate_render` kept erroring still reports the incomplete-artifact failure rather than being mistaken for prose.

## Test Cases

`tests/unit_tests/agent/node/test_gen_visual_dashboard_agentic_node.py`, `..._report_agentic_node.py`:

- **new** `test_execute_stream_bound_consultative_turn_ends_normally` (both nodes) — seeds an artifact on disk, drives `bind_existing_*` + `read_file` + a prose answer, asserts `success is True`, no `error`, `app_jsx_path is None`. Both fail on `main` with the incomplete-artifact error and pass here.
- **updated** `test_execute_stream_fails_when_validate_render_not_called` (dashboard) / `test_execute_stream_bound_but_no_validate_marks_failure` (report) — the fixtures now `write_file` into `render/app.jsx` before stopping, so they keep asserting the real half-finished-build failure under the new rule.
- Existing `test_execute_stream_informational_answer_ends_normally`, the end-to-end validate tests, and `tests/unit_tests/api/services/test_action_sse_converter.py` are unchanged and green (162 passed).

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of consultative conversations involving existing visual artifacts.
  * Informational responses now complete successfully without requiring rendering or artifact output.
  * Incomplete artifact builds that begin writing but skip render validation continue to be reported as incomplete.

* **Tests**
  * Added coverage for dashboard and report scenarios involving read-only responses and incomplete renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of consultative conversations involving existing visual artifacts.
  * Informational responses now complete successfully without requiring rendering or artifact output.
  * Incomplete artifact builds that begin writing but skip render validation continue to be reported as incomplete.
  * Previous artifact-building activity no longer affects the outcome of later read-only conversations.

* **Tests**
  * Added coverage for dashboard and report scenarios involving read-only responses, reused history, and incomplete renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->