### PR TITLE
[Enhancement] Make table_prefix request-scoped so one process can serve two table sets

### DIFF
--- a/datus/storage/registry.py
+++ b/datus/storage/registry.py
@@ -13,8 +13,10 @@ gets its own directory under ``{data_dir}/{project}/``.
 from __future__ import annotations
 
 import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, Optional
 
 from datus_storage_base.backend_config import StorageBackendConfig
 
@@ -34,6 +36,50 @@ _factory_registry: Dict[str, Callable[..., BaseEmbeddingStore]] = {}
 
 # Deployment-level config injected once via configure_storage_defaults().
 _storage_defaults: Dict[str, Any] = {}
+
+# Per-context override for ``table_prefix`` only.
+#
+# WHY: a process may have to serve two table sets at once. Datus-backend can host
+# the Studio surface (``tb_*``) and the publication surface (``pub_tb_*``) in one
+# process, and which one a request reads is a property OF THE REQUEST, not of the
+# deployment — so it cannot come from ``_storage_defaults``, which is a module
+# global written once at startup.
+#
+# A ContextVar rather than a thread-local: the callers are asyncio tasks, and
+# each task inherits a copy of the context at creation, so a value set for one
+# request cannot leak into a concurrently running one.
+#
+# Only ``table_prefix``. The rest of the defaults (``extra_fields``,
+# ``scope_indices``) genuinely are deployment-level, and making them overridable
+# would invite per-request schema divergence.
+_table_prefix_override: ContextVar[Optional[str]] = ContextVar("datus_table_prefix_override", default=None)
+
+
+@contextmanager
+def table_prefix_scope(table_prefix: str) -> Iterator[None]:
+    """Read and write the ``table_prefix`` table set inside this block.
+
+    Nests and restores, so a caller that wraps a whole request cannot be undone
+    by an inner block. Prefer this over ``configure_storage_defaults`` for
+    anything request-scoped: that one mutates a module global, which in a
+    serving process races every concurrent request (and poisons the store cache
+    — see ``_get_storage_cached``).
+
+    Example::
+
+        with table_prefix_scope("pub_tb_"):
+            store = get_storage(MetricStore, "default", project=pid)
+    """
+    token = _table_prefix_override.set(table_prefix)
+    try:
+        yield
+    finally:
+        _table_prefix_override.reset(token)
+
+
+def current_table_prefix() -> str:
+    """The prefix in force here — the context override, else the global default."""
+    return get_storage_defaults().get("table_prefix", "")
 
 
 def configure_storage_defaults(
@@ -59,8 +105,19 @@ def configure_storage_defaults(
 
 
 def get_storage_defaults() -> Dict[str, Any]:
-    """Return the current deployment-level defaults (read-only copy)."""
-    return dict(_storage_defaults)
+    """Return the defaults in force here (read-only copy).
+
+    The deployment-level dict, with ``table_prefix`` replaced by the context
+    override when one is in force. Every reader of the defaults goes through
+    this function, which is what makes the override reach places that take no
+    parameter for it — notably ``SubjectTreeStore.__init__``, which calls this
+    itself and has no ``table_prefix`` argument.
+    """
+    defaults = dict(_storage_defaults)
+    override = _table_prefix_override.get()
+    if override is not None:
+        defaults["table_prefix"] = override
+    return defaults
 
 
 @lru_cache(maxsize=256)
@@ -69,14 +126,32 @@ def _get_storage_cached(
     embedding_model_conf_name: str,
     project: str,
     datasource_id: str,
+    table_prefix: str,
 ) -> BaseEmbeddingStore:
-    """LRU-cached storage creation, keyed by (factory, embedding model, project, datasource)."""
+    """LRU-cached storage creation, keyed by (factory, embedding model, project, datasource, prefix).
+
+    ⚠️ ``table_prefix`` IS PART OF THE KEY, and that is the whole reason this
+    signature has a parameter it never reads for anything but the key.
+
+    A store snapshots the prefix into its table names at construction time. With
+    the prefix out of the key, an instance built while the process pointed at one
+    table set stays cached under a key that says nothing about it — so a process
+    serving two table sets would answer from whichever one happened to construct
+    first, until it restarted. Keying on it makes the two sets two entries.
+    """
     from datus.storage.backend_holder import create_vector_connection
     from datus.storage.subject_tree.store import BaseSubjectEmbeddingStore
 
     with _registry_lock:
         factory = _factory_registry[factory_name]
-    kwargs = dict(_storage_defaults)
+    # Through the accessor, not ``_storage_defaults`` directly, so a context
+    # override reaches this instance as well as the nested stores that read it
+    # themselves. It resolves to the same value as the ``table_prefix`` in the
+    # key: both come from ``get_storage_defaults()`` in this same call stack, and
+    # therefore this same context. The parameter is here to key the cache, and
+    # is deliberately NOT re-assigned into kwargs — doing so handed the factory
+    # a ``table_prefix=""`` it never used to receive when no defaults were set.
+    kwargs = get_storage_defaults()
     kwargs["db"] = create_vector_connection(project)
 
     # Subject-aware stores need ``project`` so their constructor can build the
@@ -109,20 +184,31 @@ def get_storage(
     """
     with _registry_lock:
         _factory_registry[factory.__name__] = factory
-    return _get_storage_cached(factory.__name__, embedding_model_conf_name, project, datasource_id or "")
+    return _get_storage_cached(
+        factory.__name__,
+        embedding_model_conf_name,
+        project,
+        datasource_id or "",
+        current_table_prefix(),
+    )
 
 
 @lru_cache(maxsize=256)
-def _get_subject_tree_cached(project: str, datasource_id: str) -> "SubjectTreeStore":
-    """LRU-cached SubjectTreeStore creation."""
+def _get_subject_tree_cached(project: str, datasource_id: str, table_prefix: str) -> "SubjectTreeStore":
+    """LRU-cached SubjectTreeStore creation, keyed by the prefix too.
+
+    ``SubjectTreeStore.__init__`` reads ``get_storage_defaults()`` itself and
+    takes no prefix argument, so the value it picks up is whatever the context
+    said at construction time — same trap as ``_get_storage_cached``, same fix.
+    """
     from datus.storage.subject_tree.store import SubjectTreeStore
 
     return SubjectTreeStore(project=project, datasource_id=datasource_id)
 
 
 def get_subject_tree_store(project: str, datasource_id: str = "") -> "SubjectTreeStore":
-    """Return a SubjectTreeStore instance (LRU-cached per project/datasource)."""
-    return _get_subject_tree_cached(project, datasource_id or "")
+    """Return a SubjectTreeStore instance (LRU-cached per project/datasource/prefix)."""
+    return _get_subject_tree_cached(project, datasource_id or "", current_table_prefix())
 
 
 def preload_all_storages(

--- a/tests/unit_tests/storage/test_registry_cache.py
+++ b/tests/unit_tests/storage/test_registry_cache.py
@@ -101,7 +101,9 @@ class TestGetStorageLRUCache:
             store = get_storage(MetricStorage, "metric", project="my_project", datasource_id="ds1")
 
         assert store.subject_tree is project_tree
-        assert call("my_project", "ds1") in mock_tree.call_args_list
+        # The third component is the table prefix, which joined the cache key so
+        # one process can serve two table sets — "" here, no defaults configured.
+        assert call("my_project", "ds1", "") in mock_tree.call_args_list
 
     def test_datasource_scopes_wrapper_not_backend_namespace(self, reset_global_singletons):
         """Different datasource wrappers share the same project backend namespace."""

--- a/tests/unit_tests/storage/test_storage_cache.py
+++ b/tests/unit_tests/storage/test_storage_cache.py
@@ -127,3 +127,107 @@ class TestConfigureStorageDefaults:
         with patch("datus.storage.registry.get_embedding_model", side_effect=_fake_get_embedding_model):
             store = get_storage(_DummyStore, "metric", project="test")
         assert store.init_kwargs.get("table_prefix") == "tb_"
+
+
+class TestRequestScopedTablePrefix:
+    """``table_prefix_scope`` — one process serving two table sets.
+
+    Datus-backend can host the Studio surface (``tb_*``) and the publication
+    surface (``pub_tb_*``) together, and which one a request reads is a property
+    of the request. These tests pin the two things that made that impossible
+    before: the global-only prefix, and a store cache that did not key on it.
+    """
+
+    def test_scope_overrides_the_deployment_default(self):
+        from datus.storage.registry import get_storage_defaults, table_prefix_scope
+
+        configure_storage_defaults(table_prefix="tb_")
+        assert get_storage_defaults()["table_prefix"] == "tb_"
+        with table_prefix_scope("pub_tb_"):
+            assert get_storage_defaults()["table_prefix"] == "pub_tb_"
+        # ...and is restored, so a wrapped request cannot leak into the next one.
+        assert get_storage_defaults()["table_prefix"] == "tb_"
+
+    def test_scope_nests_and_restores(self):
+        from datus.storage.registry import get_storage_defaults, table_prefix_scope
+
+        configure_storage_defaults(table_prefix="tb_")
+        with table_prefix_scope("pub_tb_"):
+            with table_prefix_scope("other_"):
+                assert get_storage_defaults()["table_prefix"] == "other_"
+            assert get_storage_defaults()["table_prefix"] == "pub_tb_"
+        assert get_storage_defaults()["table_prefix"] == "tb_"
+
+    def test_the_store_built_inside_a_scope_carries_that_prefix(self):
+        from datus.storage.registry import table_prefix_scope
+
+        configure_storage_defaults(table_prefix="tb_")
+        with patch("datus.storage.registry.get_embedding_model", side_effect=_fake_get_embedding_model):
+            studio = get_storage(_DummyStore, "metric", project="p1")
+            with table_prefix_scope("pub_tb_"):
+                published = get_storage(_DummyStore, "metric", project="p1")
+
+        assert studio.init_kwargs["table_prefix"] == "tb_"
+        assert published.init_kwargs["table_prefix"] == "pub_tb_"
+
+    def test_two_table_sets_are_two_cache_entries_for_the_same_project(self):
+        """THE regression this exists for.
+
+        Same project, same factory, same datasource — only the prefix differs. If
+        the prefix is not in the key, the second call returns the first instance
+        and the process serves the wrong table set until it restarts.
+        """
+        from datus.storage.registry import table_prefix_scope
+
+        configure_storage_defaults(table_prefix="tb_")
+        with patch("datus.storage.registry.get_embedding_model", side_effect=_fake_get_embedding_model):
+            studio = get_storage(_DummyStore, "metric", project="same", datasource_id="ds")
+            with table_prefix_scope("pub_tb_"):
+                published = get_storage(_DummyStore, "metric", project="same", datasource_id="ds")
+            studio_again = get_storage(_DummyStore, "metric", project="same", datasource_id="ds")
+
+        assert studio is not published
+        # Still a cache, not a factory: the same prefix returns the same instance.
+        assert studio is studio_again
+
+    def test_a_scope_does_not_leak_into_a_concurrent_task(self):
+        """ContextVar, not a thread-local or a global: asyncio tasks must not see it.
+
+        Each task inherits a COPY of the context at creation, so the publication
+        task's override is invisible to the Studio task running beside it.
+        """
+        import asyncio
+
+        from datus.storage.registry import get_storage_defaults, table_prefix_scope
+
+        configure_storage_defaults(table_prefix="tb_")
+        seen: dict[str, str] = {}
+        started = asyncio.Event()
+
+        async def publication():
+            with table_prefix_scope("pub_tb_"):
+                started.set()
+                # Yield with the override in force, so the other task runs inside
+                # this window rather than before or after it.
+                await asyncio.sleep(0)
+                seen["publication"] = get_storage_defaults()["table_prefix"]
+
+        async def studio():
+            await started.wait()
+            seen["studio"] = get_storage_defaults()["table_prefix"]
+
+        async def main():
+            await asyncio.gather(publication(), studio())
+
+        asyncio.run(main())
+        assert seen == {"publication": "pub_tb_", "studio": "tb_"}
+
+    def test_no_scope_leaves_the_kwargs_shape_alone(self):
+        """With no defaults and no scope, the factory sees only ``db`` — as before.
+
+        An unconditional ``table_prefix=""`` would be handing every factory a
+        keyword it never used to receive.
+        """
+        with patch("datus.storage.registry.get_embedding_model", side_effect=_fake_get_embedding_model):
+            store = get_storage(_DummyStore, "metric", project="test")
+        assert set(store.init_kwargs) == {"db"}


### PR DESCRIPTION
## Why

A process may have to read two table sets at once.

Datus-backend can host the **Studio** surface (`tb_*`) and the **publication**
surface (`pub_tb_*`) in one process — that is the lower-requirement on-prem
topology — and which set a request reads is a property **of the request**, not of
the deployment. Two things in the registry made that impossible.

### 1. The prefix was only reachable through a module global

`configure_storage_defaults()` writes `_storage_defaults`. Flipping it per
request races every concurrent request.

Adds **`table_prefix_scope(prefix)`**, a `ContextVar`-backed context manager,
applied by `get_storage_defaults()`. Every reader already goes through that
accessor, which is what makes the override reach places that take no parameter
for it — notably `SubjectTreeStore.__init__`, which calls `get_storage_defaults()`
itself and has no `table_prefix` argument. **`subject_tree/store.py` needs no
change.**

A ContextVar rather than a thread-local because the callers are asyncio tasks:
each task inherits a copy of the context at creation, so one request's override
cannot leak into a concurrently running one. There is a test for exactly that.

Only `table_prefix` is overridable. `extra_fields` and `scope_indices` genuinely
are deployment-level, and making them per-request would invite per-request schema
divergence.

### 2. The store cache did not key on the prefix

A store snapshots the prefix into its table names at construction, but
`_get_storage_cached` was keyed on `(factory, embedding_conf, project,
datasource_id)` — **prefix absent**. An instance built while the process pointed
at one table set stayed cached under a key that said nothing about it, so a
process serving both answered from whichever constructed first, **until it
restarted**.

The prefix now joins that key, and `_get_subject_tree_cached`'s for the same
reason.

## Note on one deliberate non-change

`_get_storage_cached` takes `table_prefix` for the **key** and does not
re-assign it into the factory kwargs. An unconditional `table_prefix=""` handed
every factory a keyword it never used to receive when no defaults were
configured — caught by `test_no_defaults_gives_empty_kwargs`, which is why that
test is unmodified.

## Tests

`tests/unit_tests/storage/test_storage_cache.py` — new `TestRequestScopedTablePrefix`:

- scope overrides the deployment default, nests, and restores
- a store built inside a scope carries that prefix
- **the regression this exists for**: same project + datasource, two prefixes →
  two instances; same prefix → the same instance (still a cache, not a factory)
- an asyncio task's scope is invisible to a task running beside it
- the no-defaults kwargs shape is unchanged

Verified the two cache-key assertions go **red** without the key component
(2 failed / 4 passed).

`test_registry_cache.py` — one assertion updated: `_get_subject_tree_cached`
gained a third key component, so the `call(...)` it asserts follows.

Storage suite: **1954 passed, 1838 skipped**. `ruff format` + `ruff check` clean.

## Consumers

Nothing in this repo calls `table_prefix_scope` yet — it is the seam
Datus-backend needs to fold the publication surface into the Studio process.
Existing behaviour is unchanged when no scope is entered.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request-scoped table prefix overrides for storage operations.
  * Supports nested scopes and automatically restores previous settings.
  * Isolates table prefix settings across asynchronous tasks.
* **Bug Fixes**
  * Prevented storage and subject-tree instances from being incorrectly reused across different table sets.
  * Ensured stores created within a scoped override use the correct table prefix.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->