### PR TITLE
[Enhancement] Inject connector SQL context into prompts

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -692,10 +692,10 @@ class AgenticNode(Node):
         stale dialect in every later turn. Instead this line rides in the
         ``<system_reminder>`` envelope of each user message. It merges what
         used to be a separate "Database Context" block — dialect, catalog,
-        database (resolved via the connector default), and schema — into one
-        line so the dialect is stated exactly once per turn. Gated on
-        ``db_func_tool`` so non-DB nodes add no noise; returns an empty string
-        when no datasource is selected.
+        database (resolved via the connector default), adapter-provided SQL
+        semantics, and schema — into one line so the dialect is stated exactly
+        once per turn. Gated on ``db_func_tool`` so non-DB nodes add no noise;
+        returns an empty string when no datasource is selected.
         """
         agent_config = getattr(self, "agent_config", None)
         if not agent_config or getattr(self, "db_func_tool", None) is None:
@@ -718,6 +718,20 @@ class AgenticNode(Node):
         database = resolve_database_name_for_prompt(connector, getattr(user_input, "database", "") or "")
         if database:
             details.append(f"database: {database}")
+        sql_context_getter = getattr(connector, "get_sql_generation_context", None)
+        if callable(sql_context_getter):
+            try:
+                sql_context = sql_context_getter(database_name=database) or {}
+                compatibility_mode = sql_context.get("compatibility_mode") if isinstance(sql_context, dict) else None
+                if compatibility_mode:
+                    compatibility_mode = str(compatibility_mode).strip()
+                    if compatibility_mode:
+                        details.append(f"compatibility mode: {compatibility_mode}")
+            except Exception as e:
+                # SQL-generation hints must never make an otherwise usable
+                # datasource fail. The adapter may be talking to an older or
+                # restricted server that cannot expose the requested trait.
+                logger.debug("Unable to read connector SQL-generation context: %s", e)
         schema = getattr(user_input, "db_schema", "") or ""
         if schema:
             details.append(f"schema: {schema}")

--- a/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
@@ -322,6 +322,81 @@ class TestDatasourceReminder:
         assert "database: explicit_db" in line
         assert "default_db" not in line
 
+    def test_connector_sql_generation_context_is_included(self, session_manager):
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="dws")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        requested_databases = []
+
+        class Connector:
+            database_name = "customer_db"
+
+            def get_sql_generation_context(self, database_name=""):
+                requested_databases.append(database_name)
+                return {"compatibility_mode": "TD"}
+
+        node = _SnapshotNode(
+            session_manager,
+            cfg,
+            db_func_tool=SimpleNamespace(connector=Connector()),
+        )
+
+        line = node._build_datasource_reminder(SimpleNamespace(db_schema="test"))
+
+        assert (
+            "Current datasource: main "
+            "(dialect: dws, database: customer_db, compatibility mode: TD, schema: test)" in line
+        )
+        assert requested_databases == ["customer_db"]
+
+    def test_connector_sql_generation_context_failure_is_non_blocking(self, session_manager):
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="dws")})
+        cfg = _agent_config(current_datasource="main", services=services)
+
+        class Connector:
+            database_name = "customer_db"
+
+            def get_sql_generation_context(self, database_name=""):
+                raise RuntimeError("catalog unavailable")
+
+        node = _SnapshotNode(
+            session_manager,
+            cfg,
+            db_func_tool=SimpleNamespace(connector=Connector()),
+        )
+
+        line = node._build_datasource_reminder()
+
+        assert "Current datasource: main (dialect: dws, database: customer_db)" in line
+        assert "compatibility mode" not in line
+
+    def test_connector_sql_generation_context_tracks_datasource_switch(self, session_manager):
+        services = SimpleNamespace(
+            datasources={
+                "warehouse_td": SimpleNamespace(type="dws"),
+                "warehouse_ora": SimpleNamespace(type="dws"),
+            }
+        )
+        cfg = _agent_config(current_datasource="warehouse_td", services=services)
+
+        def connector(database_name, compatibility_mode):
+            return SimpleNamespace(
+                database_name=database_name,
+                get_sql_generation_context=lambda **_kwargs: {"compatibility_mode": compatibility_mode},
+            )
+
+        db_tool = SimpleNamespace(connector=connector("sales_td", "TD"))
+        node = _SnapshotNode(session_manager, cfg, db_func_tool=db_tool)
+
+        assert "database: sales_td, compatibility mode: TD" in node._build_datasource_reminder()
+
+        cfg.current_datasource = "warehouse_ora"
+        db_tool.connector = connector("sales_ora", "ORA")
+
+        switched = node._build_datasource_reminder()
+        assert "Current datasource: warehouse_ora" in switched
+        assert "database: sales_ora, compatibility mode: ORA" in switched
+        assert "TD" not in switched
+
     def test_enhanced_message_carries_reminder_in_envelope(self, session_manager):
         """The reminder rides inside the existing <system_reminder> envelope."""
         from datus.utils.message_utils import extract_enhanced_context, extract_user_input

--- a/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
@@ -348,6 +348,30 @@ class TestDatasourceReminder:
         )
         assert requested_databases == ["customer_db"]
 
+    def test_connector_sql_generation_context_ignores_whitespace_mode(self, session_manager):
+        services = SimpleNamespace(datasources={"main": SimpleNamespace(type="dws")})
+        cfg = _agent_config(current_datasource="main", services=services)
+        requested_databases = []
+
+        class Connector:
+            database_name = "customer_db"
+
+            def get_sql_generation_context(self, database_name=""):
+                requested_databases.append(database_name)
+                return {"compatibility_mode": "   "}
+
+        node = _SnapshotNode(
+            session_manager,
+            cfg,
+            db_func_tool=SimpleNamespace(connector=Connector()),
+        )
+
+        line = node._build_datasource_reminder(SimpleNamespace(db_schema="test"))
+
+        assert "Current datasource: main (dialect: dws, database: customer_db, schema: test)" in line
+        assert "compatibility mode:" not in line
+        assert requested_databases == ["customer_db"]
+
     def test_connector_sql_generation_context_failure_is_non_blocking(self, session_manager):
         services = SimpleNamespace(datasources={"main": SimpleNamespace(type="dws")})
         cfg = _agent_config(current_datasource="main", services=services)


### PR DESCRIPTION
## Summary

- read optional adapter-provided SQL-generation context while building the live per-turn datasource reminder
- include the active DWS compatibility mode next to dialect and database context
- keep the hook duck-typed and failure-isolated so existing connectors and non-database nodes remain unchanged
- cover mode injection, probe failure fallback, and datasource switching

## Motivation

DWS TD and ORA databases share the same DWS dialect but differ in expression semantics. The mode must follow the current datasource and database at runtime instead of being frozen into the cached system prompt.

## Validation

- uv run pytest tests/unit_tests/agent/node (1656 passed, 1 skipped)
- uv run ruff check datus/agent/node/agentic_node.py tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
- uv run ruff format --check datus/agent/node/agentic_node.py tests/unit_tests/agent/node/test_agentic_node_sysprompt_cache.py
- git diff --check upstream/main...HEAD

## Adapter integration

Companion adapter PR: https://github.com/Datus-ai/datus-db-adapters/pull/121

This change is backward compatible on its own: connectors without get_sql_generation_context keep the existing reminder text.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Improvements**
  * SQL generation guidance now reflects datasource-specific compatibility modes when available.
  * Datasource reminders continue to display even if compatibility information cannot be retrieved.

* **Tests**
  * Added coverage for compatibility details, retrieval failures, and switching between datasources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Datasource reminders now display the connector’s SQL compatibility mode when available, providing clearer context for generated queries.

- **Bug Fixes**
  - Datasource reminders continue to render even when compatibility information cannot be retrieved.
  - Empty or whitespace-only compatibility settings are omitted to keep reminders concise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->