### PR TITLE
[BugFix] Deliver mid-run message inserts on the Claude native and Codex paths

### DIFF
--- a/datus/models/base.py
+++ b/datus/models/base.py
@@ -12,6 +12,7 @@ from typing import Any, AsyncGenerator, ClassVar, Dict, List, Optional, Tuple, U
 
 from agents import SQLiteSession, Tool
 from agents.mcp import MCPServerStdio
+from agents.run import CallModelData, ModelInputData, RunConfig
 
 from datus.configuration.agent_config import AgentConfig, ModelConfig
 from datus.schemas.action_history import ActionHistory, ActionHistoryManager
@@ -220,6 +221,115 @@ class LLMBaseModel(ABC):  # Changed from BaseModel to LLMBaseModel
         """
         self.workflow = workflow
         self.current_node = current_node
+
+    @staticmethod
+    def drain_pending_user_inserts(
+        pending_input_queue,
+        interrupt_controller=None,
+        interaction_broker=None,
+    ) -> List[str]:
+        """Drain mid-run user messages staged during the current agent run.
+
+        Shared by every model path that supports mid-run insertion so the
+        "when is a staged message flushed" contract has exactly one definition:
+        at a turn boundary, all-or-nothing, and never while an interrupt is in
+        flight (an aborting run must not swallow text the user will re-send).
+
+        Each drained message is emitted as a USER ``ActionHistory`` through the
+        broker so the CLI transcript and the API SSE stream show the injection
+        at the moment the model actually receives it. Callers own the
+        provider-specific step of appending the text to the model input.
+
+        Returns the drained messages in FIFO order, empty when there is
+        nothing to flush.
+        """
+        if pending_input_queue is None:
+            return []
+        if interrupt_controller is not None and getattr(interrupt_controller, "is_interrupted", False):
+            return []
+        try:
+            pending = pending_input_queue.drain()
+        except Exception:  # noqa: BLE001 — a queue hiccup must never abort the run
+            logger.exception("Failed to drain pending user inserts; continuing without them.")
+            return []
+        if not pending:
+            return []
+
+        if interaction_broker is not None:
+            for text in pending:
+                try:
+                    interaction_broker.emit_user_insert(text)
+                except Exception:  # noqa: BLE001 — emission is best-effort
+                    logger.exception("Failed to emit user_insert ActionHistory; model still sees the text.")
+        return pending
+
+    def _build_run_config(
+        self,
+        pending_input_queue=None,
+        session: Optional[SQLiteSession] = None,
+        interrupt_controller=None,
+        interaction_broker=None,
+        agent_name: Optional[str] = None,
+    ) -> Optional[RunConfig]:
+        """Build a :class:`RunConfig` carrying our mid-run input filter.
+
+        Lives on the base class because every agents-SDK-driven provider needs
+        the same filter: ``OpenAICompatibleModel`` and ``CodexModel`` build
+        their own ``Runner.run_streamed`` calls, and a provider that quietly
+        omits the filter silently loses mid-run insertion (the queue then only
+        drains at the run boundary, via the chat layer's auto-continuation).
+
+        Returns ``None`` when neither tracing context nor ``pending_input_queue``
+        is wired in — the SDK then runs with its default config and behavior is
+        unchanged.
+
+        The filter is invoked by the SDK before every LLM turn within a
+        ``Runner.run_streamed`` invocation (``agents/run.py`` ~1483). It drains
+        the queue (every queued item, FIFO) and appends each as a structured
+        Responses-API user message, also persisting them onto the session so
+        future runs see them.
+
+        All exceptions in the filter body are swallowed: the SDK re-raises
+        uncaught filter errors and aborts the entire run, which we must never
+        let a queue or sqlite hiccup do.
+        """
+        from datus.utils.trace_context import build_agents_run_config_kwargs
+
+        trace_kwargs = build_agents_run_config_kwargs(agent_name=agent_name)
+        if pending_input_queue is None and not trace_kwargs:
+            return None
+
+        async def _filter(data: CallModelData) -> ModelInputData:
+            try:
+                pending = LLMBaseModel.drain_pending_user_inserts(
+                    pending_input_queue,
+                    interrupt_controller=interrupt_controller,
+                    interaction_broker=interaction_broker,
+                )
+                if not pending:
+                    return data.model_data
+                new_items = list(data.model_data.input)
+                for text in pending:
+                    user_item = {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": text}],
+                    }
+                    new_items.append(user_item)
+                    if session is not None:
+                        try:
+                            await session.add_items([user_item])
+                        except Exception:  # noqa: BLE001 — never abort the run on a session write
+                            logger.exception("Failed to persist injected user item; in-memory only.")
+                return ModelInputData(input=new_items, instructions=data.model_data.instructions)
+            except Exception:  # noqa: BLE001 — filter exceptions abort the SDK run
+                logger.exception("call_model_input_filter raised; returning original input unchanged.")
+                return data.model_data
+
+        if pending_input_queue is None:
+            return RunConfig(**trace_kwargs)
+
+        return RunConfig(call_model_input_filter=_filter, **trace_kwargs)
 
     def supports_builtin_web_search(self) -> bool:
         """Whether this provider serves web search through a vendor-native tool.

--- a/datus/models/claude_model.py
+++ b/datus/models/claude_model.py
@@ -690,6 +690,8 @@ class ClaudeModel(OpenAICompatibleModel):
         interrupt_controller=None,
         session: Optional[Any] = None,
         hooks=None,
+        pending_input_queue=None,
+        interaction_broker=None,
         **kwargs,
     ) -> AsyncGenerator[ActionHistory, None]:
         """Async generator: native Anthropic API with real-time tool call ActionHistory.
@@ -850,6 +852,31 @@ class ClaudeModel(OpenAICompatibleModel):
                         raise ExecutionInterrupted("Interrupted by user")
 
                     logger.debug(f"Turn {turn + 1}/{max_turns}")
+
+                    # Mid-run message insertion. The native loop is not driven by
+                    # the SDK Runner, so ``call_model_input_filter`` never fires
+                    # here; this is its equivalent and sits at the same point in
+                    # the cycle — after the previous round's tool_results were
+                    # appended, before the next model call. Without it a message
+                    # typed mid-run stays queued for the whole run and only lands
+                    # via the chat layer's auto-continuation, i.e. a full round
+                    # trip too late to steer anything.
+                    #
+                    # Appending to ``messages`` is the only persistence needed:
+                    # ``persisted_message_index`` was advanced to ``len(messages)``
+                    # at the end of the previous round, so this round's checkpoint
+                    # writes the inserted message along with the rest of the turn.
+                    for inserted_text in self.drain_pending_user_inserts(
+                        pending_input_queue,
+                        interrupt_controller=interrupt_controller,
+                        interaction_broker=interaction_broker,
+                    ):
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": [{"type": "text", "text": inserted_text}],
+                            }
+                        )
 
                     request_kwargs = dict(
                         model=self.model_name,
@@ -1932,12 +1959,21 @@ class ClaudeModel(OpenAICompatibleModel):
         session=None,
         action_history_manager: Optional[ActionHistoryManager] = None,
         hooks=None,
+        interrupt_controller=None,
+        pending_input_queue=None,
+        interaction_broker=None,
         **kwargs,
     ) -> AsyncGenerator[ActionHistory, None]:
         """Generate response with streaming and tool support.
 
         Routes to native Anthropic API for OAuth subscription tokens,
         otherwise uses parent class LiteLLM implementation.
+
+        The mid-run insertion plumbing (``pending_input_queue`` /
+        ``interaction_broker``) is named explicitly rather than left to
+        ``**kwargs``: both branches need it, and the base signature ends in
+        ``**kwargs``, so forwarding it implicitly hides a dropped argument as
+        "insertion silently doesn't work" instead of a TypeError.
         """
         # Route to the native Anthropic path for (a) OAuth subscription tokens
         # (LiteLLM sends x-api-key which is incompatible with Bearer auth), or
@@ -1961,9 +1997,11 @@ class ClaudeModel(OpenAICompatibleModel):
                 max_turns=max_turns,
                 func_tools=tools,
                 action_history_manager=action_history_manager,
-                interrupt_controller=kwargs.pop("interrupt_controller", None),
+                interrupt_controller=interrupt_controller,
                 session=session,
                 hooks=hooks,
+                pending_input_queue=pending_input_queue,
+                interaction_broker=interaction_broker,
                 **kwargs,
             ):
                 yield action
@@ -1982,6 +2020,9 @@ class ClaudeModel(OpenAICompatibleModel):
                 session=session,
                 action_history_manager=action_history_manager,
                 hooks=hooks,
+                interrupt_controller=interrupt_controller,
+                pending_input_queue=pending_input_queue,
+                interaction_broker=interaction_broker,
                 **kwargs,
             ):
                 yield action

--- a/datus/models/codex_model.py
+++ b/datus/models/codex_model.py
@@ -562,9 +562,18 @@ class CodexModel(LLMBaseModel):
         action_history_manager: Optional[ActionHistoryManager] = None,
         hooks=None,
         interrupt_controller=None,
+        pending_input_queue=None,
+        interaction_broker=None,
         **kwargs,
     ) -> AsyncGenerator[ActionHistory, None]:
-        """Generate response with streaming and tool support via the Codex Responses API."""
+        """Generate response with streaming and tool support via the Codex Responses API.
+
+        ``pending_input_queue`` and ``interaction_broker`` are named explicitly
+        rather than read out of ``**kwargs``: the base signature ends in
+        ``**kwargs``, so a provider that forgets to forward them loses mid-run
+        message insertion without any error — the queue then only drains at the
+        run boundary via the chat layer's auto-continuation.
+        """
         if action_history_manager is None:
             action_history_manager = ActionHistoryManager()
 
@@ -591,8 +600,16 @@ class CodexModel(LLMBaseModel):
 
             agent = Agent(**agent_kwargs)
 
-            run_config_kwargs = build_agents_run_config_kwargs(agent_name=agent_kwargs["name"])
-            run_config = RunConfig(**run_config_kwargs) if run_config_kwargs else None
+            # Carries the mid-run input filter as well as the trace kwargs, so a
+            # message typed while this run is streaming reaches the model at the
+            # next turn boundary instead of waiting for the whole run to finish.
+            run_config = self._build_run_config(
+                pending_input_queue=pending_input_queue,
+                session=session,
+                interrupt_controller=interrupt_controller,
+                interaction_broker=interaction_broker,
+                agent_name=agent_kwargs["name"],
+            )
             with _agents_trace_baggage(agent_kwargs["name"]):
                 result = Runner.run_streamed(
                     agent, input=prompt, max_turns=max_turns, session=session, run_config=run_config

--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -22,7 +22,6 @@ from agents import Agent, ModelSettings, Runner, Tool, WebSearchTool
 from agents.exceptions import MaxTurnsExceeded, ModelBehaviorError
 from agents.extensions.memory import AdvancedSQLiteSession
 from agents.mcp import MCPServerStdio
-from agents.run import CallModelData, ModelInputData, RunConfig
 from openai import APIConnectionError, APIError, APITimeoutError, RateLimitError
 from openai.types.shared.reasoning import Reasoning
 from pydantic import AnyUrl
@@ -41,7 +40,7 @@ from datus.utils.json_utils import to_str
 from datus.utils.loggings import configure_litellm_logging, get_logger
 from datus.utils.resource_utils import read_data_file_text
 from datus.utils.text_utils import LitellmPlaceholderStreamFilter, strip_litellm_placeholder
-from datus.utils.trace_context import build_agents_run_config_kwargs, build_trace_span_attributes
+from datus.utils.trace_context import build_trace_span_attributes
 
 logger = get_logger(__name__)
 
@@ -974,75 +973,6 @@ class OpenAICompatibleModel(LLMBaseModel):
             **kwargs,
         ):
             yield action
-
-    def _build_run_config(
-        self,
-        pending_input_queue=None,
-        session: Optional[AdvancedSQLiteSession] = None,
-        interrupt_controller=None,
-        interaction_broker=None,
-        agent_name: Optional[str] = None,
-    ) -> Optional[RunConfig]:
-        """Build a :class:`RunConfig` carrying our mid-run input filter.
-
-        Returns ``None`` when neither tracing context nor ``pending_input_queue``
-        is wired in — the SDK then runs with its default config and behavior is
-        unchanged.
-
-        The filter is invoked by the SDK before every LLM turn within a
-        ``Runner.run_streamed`` invocation (``agents/run.py`` ~1483). It
-        drains the queue (every queued item, FIFO) and appends each as a
-        structured Responses-API user message, also persisting them onto
-        the session so future runs see them.
-
-        When ``interaction_broker`` is provided, each drained item is also
-        emitted as a USER ``ActionHistory`` via
-        :meth:`InteractionBroker.emit_user_insert`. That makes the
-        injection visible to the TUI's streaming display and to the API
-        SSE consumer at the exact moment it's being flushed to the model.
-
-        All exceptions in the filter body are swallowed: the SDK re-raises
-        uncaught filter errors and aborts the entire run, which we must
-        never let a queue or sqlite hiccup do.
-        """
-        trace_kwargs = build_agents_run_config_kwargs(agent_name=agent_name)
-        if pending_input_queue is None and not trace_kwargs:
-            return None
-
-        async def _filter(data: CallModelData) -> ModelInputData:
-            try:
-                if interrupt_controller is not None and getattr(interrupt_controller, "is_interrupted", False):
-                    return data.model_data
-                pending = pending_input_queue.drain()
-                if not pending:
-                    return data.model_data
-                new_items = list(data.model_data.input)
-                for text in pending:
-                    user_item = {
-                        "type": "message",
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": text}],
-                    }
-                    new_items.append(user_item)
-                    if session is not None:
-                        try:
-                            await session.add_items([user_item])
-                        except Exception:  # noqa: BLE001 — never abort the run on a session write
-                            logger.exception("Failed to persist injected user item; in-memory only.")
-                    if interaction_broker is not None:
-                        try:
-                            interaction_broker.emit_user_insert(text)
-                        except Exception:  # noqa: BLE001 — broker emission is best-effort
-                            logger.exception("Failed to emit user_insert ActionHistory; model still sees the text.")
-                return ModelInputData(input=new_items, instructions=data.model_data.instructions)
-            except Exception:  # noqa: BLE001 — filter exceptions abort the SDK run
-                logger.exception("call_model_input_filter raised; returning original input unchanged.")
-                return data.model_data
-
-        if pending_input_queue is None:
-            return RunConfig(**trace_kwargs)
-
-        return RunConfig(call_model_input_filter=_filter, **trace_kwargs)
 
     def _build_agent(
         self,

--- a/tests/unit_tests/models/conftest.py
+++ b/tests/unit_tests/models/conftest.py
@@ -1,0 +1,101 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Shared fixtures for model-layer unit tests.
+
+The ``two_turn_agents_model`` factory below builds a real agents-SDK
+:class:`~agents.models.interface.Model` so a test can drive the SDK's genuine
+turn loop (``Runner.run_streamed``) without any network. That matters for the
+mid-run-insert tests: the injection point is a per-turn SDK hook, so a mocked
+``Runner`` would assert nothing about when a staged message is actually
+flushed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator, List
+
+import pytest
+from agents.models.interface import Model
+from openai.types.responses import (
+    Response,
+    ResponseCompletedEvent,
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+
+
+def _response(output: List[Any], response_id: str) -> Response:
+    return Response(
+        id=response_id,
+        created_at=0.0,
+        model="stub",
+        object="response",
+        output=output,
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+class RecordingTwoTurnModel(Model):
+    """Two-turn stub: turn 1 calls ``tool_name``, turn 2 returns final text.
+
+    Every turn's input list is snapshotted into :attr:`inputs`, which is what
+    lets a test assert *which* LLM turn first saw a given message.
+    """
+
+    def __init__(self, tool_name: str = "probe_tool", final_text: str = "done") -> None:
+        self.inputs: List[Any] = []
+        self.turn = 0
+        self._tool_name = tool_name
+        self._final_text = final_text
+
+    def saw_on_turn(self, index: int, needle: str) -> bool:
+        """Whether ``needle`` appears in the input of turn ``index`` (0-based)."""
+        if index >= len(self.inputs):
+            return False
+        return needle in json.dumps(self.inputs[index])
+
+    async def get_response(self, *args, **kwargs):  # pragma: no cover - streaming only
+        raise NotImplementedError("RecordingTwoTurnModel is streaming-only")
+
+    async def stream_response(self, system_instructions, input, *args, **kwargs) -> AsyncIterator[Any]:
+        self.turn += 1
+        self.inputs.append(json.loads(json.dumps(input, default=str)))
+
+        if self.turn == 1:
+            output: List[Any] = [
+                ResponseFunctionToolCall(
+                    id="fc_1",
+                    call_id="call_1",
+                    name=self._tool_name,
+                    arguments="{}",
+                    type="function_call",
+                )
+            ]
+        else:
+            output = [
+                ResponseOutputMessage(
+                    id="msg_1",
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                    content=[ResponseOutputText(text=self._final_text, type="output_text", annotations=[])],
+                )
+            ]
+
+        yield ResponseCompletedEvent(
+            response=_response(output, f"resp_{self.turn}"),
+            type="response.completed",
+            sequence_number=0,
+        )
+
+
+@pytest.fixture
+def two_turn_agents_model():
+    """Factory for :class:`RecordingTwoTurnModel`."""
+    return RecordingTwoTurnModel

--- a/tests/unit_tests/models/test_base.py
+++ b/tests/unit_tests/models/test_base.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -164,3 +165,173 @@ class TestCreateModelCache:
             on = LLMBaseModel.create_model(self._agent_config(cfg_on))
         assert off is not on
         assert module.OpenAIModel.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Mid-run message insertion — shared drain contract + SDK input filter
+# ---------------------------------------------------------------------------
+
+
+class _RecordingBroker:
+    def __init__(self, explode: bool = False):
+        self.emitted: list[str] = []
+        self._explode = explode
+
+    def emit_user_insert(self, text: str) -> None:
+        if self._explode:
+            raise RuntimeError("broker down")
+        self.emitted.append(text)
+
+
+class TestDrainPendingUserInserts:
+    """Contract for the single definition of "flush staged user messages".
+
+    Every provider path (agents-SDK filter, Claude's native Anthropic loop)
+    routes through this helper, so the invariants below are what keep the
+    three paths behaving identically.
+    """
+
+    def test_no_queue_returns_empty(self):
+        assert LLMBaseModel.drain_pending_user_inserts(None) == []
+
+    def test_drains_fifo_and_empties_queue(self):
+        from datus.cli.execution_state import PendingInputQueue
+
+        queue = PendingInputQueue()
+        queue.push("first")
+        queue.push("second")
+
+        assert LLMBaseModel.drain_pending_user_inserts(queue) == ["first", "second"]
+        assert len(queue) == 0
+
+    def test_interrupted_run_leaves_queue_intact(self):
+        """An aborting run must not consume text the user will re-send.
+
+        Draining here would delete the message from the queue *and* never
+        deliver it: the interrupted run makes no further LLM call, so the
+        text would vanish silently.
+        """
+        from datus.cli.execution_state import InterruptController, PendingInputQueue
+
+        queue = PendingInputQueue()
+        queue.push("steer me")
+        controller = InterruptController()
+        controller.interrupt()
+
+        assert LLMBaseModel.drain_pending_user_inserts(queue, interrupt_controller=controller) == []
+        assert queue.snapshot() == ["steer me"]
+
+    def test_emits_each_message_to_the_broker(self):
+        from datus.cli.execution_state import PendingInputQueue
+
+        queue = PendingInputQueue()
+        queue.push("a")
+        queue.push("b")
+        broker = _RecordingBroker()
+
+        drained = LLMBaseModel.drain_pending_user_inserts(queue, interaction_broker=broker)
+
+        assert drained == ["a", "b"]
+        assert broker.emitted == ["a", "b"]
+
+    def test_broker_failure_still_delivers_text_to_the_model(self):
+        """Transcript rendering is best-effort; the model input is not."""
+        from datus.cli.execution_state import PendingInputQueue
+
+        queue = PendingInputQueue()
+        queue.push("a")
+
+        assert LLMBaseModel.drain_pending_user_inserts(queue, interaction_broker=_RecordingBroker(explode=True)) == [
+            "a"
+        ]
+
+    def test_broken_queue_does_not_propagate(self):
+        """A queue hiccup must never abort the agent run."""
+        broken = MagicMock()
+        broken.drain.side_effect = RuntimeError("queue exploded")
+
+        assert LLMBaseModel.drain_pending_user_inserts(broken) == []
+
+
+class TestBuildRunConfigDeliversInsertAtTurnBoundary:
+    """End-to-end through the real SDK turn loop.
+
+    ``_build_run_config`` lives on the base class precisely so every
+    agents-SDK-driven provider gets the filter. These tests drive
+    ``Runner.run_streamed`` for real (stub model, no network) and assert the
+    turn on which the model first sees an inserted message — the thing a
+    mocked Runner cannot check.
+    """
+
+    @staticmethod
+    async def _run(model, queue, tool_pushes: str | None):
+        from agents import Agent, Runner, function_tool
+
+        @function_tool
+        def probe_tool() -> str:
+            """Probe tool; the user types while it runs."""
+            if tool_pushes is not None:
+                queue.push(tool_pushes)
+            return "tool finished"
+
+        agent = Agent(name="probe_agent", instructions="", model=model, tools=[probe_tool])
+        run_config = LLMBaseModel._build_run_config(
+            MagicMock(),
+            pending_input_queue=queue,
+            session=None,
+            agent_name="probe_agent",
+        )
+        result = Runner.run_streamed(agent, input="start", max_turns=5, run_config=run_config)
+        async for _ in result.stream_events():
+            pass
+
+    def test_message_typed_during_tool_call_reaches_the_next_turn(self, two_turn_agents_model):
+        """The whole point of insertion: steer the run already in progress.
+
+        Before the fix on the codex/native paths this text only arrived after
+        the run had finished, via the chat layer's auto-continuation.
+        """
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = two_turn_agents_model()
+        queue = PendingInputQueue()
+
+        asyncio.run(self._run(model, queue, tool_pushes="STOP_AND_CHECK"))
+
+        assert model.turn == 2
+        assert not model.saw_on_turn(0, "STOP_AND_CHECK")
+        assert model.saw_on_turn(1, "STOP_AND_CHECK")
+        assert len(queue) == 0
+
+    def test_inserted_text_arrives_as_a_user_role_item(self, two_turn_agents_model):
+        """Injection must be a user message, not an edit of the tool result."""
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = two_turn_agents_model()
+        queue = PendingInputQueue()
+
+        asyncio.run(self._run(model, queue, tool_pushes="STOP_AND_CHECK"))
+
+        injected = [
+            item
+            for item in model.inputs[1]
+            if isinstance(item, dict) and item.get("role") == "user" and "STOP_AND_CHECK" in json.dumps(item)
+        ]
+        assert len(injected) == 1
+        assert injected[0]["content"] == [{"type": "input_text", "text": "STOP_AND_CHECK"}]
+
+    def test_idle_queue_leaves_turn_input_untouched(self, two_turn_agents_model):
+        """No staged text → the filter is a no-op, not an empty user message."""
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = two_turn_agents_model()
+        queue = PendingInputQueue()
+
+        asyncio.run(self._run(model, queue, tool_pushes=None))
+
+        assert model.turn == 2
+        for turn_input in model.inputs:
+            assert all(
+                not (isinstance(item, dict) and item.get("role") == "user" and item.get("content") == [])
+                for item in turn_input
+            )

--- a/tests/unit_tests/models/test_claude_model.py
+++ b/tests/unit_tests/models/test_claude_model.py
@@ -8,6 +8,8 @@ Unit tests for datus/models/claude_model.py.
 CI-level: zero external dependencies. Anthropic client and all I/O mocked.
 """
 
+import copy
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -3353,3 +3355,153 @@ class TestSslVerify:
         assert model.proxy_client is None
         assert model.async_proxy_client is None
         assert "SSL_VERIFY" not in os.environ
+
+
+class TestNativeMidRunInsert:
+    """Mid-run message insertion on the native Anthropic loop.
+
+    Every Claude model pointed at the official ``api.anthropic.com`` endpoint
+    runs here — ``supports_builtin_web_search()`` is true for that host, which
+    routes ``generate_with_tools_stream`` to the native path for API-key and
+    subscription auth alike. The native loop is not driven by the agents-SDK
+    Runner, so it gets no ``call_model_input_filter``; without an explicit
+    drain, a message typed mid-run stayed queued for the whole run and only
+    landed afterwards through the chat layer's auto-continuation.
+    """
+
+    @staticmethod
+    async def _run_two_turns(model, queue, push_during_tool: bool = True):
+        """Drive turn 1 (tool_use) → turn 2 (text), recording each turn's messages."""
+        from unittest.mock import AsyncMock
+
+        from datus.schemas.action_history import ActionHistoryManager
+
+        seen_messages = []
+        responses = [
+            _make_response([_make_tool_use_block(name="probe_tool", block_id="tu_1", input_data={})]),
+            _make_response([_make_text_block("done")]),
+        ]
+
+        def _create(**request_kwargs):
+            seen_messages.append(copy.deepcopy(request_kwargs.get("messages")))
+            return responses[len(seen_messages) - 1]
+
+        func_tool = MagicMock()
+        func_tool.name = "probe_tool"
+        func_tool.description = "Probe tool"
+        func_tool.params_json_schema = {"type": "object"}
+
+        async def _invoke(ctx, input_json):
+            # The user types while the tool is executing.
+            if push_during_tool:
+                queue.push("STOP_AND_CHECK")
+            return "tool finished"
+
+        func_tool.on_invoke_tool = _invoke
+
+        with (
+            patch.object(type(model), "_anthropic_messages_create", lambda self, **kw: _create(**kw)),
+            patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp,
+        ):
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            async for _ in model._generate_with_mcp_stream(
+                prompt="start",
+                mcp_servers={},
+                instruction="sys",
+                output_type={},
+                func_tools=[func_tool],
+                action_history_manager=ActionHistoryManager(),
+                pending_input_queue=queue,
+            ):
+                pass
+
+        return seen_messages
+
+    @pytest.mark.asyncio
+    async def test_insert_during_tool_call_reaches_the_next_model_call(self):
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = _make_claude_model()
+        queue = PendingInputQueue()
+
+        seen = await self._run_two_turns(model, queue)
+
+        assert len(seen) == 2
+        assert "STOP_AND_CHECK" not in json.dumps(seen[0], default=str)
+        assert "STOP_AND_CHECK" in json.dumps(seen[1], default=str)
+        assert len(queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_insert_is_appended_as_a_user_text_message(self):
+        """Anthropic shape check: a user message with a plain ``text`` block.
+
+        The native path speaks the Messages API, not the Responses API, so the
+        item shape differs from the SDK filter's ``input_text`` block. Getting
+        this wrong yields a 400 from Anthropic rather than a silent no-op.
+        """
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = _make_claude_model()
+        queue = PendingInputQueue()
+
+        seen = await self._run_two_turns(model, queue)
+
+        inserted = [
+            m
+            for m in seen[1]
+            if m.get("role") == "user" and "STOP_AND_CHECK" in json.dumps(m.get("content"), default=str)
+        ]
+        assert len(inserted) == 1
+        # A plain ``text`` block, not the Responses API's ``input_text``.
+        # ``cache_control`` may be attached by ``wrap_prompt_cache`` — being the
+        # newest message, the insert legitimately becomes the cache breakpoint.
+        (block,) = inserted[0]["content"]
+        assert block["type"] == "text"
+        assert block["text"] == "STOP_AND_CHECK"
+        # It must trail the tool_result, never replace or precede it: Anthropic
+        # requires the tool_use to be answered by its tool_result.
+        assert json.dumps(seen[1][-1], default=str) == json.dumps(inserted[0], default=str)
+        assert any("tool_result" in json.dumps(m.get("content"), default=str) for m in seen[1])
+
+    @pytest.mark.asyncio
+    async def test_interrupted_run_does_not_consume_the_queue(self):
+        """An aborting native run must leave staged text for the next run."""
+        from datus.cli.execution_state import ExecutionInterrupted, InterruptController, PendingInputQueue
+        from datus.schemas.action_history import ActionHistoryManager
+
+        model = _make_claude_model()
+        queue = PendingInputQueue()
+        queue.push("STOP_AND_CHECK")
+        controller = InterruptController()
+        controller.interrupt()
+
+        with patch("datus.models.claude_model.multiple_mcp_servers") as mock_mcp:
+            mock_mcp.return_value.__aenter__ = AsyncMock(return_value={})
+            mock_mcp.return_value.__aexit__ = AsyncMock(return_value=False)
+            with pytest.raises(ExecutionInterrupted):
+                async for _ in model._generate_with_mcp_stream(
+                    prompt="start",
+                    mcp_servers={},
+                    instruction="sys",
+                    output_type={},
+                    func_tools=[],
+                    action_history_manager=ActionHistoryManager(),
+                    interrupt_controller=controller,
+                    pending_input_queue=queue,
+                ):
+                    pass
+
+        assert queue.snapshot() == ["STOP_AND_CHECK"]
+
+    @pytest.mark.asyncio
+    async def test_idle_queue_adds_no_message(self):
+        from datus.cli.execution_state import PendingInputQueue
+
+        model = _make_claude_model()
+        queue = PendingInputQueue()
+
+        seen = await self._run_two_turns(model, queue, push_during_tool=False)
+
+        # Turn 2 = initial user prompt + assistant tool_use + tool_result.
+        assert len(seen[1]) == 3

--- a/tests/unit_tests/models/test_codex_model.py
+++ b/tests/unit_tests/models/test_codex_model.py
@@ -1457,3 +1457,111 @@ class TestConsumeStreamText:
         with patch.object(model, "_refresh_client_token"), patch.object(model, "_get_client") as client:
             client.return_value.responses.create.return_value = events
             assert model.generate_with_json_output("judge this", output_schema={"type": "object"}) == payload
+
+
+class TestCodexMidRunInsert:
+    """Mid-run message insertion on the Codex streaming path.
+
+    ``CodexModel`` builds its own ``Runner.run_streamed`` call, and its
+    ``RunConfig`` used to carry only trace kwargs — the ``pending_input_queue``
+    handed down by ``AgenticNode`` was swallowed by ``**kwargs``, so a message
+    typed mid-run never reached the model until the run had finished and the
+    chat layer's auto-continuation started a fresh one.
+    """
+
+    @staticmethod
+    async def _run_two_turns(model, stub, queue, push_during_tool: bool = True):
+        from agents import function_tool
+
+        @function_tool
+        def probe_tool() -> str:
+            """Probe tool; the user types while it runs."""
+            if push_during_tool:
+                queue.push("STOP_AND_CHECK")
+            return "tool finished"
+
+        with (
+            patch.object(type(model), "_get_responses_model", lambda self: stub),
+            patch.object(type(model), "_refresh_client_token", lambda self: None),
+        ):
+            async for _ in model.generate_with_tools_stream(
+                prompt="start",
+                tools=[probe_tool],
+                mcp_servers={},
+                instruction="",
+                max_turns=5,
+                session=None,
+                pending_input_queue=queue,
+            ):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_insert_during_tool_call_reaches_the_next_turn(self, model_config, mock_oauth, two_turn_agents_model):
+        from datus.cli.execution_state import PendingInputQueue
+        from datus.models.codex_model import CodexModel
+
+        model = CodexModel(model_config=model_config)
+        stub = two_turn_agents_model()
+        queue = PendingInputQueue()
+
+        await self._run_two_turns(model, stub, queue)
+
+        assert stub.turn == 2
+        assert not stub.saw_on_turn(0, "STOP_AND_CHECK")
+        assert stub.saw_on_turn(1, "STOP_AND_CHECK")
+        assert len(queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_idle_queue_leaves_the_run_unchanged(self, model_config, mock_oauth, two_turn_agents_model):
+        from datus.cli.execution_state import PendingInputQueue
+        from datus.models.codex_model import CodexModel
+
+        model = CodexModel(model_config=model_config)
+        stub = two_turn_agents_model()
+        queue = PendingInputQueue()
+
+        await self._run_two_turns(model, stub, queue, push_during_tool=False)
+
+        assert stub.turn == 2
+        assert not stub.saw_on_turn(1, "STOP_AND_CHECK")
+
+    @pytest.mark.asyncio
+    async def test_interrupted_run_does_not_consume_the_queue(self, model_config, mock_oauth, two_turn_agents_model):
+        """Text staged while an interrupt is in flight survives for the next run."""
+        from datus.cli.execution_state import ExecutionInterrupted, InterruptController, PendingInputQueue
+        from datus.models.codex_model import CodexModel
+
+        model = CodexModel(model_config=model_config)
+        stub = two_turn_agents_model()
+        queue = PendingInputQueue()
+        controller = InterruptController()
+
+        from agents import function_tool
+
+        @function_tool
+        def probe_tool() -> str:
+            """Probe tool; the user types, then interrupts."""
+            queue.push("STOP_AND_CHECK")
+            controller.interrupt()
+            return "tool finished"
+
+        with (
+            patch.object(type(model), "_get_responses_model", lambda self: stub),
+            patch.object(type(model), "_refresh_client_token", lambda self: None),
+        ):
+            # The interrupt aborts the run, as it should.
+            with pytest.raises(ExecutionInterrupted):
+                async for _ in model.generate_with_tools_stream(
+                    prompt="start",
+                    tools=[probe_tool],
+                    mcp_servers={},
+                    instruction="",
+                    max_turns=5,
+                    session=None,
+                    pending_input_queue=queue,
+                    interrupt_controller=controller,
+                ):
+                    pass
+
+        assert not stub.saw_on_turn(1, "STOP_AND_CHECK")
+        assert queue.snapshot() == ["STOP_AND_CHECK"]


### PR DESCRIPTION
## Why

Mid-run message insertion — type while the agent is running, and the text is delivered to the model at its next LLM turn — only worked on the `openai_compatible` path. On the other two model paths the message stayed queued for the entire run and reached the model only afterwards, through the chat layer's auto-continuation. That is a full round trip too late to steer anything: by then the agent has already finished the work the user was trying to redirect.

User-visible symptom: the pinned `⏎ queued for agent (N)` preview stays up for the whole run, across many tool-call turns, and the message is finally sent as a fresh turn once the run ends.

Both misses had the same shape. `AgenticNode` passes `pending_input_queue` down correctly, but the base `generate_with_tools_stream` signature ends in `**kwargs`, so a provider that never reads the key drops it with no error at all — the chain looks wired end to end and the only symptom is "insertion quietly doesn't work".

- **Codex** built its `RunConfig` from trace kwargs only, so the SDK ran without `call_model_input_filter`.
- **Claude's native Anthropic loop** is not driven by the SDK `Runner`, so no per-turn filter hook exists there at all. This is the larger of the two: it serves **every** Claude model on the official `api.anthropic.com` endpoint, not just subscription tokens. `supports_builtin_web_search()` is true for that host, and `AgenticNode` sets `_builtin_web_tools` from model capability alone, which routes `generate_with_tools_stream` to the native branch for API-key and subscription auth alike. Only third-party Claude-compatible endpoints (e.g. `kimi_coding`, excluded by `is_official_anthropic_endpoint`) stayed on the working LiteLLM path.

## Solution

**Collapse the contract onto the base class.** `_build_run_config` moves from `OpenAICompatibleModel` to `LLMBaseModel`. It lived on a subclass while `CodexModel` inherits `LLMBaseModel` directly, which is the structural reason the filter was easy to omit: every provider that builds its own `Runner.run_streamed` had to remember to attach it.

**One definition of "flush staged messages."** New `LLMBaseModel.drain_pending_user_inserts` drains the queue and emits each message through the broker. It also pins the invariant both paths need: **never drain while an interrupt is in flight**. An aborting run makes no further LLM call, so draining there would silently delete text the user expects to re-send.

**Claude native loop** (`_generate_with_mcp_stream`): drain and append a `role=user` text message at the top of the turn loop, before the request is built. That is the same point in the cycle as the SDK filter — after the previous round's `tool_result`s were appended, before the next model call. Appending to `messages` is the only persistence needed: `persisted_message_index` was advanced to `len(messages)` at the end of the previous round, so this round's checkpoint writes the insert along with the rest of the turn. Consecutive `user` messages are safe here — the loop already appends one per `tool_use` when a turn calls several tools.

**Codex streaming path**: use `_build_run_config`. The non-streaming path is deliberately left alone — compaction and summarization run there, and injecting a user aside would corrupt the summary. This matches `openai_compatible`, which also only injects on the streaming path.

**Named parameters over `**kwargs`.** `pending_input_queue` / `interaction_broker` are now explicit on both providers, so a dropped argument surfaces as a `TypeError` rather than as silently broken insertion.

Refactor is behavior-neutral for `openai_compatible`: the filter body is unchanged and its existing tests pass untouched via inheritance.

## Test Cases

12 new unit tests across three files, plus `tests/unit_tests/models/conftest.py`.

**Red first.** With the four source files stashed (`git stash push -- datus/models/`), all 12 fail; restored, all pass. The 4 tests that pass both before and after are the interrupt-protection ones — pre-fix the queue was never drained at all, so they were already satisfied for the wrong reason and exist to keep the invariant from regressing.

`conftest.py` adds `RecordingTwoTurnModel`, a real agents-SDK `Model` that drives turn 1 → tool call, turn 2 → final text and snapshots each turn's input. Mocking `Runner` was not an option: the injection point *is* a per-turn SDK hook, so a mocked Runner would assert nothing about when a staged message is actually flushed.

- `test_base.py` — drain contract (interrupt leaves the queue intact, broker failure still delivers to the model, a raising queue never aborts the run) plus end-to-end through the real SDK loop: a message pushed during tool execution is absent from turn 1's input and present in turn 2's, as a `user` item.
- `test_claude_model.py` — native loop, two turns via a stubbed `_anthropic_messages_create`. Asserts the insert lands in turn 2's `messages`, carries a Messages-API `text` block (not the Responses API's `input_text` — wrong shape here is a 400 from Anthropic, not a no-op), and trails the `tool_result` rather than replacing or preceding it.
- `test_codex_model.py` — same three scenarios through the real `CodexModel.generate_with_tools_stream`, stubbing only `_get_responses_model`.

No integration/nightly tests added: mid-run insertion needs a real mid-run keystroke and a multi-turn tool loop, which the deterministic unit harness above reproduces exactly and a live-LLM test could not do reliably.

**Gates.** `ruff format` + `check` clean. `audit_tests.py` on the changed test files: P0=0, P1=0. Full `tests/unit_tests/`: 9764 passed. `ci/run-pr-tests.py datus/main`: impacted unit tests 923 passed (exit 0), **diff coverage 94%**. The harness's 17 failed / 68 errors are pre-existing locally — an identical run on `datus/main` produces exactly the same 17/68 (local `.datus/config.yml` overrides), unaffected by this change.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sending user messages while an AI run is still in progress.
  - Messages are delivered at the next conversation turn and preserved in the session history.
  - Supports mid-run input across supported streaming model integrations.

- **Reliability**
  - Pending messages remain available when a run is interrupted.
  - Input and delivery errors are handled safely without stopping the active run.

- **Tests**
  - Added coverage for message ordering, interruptions, idle runs, and delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->