### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,33 @@
+name: Trustabl Agent Scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Minimal top-level permissions; write grants are scoped to the scan job only.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: trustabl-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    # continue-on-error keeps this job advisory — findings are reported but
+    # CI does not go red so unrelated work is never blocked.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: trustabl/trustabl-action@973f666d20b5fbb2e6a4511bd3846e965a08c28b # v0.4.1
+        with:
+          version: v0.1.6


### PR DESCRIPTION
We came across your repo and we like that you're building an open-source tool to help streamline data engineering workflows. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Skill processes sensitive data
   File: datus/resources/skills/build-kb/SKILL.md
   What it means: This skill's body or description names a sensitive data class -passwords, tokens, SSNs, credit card numbers, PII, or private keys - without stating what it does with that data beyond naming it. 

2. [HIGH] Skill processes sensitive data
   File: datus/resources/skills/create-subagent/SKILL.md
   What it means: This skill's body or description names a sensitive data class - passwords, tokens, SSNs, credit card numbers, PII, or private keys - without stating what it does with that data beyond naming it. 

3. [HIGH] Skill processes sensitive data
   File: datus/resources/skills/dashboard-bootstrap/SKILL.md
   What it means: This skill's body or description names a sensitive data class - passwords, tokens, SSNs, credit card numbers, PII, or private keys - without stating what it does with that data beyond naming it.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated security scanning for pushes, pull requests, and manually triggered runs.
  - Security findings are reported as advisory results and do not block continuous integration.
  - Scans include concurrency controls and a 15-minute execution limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->