### PR TITLE
[BugFix] Stop the agent replaying one tool call until max_turns

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -197,6 +197,10 @@ class AgenticNode(Node):
         # first ``_compose_hooks`` call, after ``setup_tools`` and any
         # ``apply_proxy_tools`` rewrites — see ``_ensure_tool_transformers``.
         self._tool_transformers_applied = False
+        # Same lazy-once pattern for the tool no-progress guard (see
+        # ``_ensure_repeat_guard``); reset alongside the flag above whenever
+        # ``self.tools`` is rebuilt so remounted tools get re-wrapped.
+        self._repeat_guard_applied = False
 
         # Parse node configuration from agent.yml (available to all agentic nodes)
         self.node_config = self._parse_node_config(agent_config, self.get_node_name())
@@ -2872,6 +2876,7 @@ class AgenticNode(Node):
         # ``apply_tool_transformers`` skips already-wrapped tools, so the re-wrap
         # never double-transforms the tools carried over above.
         self._tool_transformers_applied = False
+        self._repeat_guard_applied = False
         if desired:
             logger.info(
                 f"Web tools injected into node '{self.get_node_name()}': "
@@ -3332,6 +3337,13 @@ class AgenticNode(Node):
         # deferring to ``hooks=self._compose_run_hooks(ctx)`` would be one
         # argument too late and the first run would execute unwrapped tools.
         self._ensure_tool_transformers()
+        # Guard wrapping and its per-run counter reset share this chokepoint:
+        # the window must cover exactly one stream run, so a retry-policy
+        # iteration starts counting from zero rather than inheriting a streak.
+        self._ensure_repeat_guard()
+        from datus.tools.middleware import reset_repeat_guard
+
+        reset_repeat_guard()
         self._current_action_history = ctx.action_history_manager
         try:
             async for stream_action in self.model.generate_with_tools_stream(
@@ -4120,6 +4132,30 @@ class AgenticNode(Node):
                 code=ErrorCode.COMMON_CONFIG_ERROR,
                 message_args={"config_error": f"Tool transformer setup failed for {self.get_node_name()}: {e}"},
             ) from e
+
+    def _ensure_repeat_guard(self) -> None:
+        """Wrap ``self.tools`` with the no-progress guard, once.
+
+        Unlike the plugin transformers above this is unconditional: a model that
+        replays one tool call until ``max_turns`` is a failure mode of the loop
+        itself, not of any plugin, so the guard must not depend on an operator
+        having enabled anything. Failures are swallowed — losing the guard costs
+        a wasted turn budget, while failing the run costs the whole answer.
+        """
+        if getattr(self, "_repeat_guard_applied", False):
+            return
+        try:
+            from datus.tools.middleware import apply_repeat_guard
+
+            wrapped = apply_repeat_guard(self)
+            logger.debug(
+                "Applied the tool no-progress guard on node '%s': %d tool(s) wrapped",
+                self.get_node_name(),
+                wrapped,
+            )
+        except Exception as e:  # noqa: BLE001 - the guard is a safety net, never a gate
+            logger.warning("Could not apply the tool no-progress guard for %s: %s", self.get_node_name(), e)
+        self._repeat_guard_applied = True
 
     @staticmethod
     def _extract_total_tokens(actions: List[ActionHistory]) -> int:

--- a/datus/models/sdk_patches.py
+++ b/datus/models/sdk_patches.py
@@ -477,6 +477,34 @@ class _ReasoningContentStreamWrapper:
         return getattr(self._stream, name)
 
 
+# Stand-in for a turn whose reasoning the provider never returned. Both DeepSeek
+# and Moonshot require reasoning_content to be present and non-empty on
+# tool-calling turns; neither requires it to carry any particular text. A neutral
+# marker satisfies them without asserting anything the model did not think.
+REASONING_UNAVAILABLE_PLACEHOLDER = "(no reasoning was returned for this turn)"
+
+
+def _last_patchable_assistant_index(messages: list[dict[str, Any]], is_deepseek: bool) -> int:
+    """Index of the assistant message the current API response belongs to.
+
+    Mirrors the patch loop's own ``should_patch_message`` test so the two never
+    disagree about which message is the in-flight one: an assistant message with
+    tool_calls, or -- DeepSeek only -- one that directly follows a tool result.
+    Returns ``-1`` when there is none.
+    """
+    last = -1
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        previous_message = messages[idx - 1] if idx > 0 else None
+        follows_tool_result = (
+            is_deepseek and isinstance(previous_message, dict) and previous_message.get("role") == "tool"
+        )
+        if msg.get("tool_calls") or follows_tool_result:
+            last = idx
+    return last
+
+
 def _postprocess_messages_for_reasoning(
     messages: list[dict[str, Any]],
     model: str | None,
@@ -488,31 +516,39 @@ def _postprocess_messages_for_reasoning(
     Per DeepSeek/Moonshot docs, reasoning_content must be passed back during
     tool calling to allow the model to continue reasoning.
     See: https://api-docs.deepseek.com/guides/thinking_mode
+
+    A message may only carry reasoning that is actually its own: either the text
+    it arrived with, or -- for the single in-flight turn -- the streaming cache,
+    which holds the reasoning of the most recent API response. Everything else
+    gets :data:`REASONING_UNAVAILABLE_PLACEHOLDER`.
+
+    This function used to fill any gap with the last reasoning found anywhere in
+    the list, and rewrote the whole history on every call. That put "I have my
+    answer, let me produce the final output" onto turns whose actual emission was
+    another tool call, and the model -- shown twenty such precedents -- kept
+    reproducing them: 28 identical ``execute_sql`` calls against the same 23-row
+    result until ``max_turns`` tripped. Borrowed reasoning is context poisoning;
+    a neutral placeholder satisfies the same provider requirement without
+    asserting a thought that was never had.
     """
     if not model or not _needs_reasoning_injection(model):
         return messages
 
-    is_kimi = _is_kimi_model(model)
     is_deepseek = _is_deepseek_model(model)
 
-    # Find the last non-empty reasoning_content to reuse if needed
-    last_reasoning_content = None
-    for msg in messages:
-        if isinstance(msg, dict):
-            rc = _extract_reasoning_content(msg)
-            if rc:
-                last_reasoning_content = rc
-                logger.debug(f"[SDK Patch] Found non-empty reasoning_content in messages, length={len(rc)}")
+    # The streaming cache holds the reasoning of the *most recent* API response,
+    # so it belongs to the in-flight assistant turn and to nothing else. Any
+    # earlier message that arrives without reasoning_content never had any.
+    cached_rc = _get_cached_reasoning_content(model) if model else None
+    if cached_rc:
+        logger.debug(f"[SDK Patch] Cached reasoning_content available, length={len(cached_rc)}")
 
-    # Fallback: use cached reasoning_content from a previous API response
-    if not last_reasoning_content and model:
-        cached_rc = _get_cached_reasoning_content(model)
-        if cached_rc:
-            last_reasoning_content = cached_rc
-            logger.debug(f"[SDK Patch] Using cached reasoning_content as fallback, length={len(cached_rc)}")
+    has_own_reasoning = any(isinstance(msg, dict) and _extract_reasoning_content(msg) for msg in messages)
 
-    if is_deepseek and not last_reasoning_content:
+    if is_deepseek and not has_own_reasoning and not cached_rc:
         messages = _sanitize_deepseek_history_without_reasoning(messages)
+
+    last_patchable_idx = _last_patchable_assistant_index(messages, is_deepseek)
 
     # Ensure assistant messages preserve reasoning_content on tool-calling turns.
     # DeepSeek also requires the final assistant message immediately after a tool
@@ -531,19 +567,16 @@ def _postprocess_messages_for_reasoning(
             current_rc = _coerce_reasoning_text(msg.get("reasoning_content"))
             if current_rc:
                 msg["reasoning_content"] = current_rc
-            elif last_reasoning_content:
-                msg["reasoning_content"] = last_reasoning_content
-                logger.debug("[SDK Patch] Injected reasoning_content into assistant message")
-            elif has_tool_calls and "reasoning_content" not in msg and is_kimi:
-                # Moonshot historically tolerates an empty reasoning_content field when
-                # thinking is off; DeepSeek rejects both missing and empty, so we must
-                # NOT inject an empty placeholder for DeepSeek — leave the message as-is
-                # and let the provider surface a clean error if thinking was actually on.
-                msg["reasoning_content"] = ""
-                logger.warning(
-                    "[SDK Patch] No reasoning_content available for assistant+tool_calls message. "
-                    "Moonshot API may reject this request. Check if streaming cache is working."
-                )
+            elif idx == last_patchable_idx and cached_rc:
+                msg["reasoning_content"] = cached_rc
+                logger.debug("[SDK Patch] Restored the in-flight turn's cached reasoning_content")
+            else:
+                # Never borrow another turn's thought. Both providers require the
+                # field to be present and non-empty; neither requires it to say
+                # anything in particular. A thought that contradicts the call it
+                # is stapled to is read by the model as a precedent to imitate.
+                msg["reasoning_content"] = REASONING_UNAVAILABLE_PLACEHOLDER
+                logger.debug("[SDK Patch] No reasoning for this turn; used the neutral placeholder")
 
             # Ensure content is empty string, not None (Moonshot requirement;
             # DeepSeek also accepts content="" for tool_calls-only messages).

--- a/datus/tools/middleware/__init__.py
+++ b/datus/tools/middleware/__init__.py
@@ -2,6 +2,12 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
+from datus.tools.middleware.repeat_guard import (
+    apply_repeat_guard,
+    reset_repeat_guard,
+    tool_is_repeat_guarded,
+    wrap_tool_with_repeat_guard,
+)
 from datus.tools.middleware.tool_middleware import (
     ToolTransformDenied,
     apply_tool_transformers,
@@ -11,7 +17,11 @@ from datus.tools.middleware.tool_middleware import (
 
 __all__ = [
     "ToolTransformDenied",
+    "apply_repeat_guard",
     "apply_tool_transformers",
+    "reset_repeat_guard",
+    "tool_is_repeat_guarded",
     "transform_tool_args",
+    "wrap_tool_with_repeat_guard",
     "wrap_tool_with_transformers",
 ]

--- a/datus/tools/middleware/repeat_guard.py
+++ b/datus/tools/middleware/repeat_guard.py
@@ -1,0 +1,234 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""No-progress guard: stop a model from replaying a tool call that changes nothing.
+
+A reasoning model that already holds the answer can still emit the same function
+call on every turn. The tool succeeds, the context grows by one more identical
+``(call, result)`` pair, and the next prompt therefore differs from the previous
+one *only* by that pair -- a fixed point the run leaves only when ``max_turns``
+trips. Seen in production as 28 identical ``execute_sql`` calls returning the
+same 23 rows, ~190k tokens, ending in ``Maximum turns (30) exceeded`` with the
+correct answer in hand since call 3.
+
+The guard never suppresses execution: tools stay authoritative and side effects
+happen exactly as before. It only watches whether a call *changed anything*. A
+repeat whose result differs is progress -- polling a table until a job lands,
+re-reading a file after writing it -- and resets the streak. Only a repeat whose
+result is byte-identical counts:
+
+* from :data:`WARN_AFTER` identical results in a row the payload carries a
+  :data:`NOTE_KEY` note telling the model the call is not advancing;
+* from :data:`DENY_AFTER` the guard returns a failure payload instead of the
+  result the model already has verbatim in its context.
+
+State is per run and per call signature, held in a ContextVar so concurrent runs
+(sub-agents included) never share counters. Call :func:`reset_repeat_guard` once
+per agent run; a run that forgets to simply carries the previous window's
+counters, which is why the reset lives at the single stream chokepoint.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from contextvars import ContextVar
+from typing import Any, Dict, Optional
+
+from agents import FunctionTool
+
+from datus.utils.loggings import get_logger
+
+logger = get_logger(__name__)
+
+# Marker on a rebuilt tool's ``on_invoke_tool`` so :func:`apply_repeat_guard` can
+# recognise already-guarded tools. Mirrors the transformer layer's marker so the
+# two wrappers compose in either order without double-wrapping.
+_GUARDED_MARKER = "_datus_repeat_guarded"
+
+# Streak thresholds, counted in *identical results for the same call*. A streak
+# of 1 is the first repeat, so WARN_AFTER=2 fires on the second identical result
+# and leaves the model two more chances to self-correct before the deny.
+WARN_AFTER = 2
+DENY_AFTER = 4
+
+# Top-level key the note is attached under. Namespaced so it cannot collide with
+# a tool's own payload keys, and ignorable by any consumer that does not know it.
+NOTE_KEY = "datus_guard"
+
+# Tools whose whole purpose is to be asked the same thing again. ``ask_user``
+# repeats are driven by the human, not by the model failing to converge.
+_REPEATS_ALWAYS_ALLOWED = frozenset({"ask_user"})
+
+
+@dataclasses.dataclass
+class _CallState:
+    """How many times in a row this exact call returned this exact result."""
+
+    fingerprint: Optional[str] = None
+    streak: int = 0
+
+
+_repeat_state_var: ContextVar[Optional[Dict[str, _CallState]]] = ContextVar("datus_tool_repeat_state", default=None)
+
+
+def reset_repeat_guard() -> None:
+    """Open a fresh no-progress window. Call once per agent run."""
+    _repeat_state_var.set({})
+
+
+def _state() -> Dict[str, _CallState]:
+    store = _repeat_state_var.get()
+    if store is None:
+        store = {}
+        _repeat_state_var.set(store)
+    return store
+
+
+def _signature(tool_name: str, args_str: str) -> str:
+    """Identify a call by name plus canonicalised arguments.
+
+    Key ordering is not stable across turns, so the raw argument string cannot
+    be compared directly. Arguments that do not parse fall back to the raw
+    string: a malformed call repeated verbatim is still a repeat.
+    """
+    try:
+        parsed = json.loads(args_str) if args_str else {}
+    except (json.JSONDecodeError, TypeError):
+        parsed = None
+    if isinstance(parsed, (dict, list)):
+        canonical = json.dumps(parsed, sort_keys=True, ensure_ascii=False, default=str)
+    else:
+        canonical = args_str or ""
+    return f"{tool_name}:{hashlib.sha256(canonical.encode('utf-8', 'replace')).hexdigest()}"
+
+
+def _fingerprint(result: Any) -> str:
+    """Hash a tool result so large payloads cost a digest, not a retained copy."""
+    try:
+        rendered = json.dumps(result, sort_keys=True, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        rendered = repr(result)
+    return hashlib.sha256(rendered.encode("utf-8", "replace")).hexdigest()
+
+
+def _note(tool_name: str, streak: int) -> str:
+    return (
+        f"'{tool_name}' has now returned an identical result {streak} times in a row for identical "
+        "arguments. Repeating it cannot produce new information — use the result you already have "
+        "and write your final answer instead of calling this tool again."
+    )
+
+
+def _no_progress_payload(tool_name: str, streak: int) -> dict:
+    """Standard failure payload returned once a call is provably not advancing.
+
+    Shaped like ``FuncToolResult`` (and the transformer layer's denial) so the
+    model sees an ordinary tool error rather than a crashed run.
+    """
+    return {
+        "success": 0,
+        "error": (
+            f"Tool call '{tool_name}' was blocked: the last {streak} identical calls all returned the "
+            "same result, so calling it again cannot produce new information. That result is already "
+            "in this conversation — use it and write your final answer now."
+        ),
+        "result": None,
+    }
+
+
+def _annotate(result: Any, note: str) -> Any:
+    """Attach ``note`` to a dict payload without mutating the tool's own object.
+
+    Non-dict results pass through untouched: there is nowhere to put the note
+    that would not corrupt the tool's contract with its renderers.
+    """
+    if not isinstance(result, dict):
+        return result
+    annotated = dict(result)
+    annotated[NOTE_KEY] = note
+    return annotated
+
+
+def tool_is_repeat_guarded(tool: Any) -> bool:
+    """Return True if ``tool`` was already wrapped by :func:`wrap_tool_with_repeat_guard`."""
+    return bool(getattr(getattr(tool, "on_invoke_tool", None), _GUARDED_MARKER, False))
+
+
+def wrap_tool_with_repeat_guard(
+    original: FunctionTool,
+    warn_after: int = WARN_AFTER,
+    deny_after: int = DENY_AFTER,
+) -> FunctionTool:
+    """Rebuild ``original`` so identical calls returning identical results are flagged.
+
+    The wrapper is transparent until a streak forms: the first call of any
+    signature, and every call whose result differs from the previous one, is
+    returned exactly as the tool produced it.
+    """
+
+    async def guarded_invoke(tool_ctx: Any, args_str: str) -> Any:
+        result = await original.on_invoke_tool(tool_ctx, args_str)
+        if original.name in _REPEATS_ALWAYS_ALLOWED:
+            return result
+
+        signature = _signature(original.name, args_str)
+        fingerprint = _fingerprint(result)
+        store = _state()
+        state = store.get(signature)
+
+        if state is None or state.fingerprint != fingerprint:
+            store[signature] = _CallState(fingerprint=fingerprint, streak=1)
+            return result
+
+        state.streak += 1
+        if state.streak >= deny_after:
+            logger.warning(
+                "[Repeat guard] '%s' returned an identical result %d times in a row; blocking the call.",
+                original.name,
+                state.streak,
+            )
+            return _no_progress_payload(original.name, state.streak)
+        if state.streak >= warn_after:
+            logger.info(
+                "[Repeat guard] '%s' returned an identical result %d times in a row; nudging the model.",
+                original.name,
+                state.streak,
+            )
+            return _annotate(result, _note(original.name, state.streak))
+        return result
+
+    guarded_invoke._datus_repeat_guarded = True  # type: ignore[attr-defined]
+
+    # Forward every declared field by name so the rebuild stays faithful across
+    # SDK versions (same rationale as ``wrap_tool_with_transformers``): rebuilding
+    # must not silently re-enable a gated tool or drop its guardrails.
+    carried = {
+        field.name: getattr(original, field.name, None)
+        for field in dataclasses.fields(FunctionTool)
+        if field.init and field.name != "on_invoke_tool"
+    }
+    carried["on_invoke_tool"] = guarded_invoke
+    return FunctionTool(**carried)
+
+
+def apply_repeat_guard(node: Any) -> int:
+    """Wrap every tool on ``node`` with the no-progress guard, in place.
+
+    Returns the number of tools wrapped. Already-guarded tools are skipped, so
+    callers may re-run this after a tool-list rebuild (a runtime ``/model``
+    switch remounts web tools) without double-wrapping.
+    """
+    tools = getattr(node, "tools", None)
+    if not tools:
+        return 0
+
+    wrapped = 0
+    for idx, tool in enumerate(tools):
+        if not isinstance(tool, FunctionTool) or tool_is_repeat_guarded(tool):
+            continue
+        tools[idx] = wrap_tool_with_repeat_guard(tool)
+        wrapped += 1
+    return wrapped

--- a/tests/unit_tests/models/test_sdk_patches.py
+++ b/tests/unit_tests/models/test_sdk_patches.py
@@ -23,6 +23,7 @@ import warnings
 import pytest
 
 from datus.models.sdk_patches import (
+    REASONING_UNAVAILABLE_PLACEHOLDER,
     _cache_reasoning_content,
     _extract_reasoning_content,
     _get_cached_reasoning_content,
@@ -450,7 +451,13 @@ class TestReasoningContentStreamWrapper:
 
 
 class TestPostprocessMessagesForReasoning:
-    """Tests for _postprocess_messages_for_reasoning."""
+    """Tests for _postprocess_messages_for_reasoning.
+
+    The rule under test: a message may only carry reasoning that is its own --
+    the text it arrived with, or (for the single in-flight turn) the streaming
+    cache. Every other gap is filled with the neutral placeholder, never with a
+    thought borrowed from a different turn.
+    """
 
     def test_non_kimi_model_returns_unchanged(self):
         """Non-Kimi model messages are returned unchanged."""
@@ -464,8 +471,10 @@ class TestPostprocessMessagesForReasoning:
         result = _postprocess_messages_for_reasoning(messages, None)
         assert result is messages
 
-    def test_kimi_injects_reasoning_content(self):
-        """Kimi model injects reasoning_content into assistant+tool_calls messages."""
+    def test_kimi_keeps_own_reasoning_and_never_lends_it(self):
+        """An earlier turn's reasoning stays on that turn; the next gap gets the placeholder."""
+        _reasoning_content_cache.clear()
+
         messages = [
             {
                 "role": "assistant",
@@ -477,16 +486,17 @@ class TestPostprocessMessagesForReasoning:
             {"role": "assistant", "content": None, "tool_calls": [{"id": "2"}]},
         ]
         result = _postprocess_messages_for_reasoning(messages, "kimi-1.5")
-        # First message already has reasoning_content
+
         assert result[0]["reasoning_content"] == "I should think..."
-        # Second assistant message should get injected reasoning_content
-        assert result[2]["reasoning_content"] == "I should think..."
+        assert result[2]["reasoning_content"] == REASONING_UNAVAILABLE_PLACEHOLDER
         # content=None should be set to ""
         assert result[0]["content"] == ""
         assert result[2]["content"] == ""
 
+        _reasoning_content_cache.clear()
+
     def test_kimi_uses_cached_reasoning_content(self):
-        """When no reasoning_content in messages, uses cached value."""
+        """The in-flight turn recovers its own reasoning from the streaming cache."""
         _reasoning_content_cache.clear()
         _reasoning_content_cache["kimi-cached"] = "Cached thinking..."
 
@@ -498,20 +508,20 @@ class TestPostprocessMessagesForReasoning:
 
         _reasoning_content_cache.clear()
 
-    def test_kimi_empty_reasoning_when_no_source(self):
-        """When no reasoning_content anywhere, sets empty string."""
+    def test_kimi_placeholder_when_no_source(self):
+        """With no reasoning anywhere the field is filled, not left empty."""
         _reasoning_content_cache.clear()
 
         messages = [
             {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
         ]
         result = _postprocess_messages_for_reasoning(messages, "kimi-norcache")
-        assert result[0]["reasoning_content"] == ""
+        assert result[0]["reasoning_content"] == REASONING_UNAVAILABLE_PLACEHOLDER
 
         _reasoning_content_cache.clear()
 
-    def test_deepseek_injects_reasoning_content_from_cache(self):
-        """DeepSeek model uses cached reasoning_content as fallback for tool_calls messages."""
+    def test_deepseek_cache_applies_only_to_the_inflight_turn(self):
+        """Cached reasoning belongs to the latest response, so only the last turn may use it."""
         _reasoning_content_cache.clear()
         _reasoning_content_cache["deepseek/deepseek-v4"] = "cached deepseek thinking"
 
@@ -521,7 +531,8 @@ class TestPostprocessMessagesForReasoning:
             {"role": "assistant", "content": None, "tool_calls": [{"id": "2"}]},
         ]
         result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4")
-        assert result[0]["reasoning_content"] == "cached deepseek thinking"
+
+        assert result[0]["reasoning_content"] == REASONING_UNAVAILABLE_PLACEHOLDER
         assert result[2]["reasoning_content"] == "cached deepseek thinking"
         # content=None must be normalized to "" so the provider accepts tool_calls-only messages
         assert result[0]["content"] == ""
@@ -529,13 +540,12 @@ class TestPostprocessMessagesForReasoning:
 
         _reasoning_content_cache.clear()
 
-    def test_deepseek_does_not_inject_empty_placeholder(self):
-        """DeepSeek must NOT get an empty reasoning_content placeholder when no source exists.
+    def test_deepseek_placeholder_is_never_empty(self):
+        """DeepSeek rejects an empty reasoning_content in thinking mode.
 
-        DeepSeek's API rejects empty reasoning_content in thinking mode with the same error
-        we're trying to fix; Kimi tolerates it. Only Kimi gets the "" fallback. Since this
-        message is after the last user turn, it is an in-flight tool call and must not be
-        hidden by cross-provider history cleanup.
+        The filler therefore has to be non-empty. It also has to be neutral: an
+        empty string is safe but rejected, and a borrowed thought is accepted but
+        poisons the context.
         """
         _reasoning_content_cache.clear()
 
@@ -544,28 +554,45 @@ class TestPostprocessMessagesForReasoning:
             {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
         ]
         result = _postprocess_messages_for_reasoning(messages, "deepseek-v4")
-        # Key should NOT be present (leave the message alone)
-        assert "reasoning_content" not in result[1]
+
+        assert result[1]["reasoning_content"] == REASONING_UNAVAILABLE_PLACEHOLDER
+        assert result[1]["reasoning_content"].strip()
 
         _reasoning_content_cache.clear()
 
-    def test_deepseek_reuses_existing_reasoning_content_in_messages(self):
-        """Existing non-empty reasoning_content in messages is propagated to later tool_calls msgs."""
+    def test_deepseek_never_borrows_another_turns_reasoning(self):
+        """Regression: an earlier turn's reasoning must not be stamped onto a later one.
+
+        This is the production loop in miniature. The model calls a tool, thinks
+        "I have my answer, let me produce the final output", then emits another
+        tool call with no reasoning of its own. Lending that sentence to the
+        second call shows the model a precedent -- "thinking I am done means
+        calling the tool again" -- which it then imitates until max_turns.
+        """
         _reasoning_content_cache.clear()
 
         messages = [
             {
                 "role": "assistant",
                 "content": None,
-                "reasoning_content": "first turn thinking",
+                "reasoning_content": "The SQL validated. I have my answer. Final JSON output.",
                 "tool_calls": [{"id": "1"}],
             },
-            {"role": "tool", "content": "result"},
+            {"role": "tool", "content": "23 rows"},
             {"role": "assistant", "content": None, "tool_calls": [{"id": "2"}]},
+            {"role": "tool", "content": "23 rows"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "3"}]},
         ]
+        borrowed = "The SQL validated. I have my answer. Final JSON output."
         result = _postprocess_messages_for_reasoning(messages, "deepseek-reasoner")
-        assert result[0]["reasoning_content"] == "first turn thinking"
-        assert result[2]["reasoning_content"] == "first turn thinking"
+
+        assert result[0]["reasoning_content"] == borrowed
+        for idx in (2, 4):
+            # The property, not the filler: whatever fills the gap, it must not
+            # be another turn's thought, and it must be non-empty because both
+            # providers reject an empty reasoning_content in thinking mode.
+            assert result[idx]["reasoning_content"] != borrowed
+            assert result[idx]["reasoning_content"].strip()
 
         _reasoning_content_cache.clear()
 
@@ -612,7 +639,9 @@ class TestPostprocessMessagesForReasoning:
         ]
         result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-pro")
 
-        assert result[0]["reasoning_content"] == "final answer thinking"
+        # The cache belongs to the newest response, which produced the final
+        # assistant message -- not the tool call two turns back.
+        assert result[0]["reasoning_content"] == REASONING_UNAVAILABLE_PLACEHOLDER
         assert result[0]["content"] == ""
         assert result[2]["reasoning_content"] == "final answer thinking"
         assert result[2]["content"] == "Final answer after tool."
@@ -693,7 +722,7 @@ class TestPostprocessMessagesForReasoning:
 
         assert result is messages
         assert result[1]["tool_calls"]
-        assert "reasoning_content" not in result[1]
+        assert result[1]["reasoning_content"] == REASONING_UNAVAILABLE_PLACEHOLDER
         assert result[2]["role"] == "tool"
 
         _reasoning_content_cache.clear()
@@ -718,7 +747,8 @@ class TestPostprocessMessagesForReasoning:
         result = _postprocess_messages_for_reasoning(messages, "deepseek/deepseek-v4-flash")
 
         assert result is messages
-        assert result[1]["reasoning_content"] == "cached reasoning"
+        # History is kept (not dropped) but only the newest turn may claim the cache.
+        assert result[1]["reasoning_content"] == REASONING_UNAVAILABLE_PLACEHOLDER
         assert result[1]["content"] == ""
         assert result[3]["reasoning_content"] == "cached reasoning"
 

--- a/tests/unit_tests/tools/middleware/test_repeat_guard.py
+++ b/tests/unit_tests/tools/middleware/test_repeat_guard.py
@@ -1,0 +1,241 @@
+# Copyright 2025-present DatusAI, Inc.
+# Licensed under the Apache License, Version 2.0.
+# See http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"""Unit tests for the tool no-progress guard.
+
+Covers the streak rules end to end: transparency on the first call and on any
+call that changes something, the note at ``WARN_AFTER``, the denial at
+``DENY_AFTER``, argument canonicalisation, per-run isolation, and the
+``apply_repeat_guard`` wrapping/skipping behavior.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from agents import FunctionTool
+
+from datus.tools.middleware.repeat_guard import (
+    DENY_AFTER,
+    NOTE_KEY,
+    WARN_AFTER,
+    apply_repeat_guard,
+    reset_repeat_guard,
+    tool_is_repeat_guarded,
+    wrap_tool_with_repeat_guard,
+)
+
+
+def _tool(name, handler):
+    """Build a minimal FunctionTool whose invocation runs ``handler(args_str)``."""
+
+    async def on_invoke_tool(tool_ctx, args_str):
+        return handler(args_str)
+
+    return FunctionTool(
+        name=name,
+        description=f"{name} test double",
+        params_json_schema={"type": "object", "properties": {}},
+        on_invoke_tool=on_invoke_tool,
+    )
+
+
+def _constant_tool(name="execute_sql", result=None):
+    result = {"success": 1, "error": None, "result": {"rows": 23}} if result is None else result
+    return _tool(name, lambda _args: result)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_window():
+    reset_repeat_guard()
+    yield
+    reset_repeat_guard()
+
+
+async def _call(tool, args='{"sql": "SELECT 1"}'):
+    return await tool.on_invoke_tool(SimpleNamespace(), args)
+
+
+class TestStreakBehaviour:
+    @pytest.mark.asyncio
+    async def test_first_call_is_untouched(self):
+        """The guard is invisible until a streak forms."""
+        guarded = wrap_tool_with_repeat_guard(_constant_tool())
+        result = await _call(guarded)
+        assert result == {"success": 1, "error": None, "result": {"rows": 23}}
+        assert NOTE_KEY not in result
+
+    @pytest.mark.asyncio
+    async def test_note_appears_once_the_result_stops_changing(self):
+        """From WARN_AFTER identical results the payload carries the nudge."""
+        guarded = wrap_tool_with_repeat_guard(_constant_tool())
+
+        for _ in range(WARN_AFTER - 1):
+            assert NOTE_KEY not in await _call(guarded)
+
+        noted = await _call(guarded)
+        assert noted[NOTE_KEY]
+        # The tool's own payload is preserved alongside the note.
+        assert noted["success"] == 1
+        assert noted["result"] == {"rows": 23}
+
+    @pytest.mark.asyncio
+    async def test_call_is_blocked_once_it_is_provably_stuck(self):
+        """At DENY_AFTER the guard answers with a failure instead of the known result."""
+        guarded = wrap_tool_with_repeat_guard(_constant_tool())
+
+        for _ in range(DENY_AFTER - 1):
+            await _call(guarded)
+
+        blocked = await _call(guarded)
+        assert blocked["success"] == 0
+        assert blocked["result"] is None
+        assert "cannot produce new information" in blocked["error"]
+
+    @pytest.mark.asyncio
+    async def test_the_tool_still_runs_every_time(self):
+        """The guard observes; it never suppresses execution or its side effects."""
+        calls = []
+
+        def handler(args_str):
+            calls.append(args_str)
+            return {"success": 1, "result": "same"}
+
+        guarded = wrap_tool_with_repeat_guard(_tool("write_thing", handler))
+        for _ in range(DENY_AFTER + 2):
+            await _call(guarded)
+
+        assert len(calls) == DENY_AFTER + 2
+
+    @pytest.mark.asyncio
+    async def test_a_changing_result_is_progress_and_resets_the_streak(self):
+        """Polling until something lands must never trip the guard."""
+        counter = {"n": 0}
+
+        def handler(_args):
+            counter["n"] += 1
+            return {"success": 1, "result": counter["n"]}
+
+        guarded = wrap_tool_with_repeat_guard(_tool("list_tables", handler))
+        for _ in range(DENY_AFTER + 3):
+            result = await _call(guarded)
+            assert result["success"] == 1
+            assert NOTE_KEY not in result
+
+    @pytest.mark.asyncio
+    async def test_streak_resets_when_the_result_changes_mid_run(self):
+        """A single changed result clears an accumulated streak."""
+        state = {"value": "same"}
+        guarded = wrap_tool_with_repeat_guard(_tool("probe", lambda _a: {"result": state["value"]}))
+
+        for _ in range(DENY_AFTER - 1):
+            await _call(guarded)
+
+        state["value"] = "changed"
+        assert NOTE_KEY not in await _call(guarded)
+
+        # The streak restarted: the next identical result is the second one, so
+        # it earns a note rather than the denial the old streak had reached.
+        second = await _call(guarded)
+        assert second[NOTE_KEY]
+        assert second.get("success") != 0
+
+
+class TestSignature:
+    @pytest.mark.asyncio
+    async def test_key_order_does_not_hide_a_repeat(self):
+        """Arguments are canonicalised, so a reordered dict is still the same call."""
+        guarded = wrap_tool_with_repeat_guard(_constant_tool())
+
+        await _call(guarded, json.dumps({"a": 1, "b": 2}))
+        noted = await _call(guarded, json.dumps({"b": 2, "a": 1}))
+        assert noted[NOTE_KEY]
+
+    @pytest.mark.asyncio
+    async def test_different_arguments_are_different_calls(self):
+        """Two distinct queries never accumulate a shared streak."""
+        guarded = wrap_tool_with_repeat_guard(_constant_tool())
+
+        for i in range(DENY_AFTER + 2):
+            result = await _call(guarded, json.dumps({"sql": f"SELECT {i}"}))
+            assert NOTE_KEY not in result
+
+    @pytest.mark.asyncio
+    async def test_malformed_arguments_still_count_as_a_repeat(self):
+        """A call that does not parse as JSON is compared by its raw string."""
+        guarded = wrap_tool_with_repeat_guard(_constant_tool())
+
+        await _call(guarded, "not json")
+        noted = await _call(guarded, "not json")
+        assert noted[NOTE_KEY]
+
+
+class TestPayloadShapes:
+    @pytest.mark.asyncio
+    async def test_non_dict_results_pass_through_unannotated(self):
+        """There is nowhere to put a note on a string without corrupting it."""
+        guarded = wrap_tool_with_repeat_guard(_tool("read_file", lambda _a: "file contents"))
+
+        for _ in range(WARN_AFTER + 1):
+            assert await _call(guarded) == "file contents"
+
+    @pytest.mark.asyncio
+    async def test_the_tools_own_payload_object_is_not_mutated(self):
+        """Annotating must not leak the note back into the tool's own state."""
+        payload = {"success": 1, "result": "x"}
+        guarded = wrap_tool_with_repeat_guard(_tool("t", lambda _a: payload))
+
+        for _ in range(WARN_AFTER):
+            await _call(guarded)
+
+        assert NOTE_KEY not in payload
+
+    @pytest.mark.asyncio
+    async def test_ask_user_repeats_are_the_humans_business(self):
+        """Asking the same question twice is the user's prerogative, not a loop."""
+        guarded = wrap_tool_with_repeat_guard(_tool("ask_user", lambda _a: {"success": 1, "result": "yes"}))
+
+        for _ in range(DENY_AFTER + 2):
+            result = await _call(guarded)
+            assert result["success"] == 1
+            assert NOTE_KEY not in result
+
+
+class TestRunIsolation:
+    @pytest.mark.asyncio
+    async def test_reset_opens_a_fresh_window(self):
+        """A new run must not inherit the previous run's streak."""
+        guarded = wrap_tool_with_repeat_guard(_constant_tool())
+
+        for _ in range(DENY_AFTER + 1):
+            await _call(guarded)
+
+        reset_repeat_guard()
+        assert NOTE_KEY not in await _call(guarded)
+
+
+class TestApplyRepeatGuard:
+    def test_wraps_every_tool_and_marks_them(self):
+        node = SimpleNamespace(tools=[_constant_tool("a"), _constant_tool("b")])
+        assert apply_repeat_guard(node) == 2
+        assert all(tool_is_repeat_guarded(t) for t in node.tools)
+
+    def test_is_idempotent(self):
+        node = SimpleNamespace(tools=[_constant_tool("a")])
+        assert apply_repeat_guard(node) == 1
+        assert apply_repeat_guard(node) == 0
+
+    def test_preserves_the_declared_tool_fields(self):
+        original = _constant_tool("keep_me")
+        node = SimpleNamespace(tools=[original])
+        apply_repeat_guard(node)
+
+        wrapped = node.tools[0]
+        assert wrapped.name == original.name
+        assert wrapped.description == original.description
+        assert wrapped.params_json_schema == original.params_json_schema
+
+    def test_tolerates_a_node_without_tools(self):
+        assert apply_repeat_guard(SimpleNamespace(tools=[])) == 0
+        assert apply_repeat_guard(SimpleNamespace()) == 0


### PR DESCRIPTION
## Why

A production run answered `每个月的收入是多少?` on its **third** turn, then called `execute_sql` with byte-identical arguments **25 more times** against the same 23-row result until `max_turns (30)` tripped. The user got a bare `Max turns (30) exceeded` and the ledger got 190k tokens, with a correct validated answer sitting in the context the whole time.

Langfuse trace `17afc137e38a4055157e3df959679f62` (`Datus-saas-prod`, `agent/olist_order_analyst`, `deepseek/deepseek-v4-pro`, 2026-09-03 15:57:56Z): 30 generations, 28 `execute_sql`, `tool_choice: auto`, **234 completion tokens on every single turn**.

Two independent defects had to line up.

**1. The reasoning shim fabricated a thought.** DeepSeek and Moonshot both require `reasoning_content` to be echoed back on tool-calling turns. When a turn came back without any, `_postprocess_messages_for_reasoning` filled the gap with the last reasoning found *anywhere* in the message list — rewriting the entire history in place on every call. Turns 4, 5 and 7 emitted no `reasoning` item at all (verifiable in the trace: their responses contain only a `function_call`), yet the request history stamps all three with:

> "The SQL validated successfully. I have my answer. Let me produce the final output. … Final JSON output."

attached to yet another `execute_sql` call. The model was then shown twenty precedents in which *concluding it was finished* meant *calling the tool again*, and it reproduced them exactly. Because the tool result never changed either, the context became a fixed point: nothing that could alter the next action ever entered it.

**2. Nothing was watching.** Twenty-five identical calls returning identical results is provable non-progress, and only `max_turns` noticed — after burning the whole budget and surfacing an error instead of an answer.

## Solution

**Own reasoning only** (`datus/models/sdk_patches.py`). A message may now carry only reasoning that is genuinely its own: the text it arrived with, or — for the single in-flight turn — the streaming cache, which by construction holds the most recent response's reasoning and nothing else. Any other gap gets `REASONING_UNAVAILABLE_PLACEHOLDER`.

The tradeoff considered was leaving those gaps empty, which is what the code's own comments wanted ("let the provider surface a clean error"). That is not viable: DeepSeek rejects a missing *and* an empty `reasoning_content` in thinking mode, so an empty gap fails the whole turn. Both providers require the field to be non-empty; neither requires it to say anything in particular. A neutral marker satisfies them without asserting a thought that was never had.

`_last_patchable_assistant_index` mirrors the patch loop's own `should_patch_message` test so the two can never disagree about which message is the in-flight one.

**No-progress guard** (`datus/tools/middleware/repeat_guard.py`, new). Wraps every tool and tracks, per run and per call signature, how many times in a row a call returned the same result.

Key decisions:

- **It never suppresses execution.** Tools stay authoritative and side effects happen exactly as before; the guard only observes. Short-circuiting with a cached result was rejected — it would silently serve stale data to a legitimate poll.
- **Only an unchanged result counts.** A repeat whose result *differs* is progress — polling a table until a job lands, re-reading a file after a write — and resets the streak. This is what keeps the guard off legitimate retry loops.
- **Escalation, not a cliff.** From 2 identical results in a row the payload carries a `datus_guard` note; from 4, the guard returns a failure payload instead of a result the model already has verbatim. The model gets two chances to self-correct before anything is taken away.
- **`ask_user` is exempt** — repeating a question is the human's prerogative, not a failure to converge.
- State lives in a `ContextVar` reset at the single stream chokepoint, so concurrent runs and sub-agents never share counters, and a retry-policy iteration starts from zero rather than inheriting a streak.
- Wrapping is unconditional, unlike the plugin transformer layer next to it: a model looping until `max_turns` is a failure of the loop itself, not of any plugin, so the guard must not depend on an operator having enabled anything. Wrap failures are swallowed — losing the guard costs a turn budget, failing the run costs the answer.

The guard also covers a second loop found in the same session (trace `4c0939b57c40a0cde8b8cdb32cc20212`), where a `gen_job` turn cycled `CREATE` → validate → `DROP` → "table is gone" → `CREATE` 37 times: different trigger, same missing backstop.

## Test Cases

New unit tests, mirroring source paths:

- `tests/unit_tests/tools/middleware/test_repeat_guard.py` (17 tests) — transparency on the first call; the note at `WARN_AFTER`; the denial at `DENY_AFTER`; **the tool still executing every time**; a changing result never tripping the guard; a streak resetting mid-run; argument canonicalisation (reordered keys are the same call, different SQL is not, malformed JSON still compares); non-dict payloads passing through unannotated; the tool's own payload object not being mutated; `ask_user` exemption; per-run isolation; and `apply_repeat_guard` wrapping/idempotence/field preservation.
- `tests/unit_tests/models/test_sdk_patches.py` — `TestPostprocessMessagesForReasoning` rewritten around the new rule, plus `test_deepseek_never_borrows_another_turns_reasoning`, which is the production loop in miniature.

**Red on the pre-fix code**, as required for `[BugFix]`: with the old borrow-the-last-reasoning behaviour restored, `test_deepseek_never_borrows_another_turns_reasoning` fails with

```
assert 'The SQL validated. I have my answer. Final JSON output.' != 'The SQL validated. I have my answer. Final JSON output.'
```

It asserts the property rather than the instance — the filler must not equal another turn's reasoning, and must be non-empty — so it stays red if the bug returns under a different filler.

No integration or nightly tests added: both changes are pure in-process logic with no external service involved, and the existing node-level suites already exercise the wrapped tool path.

Local gates: `ruff format` / `ruff check` clean; `ci/audit_tests.py --diff-only upstream/main` → `P0=0, P1=0`; diff coverage **94%**. The 5 failures in `test_semantic_modeling_agentic_node.py` are pre-existing on `upstream/main` in this environment (`ModuleNotFoundError: datus_semantic_dosi`), and the integration failures are a local `.datus/config.yml` pointing at a datasource the test config does not define — neither is touched by this PR.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protection against repeated tool calls during a run, including warnings for recurring results and blocking after continued repetition.
  - Repeated-call tracking resets between runs and remains compatible with user-prompt tools.

- **Bug Fixes**
  - Improved reasoning display so messages no longer inherit reasoning from unrelated turns.
  - Preserved reasoning for the originating or currently active assistant turn while showing a neutral placeholder when unavailable.
  - Improved handling of historical tool-call and reasoning content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->