### PR TITLE
[Enhancement] Let a host name its traces, without Datus learning its vocabulary

### DIFF
--- a/datus/api/services/chat_task_manager.py
+++ b/datus/api/services/chat_task_manager.py
@@ -9,6 +9,7 @@ the client can reconnect and resume from where it left off.
 
 import asyncio
 import copy
+import os
 import uuid
 from datetime import datetime
 from typing import Any, AsyncGenerator, Dict, List, Literal, Optional
@@ -37,7 +38,31 @@ from datus.tools.proxy.proxy_tool import apply_proxy_tools
 from datus.utils.loggings import get_logger
 from datus.utils.path_manager import set_current_path_manager
 from datus.utils.time_utils import now_utc_iso
-from datus.utils.trace_context import build_chat_trace_context, reset_trace_context, set_trace_context
+from datus.utils.trace_context import (
+    build_chat_trace_context,
+    reset_trace_context,
+    resolve_trace_identity,
+    set_trace_context,
+)
+
+
+def _release_stamp() -> Optional[str]:
+    """Build identity for the running agent.
+
+    ``DATUS_RELEASE`` wins so a deployment can stamp the image tag it actually
+    rolled out; the package version is the fallback for anything that runs
+    outside a container.
+    """
+    release = os.environ.get("DATUS_RELEASE")
+    if release and release.strip():
+        return release.strip()
+    try:
+        from datus import __version__
+
+        return str(__version__).strip() or None
+    except Exception:  # noqa: BLE001 - never fail a chat turn over a version lookup
+        return None
+
 
 logger = get_logger(__name__)
 
@@ -627,6 +652,9 @@ class ChatTaskManager:
                     source=request.source or self._default_source,
                     model=request.model,
                     agent_home=agent_config.home,
+                    identity=resolve_trace_identity(),
+                    max_turns=getattr(node, "max_turns", None),
+                    release=_release_stamp(),
                 )
             )
 

--- a/datus/observability/adapters/langfuse.py
+++ b/datus/observability/adapters/langfuse.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import os
 import threading
 from collections import OrderedDict
@@ -130,6 +131,40 @@ def _langfuse_attributes_from_baggage(baggage_attrs: dict[str, Any]) -> dict[str
     run_id = _clean_string(baggage_attrs.get("datus.run_id"))
     if run_id:
         attributes["langfuse.trace.metadata.run_id"] = run_id
+
+    # Join keys land in metadata, which is the mapping this adapter already
+    # proves works end to end. ``release`` additionally gets Langfuse's
+    # first-class field so the UI can group by deploy.
+    from datus.observability.manager import _TRACE_JOIN_KEYS
+    from datus.utils.trace_context import TRACE_IDENTITY_ATTRIBUTE_PREFIX
+
+    for baggage_key, metadata_key in _TRACE_JOIN_KEYS.items():
+        value = _clean_string(baggage_attrs.get(baggage_key))
+        if value:
+            attributes[f"langfuse.trace.metadata.{metadata_key}"] = value
+    # Host identity, forwarded under its own names. This adapter never learns
+    # what they mean -- it strips the namespace and hands them to Langfuse.
+    for baggage_key, raw_value in baggage_attrs.items():
+        key = str(baggage_key)
+        if not key.startswith(TRACE_IDENTITY_ATTRIBUTE_PREFIX):
+            continue
+        value = _clean_string(raw_value)
+        name = key[len(TRACE_IDENTITY_ATTRIBUTE_PREFIX) :]
+        if value and name:
+            attributes[f"langfuse.trace.metadata.{name}"] = value
+    release = _clean_string(baggage_attrs.get("datus.release"))
+    if release:
+        attributes["langfuse.release"] = release
+
+    # Tags are the only trace field the Langfuse list API filters on, which is
+    # what makes an unattended scan cheap: one filtered query instead of paging
+    # every trace in the window.
+    tags = _clean_string(baggage_attrs.get("datus.tags"))
+    if tags:
+        attributes["langfuse.trace.tags"] = json.dumps(
+            [tag for tag in (part.strip() for part in tags.split(",")) if tag],
+            ensure_ascii=False,
+        )
 
     return attributes
 

--- a/datus/observability/adapters/otlp.py
+++ b/datus/observability/adapters/otlp.py
@@ -185,7 +185,12 @@ class _BaggageAttributeSpanProcessor(SpanProcessor):
 
 
 def _is_trace_baggage_key(key: str) -> bool:
-    return key in {"session.id", "user.id", "datus.trace.name", "datus.run_id"}
+    from datus.observability.manager import _TRACE_JOIN_KEYS
+    from datus.utils.trace_context import TRACE_IDENTITY_ATTRIBUTE_PREFIX
+
+    if key.startswith(TRACE_IDENTITY_ATTRIBUTE_PREFIX):
+        return True
+    return key in {"session.id", "user.id", "datus.trace.name", "datus.run_id", "datus.tags"} or key in _TRACE_JOIN_KEYS
 
 
 def _provider_neutral_attributes_from_baggage(baggage_attrs: dict[str, Any]) -> dict[str, Any]:

--- a/datus/observability/manager.py
+++ b/datus/observability/manager.py
@@ -341,7 +341,13 @@ def _trace_baggage_attributes(span_name: str, attributes: dict[str, Any]) -> dic
     # span: exporters read trace-level identity from the baggage a child span
     # carries, so a key left behind is a key no backend ever sees.
     for baggage_key, metadata_key in _TRACE_JOIN_KEYS.items():
-        value = _string_attr(attributes.get(baggage_key) or attributes.get(f"datus.metadata.{metadata_key}"))
+        # Fall back on absence, not on falsiness: these carry numbers, and an
+        # ``or`` chain would read a configured ``max_turns: 0`` as "unset" and
+        # then either drop it or let a stale metadata copy win.
+        raw = attributes.get(baggage_key)
+        if raw is None:
+            raw = attributes.get(f"datus.metadata.{metadata_key}")
+        value = _string_attr(raw)
         if value:
             baggage_attrs[baggage_key] = value
 

--- a/datus/observability/manager.py
+++ b/datus/observability/manager.py
@@ -19,6 +19,7 @@ from datus.observability.privacy import redact_value
 from datus.observability.reference import TraceReference
 from datus.observability.registry import adapter_registry
 from datus.utils.loggings import get_logger
+from datus.utils.trace_context import TRACE_IDENTITY_ATTRIBUTE_PREFIX
 
 logger = get_logger(__name__)
 
@@ -301,6 +302,17 @@ def _attach_trace_baggage(span_name: str, attributes: dict[str, Any]) -> Any | N
         return None
 
 
+# Agent-owned join keys, as ``baggage key -> TraceContext metadata key``. Only
+# facts Datus itself knows belong here; anything a *deployment* defines arrives
+# under ``TRACE_IDENTITY_ATTRIBUTE_PREFIX`` instead and is forwarded by prefix,
+# so this list never has to learn a host's vocabulary.
+_TRACE_JOIN_KEYS = {
+    "datus.node_name": "node_name",
+    "datus.max_turns": "max_turns",
+    "datus.release": "release",
+}
+
+
 def _trace_baggage_attributes(span_name: str, attributes: dict[str, Any]) -> dict[str, str]:
     """Return trace-level attributes that should propagate to every span."""
     baggage_attrs: dict[str, str] = {}
@@ -324,6 +336,28 @@ def _trace_baggage_attributes(span_name: str, attributes: dict[str, Any]) -> dic
     )
     if run_id:
         baggage_attrs["datus.run_id"] = run_id
+
+    # Join keys. These have to ride the baggage rather than stay on the root
+    # span: exporters read trace-level identity from the baggage a child span
+    # carries, so a key left behind is a key no backend ever sees.
+    for baggage_key, metadata_key in _TRACE_JOIN_KEYS.items():
+        value = _string_attr(attributes.get(baggage_key) or attributes.get(f"datus.metadata.{metadata_key}"))
+        if value:
+            baggage_attrs[baggage_key] = value
+
+    # Host identity travels by prefix, not by name. Forwarding the namespace
+    # whole is the whole point: a deployment adds a correlation field and every
+    # layer below carries it without a code change.
+    for key, value in attributes.items():
+        if not str(key).startswith(TRACE_IDENTITY_ATTRIBUTE_PREFIX):
+            continue
+        text = _string_attr(value)
+        if text:
+            baggage_attrs[str(key)] = text
+
+    tags = _string_attr(attributes.get("datus.tags"))
+    if tags:
+        baggage_attrs["datus.tags"] = tags
 
     return baggage_attrs
 

--- a/datus/utils/trace_context.py
+++ b/datus/utils/trace_context.py
@@ -20,6 +20,57 @@ _CURRENT_TRACE_CONTEXT: contextvars.ContextVar[Optional["TraceContext"]] = conte
     default=None,
 )
 
+# Attribute namespace for host-supplied trace identity. Everything downstream
+# (baggage propagation, the exporters) forwards this prefix as a whole, so a
+# deployment can add a correlation field without a change anywhere in Datus.
+TRACE_IDENTITY_ATTRIBUTE_PREFIX = "datus.identity."
+
+# A host registers one of these at startup to name the runs it serves. It takes
+# no arguments on purpose: the host owns its request-scoped state, and Datus
+# passing it something would mean guessing which of the host's own channels the
+# identity lives in. Called inside the run, so a contextvar the host set at the
+# request boundary is still visible.
+TraceIdentityProvider = Any  # Callable[[], Mapping[str, Any]]
+
+_TRACE_IDENTITY_PROVIDER: Optional[TraceIdentityProvider] = None
+
+
+def set_trace_identity_provider(provider: Optional[TraceIdentityProvider]) -> None:
+    """Register (or clear, with ``None``) the host's trace-identity provider.
+
+    Called once at startup by whatever application embeds Datus. A plain OSS
+    install registers nothing and its traces simply carry no host identity.
+    """
+    global _TRACE_IDENTITY_PROVIDER
+    _TRACE_IDENTITY_PROVIDER = provider
+
+
+def resolve_trace_identity() -> dict[str, str]:
+    """Ask the host to name this run, and normalise whatever comes back.
+
+    Returns ``{}`` when no provider is registered, when the provider declines,
+    or when it raises -- identity is a correlation aid, and losing it must never
+    cost a user their answer. Values are coerced to non-empty strings so a
+    provider cannot inject ``None`` into an exporter's attributes.
+    """
+    provider = _TRACE_IDENTITY_PROVIDER
+    if provider is None:
+        return {}
+    try:
+        resolved = provider()
+    except Exception:  # noqa: BLE001 - a broken host hook must not fail the run
+        return {}
+    if not isinstance(resolved, Mapping):
+        return {}
+    identity: dict[str, str] = {}
+    for key, value in resolved.items():
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text and str(key).strip():
+            identity[str(key).strip()] = text
+    return identity
+
 
 def _compact_slug(value: Any, fallback: str = "unknown") -> str:
     text = str(value or "").strip()
@@ -69,6 +120,12 @@ class TraceContext:
     user_id: Optional[str] = None
     tags: tuple[str, ...] = ()
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    # Host-supplied correlation fields, propagated verbatim and never
+    # interpreted here. Datus has no opinion on what a deployment considers an
+    # identity -- a private install may key runs by workspace and project,
+    # another by tenant, an OSS user by nothing at all -- so the names live
+    # with the host that defines them. See :func:`resolve_trace_identity`.
+    identity: Mapping[str, str] = field(default_factory=dict)
 
     def langfuse_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {"trace_name": self.name}
@@ -78,9 +135,10 @@ class TraceContext:
             kwargs["user_id"] = self.user_id
         if self.tags:
             kwargs["tags"] = list(dict.fromkeys(self.tags))
-        if self.metadata:
+        merged_metadata = {**(self.metadata or {}), **(self.identity or {})}
+        if merged_metadata:
             kwargs["metadata"] = {
-                str(key): _string_metadata_value(value) for key, value in self.metadata.items() if value is not None
+                str(key): _string_metadata_value(value) for key, value in merged_metadata.items() if value is not None
             }
         return kwargs
 
@@ -174,6 +232,14 @@ def build_trace_span_attributes(
     run_id = (trace_ctx.metadata or {}).get("run_id") or (trace_ctx.metadata or {}).get("benchmark_run_id")
     if run_id:
         attrs["datus.run_id"] = run_id
+    # Host identity gets its own namespace rather than joining
+    # ``datus.metadata.*``: the layers downstream propagate this prefix
+    # wholesale, which is what lets a host add a field without any of them
+    # learning its name.
+    for key, value in (trace_ctx.identity or {}).items():
+        if value is None or not str(value).strip():
+            continue
+        attrs[f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}{key}"] = str(value)
     return attrs
 
 
@@ -366,8 +432,26 @@ def build_chat_trace_context(
     source: Optional[str] = None,
     model: Optional[str] = None,
     agent_home: Optional[str] = None,
+    max_turns: Optional[int] = None,
+    release: Optional[str] = None,
+    identity: Optional[Mapping[str, str]] = None,
     extra: Optional[Mapping[str, Any]] = None,
 ) -> TraceContext:
+    """Trace identity for one chat turn.
+
+    The last three arguments exist so a trace can be tied back to the rest of
+    the system without guessing. Before them the only shared identifiers were
+    ``user_id`` and a timestamp, so correlating a trace with its HTTP request or
+    its pod meant eyeballing two clocks:
+
+    * ``max_turns`` makes "did this run hit its ceiling" a comparison instead of
+      an assumption about which node ran with which config.
+    * ``release`` records the build, so a bad run can be attributed to a deploy.
+    * ``identity`` is whatever the host uses to name a run, forwarded verbatim.
+      Datus does not define those names: a private install may key runs by
+      workspace and project, another deployment by tenant, a plain OSS install
+      by nothing. Build it with :func:`resolve_trace_identity`.
+    """
     display_name = node_name or subagent_id or "chat"
     display_slug = _compact_slug(display_name, "chat")
     tags = ["chat", f"agent:{display_slug}"]
@@ -375,6 +459,13 @@ def build_chat_trace_context(
         tags.append(f"datasource:{_compact_slug(datasource)}")
     if source:
         tags.append(f"source:{_compact_slug(source)}")
+    # Tags are the only trace field the Langfuse list API can filter on, so
+    # every host identity field is tagged as well as recorded, letting a scan
+    # group by it server-side. The key is the host's, so the tag name is too.
+    identity = dict(identity or {})
+    for key, value in identity.items():
+        if value:
+            tags.append(f"{_compact_slug(key)}:{_compact_slug(value)}")
 
     metadata = _metadata_base(
         component="chat",
@@ -388,6 +479,8 @@ def build_chat_trace_context(
             "source_session_id": source_session_id,
             "source": source,
             "model": model,
+            "max_turns": max_turns,
+            "release": release,
             **(dict(extra) if extra else {}),
         },
     )
@@ -397,4 +490,5 @@ def build_chat_trace_context(
         user_id=user_id,
         tags=tuple(tags),
         metadata=metadata,
+        identity=identity,
     )

--- a/tests/unit_tests/api/services/test_chat_task_manager.py
+++ b/tests/unit_tests/api/services/test_chat_task_manager.py
@@ -2560,3 +2560,20 @@ class TestDuplicateAssistantMessage:
 
         other = _make_assistant_message("second", "m2", SSEDataType.UPDATE_MESSAGE)
         assert _should_skip_duplicate_assistant_message(_response_action(), other, seen) is False
+
+
+class TestReleaseStamp:
+    """The build identity is Datus' own fact, so Datus reads it."""
+
+    def test_release_prefers_the_deployed_image_tag(self, monkeypatch):
+        from datus.api.services.chat_task_manager import _release_stamp
+
+        monkeypatch.setenv("DATUS_RELEASE", "0.4.0")
+        assert _release_stamp() == "0.4.0"
+
+    def test_release_falls_back_to_the_package_version(self, monkeypatch):
+        from datus import __version__
+        from datus.api.services.chat_task_manager import _release_stamp
+
+        monkeypatch.delenv("DATUS_RELEASE", raising=False)
+        assert _release_stamp() == str(__version__)

--- a/tests/unit_tests/observability/test_manager.py
+++ b/tests/unit_tests/observability/test_manager.py
@@ -19,7 +19,7 @@ from datus.observability.manager import (
     _trace_baggage_attributes,
 )
 from datus.observability.reference import TraceReference
-from datus.utils.trace_context import TraceContext, trace_context
+from datus.utils.trace_context import TRACE_IDENTITY_ATTRIBUTE_PREFIX, TraceContext, trace_context
 
 
 class FakeAdapter:
@@ -461,3 +461,48 @@ def test_module_helpers_register_flush_and_delegate(monkeypatch):
 
     assert fake_manager.shutdown_called is True
     assert fake_manager.flush_called is True
+
+
+def test_trace_baggage_attributes_carry_agent_owned_join_keys():
+    """Join keys must ride the baggage; a key left on the root span reaches no exporter."""
+    attrs = _trace_baggage_attributes(
+        "chat",
+        {
+            "datus.trace.name": "agent/chat",
+            "datus.metadata.node_name": "olist_order_analyst",
+            "datus.metadata.max_turns": 30,
+            "datus.metadata.release": "0.4.0",
+            "datus.tags": "chat,agent:chat",
+        },
+    )
+
+    assert attrs["datus.node_name"] == "olist_order_analyst"
+    assert attrs["datus.max_turns"] == "30"
+    assert attrs["datus.release"] == "0.4.0"
+    assert attrs["datus.tags"] == "chat,agent:chat"
+    assert all(not key.startswith("langfuse.") for key in attrs)
+
+
+def test_trace_baggage_forwards_host_identity_by_prefix():
+    """Identity travels as a namespace so a host can add a field with no code change."""
+    attrs = _trace_baggage_attributes(
+        "chat",
+        {
+            "datus.trace.name": "agent/chat",
+            f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}workspace_id": "ws_abc",
+            f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}anything_the_host_invents": "v",
+        },
+    )
+
+    assert attrs[f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}workspace_id"] == "ws_abc"
+    assert attrs[f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}anything_the_host_invents"] == "v"
+
+
+def test_trace_baggage_attributes_skip_absent_join_keys():
+    """A host that supplies nothing must not add empty baggage entries."""
+    attrs = _trace_baggage_attributes(
+        "chat",
+        {"datus.trace.name": "agent/chat", f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}blank": "  "},
+    )
+
+    assert attrs == {"datus.trace.name": "agent/chat"}

--- a/tests/unit_tests/observability/test_manager.py
+++ b/tests/unit_tests/observability/test_manager.py
@@ -463,15 +463,22 @@ def test_module_helpers_register_flush_and_delegate(monkeypatch):
     assert fake_manager.flush_called is True
 
 
-def test_trace_baggage_attributes_carry_agent_owned_join_keys():
-    """Join keys must ride the baggage; a key left on the root span reaches no exporter."""
+@pytest.mark.parametrize("prefix", ["datus.metadata.", "datus."])
+def test_trace_baggage_attributes_carry_agent_owned_join_keys(prefix):
+    """Join keys must ride the baggage; a key left on the root span reaches no exporter.
+
+    Both accepted input shapes have to produce identical baggage: callers write
+    ``datus.metadata.<key>`` (what ``build_trace_span_attributes`` emits) or the
+    direct ``datus.<key>`` form, and the fallback between them is the kind of
+    thing that silently prefers the wrong one.
+    """
     attrs = _trace_baggage_attributes(
         "chat",
         {
             "datus.trace.name": "agent/chat",
-            "datus.metadata.node_name": "olist_order_analyst",
-            "datus.metadata.max_turns": 30,
-            "datus.metadata.release": "0.4.0",
+            f"{prefix}node_name": "olist_order_analyst",
+            f"{prefix}max_turns": 30,
+            f"{prefix}release": "0.4.0",
             "datus.tags": "chat,agent:chat",
         },
     )
@@ -481,6 +488,24 @@ def test_trace_baggage_attributes_carry_agent_owned_join_keys():
     assert attrs["datus.release"] == "0.4.0"
     assert attrs["datus.tags"] == "chat,agent:chat"
     assert all(not key.startswith("langfuse.") for key in attrs)
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {"datus.max_turns": 0},
+        {"datus.metadata.max_turns": 0},
+        # The direct form is explicit and must win, even when it is falsy.
+        {"datus.max_turns": 0, "datus.metadata.max_turns": 30},
+    ],
+)
+def test_a_zero_join_key_is_a_value_not_an_absence(attributes):
+    """A configured ``max_turns: 0`` must survive as "0", not be read as unset.
+
+    Falling back on falsiness rather than absence dropped it entirely in the
+    direct form, and let a stale metadata copy override it when both were set.
+    """
+    assert _trace_baggage_attributes("chat", attributes)["datus.max_turns"] == "0"
 
 
 def test_trace_baggage_forwards_host_identity_by_prefix():

--- a/tests/unit_tests/observability/test_platform_adapters.py
+++ b/tests/unit_tests/observability/test_platform_adapters.py
@@ -200,23 +200,32 @@ def test_datadog_adapter_defaults_to_local_agent(monkeypatch):
 
 
 def test_langfuse_maps_join_keys_onto_the_trace():
-    """Every join key the baggage carries must land somewhere queryable."""
+    """The whole chain, end to end: trace context -> span attrs -> baggage -> Langfuse.
+
+    Driven by the real producers rather than a hand-built baggage dict, because
+    the failure this guards against is precisely the three layers disagreeing
+    about a key's spelling -- and a hand-built input would encode the mistake on
+    both sides and pass.
+    """
     import json as _json
 
-    from datus.utils.trace_context import TRACE_IDENTITY_ATTRIBUTE_PREFIX
+    from datus.observability.manager import _trace_baggage_attributes
+    from datus.utils.trace_context import build_chat_trace_context, build_trace_span_attributes
 
-    attrs = _langfuse_attributes_from_baggage(
-        {
-            "datus.trace.name": "agent/chat",
-            "datus.node_name": "olist_order_analyst",
-            "datus.max_turns": "30",
-            "datus.release": "0.4.0",
-            f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}workspace_id": "ws_abc",
-            f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}tenant": "acme",
-            "datus.tags": "chat,workspace_id:ws_abc",
-        }
+    ctx = build_chat_trace_context(
+        session_id="chat_session_1",
+        node_name="olist_order_analyst",
+        max_turns=30,
+        release="0.4.0",
+        identity={"workspace_id": "ws_abc", "tenant": "acme"},
     )
+    span_attributes = build_trace_span_attributes(operation="chat", ctx=ctx)
+    baggage_attrs = _trace_baggage_attributes("chat", span_attributes)
 
+    attrs = _langfuse_attributes_from_baggage(baggage_attrs)
+
+    assert attrs["langfuse.trace.name"] == "agent/olist_order_analyst"
+    assert attrs["langfuse.session.id"] == "chat_session_1"
     assert attrs["langfuse.trace.metadata.node_name"] == "olist_order_analyst"
     assert attrs["langfuse.trace.metadata.max_turns"] == "30"
     assert attrs["langfuse.trace.metadata.release"] == "0.4.0"
@@ -226,7 +235,12 @@ def test_langfuse_maps_join_keys_onto_the_trace():
     # the namespace and never interprets what is left
     assert attrs["langfuse.trace.metadata.workspace_id"] == "ws_abc"
     assert attrs["langfuse.trace.metadata.tenant"] == "acme"
-    assert _json.loads(attrs["langfuse.trace.tags"]) == ["chat", "workspace_id:ws_abc"]
+    assert set(_json.loads(attrs["langfuse.trace.tags"])) == {
+        "chat",
+        "agent:olist_order_analyst",
+        "workspace_id:ws_abc",
+        "tenant:acme",
+    }
 
 
 def test_langfuse_omits_join_keys_that_were_never_set():

--- a/tests/unit_tests/observability/test_platform_adapters.py
+++ b/tests/unit_tests/observability/test_platform_adapters.py
@@ -197,3 +197,40 @@ def test_datadog_adapter_defaults_to_local_agent(monkeypatch):
 
     assert resolved.endpoint == "http://localhost:4318/v1/traces"
     assert resolved.headers == {}
+
+
+def test_langfuse_maps_join_keys_onto_the_trace():
+    """Every join key the baggage carries must land somewhere queryable."""
+    import json as _json
+
+    from datus.utils.trace_context import TRACE_IDENTITY_ATTRIBUTE_PREFIX
+
+    attrs = _langfuse_attributes_from_baggage(
+        {
+            "datus.trace.name": "agent/chat",
+            "datus.node_name": "olist_order_analyst",
+            "datus.max_turns": "30",
+            "datus.release": "0.4.0",
+            f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}workspace_id": "ws_abc",
+            f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}tenant": "acme",
+            "datus.tags": "chat,workspace_id:ws_abc",
+        }
+    )
+
+    assert attrs["langfuse.trace.metadata.node_name"] == "olist_order_analyst"
+    assert attrs["langfuse.trace.metadata.max_turns"] == "30"
+    assert attrs["langfuse.trace.metadata.release"] == "0.4.0"
+    # release also gets Langfuse's first-class field so runs group by deploy
+    assert attrs["langfuse.release"] == "0.4.0"
+    # host identity keeps the host's own key names -- the adapter strips only
+    # the namespace and never interprets what is left
+    assert attrs["langfuse.trace.metadata.workspace_id"] == "ws_abc"
+    assert attrs["langfuse.trace.metadata.tenant"] == "acme"
+    assert _json.loads(attrs["langfuse.trace.tags"]) == ["chat", "workspace_id:ws_abc"]
+
+
+def test_langfuse_omits_join_keys_that_were_never_set():
+    """Absent keys must not become empty strings on the trace."""
+    attrs = _langfuse_attributes_from_baggage({"datus.trace.name": "agent/chat"})
+
+    assert attrs == {"langfuse.trace.name": "agent/chat"}

--- a/tests/unit_tests/utils/test_trace_context.py
+++ b/tests/unit_tests/utils/test_trace_context.py
@@ -3,11 +3,14 @@
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
 from datus.utils.trace_context import (
+    TRACE_IDENTITY_ATTRIBUTE_PREFIX,
     build_benchmark_trace_context,
     build_bootstrap_trace_context,
     build_chat_trace_context,
     build_trace_span_attributes,
     build_workflow_trace_context_from_runner,
+    resolve_trace_identity,
+    set_trace_identity_provider,
     trace_context,
 )
 
@@ -166,3 +169,92 @@ def test_trace_span_attributes_normalize_complex_metadata_values():
 
     assert attrs["datus.metadata.payload"] == '{"tables": ["schools"]}'
     assert attrs["datus.metadata.attempt"] == 2
+
+
+def test_chat_context_carries_agent_owned_join_keys():
+    """max_turns and release are Datus' own facts and stay first-class."""
+    ctx = build_chat_trace_context(
+        session_id="chat_session_1",
+        node_name="olist_order_analyst",
+        user_id="u1",
+        max_turns=30,
+        release="0.4.0",
+    )
+
+    assert ctx.metadata["max_turns"] == 30
+    assert ctx.metadata["release"] == "0.4.0"
+    assert ctx.metadata["node_name"] == "olist_order_analyst"
+
+
+def test_chat_context_forwards_host_identity_verbatim():
+    """Datus must not interpret the host's identity fields, only carry them."""
+    ctx = build_chat_trace_context(
+        session_id="chat_session_1",
+        node_name="chat",
+        identity={"workspace_id": "ws_abc", "tenant": "acme"},
+    )
+
+    assert ctx.identity == {"workspace_id": "ws_abc", "tenant": "acme"}
+    # Tags are the only filterable trace field, so each identity field is tagged
+    # under the host's own key -- no Datus-side vocabulary.
+    assert "workspace_id:ws_abc" in ctx.tags
+    assert "tenant:acme" in ctx.tags
+
+
+def test_chat_context_without_a_host_carries_no_identity():
+    """A plain OSS install registers no provider and must produce no empty tags."""
+    ctx = build_chat_trace_context(session_id="chat_session_1", node_name="chat")
+
+    assert ctx.identity == {}
+    assert ctx.tags == ("chat", "agent:chat")
+
+
+def test_identity_reaches_span_attributes_under_its_own_namespace():
+    """Exporters forward this prefix wholesale; a field that stops here is lost."""
+    ctx = build_chat_trace_context(
+        session_id="chat_session_1",
+        node_name="chat",
+        max_turns=30,
+        identity={"workspace_id": "ws_abc", "request_trace_id": "abc123"},
+    )
+    attrs = build_trace_span_attributes(operation="chat", ctx=ctx)
+
+    assert attrs[f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}workspace_id"] == "ws_abc"
+    assert attrs[f"{TRACE_IDENTITY_ATTRIBUTE_PREFIX}request_trace_id"] == "abc123"
+    assert attrs["datus.metadata.max_turns"] == 30
+
+
+class TestTraceIdentityProvider:
+    """The host names its runs; Datus only asks."""
+
+    def teardown_method(self):
+        set_trace_identity_provider(None)
+
+    def test_no_provider_means_no_identity(self):
+        set_trace_identity_provider(None)
+        assert resolve_trace_identity() == {}
+
+    def test_provider_reads_the_hosts_own_request_state(self):
+        """The hook takes no arguments; a contextvar the host set is still visible."""
+        import contextvars
+
+        host_var = contextvars.ContextVar("host_request", default=None)
+        set_trace_identity_provider(lambda: {"workspace_id": host_var.get()})
+
+        host_var.set("ws_abc")
+        assert resolve_trace_identity() == {"workspace_id": "ws_abc"}
+
+    def test_values_are_coerced_and_blanks_dropped(self):
+        set_trace_identity_provider(lambda: {"a": 7, "b": None, "c": "  ", "d": " x "})
+        assert resolve_trace_identity() == {"a": "7", "d": "x"}
+
+    def test_a_broken_provider_costs_identity_not_the_run(self):
+        def boom():
+            raise RuntimeError("host hook is broken")
+
+        set_trace_identity_provider(boom)
+        assert resolve_trace_identity() == {}
+
+    def test_a_provider_returning_junk_is_ignored(self):
+        set_trace_identity_provider(lambda: "not a mapping")
+        assert resolve_trace_identity() == {}


### PR DESCRIPTION
## Why

A Langfuse trace and the rest of the system share exactly two identifiers today: a user id and a timestamp. Correlating a trace with its HTTP request, its pod, or the tenant it belonged to means lining up two clocks and hoping.

That is worse than it sounds wherever the agent runs without log collection — the trace is then the only surviving artefact of a run, and it cannot say whose run it was.

## Solution

Two of the missing identifiers are Datus' own facts, so they become first-class parameters:

- **`max_turns`** — turns "did this run hit its ceiling" into a comparison rather than an assumption about which node ran with which config.
- **`release`** — `DATUS_RELEASE` if a deployment stamped its image tag, else the package version, so a bad run can be attributed to a build.

Everything else belongs to whoever deploys Datus. **A private install may key runs by workspace and project, another by tenant, an OSS user by nothing at all — and none of those names mean anything in this repo.** So rather than parameters, there is one hook:

```python
set_trace_identity_provider(provider)          # once, at startup, by the host
```

Whatever mapping the provider returns is forwarded verbatim — into trace metadata, and as tags under **the host's own key names**, since tags are the only trace field the Langfuse list API can filter on. An install that registers nothing behaves exactly as before.

### The provider takes no arguments

This is the design decision worth reviewing. Passing it something would mean guessing which of the host's own channels the identity lives in, and **the obvious guess is wrong**: an earlier draft of this PR passed `policy_context`, which on the SaaS backend carries row-level filter policy — identity there comes from the request token. On a single-node deployment that same field *is* the right place. Datus cannot know, so it doesn't ask; the hook is called inside the run, where a contextvar the host set at the request boundary is still visible, and the host reads its own state.

### Propagation is by namespace, not by name

Identity rides span attributes, baggage, and the exporter mapping under a `datus.identity.` prefix that each layer forwards **whole**. A deployment can add a correlation field without a change anywhere in Datus. Only the three keys Datus itself owns (`node_name`, `max_turns`, `release`) remain enumerated.

Three layers had to agree for any of this to arrive, and **the baggage step is the one that is easy to miss**: exporters read trace-level identity from the baggage a *child* span carries, so a field left on the root span reaches no backend at all.

### Failure is never the user's problem

No provider, a provider that declines, one that returns junk, one that raises — all yield no identity and a normal run. Identity is a correlation aid; losing it must not cost anyone their answer.

**Tradeoff worth flagging:** `langfuse.trace.tags` is the only mapping here not already proven end to end by this adapter — the metadata mapping is, and every field lands there too, so nothing depends on the tag attribute being right. Worth confirming against a live trace after the first deploy; if it is wrong the fix is one line and no data is lost meanwhile.

## Test Cases

Unit tests only, mirroring source paths — every layer is a pure in-process transformation with no external service:

- `tests/unit_tests/utils/test_trace_context.py` — agent-owned keys stay first-class; host identity is forwarded verbatim and tagged under the host's own keys; an install with no provider produces no identity and no empty tags; identity reaches `build_trace_span_attributes` under its namespace (the layer exporters actually read). Plus the provider contract: no provider → nothing; the hook reads the host's own contextvar; values coerced and blanks dropped; a raising provider and a provider returning a non-mapping both degrade to no identity.
- `tests/unit_tests/observability/test_manager.py` — agent-owned keys copied onto the baggage under provider-neutral names; identity forwarded **by prefix**, including a key name invented by the test to prove no enumeration is involved; blank values produce no baggage entry.
- `tests/unit_tests/observability/test_platform_adapters.py` — every field maps onto the trace, host keys keep their own names, `release` also gets Langfuse's first-class field, tags serialise as a JSON array, unset keys omitted.
- `tests/unit_tests/api/services/test_chat_task_manager.py` — the one helper that stayed here, `_release_stamp`: `DATUS_RELEASE` preferred over the package version.

No integration or nightly tests: nothing here talks to a service, and the Langfuse export path is already covered by the adapter suite.

Local gates: `ruff format` / `ruff check` clean; `ci/audit_tests.py --diff-only upstream/main` → `P0=0, P1=0`. Rebased on `upstream/main`.

## Companion

Datus-ai/Datus-backend#510 registers the provider for the SaaS deployment (workspace / project / tenant from the token, `request_trace_id` from the trace middleware) and must land after this.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
