### PR TITLE
[BugFix] Use connector quoting for semantic key validation

### DIFF
--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -483,6 +483,16 @@ class DBFuncTool:
         """Get the primary/default connector (for backward compatibility)."""
         return self._primary_connector
 
+    def quote_sql_identifier(
+        self,
+        name: str,
+        database: str = "",
+        datasource: Optional[str] = "",
+    ) -> str:
+        """Quote one identifier with the connector selected for this request."""
+        connector = self._get_connector(datasource, database)
+        return connector.quote_identifier(name)
+
     def _get_connector(self, datasource: Optional[str] = None, database: str = "") -> BaseSqlConnector:
         """
         Get connector for the specified (datasource, database).

--- a/datus/tools/func_tool/database.py
+++ b/datus/tools/func_tool/database.py
@@ -1120,6 +1120,7 @@ class DBFuncTool:
             "execute_write",
             "execute_ddl",
             "get_table_ddl",
+            "quote_sql_identifier",
         }
     )
 

--- a/datus/tools/func_tool/semantic_discovery_tools.py
+++ b/datus/tools/func_tool/semantic_discovery_tools.py
@@ -1942,6 +1942,9 @@ class SemanticDiscoveryTools:
         value = str(value).strip().strip('"`[]')
         if value and value.replace("_", "").isalnum() and not value[0].isdigit():
             return value
+        connector_quote = getattr(self.db_tool, "quote_sql_identifier", None)
+        if callable(connector_quote):
+            return connector_quote(value, database=database)
         return '"' + value.replace('"', '""') + '"'
 
     def _sanitize_profile_sql(self, value: str) -> str:

--- a/tests/integration/tools/test_func_tools_db.py
+++ b/tests/integration/tools/test_func_tools_db.py
@@ -474,6 +474,7 @@ class TestAllToolsNameContract:
             "execute_write",
             "execute_ddl",
             "get_table_ddl",
+            "quote_sql_identifier",
         ):
             assert hasattr(DBFuncTool, method), f"{method} should still exist as a method"
             assert method not in names, f"{method} is not an agent tool and must be excluded"

--- a/tests/unit_tests/tools/func_tool/test_database.py
+++ b/tests/unit_tests/tools/func_tool/test_database.py
@@ -1131,6 +1131,19 @@ class TestGetConnectorRouting:
         assert conn_named is conn_other
         assert conn_default is mock_connector
 
+    def test_quote_sql_identifier_uses_selected_connector(self):
+        mock_connector = Mock()
+        mock_connector.dialect = "bigquery"
+        mock_connector.get_databases.return_value = []
+        mock_connector.quote_identifier.return_value = "`example-analytics-12345`"
+
+        tool = self._make_single_mode_tool(mock_connector)
+
+        quoted = tool.quote_sql_identifier("example-analytics-12345", database="main")
+
+        assert quoted == "`example-analytics-12345`"
+        mock_connector.quote_identifier.assert_called_once_with("example-analytics-12345")
+
     def test_multi_connector_routes_by_database_name(self):
         """In multi-connector mode, _get_connector returns different connectors."""
         from datus.tools.db_tools.db_manager import DBManager

--- a/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py
@@ -6,6 +6,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from datus.tools.func_tool.base import FuncToolResult
 from datus.tools.func_tool.semantic_discovery_tools import SemanticDiscoveryTools
 
@@ -299,6 +301,57 @@ class TestGetMultipleTablesDDL:
 
 
 class TestValidateSemanticKeyCandidate:
+    @pytest.mark.parametrize(
+        "table_name",
+        [
+            "example-analytics-12345.main.customers",
+            "`example-analytics-12345.main.customers`",
+        ],
+    )
+    def test_quotes_non_simple_table_parts_with_the_selected_connector(self, table_name):
+        db_tool = _make_db_tool()
+        db_tool.quote_sql_identifier.side_effect = lambda name, database="": f"`{name}`"
+        db_tool.read_query.side_effect = [
+            FuncToolResult(
+                success=1,
+                result={"compressed_data": "index,row_count,null_key_rows\n0,12,0\n"},
+            ),
+            FuncToolResult(
+                success=1,
+                result={"compressed_data": ("index,duplicate_group_count,duplicate_row_count\n0,0,0\n")},
+            ),
+        ]
+        tools = _make_tools(db_tool)
+
+        result = tools.validate_semantic_key_candidate(
+            table_name,
+            ["customer_id"],
+        )
+
+        assert result.success == 1
+        summary_sql = db_tool.read_query.call_args_list[0].args[0]
+        duplicate_sql = db_tool.read_query.call_args_list[1].args[0]
+        expected_table = "`example-analytics-12345`.main.customers"
+        assert f"FROM {expected_table}" in summary_sql
+        assert f"FROM {expected_table}" in duplicate_sql
+        assert '"example-analytics-12345"' not in summary_sql
+        db_tool.quote_sql_identifier.assert_called_once_with(
+            "example-analytics-12345",
+            database="",
+        )
+
+    def test_keeps_simple_identifiers_unquoted(self):
+        db_tool = _make_db_tool()
+        tools = _make_tools(db_tool)
+
+        assert tools._quote_sql_identifier("customer_id") == "customer_id"
+        db_tool.quote_sql_identifier.assert_not_called()
+
+    def test_legacy_db_tool_keeps_ansi_fallback_for_non_simple_identifiers(self):
+        tools = SemanticDiscoveryTools(db_tool=SimpleNamespace())
+
+        assert tools._quote_sql_identifier("order-detail") == '"order-detail"'
+
     def test_accepts_full_table_non_null_unique_composite_key(self):
         db_tool = _make_db_tool()
         db_tool.read_query.side_effect = [


### PR DESCRIPTION
## Summary

- delegate non-simple semantic-key identifiers to the connector selected for the request
- preserve existing behavior for simple identifiers, dialect-operation overrides, and legacy DB-tool fallbacks
- add regression coverage for BigQuery-style project IDs containing hyphens using fictional identifiers

## Problem

Semantic-key validation fell back to ANSI double quotes for non-simple identifiers. BigQuery interprets a double-quoted project ID as a string literal, so a qualified table reference such as a hyphenated project plus dataset and table failed with `Unexpected string literal`.

## Validation

- `.venv/bin/python -m pytest tests/unit_tests/tools/func_tool/test_semantic_discovery_tools.py tests/unit_tests/tools/func_tool/test_database.py -q` — 274 passed
- `uv run ruff check` on all changed files — passed
- `uv run ruff format --check` on all changed files — passed
- `uv run pytest datus-bigquery/tests/unit/test_connector_unit.py -q` in datus-db-adapters — 28 passed

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Added connector-aware SQL identifier quoting, supporting database-specific quoting styles.
  * Improved handling of multipart table names and identifiers containing special characters.

* **Bug Fixes**
  * Preserved standard ANSI quoting as a fallback for connectors that do not provide custom quoting.

* **Tests**
  * Added coverage for connector-specific quoting, simple identifiers, hyphenated names, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connector-aware SQL identifier quoting with support for database-specific quoting styles.
  * Improved handling of multipart table names and identifiers containing special characters.

* **Bug Fixes**
  * Preserved standard ANSI quoting as a fallback for connectors without custom quoting support.
  * Improved SQL identifier handling across different database dialects.

* **Tests**
  * Added coverage for connector-specific quoting, simple identifiers, hyphenated names, multipart names, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->