### PR TITLE
[BugFix] Preserve query_metrics across tool registration paths

### DIFF
--- a/datus/tools/func_tool/base.py
+++ b/datus/tools/func_tool/base.py
@@ -6,7 +6,7 @@
 import asyncio
 import inspect
 import json
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional, TypeVar
 
 import json_repair
 from agents import FunctionTool, function_tool
@@ -183,10 +183,27 @@ class FuncToolListResult(BaseModel):
     )
 
 
+_ToolMethod = TypeVar("_ToolMethod", bound=Callable)
+
+
+def tool_schema(*, strict_mode: bool) -> Callable[[_ToolMethod], _ToolMethod]:
+    """Declare schema policy on a callable without wrapping or registering it.
+
+    ``trans_to_function_tool`` reads this declaration for every registration path,
+    including methods selected by name and methods listed by ``available_tools``.
+    """
+
+    def declare(method: _ToolMethod) -> _ToolMethod:
+        method.__datus_tool_strict_mode__ = strict_mode
+        return method
+
+    return declare
+
+
 def trans_to_function_tool(
     bound_method: Callable,
     *,
-    strict_mode: bool = True,
+    strict_mode: Optional[bool] = None,
     excluded_params: Optional[Iterable[str]] = None,
 ) -> FunctionTool:
     """
@@ -195,14 +212,15 @@ def trans_to_function_tool(
 
     Args:
         bound_method: The instance method to wrap.
-        strict_mode: When True (default), the OpenAI Agents SDK enforces a strict JSON schema
-            (no extra properties, no free-form ``Dict[str, Any]`` parameters). Set to False
-            for tools that genuinely need an open-ended object parameter — e.g. a
-            ``sample_params``-style dict where the LLM provides arbitrary keys matching
-            a declaration the tool itself validates.
+        strict_mode: Override the method's ``@tool_schema`` declaration. When omitted,
+            use the declaration, defaulting to True for undeclared methods. Strict mode
+            rejects free-form ``Dict[str, Any]`` parameters. Declare ``strict_mode=False``
+            on methods that accept binding names validated by the tool itself.
         excluded_params: Optional parameter names to remove from the exposed JSON schema.
             Use this for dialect-specific parameters that the current tool instance does not support.
     """
+    if strict_mode is None:
+        strict_mode = getattr(bound_method, "__datus_tool_strict_mode__", True)
     tool_template = function_tool(bound_method, strict_mode=strict_mode)
     excluded_param_set = set(excluded_params or [])
 

--- a/datus/tools/func_tool/semantic_tools.py
+++ b/datus/tools/func_tool/semantic_tools.py
@@ -28,7 +28,13 @@ from datus.tools.func_tool.attribution_utils import (
     AttributionValidationException,
     DimensionAttributionUtil,
 )
-from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, normalize_null, trans_to_function_tool
+from datus.tools.func_tool.base import (
+    FuncToolListResult,
+    FuncToolResult,
+    normalize_null,
+    tool_schema,
+    trans_to_function_tool,
+)
 from datus.tools.func_tool.generation_evidence import GenerationEvidence
 from datus.tools.semantic_tools.base import BaseSemanticAdapter
 from datus.tools.semantic_tools.models import AnomalyContext
@@ -820,9 +826,7 @@ class SemanticTools:
         return [
             trans_to_function_tool(self.list_metrics),
             trans_to_function_tool(self.get_dimensions),
-            # Parameterized Dosi metrics need arbitrary declaration-driven
-            # binding names, so this one schema cannot be strict/closed.
-            trans_to_function_tool(self.query_metrics, strict_mode=False),
+            trans_to_function_tool(self.query_metrics),
             trans_to_function_tool(self.validate_semantic),
             trans_to_function_tool(self.attribution_analyze),
         ]
@@ -973,6 +977,8 @@ class SemanticTools:
                 error=f"Failed to get dimensions: {str(e)}",
             )
 
+    # Dosi binding names come from metric declarations and require an open schema.
+    @tool_schema(strict_mode=False)
     def query_metrics(
         self,
         metrics: List[str],

--- a/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_ask_metrics_agentic_node.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0.
 # See http://www.apache.org/licenses/LICENSE-2.0 for details.
 
-from unittest.mock import MagicMock, Mock, patch
+import json
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -70,6 +71,62 @@ def _make_node(real_agent_config, *, tree, adapter=True, node_config=None, node_
 
 
 class TestAskMetricsAgenticNode:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "tool_patterns, expected_names",
+        [
+            (
+                "semantic_tools.list_metrics,semantic_tools.query_metrics",
+                {"list_metrics", "query_metrics"},
+            ),
+            (
+                "semantic_tools.*",
+                {"list_metrics", "get_dimensions", "query_metrics", "validate_semantic", "attribution_analyze"},
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("params", [None, {"regions": ["APAC", "EMEA"], "threshold": 100}])
+    async def test_registered_query_metrics_executes_with_parameter_bindings(
+        self, real_agent_config, mock_llm_create, tool_patterns, expected_names, params
+    ):
+        from datus.agent.node.ask_metrics_agentic_node import AskMetricsAgenticNode
+        from datus.tools.func_tool.semantic_tools import SemanticTools
+        from datus.tools.semantic_tools.models import QueryResult
+
+        real_agent_config.agentic_nodes["ask_metrics"] = {"tools": tool_patterns}
+        semantic_tools = SemanticTools(real_agent_config, adapter_type="dosi")
+        adapter = Mock()
+        adapter.query_metrics = AsyncMock(return_value=QueryResult(columns=["revenue"], data=[{"revenue": 100}]))
+        semantic_tools._adapter = adapter
+        with (
+            patch("datus.agent.node.ask_metrics_agentic_node.SemanticTools", return_value=semantic_tools),
+            patch("datus.agent.node.ask_metrics_agentic_node.ContextSearchTools", return_value=_context_tools({})),
+        ):
+            node = AskMetricsAgenticNode(
+                node_id="ask_metrics_schema_test",
+                description="Ask metrics",
+                node_type=NodeType.TYPE_ASK_METRICS,
+                agent_config=real_agent_config,
+            )
+
+        tools = {tool.name: tool for tool in node.tools}
+        assert set(tools) == expected_names
+        assert tools["list_metrics"].strict_json_schema is True
+        query_tool = tools["query_metrics"]
+        assert query_tool.strict_json_schema is False
+
+        arguments = {"metrics": ["revenue"]}
+        if params is not None:
+            arguments["params"] = params
+        result = await query_tool.on_invoke_tool(None, json.dumps(arguments))
+
+        assert result["success"] == 1
+        assert result["result"]["columns"] == ["revenue"]
+        assert result["result"]["data"]["original_rows"] == 1
+        assert adapter.query_metrics.await_count == 1
+        assert adapter.query_metrics.call_args.kwargs["metrics"] == ["revenue"]
+        assert adapter.query_metrics.call_args.kwargs.get("params") == params
+
     def test_small_subject_tree_in_prompt_and_no_list_subject_tree_tool(self, real_agent_config, mock_llm_create):
         tree = {
             "Sales": {

--- a/tests/unit_tests/tools/func_tool/test_base.py
+++ b/tests/unit_tests/tools/func_tool/test_base.py
@@ -7,11 +7,12 @@ import asyncio
 import json
 import threading
 from types import SimpleNamespace
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import MagicMock
 
 import pytest
 from agents import Agent, Runner, SQLiteSession
+from agents.exceptions import UserError
 from agents.items import ToolCallItem
 from agents.models.interface import Model
 from agents.run import RunConfig
@@ -22,7 +23,7 @@ from openai.types.responses import (
     ResponseOutputText,
 )
 
-from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, trans_to_function_tool
+from datus.tools.func_tool.base import FuncToolListResult, FuncToolResult, tool_schema, trans_to_function_tool
 from datus.tools.permission.permission_hooks import PermissionHooks
 from datus.tools.permission.permission_manager import PermissionManager
 from datus.tools.permission.profiles import get_profile
@@ -35,6 +36,46 @@ class TestTransToFunctionTool:
     def _make_tool_from_method(self, method):
         """Helper to create a FunctionTool from a bound method."""
         return trans_to_function_tool(method)
+
+    @pytest.mark.asyncio
+    async def test_method_schema_declaration_preserves_dynamic_bindings(self):
+        class ParameterTool:
+            @tool_schema(strict_mode=False)
+            def query(self, params: dict[str, Any]) -> FuncToolResult:
+                return FuncToolResult(result=params)
+
+        class InheritedTool(ParameterTool):
+            pass
+
+        instance = InheritedTool()
+        params = {"regions": ["APAC", "EMEA"], "threshold": 100, "enabled": False}
+        assert instance.query(params).result == params
+        tool = trans_to_function_tool(instance.query)
+        assert tool.strict_json_schema is False
+        assert tool.params_json_schema["properties"]["params"]["additionalProperties"] is True
+        assert "self" not in tool.params_json_schema["properties"]
+        result = await tool.on_invoke_tool(None, json.dumps({"params": params}))
+        assert result == {"success": 1, "error": None, "result": params}
+
+    def test_undeclared_methods_keep_strict_schema(self):
+        class ParameterTool:
+            def query(self, params: dict[str, Any]) -> FuncToolResult:
+                return FuncToolResult(result=params)
+
+        with pytest.raises(UserError, match="additionalProperties should not be set"):
+            trans_to_function_tool(ParameterTool().query)
+
+    @pytest.mark.parametrize("declared_strict", [True, False])
+    @pytest.mark.parametrize("override_strict", [True, False])
+    def test_explicit_schema_mode_overrides_method_declaration(self, declared_strict, override_strict):
+        class ParameterTool:
+            @tool_schema(strict_mode=declared_strict)
+            def query(self, name: str) -> FuncToolResult:
+                return FuncToolResult(result=name)
+
+        tool = trans_to_function_tool(ParameterTool().query, strict_mode=override_strict)
+        assert tool.strict_json_schema is override_strict
+        assert tool.params_json_schema.get("additionalProperties", True) is not override_strict
 
     @pytest.mark.asyncio
     async def test_filters_unexpected_parameters(self):

--- a/tests/unit_tests/tools/func_tool/test_semantic_tools.py
+++ b/tests/unit_tests/tools/func_tool/test_semantic_tools.py
@@ -5,6 +5,7 @@ Test cases for SemanticTools utility functions and query_metrics compression.
 import hashlib
 import json
 from enum import Enum
+from importlib import import_module
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -104,8 +105,57 @@ def mock_adapter(semantic_tools):
 class TestQueryMetricsCompression:
     """Test cases for query_metrics with DataCompressor integration."""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "node_module, node_class",
+        [
+            ("gen_sql_agentic_node", "GenSQLAgenticNode"),
+            ("gen_report_agentic_node", "GenReportAgenticNode"),
+            ("gen_visual_report_agentic_node", "GenVisualReportAgenticNode"),
+            ("gen_visual_dashboard_agentic_node", "GenVisualDashboardAgenticNode"),
+        ],
+    )
+    async def test_named_registration_preserves_parameter_schema(self, semantic_tools, node_module, node_class):
+        node_type = getattr(import_module(f"datus.agent.node.{node_module}"), node_class)
+        node = object.__new__(node_type)
+        node.tools = []
+        node.semantic_tools = semantic_tools
+        node._setup_specific_tool_method("semantic_tools", "query_metrics")
+
+        assert [tool.name for tool in node.tools] == ["query_metrics"]
+        await self._assert_parameterized_query_executes(semantic_tools, node.tools[0])
+
+    @pytest.mark.asyncio
+    async def test_cli_registration_preserves_parameter_schema(self, semantic_tools):
+        from datus.cli.service_client import READ_METHODS, ServiceClient
+
+        client = ServiceClient("semantic_layer", "dosi", semantic_tools, READ_METHODS["semantic_layer"])
+        query_tool = client.get_tool("query_metrics")
+
+        assert query_tool.name == "query_metrics"
+        assert query_tool is client.get_tool("query_metrics")
+        await self._assert_parameterized_query_executes(semantic_tools, query_tool)
+
+    async def _assert_parameterized_query_executes(self, semantic_tools, query_tool):
+        calls = []
+
+        class Adapter:
+            async def query_metrics(self, metrics, params=None, **kwargs):
+                calls.append((metrics, params))
+                return QueryResult(columns=["revenue"], data=[{"revenue": 100}])
+
+        semantic_tools.adapter_type = "dosi"
+        semantic_tools._adapter = Adapter()
+        params = {"regions": ["APAC", "EMEA"], "threshold": 100}
+        assert query_tool.strict_json_schema is False
+        result = await query_tool.on_invoke_tool(None, json.dumps({"metrics": ["revenue"], "params": params}))
+
+        assert result["success"] == 1
+        assert result["result"]["columns"] == ["revenue"]
+        assert calls == [(["revenue"], params)]
+
     def test_tool_schema_exposes_osi_half_open_time_range(self, semantic_tools):
-        schema = trans_to_function_tool(semantic_tools.query_metrics, strict_mode=False).params_json_schema
+        schema = trans_to_function_tool(semantic_tools.query_metrics).params_json_schema
 
         start_description = schema["properties"]["time_start"]["description"].lower()
         end_description = schema["properties"]["time_end"]["description"].lower()


### PR DESCRIPTION
## Why

After #1392 added free-form parameter bindings to `query_metrics`, named tool registration still used strict JSON schema and failed with `additionalProperties should not be set for object types`. AskMetrics consequently lost its default query tool, as detected by [nightly run 33994384699](https://github.com/Datus-ai/Datus-agent/actions/runs/33994384699). Explicit method selection in GenSQL, GenReport, visual report/dashboard nodes, and CLI semantic-service binding reaches the same conversion path.

## Solution

Declare the schema policy on `query_metrics` and have the shared `trans_to_function_tool()` read it. Named registration and `available_tools()` now apply the same policy. Undeclared tools remain strict, and explicit caller overrides retain precedence.

Broader tool selection, capability filtering, and rebuild inconsistencies are tracked separately in #1398.

## Test Cases

- Added real schema conversion and invocation coverage for AskMetrics named/wildcard selection, all four other node entry points, and the CLI; verifies ordinary queries and scalar/list parameter bindings.
- Added converter coverage for inherited methods, unchanged strict defaults, and explicit overrides.
- Latest focused review run: **202 passed**. Broader affected func-tool, node, and CLI suites: **2301 passed, 7 skipped**.
- Whole-repository Ruff lint/format checks and `git diff --check` passed; test audit reports **0 issues**.
- No integration/nightly tests changed: registration is deterministic and covered without an LLM. The existing nightly AskMetrics tool-presence check remains applicable; the complete nightly workflow has not been rerun locally.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-tool schema configuration, allowing tools to declare whether strict schema validation is enabled.
  * Metric query tools now preserve flexible parameter bindings while other tools continue using strict schemas.

* **Bug Fixes**
  * Improved metric query execution across agentic nodes and the CLI, including forwarding optional parameters correctly.

* **Tests**
  * Added coverage for schema configuration, tool registration, parameter handling, and metric query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->