### PR TITLE
[BugFix] Gate Dashboard Bootstrap nightly on deterministic checks

### DIFF
--- a/ci/cross-repo-harness.md
+++ b/ci/cross-repo-harness.md
@@ -30,3 +30,28 @@ When an adapter workflow job is renamed or a new adapter capability is added,
 update the owning adapter repository's required-check document and GitHub ruleset
 in the same change sequence. Datus-agent should only need updates when the
 cross-repository integration contract changes.
+
+## Dashboard Bootstrap Nightly Scope
+
+The P0 Superset group gates four deterministic checks: managed plugin installation
+and real SQL export integrity, two dashboard-node/tool initialization contracts,
+and BI orchestration with fixed generation results. It selects `nightly and not
+product_e2e` from the three dashboard test files. These files are excluded from
+the broad nightly groups, so their three real-model workflows do not run again
+through Product E2E. The deterministic checks do not require provider credentials.
+
+Real-model dashboard workflows are explicit evaluations when changing a skill,
+prompt, or model. They are not warn-only nightly checks. With the normal integration
+environment prepared (test configuration/data, source checkouts, adapter packages,
+Superset/PostgreSQL, and provider credentials), run:
+
+```bash
+uv run pytest -m product_e2e \
+  tests/integration/plugins/test_dashboard_bootstrap_plugin.py \
+  tests/integration/agent/test_gen_dashboard_agentic.py \
+  tests/integration/tools/test_bi_dashboard.py
+```
+
+Evaluation failures retain pytest's nonzero exit status. A green P0 Superset gate
+proves the deterministic contracts, not that a model will always honor the skill's
+confirmation boundary.

--- a/ci/flaky-registry.yml
+++ b/ci/flaky-registry.yml
@@ -33,17 +33,6 @@ entries:
       - nightly
     action: rerun_only
 
-  - id: superset-bi-complete-workflow-provider-disconnect
-    type: test
-    nodeid: tests/integration/tools/test_bi_dashboard.py::TestE2EIntegration::test_complete_workflow
-    owner: bi-agent
-    layer: product_e2e
-    reason: DeepSeek provider disconnected during Superset BI metric generation; rerun passed.
-    allowed_until: 2026-09-05
-    allowed_in:
-      - nightly
-    action: rerun_only
-
   - id: litellm-async-pending-task-teardown
     type: log_pattern
     pattern: "Task was destroyed but it is pending"

--- a/ci/harness/coverage-map.yml
+++ b/ci/harness/coverage-map.yml
@@ -120,14 +120,15 @@ flow_groups:
             status: covered
             nodeids:
               - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_installs_plugin_and_exports_verified_superset_queries
-              - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_real_llm_loads_skill_and_stops_at_manifest
-              - tests/integration/agent/test_gen_dashboard_agentic.py
-              - tests/integration/tools/test_bi_dashboard.py
+              - tests/integration/agent/test_gen_dashboard_agentic.py::TestGenDashboardAgenticInit
+              - tests/integration/tools/test_bi_dashboard.py::TestPartialIntegration::test_workflow_without_llm
               - tests/integration/tools/test_bi_grafana.py
             notes: >
               The P0 Superset path installs the managed plugin from source, verifies a real
-              dashboard SQL export manifest and checksums, and uses a real LLM to load the
-              dashboard-bootstrap skill and stop at its explicit confirmation boundary.
+              dashboard SQL export manifest and checksums, checks node/tool initialization,
+              and exercises BI orchestration with fixed generation results. Superset real-model
+              workflows are manual evaluations; nightly does not guarantee model adherence
+              to the skill's confirmation boundary. See ci/cross-repo-harness.md.
           weekly_benchmark:
             status: not_applicable
             notes: >
@@ -453,7 +454,7 @@ flow_groups:
           nightly:
             status: covered
             nodeids:
-              - tests/integration/tools/test_bi_dashboard.py
+              - tests/integration/tools/test_bi_dashboard.py::TestPartialIntegration::test_workflow_without_llm
               - tests/integration/tools/test_bi_grafana.py
               - tests/integration/agent/test_scheduler_agentic.py
               - tests/integration/adapters/test_starrocks.py
@@ -786,7 +787,7 @@ flow_groups:
           nightly:
             status: covered
             nodeids:
-              - tests/integration/agent/test_gen_dashboard_agentic.py
+              - tests/integration/agent/test_gen_dashboard_agentic.py::TestGenDashboardAgenticInit
               - tests/integration/agent/test_scheduler_agentic.py
               - tests/integration/tools/test_bi_grafana.py
               - tests/integration/agent/test_gen_table_agentic.py
@@ -800,7 +801,9 @@ flow_groups:
             notes: >
               Real-LLM smoke now covers gen_table (CTAS), gen_job (single-DB ETL on an isolated
               SQLite copy), gen_visual_report, and gen_visual_dashboard in addition to the existing
-              dashboard/scheduler/Grafana paths. gen_job cross-DB transfer stays in the unit tier.
+              scheduler/Grafana paths. Superset dashboard initialization is checked with a fake
+              model; its real-model workflow is a manual evaluation. gen_job cross-DB transfer
+              stays in the unit tier.
           weekly_benchmark:
             status: not_applicable
             notes: >
@@ -980,7 +983,6 @@ flow_groups:
             nodeids:
               - tests/integration/plugins/test_sql_policy_plugin.py::test_managed_sql_policy_enforces_sql_semantic_and_api_reads
               - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_installs_plugin_and_exports_verified_superset_queries
-              - tests/integration/plugins/test_dashboard_bootstrap_plugin.py::test_dashboard_bootstrap_real_llm_loads_skill_and_stops_at_manifest
             notes: >
               P0 installs two real source packages only into isolated managed plugin stores (with no
               globally installed fallback), exercises fresh-process entry-point discovery and CLI

--- a/ci/run-nightly-tests.sh
+++ b/ci/run-nightly-tests.sh
@@ -1741,7 +1741,9 @@ run_logged "Main Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PR
 
 run_logged "Product E2E Nightly Tests" run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m "nightly and product_e2e and not provider_health" "${NIGHTLY_PYTEST_ROOTS[@]}" "${NIGHTLY_DEDICATED_SUITE_DESELECTS[@]}" --tb=short --verbose --timeout=600 --timeout-method=thread --reruns 1 --reruns-delay 5
 
-run_compose_suite "P0 Dashboard Bootstrap Skill E2E" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run python -m pytest -m nightly tests/integration/plugins/test_dashboard_bootstrap_plugin.py tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py -p ci.pytest_fail_on_skip_plugin --fail-on-skip --tb=short --verbose --timeout=600 --timeout-method=thread
+# Gate deterministic Superset contracts only. Real-model dashboard workflows
+# remain available for explicit evaluation; see ci/cross-repo-harness.md.
+run_compose_suite "P0 Dashboard Bootstrap Skill E2E" "$SUPERSET_COMPOSE" "postgres:300" "superset:1200" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run python -m pytest -m "nightly and not product_e2e" tests/integration/plugins/test_dashboard_bootstrap_plugin.py tests/integration/agent/test_gen_dashboard_agentic.py tests/integration/tools/test_bi_dashboard.py -p ci.pytest_fail_on_skip_plugin --fail-on-skip --tb=short --verbose --timeout=600 --timeout-method=thread
 
 run_compose_suite "Grafana Nightly Tests" "$GRAFANA_COMPOSE" "postgres:300" "grafana:600" -- run_with_agent_home "$NIGHTLY_HOME" "$NIGHTLY_PROJECT_ROOT" env DATUS_TEST_LAYER=nightly uv run pytest -m nightly tests/integration/tools/test_bi_grafana.py --tb=short --verbose --timeout=300 --timeout-method=thread --reruns 1 --reruns-delay 5
 

--- a/tests/integration/agent/test_gen_dashboard_agentic.py
+++ b/tests/integration/agent/test_gen_dashboard_agentic.py
@@ -5,15 +5,18 @@
 """
 Integration tests for GenDashboardAgenticNode.
 
-Tests the BI dashboard subagent with real Superset (Docker) + real LLM.
+Tests the BI dashboard subagent with real Superset (Docker).
+Initialization contracts use a fake model in nightly. Real-model execution is
+available for manual evaluation with ``-m product_e2e``.
 Requires:
 - Superset running on localhost:8088 (docker compose -f ../datus-bi-adapters/datus-bi-superset/tests/integration/docker-compose.yml up -d)
 - datus-bi-superset package installed
-- LLM API key (DEEPSEEK_API_KEY)
+- LLM API key (DEEPSEEK_API_KEY) for manual real-model evaluation only
 """
 
 import copy
 import os
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -39,8 +42,6 @@ def _is_superset_running() -> bool:
 @pytest.fixture(scope="module")
 def dashboard_agent_config():
     """Load acceptance config with gen_dashboard agentic node configured."""
-    if not os.environ.get("DEEPSEEK_API_KEY"):
-        pytest.skip("DEEPSEEK_API_KEY not set")
     if not _is_superset_running():
         pytest.skip(f"Superset not reachable at {SUPERSET_URL}. Run docker compose up -d")
     pytest.importorskip("datus_bi_superset", reason="datus-bi-superset package not installed")
@@ -72,7 +73,17 @@ def dashboard_agent_config():
     return config
 
 
+@pytest.fixture
+def mock_dashboard_model():
+    """Keep node/tool initialization independent of provider credentials and APIs."""
+    from tests.unit_tests.mock_llm_model import MockLLMModel
+
+    with patch("datus.models.base.LLMBaseModel.create_model", return_value=MockLLMModel()):
+        yield
+
+
 @pytest.mark.nightly
+@pytest.mark.usefixtures("mock_dashboard_model")
 class TestGenDashboardAgenticInit:
     """Integration tests for GenDashboardAgenticNode initialization with real Superset."""
 
@@ -125,12 +136,15 @@ class TestGenDashboardAgenticInit:
 @pytest.mark.nightly
 @pytest.mark.product_e2e
 class TestGenDashboardAgenticExecution:
-    """Integration tests for GenDashboardAgenticNode execute_stream with real Superset + LLM."""
+    """Manual evaluation of execute_stream with real Superset + LLM."""
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(300)
     async def test_list_dashboards(self, dashboard_agent_config):
         """execute_stream should list dashboards from real Superset."""
+        if not os.environ.get("DEEPSEEK_API_KEY"):
+            pytest.skip("DEEPSEEK_API_KEY not set")
+
         from datus.agent.node.gen_dashboard_agentic_node import GenDashboardAgenticNode
         from datus.schemas.action_history import ActionHistoryManager, ActionRole, ActionStatus
         from datus.schemas.gen_dashboard_agentic_node_models import GenDashboardNodeInput

--- a/tests/integration/plugins/test_dashboard_bootstrap_plugin.py
+++ b/tests/integration/plugins/test_dashboard_bootstrap_plugin.py
@@ -233,7 +233,7 @@ def test_dashboard_bootstrap_real_llm_loads_skill_and_stops_at_manifest(
     managed_plugin_runtime,
     tmp_path,
 ):
-    """Keep one real-model smoke at the skill's explicit confirmation boundary."""
+    """Manual real-model evaluation of the skill's confirmation boundary."""
     assert os.environ.get("DEEPSEEK_API_KEY"), "P0 Dashboard LLM smoke requires DEEPSEEK_API_KEY"
     assert importlib.util.find_spec("datus_superset_plugin") is None, (
         "P0 must not have a globally installed datus-superset-plugin fallback"

--- a/tests/integration/tools/test_bi_dashboard.py
+++ b/tests/integration/tools/test_bi_dashboard.py
@@ -6,7 +6,7 @@
 
 Contains two test classes at different verification levels:
 - TestPartialIntegration: Real Superset API + mocked LLM (nightly)
-- TestE2EIntegration: Full end-to-end with zero mocks (nightly only)
+- TestE2EIntegration: Full end-to-end with zero mocks (manual, ``-m product_e2e``)
 """
 
 import os

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -1,6 +1,8 @@
 import os
 import re
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -131,6 +133,48 @@ def test_nightly_runs_p0_contracts_without_reruns_or_skips():
 
     assert '"P0 PostgreSQL Agent Storage Contracts"' in script.split("DOCKER_GROUPS=(", maxsplit=1)[1]
     assert '"P0 Dashboard Bootstrap Skill E2E"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
+
+
+def test_dashboard_nightly_collects_only_deterministic_contracts(monkeypatch):
+    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
+    command = next(
+        line
+        for line in script.replace("\\\n", " ").splitlines()
+        if line.startswith('run_compose_suite "P0 Dashboard Bootstrap Skill E2E"')
+    )
+    tokens = shlex.split(command)
+    pytest_args = tokens[tokens.index("pytest") + 1 :]
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *pytest_args,
+            "--collect-only",
+            "-o",
+            "addopts=",
+            "-o",
+            "log_cli=false",
+            "-q",
+            "-q",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    nodeids = {line.strip() for line in result.stdout.splitlines() if line.startswith("tests/") and "::" in line}
+    assert nodeids == {
+        "tests/integration/plugins/test_dashboard_bootstrap_plugin.py::"
+        "test_dashboard_bootstrap_installs_plugin_and_exports_verified_superset_queries",
+        "tests/integration/agent/test_gen_dashboard_agentic.py::"
+        "TestGenDashboardAgenticInit::test_node_initialization_with_bi_tools",
+        "tests/integration/agent/test_gen_dashboard_agentic.py::"
+        "TestGenDashboardAgenticInit::test_no_db_or_filesystem_tools",
+        "tests/integration/tools/test_bi_dashboard.py::TestPartialIntegration::test_workflow_without_llm",
+    }
 
 
 def test_nightly_tracebacks_do_not_publish_local_credentials():

--- a/tests/unit_tests/ci/test_nightly_checkout_contract.py
+++ b/tests/unit_tests/ci/test_nightly_checkout_contract.py
@@ -1,8 +1,6 @@
 import os
 import re
-import shlex
 import subprocess
-import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -133,48 +131,6 @@ def test_nightly_runs_p0_contracts_without_reruns_or_skips():
 
     assert '"P0 PostgreSQL Agent Storage Contracts"' in script.split("DOCKER_GROUPS=(", maxsplit=1)[1]
     assert '"P0 Dashboard Bootstrap Skill E2E"' in script.split("COMPOSE_GROUPS=(", maxsplit=1)[1]
-
-
-def test_dashboard_nightly_collects_only_deterministic_contracts(monkeypatch):
-    script = NIGHTLY_SCRIPT.read_text(encoding="utf-8")
-    command = next(
-        line
-        for line in script.replace("\\\n", " ").splitlines()
-        if line.startswith('run_compose_suite "P0 Dashboard Bootstrap Skill E2E"')
-    )
-    tokens = shlex.split(command)
-    pytest_args = tokens[tokens.index("pytest") + 1 :]
-    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            *pytest_args,
-            "--collect-only",
-            "-o",
-            "addopts=",
-            "-o",
-            "log_cli=false",
-            "-q",
-            "-q",
-        ],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
-    nodeids = {line.strip() for line in result.stdout.splitlines() if line.startswith("tests/") and "::" in line}
-    assert nodeids == {
-        "tests/integration/plugins/test_dashboard_bootstrap_plugin.py::"
-        "test_dashboard_bootstrap_installs_plugin_and_exports_verified_superset_queries",
-        "tests/integration/agent/test_gen_dashboard_agentic.py::"
-        "TestGenDashboardAgenticInit::test_node_initialization_with_bi_tools",
-        "tests/integration/agent/test_gen_dashboard_agentic.py::"
-        "TestGenDashboardAgenticInit::test_no_db_or_filesystem_tools",
-        "tests/integration/tools/test_bi_dashboard.py::TestPartialIntegration::test_workflow_without_llm",
-    }
 
 
 def test_nightly_tracebacks_do_not_publish_local_credentials():


### PR DESCRIPTION
## Why

The P0 Dashboard Bootstrap nightly group currently mixes deterministic integration contracts with three real-model workflows. A model's exploratory command choice or convergence can therefore fail the release gate even when plugin installation, BI APIs, and SQL export work correctly, as in [nightly run 34023760920](https://github.com/Datus-ai/Datus-agent/actions/runs/34023760920).

Related: #910.

## Solution

- Run the four deterministic Superset contracts in the P0 nightly group: managed plugin installation and export integrity, two node/tool initialization checks, and BI orchestration with fixed generation results.
- Keep the three real-model workflows available for explicit manual evaluation with their normal pytest failure status. Existing exclusions prevent them from running through the broad nightly groups.
- Use the existing fake model for initialization checks and require provider credentials only for real-model execution.
- Align coverage claims and evaluation instructions, and remove the nightly flaky-registry entry for the now-manual BI workflow.

Scope is limited to test execution and coverage bookkeeping. The original skill, confirmation rules, and production code are unchanged.

## Test Cases

- Real local Superset 4.1.2/PostgreSQL 16 integration, with DeepSeek and OpenAI keys unset: **4 passed, 3 deselected**.
- Related CI, coverage-map, and GenDashboard unit suites: **146 passed**.
- Explicit manual evaluation collection: **3 selected, 4 deselected**; real-model evaluations were not executed.
- Repository Ruff lint/format, strict coverage-map validation, shell syntax, and git diff checks passed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **New Features**
  * Added documentation for the Dashboard Bootstrap nightly test scope and explicit real-model evaluation command.
  * Nightly coverage now includes deterministic dashboard initialization and BI orchestration checks without requiring provider credentials.

* **Bug Fixes**
  * Improved nightly reliability by replacing real-model checks with deterministic validation and fixed results.

* **Tests**
  * Real-model dashboard and BI workflows are now opt-in evaluations rather than nightly checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->