### PR TITLE
[BugFix] Defer unknown OpenAI cache retention to API defaults

### DIFF
--- a/datus/models/openai_compatible.py
+++ b/datus/models/openai_compatible.py
@@ -324,12 +324,13 @@ class OpenAICompatibleModel(LLMBaseModel):
         return is_official_openai_endpoint(self.model_config.type, self.base_url)
 
     def _default_prompt_cache_retention(self) -> Optional[str]:
-        """Choose a safe default prompt cache retention policy for OpenAI."""
+        """Set known OpenAI retention policies; otherwise defer to the API default."""
         if not self._is_official_openai_api():
             return None
-        if self.model_name.startswith("gpt-5"):
+        # GPT-6 Astra rejects in_memory and requires extended prompt caching.
+        if self.model_name.startswith(("gpt-5", "gpt-6-astra")):
             return "24h"
-        return "in_memory"
+        return None
 
     def _model_supports_reasoning(self) -> bool:
         """Decide whether ``/effort`` should inject ``Reasoning(effort=…)``.
@@ -1072,11 +1073,11 @@ class OpenAICompatibleModel(LLMBaseModel):
         prompt_cache_retention = self._default_prompt_cache_retention()
         if prompt_cache_retention:
             model_settings_kwargs["prompt_cache_retention"] = prompt_cache_retention
-            prompt_cache_key = self._default_prompt_cache_key(agent_name)
-            if prompt_cache_key:
-                existing_extra_args = model_settings_kwargs.get("extra_args", {})
-                existing_extra_args["prompt_cache_key"] = prompt_cache_key
-                model_settings_kwargs["extra_args"] = existing_extra_args
+        prompt_cache_key = self._default_prompt_cache_key(agent_name)
+        if prompt_cache_key:
+            existing_extra_args = model_settings_kwargs.get("extra_args", {})
+            existing_extra_args["prompt_cache_key"] = prompt_cache_key
+            model_settings_kwargs["extra_args"] = existing_extra_args
 
         # When the hosted web_search tool is in play, ask the Responses API to
         # echo the per-call source URLs (``action.sources``). They are a fallback

--- a/tests/unit_tests/models/test_openai_compatible.py
+++ b/tests/unit_tests/models/test_openai_compatible.py
@@ -1747,6 +1747,30 @@ class TestBuildAgent:
         ms = call_args[1]["model_settings"]
         assert ms.extra_headers == {"X-Custom": "value"}
 
+    @pytest.mark.parametrize(
+        "model_name,provider,base_url,expected_retention,expected_cache_key",
+        [
+            ("gpt-6-astra", "openai", None, "24h", True),
+            ("gpt-6-astra", "openai", "https://api.openai.com/v1", "24h", True),
+            ("gpt-6-astra-2026-09-01", "openai", None, "24h", True),
+            ("gpt-5.5", "openai", None, "24h", True),
+            ("gpt-4o", "openai", None, None, True),
+            ("gpt-7-test", "openai", None, None, True),
+            ("gpt-7-test", "openai", "https://api.openai.com/v1", None, True),
+            ("future-model", "openai", None, None, True),
+            ("gpt-6-astra", "openai", "https://proxy.example.com/v1", None, False),
+            ("openai/gpt-6-astra", "openrouter", None, None, False),
+        ],
+    )
+    def test_prompt_cache_settings(self, model_name, provider, base_url, expected_retention, expected_cache_key):
+        cfg = _make_model_config(model=model_name, model_type=provider, base_url=base_url)
+        model = _make_model(cfg)
+        model.litellm_adapter.provider = provider
+        _, call_args = self._call_build_agent(model)
+        ms = call_args[1]["model_settings"]
+        assert ms.prompt_cache_retention == expected_retention
+        assert bool((ms.extra_args or {}).get("prompt_cache_key")) == expected_cache_key
+
     def test_max_tokens_from_model_specs_applied_to_model_settings(self):
         """Streaming/tool path: model_specs.max_tokens flows into ModelSettings."""
         model = _make_model()


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

<!-- What problem does this PR solve? Link related issues if applicable. -->

Datus sends `prompt_cache_retention="in_memory"` for OpenAI models outside the GPT-5 family. GPT-6 Astra rejects that value with HTTP 400 because it requires `24h` extended caching. The same fallback can also reject future models with different retention requirements.

## Solution

<!-- How does this PR solve the problem? Describe the approach, key design decisions, and any tradeoffs considered. -->

- Use `24h` for GPT-6 Astra while preserving the existing GPT-5 rule.
- Omit `prompt_cache_retention` for models without a matching rule so the API selects its default.
- Set the stable `prompt_cache_key` independently of retention. Keep both parameters omitted for third-party endpoints.

## Test Cases

<!-- What integration/nightly test cases were added or modified? If none, explain why. -->

- Parameterized agent-construction tests cover Astra, dated model names, GPT-5, models without retention rules, explicit official URLs, and third-party endpoints. Assertions check retention and cache-key presence independently.
- Verified red before green: Astra cases failed before the Astra fix, and four default-retention cases failed before replacing the `in_memory` fallback.
- No integration/nightly tests added: this change controls request settings and is covered deterministically with mocked external calls; no real API credentials are needed.
- Ruff formatting/lint and both pre-commit hooks passed.
- Test-quality audit against `datus/main`: P0=0, P1=0.

- PR harness (`uv run --no-sync python ci/run-pr-tests.py datus/main`) passed in a clean worktree: 1,193 tests, 0 failures, 100% diff coverage. The clean worktree excludes personal `.datus/config.yml` overrides that interfere with acceptance fixtures.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated prompt caching behavior for newer OpenAI model families.
  * Prompt cache keys are now applied consistently when supported, including when no retention policy is specified.
  * Prompt caching remains disabled for unsupported proxy and OpenRouter routes.

* **Tests**
  * Added coverage for prompt-cache behavior across model generations, providers, direct routes, and proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->