### PR TITLE
[BugFix] Sync requirements.txt with pyproject.toml and check it stays that way

### DIFF
--- a/ci/check_release_readiness.py
+++ b/ci/check_release_readiness.py
@@ -146,6 +146,47 @@ def check_console_script_versions(
     return errors
 
 
+def check_requirements_match_pyproject(repo_root: Path) -> list[str]:
+    """Require requirements.txt to restate ``project.dependencies`` exactly.
+
+    Both lists are maintained by hand — nothing regenerates ``requirements.txt``
+    — so they drift silently, and the drift is not cosmetic. Consumers install
+    ``-r requirements.txt`` before ``pip install -e .``, and only the second
+    command reads pyproject, so a stale pin here decides what actually gets
+    installed until some later command happens to override it. That is how
+    ``openai-agents`` sat at 0.7.0 here for a release after pyproject moved to
+    0.13.4, and how ``jsonschema``/``jinja2`` — required by the plugin manifest
+    loader — were missing from this file entirely.
+
+    ``check_adapter_dependency_consistency`` below covers only the four adapter
+    packages, and only their lower bounds, which is why none of that was caught.
+    """
+    pyproject_deps = read_pyproject_dependencies(repo_root)
+    requirements_deps = read_requirements_dependencies(repo_root)
+    errors: list[str] = []
+
+    for name in sorted(set(pyproject_deps) - set(requirements_deps)):
+        errors.append(f"{pyproject_deps[name].name} is in pyproject.toml but missing from requirements.txt")
+    for name in sorted(set(requirements_deps) - set(pyproject_deps)):
+        errors.append(f"{requirements_deps[name].name} is in requirements.txt but missing from pyproject.toml")
+
+    for name in sorted(set(pyproject_deps) & set(requirements_deps)):
+        expected = pyproject_deps[name]
+        actual = requirements_deps[name]
+        if expected.specifier != actual.specifier:
+            errors.append(
+                f"{expected.name} version mismatch: pyproject.toml has "
+                f"'{expected.specifier}', requirements.txt has '{actual.specifier}'"
+            )
+        if expected.extras != actual.extras:
+            errors.append(
+                f"{expected.name} extras mismatch: pyproject.toml has "
+                f"{sorted(expected.extras)}, requirements.txt has {sorted(actual.extras)}"
+            )
+
+    return errors
+
+
 def check_adapter_dependency_consistency(
     repo_root: Path,
     package_names: Iterable[str] = ADAPTER_CORE_PACKAGES,
@@ -284,6 +325,8 @@ def main(argv: list[str] | None = None) -> int:
         errors.extend(check_installed_distribution_version(version))
     if args.check_console_versions:
         errors.extend(check_console_script_versions(version))
+
+    errors.extend(check_requirements_match_pyproject(repo_root))
 
     dependency_checks, dependency_errors = check_adapter_dependency_consistency(repo_root)
     errors.extend(dependency_errors)

--- a/ci/check_release_readiness.py
+++ b/ci/check_release_readiness.py
@@ -183,6 +183,19 @@ def check_requirements_match_pyproject(repo_root: Path) -> list[str]:
                 f"{expected.name} extras mismatch: pyproject.toml has "
                 f"{sorted(expected.extras)}, requirements.txt has {sorted(actual.extras)}"
             )
+        # A marker or a direct-reference URL decides whether a dependency is
+        # installed at all, and from where, while leaving the specifier and
+        # extras identical — so neither is covered by the comparisons above.
+        if expected.marker != actual.marker:
+            errors.append(
+                f"{expected.name} marker mismatch: pyproject.toml has "
+                f"'{expected.marker}', requirements.txt has '{actual.marker}'"
+            )
+        if expected.url != actual.url:
+            errors.append(
+                f"{expected.name} URL mismatch: pyproject.toml has "
+                f"'{expected.url}', requirements.txt has '{actual.url}'"
+            )
 
     return errors
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,28 @@
+# Runtime dependencies, mirroring `project.dependencies` in pyproject.toml.
+# `ci/check_release_readiness.py` compares the two and fails on any drift, so
+# every edit here needs the matching edit there (and vice versa).
 python-dotenv==1.0.0
 pandas==2.1.4
 sqlalchemy==2.0.23
 sqlglot>=26.12.0,<31
 pyyaml==6.0.1
-lancedb==0.18.0
+packaging>=21.0
+lancedb==0.34.0
 fastembed==0.4.2
 structlog>=23.1.0
-openai>=2.8.0
+# Floor: openai-agents 0.13.x requires openai>=2.26. Cap below 2.45.0: openai
+# 2.45.0 made ``InputTokensDetails.cache_write_tokens`` a required field and
+# ``datus/models/claude_model.py`` still constructs ``InputTokensDetails``
+# without it. Lift the cap together with that code.
+openai>=2.26.0,<2.45.0
 httpx[socks]==0.27.2
 tantivy>=0.22.2
 aiohttp>=3.11.16
 xlsxwriter>=3.2.2
 openpyxl>=3.1.5
 xlrd>=2.0.1
-openai-agents[litellm]==0.7.0
-openinference-instrumentation-openai-agents>=1.0.0
+openai-agents[litellm]==0.13.4
+openinference-instrumentation-openai-agents==1.6.2
 opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp>=1.20.0
@@ -43,7 +51,10 @@ beautifulsoup4>=4.12.0
 lxml>=5.0.0
 markdown-it-py>=3.0.0
 tabulate>=0.9.0
-datus-storage-base==0.1.5
+# Plugin manifest: config-schema validation and system-prompt templates
+jsonschema>=4.17,<5
+jinja2>=3.1,<4
+datus-storage-base>=0.1.5,<0.2.0
 datus-db-core>=0.1.6
 datus-semantic-core>=0.2.3
 datus-bi-core>=0.1.2

--- a/tests/unit_tests/ci/test_check_release_readiness.py
+++ b/tests/unit_tests/ci/test_check_release_readiness.py
@@ -136,7 +136,7 @@ def test_requirements_match_pyproject_accepts_identical_lists(tmp_path, check_re
         ("version", "datus-db-core>=0.9.9", "datus-db-core>=0.1.3", (">=0.9.9", ">=0.1.3")),
         # Extras decide what else gets installed — `openai-agents[litellm]` is
         # what pulls in litellm — while leaving the specifier identical.
-        ("extras", "datus-db-core[extra]>=0.1.3", "datus-db-core>=0.1.3", ("extra",)),
+        ("extras", "datus-db-core[extra]>=0.1.3", "datus-db-core>=0.1.3", ("['extra']", "[]")),
         # A marker decides whether the dependency is installed at all.
         (
             "marker",

--- a/tests/unit_tests/ci/test_check_release_readiness.py
+++ b/tests/unit_tests/ci/test_check_release_readiness.py
@@ -112,24 +112,66 @@ def test_console_script_versions_reports_missing_command(check_release_readiness
     assert errors == ["datus --version failed to execute: missing datus"]
 
 
+def _rewrite_dependency(repo_root: Path, filename: str, old: str, new: str) -> None:
+    """Restate one dependency in either file, in that file's own syntax."""
+    path = repo_root / filename
+    if filename == "pyproject.toml":
+        # A marker embeds double quotes, so quote those entries as TOML literal
+        # strings instead — otherwise the array stops parsing mid-value.
+        quote = "'" if '"' in new else '"'
+        old, new = f'"{old}"', f"{quote}{new}{quote}"
+    path.write_text(path.read_text(encoding="utf-8").replace(old, new), encoding="utf-8")
+
+
 def test_requirements_match_pyproject_accepts_identical_lists(tmp_path, check_release_readiness):
     repo_root = _write_release_repo(tmp_path)
 
     assert check_release_readiness.check_requirements_match_pyproject(repo_root) == []
 
 
-def test_requirements_match_pyproject_rejects_a_stale_pin(tmp_path, check_release_readiness):
-    """The exact drift this check was added for: a pin left behind in one file."""
+@pytest.mark.parametrize(
+    ("field", "pyproject_form", "requirements_form", "expected_fragments"),
+    [
+        # The drift this check was added for: a pin left behind in one file.
+        ("version", "datus-db-core>=0.9.9", "datus-db-core>=0.1.3", (">=0.9.9", ">=0.1.3")),
+        # Extras decide what else gets installed — `openai-agents[litellm]` is
+        # what pulls in litellm — while leaving the specifier identical.
+        ("extras", "datus-db-core[extra]>=0.1.3", "datus-db-core>=0.1.3", ("extra",)),
+        # A marker decides whether the dependency is installed at all.
+        (
+            "marker",
+            'datus-db-core>=0.1.3; python_version < "3.12"',
+            'datus-db-core>=0.1.3; python_version >= "3.12"',
+            ('python_version < "3.12"', 'python_version >= "3.12"'),
+        ),
+        # A direct reference decides where it is installed from.
+        (
+            "URL",
+            "datus-db-core@ https://example.invalid/a.whl",
+            "datus-db-core@ https://example.invalid/b.whl",
+            ("a.whl", "b.whl"),
+        ),
+    ],
+)
+def test_requirements_match_pyproject_rejects_every_kind_of_divergence(
+    tmp_path, check_release_readiness, field, pyproject_form, requirements_form, expected_fragments
+):
+    """Any field that changes what pip installs must be compared, not just the version.
+
+    Asserts the invariant rather than the wording: exactly one error, naming the
+    package, the field, and what each file declares — enough to act on.
+    """
     repo_root = _write_release_repo(tmp_path)
-    pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
-    (repo_root / "pyproject.toml").write_text(
-        pyproject.replace('"datus-db-core>=0.1.3"', '"datus-db-core>=0.9.9"'),
-        encoding="utf-8",
-    )
+    _rewrite_dependency(repo_root, "pyproject.toml", "datus-db-core>=0.1.3", pyproject_form)
+    _rewrite_dependency(repo_root, "requirements.txt", "datus-db-core>=0.1.3", requirements_form)
 
-    errors = check_release_readiness.check_requirements_match_pyproject(repo_root)
+    (error,) = check_release_readiness.check_requirements_match_pyproject(repo_root)
 
-    assert errors == ["datus-db-core version mismatch: pyproject.toml has '>=0.9.9', requirements.txt has '>=0.1.3'"]
+    assert "datus-db-core" in error
+    assert field in error
+    assert "pyproject.toml" in error and "requirements.txt" in error
+    for fragment in expected_fragments:
+        assert fragment in error
 
 
 def test_requirements_match_pyproject_reports_dependencies_missing_from_either_side(tmp_path, check_release_readiness):
@@ -142,27 +184,13 @@ def test_requirements_match_pyproject_reports_dependencies_missing_from_either_s
 
     errors = check_release_readiness.check_requirements_match_pyproject(repo_root)
 
-    assert errors == [
-        "datus-bi-core is in pyproject.toml but missing from requirements.txt",
-        "leftover-package is in requirements.txt but missing from pyproject.toml",
-    ]
-
-
-def test_requirements_match_pyproject_rejects_dropped_extras(tmp_path, check_release_readiness):
-    """Extras carry real installs — `openai-agents[litellm]` pulls in litellm."""
-    repo_root = _write_release_repo(tmp_path)
-    for name, replacement in (
-        ("pyproject.toml", '"datus-db-core[extra]>=0.1.3"'),
-        ("requirements.txt", None),
-    ):
-        if replacement is None:
-            continue
-        content = (repo_root / name).read_text(encoding="utf-8")
-        (repo_root / name).write_text(content.replace('"datus-db-core>=0.1.3"', replacement), encoding="utf-8")
-
-    errors = check_release_readiness.check_requirements_match_pyproject(repo_root)
-
-    assert errors == ["datus-db-core extras mismatch: pyproject.toml has ['extra'], requirements.txt has []"]
+    # Both directions are reported, each naming the file it is missing from —
+    # a one-way check would let a dependency added to only pyproject slip past.
+    assert len(errors) == 2
+    dropped = next(error for error in errors if "datus-bi-core" in error)
+    assert "missing from requirements.txt" in dropped
+    stale = next(error for error in errors if "leftover-package" in error)
+    assert "missing from pyproject.toml" in stale
 
 
 def test_adapter_dependency_consistency_accepts_matching_lower_bounds(tmp_path, check_release_readiness):

--- a/tests/unit_tests/ci/test_check_release_readiness.py
+++ b/tests/unit_tests/ci/test_check_release_readiness.py
@@ -112,6 +112,59 @@ def test_console_script_versions_reports_missing_command(check_release_readiness
     assert errors == ["datus --version failed to execute: missing datus"]
 
 
+def test_requirements_match_pyproject_accepts_identical_lists(tmp_path, check_release_readiness):
+    repo_root = _write_release_repo(tmp_path)
+
+    assert check_release_readiness.check_requirements_match_pyproject(repo_root) == []
+
+
+def test_requirements_match_pyproject_rejects_a_stale_pin(tmp_path, check_release_readiness):
+    """The exact drift this check was added for: a pin left behind in one file."""
+    repo_root = _write_release_repo(tmp_path)
+    pyproject = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    (repo_root / "pyproject.toml").write_text(
+        pyproject.replace('"datus-db-core>=0.1.3"', '"datus-db-core>=0.9.9"'),
+        encoding="utf-8",
+    )
+
+    errors = check_release_readiness.check_requirements_match_pyproject(repo_root)
+
+    assert errors == ["datus-db-core version mismatch: pyproject.toml has '>=0.9.9', requirements.txt has '>=0.1.3'"]
+
+
+def test_requirements_match_pyproject_reports_dependencies_missing_from_either_side(tmp_path, check_release_readiness):
+    repo_root = _write_release_repo(tmp_path)
+    requirements = (repo_root / "requirements.txt").read_text(encoding="utf-8")
+    (repo_root / "requirements.txt").write_text(
+        requirements.replace("datus-bi-core>=0.1.2\n", "") + "\nleftover-package>=1.0\n",
+        encoding="utf-8",
+    )
+
+    errors = check_release_readiness.check_requirements_match_pyproject(repo_root)
+
+    assert errors == [
+        "datus-bi-core is in pyproject.toml but missing from requirements.txt",
+        "leftover-package is in requirements.txt but missing from pyproject.toml",
+    ]
+
+
+def test_requirements_match_pyproject_rejects_dropped_extras(tmp_path, check_release_readiness):
+    """Extras carry real installs — `openai-agents[litellm]` pulls in litellm."""
+    repo_root = _write_release_repo(tmp_path)
+    for name, replacement in (
+        ("pyproject.toml", '"datus-db-core[extra]>=0.1.3"'),
+        ("requirements.txt", None),
+    ):
+        if replacement is None:
+            continue
+        content = (repo_root / name).read_text(encoding="utf-8")
+        (repo_root / name).write_text(content.replace('"datus-db-core>=0.1.3"', replacement), encoding="utf-8")
+
+    errors = check_release_readiness.check_requirements_match_pyproject(repo_root)
+
+    assert errors == ["datus-db-core extras mismatch: pyproject.toml has ['extra'], requirements.txt has []"]
+
+
 def test_adapter_dependency_consistency_accepts_matching_lower_bounds(tmp_path, check_release_readiness):
     repo_root = _write_release_repo(tmp_path)
 


### PR DESCRIPTION
## Why

`requirements.txt` and `project.dependencies` are both maintained by hand, and nothing regenerates the former — `prepare-release.yml` only writes `requirements-test.txt`, then `git add`s both, which reads as if the first were being updated too. It was not, and it had drifted across eight entries:

| package | requirements.txt | pyproject.toml |
|---|---|---|
| `openai-agents[litellm]` | `==0.7.0` | `==0.13.4` |
| `openai` | `>=2.8.0` | `>=2.26.0,<2.45.0` |
| `openinference-instrumentation-openai-agents` | `>=1.0.0` | `==1.6.2` |
| `lancedb` | `==0.18.0` | `==0.34.0` |
| `datus-storage-base` | `==0.1.5` | `>=0.1.5,<0.2.0` |
| `packaging` | **absent** | `>=21.0` |
| `jsonschema` | **absent** | `>=4.17,<5` |
| `jinja2` | **absent** | `>=3.1,<4` |

This is not cosmetic. Consumers install `-r requirements.txt` before `pip install -e .`, and only the second command reads pyproject, so the stale pins decide what actually lands until something later happens to override them — an ordering dependency that is load-bearing and undocumented.

Two specifics worth calling out:

- **`jsonschema` and `jinja2` back the plugin manifest loader** (`datus/plugins/registry.py`) — config-schema validation and system-prompt templates — and were missing from this file entirely.
- **`openai` carried no upper bound** while pyproject caps it below 2.45.0, where `InputTokensDetails.cache_write_tokens` became a required field and `datus/models/claude_model.py` still constructs it without one.

This surfaced while debugging a benchmark run: `openai-agents` resolved to 0.7.0, whose `LitellmModel.__init__` does not accept the `should_replay_reasoning_content` argument that #1400 started passing, and every model turn died with a `TypeError`.

**Why the existing check missed it.** `check_adapter_dependency_consistency` already compares the two files, but only across `ADAPTER_CORE_PACKAGES` (the four `datus-*-core` packages) and only their `>=` lower bounds. Nothing else in either file was ever compared — 48 of the 52 dependencies were invisible to it, and even for those four, an upper bound could differ freely.

## Solution

- Sync all eight entries, carrying over the explanatory comments that justify the `openai` cap so the reason travels with the pin.
- Add `check_requirements_match_pyproject`, comparing **every** dependency across all four fields that decide what pip installs: names in both directions, `specifier`, `extras`, `marker`, and direct-reference `url`. The last three matter on their own — `openai-agents[litellm]` is what pulls in litellm, a marker decides whether a dependency is installed at all, and a URL decides where it comes from, each while leaving the specifier identical.
- Head `requirements.txt` with a comment stating that the check enforces this, so the next editor knows both files move together.

The check already runs on every PR: `code-quality.yml` fires on `pull_request_target` and calls `run-ut-and-coverage.yml`, whose `Check release metadata` step is unconditional. (`merge-queue.yml` runs it too, but that step is gated on `github.event_name != 'pull_request_target'`, so there it only fires in the merge queue. PRs titled `[Doc]` skip the coverage job entirely.) So the next drift fails on the contributor's PR rather than at release time.

## Test Cases

Unit tests only, in `tests/unit_tests/ci/test_check_release_readiness.py` — this is a CI metadata script with no runtime surface, so there is nothing for an integration or nightly case to exercise.

- `test_requirements_match_pyproject_accepts_identical_lists` — the passing baseline.
- `test_requirements_match_pyproject_rejects_every_kind_of_divergence` — parametrized over `version`, `extras`, `marker`, and `URL`. Asserts the property rather than the message: exactly one error, naming the package, the field, and what each file declares.
- `test_requirements_match_pyproject_reports_dependencies_missing_from_either_side` — both directions, since a one-way check would let a dependency added to only pyproject slip past.

Pre-existing `test_main_offline_checks_pass_for_current_repo` runs the full offline check against this repo, so the new comparison is exercised against the real dependency lists, not just fixtures.

**Red-first verification** (per the `[BugFix]` requirement in CLAUDE.md), done in both directions:

1. *New tests against the pre-fix implementation.* Replacing `ci/check_release_readiness.py` with `main`'s copy and rerunning: **6 failed**, all of them the new cases.
2. *New check against the pre-fix `requirements.txt`.* Running `check_requirements_match_pyproject` over `main`'s dependency list reports all eight real divergences, none missed:

```
jinja2 is in pyproject.toml but missing from requirements.txt
jsonschema is in pyproject.toml but missing from requirements.txt
packaging is in pyproject.toml but missing from requirements.txt
datus-storage-base version mismatch: pyproject.toml has '<0.2.0,>=0.1.5', requirements.txt has '==0.1.5'
lancedb version mismatch: pyproject.toml has '==0.34.0', requirements.txt has '==0.18.0'
openai version mismatch: pyproject.toml has '<2.45.0,>=2.26.0', requirements.txt has '>=2.8.0'
openai-agents version mismatch: pyproject.toml has '==0.13.4', requirements.txt has '==0.7.0'
openinference-instrumentation-openai-agents version mismatch: pyproject.toml has '==1.6.2', requirements.txt has '>=1.0.0'
```

For contrast, the pre-fix script over that same pre-fix list prints `Release readiness checks passed for datus-agent 0.4.0` — a major-version gap plus three absent dependencies, entirely silent.

`17 passed` after restoring both files.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependency requirements, including package upgrades and additional dependencies.
  * Added validation to ensure declared dependency requirements remain synchronized and consistent.

* **Tests**
  * Added coverage for matching dependencies, version differences, missing packages, and extras mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependency requirements with package upgrades, newly specified dependencies, and revised version constraints.
  * Added an automated check that verifies dependency declarations remain synchronized across project configuration and installation requirements.

* **Tests**
  * Expanded coverage for dependency version differences, missing packages, extras, environment markers, and direct-reference URLs.
  * Improved validation of reported dependency mismatches without relying on message ordering or exact wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->