### PR TITLE
[Refactor] Consolidate session metadata into the session database

### DIFF
--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -280,7 +280,6 @@ class AgenticNode(Node):
         # the restore call so the restored values are not clobbered.
         self._context_state: Optional["ContextState"] = None
         self._restored_context_used: int = 0
-        self._restored_context_length: int = 0
         try:
             self.restore_plan_mode_state()
         except Exception as exc:  # noqa: BLE001 — restore must never crash construction
@@ -629,24 +628,19 @@ class AgenticNode(Node):
             self.workflow_prompt_sent,
         )
 
-    def persist_context_state(
-        self, last_call_input_tokens: int, context_length: int, *, valid: Optional[bool] = None
-    ) -> None:
-        """Publish a measured occupancy or invalidation, then persist it.
+    def persist_context_state(self, last_call_input_tokens: int) -> None:
+        """Publish a measured occupancy, then persist it. Zero invalidates.
 
-        Memory is authoritative for the running node even when persistence fails.
-        SQLite stores the durable state atomically invalidated by history rewrites;
-        the JSON section remains a compatibility mirror for existing sessions.
+        Memory is authoritative for the running node even when persistence
+        fails. The session db holds the durable value, zeroed by any history
+        rewrite in the same transaction; the JSON section remains a
+        compatibility mirror for sessions that predate the move.
         """
         from datus.storage.session_state import ContextState
 
-        used = max(0, int(last_call_input_tokens or 0))
-        length = max(0, int(context_length or 0))
-        known = used > 0 if valid is None else valid
-        state = ContextState(used if known else 0, length, known)
+        state = ContextState(max(0, int(last_call_input_tokens or 0)))
         self._context_state = state
         self._restored_context_used = state.last_call_input_tokens
-        self._restored_context_length = length
         if self.session_id:
             try:
                 self.session_manager.save_context_state(self.session_id, state)
@@ -660,7 +654,7 @@ class AgenticNode(Node):
             logger.debug("Failed to persist JSON context state", exc_info=True)
 
     def restore_context_state(self) -> None:
-        """Restore SQLite's state, falling back to legacy JSON when absent."""
+        """Restore the durable measurement, falling back to legacy JSON."""
         from datus.storage.session_state import ContextState
 
         loaded = None
@@ -668,7 +662,7 @@ class AgenticNode(Node):
             try:
                 loaded = self.session_manager.load_context_state(self.session_id)
             except Exception:
-                # An unreadable durable invalidation must not revive an old JSON value.
+                # An unreadable durable zero must not revive an old JSON value.
                 loaded = ContextState()
                 logger.debug("Failed to restore SQLite context state", exc_info=True)
         if not isinstance(loaded, ContextState):
@@ -677,8 +671,7 @@ class AgenticNode(Node):
                 return
             loaded = ContextState.load(state_path)
         self._context_state = loaded
-        self._restored_context_used = loaded.last_call_input_tokens if loaded.valid else 0
-        self._restored_context_length = loaded.context_length
+        self._restored_context_used = loaded.last_call_input_tokens
 
     def get_context_usage(self) -> "ContextState":
         """Return the latest measured input occupancy; never substitute spend."""
@@ -1596,7 +1589,7 @@ class AgenticNode(Node):
     async def _count_session_tokens(self) -> int:
         """Return measured input occupancy, or zero when it is unknown."""
         state = self.get_context_usage()
-        return state.last_call_input_tokens if state.valid else 0
+        return state.last_call_input_tokens
 
     # ── Compact subsystem ──────────────────────────────────────────────
     # Public entry: ``compact(mode, reason)``. CLI, RunHooks, and model-layer
@@ -1818,8 +1811,8 @@ class AgenticNode(Node):
     def _history_token_ratio_sync(self) -> float:
         """Return measured occupancy for explicit compact(auto) callers."""
         state = self.get_context_usage()
-        length = self.context_length or state.context_length
-        return state.last_call_input_tokens / length if state.valid and length else 0.0
+        length = self.context_length
+        return state.last_call_input_tokens / length if length else 0.0
 
     def _get_compact_lock(self) -> asyncio.Lock:
         """Lazily allocate the per-node compact lock.
@@ -2207,12 +2200,7 @@ class AgenticNode(Node):
                     "context_usage_valid": False,
                 }
             )
-        length = getattr(self, "_restored_context_length", 0) or 0
-        try:
-            length = int(self.context_length or length)
-        except Exception:
-            logger.debug("Cannot resolve context length after rewrite", exc_info=True)
-        self.persist_context_state(0, length, valid=False)
+        self.persist_context_state(0)
         self._notify_status_dirty()
 
     def _refresh_turn_checkpoint_after_rewrite(self) -> None:
@@ -3907,7 +3895,6 @@ class AgenticNode(Node):
         self.running_turn_usage = None
         self._context_state = None
         self._restored_context_used = 0
-        self._restored_context_length = 0
         if not self.session_id:
             return
         try:
@@ -3970,7 +3957,7 @@ class AgenticNode(Node):
             "context_usage_ratio": current_tokens / self.context_length if self.context_length else 0,
             "context_remaining": (
                 max(0, self.context_length - current_tokens)
-                if self.context_length and self.get_context_usage().valid
+                if self.context_length and self.get_context_usage().last_call_input_tokens
                 else 0
             ),
             "context_length": self.context_length,
@@ -4004,7 +3991,7 @@ class AgenticNode(Node):
                 return _TokenUsage.from_usage_dict(
                     usage_dict,
                     session_total_tokens=self.get_context_usage().last_call_input_tokens,
-                    context_usage_valid=self.get_context_usage().valid,
+                    context_usage_valid=self.get_context_usage().last_call_input_tokens > 0,
                     context_length=self.context_length or 0,
                 )
         return None

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -550,17 +550,53 @@ class AgenticNode(Node):
             return None
 
     def _persist_plan_mode_state(self) -> None:
-        """Flush current plan-mode fields to disk. No-op without session_id."""
-        state_path = self._agent_state_file()
-        if state_path is None:
+        """Flush current plan-mode fields to the session db. No-op without session_id.
+
+        Plan mode can be toggled before the first message, when the database
+        does not exist yet; ``save_session_meta`` skips that write rather than
+        materialising an empty file that would list as a session, and
+        ``_get_or_create_session`` repeats the call once the session is real.
+        Nothing is lost in that window: a session with no database cannot be
+        resumed, so there is no reader for the state it would have stored.
+        """
+        if not self.session_id:
             return
+        from datus.models.sqlite_session import SESSION_PLAN_MODE_KEY
         from datus.storage.session_state import PlanModeState
 
-        PlanModeState(
-            plan_mode_active=self.plan_mode_active,
-            plan_file_path=self.plan_file_path,
-            workflow_prompt_sent=self.workflow_prompt_sent,
-        ).save(state_path)
+        try:
+            payload = PlanModeState(
+                plan_mode_active=self.plan_mode_active,
+                plan_file_path=self.plan_file_path,
+                workflow_prompt_sent=self.workflow_prompt_sent,
+            ).to_json()
+            self.session_manager.save_session_meta(self.session_id, SESSION_PLAN_MODE_KEY, payload)
+        except Exception:  # noqa: BLE001 — session creation must not fail over a flag
+            logger.debug("Failed to persist plan-mode state", exc_info=True)
+
+    def _load_plan_mode_state(self) -> Optional["PlanModeState"]:  # noqa: F821 — forward-ref
+        """Read plan-mode state, preferring the session db over legacy JSON.
+
+        Sessions that predate the move still carry a ``plan_mode`` section in
+        ``{project_data_dir}/state/{session_id}.json``; they keep working and
+        migrate to the database on their next toggle.
+        """
+        from datus.models.sqlite_session import SESSION_PLAN_MODE_KEY
+        from datus.storage.session_state import PlanModeState
+
+        if self.session_id:
+            try:
+                payload = self.session_manager.load_session_meta(self.session_id, SESSION_PLAN_MODE_KEY)
+            except Exception:  # noqa: BLE001
+                payload = None
+                logger.debug("Failed to read plan-mode state from the session db", exc_info=True)
+            state = PlanModeState.from_json(payload)
+            if state is not None:
+                return state
+        state_path = self._agent_state_file()
+        if state_path is None or not state_path.exists():
+            return None
+        return PlanModeState.load(state_path)
 
     def restore_plan_mode_state(self) -> None:
         """Re-hydrate plan-mode fields from disk into this node.
@@ -578,12 +614,9 @@ class AgenticNode(Node):
         ``_plan_just_confirmed`` is intentionally NOT restored — it is a
         turn-local one-shot flag and should always start False on resume.
         """
-        state_path = self._agent_state_file()
-        if state_path is None or not state_path.exists():
+        loaded = self._load_plan_mode_state()
+        if loaded is None:
             return
-        from datus.storage.session_state import PlanModeState
-
-        loaded = PlanModeState.load(state_path)
         self.plan_mode_active = loaded.plan_mode_active
         self.plan_file_path = loaded.plan_file_path
         self.workflow_prompt_sent = loaded.workflow_prompt_sent
@@ -1553,6 +1586,10 @@ class AgenticNode(Node):
         if self._session is None:
             self._session = self.session_manager.create_session(self.session_id)
             logger.debug(f"Created session: {self.session_id}")
+            # Plan mode may have been toggled before the database existed, in
+            # which case that write was skipped. There is somewhere to put it
+            # now, and a resumable session must carry its plan-mode flags.
+            self._persist_plan_mode_state()
 
         return self._session
 

--- a/datus/agent/node/agentic_node.py
+++ b/datus/agent/node/agentic_node.py
@@ -548,7 +548,7 @@ class AgenticNode(Node):
             logger.debug("agent_state_path unavailable: %s", exc)
             return None
 
-    def _persist_plan_mode_state(self) -> None:
+    def _persist_plan_mode_state(self, only_if_absent: bool = False) -> None:
         """Flush current plan-mode fields to the session db. No-op without session_id.
 
         Plan mode can be toggled before the first message, when the database
@@ -557,6 +557,11 @@ class AgenticNode(Node):
         ``_get_or_create_session`` repeats the call once the session is real.
         Nothing is lost in that window: a session with no database cannot be
         resumed, so there is no reader for the state it would have stored.
+
+        ``only_if_absent`` seeds a session that has no plan-mode row yet without
+        overwriting one. Callers that merely materialise the session hold a
+        snapshot taken at construction time, which another process may have
+        moved on from — see :meth:`_get_or_create_session`.
         """
         if not self.session_id:
             return
@@ -564,6 +569,8 @@ class AgenticNode(Node):
         from datus.storage.session_state import PlanModeState
 
         try:
+            if only_if_absent and self.session_manager.load_session_meta(self.session_id, SESSION_PLAN_MODE_KEY):
+                return
             payload = PlanModeState(
                 plan_mode_active=self.plan_mode_active,
                 plan_file_path=self.plan_file_path,
@@ -633,8 +640,11 @@ class AgenticNode(Node):
 
         Memory is authoritative for the running node even when persistence
         fails. The session db holds the durable value, zeroed by any history
-        rewrite in the same transaction; the JSON section remains a
-        compatibility mirror for sessions that predate the move.
+        rewrite in the same transaction; the JSON section is only a
+        compatibility mirror for sessions that predate the move, so it is
+        refreshed where it already exists and never created — a new file would
+        be a second storage location ``SessionManager`` has to clean up for no
+        reader's benefit.
         """
         from datus.storage.session_state import ContextState
 
@@ -648,7 +658,7 @@ class AgenticNode(Node):
                 logger.debug("Failed to persist SQLite context state", exc_info=True)
         try:
             state_path = self._agent_state_file()
-            if state_path is not None:
+            if state_path is not None and state_path.exists():
                 state.save(state_path)
         except Exception:
             logger.debug("Failed to persist JSON context state", exc_info=True)
@@ -1582,7 +1592,13 @@ class AgenticNode(Node):
             # Plan mode may have been toggled before the database existed, in
             # which case that write was skipped. There is somewhere to put it
             # now, and a resumable session must carry its plan-mode flags.
-            self._persist_plan_mode_state()
+            #
+            # Seed only, never overwrite: this method also runs from paths that
+            # only need a session object — turn counting, the API's throwaway
+            # compaction node — whose in-memory flags were restored when the
+            # node was built and may already be stale. Blindly writing them
+            # back would drop a live process out of plan mode.
+            self._persist_plan_mode_state(only_if_absent=True)
 
         return self._session
 

--- a/datus/agent/node/gen_sql_agentic_node.py
+++ b/datus/agent/node/gen_sql_agentic_node.py
@@ -374,7 +374,7 @@ class GenSQLAgenticNode(AgenticNode):
         try:
             from datus.tools.func_tool.plan_tools import PlanTool
 
-            session, _ = self._get_or_create_session()
+            session = self._get_or_create_session()
             # Lazy resolver mirrors AgenticNode._get_plan_mode_tools — even
             # though we've already called _get_or_create_session here, future
             # session swaps (rewind / switch) should be picked up too.

--- a/datus/agent/node/token_usage_hook.py
+++ b/datus/agent/node/token_usage_hook.py
@@ -139,7 +139,7 @@ class TokenUsageHook(RunHooks):
         self._update_node_snapshot(cumulative, context_length, last_call_input_tokens, delta)
         persist = getattr(self._node, "persist_context_state", None)
         if callable(persist):
-            persist(last_call_input_tokens, context_length)
+            persist(last_call_input_tokens)
         self._persist_snapshot(cumulative, context_length)
         self._enqueue_action(cumulative, delta, context_length, last_call_input_tokens)
         self._notify_status_dirty()

--- a/datus/cli/status_bar.py
+++ b/datus/cli/status_bar.py
@@ -359,8 +359,7 @@ class StatusBarProvider:
             return 0
         from datus.storage.session_state import read_context_state
 
-        state = read_context_state(node)
-        return state.last_call_input_tokens if state.valid else 0
+        return read_context_state(node).last_call_input_tokens
 
     def _resolve_context_total(self) -> int:
         node = self._current_node()
@@ -382,13 +381,4 @@ class StatusBarProvider:
                         return fallback
                 except (TypeError, ValueError):
                     pass
-            # Resume fallback: the context length re-hydrated from disk so the
-            # bar's denominator is correct before the node populates it on the
-            # first call of the resumed session.
-            try:
-                restored = int(getattr(node, "_restored_context_length", 0) or 0)
-                if restored > 0:
-                    return restored
-            except (TypeError, ValueError):
-                pass
         return 0

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -18,6 +18,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from agents.extensions.memory import AdvancedSQLiteSession
 
 from datus.models.sqlite_session import (
+    CONTEXT_USED_RESET_SQL,
+    DERIVED_SESSION_META_KEYS,
+    MAX_SESSION_TITLE_CHARS,
     SESSION_CONTEXT_USED_KEY,
     SESSION_META_TABLE,
     SESSION_TITLE_KEY,
@@ -121,6 +124,13 @@ class SessionManager:
             self.session_dir = os.path.join(self.session_dir, resolved_scope)
         os.makedirs(self.session_dir, exist_ok=True)
         self._sessions: Dict[str, AdvancedSQLiteSession] = {}
+        # Kept for cleanup: the legacy per-session JSON state file lives under
+        # ``{project_data_dir}/state/``, outside ``session_dir``, and
+        # ``delete_session`` has to be able to resolve it — otherwise a deleted
+        # conversation leaves its plan-mode payload (``plan_file_path``
+        # included) behind.
+        self._path_manager = path_manager
+        self._agent_config = agent_config
 
     # Shared pattern for validating session IDs.
     # Allows alphanumerics, hyphens, underscores, and dots.
@@ -224,11 +234,8 @@ class SessionManager:
     def save_context_state(self, session_id: str, state: ContextState) -> None:
         """Store the measured occupancy beside the transactional history.
 
-        Never creates the database: ``sqlite3.connect`` would materialise an
-        empty file that ``list_sessions`` then reports as a session. A missing
-        file also means there is no stale measurement to overwrite. Write
-        failures are logged rather than raised so history clearing and the
-        post-response bookkeeping stay unaffected by a locked database.
+        See :meth:`save_session_meta` for the ghost-session and write-failure
+        guarantees this inherits.
         """
         self.save_session_meta(session_id, SESSION_CONTEXT_USED_KEY, str(state.last_call_input_tokens))
 
@@ -343,11 +350,7 @@ class SessionManager:
                 if self._table_exists(conn, "running_turn_usage"):
                     conn.execute("DELETE FROM running_turn_usage WHERE session_id = ?", (session_id,))
                 conn.execute(SESSION_META_TABLE)
-                conn.execute(
-                    "INSERT INTO session_meta (session_id, key, value) VALUES (?, ?, '0') "
-                    "ON CONFLICT(session_id, key) DO UPDATE SET value = '0'",
-                    (session_id, SESSION_CONTEXT_USED_KEY),
-                )
+                conn.execute(CONTEXT_USED_RESET_SQL, (session_id, SESSION_CONTEXT_USED_KEY))
                 conn.commit()
         except sqlite3.Error as exc:
             logger.warning("Failed to roll back unanswered turn for session %s: %s", session_id, exc)
@@ -480,6 +483,35 @@ class SessionManager:
         # The frozen system prompt belongs to the deleted conversation.
         self.delete_system_prompt_snapshot(session_id)
 
+        # So does the legacy JSON state mirror, which sessions predating
+        # ``session_meta`` still carry.
+        self._delete_agent_state_file(session_id)
+
+    def _delete_agent_state_file(self, session_id: str) -> None:
+        """Remove a session's legacy JSON state mirror (best-effort, idempotent).
+
+        Sessions created before plan mode and the occupancy reading moved into
+        ``session_meta`` keep a ``{project_data_dir}/state/{session_id}.json``
+        file. It sits outside ``session_dir``, so nothing else in this class
+        reaches it.
+        """
+        try:
+            from datus.utils.path_manager import get_path_manager
+
+            path = get_path_manager(path_manager=self._path_manager, agent_config=self._agent_config).agent_state_path(
+                session_id
+            )
+        except Exception as exc:  # noqa: BLE001 — cleanup must never fail a delete
+            logger.debug("agent_state_path unavailable for session %s: %s", session_id, exc)
+            return
+        try:
+            os.remove(path)
+            logger.debug(f"Deleted legacy session state file: {path}")
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Failed to remove session state file %s: %s", path, exc)
+
     def copy_session(self, source_session_id: str, target_node_name: str) -> str:
         """Copy a session to a new one with a different node-name prefix.
 
@@ -552,7 +584,7 @@ class SessionManager:
         # for all writes. Avoids two concurrent connections on the same file and
         # is substantially faster for long histories.
         new_db_path = os.path.join(self.session_dir, f"{new_session_id}.db")
-        AdvancedSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
+        DatusSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
 
         with sqlite3.connect(new_db_path, timeout=5.0) as new_conn:
             new_conn.execute(
@@ -585,8 +617,11 @@ class SessionManager:
             self._write_session_meta(new_conn, new_session_id, meta_rows)
             new_conn.commit()
 
-        # Cache a fresh session pointing at the populated DB (tables already exist).
-        self._sessions[new_session_id] = AdvancedSQLiteSession(
+        # Cache a fresh session pointing at the populated DB (tables already
+        # exist). Must be a ``DatusSQLiteSession``: the rest of the process
+        # calls ``replace_items`` / ``forget_recorded_title`` on whatever
+        # ``get_session`` hands back, and the SDK base class has neither.
+        self._sessions[new_session_id] = DatusSQLiteSession(
             session_id=new_session_id, db_path=new_db_path, create_tables=False
         )
 
@@ -678,7 +713,10 @@ class SessionManager:
 
         # Create the new session database
         new_db_path = os.path.join(self.session_dir, f"{new_session_id}.db")
-        new_session = AdvancedSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
+        # ``DatusSQLiteSession`` for the same reason as in ``copy_session``:
+        # the cached object is what every later caller gets from
+        # ``get_session``, and it has to carry the Datus-owned methods.
+        new_session = DatusSQLiteSession(session_id=new_session_id, db_path=new_db_path, create_tables=True)
         # Store in cache
         self._sessions[new_session_id] = new_session
 
@@ -950,12 +988,17 @@ class SessionManager:
                     )
 
                 # Get latest user message (need to check all messages to find the most recent user message)
+                # ``id DESC`` is not cosmetic: SQLite's CURRENT_TIMESTAMP has
+                # one-second resolution and a whole turn lands inside one
+                # second, so ordering on the timestamp alone leaves the rows
+                # tied and the reversed() scan below walks them forwards —
+                # swapping the first and latest user message.
                 cursor.execute(
                     """
                     SELECT message_data, created_at
                     FROM agent_messages
                     WHERE session_id = ?
-                    ORDER BY created_at DESC
+                    ORDER BY created_at DESC, id DESC
                     """,
                     (session_id,),
                 )
@@ -990,7 +1033,10 @@ class SessionManager:
                         role = message_json.get("role", "")
                         if role == "user":
                             content = extract_user_input(message_json.get("content", ""))
-                            first_user_message = content
+                            # Same cap as the stored title, so a session does
+                            # not render at a different length depending on
+                            # which of the two sources answered.
+                            first_user_message = (content or "")[:MAX_SESSION_TITLE_CHARS]
                             first_user_message_at = created_at
                             break
                     except (json.JSONDecodeError, TypeError):
@@ -1010,7 +1056,14 @@ class SessionManager:
                 # a mid-conversation one that would silently retitle the chat.
                 # The recorded title predates every rewrite and wins. Sessions
                 # older than the table have none and keep the scanned value.
-                recorded_title = self._read_session_title(conn, session_id)
+                # Guarded on its own: the handler below discards the whole
+                # metadata dict, and a title is not worth losing a session's
+                # timestamps and message count over.
+                try:
+                    recorded_title = self._read_session_title(conn, session_id)
+                except sqlite3.Error as exc:
+                    logger.debug("Could not read the title of session %s: %s", session_id, exc)
+                    recorded_title = None
                 if recorded_title:
                     session_metadata["first_user_message"] = recorded_title
 
@@ -1056,11 +1109,18 @@ class SessionManager:
 
     @staticmethod
     def _read_session_meta(cursor: sqlite3.Cursor, session_id: str) -> list:
-        """Read a session's metadata rows, or none for a database without them."""
+        """Read the metadata a derived session may inherit, or none for a database without it.
+
+        Restricted to :data:`DERIVED_SESSION_META_KEYS`: a copy or a rewind
+        produces a session with different history, so every reading that
+        describes the source's history has to be left behind rather than
+        carried over. New keys opt in there deliberately.
+        """
         try:
+            placeholders = ", ".join("?" * len(DERIVED_SESSION_META_KEYS))
             cursor.execute(
-                "SELECT key, value FROM session_meta WHERE session_id = ?",
-                (session_id,),
+                f"SELECT key, value FROM session_meta WHERE session_id = ? AND key IN ({placeholders})",
+                (session_id, *DERIVED_SESSION_META_KEYS),
             )
             return cursor.fetchall()
         except sqlite3.OperationalError:

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from agents.extensions.memory import AdvancedSQLiteSession
 
 from datus.models.sqlite_session import (
-    CONTEXT_STATE_TABLE,
+    SESSION_CONTEXT_USED_KEY,
     SESSION_META_TABLE,
     SESSION_TITLE_KEY,
     DatusSQLiteSession,
@@ -230,35 +230,23 @@ class SessionManager:
         failures are logged rather than raised so history clearing and the
         post-response bookkeeping stay unaffected by a locked database.
         """
-        self._validate_session_id(session_id)
-        db_path = os.path.join(self.session_dir, f"{session_id}.db")
-        if not os.path.exists(db_path):
-            return
-        try:
-            with sqlite3.connect(db_path, timeout=5.0) as conn:
-                conn.execute(CONTEXT_STATE_TABLE)
-                conn.execute(
-                    "INSERT OR REPLACE INTO context_occupancy "
-                    "(session_id, input_tokens, context_length, valid) VALUES (?, ?, ?, ?)",
-                    (session_id, state.last_call_input_tokens, state.context_length, int(state.valid)),
-                )
-        except sqlite3.Error as exc:
-            logger.warning("Failed to save context state for session %s: %s", session_id, exc)
+        self.save_session_meta(session_id, SESSION_CONTEXT_USED_KEY, str(state.last_call_input_tokens))
 
     def load_context_state(self, session_id: str) -> Optional[ContextState]:
-        """Read the durable measurement, including an explicit invalidation."""
-        self._validate_session_id(session_id)
-        db_path = os.path.join(self.session_dir, f"{session_id}.db")
-        if not os.path.exists(db_path):
+        """Read the durable measurement, or ``None`` when none was recorded.
+
+        ``None`` and a recorded zero are different answers: the first lets the
+        caller fall through to the legacy JSON mirror, the second is a session
+        whose reading a rewrite has invalidated.
+        """
+        raw = self.load_session_meta(session_id, SESSION_CONTEXT_USED_KEY)
+        if raw is None:
             return None
-        with sqlite3.connect(db_path, timeout=5.0) as conn:
-            if not self._table_exists(conn, "context_occupancy"):
-                return None
-            row = conn.execute(
-                "SELECT input_tokens, context_length, valid FROM context_occupancy WHERE session_id = ?",
-                (session_id,),
-            ).fetchone()
-            return ContextState(row[0], row[1], bool(row[2])) if row else None
+        try:
+            return ContextState(max(0, int(raw)))
+        except (TypeError, ValueError):
+            logger.warning("Ignoring unreadable occupancy %r for session %s", raw, session_id)
+            return ContextState()
 
     def checkpoint_turn(self, session_id: str) -> Optional[SessionTurnCheckpoint]:
         """Capture the SQLite boundary before dispatching a model turn.
@@ -354,11 +342,11 @@ class SessionManager:
                     )
                 if self._table_exists(conn, "running_turn_usage"):
                     conn.execute("DELETE FROM running_turn_usage WHERE session_id = ?", (session_id,))
-                conn.execute(CONTEXT_STATE_TABLE)
+                conn.execute(SESSION_META_TABLE)
                 conn.execute(
-                    "INSERT INTO context_occupancy (session_id) VALUES (?) "
-                    "ON CONFLICT(session_id) DO UPDATE SET input_tokens = 0, valid = 0",
-                    (session_id,),
+                    "INSERT INTO session_meta (session_id, key, value) VALUES (?, ?, '0') "
+                    "ON CONFLICT(session_id, key) DO UPDATE SET value = '0'",
+                    (session_id, SESSION_CONTEXT_USED_KEY),
                 )
                 conn.commit()
         except sqlite3.Error as exc:

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -1089,6 +1089,50 @@ class SessionManager:
             [(session_id, *row) for row in rows],
         )
 
+    def save_session_meta(self, session_id: str, key: str, value: str) -> None:
+        """Upsert one metadata value beside the session's history.
+
+        Never creates the database, matching :meth:`save_context_state`:
+        ``sqlite3.connect`` would materialise an empty file that
+        ``list_sessions`` then reports as a session. A caller writing before
+        the first message is expected to write again once the session exists.
+        Write failures are logged rather than raised — metadata is auxiliary
+        to whatever the caller was actually doing.
+        """
+        self._validate_session_id(session_id)
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if not os.path.exists(db_path):
+            return
+        try:
+            with sqlite3.connect(db_path, timeout=5.0) as conn:
+                conn.execute(SESSION_META_TABLE)
+                conn.execute(
+                    "INSERT INTO session_meta (session_id, key, value) VALUES (?, ?, ?) "
+                    "ON CONFLICT(session_id, key) DO UPDATE SET value = excluded.value",
+                    (session_id, key, value),
+                )
+        except sqlite3.Error as exc:
+            logger.warning("Failed to save session meta %r for %s: %s", key, session_id, exc)
+
+    def load_session_meta(self, session_id: str, key: str) -> Optional[str]:
+        """Read one metadata value, or ``None`` when it was never written."""
+        self._validate_session_id(session_id)
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if not os.path.exists(db_path):
+            return None
+        try:
+            with sqlite3.connect(db_path, timeout=5.0) as conn:
+                if not self._table_exists(conn, "session_meta"):
+                    return None
+                row = conn.execute(
+                    "SELECT value FROM session_meta WHERE session_id = ? AND key = ?",
+                    (session_id, key),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            logger.warning("Failed to read session meta %r for %s: %s", key, session_id, exc)
+            return None
+        return row[0] if row else None
+
     def get_detailed_usage(self, session_id: str) -> Dict[str, Any]:
         """Query turn_usage table and return aggregated + per-turn token usage.
 

--- a/datus/models/session_manager.py
+++ b/datus/models/session_manager.py
@@ -17,7 +17,12 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from agents.extensions.memory import AdvancedSQLiteSession
 
-from datus.models.sqlite_session import CONTEXT_STATE_TABLE, DatusSQLiteSession
+from datus.models.sqlite_session import (
+    CONTEXT_STATE_TABLE,
+    SESSION_META_TABLE,
+    SESSION_TITLE_KEY,
+    DatusSQLiteSession,
+)
 from datus.schemas.action_history import ActionHistory, ActionRole, ActionStatus
 from datus.storage.session_state import ContextState
 from datus.utils.async_utils import run_async
@@ -188,6 +193,33 @@ class SessionManager:
         # so the next turn re-bakes it instead of replaying pre-clear context.
         self.delete_system_prompt_snapshot(session_id)
         self.save_context_state(session_id, ContextState())
+        self.clear_session_title(session_id)
+
+    def clear_session_title(self, session_id: str) -> None:
+        """Forget the recorded title so the next message renames the session.
+
+        ``/clear`` restarts the conversation, and the old opening message stops
+        describing what follows. Compaction deliberately does *not* come
+        through here: it rewrites history via ``replace_items`` and the same
+        chat continues, so it keeps its title.
+        """
+        self._validate_session_id(session_id)
+        db_path = os.path.join(self.session_dir, f"{session_id}.db")
+        if os.path.exists(db_path):
+            try:
+                with sqlite3.connect(db_path, timeout=5.0) as conn:
+                    if self._table_exists(conn, "session_meta"):
+                        conn.execute(
+                            "DELETE FROM session_meta WHERE session_id = ? AND key = ?",
+                            (session_id, SESSION_TITLE_KEY),
+                        )
+            except sqlite3.Error as exc:
+                logger.warning("Failed to clear the title of session %s: %s", session_id, exc)
+        # A cached session stops recording once it has written a title, so the
+        # row alone is not enough — the live object has to be told as well.
+        forget = getattr(self._sessions.get(session_id), "forget_recorded_title", None)
+        if callable(forget):
+            forget()
 
     def save_context_state(self, session_id: str, state: ContextState) -> None:
         """Store the measured occupancy beside the transactional history.
@@ -522,6 +554,11 @@ class SessionManager:
             except sqlite3.OperationalError:
                 pass
 
+            # Carry the title over: a compacted source has no user rows left
+            # for the copy's own scan to find, so without this the new session
+            # would list as untitled.
+            meta_rows = self._read_session_meta(cursor, source_session_id)
+
         # Materialize tables in the new DB first (short-lived session is released
         # before bulk inserts), then use a single raw connection with executemany
         # for all writes. Avoids two concurrent connections on the same file and
@@ -557,6 +594,7 @@ class SessionManager:
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 [(new_session_id, *row) for row in turn_usage_rows],
             )
+            self._write_session_meta(new_conn, new_session_id, meta_rows)
             new_conn.commit()
 
         # Cache a fresh session pointing at the populated DB (tables already exist).
@@ -687,6 +725,12 @@ class SessionManager:
             except sqlite3.OperationalError:
                 pass
 
+            # The recorded title is the conversation's opening message, which a
+            # rewind keeps by definition, so it stays correct for the new
+            # session — and it is the only copy left once the source has been
+            # compacted.
+            meta_rows = self._read_session_meta(cursor, source_session_id)
+
         # Insert session record, messages, message_structure, and turn_usage into the new DB.
         # Preserve agent_messages.id so message_structure.message_id references remain valid.
         with sqlite3.connect(new_db_path, timeout=5.0) as new_conn:
@@ -735,6 +779,7 @@ class SessionManager:
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (new_session_id, *usage_row),
                 )
+            self._write_session_meta(new_conn, new_session_id, meta_rows)
             new_conn.commit()
 
         logger.info(
@@ -972,6 +1017,15 @@ class SessionManager:
                     }
                 )
 
+                # A major compact clears the history the scan above walks, so
+                # on a compacted session it finds either no user rows at all or
+                # a mid-conversation one that would silently retitle the chat.
+                # The recorded title predates every rewrite and wins. Sessions
+                # older than the table have none and keep the scanned value.
+                recorded_title = self._read_session_title(conn, session_id)
+                if recorded_title:
+                    session_metadata["first_user_message"] = recorded_title
+
         except Exception as e:
             logger.debug(f"Could not get session metadata for {session_id}: {e}")
             # Return basic info even if database query fails
@@ -995,6 +1049,45 @@ class SessionManager:
             **file_info,
             **session_metadata,
         }
+
+    def _read_session_title(self, conn: sqlite3.Connection, session_id: str) -> Optional[str]:
+        """Return the recorded title, or ``None`` when the session has none.
+
+        Reuses the caller's connection: ``get_session_info`` has the database
+        open already, and listing sessions calls it once per row.
+        """
+        if not self._table_exists(conn, "session_meta"):
+            return None
+        row = conn.execute(
+            "SELECT value FROM session_meta WHERE session_id = ? AND key = ?",
+            (session_id, SESSION_TITLE_KEY),
+        ).fetchone()
+        if not row:
+            return None
+        return (row[0] or "").strip() or None
+
+    @staticmethod
+    def _read_session_meta(cursor: sqlite3.Cursor, session_id: str) -> list:
+        """Read a session's metadata rows, or none for a database without them."""
+        try:
+            cursor.execute(
+                "SELECT key, value FROM session_meta WHERE session_id = ?",
+                (session_id,),
+            )
+            return cursor.fetchall()
+        except sqlite3.OperationalError:
+            return []
+
+    @staticmethod
+    def _write_session_meta(conn: sqlite3.Connection, session_id: str, rows: list) -> None:
+        """Attach metadata rows read from a source session to a derived one."""
+        if not rows:
+            return
+        conn.execute(SESSION_META_TABLE)
+        conn.executemany(
+            "INSERT OR IGNORE INTO session_meta (session_id, key, value) VALUES (?, ?, ?)",
+            [(session_id, *row) for row in rows],
+        )
 
     def get_detailed_usage(self, session_id: str) -> Dict[str, Any]:
         """Query turn_usage table and return aggregated + per-turn token usage.

--- a/datus/models/sqlite_session.py
+++ b/datus/models/sqlite_session.py
@@ -38,6 +38,10 @@ CREATE TABLE IF NOT EXISTS session_meta (
 #: Label a session is listed under. Holds the first user message.
 SESSION_TITLE_KEY = "title"
 
+#: Plan-mode flags, stored as one JSON object so the three fields that are
+#: always written together cannot land out of step with each other.
+SESSION_PLAN_MODE_KEY = "plan_mode"
+
 #: Cap on the stored title. It labels a list row, it is not a document.
 MAX_SESSION_TITLE_CHARS = 500
 

--- a/datus/models/sqlite_session.py
+++ b/datus/models/sqlite_session.py
@@ -9,7 +9,10 @@ from typing import Any
 
 from agents.extensions.memory import AdvancedSQLiteSession
 
+from datus.utils.loggings import get_logger
 from datus.utils.message_utils import extract_user_input, is_compact_resume_text
+
+logger = get_logger(__name__)
 
 CONTEXT_STATE_TABLE = """
 CREATE TABLE IF NOT EXISTS context_occupancy (
@@ -19,6 +22,24 @@ CREATE TABLE IF NOT EXISTS context_occupancy (
     valid INTEGER NOT NULL DEFAULT 0
 )
 """
+
+# Sparse, write-once metadata that must outlive a history rewrite. Kept apart
+# from ``context_occupancy``: that table exists to be zeroed by every rewrite,
+# which is the opposite of what these rows need.
+SESSION_META_TABLE = """
+CREATE TABLE IF NOT EXISTS session_meta (
+    session_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT,
+    PRIMARY KEY (session_id, key)
+)
+"""
+
+#: Label a session is listed under. Holds the first user message.
+SESSION_TITLE_KEY = "title"
+
+#: Cap on the stored title. It labels a list row, it is not a document.
+MAX_SESSION_TITLE_CHARS = 500
 
 
 class DatusSQLiteSession(AdvancedSQLiteSession):
@@ -47,9 +68,63 @@ class DatusSQLiteSession(AdvancedSQLiteSession):
     async def add_items(self, items: list[dict[str, Any]]) -> None:
         persisted = getattr(self, "_persisted_input", [])
         self._persisted_input = []
+        appended = items
         if persisted and items[: len(persisted)] == persisted:
-            items = items[len(persisted) :]
-        await super().add_items(items)
+            appended = items[len(persisted) :]
+        await super().add_items(appended)
+        # Title from the unfiltered batch: when compaction ran on the very
+        # first request, the opening message is the part skipped here, and it
+        # would otherwise never be seen by the recorder.
+        await self._record_title_once(items)
+
+    async def _record_title_once(self, items: list[dict[str, Any]]) -> None:
+        """Persist the first user message as the session's durable title.
+
+        Recorded as messages arrive rather than salvaged before a compact: the
+        row lives in ``session_meta``, which a history rewrite never touches,
+        so the label survives any number of compacts without a caller having to
+        race the clear. ``INSERT OR IGNORE`` makes only the first user message
+        of a session ever win, so a later batch cannot retitle the chat.
+
+        Best-effort — a title is a list label, and losing one must never fail
+        the message write that just succeeded.
+        """
+        if getattr(self, "_title_recorded", False):
+            return
+        title = ""
+        for item in items:
+            if self._is_user_message(item):
+                title = extract_user_input(item.get("content", "")).strip()
+                if title:
+                    break
+        if not title:
+            return
+
+        def record() -> None:
+            conn = self._get_connection()
+            with self._lock:
+                conn.execute(SESSION_META_TABLE)
+                conn.execute(
+                    "INSERT OR IGNORE INTO session_meta (session_id, key, value) VALUES (?, ?, ?)",
+                    (self.session_id, SESSION_TITLE_KEY, title[:MAX_SESSION_TITLE_CHARS]),
+                )
+                conn.commit()
+
+        try:
+            await asyncio.to_thread(record)
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            logger.warning("Could not record the title of session %s: %s", self.session_id, exc)
+            return
+        self._title_recorded = True
+
+    def forget_recorded_title(self) -> None:
+        """Let the next user message name the session again.
+
+        Called when the stored title is dropped (``/clear``). Without it the
+        write-once guard above would keep short-circuiting and the restarted
+        conversation would stay unnamed.
+        """
+        self._title_recorded = False
 
     async def replace_items(self, items: list[dict[str, Any]], *, pending_user_turns: int = 0) -> None:
         """Replace history and invalidate its measurement in one transaction.

--- a/datus/models/sqlite_session.py
+++ b/datus/models/sqlite_session.py
@@ -42,6 +42,21 @@ SESSION_CONTEXT_USED_KEY = "context_used"
 #: Cap on the stored title. It labels a list row, it is not a document.
 MAX_SESSION_TITLE_CHARS = 500
 
+#: Metadata a derived session (copy / rewind) inherits. Only the title
+#: survives a history rewrite: ``context_used`` describes the exact history the
+#: derivation just changed, and ``plan_mode`` is a live user toggle that the
+#: derived session's own user has not asked for.
+DERIVED_SESSION_META_KEYS = (SESSION_TITLE_KEY,)
+
+#: Invalidate the occupancy reading of a session whose history was rewritten.
+#: Shared by every rewrite path so they cannot drift apart — the atomicity
+#: argument for ``replace_items`` and ``rollback_turn`` rests on them writing
+#: the same row the same way.
+CONTEXT_USED_RESET_SQL = (
+    "INSERT INTO session_meta (session_id, key, value) VALUES (?, ?, '0') "
+    "ON CONFLICT(session_id, key) DO UPDATE SET value = '0'"
+)
+
 
 class DatusSQLiteSession(AdvancedSQLiteSession):
     def _is_user_message(self, item: dict[str, Any]) -> bool:
@@ -73,50 +88,84 @@ class DatusSQLiteSession(AdvancedSQLiteSession):
         if persisted and items[: len(persisted)] == persisted:
             appended = items[len(persisted) :]
         await super().add_items(appended)
-        # Title from the unfiltered batch: when compaction ran on the very
-        # first request, the opening message is the part skipped here, and it
-        # would otherwise never be seen by the recorder.
-        await self._record_title_once(items)
+        # After the write, so the scan below sees this batch too: when
+        # compaction ran on the very first request, the opening message is the
+        # part skipped here and only the stored history still holds it.
+        await self._record_title_once()
 
-    async def _record_title_once(self, items: list[dict[str, Any]]) -> None:
-        """Persist the first user message as the session's durable title.
+    async def _record_title_once(self) -> None:
+        """Persist the session's opening user message as its durable title.
 
         Recorded as messages arrive rather than salvaged before a compact: the
         row lives in ``session_meta``, which a history rewrite never touches,
         so the label survives any number of compacts without a caller having to
-        race the clear. ``INSERT OR IGNORE`` makes only the first user message
-        of a session ever win, so a later batch cannot retitle the chat.
+        race the clear. An existing row always wins, so a later message can
+        never retitle the chat.
 
         Best-effort — a title is a list label, and losing one must never fail
         the message write that just succeeded.
         """
         if getattr(self, "_title_recorded", False):
             return
-        title = ""
-        for item in items:
-            if self._is_user_message(item):
-                title = extract_user_input(item.get("content", "")).strip()
-                if title:
-                    break
-        if not title:
-            return
 
-        def record() -> None:
+        def record() -> bool:
+            """Return whether the session now has a title, so the guard latches.
+
+            A batch of purely assistant messages leaves an untitled session
+            untitled; latching on that would stop the recorder before the
+            opening message ever arrives.
+            """
             conn = self._get_connection()
             with self._lock:
                 conn.execute(SESSION_META_TABLE)
-                conn.execute(
-                    "INSERT OR IGNORE INTO session_meta (session_id, key, value) VALUES (?, ?, ?)",
-                    (self.session_id, SESSION_TITLE_KEY, title[:MAX_SESSION_TITLE_CHARS]),
+                titled = bool(
+                    conn.execute(
+                        "SELECT 1 FROM session_meta WHERE session_id = ? AND key = ?",
+                        (self.session_id, SESSION_TITLE_KEY),
+                    ).fetchone()
                 )
+                if not titled:
+                    title = self._opening_user_message(conn)
+                    if title:
+                        conn.execute(
+                            "INSERT OR IGNORE INTO session_meta (session_id, key, value) VALUES (?, ?, ?)",
+                            (self.session_id, SESSION_TITLE_KEY, title[:MAX_SESSION_TITLE_CHARS]),
+                        )
+                        titled = True
                 conn.commit()
+                return titled
 
         try:
-            await asyncio.to_thread(record)
+            self._title_recorded = await asyncio.to_thread(record)
         except Exception as exc:  # noqa: BLE001 — see docstring
             logger.warning("Could not record the title of session %s: %s", self.session_id, exc)
-            return
-        self._title_recorded = True
+
+    def _opening_user_message(self, conn: Any) -> str:
+        """Return the session's own opening message, not this batch's first one.
+
+        A session that predates ``session_meta`` has no title row but does have
+        history, so naming it from the incoming batch would rename the chat to
+        whatever the user says next — the exact bug the stored title exists to
+        prevent. Reading the earliest stored user message names old and new
+        sessions the same way, and yields what ``get_session_info``'s scan
+        would have shown.
+
+        Runs at most once per session: the caller only reaches here while no
+        title row exists, and the row check short-circuits every later call.
+        """
+        for (data,) in conn.execute(
+            f"SELECT message_data FROM {self.messages_table} WHERE session_id = ? ORDER BY id",
+            (self.session_id,),
+        ):
+            try:
+                item = json.loads(data)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(item, dict) and self._is_user_message(item):
+                title = extract_user_input(item.get("content", "")).strip()
+                if title:
+                    return title
+        return ""
 
     def forget_recorded_title(self) -> None:
         """Let the next user message name the session again.
@@ -195,11 +244,7 @@ class DatusSQLiteSession(AdvancedSQLiteSession):
                     # The occupancy reading describes the history just deleted.
                     # Zeroed in this same transaction so the compaction gate
                     # and the status bar can never see it outlive its subject.
-                    conn.execute(
-                        "INSERT INTO session_meta (session_id, key, value) VALUES (?, ?, '0') "
-                        "ON CONFLICT(session_id, key) DO UPDATE SET value = '0'",
-                        (self.session_id, SESSION_CONTEXT_USED_KEY),
-                    )
+                    conn.execute(CONTEXT_USED_RESET_SQL, (self.session_id, SESSION_CONTEXT_USED_KEY))
                     if conn.execute(
                         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'running_turn_usage'"
                     ).fetchone():

--- a/datus/models/sqlite_session.py
+++ b/datus/models/sqlite_session.py
@@ -14,18 +14,9 @@ from datus.utils.message_utils import extract_user_input, is_compact_resume_text
 
 logger = get_logger(__name__)
 
-CONTEXT_STATE_TABLE = """
-CREATE TABLE IF NOT EXISTS context_occupancy (
-    session_id TEXT PRIMARY KEY,
-    input_tokens INTEGER NOT NULL DEFAULT 0,
-    context_length INTEGER NOT NULL DEFAULT 0,
-    valid INTEGER NOT NULL DEFAULT 0
-)
-"""
-
-# Sparse, write-once metadata that must outlive a history rewrite. Kept apart
-# from ``context_occupancy``: that table exists to be zeroed by every rewrite,
-# which is the opposite of what these rows need.
+# One row per (session, key), holding everything about a session that is not
+# a message or a usage record. Values are text; each key documents its own
+# shape below.
 SESSION_META_TABLE = """
 CREATE TABLE IF NOT EXISTS session_meta (
     session_id TEXT NOT NULL,
@@ -41,6 +32,12 @@ SESSION_TITLE_KEY = "title"
 #: Plan-mode flags, stored as one JSON object so the three fields that are
 #: always written together cannot land out of step with each other.
 SESSION_PLAN_MODE_KEY = "plan_mode"
+
+#: Context-window occupancy of the last model call, as a decimal integer.
+#: Unlike its neighbours this one is rewritten on every model response and
+#: reset to ``"0"`` by any history rewrite — the reading describes the history
+#: that was just deleted, so it cannot outlive it.
+SESSION_CONTEXT_USED_KEY = "context_used"
 
 #: Cap on the stored title. It labels a list row, it is not a document.
 MAX_SESSION_TITLE_CHARS = 500
@@ -154,7 +151,7 @@ class DatusSQLiteSession(AdvancedSQLiteSession):
             with self._lock:
                 conn.execute("BEGIN IMMEDIATE")
                 try:
-                    conn.execute(CONTEXT_STATE_TABLE)
+                    conn.execute(SESSION_META_TABLE)
                     seq, turn, branch_turn = conn.execute(
                         "SELECT COALESCE(MAX(sequence_number), 0), COALESCE(MAX(user_turn_number), 0), "
                         "COALESCE(MAX(branch_turn_number), 0) FROM message_structure WHERE session_id = ?",
@@ -195,10 +192,13 @@ class DatusSQLiteSession(AdvancedSQLiteSession):
                                 tool,
                             ),
                         )
+                    # The occupancy reading describes the history just deleted.
+                    # Zeroed in this same transaction so the compaction gate
+                    # and the status bar can never see it outlive its subject.
                     conn.execute(
-                        "INSERT INTO context_occupancy (session_id) VALUES (?) "
-                        "ON CONFLICT(session_id) DO UPDATE SET input_tokens = 0, valid = 0",
-                        (self.session_id,),
+                        "INSERT INTO session_meta (session_id, key, value) VALUES (?, ?, '0') "
+                        "ON CONFLICT(session_id, key) DO UPDATE SET value = '0'",
+                        (self.session_id, SESSION_CONTEXT_USED_KEY),
                     )
                     if conn.execute(
                         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'running_turn_usage'"

--- a/datus/storage/session_state.py
+++ b/datus/storage/session_state.py
@@ -167,47 +167,43 @@ class PlanModeState:
 
 @dataclass
 class ContextState:
-    """Measured context occupancy with an explicit unknown state.
+    """Context-window occupancy measured on the last model call.
 
-    Persisted separately from the SQLite usage tables: ``turn_usage`` has no
-    per-call occupancy column, and ``running_turn_usage`` is cleared at turn
-    end (to avoid double-counting cumulative totals). A rewrite invalidates
-    this measurement until another model response arrives. Legacy JSON without
-    an explicit validity flag is unknown because it may contain an estimate.
+    Persisted separately from the usage tables: ``turn_usage`` records billed
+    consumption, which occupancy is not (cache reads cost little but fill the
+    window just the same), and ``running_turn_usage`` is cleared at turn end to
+    avoid double-counting cumulative totals.
 
-    ``last_call_input_tokens`` is the real context-window usage of the last
-    call (input + cache_read + cache_creation); ``context_length`` is the
-    model's maximum context (the bar's denominator).
+    Zero means "no measurement": a history rewrite invalidates the reading
+    until another model response arrives, and a session that has not called the
+    model yet has nothing to report. Both cases render as an empty bar and hold
+    compaction off, which is the intended behaviour for an unknown occupancy.
+
+    The denominator is not stored — ``AgenticNode.context_length`` resolves the
+    active model's window on every access.
     """
 
     last_call_input_tokens: int = 0
-    context_length: int = 0
-    valid: Optional[bool] = None
-
-    def __post_init__(self) -> None:
-        if self.valid is None:
-            self.valid = self.last_call_input_tokens > 0
-        if not self.valid:
-            self.last_call_input_tokens = 0
 
     @classmethod
     def from_dict(cls, data: Optional[Dict[str, Any]]) -> "ContextState":
-        """Build from a dict, coercing non-int fields to the safe default."""
+        """Build from a dict, coercing anything unusable to zero.
+
+        A pre-migration payload carrying ``valid: false`` reads as zero. Those
+        records were written when an explicit flag was the only way to mark a
+        reading stale, and their token count may be a text estimate rather than
+        a measurement. Nothing writes that flag any more.
+        """
         if not isinstance(data, dict):
             return cls()
-
-        def _as_int(value: Any) -> int:
-            # ``bool`` is an ``int`` subclass but is never a valid token count;
-            # reject it (and any non-int) so corrupted payloads fall back to 0.
-            if isinstance(value, bool) or not isinstance(value, int):
-                return 0
-            return max(0, value)
-
-        return cls(
-            last_call_input_tokens=_as_int(data.get("last_call_input_tokens", 0)),
-            context_length=_as_int(data.get("context_length", 0)),
-            valid=data.get("valid") is True,
-        )
+        if data.get("valid") is False:
+            return cls()
+        value = data.get("last_call_input_tokens", 0)
+        # ``bool`` is an ``int`` subclass but is never a valid token count;
+        # reject it (and any non-int) so corrupted payloads fall back to 0.
+        if isinstance(value, bool) or not isinstance(value, int):
+            return cls()
+        return cls(max(0, value))
 
     @classmethod
     def load(cls, path: Path) -> "ContextState":
@@ -227,24 +223,16 @@ class ContextState:
 
 
 def read_context_state(node: Any) -> ContextState:
-    """Read one node's measured occupancy without consulting billing history."""
+    """Read one node's measured occupancy without consulting billing history.
+
+    ``running_turn_usage.session_total_tokens`` is already zeroed by
+    :class:`~datus.schemas.token_usage.TokenUsage` whenever that snapshot is
+    marked invalid, so a stale reading never reaches here as a live one.
+    """
     state = getattr(node, "_context_state", None)
     if isinstance(state, ContextState):
         return state
     running = getattr(node, "running_turn_usage", None)
     if running is not None:
-        used = getattr(running, "session_total_tokens", 0)
-        return ContextState.from_dict(
-            {
-                "last_call_input_tokens": used,
-                "context_length": getattr(running, "context_length", 0),
-                "valid": getattr(running, "context_usage_valid", isinstance(used, int) and used > 0),
-            }
-        )
-    return ContextState.from_dict(
-        {
-            "last_call_input_tokens": getattr(node, "_restored_context_used", 0),
-            "context_length": getattr(node, "_restored_context_length", 0),
-            "valid": isinstance(getattr(node, "_restored_context_used", None), int) and node._restored_context_used > 0,
-        }
-    )
+        return ContextState.from_dict({"last_call_input_tokens": getattr(running, "session_total_tokens", 0)})
+    return ContextState.from_dict({"last_call_input_tokens": getattr(node, "_restored_context_used", 0)})

--- a/datus/storage/session_state.py
+++ b/datus/storage/session_state.py
@@ -138,14 +138,31 @@ class PlanModeState:
         # Legacy flat layout — read the plan-mode keys at top level.
         return cls.from_dict(data)
 
-    def save(self, path: Path) -> None:
-        """Write the plan-mode section under the nested ``plan_mode`` key.
+    def to_json(self) -> str:
+        """Serialize for the session database's metadata row.
 
-        Merges into the file via :func:`_save_section` so sibling sections
-        (e.g. ``context_state``) survive, while the legacy flat layout and
-        retired sections are dropped.
+        The three fields are always written together, so they travel as one
+        JSON value rather than three rows that could land out of step.
         """
-        _save_section(path, "plan_mode", asdict(self))
+        return json.dumps(asdict(self), ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, payload: Optional[str]) -> Optional["PlanModeState"]:
+        """Parse a stored payload; ``None`` means "nothing recorded".
+
+        Distinct from :meth:`from_dict`, which defaults a malformed field but
+        still returns a state. Here the caller needs to tell "no plan-mode row"
+        from "plan mode is off", because only the former should fall through to
+        the legacy JSON file.
+        """
+        if not payload:
+            return None
+        try:
+            data = json.loads(payload)
+        except (TypeError, json.JSONDecodeError) as exc:
+            logger.warning("Ignoring unreadable plan-mode payload: %s", exc)
+            return None
+        return cls.from_dict(data) if isinstance(data, dict) else None
 
 
 @dataclass

--- a/datus/storage/session_state.py
+++ b/datus/storage/session_state.py
@@ -185,6 +185,17 @@ class ContextState:
 
     last_call_input_tokens: int = 0
 
+    def __post_init__(self) -> None:
+        """Keep a negative occupancy unrepresentable.
+
+        ``save_context_state`` takes a caller-supplied state and writes the
+        number through verbatim; a negative value would surface as a negative
+        occupancy in the status bar and a negative ratio in the compaction
+        gate. Clamping here means no call site has to remember to.
+        """
+        if self.last_call_input_tokens < 0:
+            self.last_call_input_tokens = 0
+
     @classmethod
     def from_dict(cls, data: Optional[Dict[str, Any]]) -> "ContextState":
         """Build from a dict, coercing anything unusable to zero.

--- a/tests/unit_tests/agent/node/test_agentic_node.py
+++ b/tests/unit_tests/agent/node/test_agentic_node.py
@@ -1105,6 +1105,12 @@ def _make_simple_node(context_length=_UNSET, **overrides):
     node.dependencies = []
     node.input = None
 
+    # Set by the real ``__init__``; creating a session flushes them to the
+    # session db, so the stand-in has to carry them too.
+    node.plan_mode_active = False
+    node.plan_file_path = None
+    node.workflow_prompt_sent = False
+
     from datus.cli.execution_state import InteractionBroker, InterruptController
     from datus.schemas.action_bus import ActionBus
 

--- a/tests/unit_tests/agent/node/test_agentic_node_persistence.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_persistence.py
@@ -7,8 +7,6 @@ import json
 
 import pytest
 
-from datus.storage.session_state import PlanModeState
-
 
 @pytest.fixture
 def chdir_tmp(tmp_path, monkeypatch):
@@ -28,6 +26,22 @@ def _state_path(node, session_id):
     return _path_manager(node).agent_state_path(session_id)
 
 
+def _write_legacy_plan_mode(path, **fields):
+    """Write the pre-migration ``plan_mode`` section by hand.
+
+    Plan-mode state now lives in the session database, so production no longer
+    produces this layout. Sessions created before the move still carry it and
+    must keep restoring, which is what these fixtures exercise.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"plan_mode": fields}), encoding="utf-8")
+
+
+def _materialize_session(node):
+    """Create the session database, the way the first message does."""
+    node._get_or_create_session()
+
+
 def _make_chat_node(real_agent_config, session_id=None):
     """Build a real ChatAgenticNode with the persistence-test config."""
     from datus.agent.node.chat_agentic_node import ChatAgenticNode
@@ -43,36 +57,48 @@ def _make_chat_node(real_agent_config, session_id=None):
 
 
 class TestPlanModeStatePersistence:
-    """``activate_plan_mode`` / ``deactivate_plan_mode`` flush to disk."""
+    """``activate_plan_mode`` / ``deactivate_plan_mode`` flush to the session db."""
 
-    def test_activate_writes_state_file(self, chdir_tmp, real_agent_config):
+    def test_activate_survives_a_rebuilt_node(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_aaaa")
+        _materialize_session(node)
 
         node.activate_plan_mode()
 
-        state_path = _state_path(node, "chat_session_aaaa")
-        assert state_path.exists()
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-        # On-disk layout is nested under a top-level ``plan_mode`` key so the
-        # state file can grow additional sections later without breaking
-        # forward/backward compatibility. Today only ``plan_mode`` is written
-        # here — the compact subsystem keeps its own state in memory and on
-        # the session DB, not in this file.
-        assert data["plan_mode"]["plan_mode_active"] is True
-        assert data["plan_mode"]["plan_file_path"] == node.plan_file_path
-        assert data["plan_mode"]["workflow_prompt_sent"] is False
+        rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_aaaa")
+        assert rebuilt.plan_mode_active is True
+        assert rebuilt.plan_file_path == node.plan_file_path
+        assert rebuilt.workflow_prompt_sent is False
 
-    def test_deactivate_writes_state_file(self, chdir_tmp, real_agent_config):
+    def test_deactivate_survives_a_rebuilt_node(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_bbbb")
+        _materialize_session(node)
         node.activate_plan_mode()
         node.deactivate_plan_mode()
 
-        state_path = _state_path(node, "chat_session_bbbb")
-        data = json.loads(state_path.read_text(encoding="utf-8"))
+        rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_bbbb")
         # plan_mode_active flipped back to False; plan_file_path is preserved.
-        assert data["plan_mode"]["plan_mode_active"] is False
-        assert data["plan_mode"]["plan_file_path"] == node.plan_file_path
-        assert data["plan_mode"]["workflow_prompt_sent"] is False
+        assert rebuilt.plan_mode_active is False
+        assert rebuilt.plan_file_path == node.plan_file_path
+        assert rebuilt.workflow_prompt_sent is False
+
+    def test_plan_mode_entered_before_the_first_message_is_still_persisted(self, chdir_tmp, real_agent_config):
+        """Entering plan mode before typing finds no database to write to.
+
+        ``session_id`` is allocated in ``__init__`` but the database is only
+        created on the first message, and the write is skipped rather than
+        materialising an empty file that would list as a session. Creating the
+        session has to flush the pending flags, or a chat that entered plan
+        mode before its first message would resume without it.
+        """
+        node = _make_chat_node(real_agent_config, session_id="chat_session_early")
+        node.activate_plan_mode()
+
+        _materialize_session(node)
+
+        rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_early")
+        assert rebuilt.plan_mode_active is True
+        assert rebuilt.plan_file_path == node.plan_file_path
 
     def test_fresh_node_generates_session_id(self, chdir_tmp, real_agent_config):
         """When caller omits ``session_id``, ``__init__`` allocates one eagerly
@@ -82,28 +108,59 @@ class TestPlanModeStatePersistence:
         assert node.session_id  # always non-empty after construction
         assert node.session_id.startswith("chat_session_")
 
+        _materialize_session(node)
         node.activate_plan_mode()
-        # State file lands under the generated id.
-        state_path = _state_path(node, node.session_id)
-        assert state_path.exists()
+
+        rebuilt = _make_chat_node(real_agent_config, session_id=node.session_id)
+        assert rebuilt.plan_mode_active is True
 
 
 class TestSessionIdConstructorTriggersRestore:
     """Passing ``session_id`` to ``__init__`` rehydrates persisted plan-mode."""
 
     def test_constructor_session_id_restores(self, chdir_tmp, real_agent_config):
-        anchor = _make_chat_node(real_agent_config)
-        PlanModeState(
-            plan_mode_active=True,
-            plan_file_path="./.datus/plans/init.md",
-            workflow_prompt_sent=False,
-        ).save(_state_path(anchor, "chat_session_dddd"))
+        anchor = _make_chat_node(real_agent_config, session_id="chat_session_dddd")
+        _materialize_session(anchor)
+        anchor.plan_file_path = "./.datus/plans/init.md"
+        anchor.activate_plan_mode()
 
         node = _make_chat_node(real_agent_config, session_id="chat_session_dddd")
 
         assert node.plan_mode_active is True
         assert node.plan_file_path == "./.datus/plans/init.md"
         assert node._plan_just_confirmed is False  # one-shot flag never restored
+
+    def test_a_state_file_from_before_the_move_still_restores(self, chdir_tmp, real_agent_config):
+        """Sessions predating the database move keep their JSON section."""
+        anchor = _make_chat_node(real_agent_config)
+        _write_legacy_plan_mode(
+            _state_path(anchor, "chat_session_legacyplan"),
+            plan_mode_active=True,
+            plan_file_path="./.datus/plans/init.md",
+            workflow_prompt_sent=False,
+        )
+
+        node = _make_chat_node(real_agent_config, session_id="chat_session_legacyplan")
+
+        assert node.plan_mode_active is True
+        assert node.plan_file_path == "./.datus/plans/init.md"
+
+    def test_the_database_wins_over_a_stale_state_file(self, chdir_tmp, real_agent_config):
+        """A migrated session must not be dragged back by its leftover file."""
+        anchor = _make_chat_node(real_agent_config, session_id="chat_session_bothsources")
+        _materialize_session(anchor)
+        anchor.activate_plan_mode()
+        anchor.deactivate_plan_mode()
+        _write_legacy_plan_mode(
+            _state_path(anchor, "chat_session_bothsources"),
+            plan_mode_active=True,
+            plan_file_path="./.datus/plans/stale.md",
+            workflow_prompt_sent=True,
+        )
+
+        node = _make_chat_node(real_agent_config, session_id="chat_session_bothsources")
+
+        assert node.plan_mode_active is False
 
     def test_constructor_no_state_file_keeps_defaults(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_unknown")
@@ -120,27 +177,14 @@ class TestCompactStateNotPersisted:
     ``[DATUS_ARCHIVED]`` marker, not from disk state.
     """
 
-    def test_compact_run_does_not_write_compact_section(self, chdir_tmp, real_agent_config):
-        """A direct mutation of ``_compacted_until`` plus a plan-mode write
-        must NOT leak a ``compact`` key into the on-disk file. We trigger a
-        plan-mode persistence to ensure the file exists, then read it back.
-        """
-        node = _make_chat_node(real_agent_config, session_id="chat_session_compact_w")
-        node._compacted_until = 7
-        node.activate_plan_mode()
-
-        state_path = _state_path(node, "chat_session_compact_w")
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-        # Only the plan_mode key is written — compact is a process-local field.
-        assert set(data.keys()) == {"plan_mode"}
-
     def test_rebuilt_node_starts_at_zero_even_after_in_memory_advance(self, chdir_tmp, real_agent_config):
         """Anchor node advances the in-memory mark; a second node opened on
         the same session must NOT see that advance — it always starts fresh.
         """
         anchor = _make_chat_node(real_agent_config, session_id="chat_session_compact_r")
+        _materialize_session(anchor)
         anchor._compacted_until = 10
-        anchor.activate_plan_mode()  # forces an on-disk state file
+        anchor.activate_plan_mode()  # forces a persisted plan-mode row
 
         rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_compact_r")
         # Fresh process → fresh scan; in-memory state is intentionally NOT
@@ -207,10 +251,10 @@ class TestContextStatePersistence:
         assert node._restored_context_used == 0
         assert node._restored_context_length == 0
 
-    def test_persist_preserves_plan_mode_section(self, chdir_tmp, real_agent_config):
-        """The two sections share one file — persisting context state must not
-        wipe a previously-written plan-mode section."""
+    def test_persist_preserves_plan_mode_state(self, chdir_tmp, real_agent_config):
+        """Writing occupancy must not disturb the session's plan-mode flags."""
         node = _make_chat_node(real_agent_config, session_id="chat_session_ctx3")
+        _materialize_session(node)
         node.activate_plan_mode()
         node.persist_context_state(last_call_input_tokens=7, context_length=99)
 
@@ -241,10 +285,10 @@ class TestResetUsageCaches:
         assert rebuilt._restored_context_used == 0
         assert rebuilt._restored_context_length == 0
 
-    def test_reset_preserves_plan_mode_section(self, chdir_tmp, real_agent_config):
-        """Only the usage mirror is dropped — a sibling plan-mode section in the
-        same state file must survive the reset."""
+    def test_reset_preserves_plan_mode_state(self, chdir_tmp, real_agent_config):
+        """Only the usage mirror is dropped — plan mode is not usage state."""
         node = _make_chat_node(real_agent_config, session_id="chat_session_reset2")
+        _materialize_session(node)
         node.activate_plan_mode()
         node.persist_context_state(last_call_input_tokens=7, context_length=99)
 

--- a/tests/unit_tests/agent/node/test_agentic_node_persistence.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_persistence.py
@@ -224,44 +224,36 @@ class TestContextStatePersistence:
     def test_persist_writes_context_state_section(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_ctx1")
 
-        node.persist_context_state(last_call_input_tokens=52_499, context_length=1_000_000)
+        node.persist_context_state(52_499)
 
         state_path = _state_path(node, "chat_session_ctx1")
         assert state_path.exists()
         data = json.loads(state_path.read_text(encoding="utf-8"))
-        assert data["context_state"] == {
-            "last_call_input_tokens": 52_499,
-            "context_length": 1_000_000,
-            "valid": True,
-        }
+        assert data["context_state"] == {"last_call_input_tokens": 52_499}
         # In-memory mirror updated so a same-process status-bar read is correct.
         assert node._restored_context_used == 52_499
-        assert node._restored_context_length == 1_000_000
 
     def test_rebuilt_node_restores_context_state(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_ctx2")
-        node.persist_context_state(last_call_input_tokens=12_004, context_length=200_000)
+        node.persist_context_state(12_004)
 
         rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_ctx2")
         assert rebuilt._restored_context_used == 12_004
-        assert rebuilt._restored_context_length == 200_000
 
     def test_fresh_session_restores_zero(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_ctx_fresh")
         assert node._restored_context_used == 0
-        assert node._restored_context_length == 0
 
     def test_persist_preserves_plan_mode_state(self, chdir_tmp, real_agent_config):
         """Writing occupancy must not disturb the session's plan-mode flags."""
         node = _make_chat_node(real_agent_config, session_id="chat_session_ctx3")
         _materialize_session(node)
         node.activate_plan_mode()
-        node.persist_context_state(last_call_input_tokens=7, context_length=99)
+        node.persist_context_state(7)
 
         rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_ctx3")
         assert rebuilt.plan_mode_active is True  # survived the context-state write
         assert rebuilt._restored_context_used == 7
-        assert rebuilt._restored_context_length == 99
 
 
 class TestResetUsageCaches:
@@ -271,7 +263,7 @@ class TestResetUsageCaches:
 
     def test_reset_zeros_in_memory_and_removes_context_state(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_reset1")
-        node.persist_context_state(last_call_input_tokens=52_499, context_length=1_000_000)
+        node.persist_context_state(52_499)
         node.running_turn_usage = object()  # stand-in for a TokenUsage snapshot
 
         node._reset_usage_caches()
@@ -279,18 +271,16 @@ class TestResetUsageCaches:
         # In-memory mirrors zeroed.
         assert node.running_turn_usage is None
         assert node._restored_context_used == 0
-        assert node._restored_context_length == 0
         # Persisted ContextState mirror removed — a rebuilt node restores zero.
         rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_reset1")
         assert rebuilt._restored_context_used == 0
-        assert rebuilt._restored_context_length == 0
 
     def test_reset_preserves_plan_mode_state(self, chdir_tmp, real_agent_config):
         """Only the usage mirror is dropped — plan mode is not usage state."""
         node = _make_chat_node(real_agent_config, session_id="chat_session_reset2")
         _materialize_session(node)
         node.activate_plan_mode()
-        node.persist_context_state(last_call_input_tokens=7, context_length=99)
+        node.persist_context_state(7)
 
         node._reset_usage_caches()
 

--- a/tests/unit_tests/agent/node/test_agentic_node_persistence.py
+++ b/tests/unit_tests/agent/node/test_agentic_node_persistence.py
@@ -100,6 +100,27 @@ class TestPlanModeStatePersistence:
         assert rebuilt.plan_mode_active is True
         assert rebuilt.plan_file_path == node.plan_file_path
 
+    def test_materializing_a_session_never_overwrites_stored_plan_mode(self, chdir_tmp, real_agent_config):
+        """Getting a session object must not write a stale snapshot back.
+
+        ``_get_or_create_session`` also runs from paths that only need the
+        session — the minor-compact turn count, the API's throwaway compaction
+        node. Those nodes restored plan mode when they were built, so if the
+        live process toggles it afterwards, re-persisting their snapshot
+        silently drops the user out of plan mode.
+        """
+        live = _make_chat_node(real_agent_config, session_id="chat_session_race")
+        _materialize_session(live)
+        # Built before the toggle, so its in-memory flags say plan mode is off.
+        stale = _make_chat_node(real_agent_config, session_id="chat_session_race")
+        live.activate_plan_mode()
+
+        _materialize_session(stale)
+
+        rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_race")
+        assert rebuilt.plan_mode_active is True
+        assert rebuilt.plan_file_path == live.plan_file_path
+
     def test_fresh_node_generates_session_id(self, chdir_tmp, real_agent_config):
         """When caller omits ``session_id``, ``__init__`` allocates one eagerly
         so persistence has a stable key from the very first turn."""
@@ -221,20 +242,44 @@ class TestCompactStateNotPersisted:
 class TestContextStatePersistence:
     """``persist_context_state`` flushes occupancy; a rebuilt node restores it."""
 
-    def test_persist_writes_context_state_section(self, chdir_tmp, real_agent_config):
+    def test_persist_writes_the_measurement_to_the_session_database(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_ctx1")
+        _materialize_session(node)
 
         node.persist_context_state(52_499)
 
-        state_path = _state_path(node, "chat_session_ctx1")
-        assert state_path.exists()
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-        assert data["context_state"] == {"last_call_input_tokens": 52_499}
+        stored = node.session_manager.load_context_state("chat_session_ctx1")
+        assert stored is not None and stored.last_call_input_tokens == 52_499
         # In-memory mirror updated so a same-process status-bar read is correct.
         assert node._restored_context_used == 52_499
 
+    def test_persist_does_not_create_a_json_mirror_for_a_new_session(self, chdir_tmp, real_agent_config):
+        """The JSON file is a compatibility mirror, not a second store.
+
+        ``SessionManager`` only reaches it by name on delete, so writing one for
+        every session recreates the unreachable location the move to
+        ``session_meta`` removed.
+        """
+        node = _make_chat_node(real_agent_config, session_id="chat_session_ctxnew")
+        _materialize_session(node)
+
+        node.persist_context_state(52_499)
+
+        assert not _state_path(node, "chat_session_ctxnew").exists()
+
+    def test_persist_still_refreshes_an_existing_json_mirror(self, chdir_tmp, real_agent_config):
+        """A session that predates the move keeps its file consistent."""
+        node = _make_chat_node(real_agent_config, session_id="chat_session_ctxlegacy")
+        _write_legacy_plan_mode(_state_path(node, "chat_session_ctxlegacy"), plan_mode_active=False)
+
+        node.persist_context_state(52_499)
+
+        data = json.loads(_state_path(node, "chat_session_ctxlegacy").read_text(encoding="utf-8"))
+        assert data["context_state"] == {"last_call_input_tokens": 52_499}
+
     def test_rebuilt_node_restores_context_state(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_ctx2")
+        _materialize_session(node)
         node.persist_context_state(12_004)
 
         rebuilt = _make_chat_node(real_agent_config, session_id="chat_session_ctx2")
@@ -263,6 +308,7 @@ class TestResetUsageCaches:
 
     def test_reset_zeros_in_memory_and_removes_context_state(self, chdir_tmp, real_agent_config):
         node = _make_chat_node(real_agent_config, session_id="chat_session_reset1")
+        _materialize_session(node)
         node.persist_context_state(52_499)
         node.running_turn_usage = object()  # stand-in for a TokenUsage snapshot
 

--- a/tests/unit_tests/agent/node/test_compact_helpers.py
+++ b/tests/unit_tests/agent/node/test_compact_helpers.py
@@ -940,8 +940,6 @@ class TestOccupancyAfterSessionRewrite:
 
         on_disk = ContextState.load(state_path)
         assert on_disk.last_call_input_tokens == 0
-        assert on_disk.valid is False
-        assert on_disk.context_length == self.WINDOW
         # The in-memory mirror agrees, so a between-turns status-bar read and a
         # post-restart read cannot disagree.
         assert node._restored_context_used == on_disk.last_call_input_tokens
@@ -1000,7 +998,7 @@ class TestMeasuredContextContracts:
 
         node = self._node(tmp_path)
         await node._session.add_items(TestOccupancyAfterSessionRewrite._history())
-        node.persist_context_state(95_000, 100_000)
+        node.persist_context_state(95_000)
         result = await node.compact(mode="major")
         assert result["success"] is True
         assert node.running_turn_usage.session_total_tokens == 0
@@ -1022,7 +1020,7 @@ class TestMeasuredContextContracts:
     async def test_rewrite_updates_memory_without_a_state_file(self, tmp_path):
         """A missing state path must not leave pre-rewrite occupancy in memory."""
         node = self._node(tmp_path)
-        node.persist_context_state(95_000, 100_000)
+        node.persist_context_state(95_000)
         node._agent_state_file = lambda: None
         node.running_turn_usage = None
         await node._replace_session_items([{"role": "assistant", "content": "recap"}])
@@ -1121,7 +1119,7 @@ async def test_cancelled_rewrite_finishes_bookkeeping_before_esc_rollback(tmp_pa
     with pytest.raises(asyncio.CancelledError):
         await task
     assert node._session_rewritten_this_turn is True
-    assert node.get_context_usage().valid is False
+    assert node.get_context_usage().last_call_input_tokens == 0
     node.session_manager.rollback_turn(node.session_id, node.mid_turn_rewrite_checkpoint)
     assert await node._session.get_items() == rewritten
     node._session.close()

--- a/tests/unit_tests/agent/node/test_token_usage_hook.py
+++ b/tests/unit_tests/agent/node/test_token_usage_hook.py
@@ -136,7 +136,7 @@ async def test_on_llm_end_first_call_emits_full_delta_and_persists():
 
     # context-window occupancy persisted to the on-disk session_state via the
     # node, using the call's real context window (``last_call_input_tokens``).
-    node.persist_context_state.assert_called_once_with(800, 200_000)
+    node.persist_context_state.assert_called_once_with(800)
 
     # node snapshot populated so the status bar's next render sees it
     snapshot = node.running_turn_usage

--- a/tests/unit_tests/cli/test_status_bar.py
+++ b/tests/unit_tests/cli/test_status_bar.py
@@ -581,7 +581,6 @@ class TestStatusBarProviderTokens:
             context_length=1_000_000,
             running_turn_usage=running,
             _restored_context_used=52_499,
-            _restored_context_length=1_000_000,
         )
         state = StatusBarProvider(self._make_cli(node)).current_state()
         assert state.context_used == 60_000  # live snapshot, not restored 52_499
@@ -602,7 +601,6 @@ class TestStatusBarProviderTokens:
             context_length=200_000,
             running_turn_usage=None,
             _restored_context_used=1_200,
-            _restored_context_length=200_000,
         )
         state = StatusBarProvider(self._make_cli(node)).current_state()
         assert state.context_used == 1_200

--- a/tests/unit_tests/cli/test_status_bar.py
+++ b/tests/unit_tests/cli/test_status_bar.py
@@ -494,7 +494,6 @@ class TestStatusBarProviderTokens:
             context_length=0,
             running_turn_usage=running,
             _restored_context_used=object(),
-            _restored_context_length=object(),
         )
         state = StatusBarProvider(self._make_cli(node)).current_state()
         assert state.context_used == 0
@@ -538,19 +537,38 @@ class TestStatusBarProviderTokens:
     def test_context_used_falls_back_to_restored_state_on_resume(self):
         """A freshly resumed process has no running snapshot and no live
         actions, so the bar must surface the occupancy re-hydrated from the
-        on-disk ``context_state`` section (``_restored_context_used``)."""
+        session db (``_restored_context_used``). The denominator comes from the
+        model the node resolves, not from anything stored with the reading."""
         node = SimpleNamespace(
             model=None,
             session_id="sess-resume",
             actions=[],
-            context_length=0,
+            context_length=1_000_000,
             running_turn_usage=None,
             _restored_context_used=52_499,
-            _restored_context_length=1_000_000,
         )
         state = StatusBarProvider(self._make_cli(node)).current_state()
         assert state.context_used == 52_499
         assert state.context_total == 1_000_000
+
+    def test_a_model_that_reports_no_window_leaves_the_bar_without_a_denominator(self):
+        """Occupancy is stored, the window is not — it is resolved per access.
+
+        A resumed session whose model cannot report its window therefore has a
+        reading but no ratio, and the bar shows an empty total rather than
+        dividing by a figure measured against some other model.
+        """
+        node = SimpleNamespace(
+            model=None,
+            session_id="sess-nowindow",
+            actions=[],
+            context_length=0,
+            running_turn_usage=None,
+            _restored_context_used=52_499,
+        )
+        state = StatusBarProvider(self._make_cli(node)).current_state()
+        assert state.context_used == 52_499
+        assert state.context_total == 0
 
     def test_restored_state_yields_to_live_snapshot(self):
         """Once the resumed turn issues its first LLM call the live running

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -2561,3 +2561,63 @@ def test_get_session_messages_hides_the_mid_turn_resume_instruction(sm):
     user_texts = [m["content"] for m in messages if m["role"] == "user"]
     assert user_texts == ["analyse refunds"]
     assert not any("DATUS_COMPACT_RESUME" in json.dumps(m, default=str) for m in messages)
+
+
+class TestSessionTitleAcrossSessionRewrites:
+    """The recorded title outlives a compact, follows a copy, and resets on ``/clear``.
+
+    Listing a session shows its first user message. A major compact deletes the
+    history that message lived in, so the title is recorded when it arrives and
+    read back from ``session_meta``. Every path that builds a new session from
+    an old one has to carry that row, or the bug reappears one step later.
+    """
+
+    def _compacted_session(self, sm, session_id, opening_message):
+        """A session a major compact reduced to a single assistant recap."""
+        import asyncio
+
+        session = sm.get_session(session_id)
+        asyncio.run(session.add_items([{"role": "user", "content": opening_message}]))
+        asyncio.run(session.replace_items([{"role": "assistant", "content": "Recap of the conversation."}]))
+        return session
+
+    def test_clearing_history_lets_the_next_message_rename_the_session(self, sm_custom):
+        """``/clear`` restarts the conversation, so the old opening no longer describes it."""
+        import asyncio
+
+        session_id = "chat_session_cleared"
+        session = sm_custom.get_session(session_id)
+        asyncio.run(session.add_items([{"role": "user", "content": "How many buses ran today?"}]))
+
+        sm_custom.clear_session(session_id)
+        asyncio.run(session.add_items([{"role": "user", "content": "Unrelated new topic"}]))
+
+        assert sm_custom.get_session_info(session_id)["first_user_message"] == "Unrelated new topic"
+
+    def test_copying_a_compacted_session_carries_its_title(self, sm_custom):
+        """Switching node type copies a session whose user rows a compact removed."""
+        source_id = "chat_session_tocopy"
+        self._compacted_session(sm_custom, source_id, "How many buses ran today?")
+
+        new_id = sm_custom.copy_session(source_id, "gen_sql")
+
+        assert sm_custom.get_session_info(new_id)["first_user_message"] == "How many buses ran today?"
+
+    def test_rewinding_a_compacted_session_carries_its_title(self, sm_custom):
+        """A rewind keeps the conversation's opening turn, so it keeps its name."""
+        source_id = "chat_session_torewind"
+        self._compacted_session(sm_custom, source_id, "How many buses ran today?")
+
+        new_id = sm_custom.rewind_session(source_id, up_to_user_turn=1)
+
+        assert sm_custom.get_session_info(new_id)["first_user_message"] == "How many buses ran today?"
+
+    def test_copying_a_session_that_never_recorded_a_title_still_works(self, sm_custom):
+        """Sessions older than ``session_meta`` have no row to carry."""
+        source_id = "chat_session_legacycopy"
+        sm_custom.get_session(source_id)
+        _insert_messages(sm_custom.session_dir, source_id, [{"role": "user", "content": "What is SQL?"}])
+
+        new_id = sm_custom.copy_session(source_id, "gen_sql")
+
+        assert sm_custom.get_session_info(new_id)["first_user_message"] == "What is SQL?"

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -520,6 +520,32 @@ class TestSessionManagerExecution:
         assert "file_size" in info
         assert info["file_size"] > 0
 
+    def test_get_session_info_orders_user_messages_within_one_second(self, sm):
+        """Messages of one turn share a timestamp, and the scan still has to order them.
+
+        SQLite's ``CURRENT_TIMESTAMP`` has one-second resolution, so a real
+        turn writes every row with the same value. Ordering on the timestamp
+        alone leaves them tied, and the reverse scan that looks for the opening
+        message walks forwards instead — swapping first and latest.
+        """
+        session_id = "same-second"
+        sm.get_session(session_id)
+        _insert_messages(
+            sm.session_dir,
+            session_id,
+            [
+                {"role": "user", "content": "FIRST", "created_at": "2025-01-01T00:00:00"},
+                {"role": "assistant", "content": "answer one", "created_at": "2025-01-01T00:00:00"},
+                {"role": "user", "content": "SECOND", "created_at": "2025-01-01T00:00:00"},
+                {"role": "assistant", "content": "answer two", "created_at": "2025-01-01T00:00:00"},
+            ],
+        )
+
+        info = sm.get_session_info(session_id)
+
+        assert info["first_user_message"] == "FIRST"
+        assert info["latest_user_message"] == "SECOND"
+
     def test_get_session_info_db_path(self, sm):
         """get_session_info returns the correct db_path."""
         session_id = "path-check"
@@ -2440,6 +2466,30 @@ class TestSystemPromptSnapshot:
         assert not os.path.exists(self._path(sm_custom, session_id))
         assert sm_custom.load_system_prompt_snapshot(session_id) is None
 
+    def test_delete_session_drops_the_legacy_state_file(self, tmp_path):
+        """A deleted conversation must not leave its plan-mode payload on disk.
+
+        Sessions predating ``session_meta`` keep plan-mode state — including
+        ``plan_file_path`` — in ``{project_data_dir}/state/{session_id}.json``,
+        which lives outside ``session_dir`` and so needs deleting by name.
+        """
+        from datus.utils.path_manager import DatusPathManager
+
+        pm = DatusPathManager(datus_home=tmp_path / "home", project_name="proj")
+        manager = SessionManager(path_manager=pm)
+        session_id = "chat_session_legacystate"
+        manager.get_session(session_id)
+        state_path = pm.agent_state_path(session_id)
+        state_path.write_text(
+            json.dumps({"plan_mode": {"plan_mode_active": True, "plan_file_path": "./.datus/plans/ab12.md"}}),
+            encoding="utf-8",
+        )
+
+        manager.delete_session(session_id)
+
+        assert not state_path.exists()
+        manager.close_all_sessions()
+
     def test_clear_session_drops_snapshot(self, sm_custom):
         """Clearing history is a session rebuild: the frozen prompt must go."""
         session_id = "chat_session_clear"
@@ -2621,3 +2671,105 @@ class TestSessionTitleAcrossSessionRewrites:
         new_id = sm_custom.copy_session(source_id, "gen_sql")
 
         assert sm_custom.get_session_info(new_id)["first_user_message"] == "What is SQL?"
+
+    def test_a_derived_session_can_still_rewrite_its_history(self, sm_custom):
+        """Whatever ``copy_session``/``rewind_session`` cache has to be a Datus session.
+
+        Every compact path calls ``replace_items`` on the object ``get_session``
+        hands back, and ``/clear`` calls ``forget_recorded_title``; neither
+        exists on the SDK base class, so caching one turns the next compact
+        after an agent switch or a rewind into an ``AttributeError``.
+        """
+        import asyncio
+
+        source_id = "chat_session_derivedrewrite"
+        session = sm_custom.get_session(source_id)
+        asyncio.run(session.add_items([{"role": "user", "content": "How many buses ran today?"}]))
+
+        for derived_id in (
+            sm_custom.copy_session(source_id, "gen_sql"),
+            sm_custom.rewind_session(source_id, up_to_user_turn=1),
+        ):
+            derived = sm_custom.get_session(derived_id)
+            asyncio.run(derived.replace_items([{"role": "assistant", "content": "Recap."}]))
+            assert asyncio.run(derived.get_items()) == [{"role": "assistant", "content": "Recap."}]
+            derived.forget_recorded_title()
+
+
+class TestDerivedSessionsDoNotInheritHistoryReadings:
+    """A copy or a rewind produces different history, so readings of the old one stay behind.
+
+    ``session_meta`` holds the durable title next to state that describes the
+    exact history it was measured against. Only the title survives a rewrite,
+    so only the title travels.
+    """
+
+    def _measured_session(self, sm, session_id):
+        """A session with two turns, a recorded occupancy, and plan mode on."""
+        import asyncio
+
+        from datus.models.sqlite_session import SESSION_PLAN_MODE_KEY
+        from datus.storage.session_state import PlanModeState
+
+        session = sm.get_session(session_id)
+        asyncio.run(
+            session.add_items(
+                [
+                    {"role": "user", "content": "How many buses ran today?"},
+                    {"role": "assistant", "content": "412."},
+                ]
+            )
+        )
+        sm.save_context_state(session_id, ContextState(190_000))
+        sm.save_session_meta(
+            session_id,
+            SESSION_PLAN_MODE_KEY,
+            PlanModeState(plan_mode_active=True, plan_file_path="./.datus/plans/ab12.md").to_json(),
+        )
+        return session
+
+    @pytest.mark.parametrize("derive", ["copy", "rewind"])
+    def test_a_derived_session_reports_an_unknown_occupancy(self, sm_custom, derive):
+        """The reading describes the history the derivation just changed.
+
+        Carrying it over makes the first turn of a two-message session compute a
+        near-full window: the compaction gate fires a major pass immediately and
+        the status bar shows a context that is not there.
+        """
+        source_id = "chat_session_measured_" + derive
+        self._measured_session(sm_custom, source_id)
+
+        if derive == "copy":
+            new_id = sm_custom.copy_session(source_id, "gen_sql")
+        else:
+            new_id = sm_custom.rewind_session(source_id, up_to_user_turn=1)
+
+        assert sm_custom.load_context_state(new_id) is None
+
+    @pytest.mark.parametrize("derive", ["copy", "rewind"])
+    def test_a_derived_session_does_not_start_in_plan_mode(self, sm_custom, derive):
+        """Plan mode is a live toggle of the source session's user, not a property of its history."""
+        from datus.models.sqlite_session import SESSION_PLAN_MODE_KEY
+
+        source_id = "chat_session_planned_" + derive
+        self._measured_session(sm_custom, source_id)
+
+        if derive == "copy":
+            new_id = sm_custom.copy_session(source_id, "gen_sql")
+        else:
+            new_id = sm_custom.rewind_session(source_id, up_to_user_turn=1)
+
+        assert sm_custom.load_session_meta(new_id, SESSION_PLAN_MODE_KEY) is None
+
+    @pytest.mark.parametrize("derive", ["copy", "rewind"])
+    def test_a_derived_session_still_keeps_the_title(self, sm_custom, derive):
+        """The one reading that outlives a rewrite still has to travel."""
+        source_id = "chat_session_titled_" + derive
+        self._measured_session(sm_custom, source_id)
+
+        if derive == "copy":
+            new_id = sm_custom.copy_session(source_id, "gen_sql")
+        else:
+            new_id = sm_custom.rewind_session(source_id, up_to_user_turn=1)
+
+        assert sm_custom.get_session_info(new_id)["first_user_message"] == "How many buses ran today?"

--- a/tests/unit_tests/models/test_session_manager.py
+++ b/tests/unit_tests/models/test_session_manager.py
@@ -2470,8 +2470,8 @@ class TestContextStatePersistence:
     """save/load_context_state: the durable occupancy measurement."""
 
     def _enable_state_table(self, sm_custom, session_id):
-        """Materialise ``context_occupancy`` through the public writer."""
-        sm_custom.save_context_state(session_id, ContextState(500, 1000, True))
+        """Materialise ``session_meta`` through the public writer."""
+        sm_custom.save_context_state(session_id, ContextState(500))
 
     def test_writing_a_state_never_creates_the_session_database(self, sm_custom):
         """No occupancy write may invent a session that ``list_sessions`` reports.
@@ -2480,7 +2480,7 @@ class TestContextStatePersistence:
         purely ``*.db`` filenames — so writing state for an absent session
         would conjure a session out of nothing.
         """
-        sm_custom.save_context_state("state_ghost", ContextState(400, 1000, True))
+        sm_custom.save_context_state("state_ghost", ContextState(400))
 
         assert "state_ghost" not in sm_custom.list_sessions()
         assert not os.path.exists(os.path.join(sm_custom.session_dir, "state_ghost.db"))
@@ -2506,13 +2506,13 @@ class TestContextStatePersistence:
         db_path = os.path.join(sm_custom.session_dir, f"{session_id}.db")
         with sqlite3.connect(db_path) as conn:
             conn.execute(
-                "CREATE TRIGGER reject_state BEFORE INSERT ON context_occupancy "
+                "CREATE TRIGGER reject_state BEFORE INSERT ON session_meta "
                 "BEGIN SELECT RAISE(ABORT, 'state rejected'); END"
             )
 
-        sm_custom.save_context_state(session_id, ContextState(0, 1000, False))
+        sm_custom.save_context_state(session_id, ContextState(0))
 
-        assert sm_custom.load_context_state(session_id) == ContextState(500, 1000, True)
+        assert sm_custom.load_context_state(session_id) == ContextState(500)
 
     def test_clear_session_does_not_surface_a_rejected_state_write(self, sm_custom):
         """History clearing completes even when the occupancy reset fails."""
@@ -2523,7 +2523,7 @@ class TestContextStatePersistence:
         db_path = os.path.join(sm_custom.session_dir, f"{session_id}.db")
         with sqlite3.connect(db_path) as conn:
             conn.execute(
-                "CREATE TRIGGER reject_state_clear BEFORE INSERT ON context_occupancy "
+                "CREATE TRIGGER reject_state_clear BEFORE INSERT ON session_meta "
                 "BEGIN SELECT RAISE(ABORT, 'state rejected'); END"
             )
 

--- a/tests/unit_tests/models/test_sqlite_session.py
+++ b/tests/unit_tests/models/test_sqlite_session.py
@@ -110,3 +110,120 @@ async def test_an_unreadable_usage_snapshot_never_blocks_the_rewrite(tmp_path, s
     assert cumulative["last_call_input_tokens"] == 0
     assert cumulative["context_usage_valid"] is False
     session.close()
+
+
+# ===========================================================================
+# Session title
+#
+# A session is listed under its first user message. That message used to be
+# found by scanning the history, which a major compact deletes: the scan then
+# reports nothing, or — once the conversation continues — a mid-conversation
+# message that silently retitles the chat. The title is now recorded as it
+# arrives and read back from ``session_meta``, which no rewrite touches.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_the_first_user_message_names_the_session(tmp_path):
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("named")
+
+    await session.add_items([{"role": "user", "content": "How many buses ran today?"}])
+
+    assert manager.get_session_info("named")["first_user_message"] == "How many buses ran today?"
+    session.close()
+
+
+@pytest.mark.asyncio
+async def test_a_compact_cannot_erase_the_session_title(tmp_path):
+    """The post-compact shape: an assistant recap and no user rows at all."""
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("compacted")
+    await session.add_items(
+        [
+            {"role": "user", "content": "How many buses ran today?"},
+            {"role": "assistant", "content": "412."},
+        ]
+    )
+
+    await session.replace_items([{"role": "assistant", "content": "Recap of the conversation."}])
+
+    assert await session.get_items() == [{"role": "assistant", "content": "Recap of the conversation."}]
+    assert manager.get_session_info("compacted")["first_user_message"] == "How many buses ran today?"
+    session.close()
+
+
+@pytest.mark.asyncio
+async def test_a_later_message_cannot_retitle_a_compacted_session(tmp_path):
+    """After a compact the earliest surviving user row is mid-conversation.
+
+    The session is reopened first, so the write-once guard is enforced by the
+    stored row rather than by an in-memory flag that a resume would reset.
+    """
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("continued")
+    await session.add_items([{"role": "user", "content": "How many buses ran today?"}])
+    await session.replace_items([{"role": "assistant", "content": "Recap of the conversation."}])
+    manager.close_all_sessions()
+
+    reopened = manager.get_session("continued")
+    await reopened.add_items([{"role": "user", "content": "And by route?"}])
+
+    assert manager.get_session_info("continued")["first_user_message"] == "How many buses ran today?"
+    reopened.close()
+
+
+@pytest.mark.asyncio
+async def test_a_session_recorded_before_the_title_existed_still_names_itself(tmp_path):
+    """Sessions older than ``session_meta`` keep the scan as their only source."""
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("legacy")
+    await session.add_items([{"role": "user", "content": "What is SQL?"}])
+    with sqlite3.connect(tmp_path / "legacy.db") as conn:
+        conn.execute("DROP TABLE session_meta")
+
+    assert manager.get_session_info("legacy")["first_user_message"] == "What is SQL?"
+    session.close()
+
+
+@pytest.mark.asyncio
+async def test_a_first_request_compact_still_names_the_session(tmp_path):
+    """Compaction on the very first request persists the input itself.
+
+    The SDK re-appends that same input afterwards and ``add_items`` drops it as
+    a duplicate, so the opening message only ever appears in the dropped part.
+    A later compact then removes the stored copy too, leaving nothing to scan.
+    """
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("firstreq")
+    opening = [{"role": "user", "content": "How many buses ran today?"}]
+    await session.replace_items(opening)
+    session.skip_persisted_input_once(opening)
+    await session.add_items(opening)
+
+    await session.replace_items([{"role": "assistant", "content": "Recap of the conversation."}])
+
+    assert manager.get_session_info("firstreq")["first_user_message"] == "How many buses ran today?"
+    session.close()
+
+
+@pytest.mark.asyncio
+async def test_a_tool_result_never_names_the_session(tmp_path):
+    """Claude-native tool results arrive as user messages but are not turns.
+
+    ``_is_user_message`` already rejects them for turn numbering; the title has
+    to honour the same definition or a resumed session would be listed under a
+    blob of tool output.
+    """
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("tooled")
+
+    await session.add_items(
+        [
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "412"}]},
+            {"role": "user", "content": "How many buses ran today?"},
+        ]
+    )
+
+    assert manager.get_session_info("tooled")["first_user_message"] == "How many buses ran today?"
+    session.close()

--- a/tests/unit_tests/models/test_sqlite_session.py
+++ b/tests/unit_tests/models/test_sqlite_session.py
@@ -187,6 +187,34 @@ async def test_a_session_recorded_before_the_title_existed_still_names_itself(tm
 
 
 @pytest.mark.asyncio
+async def test_resuming_a_session_older_than_the_title_does_not_rename_it(tmp_path):
+    """An absent title row means "never recorded", not "no conversation yet".
+
+    Every session created before ``session_meta`` existed has history but no
+    row. Naming such a session from the batch that happens to arrive next
+    renames the whole installed base to whatever its user says after upgrading,
+    and the write-once row makes that permanent.
+    """
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("upgraded")
+    await session.add_items(
+        [
+            {"role": "user", "content": "How many buses ran today?"},
+            {"role": "assistant", "content": "412."},
+        ]
+    )
+    with sqlite3.connect(tmp_path / "upgraded.db") as conn:
+        conn.execute("DROP TABLE session_meta")
+    manager.close_all_sessions()
+
+    resumed = manager.get_session("upgraded")
+    await resumed.add_items([{"role": "user", "content": "Actually, show me refunds instead"}])
+
+    assert manager.get_session_info("upgraded")["first_user_message"] == "How many buses ran today?"
+    resumed.close()
+
+
+@pytest.mark.asyncio
 async def test_a_first_request_compact_still_names_the_session(tmp_path):
     """Compaction on the very first request persists the input itself.
 
@@ -204,6 +232,23 @@ async def test_a_first_request_compact_still_names_the_session(tmp_path):
     await session.replace_items([{"role": "assistant", "content": "Recap of the conversation."}])
 
     assert manager.get_session_info("firstreq")["first_user_message"] == "How many buses ran today?"
+    session.close()
+
+
+@pytest.mark.asyncio
+async def test_an_assistant_only_batch_does_not_stop_the_recorder(tmp_path):
+    """Nothing to record is not the same as recorded.
+
+    A batch that carries no user message leaves the session untitled, so the
+    write-once guard must not latch — the opening message may still be coming.
+    """
+    manager = SessionManager(session_dir=str(tmp_path))
+    session = manager.get_session("assistantfirst")
+
+    await session.add_items([{"role": "assistant", "content": "Ready."}])
+    await session.add_items([{"role": "user", "content": "How many buses ran today?"}])
+
+    assert manager.get_session_info("assistantfirst")["first_user_message"] == "How many buses ran today?"
     session.close()
 
 

--- a/tests/unit_tests/models/test_sqlite_session.py
+++ b/tests/unit_tests/models/test_sqlite_session.py
@@ -20,7 +20,7 @@ async def test_failed_metadata_insert_keeps_history_and_measurement(tmp_path):
     session = manager.get_session("atomic")
     original = [{"role": "user", "content": "keep"}, {"role": "assistant", "content": "history"}]
     await session.add_items(original)
-    manager.save_context_state("atomic", ContextState(700, 1000, True))
+    manager.save_context_state("atomic", ContextState(700))
     with sqlite3.connect(tmp_path / "atomic.db") as conn:
         conn.execute(
             "CREATE TRIGGER reject_rewrite BEFORE INSERT ON message_structure "
@@ -29,7 +29,7 @@ async def test_failed_metadata_insert_keeps_history_and_measurement(tmp_path):
     with pytest.raises(sqlite3.IntegrityError, match="metadata rejected"):
         await session.replace_items([{"role": "assistant", "content": "replacement"}])
     assert await session.get_items() == original
-    assert manager.load_context_state("atomic") == ContextState(700, 1000, True)
+    assert manager.load_context_state("atomic") == ContextState(700)
     session.close()
 
 
@@ -46,9 +46,9 @@ async def test_rewrite_preserves_billing_and_monotonic_turns(tmp_path):
             )
         )
     )
-    manager.save_context_state("billing", ContextState(100, 1000, True))
+    manager.save_context_state("billing", ContextState(100))
     await session.replace_items([{"role": "assistant", "content": "recap"}])
-    assert manager.load_context_state("billing") == ContextState(0, 1000, False)
+    assert manager.load_context_state("billing") == ContextState(0)
     await session.add_items([{"role": "user", "content": "second"}])
     await session.store_run_usage(
         SimpleNamespace(

--- a/tests/unit_tests/storage/test_session_state.py
+++ b/tests/unit_tests/storage/test_session_state.py
@@ -101,23 +101,19 @@ class TestPlanModeStateRoundTrip:
 class TestContextStateRoundTrip:
     def test_save_and_load_round_trip(self, tmp_path):
         path = tmp_path / "state" / "ctx.json"
-        ContextState(last_call_input_tokens=52_499, context_length=1_000_000).save(path)
+        ContextState(52_499).save(path)
         assert path.exists()
 
-        loaded = ContextState.load(path)
-        assert loaded.last_call_input_tokens == 52_499
-        assert loaded.context_length == 1_000_000
+        assert ContextState.load(path).last_call_input_tokens == 52_499
 
     def test_on_disk_layout_is_nested_under_context_state(self, tmp_path):
         path = tmp_path / "ctx.json"
-        ContextState(last_call_input_tokens=10, context_length=200).save(path)
+        ContextState(10).save(path)
         data = json.loads(path.read_text(encoding="utf-8"))
-        assert data == {"context_state": {"last_call_input_tokens": 10, "context_length": 200, "valid": True}}
+        assert data == {"context_state": {"last_call_input_tokens": 10}}
 
     def test_load_missing_file_returns_default(self, tmp_path):
-        loaded = ContextState.load(tmp_path / "absent.json")
-        assert loaded.last_call_input_tokens == 0
-        assert loaded.context_length == 0
+        assert ContextState.load(tmp_path / "absent.json").last_call_input_tokens == 0
 
     def test_load_corrupted_json_falls_back_to_default(self, tmp_path):
         path = tmp_path / "bad.json"
@@ -128,22 +124,35 @@ class TestContextStateRoundTrip:
         "raw,expected",
         [
             # Non-int (str / float / bool) coerces to the safe 0 default.
-            ({"last_call_input_tokens": "500", "context_length": 1000}, (0, 1000)),
-            ({"last_call_input_tokens": 12.5, "context_length": 1000}, (0, 1000)),
-            ({"last_call_input_tokens": True, "context_length": 1000}, (0, 1000)),
+            ({"last_call_input_tokens": "500"}, 0),
+            ({"last_call_input_tokens": 12.5}, 0),
+            ({"last_call_input_tokens": True}, 0),
             # Negative values are clamped to 0.
-            ({"last_call_input_tokens": -5, "context_length": -1}, (0, 0)),
+            ({"last_call_input_tokens": -5}, 0),
             # Valid ints preserved.
-            ({"last_call_input_tokens": 800, "context_length": 128_000}, (0, 128_000)),
-            ({"last_call_input_tokens": 800, "context_length": 128_000, "valid": True}, (800, 128_000)),
-            ({}, (0, 0)),
+            ({"last_call_input_tokens": 800}, 800),
+            ({}, 0),
+            # Fields the record no longer carries are ignored, not rejected.
+            ({"last_call_input_tokens": 800, "context_length": 128_000}, 800),
         ],
     )
     def test_load_coerces_invalid_fields(self, tmp_path, raw, expected):
         path = tmp_path / "coerce.json"
         path.write_text(json.dumps({"context_state": raw}), encoding="utf-8")
-        loaded = ContextState.load(path)
-        assert (loaded.last_call_input_tokens, loaded.context_length) == expected
+        assert ContextState.load(path).last_call_input_tokens == expected
+
+    def test_a_record_marked_invalid_before_the_flag_was_dropped_reads_as_zero(self, tmp_path):
+        """Those records may hold a text estimate rather than a measurement.
+
+        The flag is no longer written, but honouring it on read keeps a session
+        from resuming onto a number that was never a real reading.
+        """
+        path = tmp_path / "legacy_invalid.json"
+        path.write_text(
+            json.dumps({"context_state": {"last_call_input_tokens": 9_000, "valid": False}}),
+            encoding="utf-8",
+        )
+        assert ContextState.load(path).last_call_input_tokens == 0
 
 
 class TestSaveSectionErrors:
@@ -155,7 +164,7 @@ class TestSaveSectionErrors:
         # ``state`` would have to live *under* a regular file → mkdir raises
         # NotADirectoryError (an OSError), which save() must absorb.
         path = blocker / "state" / "s.json"
-        ContextState(last_call_input_tokens=1, context_length=2).save(path)
+        ContextState(1).save(path)
         assert not path.exists()
 
 
@@ -169,7 +178,7 @@ class TestSectionsCoexist:
         path = tmp_path / "state" / "s.json"
         _write_plan_mode_section(path, plan_mode_active=True, plan_file_path="p.md", workflow_prompt_sent=True)
 
-        ContextState(last_call_input_tokens=42, context_length=1000).save(path)
+        ContextState(42).save(path)
 
         plan = PlanModeState.load(path)
         ctx = ContextState.load(path)
@@ -177,12 +186,11 @@ class TestSectionsCoexist:
         assert plan.plan_file_path == "p.md"
         assert plan.workflow_prompt_sent is True
         assert ctx.last_call_input_tokens == 42
-        assert ctx.context_length == 1000
 
     def test_both_sections_present_in_file(self, tmp_path):
         path = tmp_path / "s.json"
         _write_plan_mode_section(path, plan_mode_active=True)
-        ContextState(last_call_input_tokens=7, context_length=99).save(path)
+        ContextState(7).save(path)
         data = json.loads(path.read_text(encoding="utf-8"))
         assert set(data.keys()) == {"plan_mode", "context_state"}
 
@@ -194,17 +202,16 @@ class TestContextStateClear:
 
     def test_clear_removes_context_state_section(self, tmp_path):
         path = tmp_path / "state" / "s.json"
-        ContextState(last_call_input_tokens=42, context_length=1000).save(path)
+        ContextState(42).save(path)
         ContextState.clear(path)
         # The section is gone — a subsequent load returns defaults.
-        loaded = ContextState.load(path)
-        assert (loaded.last_call_input_tokens, loaded.context_length) == (0, 0)
+        assert ContextState.load(path).last_call_input_tokens == 0
         assert "context_state" not in json.loads(path.read_text(encoding="utf-8"))
 
     def test_clear_preserves_sibling_plan_mode_section(self, tmp_path):
         path = tmp_path / "state" / "s.json"
         _write_plan_mode_section(path, plan_mode_active=True, plan_file_path="p.md")
-        ContextState(last_call_input_tokens=7, context_length=99).save(path)
+        ContextState(7).save(path)
         ContextState.clear(path)
         plan = PlanModeState.load(path)
         assert plan.plan_mode_active is True
@@ -267,7 +274,7 @@ class TestLegacyCompactSectionIgnored:
             encoding="utf-8",
         )
 
-        ContextState(last_call_input_tokens=5, context_length=100).save(path)
+        ContextState(5).save(path)
 
         data = json.loads(path.read_text(encoding="utf-8"))
         assert "compact" not in data

--- a/tests/unit_tests/storage/test_session_state.py
+++ b/tests/unit_tests/storage/test_session_state.py
@@ -10,22 +10,51 @@ import pytest
 from datus.storage.session_state import ContextState, PlanModeState
 
 
-class TestPlanModeStateRoundTrip:
-    def test_save_and_load_round_trip(self, tmp_path):
-        path = tmp_path / "state" / "s1.json"
+def _write_plan_mode_section(path, **fields):
+    """Write the legacy ``plan_mode`` section straight to the file.
+
+    Plan-mode state now lives in the session database, so nothing in
+    production writes this section any more. Files created before the move
+    still carry it and must keep loading, which is what these fixtures set up.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    data["plan_mode"] = {
+        "plan_mode_active": False,
+        "plan_file_path": None,
+        "workflow_prompt_sent": False,
+        **fields,
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestPlanModeStateJsonRoundTrip:
+    """The database stores the three flags as one JSON value."""
+
+    def test_round_trip(self):
         state = PlanModeState(
             plan_mode_active=True,
             plan_file_path="./.datus/plans/abc12345.md",
             workflow_prompt_sent=True,
         )
-        state.save(path)
-        assert path.exists()
 
-        loaded = PlanModeState.load(path)
-        assert loaded.plan_mode_active is True
-        assert loaded.plan_file_path == "./.datus/plans/abc12345.md"
-        assert loaded.workflow_prompt_sent is True
+        assert PlanModeState.from_json(state.to_json()) == state
 
+    @pytest.mark.parametrize("payload", [None, "", "{not json", '["a", "list"]', '"a string"', "17"])
+    def test_an_unusable_payload_reads_as_nothing_recorded(self, payload):
+        """``None`` is what makes the caller fall through to the legacy file.
+
+        Returning a default state instead would mask a session that still has
+        its plan mode recorded in JSON.
+        """
+        assert PlanModeState.from_json(payload) is None
+
+    def test_a_stored_state_with_every_field_false_is_not_nothing(self):
+        """Plan mode being off is a recorded fact, not a missing record."""
+        assert PlanModeState.from_json(PlanModeState().to_json()) == PlanModeState()
+
+
+class TestPlanModeStateRoundTrip:
     def test_load_missing_file_returns_default(self, tmp_path):
         loaded = PlanModeState.load(tmp_path / "absent.json")
         assert loaded.plan_mode_active is False
@@ -37,21 +66,6 @@ class TestPlanModeStateRoundTrip:
         path.write_text("{not valid json", encoding="utf-8")
         loaded = PlanModeState.load(path)
         assert loaded == PlanModeState()
-
-    def test_save_creates_parent_directories(self, tmp_path):
-        path = tmp_path / "a" / "b" / "c" / "state.json"
-        PlanModeState(plan_mode_active=True).save(path)
-        assert path.exists()
-        # On-disk JSON uses the nested ``plan_mode`` layout so future readers
-        # can tell apart a missing section from a falsy-valued one.
-        data = json.loads(path.read_text(encoding="utf-8"))
-        assert data == {
-            "plan_mode": {
-                "plan_mode_active": True,
-                "plan_file_path": None,
-                "workflow_prompt_sent": False,
-            }
-        }
 
     def test_default_values(self):
         state = PlanModeState()
@@ -146,13 +160,15 @@ class TestSaveSectionErrors:
 
 
 class TestSectionsCoexist:
-    """``plan_mode`` and ``context_state`` live in the same file and are
-    written by different subsystems at different times — neither save may
-    clobber the other's section."""
+    """A pre-migration file holds both sections, and only ``context_state`` is
+    still written. That write must leave the ``plan_mode`` section alone: it is
+    the last copy for a session that has not toggled plan mode since the move,
+    and losing it would silently drop the user out of plan mode."""
 
     def test_context_save_preserves_plan_mode(self, tmp_path):
         path = tmp_path / "state" / "s.json"
-        PlanModeState(plan_mode_active=True, plan_file_path="p.md", workflow_prompt_sent=True).save(path)
+        _write_plan_mode_section(path, plan_mode_active=True, plan_file_path="p.md", workflow_prompt_sent=True)
+
         ContextState(last_call_input_tokens=42, context_length=1000).save(path)
 
         plan = PlanModeState.load(path)
@@ -163,20 +179,9 @@ class TestSectionsCoexist:
         assert ctx.last_call_input_tokens == 42
         assert ctx.context_length == 1000
 
-    def test_plan_mode_save_preserves_context_state(self, tmp_path):
-        path = tmp_path / "state" / "s.json"
-        ContextState(last_call_input_tokens=42, context_length=1000).save(path)
-        PlanModeState(plan_mode_active=True).save(path)
-
-        ctx = ContextState.load(path)
-        plan = PlanModeState.load(path)
-        assert ctx.last_call_input_tokens == 42  # survived the plan-mode write
-        assert ctx.context_length == 1000
-        assert plan.plan_mode_active is True
-
     def test_both_sections_present_in_file(self, tmp_path):
         path = tmp_path / "s.json"
-        PlanModeState(plan_mode_active=True).save(path)
+        _write_plan_mode_section(path, plan_mode_active=True)
         ContextState(last_call_input_tokens=7, context_length=99).save(path)
         data = json.loads(path.read_text(encoding="utf-8"))
         assert set(data.keys()) == {"plan_mode", "context_state"}
@@ -198,7 +203,7 @@ class TestContextStateClear:
 
     def test_clear_preserves_sibling_plan_mode_section(self, tmp_path):
         path = tmp_path / "state" / "s.json"
-        PlanModeState(plan_mode_active=True, plan_file_path="p.md").save(path)
+        _write_plan_mode_section(path, plan_mode_active=True, plan_file_path="p.md")
         ContextState(last_call_input_tokens=7, context_length=99).save(path)
         ContextState.clear(path)
         plan = PlanModeState.load(path)
@@ -213,7 +218,7 @@ class TestContextStateClear:
 
     def test_clear_is_noop_when_section_absent(self, tmp_path):
         path = tmp_path / "state" / "s.json"
-        PlanModeState(plan_mode_active=True).save(path)
+        _write_plan_mode_section(path, plan_mode_active=True)
         ContextState.clear(path)  # context_state never written
         assert PlanModeState.load(path).plan_mode_active is True
 
@@ -247,23 +252,23 @@ class TestLegacyCompactSectionIgnored:
         assert loaded.workflow_prompt_sent is False
 
     def test_save_does_not_emit_compact_key(self, tmp_path):
-        """Even if a legacy file with a ``compact`` section is loaded and
-        re-saved, the new write must NOT round-trip the dropped section —
-        otherwise stale state would linger on disk forever.
+        """Re-saving a legacy file must not round-trip the dropped section —
+        otherwise stale state would linger on disk forever. ``plan_mode`` is a
+        sibling that has to survive; ``compact`` is the one being retired.
         """
         path = tmp_path / "legacy.json"
         path.write_text(
             json.dumps(
                 {
-                    "plan_mode": {"plan_mode_active": False, "plan_file_path": None, "workflow_prompt_sent": False},
+                    "plan_mode": {"plan_mode_active": True, "plan_file_path": None, "workflow_prompt_sent": False},
                     "compact": {"compacted_until": 7},
                 }
             ),
             encoding="utf-8",
         )
-        loaded = PlanModeState.load(path)
-        loaded.plan_mode_active = True
-        loaded.save(path)
+
+        ContextState(last_call_input_tokens=5, context_length=100).save(path)
+
         data = json.loads(path.read_text(encoding="utf-8"))
         assert "compact" not in data
-        assert data == {"plan_mode": {"plan_mode_active": True, "plan_file_path": None, "workflow_prompt_sent": False}}
+        assert data["plan_mode"] == {"plan_mode_active": True, "plan_file_path": None, "workflow_prompt_sent": False}

--- a/tests/unit_tests/storage/test_session_state.py
+++ b/tests/unit_tests/storage/test_session_state.py
@@ -99,6 +99,15 @@ class TestPlanModeStateRoundTrip:
 
 
 class TestContextStateRoundTrip:
+    def test_a_negative_occupancy_is_not_representable(self):
+        """Constructing the state clamps, so no call site has to remember to.
+
+        ``SessionManager.save_context_state`` writes a caller-supplied state
+        through verbatim; a negative reading would render as a negative
+        occupancy in the status bar and a negative ratio in the compaction gate.
+        """
+        assert ContextState(-5).last_call_input_tokens == 0
+
     def test_save_and_load_round_trip(self, tmp_path):
         path = tmp_path / "state" / "ctx.json"
         ContextState(52_499).save(path)


### PR DESCRIPTION
<!-- PR title must start with: [BugFix] [Enhancement] [Feature] [Refactor] [UT] [Doc] [Tool] [Others] -->

## Why

Three problems with a common cause — session state scattered across places
`SessionManager` does not own.

**A compact erases a chat's title.** A session is listed under its first user
message, which `get_session_info` found by scanning `agent_messages`. A major
compact deletes that history and re-adds only an assistant recap, so the scan
reported nothing and the chat went untitled. Once the conversation continued it
got worse: the earliest surviving user row is mid-conversation, so the chat
silently retitled itself to whatever was said after the compact. Fixes the same
bug as #1373, by a different route.

**Plan-mode state lives where deletion cannot reach it.** It sits in
`{project_data_dir}/state/{session_id}.json`, a directory `SessionManager` knows
nothing about, so `delete_session` leaves a deleted conversation's
`plan_file_path` on disk. The read-modify-write in `_save_section` also drops a
sibling section when a CLI and an API server write the same file concurrently.

**`ContextState` carried three fields where one carries the meaning.** `valid`
agreed with `last_call_input_tokens > 0` in every reachable state, because
`__post_init__` zeroed the count whenever the flag was false. `context_length`
is a property of the active model, not of a measurement, and both readers only
consulted the stored copy as a fallback.

## Solution

One `session_meta(session_id, key, value)` table in the session database, three
keys, three commits that can be read independently.

**`title`** — recorded as the message arrives rather than salvaged before a
compact. That removes the timing problem entirely: no caller races the clear,
and `INSERT OR IGNORE` means a later batch can never retitle the chat. The
title is read from the batch *before* the duplicate-input filter, so a compact
on the very first request — where the opening message only exists in the
filtered-out part — still names the session. `copy_session` and
`rewind_session` carry the rows over, or a session derived from a compacted one
would be untitled again one step later. `clear_session` drops the title,
because `/clear` restarts the conversation and the old opening stops describing
it. `delete_session` needs no new code: the rows go with the database file.

**`plan_mode`** — one JSON value, so the three fields that are always written
together cannot land out of step. Reads prefer the database and fall back to
the JSON section, so sessions created before this change keep restoring and
migrate on their next toggle. Plan mode can be toggled before the first
message, when the database does not exist yet; `save_session_meta` skips that
write rather than materialising an empty file that `list_sessions` would report
as a session, and `_get_or_create_session` repeats the call once the session is
real. Nothing is lost in that window — a session with no database cannot be
resumed, so there is no reader for the state it would have stored.

**`context_used`** — replaces the `context_occupancy` table. Invalidation keeps
its atomicity: `replace_items` and `rollback_turn` write `"0"` to the same row
inside the transaction that rewrites the history, so a reading can never
outlive the history it describes. `from_dict` still honours an explicit
`"valid": false` on read, so pre-migration records that may hold a text
estimate do not resurface; nothing writes that flag any more.

### Tradeoffs

- **A resumed session whose model cannot report its window now shows a reading
  with no denominator**, instead of dividing by the window recorded alongside
  the previous measurement. Compaction stays inert in that case, which is what
  it already did whenever the window was unresolvable.
- **Existing `context_occupancy` rows are not migrated.** Occupancy is a
  per-call reading, not accumulated state: the next model response supplies a
  fresh one, and until then the session reads as unknown — exactly as it does
  after a compact.
- **`session_meta` is deliberately not merged into `context_occupancy`,** and
  the reverse was considered too. The two have opposite rewrite rules: `title`
  and `plan_mode` must survive a history rewrite, `context_used` must be zeroed
  by one. Keeping one table with a documented per-key rule beat keeping two
  tables whose names encoded the same thing, but the rule is spelled out on
  each key constant.

## Test Cases

No integration or nightly tests were added: all three changes are storage
contracts exercisable deterministically against real SQLite in the unit tree,
which is where the existing coverage for `session_manager` and `sqlite_session`
lives. Diff coverage is 92%.

**Title (`tests/unit_tests/models/test_sqlite_session.py`,
`test_session_manager.py`)** — the post-compact shape (assistant recap, no user
rows) still reports the original title; a later user message cannot retitle a
compacted session, verified after reopening so the guard is enforced by the
stored row and not an in-memory flag; a compact on the first request still
names the session; tool results arriving as user messages never become the
title; `copy_session` and `rewind_session` carry the title off a compacted
source; `/clear` lets the next message rename the chat; sessions predating the
table fall back to the scan.

**Red-first verification.** With `datus/models/sqlite_session.py` and
`session_manager.py` stashed, five of these fail — title erased by a compact,
retitled after a compact, legacy fallback, copy loses the title, rewind loses
the title. The other four are unchanged-behaviour guards that pass either way
by design. The first-request case was verified separately by pointing the
recorder at the filtered batch: it goes red.

**Plan mode (`tests/unit_tests/agent/node/test_agentic_node_persistence.py`)** —
activate and deactivate survive a rebuilt node; plan mode entered before the
first message is persisted when the session is created; a state file from
before the move still restores; the database wins over a stale leftover file.

**Occupancy (`test_compact_helpers.py`, `test_session_state.py`,
`test_status_bar.py`)** — existing invalidation contracts updated to the new
shape and still passing, including atomic rollback, cancellation during commit,
and post-compact restore. Added: a record marked invalid before the flag was
dropped reads as zero, and a model that reports no window leaves the bar
without a denominator.

**Local run.** `uv run pytest tests/unit_tests/` — 18637 passed, 9 skipped,
excluding `tests/unit_tests/prompts/` which fails on this machine on any branch
(local `dosi` version drift). `ruff format`/`check` clean. Test-quality audit
`--diff-only datus/main`: **P0=0, P1=0**. The PR harness reports 85 integration
failures, all in `test_func_tools_db`, `test_platform_doc`, `test_doc_search`,
`test_cli_commands`, `test_cli_textual` and `test_platform_doc_acceptance`;
running each of those files with the changed sources checked out back to
`datus/main` produces an identical failure count, so they are pre-existing
local-environment failures (a developer datasource override in
`.datus/config.yml`) rather than regressions.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
## Summary by CodeRabbit

* **Improvements**
  * Context usage and status-bar readings now rely on the latest measured input-token usage, with clearer behavior when the model does not report a context window.
  * Plan Mode settings now persist with session data and continue to support existing saved sessions.
  * Session titles are retained when sessions are copied or rewound, and can be refreshed after clearing history.
  * Session titles are no longer affected by tool-result messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session titles now persist across history rewrites, copies, and rewinds.
  - Plan-mode settings and context usage are stored with session data for more reliable restoration.
  - Derived sessions retain titles without inheriting prior context or plan-mode readings.
  - Sessions can be cleared and retitled based on subsequent user messages.

- **Bug Fixes**
  - Improved context display when models do not report a context window.
  - Prevented stale session state from overwriting newer saved settings.
  - Legacy session data remains compatible during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->