### PR TITLE
[Feature] Add Atlas Cloud provider

### DIFF
--- a/ci/provider-coverage.yml
+++ b/ci/provider-coverage.yml
@@ -15,6 +15,19 @@ providers:
       nodeids:
         - tests/integration/models/test_other_models.py::TestOpenAIModel
 
+  atlas:
+    required_env:
+      - ATLASCLOUD_API_KEY
+    deterministic:
+      inherits_from: openai
+      nodeids:
+        - tests/unit_tests/models/test_openai_model.py::TestOpenAIModel
+        - tests/unit_tests/models/test_openai_compatible.py::TestOpenAICompatibleModelInit
+        - tests/unit_tests/configuration/test_agent_config.py::TestProviderConfigurationDispatch
+    live_provider_health:
+      mode: not-tested
+      nodeids: []
+
   deepseek:
     required_env:
       - DEEPSEEK_API_KEY

--- a/conf/providers.yml
+++ b/conf/providers.yml
@@ -25,6 +25,15 @@ providers:
       - deepseek-v4-pro
       - deepseek-v4-flash
 
+  atlas:
+    type: openai
+    base_url: https://api.atlascloud.ai/v1
+    api_key_env: ATLASCLOUD_API_KEY
+    default_model: deepseek-ai/deepseek-v4-flash
+    models:
+      - deepseek-ai/deepseek-v4-flash
+      - deepseek-ai/deepseek-v4-pro
+
   claude:
     type: claude
     base_url: https://api.anthropic.com
@@ -244,6 +253,14 @@ model_specs:
   deepseek-r1:
     context_length: 65535
     max_tokens: 65535
+
+  # Atlas Cloud Models
+  deepseek-ai/deepseek-v4-flash:
+    context_length: 1000000
+    max_tokens: 384000
+  deepseek-ai/deepseek-v4-pro:
+    context_length: 1000000
+    max_tokens: 384000
 
   # Moonshot (Kimi) Models
   kimi-k3:

--- a/datus/conf/providers.yml
+++ b/datus/conf/providers.yml
@@ -25,6 +25,15 @@ providers:
       - deepseek-v4-pro
       - deepseek-v4-flash
 
+  atlas:
+    type: openai
+    base_url: https://api.atlascloud.ai/v1
+    api_key_env: ATLASCLOUD_API_KEY
+    default_model: deepseek-ai/deepseek-v4-flash
+    models:
+      - deepseek-ai/deepseek-v4-flash
+      - deepseek-ai/deepseek-v4-pro
+
   claude:
     type: claude
     base_url: https://api.anthropic.com
@@ -244,6 +253,14 @@ model_specs:
   deepseek-r1:
     context_length: 65535
     max_tokens: 65535
+
+  # Atlas Cloud Models
+  deepseek-ai/deepseek-v4-flash:
+    context_length: 1000000
+    max_tokens: 384000
+  deepseek-ai/deepseek-v4-pro:
+    context_length: 1000000
+    max_tokens: 384000
 
   # Moonshot (Kimi) Models
   kimi-k3:

--- a/docs/configuration/agent.md
+++ b/docs/configuration/agent.md
@@ -200,6 +200,7 @@ Providers are defined in `conf/providers.yml` and activated by adding credential
 |----------|----------------|----------------|------|
 | `openai` | `gpt-5.2`, `gpt-4.1`, `o3` | `openai` | API key |
 | `deepseek` | `deepseek-v4-pro`, `deepseek-v4-flash` | `deepseek` | API key |
+| `atlas` | `deepseek-ai/deepseek-v4-flash`, `deepseek-ai/deepseek-v4-pro` | `openai` | API key |
 | `claude` | `claude-sonnet-4-5`, `claude-opus-4-5` | `claude` | API key |
 | `kimi` | `kimi-k3`, `kimi-k2.6` | `kimi` | API key |
 | `qwen` | `qwen3-max`, `qwen3-coder-plus` | `openai` | API key |
@@ -246,7 +247,7 @@ All providers support environment-variable references in `api_key`, for example:
 api_key: ${OPENAI_API_KEY}
 ```
 
-For OpenAI, DeepSeek, Claude, Kimi, Qwen, Gemini, and OpenRouter, the configuration wizard can prompt with provider-specific environment variable hints (e.g. `${OPENROUTER_API_KEY}`). For `minimax`, `glm`, and the `*_coding` providers, you can still enter values such as `${MINIMAX_API_KEY}`, `${GLM_API_KEY}`, `${KIMI_API_KEY}`, or `${DASHSCOPE_API_KEY}` directly.
+For OpenAI, DeepSeek, Atlas Cloud, Claude, Kimi, Qwen, Gemini, and OpenRouter, the configuration wizard can prompt with provider-specific environment variable hints (e.g. `${ATLASCLOUD_API_KEY}`). For `minimax`, `glm`, and the `*_coding` providers, you can still enter values such as `${MINIMAX_API_KEY}`, `${GLM_API_KEY}`, `${KIMI_API_KEY}`, or `${DASHSCOPE_API_KEY}` directly.
 
 The current implementation also auto-applies fixed parameter overrides for a few models:
 
@@ -266,6 +267,8 @@ With the new provider-level configuration, you only need to set credentials. All
           api_key: ${OPENAI_API_KEY}
         deepseek:
           api_key: ${DEEPSEEK_API_KEY}
+        atlas:
+          api_key: ${ATLASCLOUD_API_KEY}
         claude:
           api_key: ${ANTHROPIC_API_KEY}
         gemini:

--- a/docs/configuration/agent.zh.md
+++ b/docs/configuration/agent.zh.md
@@ -123,6 +123,7 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 |---|---|---|---|
 | `openai` | `gpt-5.2`、`gpt-4.1`、`o3` | `openai` | API Key |
 | `deepseek` | `deepseek-v4-pro`、`deepseek-v4-flash` | `deepseek` | API Key |
+| `atlas` | `deepseek-ai/deepseek-v4-flash`、`deepseek-ai/deepseek-v4-pro` | `openai` | API Key |
 | `claude` | `claude-sonnet-4-5`、`claude-opus-4-5` | `claude` | API Key |
 | `kimi` | `kimi-k3`、`kimi-k2.6` | `kimi` | API Key |
 | `qwen` | `qwen3-max`、`qwen3-coder-plus` | `openai` | API Key |
@@ -168,7 +169,7 @@ ssl_verify（agent.yml）  →  SSL_VERIFY 环境变量  →  SSL_CERT_FILE 环�
 api_key: ${OPENAI_API_KEY}
 ```
 
-对于 OpenAI、DeepSeek、Claude、Kimi、Qwen、Gemini、OpenRouter，配置向导会自动提示对应环境变量（如 `${OPENROUTER_API_KEY}`）。对于 `minimax`、`glm` 和各类 `*_coding` provider，你也可以在输入 API Key 时直接填入 `${MINIMAX_API_KEY}`、`${GLM_API_KEY}`、`${KIMI_API_KEY}`、`${DASHSCOPE_API_KEY}` 这类环境变量引用。
+对于 OpenAI、DeepSeek、Atlas Cloud、Claude、Kimi、Qwen、Gemini、OpenRouter，配置向导会自动提示对应环境变量（如 `${ATLASCLOUD_API_KEY}`）。对于 `minimax`、`glm` 和各类 `*_coding` provider，你也可以在输入 API Key 时直接填入 `${MINIMAX_API_KEY}`、`${GLM_API_KEY}`、`${KIMI_API_KEY}`、`${DASHSCOPE_API_KEY}` 这类环境变量引用。
 
 另外，当前实现会对少数模型自动补充固定参数覆盖：
 
@@ -202,6 +203,15 @@ deepseek:
   base_url: https://api.deepseek.com
   api_key: ${DEEPSEEK_API_KEY}
   model: deepseek-v4-flash
+```
+
+=== "Atlas Cloud"
+```yaml
+atlas:
+  type: openai
+  base_url: https://api.atlascloud.ai/v1
+  api_key: ${ATLASCLOUD_API_KEY}
+  model: deepseek-ai/deepseek-v4-flash
 ```
 
 === "Google Gemini"

--- a/tests/unit_tests/cli/test_provider_model_catalog.py
+++ b/tests/unit_tests/cli/test_provider_model_catalog.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+import yaml
 
 from datus.cli import provider_model_catalog as pmc
 
@@ -97,6 +98,28 @@ def _local_catalog() -> dict:
         },
         "model_overrides": {"kimi-k2.5": {"temperature": 1.0}},
         "model_specs": {"gpt-4.1": {"context_length": 400000, "max_tokens": 128000}},
+    }
+
+
+def test_atlas_provider_catalog_is_packaged() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    source_catalog = yaml.safe_load((repo_root / "conf/providers.yml").read_text(encoding="utf-8"))
+    packaged_catalog = yaml.safe_load((repo_root / "datus/conf/providers.yml").read_text(encoding="utf-8"))
+
+    assert source_catalog == packaged_catalog
+    assert source_catalog["providers"]["atlas"] == {
+        "type": "openai",
+        "base_url": "https://api.atlascloud.ai/v1",
+        "api_key_env": "ATLASCLOUD_API_KEY",
+        "default_model": "deepseek-ai/deepseek-v4-flash",
+        "models": [
+            "deepseek-ai/deepseek-v4-flash",
+            "deepseek-ai/deepseek-v4-pro",
+        ],
+    }
+    assert source_catalog["model_specs"]["deepseek-ai/deepseek-v4-flash"] == {
+        "context_length": 1_000_000,
+        "max_tokens": 384_000,
     }
 
 


### PR DESCRIPTION
## Why

Datus supports OpenAI-compatible providers through its provider catalog, but Atlas Cloud is not currently available as an optional configured provider.

## Solution

- Add Atlas Cloud to the source and packaged provider catalogs using the existing OpenAI-compatible interface.
- Register two current Atlas Cloud DeepSeek models and their model specifications.
- Add deterministic provider coverage, packaging assertions, and English/Chinese configuration documentation.
- Keep all existing providers and defaults unchanged.

## Test Cases

- `uv run --python 3.12 --frozen pytest tests/unit_tests/cli/test_provider_model_catalog.py tests/unit_tests/ci/test_provider_coverage_manifest.py -q` (116 passed)
- Ruff check and format check passed for the changed Python test.
- Provider coverage manifest generation passed.
- `git diff --check` passed.
- One live Atlas Cloud Chat Completions smoke request returned HTTP 200 with no retry.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as an OpenAI-compatible provider.
  * Added DeepSeek V4 Flash and V4 Pro model options, including their supported context and output limits.
  * Added Atlas Cloud to the interactive setup catalog with API key configuration support.

* **Documentation**
  * Added Atlas Cloud configuration guidance and examples in English and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->