### PR TITLE
[BugFix] Drop undeclared task() arguments instead of aborting the run

### DIFF
--- a/datus/tools/func_tool/sub_agent_task_tool.py
+++ b/datus/tools/func_tool/sub_agent_task_tool.py
@@ -278,6 +278,7 @@ class SubAgentTaskTool:
             },
             "required": ["type", "prompt", "description"],
         }
+        accepted_args = frozenset(schema["properties"])
 
         async def _invoke(_tool_ctx, args_str) -> dict:
             args, canonical_json, error = parse_tool_args(
@@ -287,6 +288,17 @@ class SubAgentTaskTool:
             write_back_tool_args(_tool_ctx, canonical_json)
             if error:
                 return FuncToolResult(success=0, error=error).model_dump()
+            # ``strict_json_schema=False`` means the provider does not enforce the
+            # schema, so a model can emit keys that are not declared here (garbled
+            # or hallucinated names, or ``call_id`` which this wrapper supplies).
+            # Splatting those into ``task()`` raises TypeError inside the tool
+            # invocation, which aborts the entire streaming run instead of failing
+            # this one call. Drop them; genuinely missing required arguments are
+            # still reported by ``task()`` with a retry hint.
+            unexpected = sorted(set(args) - accepted_args)
+            if unexpected:
+                logger.warning("Ignoring unsupported task() argument(s): %s", ", ".join(unexpected))
+                args = {key: value for key, value in args.items() if key in accepted_args}
             # Resolve parent call_id from SDK ToolContext for action linking
             call_id = getattr(_tool_ctx, "tool_call_id", None) if _tool_ctx else None
             result = await self.task(call_id=call_id, **args)

--- a/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
+++ b/tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py
@@ -149,6 +149,69 @@ class TestAvailableTools:
             description="sales query",
         )
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"laceholder": "x"},
+            {"call_id": "model-supplied"},
+            {"unknown_a": 1, "unknown_b": {"nested": True}},
+        ],
+        ids=["garbled-key", "wrapper-owned-key", "multiple-unknown-keys"],
+    )
+    async def test_unsupported_arguments_are_dropped_instead_of_raising(self, task_tool, extra):
+        """Undeclared keys must never reach ``task()``.
+
+        ``strict_json_schema=False`` lets a provider forward keys the schema
+        never declared; splatting them raised TypeError out of ``on_invoke_tool``
+        and killed the whole streaming run.
+        """
+        tool = task_tool.available_tools()[0]
+        task_tool.task = AsyncMock(return_value=FuncToolResult(result={"session_id": "child-1"}))
+        payload = {"type": "gen_sql", "prompt": "show sales", "description": "sales query", **extra}
+        raw_args = json.dumps(payload)
+        tool_ctx = SimpleNamespace(
+            tool_call_id="call_task_extra",
+            tool_arguments=raw_args,
+            tool_call=ResponseFunctionToolCall(
+                arguments=raw_args,
+                call_id="call_task_extra",
+                name="task",
+                type="function_call",
+            ),
+        )
+
+        result = await tool.on_invoke_tool(tool_ctx, raw_args)
+
+        assert result["success"] == 1
+        task_tool.task.assert_awaited_once_with(
+            call_id="call_task_extra",
+            type="gen_sql",
+            prompt="show sales",
+            description="sales query",
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsupported_arguments_still_surface_missing_required_ones(self, task_tool):
+        """Dropping unknown keys must not mask a genuinely missing required argument."""
+        tool = task_tool.available_tools()[0]
+        raw_args = json.dumps({"laceholder": "x", "prompt": "show sales"})
+        tool_ctx = SimpleNamespace(
+            tool_call_id="call_task_missing",
+            tool_arguments=raw_args,
+            tool_call=ResponseFunctionToolCall(
+                arguments=raw_args,
+                call_id="call_task_missing",
+                name="task",
+                type="function_call",
+            ),
+        )
+
+        result = await tool.on_invoke_tool(tool_ctx, raw_args)
+
+        assert result["success"] == 0
+        assert "Missing required parameter: type" in result["error"]
+
 
 # ── _get_available_types ───────────────────────────────────────────
 


### PR DESCRIPTION
## Why

A single malformed tool call from the model could kill an entire chat interaction:

```
chat interaction failed: [ErrorCode.MODEL_REQUEST_FAILED] error_code=300001,
error_message=Codex streaming failed: Error running tool task:
SubAgentTaskTool.task() got an unexpected keyword argument 'laceholder'
```

The `task` FunctionTool is registered with `strict_json_schema=False`, so the provider does
not enforce the parameter schema and the model can emit keys the schema never declared —
here a garbled `placeholder` that lost its leading `p`. `_invoke` splatted the parsed
arguments straight into `SubAgentTaskTool.task()`, so an undeclared key raised `TypeError`
inside `on_invoke_tool`. That exception escaped the Agents SDK stream, was wrapped as
`MODEL_REQUEST_FAILED` in `codex_model.py`, and aborted the whole run.

The consequence is out of proportion to the cause: one bad argument name should fail that
one tool call and let the model retry, not terminate the session. `task` is the only tool
with a hand-rolled `**args` splat — every tool registered through the SDK's `function_tool`
decorator already ignores extra keys via its generated pydantic model.

The same splat also made `call_id` a live hazard: the wrapper injects it from the SDK
`ToolContext`, so a model that emitted `call_id` itself triggered
`got multiple values for keyword argument 'call_id'`.

## Solution

Filter the parsed arguments down to the schema's declared properties before calling
`task()`, deriving the allowlist from the same `schema["properties"]` dict built a few
lines above so the two cannot drift apart. Dropped keys are logged at WARNING.

Chose "drop and execute" over "reject and ask the model to retry" for two reasons: it
matches what every other tool in the codebase already does with extra keys, and when the
required arguments are present the call is perfectly executable — failing it would cost a
round trip for nothing. Nothing is masked by this: a genuinely missing required argument
still falls through to `task()`'s existing `_missing_parameter_retry` path, which returns
an actionable retry message listing the available subagent types.

## Test Cases

Added to `tests/unit_tests/tools/func_tool/test_sub_agent_task_tool.py::TestAvailableTools`
(unit tier — this is pure argument-binding logic in the tool wrapper, with no integration
surface to exercise; the existing repair/retry test for the same `_invoke` entry point
lives in this class too):

- `test_unsupported_arguments_are_dropped_instead_of_raising` — parametrized over three
  shapes of undeclared key: the reported garbled `laceholder`, a model-supplied `call_id`
  colliding with the wrapper-owned one, and multiple unknown keys with a nested value.
  Asserts `task()` is awaited with exactly the four declared arguments.
- `test_unsupported_arguments_still_surface_missing_required_ones` — an unknown key
  alongside a missing required `type` must still return the `Missing required parameter`
  retry message rather than being silently swallowed.

Per the bug-fix regression-test rule, these were verified red on the pre-fix code:
`git stash push -- datus/tools/func_tool/sub_agent_task_tool.py` makes all 4 fail with the
original `TypeError`; restoring the fix turns them green.

Gates run locally: 206 passed in the touched test file, `ci/run-pr-tests.py datus/main`
reports impacted unit tests exit 0 (1943 passed) with **100.00% diff coverage**, and
`ci/audit_tests.py --diff-only datus/main` reports **P0=0, P1=0**. The acceptance
harness's 85 failures in `test_platform_doc` / `test_func_tools_db` are a pre-existing
local-environment issue — they reproduce identically on `datus/main` without this commit.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported arguments supplied to task tools are now ignored instead of causing invocation failures.
  * Missing required arguments continue to produce clear validation errors.
  * Improved handling of unexpected provider-supplied parameters while preserving valid task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->