### PR TITLE
[BugFix] Sync SQL policy ID contract

### DIFF
--- a/docs/configuration/sql_policy.md
+++ b/docs/configuration/sql_policy.md
@@ -13,7 +13,8 @@ agent:
       default:
         default: true
         policies:
-          - name: store_scope_sql
+          - id: sp_store_scope_sql
+            name: store_scope_sql
             type: row_filter
             applies_to:
               datasources: ["warehouse"]
@@ -24,7 +25,7 @@ agent:
               value_from: policy_context.row_filter.store_ids
 ```
 
-Policy types and their fields belong to the policy plugin. Agent only loads the plugin runtime declared by its `datus-plugin.yml` manifest.
+Policy types and their fields belong to the policy plugin. Every `row_filter` and `metric_row_filter` policy requires a stable, unique `id`. Agent only loads the plugin runtime declared by its `datus-plugin.yml` manifest.
 
 ## Request Context
 
@@ -40,6 +41,9 @@ The agreed shape has one section per policy family, without an identity or group
 {
   "row_filter": {
     "access_mode": "scoped",
+    "policy_modes": {
+      "sp_store_scope_sql": "scoped"
+    },
     "store_ids": [1, 2]
   },
   "column_mask": {
@@ -48,15 +52,21 @@ The agreed shape has one section per policy family, without an identity or group
 }
 ```
 
-The current sql-policy plugin supports these row-filter modes:
+The current sql-policy plugin first applies the request-wide row-filter mode:
 
 | `access_mode` | Behavior |
 |---|---|
 | `denied` | Reject every data read. |
-| `scoped` | Apply configured row filters and resolve their `policy_context.*` inputs. Missing inputs fail closed. |
-| `unrestricted` | Skip row filtering. Other policy families, such as future column masking, still run. |
+| `scoped` | Evaluate each configured row filter. Missing required inputs fail closed. |
 
-When row policies are configured, a missing or unknown `access_mode` is rejected. When no row policy is configured, an empty context is allowed.
+For a scoped request, the optional `policy_modes` object can override individual policies by ID:
+
+| Per-policy mode | Behavior |
+|---|---|
+| `scoped` | Apply that policy and resolve its `policy_context.*` inputs. |
+| `unrestricted` | Skip only that policy. Other row and result policies still run. |
+
+Omitted policies default to `scoped`. Unknown policy IDs, malformed modes, and a missing or unknown request-wide `access_mode` are rejected. When no row policy is configured, an empty context is allowed.
 
 `X-Datus-User-Id` remains session identity only. Agent does not merge it into `policy_context`, and it does not treat any context field as authenticated identity.
 

--- a/docs/configuration/sql_policy.zh.md
+++ b/docs/configuration/sql_policy.zh.md
@@ -13,7 +13,8 @@ agent:
       default:
         default: true
         policies:
-          - name: store_scope_sql
+          - id: sp_store_scope_sql
+            name: store_scope_sql
             type: row_filter
             applies_to:
               datasources: ["warehouse"]
@@ -24,7 +25,7 @@ agent:
               value_from: policy_context.row_filter.store_ids
 ```
 
-policy type 及其字段由 policy plugin 定义。Agent 只加载 plugin 在 `datus-plugin.yml` 中声明的运行时。
+policy type 及其字段由 policy plugin 定义。每个 `row_filter` 和 `metric_row_filter` policy 都必须有稳定且唯一的 `id`。Agent 只加载 plugin 在 `datus-plugin.yml` 中声明的运行时。
 
 ## 请求上下文
 
@@ -40,6 +41,9 @@ X-Datus-Policy-Context: {"row_filter":{"access_mode":"scoped","store_ids":[1,2]}
 {
   "row_filter": {
     "access_mode": "scoped",
+    "policy_modes": {
+      "sp_store_scope_sql": "scoped"
+    },
     "store_ids": [1, 2]
   },
   "column_mask": {
@@ -48,15 +52,21 @@ X-Datus-Policy-Context: {"row_filter":{"access_mode":"scoped","store_ids":[1,2]}
 }
 ```
 
-当前 sql-policy plugin 支持三种 row-filter 模式：
+当前 sql-policy plugin 首先应用请求级 row-filter 模式：
 
 | `access_mode` | 行为 |
 |---|---|
 | `denied` | 拒绝所有数据读取。 |
-| `scoped` | 执行已配置的行过滤，并解析其 `policy_context.*` 输入；缺少输入时 fail closed。 |
-| `unrestricted` | 仅跳过行过滤；未来的 column masking 等其他 policy family 仍会执行。 |
+| `scoped` | 逐个评估已配置的行过滤；缺少必需输入时 fail closed。 |
 
-配置了 row policy 时，缺少 `access_mode` 或传入未知值都会被拒绝；没有配置 row policy 时，空 context 可以通过。
+对于 scoped 请求，可选的 `policy_modes` object 可以按 policy ID 单独覆盖模式：
+
+| 单 policy 模式 | 行为 |
+|---|---|
+| `scoped` | 执行该 policy，并解析其 `policy_context.*` 输入。 |
+| `unrestricted` | 仅跳过该 policy；其他 row policy 和 result policy 仍会执行。 |
+
+未在 `policy_modes` 中声明的 policy 默认为 `scoped`。未知 policy ID、格式错误的模式，以及缺少或未知的请求级 `access_mode` 都会被拒绝；没有配置 row policy 时，空 context 可以通过。
 
 `X-Datus-User-Id` 只用于会话隔离。Agent 不会把它合并进 `policy_context`，也不会把 context 中的任何字段当作已认证身份。
 

--- a/tests/integration/plugins/test_sql_policy_plugin.py
+++ b/tests/integration/plugins/test_sql_policy_plugin.py
@@ -29,6 +29,7 @@ from datus.tools.permission.permission_config import PermissionLevel
 def _policies() -> list[dict]:
     return [
         {
+            "id": "sp_store_scope_sql",
             "name": "store_scope_sql",
             "type": "row_filter",
             "applies_to": {"datasources": ["warehouse"], "tables": ["orders"]},
@@ -39,6 +40,7 @@ def _policies() -> list[dict]:
             },
         },
         {
+            "id": "sp_store_scope_metrics",
             "name": "store_scope_metrics",
             "type": "metric_row_filter",
             "applies_to": {"datasets": ["orders"]},
@@ -150,6 +152,8 @@ async def test_managed_sql_policy_enforces_sql_semantic_and_api_reads(
         status = managed_plugin_runtime.run("sql-policy", "status")
         assert "2 policies configured" in status.stdout
         assert "store_scope_sql" in status.stdout
+        assert "sp_store_scope_sql" in status.stdout
+        assert "sp_store_scope_metrics" in status.stdout
         checked = managed_plugin_runtime.run(
             "sql-policy",
             "check",

--- a/tests/integration/plugins/test_sql_policy_plugin.py
+++ b/tests/integration/plugins/test_sql_policy_plugin.py
@@ -25,11 +25,14 @@ from datus.tools.middleware.tool_middleware import transform_tool_args
 from datus.tools.permission.bash_rules import evaluate_bash_command
 from datus.tools.permission.permission_config import PermissionLevel
 
+SQL_POLICY_ID = "sp_store_scope_sql"
+METRIC_POLICY_ID = "sp_store_scope_metrics"
+
 
 def _policies() -> list[dict]:
     return [
         {
-            "id": "sp_store_scope_sql",
+            "id": SQL_POLICY_ID,
             "name": "store_scope_sql",
             "type": "row_filter",
             "applies_to": {"datasources": ["warehouse"], "tables": ["orders"]},
@@ -40,7 +43,7 @@ def _policies() -> list[dict]:
             },
         },
         {
-            "id": "sp_store_scope_metrics",
+            "id": METRIC_POLICY_ID,
             "name": "store_scope_metrics",
             "type": "metric_row_filter",
             "applies_to": {"datasets": ["orders"]},
@@ -51,6 +54,34 @@ def _policies() -> list[dict]:
             },
         },
     ]
+
+
+def _scoped_context(*, sql_mode: str | None = None, metric_mode: str | None = None) -> dict:
+    """Build scoped policy context, optionally overriding either policy mode."""
+    row_filter = {"access_mode": "scoped", "store_ids": ["S001"]}
+    policy_modes = {}
+    if sql_mode is not None:
+        policy_modes[SQL_POLICY_ID] = sql_mode
+    if metric_mode is not None:
+        policy_modes[METRIC_POLICY_ID] = metric_mode
+    if policy_modes:
+        row_filter["policy_modes"] = policy_modes
+    return {"row_filter": row_filter}
+
+
+def _transform_metric(config: AgentConfig, policy_context: dict) -> dict:
+    """Apply the managed metric policy to the shared nightly query."""
+    return transform_tool_args(
+        "query_metrics",
+        {"metrics": ["order_revenue"], "where": "orders.amount > 0"},
+        category="semantic_tools",
+        active_plugin_names=config.active_plugin_names(),
+        context={
+            "agent_config": config,
+            "policy_context": policy_context,
+            "metric_datasets": {"order_revenue": ["orders"]},
+        },
+    )
 
 
 def _agent_document(home, workspace, database) -> dict:
@@ -152,8 +183,8 @@ async def test_managed_sql_policy_enforces_sql_semantic_and_api_reads(
         status = managed_plugin_runtime.run("sql-policy", "status")
         assert "2 policies configured" in status.stdout
         assert "store_scope_sql" in status.stdout
-        assert "sp_store_scope_sql" in status.stdout
-        assert "sp_store_scope_metrics" in status.stdout
+        assert SQL_POLICY_ID in status.stdout
+        assert METRIC_POLICY_ID in status.stdout
         checked = managed_plugin_runtime.run(
             "sql-policy",
             "check",
@@ -164,7 +195,7 @@ async def test_managed_sql_policy_enforces_sql_semantic_and_api_reads(
             "--dialect",
             "sqlite",
             "--policy-context",
-            json.dumps({"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}}),
+            json.dumps(_scoped_context()),
         )
         assert "store_scope_sql" in checked.stdout
         assert "S001" in checked.stdout
@@ -177,7 +208,7 @@ async def test_managed_sql_policy_enforces_sql_semantic_and_api_reads(
         managed_plugin_dir = datus_home / "plugins" / "sql-policy"
         assert Path(plugin_spec.origin).resolve().is_relative_to(managed_plugin_dir.resolve())
 
-        scoped = {"row_filter": {"access_mode": "scoped", "store_ids": ["S001"]}}
+        scoped = _scoped_context()
         config.policy_context = scoped
         tool = DBFuncTool(connector, agent_config=config, default_datasource="warehouse")
         sql_result = tool.execute_read_enforced(
@@ -188,25 +219,55 @@ async def test_managed_sql_policy_enforces_sql_semantic_and_api_reads(
         assert sql_result.success, sql_result.error
         assert sql_result.sql_return == [{"store_id": "S001", "amount": 10}]
 
-        transformed = transform_tool_args(
-            "query_metrics",
-            {"metrics": ["order_revenue"], "where": "orders.amount > 0"},
-            category="semantic_tools",
-            active_plugin_names=config.active_plugin_names(),
-            context={
-                "agent_config": config,
-                "policy_context": scoped,
-                "metric_datasets": {"order_revenue": ["orders"]},
-            },
-        )
+        transformed = _transform_metric(config, scoped)
         assert "orders.amount > 0" in transformed["where"]
         assert "orders.store_id" in transformed["where"]
         assert "S001" in transformed["where"]
 
+        sql_unrestricted = _scoped_context(sql_mode="unrestricted", metric_mode="scoped")
+        config.policy_context = sql_unrestricted
+        unrestricted_sql_result = tool.execute_read_enforced(
+            "SELECT store_id, amount FROM orders ORDER BY store_id",
+            connector,
+            datasource="warehouse",
+        )
+        assert unrestricted_sql_result.success is True, unrestricted_sql_result.error
+        assert unrestricted_sql_result.sql_return == [
+            {"store_id": "S001", "amount": 10},
+            {"store_id": "S002", "amount": 20},
+        ]
+        metric_still_scoped = _transform_metric(config, sql_unrestricted)
+        assert "orders.store_id" in metric_still_scoped["where"]
+
+        metric_unrestricted = _scoped_context(sql_mode="scoped", metric_mode="unrestricted")
+        config.policy_context = metric_unrestricted
+        sql_still_scoped = tool.execute_read_enforced(
+            "SELECT store_id, amount FROM orders ORDER BY store_id",
+            connector,
+            datasource="warehouse",
+        )
+        assert sql_still_scoped.success is True, sql_still_scoped.error
+        assert sql_still_scoped.sql_return == [{"store_id": "S001", "amount": 10}]
+        unrestricted_metric_args = _transform_metric(config, metric_unrestricted)
+        assert unrestricted_metric_args["where"] == "orders.amount > 0"
+
         provider = HeaderContextProvider()
+        config.policy_context = scoped
         scoped_context = await provider.authenticate(_request(scoped))
         assert scoped_context.policy_context == scoped
         assert _policy_context_pre_check(SimpleNamespace(agent_config=config), scoped_context) is None
+
+        unknown_policy = {
+            "row_filter": {
+                "access_mode": "scoped",
+                "policy_modes": {"sp_unknown": "unrestricted"},
+                "store_ids": ["S001"],
+            }
+        }
+        unknown_context = await provider.authenticate(_request(unknown_policy))
+        unknown_outcome = _policy_context_pre_check(SimpleNamespace(agent_config=config), unknown_context)
+        assert unknown_outcome.allow is False
+        assert unknown_outcome.error_type == "POLICY_CONTEXT_REJECTED"
 
         denied = {"row_filter": {"access_mode": "denied"}}
         denied_context = await provider.authenticate(_request(denied))


### PR DESCRIPTION
## Summary

- add stable unique IDs to the managed SQL and metric row-filter policies used by the blocking nightly P0 contract
- assert that the managed plugin exposes those IDs through `datus sql-policy status`
- update the English and Chinese SQL policy documentation for the per-policy `policy_modes` contract and removal of global unrestricted access

## Background

[Nightly run 34653067482](https://github.com/Datus-ai/Datus-agent/actions/runs/34653067482) failed in `P0 SQL Policy Plugin Contracts` after `datus-sql-policies` PR #9 made IDs mandatory for `row_filter` and `metric_row_filter` policies. The prior Agent fixture still declared policies by name only.

## Validation

- `EXTERNAL_REPOS_ROOT=/Users/kangxue/work/datus DATUS_TEST_LAYER=nightly uv run python -m pytest tests/integration/plugins/test_sql_policy_plugin.py -p ci.pytest_fail_on_skip_plugin --fail-on-skip --tb=short --verbose --timeout=300 --timeout-method=thread` (`1 passed`)
- `uv run ruff check tests/integration/plugins/test_sql_policy_plugin.py`
- `uv run ruff format --check tests/integration/plugins/test_sql_policy_plugin.py`
- `DOCS_LOCALE=en uv run --with mkdocs-material --with mike --with mkdocs-static-i18n mkdocs build --strict`
- `DOCS_LOCALE=zh uv run --with mkdocs-material --with mike --with mkdocs-static-i18n mkdocs build --strict`
- `git diff --check`

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
- [ ] release/0.4.1
## Summary by CodeRabbit

- **Documentation**
  - Updated SQL policy configuration guidance to require stable, unique IDs for row-filter policies.
  - Documented request-level access modes (`denied` or `scoped`) and optional per-policy overrides (`scoped` or `unrestricted`).
  - Clarified default behavior and rejection of missing, unknown, or invalid policy settings.
  - Added corresponding updates to the Chinese documentation.

- **Tests**
  - Added coverage confirming policy IDs appear in plugin status output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated SQL policy configuration guidance to require stable, unique IDs for row-filter policies.
  - Documented request-level access modes (`denied` or `scoped`) and optional per-policy overrides (`scoped` or `unrestricted`).
  - Clarified default behavior and rejection of missing, unknown, or invalid policy settings.
  - Added corresponding updates to the Chinese documentation.

- **Tests**
  - Added coverage for independent SQL and metric policy modes.
  - Added validation tests for unknown policy IDs and policy status output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->