### PR TITLE
[BugFix] Handle auto-review error sentinel

### DIFF
--- a/datus/tools/permission/auto_reviewer.py
+++ b/datus/tools/permission/auto_reviewer.py
@@ -262,7 +262,17 @@ class LLMAutoReviewer(AutoReviewer):
                 # the provider request; schema-only adapters ignore it.
                 timeout=config.timeout_seconds,
             )
-            verdict = AutoReviewVerdict.model_validate(raw)
+            if isinstance(raw, dict) and raw.get("error"):
+                error = str(raw["error"]).strip() or "model returned an invalid response"
+                verdict = AutoReviewVerdict(
+                    risk_level=ReviewRiskLevel.HIGH,
+                    user_authorization=UserAuthorization.UNKNOWN,
+                    decision=ReviewDecision.ASK,
+                    confidence=0.0,
+                    rationale=f"AI review unavailable: {error}"[:1000],
+                )
+            else:
+                verdict = AutoReviewVerdict.model_validate(raw)
             if span is not None:
                 span.set_attribute("datus.permission.review.risk", verdict.risk_level.value)
                 span.set_attribute("datus.permission.review.decision", verdict.decision.value)

--- a/tests/unit_tests/tools/permission/test_auto_reviewer.py
+++ b/tests/unit_tests/tools/permission/test_auto_reviewer.py
@@ -281,6 +281,27 @@ class TestReviewerRequest:
             assert await reviewer.review(request, AutoReviewConfig(enabled=True)) is None
 
     @pytest.mark.asyncio
+    async def test_adapter_error_sentinel_returns_actionable_fail_closed_verdict(self):
+        fake_model = MagicMock()
+        fake_model.generate_with_json_output.return_value = {
+            "error": "Failed to parse JSON response",
+            "raw_response": "",
+        }
+        reviewer = LLMAutoReviewer(agent_config=MagicMock())
+        request = AutoReviewRequest("bash", {"command": "make"}, {}, {})
+
+        with patch("datus.models.base.LLMBaseModel.create_model", return_value=fake_model):
+            result = await reviewer.review(request, AutoReviewConfig(enabled=True))
+
+        assert result == AutoReviewVerdict(
+            risk_level="high",
+            user_authorization="unknown",
+            decision="ask",
+            confidence=0.0,
+            rationale="AI review unavailable: Failed to parse JSON response",
+        )
+
+    @pytest.mark.asyncio
     async def test_schema_is_passed_to_adapter_and_included_in_prompt(self):
         fake_model = MagicMock()
         fake_model.generate_with_json_output.return_value = {


### PR DESCRIPTION
## Why

Fixes #1403. The model adapter can return an error sentinel instead of a review payload when JSON parsing fails. Passing that sentinel into `AutoReviewVerdict` raises validation errors and leaves non-interactive permission checks without an actionable verdict.

## Solution

Detect adapter error sentinels and convert them into a fail-closed verdict that asks for confirmation, reports high risk, and explains that AI review is unavailable. Normal review payloads still follow the existing validation path.

## Test Cases

- Added a regression test for the adapter error sentinel (verified red before the fix).
- `uv run pytest tests/unit_tests/tools/permission/test_auto_reviewer.py` — 46 passed.
- `uv run ruff check datus/tools/permission/auto_reviewer.py tests/unit_tests/tools/permission/test_auto_reviewer.py` — passed.
- `uv run ruff format --check datus/tools/permission/auto_reviewer.py tests/unit_tests/tools/permission/test_auto_reviewer.py` — passed.

## Backport

<!-- Auto-generated below by .github/workflows/sync-backport-checklist.yml. Tick the release branches to backport this PR to after merge. -->

- [ ] release/0.3.1
- [ ] release/0.3.2
- [ ] release/0.3.3
- [ ] release/0.3.4
- [ ] release/0.3.5
- [ ] release/0.3.6
- [ ] release/0.3.7
- [ ] release/0.3.8
- [ ] release/0.3.9
- [ ] release/0.4.0
- [ ] release/0.4.1
## Summary by CodeRabbit

- **Bug Fixes**
  - AI permission reviews now return a clear, fail-closed verdict when the review service reports an error.
  - Failed reviews are marked high risk, require confirmation, and include an actionable explanation instead of returning no result.
- **Tests**
  - Added coverage to verify error responses produce the expected safety verdict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - AI permission reviews now return a clear, fail-closed verdict when the review service reports an error.
  - Failed reviews are marked high risk, require confirmation, and include an actionable explanation instead of returning no result.
  - Reviews with an empty error response now provide a default explanation indicating that the AI review was unavailable.

- **Tests**
  - Added coverage for both detailed and empty error responses to verify the expected safety verdict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->